### PR TITLE
(data) Update Japanese SV set SV10 Glory of Team Rocket

### DIFF
--- a/data-asia/SV/SV10/001.ts
+++ b/data-asia/SV/SV10/001.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "クヌギダマ",
 		'zh-tw': "榛果球",
 		'zh-cn': "榛果球",
-		ja: "クヌギダマ"
 	},
 
 	illustrator: "YASHIRO Nanaco",
@@ -16,33 +15,42 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
+		ja: "木の 皮を 重ね合わせて 殻を 分厚くするのが 大好き。 重くなっても 気にしない。",
 		'zh-tw': "最喜歡把樹皮 疊在身上加厚外殼。 就算因此變重也毫不在意。",
 		'zh-cn': "最喜歡把樹皮 疊在身上加厚外殼。 就算因此變重也毫不在意。",
-		ja: "木の 皮を 重ね合わせて 殻を 分厚くするのが 大好き。 重くなっても 気にしない。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "垂吊",
-			'zh-cn': "垂吊",
-			ja: "ぶらさがる"
+	attacks: [
+		{
+			name: {
+				ja: "ぶらさがる",
+				'zh-tw': "垂吊",
+				'zh-cn': "垂吊",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
+	],
 
-		damage: 10,
-		cost: ["Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821832,
+				tcgplayer: 628642,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [204]
-}
+	dexId: [204],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/002.ts
+++ b/data-asia/SV/SV10/002.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "キノココ",
 		'zh-tw': "蘑蘑菇",
 		'zh-cn': "蘑蘑菇",
-		ja: "キノココ"
 	},
 
 	illustrator: "IKEDA Saki",
@@ -16,33 +15,42 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
+		ja: "湿った 場所を 好み 昼間は 森の 木陰で じっと している。 頭から 毒の 粉を 出す。",
 		'zh-tw': "喜歡潮濕的地方，白天會 動也不動地待在森林的樹蔭下。 會從頭上放出毒粉。",
 		'zh-cn': "喜歡潮濕的地方，白天會 動也不動地待在森林的樹蔭下。 會從頭上放出毒粉。",
-		ja: "湿った 場所を 好み 昼間は 森の 木陰で じっと している。 頭から 毒の 粉を 出す。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "滾動衝撞",
-			'zh-cn': "滾動衝撞",
-			ja: "ころがりタックル"
+	attacks: [
+		{
+			name: {
+				ja: "ころがりタックル",
+				'zh-tw': "滾動衝撞",
+				'zh-cn': "滾動衝撞",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821833,
+				tcgplayer: 628643,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [285]
-}
+	dexId: [285],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/003.ts
+++ b/data-asia/SV/SV10/003.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "キノガッサ",
 		'zh-tw': "斗笠菇",
 		'zh-cn': "斗笠菇",
-		ja: "キノガッサ"
 	},
 
 	illustrator: "nisimono",
@@ -16,54 +15,65 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
+		ja: "毒の 胞子を ばらまき 吸いこんで 苦しむ 相手に 強烈な パンチを くらわせる。",
 		'zh-tw': "會撒出毒孢子，然後再讓 因吸入孢子而痛苦不堪的 對手吃上一記重拳。",
 		'zh-cn': "會撒出毒孢子，然後再讓 因吸入孢子而痛苦不堪的 對手吃上一記重拳。",
-		ja: "毒の 胞子を ばらまき 吸いこんで 苦しむ 相手に 強烈な パンチを くらわせる。"
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "傷害衝刺",
-			'zh-cn': "傷害衝刺",
-			ja: "ダメージラッシュ"
+	attacks: [
+		{
+			name: {
+				ja: "ダメージラッシュ",
+				'zh-tw': "傷害衝刺",
+				'zh-cn': "傷害衝刺",
+			},
+			damage: "30+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数×50ダメージ追加。",
+				'zh-tw': "擲硬幣直到出現反面，增加正面出現的次數×50點傷害。",
+				'zh-cn': "擲硬幣直到出現反面，增加正面出現的次數×50點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲硬幣直到出現反面，增加正面出現的次數×50點傷害。",
-			'zh-cn': "擲硬幣直到出現反面，增加正面出現的次數×50點傷害。",
-			ja: "ウラが出るまでコインを投げ、オモテの数×50ダメージ追加。"
+		{
+			name: {
+				ja: "メガドレイン",
+				'zh-tw': "超級吸取",
+				'zh-cn': "超級吸取",
+			},
+			damage: 90,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+				'zh-tw': "將這隻寶可夢恢復「30」HP。",
+				'zh-cn': "將這隻寶可夢恢復「30」HP。",
+			},
 		},
+	],
 
-		damage: "30＋",
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "超級吸取",
-			'zh-cn': "超級吸取",
-			ja: "メガドレイン"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821834,
+				tcgplayer: 628644,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將這隻寶可夢恢復「30」HP。",
-			'zh-cn': "將這隻寶可夢恢復「30」HP。",
-			ja: "このポケモンのHPを「30」回復する。"
-		},
-
-		damage: 90,
-		cost: ["Grass", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "キノココ",
+	},
 
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [286]
-}
+	dexId: [286],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/004.ts
+++ b/data-asia/SV/SV10/004.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "カットロトム",
 		'zh-tw': "切割洛托姆",
 		'zh-cn': "切割洛托姆",
-		ja: "カットロトム"
 	},
 
 	illustrator: "Rianti Hidayat",
@@ -16,54 +15,61 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
+		ja: "ロトム図鑑が 誕生する きっかけとなった 家電製品の ひとつが 芝刈り機なのだ。",
 		'zh-tw': "成為洛托姆圖鑑 誕生契機的其中一樣 家電用品就是割草機。",
 		'zh-cn': "成為洛托姆圖鑑 誕生契機的其中一樣 家電用品就是割草機。",
-		ja: "ロトム図鑑が 誕生する きっかけとなった 家電製品の ひとつが 芝刈り機なのだ。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "割除利刃",
-			'zh-cn': "割除利刃",
-			ja: "かりとりカッター"
+	attacks: [
+		{
+			name: {
+				ja: "かりとりカッター",
+				'zh-tw': "割除利刃",
+				'zh-cn': "割除利刃",
+			},
+			damage: 20,
+			cost: ["Grass"],
+			effect: {
+				ja: "場に出ているスタジアムをトラッシュする。",
+				'zh-tw': "將場上的競技場卡丟棄。",
+				'zh-cn': "將場上的競技場卡丟棄。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將場上的競技場卡丟棄。",
-			'zh-cn': "將場上的競技場卡丟棄。",
-			ja: "場に出ているスタジアムをトラッシュする。"
+		{
+			name: {
+				ja: "ガジェットショー",
+				'zh-tw': "配件秀",
+				'zh-cn': "配件秀",
+			},
+			damage: "30×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のポケモン全員についている「ポケモンのどうぐ」の数×30ダメージ。",
+				'zh-tw': "造成自己的所有寶可夢身上附加的「寶可夢道具」卡的數量×30點傷害。",
+				'zh-cn': "造成自己的所有寶可夢身上附加的「寶可夢道具」卡的數量×30點傷害。",
+			},
 		},
+	],
 
-		damage: 20,
-		cost: ["Grass"]
-	}, {
-		name: {
-			'zh-tw': "配件秀",
-			'zh-cn': "配件秀",
-			ja: "ガジェットショー"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821835,
+				tcgplayer: 628645,
+			},
 		},
-
-		effect: {
-			'zh-tw': "造成自己的所有寶可夢身上附加的「寶可夢道具」卡的數量×30點傷害。",
-			'zh-cn': "造成自己的所有寶可夢身上附加的「寶可夢道具」卡的數量×30點傷害。",
-			ja: "自分のポケモン全員についている「ポケモンのどうぐ」の数×30ダメージ。"
-		},
-
-		damage: "30×",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [479]
-}
+	dexId: [479],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/005.ts
+++ b/data-asia/SV/SV10/005.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "カリキリ",
 		'zh-tw': "偽螳草",
 		'zh-cn': "偽螳草",
-		ja: "カリキリ"
 	},
 
 	illustrator: "mashu",
@@ -16,33 +15,42 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
+		ja: "昼寝の 邪魔を されるのが 大嫌い。 日光浴で 溜めた エネルギーで ビームを 撃ち出す。",
 		'zh-tw': "極度厭惡睡午覺的時候 遭到打擾。會用日光浴 儲存的能量放射出光束。",
 		'zh-cn': "極度厭惡睡午覺的時候 遭到打擾。會用日光浴 儲存的能量放射出光束。",
-		ja: "昼寝の 邪魔を されるのが 大嫌い。 日光浴で 溜めた エネルギーで ビームを 撃ち出す。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "切",
-			'zh-cn': "切",
-			ja: "きる"
+	attacks: [
+		{
+			name: {
+				ja: "きる",
+				'zh-tw': "切",
+				'zh-cn': "切",
+			},
+			damage: 20,
+			cost: ["Grass"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Grass"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821836,
+				tcgplayer: 628646,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [753]
-}
+	dexId: [753],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/006.ts
+++ b/data-asia/SV/SV10/006.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ラランテス",
 		'zh-tw': "蘭螳花",
 		'zh-cn': "蘭螳花",
-		ja: "ラランテス"
 	},
 
 	illustrator: "Masako Tomii",
@@ -16,48 +15,60 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
+		ja: "花の 甘い 香りに 誘われて 寄ってきた 虫ポケモンを 仲間と 油断させ カマで 仕留める。",
 		'zh-tw': "會用甜甜花香吸引蟲寶可夢接近， 然後趁著牠們誤以為自己是夥伴 而掉以輕心時用鐮刀奪取性命。",
 		'zh-cn': "會用甜甜花香吸引蟲寶可夢接近， 然後趁著牠們誤以為自己是夥伴 而掉以輕心時用鐮刀奪取性命。",
-		ja: "花の 甘い 香りに 誘われて 寄ってきた 虫ポケモンを 仲間と 油断させ カマで 仕留める。"
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "飛葉快刀",
-			'zh-cn': "飛葉快刀",
-			ja: "はっぱカッター"
+	attacks: [
+		{
+			name: {
+				ja: "はっぱカッター",
+				'zh-tw': "飛葉快刀",
+				'zh-cn': "飛葉快刀",
+			},
+			damage: 30,
+			cost: ["Colorless"],
 		},
-
-		damage: 30,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "花切舞",
-			'zh-cn': "花切舞",
-			ja: "はなきりまい"
+		{
+			name: {
+				ja: "はなきりまい",
+				'zh-tw': "花切舞",
+				'zh-cn': "花切舞",
+			},
+			damage: 130,
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の手札から「基本[G]エネルギー」を2枚トラッシュする。2枚トラッシュできないなら、このワザは失敗。",
+				'zh-tw': "從自己的手牌將2張「基本【草】能量」卡丟棄。若無法丟棄2張卡，則這個招式失敗。",
+				'zh-cn': "從自己的手牌將2張「基本【草】能量」卡丟棄。若無法丟棄2張卡，則這個招式失敗。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的手牌將2張「基本【草】能量」卡丟棄。若無法丟棄2張卡，則這個招式失敗。",
-			'zh-cn': "從自己的手牌將2張「基本【草】能量」卡丟棄。若無法丟棄2張卡，則這個招式失敗。",
-			ja: "自分の手札から「基本エネルギー」を2枚トラッシュする。2枚トラッシュできないなら、このワザは失敗。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821837,
+				tcgplayer: 628647,
+			},
 		},
+	],
 
-		damage: 130,
-		cost: ["Grass"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "カリキリ",
+	},
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Uncommon",
-	dexId: [754]
-}
+	dexId: [754],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/007.ts
+++ b/data-asia/SV/SV10/007.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のサッチムシ",
 		'zh-tw': "<火箭隊的>索偵蟲",
 		'zh-cn': "<火箭隊的>索偵蟲",
-		ja: "ロケット団のサッチムシ"
 	},
 
 	illustrator: "buchi",
@@ -16,38 +15,46 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
+		ja: "畑で よく見かける ポケモン。 体に 生えた 毛で まわりで 起きていることを 感じとる。",
 		'zh-tw': "經常出現在田地裡的寶可夢。 會透過長在身體上的毛 來感應周圍發生的事。",
 		'zh-cn': "經常出現在田地裡的寶可夢。 會透過長在身體上的毛 來感應周圍發生的事。",
-		ja: "畑で よく見かける ポケモン。 体に 生えた 毛で まわりで 起きていることを 感じとる。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "搜索之眼",
-			'zh-cn': "搜索之眼",
-			ja: "サーチアイ"
+	attacks: [
+		{
+			name: {
+				ja: "サーチアイ",
+				'zh-tw': "搜索之眼",
+				'zh-cn': "搜索之眼",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "ウラになっている相手のサイドを1枚選び、そのカードのオモテを見て、もとにもどす。",
+				'zh-tw': "選擇1張對手的反面朝上的獎賞卡，查看那張卡的正面後，回復原樣。",
+				'zh-cn': "選擇1張對手的反面朝上的獎賞卡，查看那張卡的正面後，回復原樣。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇1張對手的反面朝上的獎賞卡，查看那張卡的正面後，回復原樣。",
-			'zh-cn': "選擇1張對手的反面朝上的獎賞卡，查看那張卡的正面後，回復原樣。",
-			ja: "ウラになっている相手のサイドを1枚選び、そのカードのオモテを見て、もとにもどす。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821838,
+				tcgplayer: 628648,
+			},
 		},
-
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [824]
-}
+	dexId: [824],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/008.ts
+++ b/data-asia/SV/SV10/008.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のタマンチュラ",
 		'zh-tw': "<火箭隊的>團珠蛛",
 		'zh-cn': "<火箭隊的>團珠蛛",
-		ja: "ロケット団のタマンチュラ"
 	},
 
 	illustrator: "Saboteri",
@@ -16,39 +15,47 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
+		ja: "体を 包みこむ 糸玉は 天敵の ストライクの カマを はね返す 弾力性を 持つ。",
 		'zh-tw': "包裹著身體的線球 擁有足以把天敵飛天螳螂 的鐮刀反彈回去的彈力。",
 		'zh-cn': "包裹著身體的線球 擁有足以把天敵飛天螳螂 的鐮刀反彈回去的彈力。",
-		ja: "体を 包みこむ 糸玉は 天敵の ストライクの カマを はね返す 弾力性を 持つ。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "猛撞",
-			'zh-cn': "猛撞",
-			ja: "とっしん"
+	attacks: [
+		{
+			name: {
+				ja: "とっしん",
+				'zh-tw': "猛撞",
+				'zh-cn': "猛撞",
+			},
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "このポケモンにも10ダメージ。",
+				'zh-tw': "這隻寶可夢也受到10點傷害。",
+				'zh-cn': "這隻寶可夢也受到10點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢也受到10點傷害。",
-			'zh-cn': "這隻寶可夢也受到10點傷害。",
-			ja: "このポケモンにも10ダメージ。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821839,
+				tcgplayer: 628649,
+			},
 		},
-
-		damage: 30,
-		cost: ["Grass"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [917]
-}
+	dexId: [917],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/009.ts
+++ b/data-asia/SV/SV10/009.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のワナイダー",
 		'zh-tw': "<火箭隊的>操陷蛛",
 		'zh-cn': "<火箭隊的>操陷蛛",
-		ja: "ロケット団のワナイダー"
 	},
 
 	illustrator: "Taiga Kasai",
@@ -16,55 +15,67 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
+		ja: "木の枝や 天井に 糸で 張りつき 音もなく 行動する。 獲物に 気づかれる前に 倒す。",
 		'zh-tw': "用絲線吸附在樹枝或天花板上 無聲無息地移動。會在自己 被察覺到之前將獵物打倒。",
 		'zh-cn': "用絲線吸附在樹枝或天花板上 無聲無息地移動。會在自己 被察覺到之前將獵物打倒。",
-		ja: "木の枝や 天井に 糸で 張りつき 音もなく 行動する。 獲物に 気づかれる前に 倒す。"
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "充能",
-			'zh-cn': "充能",
-			ja: "チャージアップ"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "チャージアップ",
+				'zh-tw': "充能",
+				'zh-cn': "充能",
+			},
+			effect: {
+				ja: "自分の番に1回使える。自分のトラッシュから基本エネルギーを1枚選び、このポケモンにつける。",
+				'zh-tw': "在自己的回合時可使用1次。從自己的棄牌區選擇1張基本能量卡，附於這隻寶可夢身上。",
+				'zh-cn': "在自己的回合時可使用1次。從自己的棄牌區選擇1張基本能量卡，附於這隻寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時可使用1次。從自己的棄牌區選擇1張基本能量卡，附於這隻寶可夢身上。",
-			'zh-cn': "在自己的回合時可使用1次。從自己的棄牌區選擇1張基本能量卡，附於這隻寶可夢身上。",
-			ja: "自分の番に1回使える。自分のトラッシュから基本エネルギーを1枚選び、このポケモンにつける。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "火箭猛攻",
-			'zh-cn': "火箭猛攻",
-			ja: "ロケットラッシュ"
+	attacks: [
+		{
+			name: {
+				ja: "ロケットラッシュ",
+				'zh-tw': "火箭猛攻",
+				'zh-cn': "火箭猛攻",
+			},
+			damage: "30×",
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "自分の場の「ロケット団のポケモン」の数×30ダメージ。",
+				'zh-tw': "造成自己的場上「火箭隊的寶可夢」的數量×30點傷害。",
+				'zh-cn': "造成自己的場上「火箭隊的寶可夢」的數量×30點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "造成自己的場上「火箭隊的寶可夢」的數量×30點傷害。",
-			'zh-cn': "造成自己的場上「火箭隊的寶可夢」的數量×30點傷害。",
-			ja: "自分の場の「ロケット団のポケモン」の数×30ダメージ。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821840,
+				tcgplayer: 628650,
+			},
 		},
+	],
 
-		damage: "30×",
-		cost: ["Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ロケット団のタマンチュラ",
+	},
 
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Rare",
-	dexId: [918]
-}
+	dexId: [918],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/010.ts
+++ b/data-asia/SV/SV10/010.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ミニーブ",
 		'zh-tw': "迷你芙",
 		'zh-cn': "迷你芙",
-		ja: "ミニーブ"
 	},
 
 	illustrator: "Yuka Morii",
@@ -16,33 +15,42 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
+		ja: "頭の 実から オイルを 出して 敵から 身を 守る。 オイルは とびあがるほど 苦くて 渋い。",
 		'zh-tw': "會從頭上的果實噴出油 來保護自己不受敵人攻擊。 油的味道苦澀到會讓人跳起來。",
 		'zh-cn': "會從頭上的果實噴出油 來保護自己不受敵人攻擊。 油的味道苦澀到會讓人跳起來。",
-		ja: "頭の 実から オイルを 出して 敵から 身を 守る。 オイルは とびあがるほど 苦くて 渋い。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "衝撞",
-			'zh-cn': "衝撞",
-			ja: "ぶつかる"
+	attacks: [
+		{
+			name: {
+				ja: "ぶつかる",
+				'zh-tw': "衝撞",
+				'zh-cn': "衝撞",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
+	],
 
-		damage: 10,
-		cost: ["Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821841,
+				tcgplayer: 628651,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [928]
-}
+	dexId: [928],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/011.ts
+++ b/data-asia/SV/SV10/011.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "オリーニョ",
 		'zh-tw': "奧利紐",
 		'zh-cn': "奧利紐",
-		ja: "オリーニョ"
 	},
 
 	illustrator: "Felicia Chen",
@@ -16,47 +15,59 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
+		ja: "フレッシュな 香りの 美味しい オイルを 分けてくれる。 古くから 人間と 共存してきた。",
 		'zh-tw': "會分享自己香氣新鮮、 美味可口的油。自古以來 就與人類共存，直到現在。",
 		'zh-cn': "會分享自己香氣新鮮、 美味可口的油。自古以來 就與人類共存，直到現在。",
-		ja: "フレッシュな 香りの 美味しい オイルを 分けてくれる。 古くから 人間と 共存してきた。"
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "營養素",
-			'zh-cn': "營養素",
-			ja: "えいようそ"
+	attacks: [
+		{
+			name: {
+				ja: "えいようそ",
+				'zh-tw': "營養素",
+				'zh-cn': "營養素",
+			},
+			cost: ["Grass"],
+			effect: {
+				ja: "自分のポケモン1匹のHPを「40」回復する。",
+				'zh-tw': "將自己的1隻寶可夢恢復「40」HP。",
+				'zh-cn': "將自己的1隻寶可夢恢復「40」HP。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將自己的1隻寶可夢恢復「40」HP。",
-			'zh-cn': "將自己的1隻寶可夢恢復「40」HP。",
-			ja: "自分のポケモン1匹のHPを「40」回復する。"
+		{
+			name: {
+				ja: "たいあたり",
+				'zh-tw': "撞擊",
+				'zh-cn': "撞擊",
+			},
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Grass"]
-	}, {
-		name: {
-			'zh-tw': "撞擊",
-			'zh-cn': "撞擊",
-			ja: "たいあたり"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821842,
+				tcgplayer: 628652,
+			},
 		},
+	],
 
-		damage: 40,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ミニーブ",
+	},
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [929]
-}
+	dexId: [929],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/012.ts
+++ b/data-asia/SV/SV10/012.ts
@@ -1,61 +1,74 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "オリーヴァex",
 		'zh-tw': "奧利瓦ex",
 		'zh-cn': "奧利瓦ex",
-		ja: "オリーヴァex"
 	},
 
 	illustrator: "PLANETA Tsuji",
 	category: "Pokemon",
 	hp: 310,
 	types: ["Grass"],
+
 	stage: "Stage2",
-	suffix: "EX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "油之機關槍",
-			'zh-cn': "油之機關槍",
-			ja: "オイルマシンガン"
+	attacks: [
+		{
+			name: {
+				ja: "オイルマシンガン",
+				'zh-tw': "油之機關槍",
+				'zh-cn': "油之機關槍",
+			},
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のポケモンを6回選び、選んだポケモン全員に、弱点・抵抗力を計算せず、選んだ回数×20ダメージ。（1匹を2回以上選べる。）",
+				'zh-tw': "選擇6次對手的寶可夢，對所選的所有寶可夢不計算弱點・抵抗力，造成其選擇次數×20點傷害。（1隻可選擇2次以上。）",
+				'zh-cn': "選擇6次對手的寶可夢，對所選的所有寶可夢不計算弱點・抵抗力，造成其選擇次數×20點傷害。（1隻可選擇2次以上。）",
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇6次對手的寶可夢，對所選的所有寶可夢不計算弱點・抵抗力，造成其選擇次數×20點傷害。（1隻可選擇2次以上。）",
-			'zh-cn': "選擇6次對手的寶可夢，對所選的所有寶可夢不計算弱點・抵抗力，造成其選擇次數×20點傷害。（1隻可選擇2次以上。）",
-			ja: "相手のポケモンを6回選び、選んだポケモン全員に、弱点・抵抗力を計算せず、選んだ回数×20ダメージ。（1匹を2回以上選べる。）"
+		{
+			name: {
+				ja: "アロマシュート",
+				'zh-tw': "芳香射擊",
+				'zh-cn': "芳香射擊",
+			},
+			damage: 160,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンの特殊状態を、すべて回復する。",
+				'zh-tw': "將這隻寶可夢的特殊狀態全部恢復。",
+				'zh-cn': "將這隻寶可夢的特殊狀態全部恢復。",
+			},
 		},
+	],
 
-		cost: ["Grass"]
-	}, {
-		name: {
-			'zh-tw': "芳香射擊",
-			'zh-cn': "芳香射擊",
-			ja: "アロマシュート"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821843,
+				tcgplayer: 628653,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將這隻寶可夢的特殊狀態全部恢復。",
-			'zh-cn': "將這隻寶可夢的特殊狀態全部恢復。",
-			ja: "このポケモンの特殊状態を、すべて回復する。"
-		},
-
-		damage: 160,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "オリーニョ",
+	},
 
 	retreat: 2,
 	regulationMark: "I",
-	rarity: "Double rare"
-}
+	rarity: "Double rare",
+	dexId: [930],
 
-export default card
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV10/013.ts
+++ b/data-asia/SV/SV10/013.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ガーディ",
 		'zh-tw': "卡蒂狗",
 		'zh-cn': "卡蒂狗",
-		ja: "ガーディ"
 	},
 
 	illustrator: "ryoma uratsuka",
@@ -16,42 +15,51 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
+		ja: "自分より 強くて 大きな 相手にも 恐れずに 立ち向かう 勇敢で 頼もしい 性格。",
 		'zh-tw': "能毫不畏懼地去對抗 比自己更強更大的對手。 性格非常勇敢可靠。",
 		'zh-cn': "能毫不畏懼地去對抗 比自己更強更大的對手。 性格非常勇敢可靠。",
-		ja: "自分より 強くて 大きな 相手にも 恐れずに 立ち向かう 勇敢で 頼もしい 性格。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "火種",
-			'zh-cn': "火種",
-			ja: "ひだね"
+	attacks: [
+		{
+			name: {
+				ja: "ひだね",
+				'zh-tw': "火種",
+				'zh-cn': "火種",
+			},
+			damage: 10,
+			cost: ["Fire"],
 		},
-
-		damage: 10,
-		cost: ["Fire"]
-	}, {
-		name: {
-			'zh-tw': "豎爪",
-			'zh-cn': "豎爪",
-			ja: "ツメをたてる"
+		{
+			name: {
+				ja: "ツメをたてる",
+				'zh-tw': "豎爪",
+				'zh-cn': "豎爪",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821844,
+				tcgplayer: 628654,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [58]
-}
+	dexId: [58],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/014.ts
+++ b/data-asia/SV/SV10/014.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ウインディ",
 		'zh-tw': "風速狗",
 		'zh-cn': "風速狗",
-		ja: "ウインディ"
 	},
 
 	illustrator: "Nisota Niso",
@@ -16,48 +15,60 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
+		ja: "草原を 駆け抜ける 様子は 人々の 心を 虜にしたと 昔の 絵巻に 記されていた。",
 		'zh-tw': "根據過去的畫軸記載， 牠在草原上奔馳的姿態 擄獲了眾多人心。",
 		'zh-cn': "根據過去的畫軸記載， 牠在草原上奔馳的姿態 擄獲了眾多人心。",
-		ja: "草原を 駆け抜ける 様子は 人々の 心を 虜にしたと 昔の 絵巻に 記されていた。"
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "火焰",
-			'zh-cn': "火焰",
-			ja: "ほのお"
+	attacks: [
+		{
+			name: {
+				ja: "ほのお",
+				'zh-tw': "火焰",
+				'zh-cn': "火焰",
+			},
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
 		},
-
-		damage: 50,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "懲治獠牙",
-			'zh-cn': "懲治獠牙",
-			ja: "こらしめファング"
+		{
+			name: {
+				ja: "こらしめファング",
+				'zh-tw': "懲治獠牙",
+				'zh-cn': "懲治獠牙",
+			},
+			damage: "100+",
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが[D]ポケモンなら、100ダメージ追加。",
+				'zh-tw': "若對手的戰鬥寶可夢為【惡】寶可夢，則增加100點傷害。",
+				'zh-cn': "若對手的戰鬥寶可夢為【惡】寶可夢，則增加100點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若對手的戰鬥寶可夢為【惡】寶可夢，則增加100點傷害。",
-			'zh-cn': "若對手的戰鬥寶可夢為【惡】寶可夢，則增加100點傷害。",
-			ja: "相手のバトルポケモンがポケモンなら、100ダメージ追加。"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821845,
+				tcgplayer: 628655,
+			},
 		},
+	],
 
-		damage: "100＋",
-		cost: ["Fire", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ガーディ",
+	},
 
 	retreat: 3,
 	regulationMark: "I",
 	rarity: "Uncommon",
-	dexId: [59]
-}
+	dexId: [59],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/015.ts
+++ b/data-asia/SV/SV10/015.ts
@@ -1,66 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のファイヤーex",
 		'zh-tw': "<火箭隊的>火焰鳥ex",
 		'zh-cn': "<火箭隊的>火焰鳥ex",
-		ja: "ロケット団のファイヤーex"
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Fire"],
+
 	stage: "Basic",
-	suffix: "EX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "火焰屏障",
-			'zh-cn': "火焰屏障",
-			ja: "フレイムバリア"
+	attacks: [
+		{
+			name: {
+				ja: "フレイムバリア",
+				'zh-tw': "火焰屏障",
+				'zh-cn': "火焰屏障",
+			},
+			damage: 110,
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-50」される。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-50」點。",
+				'zh-cn': "在下個對手的回合，這隻寶可夢受到招式的傷害「-50」點。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-50」點。",
-			'zh-cn': "在下個對手的回合，這隻寶可夢受到招式的傷害「-50」點。",
-			ja: "次の相手の番、このポケモンが受けるワザのダメージは「-50」される。"
+		{
+			name: {
+				ja: "イビルバーン",
+				'zh-tw': "邪惡灼燒",
+				'zh-cn': "邪惡灼燒",
+			},
+			cost: ["Fire", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている「ロケット団エネルギー」を1枚選び、トラッシュする。その場合、相手のバトルポケモンと、ついているすべてのカードを、トラッシュする。",
+				'zh-tw': "選擇1張這隻寶可夢身上附加的「火箭隊能量」，將其丟棄。這個情況下，將對手的戰鬥寶可夢與附加的卡全部丟棄。",
+				'zh-cn': "選擇1張這隻寶可夢身上附加的「火箭隊能量」，將其丟棄。這個情況下，將對手的戰鬥寶可夢與附加的卡全部丟棄。",
+			},
 		},
+	],
 
-		damage: 110,
-		cost: ["Fire", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "邪惡灼燒",
-			'zh-cn': "邪惡灼燒",
-			ja: "イビルバーン"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821846,
+				tcgplayer: 628656,
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇1張這隻寶可夢身上附加的「火箭隊能量」，將其丟棄。這個情況下，將對手的戰鬥寶可夢與附加的卡全部丟棄。",
-			'zh-cn': "選擇1張這隻寶可夢身上附加的「火箭隊能量」，將其丟棄。這個情況下，將對手的戰鬥寶可夢與附加的卡全部丟棄。",
-			ja: "このポケモンについている「ロケット団エネルギー」を1枚選び、トラッシュする。その場合、相手のバトルポケモンと、ついているすべてのカードを、トラッシュする。"
-		},
-
-		cost: ["Fire", "Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "－30"
-	}],
+	],
 
 	retreat: 2,
 	regulationMark: "I",
-	rarity: "Double rare"
-}
+	rarity: "Double rare",
+	dexId: [146],
 
-export default card
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV10/016.ts
+++ b/data-asia/SV/SV10/016.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のデルビル",
 		'zh-tw': "<火箭隊的>戴魯比",
 		'zh-cn': "<火箭隊的>戴魯比",
-		ja: "ロケット団のデルビル"
 	},
 
 	illustrator: "Krgc",
@@ -16,33 +15,42 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
+		ja: "様々な 鳴き声を 使い分け 仲間と コミュニケーションしながら 狩りを おこなう 賢さを持つ。",
 		'zh-tw': "擁有在狩獵的時候 能使用各式各樣的叫聲 來與夥伴溝通的智慧。",
 		'zh-cn': "擁有在狩獵的時候 能使用各式各樣的叫聲 來與夥伴溝通的智慧。",
-		ja: "様々な 鳴き声を 使い分け 仲間と コミュニケーションしながら 狩りを おこなう 賢さを持つ。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "吐火",
-			'zh-cn': "吐火",
-			ja: "ひをはく"
+	attacks: [
+		{
+			name: {
+				ja: "ひをはく",
+				'zh-tw': "吐火",
+				'zh-cn': "吐火",
+			},
+			damage: 20,
+			cost: ["Fire"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Fire"]
-	}],
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821847,
+				tcgplayer: 628657,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [228]
-}
+	dexId: [228],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/017.ts
+++ b/data-asia/SV/SV10/017.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のヘルガー",
 		'zh-tw': "<火箭隊的>黑魯加",
 		'zh-cn': "<火箭隊的>黑魯加",
-		ja: "ロケット団のヘルガー"
 	},
 
 	illustrator: "Anesaki Dynamic",
@@ -16,53 +15,64 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
+		ja: "口から 吹き出す 炎で 火傷すると いつまでたっても 傷口が うずいてしまう。",
 		'zh-tw': "要是被牠口中噴出的火焰灼傷， 傷口的部分不管過了多久 都依舊會感到疼痛。",
 		'zh-cn': "要是被牠口中噴出的火焰灼傷， 傷口的部分不管過了多久 都依舊會感到疼痛。",
-		ja: "口から 吹き出す 炎で 火傷すると いつまでたっても 傷口が うずいてしまう。"
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "惡之火種",
-			'zh-cn': "惡之火種",
-			ja: "あくのひだね"
+	attacks: [
+		{
+			name: {
+				ja: "あくのひだね",
+				'zh-tw': "惡之火種",
+				'zh-cn': "惡之火種",
+			},
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどとこんらんにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【灼傷】與【混亂】。",
+				'zh-cn': "將對手的戰鬥寶可夢【灼傷】與【混亂】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【灼傷】與【混亂】。",
-			'zh-cn': "將對手的戰鬥寶可夢【灼傷】與【混亂】。",
-			ja: "相手のバトルポケモンをやけどとこんらんにする。"
+		{
+			name: {
+				ja: "バーンアウト",
+				'zh-tw': "燃燒殆盡",
+				'zh-cn': "燃燒殆盡",
+			},
+			damage: 120,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。",
+				'zh-cn': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		cost: ["Fire"]
-	}, {
-		name: {
-			'zh-tw': "燃燒殆盡",
-			'zh-cn': "燃燒殆盡",
-			ja: "バーンアウト"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821848,
+				tcgplayer: 628658,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。",
-			'zh-cn': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。",
-			ja: "このポケモンについているエネルギーを1個選び、トラッシュする。"
-		},
-
-		damage: 120,
-		cost: ["Fire", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ロケット団のデルビル",
+	},
 
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Uncommon",
-	dexId: [229]
-}
+	dexId: [229],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/018.ts
+++ b/data-asia/SV/SV10/018.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "アチャモ",
 		'zh-tw': "火稚雞",
 		'zh-cn': "火稚雞",
-		ja: "アチャモ"
 	},
 
 	illustrator: "Tika Matsuno",
@@ -16,47 +15,55 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
+		ja: "お腹に 炎袋を 持つ。 抱きしめると ぽかぽか 温かい。 命ある 限り 燃え続ける。",
 		'zh-tw': "肚子裡有火袋。 抱在懷裡暖烘烘的很溫暖。 只要生命尚存火焰就會持續燃燒。",
 		'zh-cn': "肚子裡有火袋。 抱在懷裡暖烘烘的很溫暖。 只要生命尚存火焰就會持續燃燒。",
-		ja: "お腹に 炎袋を 持つ。 抱きしめると ぽかぽか 温かい。 命ある 限り 燃え続ける。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "呼喚",
-			'zh-cn': "呼喚",
-			ja: "もってくる"
+	attacks: [
+		{
+			name: {
+				ja: "もってくる",
+				'zh-tw': "呼喚",
+				'zh-cn': "呼喚",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+				'zh-tw': "從自己的牌庫抽出1張卡。",
+				'zh-cn': "從自己的牌庫抽出1張卡。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫抽出1張卡。",
-			'zh-cn': "從自己的牌庫抽出1張卡。",
-			ja: "自分の山札を1枚引く。"
+		{
+			name: {
+				ja: "かえん",
+				'zh-tw': "烈焰",
+				'zh-cn': "烈焰",
+			},
+			damage: 10,
+			cost: ["Fire"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "烈焰",
-			'zh-cn': "烈焰",
-			ja: "かえん"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821849,
+				tcgplayer: 628659,
+			},
 		},
-
-		damage: 10,
-		cost: ["Fire"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [255]
-}
+	dexId: [255],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/019.ts
+++ b/data-asia/SV/SV10/019.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ワカシャモ",
 		'zh-tw': "力壯雞",
 		'zh-cn': "力壯雞",
-		ja: "ワカシャモ"
 	},
 
 	illustrator: "yuu",
@@ -16,48 +15,60 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
+		ja: "鋭い 鳴き声を あげて 集中力を 高める。 足技は 破壊力 抜群。",
 		'zh-tw': "會發出尖銳的叫聲 來提高集中力。 腿技極具破壞力。",
 		'zh-cn': "會發出尖銳的叫聲 來提高集中力。 腿技極具破壞力。",
-		ja: "鋭い 鳴き声を あげて 集中力を 高める。 足技は 破壊力 抜群。"
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "烈焰",
-			'zh-cn': "烈焰",
-			ja: "かえん"
+	attacks: [
+		{
+			name: {
+				ja: "かえん",
+				'zh-tw': "烈焰",
+				'zh-cn': "烈焰",
+			},
+			damage: 20,
+			cost: ["Colorless"],
 		},
-
-		damage: 20,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "二連踢",
-			'zh-cn': "二連踢",
-			ja: "にどげり"
+		{
+			name: {
+				ja: "にどげり",
+				'zh-tw': "二連踢",
+				'zh-cn': "二連踢",
+			},
+			damage: "40×",
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×40ダメージ。",
+				'zh-tw': "擲2次硬幣，造成正面出現的次數×40點傷害。",
+				'zh-cn': "擲2次硬幣，造成正面出現的次數×40點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲2次硬幣，造成正面出現的次數×40點傷害。",
-			'zh-cn': "擲2次硬幣，造成正面出現的次數×40點傷害。",
-			ja: "コインを2回投げ、オモテの数×40ダメージ。"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821850,
+				tcgplayer: 628660,
+			},
 		},
+	],
 
-		damage: "40×",
-		cost: ["Fire", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "アチャモ",
+	},
 
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [256]
-}
+	dexId: [256],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/020.ts
+++ b/data-asia/SV/SV10/020.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "バシャーモ",
 		'zh-tw': "火焰雞",
 		'zh-cn': "火焰雞",
-		ja: "バシャーモ"
 	},
 
 	illustrator: "Kazumasa Yasukuni",
@@ -16,48 +15,60 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
+		ja: "強敵に 出会うと 手首から 炎を 噴き出す。 ジャンプで ビルを 跳び越す 脚力。",
 		'zh-tw': "遇到強敵時會從手腕噴出火焰。 有著能夠躍過大樓的腳力。",
 		'zh-cn': "遇到強敵時會從手腕噴出火焰。 有著能夠躍過大樓的腳力。",
-		ja: "強敵に 出会うと 手首から 炎を 噴き出す。 ジャンプで ビルを 跳び越す 脚力。"
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "高溫爆破",
-			'zh-cn': "高溫爆破",
-			ja: "ヒートブラスト"
+	attacks: [
+		{
+			name: {
+				ja: "ヒートブラスト",
+				'zh-tw': "高溫爆破",
+				'zh-cn': "高溫爆破",
+			},
+			damage: 70,
+			cost: ["Colorless", "Colorless"],
 		},
-
-		damage: 70,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "業火連踢",
-			'zh-cn': "業火連踢",
-			ja: "ごうかれんきゃく"
+		{
+			name: {
+				ja: "ごうかれんきゃく",
+				'zh-tw': "業火連踢",
+				'zh-cn': "業火連踢",
+			},
+			damage: 120,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個トラッシュし、相手のベンチポケモン1匹にも、120ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "將2個這隻寶可夢身上附加的能量丟棄，對手的1隻備戰寶可夢也受到120點傷害。[在備戰區不計算弱點・抵抗力。]",
+				'zh-cn': "將2個這隻寶可夢身上附加的能量丟棄，對手的1隻備戰寶可夢也受到120點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將2個這隻寶可夢身上附加的能量丟棄，對手的1隻備戰寶可夢也受到120點傷害。[在備戰區不計算弱點・抵抗力。]",
-			'zh-cn': "將2個這隻寶可夢身上附加的能量丟棄，對手的1隻備戰寶可夢也受到120點傷害。[在備戰區不計算弱點・抵抗力。]",
-			ja: "このポケモンについているエネルギーを2個トラッシュし、相手のベンチポケモン1匹にも、120ダメージ。［ベンチは弱点・抵抗力を計算しない。］"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821851,
+				tcgplayer: 628661,
+			},
 		},
+	],
 
-		damage: 120,
-		cost: ["Fire", "Fire", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ワカシャモ",
+	},
 
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Rare",
-	dexId: [257]
-}
+	dexId: [257],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/021.ts
+++ b/data-asia/SV/SV10/021.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ヒートロトム",
 		'zh-tw': "加熱洛托姆",
 		'zh-cn': "加熱洛托姆",
-		ja: "ヒートロトム"
 	},
 
 	illustrator: "Dsuke",
@@ -16,53 +15,60 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
+		ja: "オーブンレンジ 自体の 調子が 悪いと 中に 入っている ロトムも 元気が なくなるのだ。",
 		'zh-tw': "如果烤箱微波爐本身運轉不良， 鑽進裡面的洛托姆 也會變得無精打采。",
 		'zh-cn': "如果烤箱微波爐本身運轉不良， 鑽進裡面的洛托姆 也會變得無精打采。",
-		ja: "オーブンレンジ 自体の 調子が 悪いと 中に 入っている ロトムも 元気が なくなるのだ。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "灼熱",
-			'zh-cn': "灼熱",
-			ja: "こがす"
+	attacks: [
+		{
+			name: {
+				ja: "こがす",
+				'zh-tw': "灼熱",
+				'zh-cn': "灼熱",
+			},
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【灼傷】。",
+				'zh-cn': "將對手的戰鬥寶可夢【灼傷】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【灼傷】。",
-			'zh-cn': "將對手的戰鬥寶可夢【灼傷】。",
-			ja: "相手のバトルポケモンをやけどにする。"
+		{
+			name: {
+				ja: "ガジェットショー",
+				'zh-tw': "配件秀",
+				'zh-cn': "配件秀",
+			},
+			damage: "30×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のポケモン全員についている「ポケモンのどうぐ」の数×30ダメージ。",
+				'zh-tw': "造成自己的所有寶可夢身上附加的「寶可夢道具」卡的數量×30點傷害。",
+				'zh-cn': "造成自己的所有寶可夢身上附加的「寶可夢道具」卡的數量×30點傷害。",
+			},
 		},
+	],
 
-		cost: ["Fire"]
-	}, {
-		name: {
-			'zh-tw': "配件秀",
-			'zh-cn': "配件秀",
-			ja: "ガジェットショー"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821852,
+				tcgplayer: 628662,
+			},
 		},
-
-		effect: {
-			'zh-tw': "造成自己的所有寶可夢身上附加的「寶可夢道具」卡的數量×30點傷害。",
-			'zh-cn': "造成自己的所有寶可夢身上附加的「寶可夢道具」卡的數量×30點傷害。",
-			ja: "自分のポケモン全員についている「ポケモンのどうぐ」の数×30ダメージ。"
-		},
-
-		damage: "30×",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [479]
-}
+	dexId: [479],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/022.ts
+++ b/data-asia/SV/SV10/022.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のフリーザー",
 		'zh-tw': "<火箭隊的>急凍鳥",
 		'zh-cn': "<火箭隊的>急凍鳥",
-		ja: "ロケット団のフリーザー"
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -16,60 +15,63 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
+		ja: "氷を 自在に 操る 力を もつ。 永久凍土の 雪山に 棲んでいるという。",
 		'zh-tw': "擁有能自在操縱冰的 能力。據說是棲息在 永凍之地的雪山中。",
 		'zh-cn': "擁有能自在操縱冰的 能力。據說是棲息在 永凍之地的雪山中。",
-		ja: "氷を 自在に 操る 力を もつ。 永久凍土の 雪山に 棲んでいるという。"
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "抵抗之幕",
-			'zh-cn': "抵抗之幕",
-			ja: "レジストヴェール"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "レジストヴェール",
+				'zh-tw': "抵抗之幕",
+				'zh-cn': "抵抗之幕",
+			},
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の場のたねポケモンの「ロケット団のポケモン」全員は、相手のポケモンが使うワザの効果を受けない。（すでに受けている効果は、なくならない。）",
+				'zh-tw': "只要這隻寶可夢在場上，自己的場上所有【基礎】寶可夢的「火箭隊的寶可夢」，不會受到對手的寶可夢使用招式的效果的影響。（已經受到的效果不會消除。）",
+				'zh-cn': "只要這隻寶可夢在場上，自己的場上所有【基礎】寶可夢的「火箭隊的寶可夢」，不會受到對手的寶可夢使用招式的效果的影響。（已經受到的效果不會消除。）",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在場上，自己的場上所有【基礎】寶可夢的「火箭隊的寶可夢」，不會受到對手的寶可夢使用招式的效果的影響。（已經受到的效果不會消除。）",
-			'zh-cn': "只要這隻寶可夢在場上，自己的場上所有【基礎】寶可夢的「火箭隊的寶可夢」，不會受到對手的寶可夢使用招式的效果的影響。（已經受到的效果不會消除。）",
-			ja: "このポケモンがいるかぎり、自分の場のたねポケモンの「ロケット団のポケモン」全員は、相手のポケモンが使うワザの効果を受けない。（すでに受けている効果は、なくならない。）"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "暗黑冰霜",
-			'zh-cn': "暗黑冰霜",
-			ja: "ダークフロスト"
+	attacks: [
+		{
+			name: {
+				ja: "ダークフロスト",
+				'zh-tw': "暗黑冰霜",
+				'zh-cn': "暗黑冰霜",
+			},
+			damage: "60+",
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンに「ロケット団エネルギー」がついているなら、60ダメージ追加。",
+				'zh-tw': "若這隻寶可夢身上附有「火箭隊能量」，則增加60點傷害。",
+				'zh-cn': "若這隻寶可夢身上附有「火箭隊能量」，則增加60點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢身上附有「火箭隊能量」，則增加60點傷害。",
-			'zh-cn': "若這隻寶可夢身上附有「火箭隊能量」，則增加60點傷害。",
-			ja: "このポケモンに「ロケット団エネルギー」がついているなら、60ダメージ追加。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821853,
+				tcgplayer: 628663,
+			},
 		},
-
-		damage: "60＋",
-		cost: ["Water", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "－30"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Rare",
-	dexId: [144]
-}
+	dexId: [144],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/023.ts
+++ b/data-asia/SV/SV10/023.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "パールル",
 		'zh-tw': "珍珠貝",
 		'zh-cn': "珍珠貝",
-		ja: "パールル"
 	},
 
 	illustrator: "Miki Tanaka",
@@ -16,39 +15,47 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
+		ja: "パールルの 真珠は とても 貴重。 シェルダーの 真珠の １０倍以上 価値が あるとも。",
 		'zh-tw': "珍珠貝的珍珠非常貴重， 據說價值是大舌貝 所產珍珠的１０倍以上。",
 		'zh-cn': "珍珠貝的珍珠非常貴重， 據說價值是大舌貝 所產珍珠的１０倍以上。",
-		ja: "パールルの 真珠は とても 貴重。 シェルダーの 真珠の １０倍以上 価値が あるとも。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "硬殼壓制",
-			'zh-cn': "硬殼壓制",
-			ja: "シェルプレス"
+	attacks: [
+		{
+			name: {
+				ja: "シェルプレス",
+				'zh-tw': "硬殼壓制",
+				'zh-cn': "硬殼壓制",
+			},
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-10」される。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-10」點。",
+				'zh-cn': "在下個對手的回合，這隻寶可夢受到招式的傷害「-10」點。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-10」點。",
-			'zh-cn': "在下個對手的回合，這隻寶可夢受到招式的傷害「-10」點。",
-			ja: "次の相手の番、このポケモンが受けるワザのダメージは「-10」される。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821854,
+				tcgplayer: 628664,
+			},
 		},
-
-		damage: 10,
-		cost: ["Water"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [366]
-}
+	dexId: [366],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/024.ts
+++ b/data-asia/SV/SV10/024.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ハンテール",
 		'zh-tw': "獵斑魚",
 		'zh-cn': "獵斑魚",
-		ja: "ハンテール"
 	},
 
 	illustrator: "Scav",
@@ -16,49 +15,62 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
+		ja: "深海に 生息。 ハンテールが 浜に 打ちあがると 不吉なことが 起こるという 言い伝えが ある。",
 		'zh-tw': "棲息在深海中。傳說如果 有獵斑魚被沖上沙灘， 就會有不好的事發生。",
 		'zh-cn': "棲息在深海中。傳說如果 有獵斑魚被沖上沙灘， 就會有不好的事發生。",
-		ja: "深海に 生息。 ハンテールが 浜に 打ちあがると 不吉なことが 起こるという 言い伝えが ある。"
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "潛者捕捉",
-			'zh-cn': "潛者捕捉",
-			ja: "ダイバーキャッチ"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ダイバーキャッチ",
+				'zh-tw': "潛者捕捉",
+				'zh-cn': "潛者捕捉",
+			},
+			effect: {
+				ja: "自分の[W]ポケモンが、相手のポケモンからワザのダメージを受けてきぜつするたび、1回使える。きぜつしたポケモンについている「基本[W]エネルギー」はトラッシュせず、すべて手札にもどす。",
+				'zh-tw': "每次當自己的【水】寶可夢受到對手的寶可夢招式的傷害而【昏厥】時，可使用1次。【昏厥】的寶可夢身上附加的「基本【水】能量」卡不丟棄，而是全部放回手牌。",
+				'zh-cn': "每次當自己的【水】寶可夢受到對手的寶可夢招式的傷害而【昏厥】時，可使用1次。【昏厥】的寶可夢身上附加的「基本【水】能量」卡不丟棄，而是全部放回手牌。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "每次當自己的【水】寶可夢受到對手的寶可夢招式的傷害而【昏厥】時，可使用1次。【昏厥】的寶可夢身上附加的「基本【水】能量」卡不丟棄，而是全部放回手牌。",
-			'zh-cn': "每次當自己的【水】寶可夢受到對手的寶可夢招式的傷害而【昏厥】時，可使用1次。【昏厥】的寶可夢身上附加的「基本【水】能量」卡不丟棄，而是全部放回手牌。",
-			ja: "自分のポケモンが、相手のポケモンからワザのダメージを受けてきぜつするたび、1回使える。きぜつしたポケモンについている「基本エネルギー」はトラッシュせず、すべて手札にもどす。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "飛濺",
-			'zh-cn': "飛濺",
-			ja: "スプラッシュ"
+	attacks: [
+		{
+			name: {
+				ja: "スプラッシュ",
+				'zh-tw': "飛濺",
+				'zh-cn': "飛濺",
+			},
+			damage: 80,
+			cost: ["Water", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 80,
-		cost: ["Water", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821856,
+				tcgplayer: 628665,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "パールル",
+	},
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Uncommon",
-	dexId: [367]
-}
+	dexId: [367],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/025.ts
+++ b/data-asia/SV/SV10/025.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "サクラビス",
 		'zh-tw': "櫻花魚",
 		'zh-cn': "櫻花魚",
-		ja: "サクラビス"
 	},
 
 	illustrator: "Naoyo Kimura",
@@ -16,39 +15,51 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
+		ja: "獲物の 体液を 吸う。 肉は 海底に 沈み 他の ポケモンの エサに なるのだ。",
 		'zh-tw': "會吸取獵物的體液。 剩下的肉會沉入海底， 成為其他寶可夢的食物。",
 		'zh-cn': "會吸取獵物的體液。 剩下的肉會沉入海底， 成為其他寶可夢的食物。",
-		ja: "獲物の 体液を 吸う。 肉は 海底に 沈み 他の ポケモンの エサに なるのだ。"
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "漸強波",
-			'zh-cn': "漸強波",
-			ja: "クレシェンドウェーブ"
+	attacks: [
+		{
+			name: {
+				ja: "クレシェンドウェーブ",
+				'zh-tw': "漸強波",
+				'zh-cn': "漸強波",
+			},
+			damage: "30×",
+			cost: ["Water"],
+			effect: {
+				ja: "このポケモンについている[W]エネルギーの数×30ダメージ。のぞむなら、ダメージを与える前に、自分の手札から「基本[W]エネルギー」を好きなだけ選び、このポケモンにつける。",
+				'zh-tw': "造成這隻寶可夢身上附加的【水】能量的數量×30點傷害。若希望，在造成傷害前，從自己的手牌選擇任意數量的「基本【水】能量」卡，附於這隻寶可夢身上。",
+				'zh-cn': "造成這隻寶可夢身上附加的【水】能量的數量×30點傷害。若希望，在造成傷害前，從自己的手牌選擇任意數量的「基本【水】能量」卡，附於這隻寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "造成這隻寶可夢身上附加的【水】能量的數量×30點傷害。若希望，在造成傷害前，從自己的手牌選擇任意數量的「基本【水】能量」卡，附於這隻寶可夢身上。",
-			'zh-cn': "造成這隻寶可夢身上附加的【水】能量的數量×30點傷害。若希望，在造成傷害前，從自己的手牌選擇任意數量的「基本【水】能量」卡，附於這隻寶可夢身上。",
-			ja: "このポケモンについているエネルギーの数×30ダメージ。のぞむなら、ダメージを与える前に、自分の手札から「基本エネルギー」を好きなだけ選び、このポケモンにつける。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821857,
+				tcgplayer: 628666,
+			},
 		},
+	],
 
-		damage: "30×",
-		cost: ["Water"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "パールル",
+	},
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Rare",
-	dexId: [368]
-}
+	dexId: [368],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/026.ts
+++ b/data-asia/SV/SV10/026.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ユキカブリ",
 		'zh-tw': "雪笠怪",
 		'zh-cn': "雪笠怪",
-		ja: "ユキカブリ"
 	},
 
 	illustrator: "Tomokazu Komiya",
@@ -16,42 +15,51 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
+		ja: "寒い 季節は 山の ふもとまで 降りてくるが 春に なると 雪が 残る 山頂に 戻っていく。",
 		'zh-tw': "在寒冷的季節裡會 移動到山腳下，一到春天就會 返回積雪尚存的山頂。",
 		'zh-cn': "在寒冷的季節裡會 移動到山腳下，一到春天就會 返回積雪尚存的山頂。",
-		ja: "寒い 季節は 山の ふもとまで 降りてくるが 春に なると 雪が 残る 山頂に 戻っていく。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "打擊",
-			'zh-cn': "打擊",
-			ja: "なぐる"
+	attacks: [
+		{
+			name: {
+				ja: "なぐる",
+				'zh-tw': "打擊",
+				'zh-cn': "打擊",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
-
-		damage: 20,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "冰柱",
-			'zh-cn': "冰柱",
-			ja: "つらら"
+		{
+			name: {
+				ja: "つらら",
+				'zh-tw': "冰柱",
+				'zh-cn': "冰柱",
+			},
+			damage: 50,
+			cost: ["Water", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 50,
-		cost: ["Water", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821858,
+				tcgplayer: 628667,
+			},
+		},
+	],
 
 	retreat: 3,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [459]
-}
+	dexId: [459],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/027.ts
+++ b/data-asia/SV/SV10/027.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ユキノオー",
 		'zh-tw': "暴雪王",
 		'zh-cn': "暴雪王",
-		ja: "ユキノオー"
 	},
 
 	illustrator: "kamonabe",
@@ -16,48 +15,60 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
+		ja: "万年雪が 積もる 山脈で 静かに 暮らす。 ブリザードを 発生させて 姿を 隠す。",
 		'zh-tw': "在萬年積雪的山脈 靜靜生活。會引發 暴風雪來隱藏自己。",
 		'zh-cn': "在萬年積雪的山脈 靜靜生活。會引發 暴風雪來隱藏自己。",
-		ja: "万年雪が 積もる 山脈で 静かに 暮らす。 ブリザードを 発生させて 姿を 隠す。"
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "撞倒",
-			'zh-cn': "撞倒",
-			ja: "つきたおし"
+	attacks: [
+		{
+			name: {
+				ja: "つきたおし",
+				'zh-tw': "撞倒",
+				'zh-cn': "撞倒",
+			},
+			damage: 90,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
-
-		damage: 90,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "結冰木",
-			'zh-cn': "結冰木",
-			ja: "ひょうけつウッド"
+		{
+			name: {
+				ja: "ひょうけつウッド",
+				'zh-tw': "結冰木",
+				'zh-cn': "結冰木",
+			},
+			damage: "120+",
+			cost: ["Water", "Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンに[G]エネルギーが2個以上ついているなら、120ダメージ追加。",
+				'zh-tw': "若這隻寶可夢身上附有2個以上【草】能量，則增加120點傷害。",
+				'zh-cn': "若這隻寶可夢身上附有2個以上【草】能量，則增加120點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢身上附有2個以上【草】能量，則增加120點傷害。",
-			'zh-cn': "若這隻寶可夢身上附有2個以上【草】能量，則增加120點傷害。",
-			ja: "このポケモンにエネルギーが2個以上ついているなら、120ダメージ追加。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821859,
+				tcgplayer: 628668,
+			},
 		},
+	],
 
-		damage: "120＋",
-		cost: ["Water", "Water", "Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ユキカブリ",
+	},
 
 	retreat: 4,
 	regulationMark: "I",
 	rarity: "Uncommon",
-	dexId: [460]
-}
+	dexId: [460],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/028.ts
+++ b/data-asia/SV/SV10/028.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ウォッシュロトム",
 		'zh-tw': "清洗洛托姆",
 		'zh-cn': "清洗洛托姆",
-		ja: "ウォッシュロトム"
 	},
 
 	illustrator: "miki kudo",
@@ -16,54 +15,61 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
+		ja: "洗濯機に 入った 姿。 あたりを 水浸しにしては 満足そうに うなずいている。",
 		'zh-tw': "鑽進了洗衣機裡的樣子。 會讓周圍都淹沒在水裡， 然後一副滿足地點著頭。",
 		'zh-cn': "鑽進了洗衣機裡的樣子。 會讓周圍都淹沒在水裡， 然後一副滿足地點著頭。",
-		ja: "洗濯機に 入った 姿。 あたりを 水浸しにしては 満足そうに うなずいている。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "搓洗",
-			'zh-cn': "搓洗",
-			ja: "もみあらう"
+	attacks: [
+		{
+			name: {
+				ja: "もみあらう",
+				'zh-tw': "搓洗",
+				'zh-cn': "搓洗",
+			},
+			damage: 20,
+			cost: ["Water"],
+			effect: {
+				ja: "自分のポケモン全員のHPを、それぞれ「10」回復する。",
+				'zh-tw': "將自己的所有寶可夢各恢復「10」HP。",
+				'zh-cn': "將自己的所有寶可夢各恢復「10」HP。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將自己的所有寶可夢各恢復「10」HP。",
-			'zh-cn': "將自己的所有寶可夢各恢復「10」HP。",
-			ja: "自分のポケモン全員のHPを、それぞれ「10」回復する。"
+		{
+			name: {
+				ja: "ガジェットショー",
+				'zh-tw': "配件秀",
+				'zh-cn': "配件秀",
+			},
+			damage: "30×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のポケモン全員についている「ポケモンのどうぐ」の数×30ダメージ。",
+				'zh-tw': "造成自己的所有寶可夢身上附加的「寶可夢道具」卡的數量×30點傷害。",
+				'zh-cn': "造成自己的所有寶可夢身上附加的「寶可夢道具」卡的數量×30點傷害。",
+			},
 		},
+	],
 
-		damage: 20,
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "配件秀",
-			'zh-cn': "配件秀",
-			ja: "ガジェットショー"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821860,
+				tcgplayer: 628669,
+			},
 		},
-
-		effect: {
-			'zh-tw': "造成自己的所有寶可夢身上附加的「寶可夢道具」卡的數量×30點傷害。",
-			'zh-cn': "造成自己的所有寶可夢身上附加的「寶可夢道具」卡的數量×30點傷害。",
-			ja: "自分のポケモン全員についている「ポケモンのどうぐ」の数×30ダメージ。"
-		},
-
-		damage: "30×",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [479]
-}
+	dexId: [479],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/029.ts
+++ b/data-asia/SV/SV10/029.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "サシカマス",
 		'zh-tw': "刺梭魚",
 		'zh-cn': "刺梭魚",
-		ja: "サシカマス"
 	},
 
 	illustrator: "OKUBO",
@@ -16,39 +15,47 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
+		ja: "真っ直ぐにしか 速く 泳げない。 食べ過ぎて 動きが 鈍いものから カイデンの 群れに 狙われる。",
 		'zh-tw': "游泳只能游直線。因吃太飽 而行動變得遲緩的個體 會先遭到電海燕的群體襲擊。",
 		'zh-cn': "游泳只能游直線。因吃太飽 而行動變得遲緩的個體 會先遭到電海燕的群體襲擊。",
-		ja: "真っ直ぐにしか 速く 泳げない。 食べ過ぎて 動きが 鈍いものから カイデンの 群れに 狙われる。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "突擊",
-			'zh-cn': "突擊",
-			ja: "とつげき"
+	attacks: [
+		{
+			name: {
+				ja: "とつげき",
+				'zh-tw': "突擊",
+				'zh-cn': "突擊",
+			},
+			damage: 30,
+			cost: ["Water"],
+			effect: {
+				ja: "このポケモンにも10ダメージ。",
+				'zh-tw': "這隻寶可夢也受到10點傷害。",
+				'zh-cn': "這隻寶可夢也受到10點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢也受到10點傷害。",
-			'zh-cn': "這隻寶可夢也受到10點傷害。",
-			ja: "このポケモンにも10ダメージ。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821861,
+				tcgplayer: 628670,
+			},
 		},
-
-		damage: 30,
-		cost: ["Water"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [846]
-}
+	dexId: [846],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/030.ts
+++ b/data-asia/SV/SV10/030.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "カマスジョー",
 		'zh-tw': "戽斗尖梭",
 		'zh-cn': "戽斗尖梭",
-		ja: "カマスジョー"
 	},
 
 	illustrator: "Kyoko Umemoto",
@@ -16,48 +15,60 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
+		ja: "尾びれを 回転させ 勢いよく 跳びあがり 水面 近くを 飛ぶ キャモメに 激しく 食らいつく。",
 		'zh-tw': "會旋轉尾鰭猛然跳起， 然後以強勁的力道咬住 飛在水面附近的長翅鷗。",
 		'zh-cn': "會旋轉尾鰭猛然跳起， 然後以強勁的力道咬住 飛在水面附近的長翅鷗。",
-		ja: "尾びれを 回転させ 勢いよく 跳びあがり 水面 近くを 飛ぶ キャモメに 激しく 食らいつく。"
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "銳利鰭",
-			'zh-cn': "銳利鰭",
-			ja: "するどいひれ"
+	attacks: [
+		{
+			name: {
+				ja: "するどいひれ",
+				'zh-tw': "銳利鰭",
+				'zh-cn': "銳利鰭",
+			},
+			damage: 40,
+			cost: ["Water"],
 		},
-
-		damage: 40,
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "潛水",
-			'zh-cn': "潛水",
-			ja: "ダイビング"
+		{
+			name: {
+				ja: "ダイビング",
+				'zh-tw': "潛水",
+				'zh-cn': "潛水",
+			},
+			damage: 60,
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+				'zh-tw': "擲1次硬幣若為正面，則在下個對手的回合，這隻寶可夢不會受到招式的傷害與效果的影響。",
+				'zh-cn': "擲1次硬幣若為正面，則在下個對手的回合，這隻寶可夢不會受到招式的傷害與效果的影響。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則在下個對手的回合，這隻寶可夢不會受到招式的傷害與效果的影響。",
-			'zh-cn': "擲1次硬幣若為正面，則在下個對手的回合，這隻寶可夢不會受到招式的傷害與效果的影響。",
-			ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821862,
+				tcgplayer: 628671,
+			},
 		},
+	],
 
-		damage: 60,
-		cost: ["Water", "Water"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "サシカマス",
+	},
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Uncommon",
-	dexId: [847]
-}
+	dexId: [847],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/031.ts
+++ b/data-asia/SV/SV10/031.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "アルクジラ",
 		'zh-tw': "走鯨",
 		'zh-cn': "走鯨",
-		ja: "アルクジラ"
 	},
 
 	illustrator: "sui",
@@ -16,42 +15,51 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
+		ja: "遥か 昔に 海から 上がって 陸地で 暮らすようになった。 ホエルコに 近い 種類らしい。",
 		'zh-tw': "遠古時代自大海上岸後， 就開始在陸地上生活。 似乎與吼吼鯨是相近的物種。",
 		'zh-cn': "遠古時代自大海上岸後， 就開始在陸地上生活。 似乎與吼吼鯨是相近的物種。",
-		ja: "遥か 昔に 海から 上がって 陸地で 暮らすようになった。 ホエルコに 近い 種類らしい。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "重摑",
-			'zh-cn': "重摑",
-			ja: "ひっぱたく"
+	attacks: [
+		{
+			name: {
+				ja: "ひっぱたく",
+				'zh-tw': "重摑",
+				'zh-cn': "重摑",
+			},
+			damage: 30,
+			cost: ["Water", "Colorless"],
 		},
-
-		damage: 30,
-		cost: ["Water", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "冰霜粉碎",
-			'zh-cn': "冰霜粉碎",
-			ja: "フロストスマッシュ"
+		{
+			name: {
+				ja: "フロストスマッシュ",
+				'zh-tw': "冰霜粉碎",
+				'zh-cn': "冰霜粉碎",
+			},
+			damage: 80,
+			cost: ["Water", "Water", "Water", "Colorless"],
 		},
+	],
 
-		damage: 80,
-		cost: ["Water", "Water", "Water", "Colorless"]
-	}],
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821863,
+				tcgplayer: 628672,
+			},
+		},
+	],
 
 	retreat: 3,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [974]
-}
+	dexId: [974],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/032.ts
+++ b/data-asia/SV/SV10/032.ts
@@ -1,63 +1,77 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ハルクジラex",
 		'zh-tw': "浩大鯨ex",
 		'zh-cn': "浩大鯨ex",
-		ja: "ハルクジラex"
 	},
 
 	illustrator: "kawayoo",
 	category: "Pokemon",
 	hp: 300,
 	types: ["Water"],
+
 	stage: "Stage1",
-	suffix: "EX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "融合為雪",
-			'zh-cn': "融合為雪",
-			ja: "ゆきにまぎれる"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ゆきにまぎれる",
+				'zh-tw': "融合為雪",
+				'zh-cn': "融合為雪",
+			},
+			effect: {
+				ja: "このポケモンは、相手が手札からグッズまたはサポートを出して使ったとき、その効果を受けない。",
+				'zh-tw': "對手從手牌使出物品卡或者支援者卡時，這隻寶可夢不會受到那個效果的影響。",
+				'zh-cn': "對手從手牌使出物品卡或者支援者卡時，這隻寶可夢不會受到那個效果的影響。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "對手從手牌使出物品卡或者支援者卡時，這隻寶可夢不會受到那個效果的影響。",
-			'zh-cn': "對手從手牌使出物品卡或者支援者卡時，這隻寶可夢不會受到那個效果的影響。",
-			ja: "このポケモンは、相手が手札からグッズまたはサポートを出して使ったとき、その効果を受けない。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "粉碎重壓",
-			'zh-cn': "粉碎重壓",
-			ja: "クラッシュプレス"
+	attacks: [
+		{
+			name: {
+				ja: "クラッシュプレス",
+				'zh-tw': "粉碎重壓",
+				'zh-cn': "粉碎重壓",
+			},
+			damage: "140+",
+			cost: ["Water", "Water", "Water", "Colorless"],
+			effect: {
+				ja: "のぞむなら、場に出ているスタジアムをトラッシュする。その場合、140ダメージ追加。",
+				'zh-tw': "若希望，將場上的競技場卡丟棄。這個情況下，增加140點傷害。",
+				'zh-cn': "若希望，將場上的競技場卡丟棄。這個情況下，增加140點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若希望，將場上的競技場卡丟棄。這個情況下，增加140點傷害。",
-			'zh-cn': "若希望，將場上的競技場卡丟棄。這個情況下，增加140點傷害。",
-			ja: "のぞむなら、場に出ているスタジアムをトラッシュする。その場合、140ダメージ追加。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821864,
+				tcgplayer: 628673,
+			},
 		},
+	],
 
-		damage: "140＋",
-		cost: ["Water", "Water", "Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "アルクジラ",
+	},
 
 	retreat: 4,
 	regulationMark: "I",
-	rarity: "Double rare"
-}
+	rarity: "Double rare",
+	dexId: [975],
 
-export default card
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV10/033.ts
+++ b/data-asia/SV/SV10/033.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のサンダー",
 		'zh-tw': "<火箭隊的>閃電鳥",
 		'zh-cn': "<火箭隊的>閃電鳥",
-		ja: "ロケット団のサンダー"
 	},
 
 	illustrator: "Nurikabe",
@@ -16,59 +15,61 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
+		ja: "羽根を こすり合わせると たちまち 雷が 落ちると 言われている 伝説の 鳥ポケモン。",
 		'zh-tw': "傳說的鳥寶可夢。 據說只要牠磨蹭翅膀， 立刻就會有雷電劈下。",
 		'zh-cn': "傳說的鳥寶可夢。 據說只要牠磨蹭翅膀， 立刻就會有雷電劈下。",
-		ja: "羽根を こすり合わせると たちまち 雷が 落ちると 言われている 伝説の 鳥ポケモン。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "阻礙之翼",
-			'zh-cn': "阻礙之翼",
-			ja: "ジャミングウイング"
+	attacks: [
+		{
+			name: {
+				ja: "ジャミングウイング",
+				'zh-tw': "阻礙之翼",
+				'zh-cn': "阻礙之翼",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、相手のバトルポケモンについているエネルギーを1個選び、相手のベンチポケモンにつけ替える。",
+				'zh-tw': "若希望，選擇1個對手的戰鬥寶可夢身上附加的能量，改附於對手的備戰寶可夢身上。",
+				'zh-cn': "若希望，選擇1個對手的戰鬥寶可夢身上附加的能量，改附於對手的備戰寶可夢身上。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "若希望，選擇1個對手的戰鬥寶可夢身上附加的能量，改附於對手的備戰寶可夢身上。",
-			'zh-cn': "若希望，選擇1個對手的戰鬥寶可夢身上附加的能量，改附於對手的備戰寶可夢身上。",
-			ja: "のぞむなら、相手のバトルポケモンについているエネルギーを1個選び、相手のベンチポケモンにつけ替える。"
+		{
+			name: {
+				ja: "バッドサンダー",
+				'zh-tw': "惡棍閃電",
+				'zh-cn': "惡棍閃電",
+			},
+			damage: "60+",
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンに「ロケット団エネルギー」がついているなら、60ダメージ追加。",
+				'zh-tw': "若這隻寶可夢身上附有「火箭隊能量」，則增加60點傷害。",
+				'zh-cn': "若這隻寶可夢身上附有「火箭隊能量」，則增加60點傷害。",
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "惡棍閃電",
-			'zh-cn': "惡棍閃電",
-			ja: "バッドサンダー"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821865,
+				tcgplayer: 628674,
+			},
 		},
-
-		effect: {
-			'zh-tw': "若這隻寶可夢身上附有「火箭隊能量」，則增加60點傷害。",
-			'zh-cn': "若這隻寶可夢身上附有「火箭隊能量」，則增加60點傷害。",
-			ja: "このポケモンに「ロケット団エネルギー」がついているなら、60ダメージ追加。"
-		},
-
-		damage: "60＋",
-		cost: ["Lightning", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "－30"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Rare",
-	dexId: [145]
-}
+	dexId: [145],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/034.ts
+++ b/data-asia/SV/SV10/034.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のメリープ",
 		'zh-tw': "<火箭隊的>咩利羊",
 		'zh-cn': "<火箭隊的>咩利羊",
-		ja: "ロケット団のメリープ"
 	},
 
 	illustrator: "Teeziro",
@@ -16,47 +15,55 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
+		ja: "体に 静電気が 溜まると 体毛が いつもの ２倍ほどに ふくらむ。 触ると 痺れる。",
 		'zh-tw': "身體裡只要儲存了靜電， 體毛就會膨脹到平時的２倍左右。 一旦觸摸就會被電得麻麻的。",
 		'zh-cn': "身體裡只要儲存了靜電， 體毛就會膨脹到平時的２倍左右。 一旦觸摸就會被電得麻麻的。",
-		ja: "体に 静電気が 溜まると 体毛が いつもの ２倍ほどに ふくらむ。 触ると 痺れる。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "籌備",
-			'zh-cn': "籌備",
-			ja: "ちょうたつ"
+	attacks: [
+		{
+			name: {
+				ja: "ちょうたつ",
+				'zh-tw': "籌備",
+				'zh-cn': "籌備",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からグッズを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張物品卡，在給對手看過後加入手牌。並且重洗牌庫。",
+				'zh-cn': "從自己的牌庫選擇1張物品卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張物品卡，在給對手看過後加入手牌。並且重洗牌庫。",
-			'zh-cn': "從自己的牌庫選擇1張物品卡，在給對手看過後加入手牌。並且重洗牌庫。",
-			ja: "自分の山札からグッズを1枚選び、相手に見せて、手札に加える。そして山札を切る。"
+		{
+			name: {
+				ja: "プチボルト",
+				'zh-tw': "小伏特",
+				'zh-cn': "小伏特",
+			},
+			damage: 10,
+			cost: ["Lightning"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "小伏特",
-			'zh-cn': "小伏特",
-			ja: "プチボルト"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821866,
+				tcgplayer: 628675,
+			},
 		},
-
-		damage: 10,
-		cost: ["Lightning"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [179]
-}
+	dexId: [179],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/035.ts
+++ b/data-asia/SV/SV10/035.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のモココ",
 		'zh-tw': "<火箭隊的>茸茸羊",
 		'zh-cn': "<火箭隊的>茸茸羊",
-		ja: "ロケット団のモココ"
 	},
 
 	illustrator: "Jerky",
@@ -16,39 +15,51 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
+		ja: "電気を 蓄えすぎた 結果 体の 表面に 産毛すら 生えない 部分が できてしまった。",
 		'zh-tw': "儲存了過多電力的結果， 造成牠身體表面有些部分 連胎毛都長不出來。",
 		'zh-cn': "儲存了過多電力的結果， 造成牠身體表面有些部分 連胎毛都長不出來。",
-		ja: "電気を 蓄えすぎた 結果 体の 表面に 産毛すら 生えない 部分が できてしまった。"
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "電擊",
-			'zh-cn': "電擊",
-			ja: "でんきショック"
+	attacks: [
+		{
+			name: {
+				ja: "でんきショック",
+				'zh-tw': "電擊",
+				'zh-cn': "電擊",
+			},
+			damage: 50,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+				'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
+				'zh-cn': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
-			'zh-cn': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
-			ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821867,
+				tcgplayer: 628676,
+			},
 		},
+	],
 
-		damage: 50,
-		cost: ["Lightning", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ロケット団のメリープ",
+	},
 
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [180]
-}
+	dexId: [180],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/036.ts
+++ b/data-asia/SV/SV10/036.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のデンリュウ",
 		'zh-tw': "<火箭隊的>電龍",
 		'zh-cn': "<火箭隊的>電龍",
-		ja: "ロケット団のデンリュウ"
 	},
 
 	illustrator: "Shiburingaru",
@@ -16,49 +15,62 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
+		ja: "尻尾の 灯りは 遠くまで 届くので 昔より かがり火として 大事に されている。",
 		'zh-tw': "尾巴的亮光能傳得很遠， 一直以來都被當成篝火， 受到人們的重視。",
 		'zh-cn': "尾巴的亮光能傳得很遠， 一直以來都被當成篝火， 受到人們的重視。",
-		ja: "尻尾の 灯りは 遠くまで 届くので 昔より かがり火として 大事に されている。"
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "黑暗脈衝",
-			'zh-cn': "黑暗脈衝",
-			ja: "ダークインパルス"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ダークインパルス",
+				'zh-tw': "黑暗脈衝",
+				'zh-cn': "黑暗脈衝",
+			},
+			effect: {
+				ja: "このポケモンがいるかぎり、相手が手札からポケモンを出して進化させるたび、そのポケモンにダメカンを4個のせる。この効果は、この特性を持つポケモンが何匹いても、重ならない。",
+				'zh-tw': "只要這隻寶可夢在場上，每次對手從手牌使出寶可夢完成進化時，在那隻寶可夢身上放置4個傷害指示物。無論有多少隻擁有這個特性的寶可夢，這個效果也不會重複。",
+				'zh-cn': "只要這隻寶可夢在場上，每次對手從手牌使出寶可夢完成進化時，在那隻寶可夢身上放置4個傷害指示物。無論有多少隻擁有這個特性的寶可夢，這個效果也不會重複。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在場上，每次對手從手牌使出寶可夢完成進化時，在那隻寶可夢身上放置4個傷害指示物。無論有多少隻擁有這個特性的寶可夢，這個效果也不會重複。",
-			'zh-cn': "只要這隻寶可夢在場上，每次對手從手牌使出寶可夢完成進化時，在那隻寶可夢身上放置4個傷害指示物。無論有多少隻擁有這個特性的寶可夢，這個效果也不會重複。",
-			ja: "このポケモンがいるかぎり、相手が手札からポケモンを出して進化させるたび、そのポケモンにダメカンを4個のせる。この効果は、この特性を持つポケモンが何匹いても、重ならない。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "伏特頭擊",
-			'zh-cn': "伏特頭擊",
-			ja: "ヘッドボルト"
+	attacks: [
+		{
+			name: {
+				ja: "ヘッドボルト",
+				'zh-tw': "伏特頭擊",
+				'zh-cn': "伏特頭擊",
+			},
+			damage: 140,
+			cost: ["Lightning", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 140,
-		cost: ["Lightning", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821868,
+				tcgplayer: 628677,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ロケット団のモココ",
+	},
 
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Uncommon",
-	dexId: [181]
-}
+	dexId: [181],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/037.ts
+++ b/data-asia/SV/SV10/037.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のスリープ",
 		'zh-tw': "<火箭隊的>催眠貘",
 		'zh-cn': "<火箭隊的>催眠貘",
-		ja: "ロケット団のスリープ"
 	},
 
 	illustrator: "matazo",
@@ -16,44 +15,47 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
+		ja: "食べた夢は 全部 覚えている。 子どもの 夢のほうが 美味しいので めったに 大人の 夢は食べない。",
 		'zh-tw': "能記住所有自己吃下的夢。 由於小孩的夢更加美味， 因此幾乎不吃大人的夢。",
 		'zh-cn': "能記住所有自己吃下的夢。 由於小孩的夢更加美味， 因此幾乎不吃大人的夢。",
-		ja: "食べた夢は 全部 覚えている。 子どもの 夢のほうが 美味しいので めったに 大人の 夢は食べない。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "催眠光線",
-			'zh-cn': "催眠光線",
-			ja: "さいみんこうせん"
+	attacks: [
+		{
+			name: {
+				ja: "さいみんこうせん",
+				'zh-tw': "催眠光線",
+				'zh-cn': "催眠光線",
+			},
+			damage: 10,
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【睡眠】。",
+				'zh-cn': "將對手的戰鬥寶可夢【睡眠】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【睡眠】。",
-			'zh-cn': "將對手的戰鬥寶可夢【睡眠】。",
-			ja: "相手のバトルポケモンをねむりにする。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821869,
+				tcgplayer: 628678,
+			},
 		},
-
-		damage: 10,
-		cost: ["Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "－30"
-	}],
+	],
 
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [96]
-}
+	dexId: [96],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/038.ts
+++ b/data-asia/SV/SV10/038.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のスリーパー",
 		'zh-tw': "<火箭隊的>引夢貘人",
 		'zh-cn': "<火箭隊的>引夢貘人",
-		ja: "ロケット団のスリーパー"
 	},
 
 	illustrator: "Yuya Oka",
@@ -16,53 +15,60 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
+		ja: "相手と 目が 合ったときに 催眠術など 数々の 超能力を 使うという。",
 		'zh-tw': "據說牠和對手對到眼時， 就會使出催眠術等 各式各樣的超能力。",
 		'zh-cn': "據說牠和對手對到眼時， 就會使出催眠術等 各式各樣的超能力。",
-		ja: "相手と 目が 合ったときに 催眠術など 数々の 超能力を 使うという。"
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "精神射擊",
-			'zh-cn': "精神射擊",
-			ja: "サイコショット"
+	attacks: [
+		{
+			name: {
+				ja: "サイコショット",
+				'zh-tw': "精神射擊",
+				'zh-cn': "精神射擊",
+			},
+			damage: 40,
+			cost: ["Psychic"],
 		},
-
-		damage: 40,
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "備戰區操縱",
-			'zh-cn': "備戰區操縱",
-			ja: "ベンチをあやつる"
+		{
+			name: {
+				ja: "ベンチをあやつる",
+				'zh-tw': "備戰區操縱",
+				'zh-cn': "備戰區操縱",
+			},
+			damage: "80×",
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "相手は相手自身のベンチポケモンの数ぶんコインを投げる。相手のバトルポケモンに、ウラの数×80ダメージ。このワザのダメージは弱点・抵抗力を計算しない。",
+				'zh-tw': "對手擲與對手自己的備戰寶可夢的數量相同次數的硬幣。對手的戰鬥寶可夢受到反面出現的次數×80點傷害。這個招式的傷害不計算弱點・抵抗力。",
+				'zh-cn': "對手擲與對手自己的備戰寶可夢的數量相同次數的硬幣。對手的戰鬥寶可夢受到反面出現的次數×80點傷害。這個招式的傷害不計算弱點・抵抗力。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "對手擲與對手自己的備戰寶可夢的數量相同次數的硬幣。對手的戰鬥寶可夢受到反面出現的次數×80點傷害。這個招式的傷害不計算弱點・抵抗力。",
-			'zh-cn': "對手擲與對手自己的備戰寶可夢的數量相同次數的硬幣。對手的戰鬥寶可夢受到反面出現的次數×80點傷害。這個招式的傷害不計算弱點・抵抗力。",
-			ja: "相手は相手自身のベンチポケモンの数ぶんコインを投げる。相手のバトルポケモンに、ウラの数×80ダメージ。このワザのダメージは弱点・抵抗力を計算しない。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821870,
+				tcgplayer: 628679,
+			},
 		},
+	],
 
-		damage: "80×",
-		cost: ["Psychic", "Psychic", "Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "－30"
-	}],
+	evolveFrom: {
+		ja: "ロケット団のスリープ",
+	},
 
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Uncommon",
-	dexId: [97]
-}
+	dexId: [97],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/039.ts
+++ b/data-asia/SV/SV10/039.ts
@@ -1,68 +1,73 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のミュウツーex",
 		'zh-tw': "<火箭隊的>超夢ex",
 		'zh-cn': "<火箭隊的>超夢ex",
-		ja: "ロケット団のミュウツーex"
 	},
 
 	illustrator: "aky CG Works",
 	category: "Pokemon",
 	hp: 280,
 	types: ["Psychic"],
+
 	stage: "Basic",
-	suffix: "EX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "力量抑制者",
-			'zh-cn': "力量抑制者",
-			ja: "パワーセーバー"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "パワーセーバー",
+				'zh-tw': "力量抑制者",
+				'zh-cn': "力量抑制者",
+			},
+			effect: {
+				ja: "自分の場の「ロケット団のポケモン」が4匹以上のときにしか、このポケモンはワザが使えない。",
+				'zh-tw': "只有在自己的場上的「火箭隊的寶可夢」數量為4隻以上時，這隻寶可夢才可使用招式。",
+				'zh-cn': "只有在自己的場上的「火箭隊的寶可夢」數量為4隻以上時，這隻寶可夢才可使用招式。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只有在自己的場上的「火箭隊的寶可夢」數量為4隻以上時，這隻寶可夢才可使用招式。",
-			'zh-cn': "只有在自己的場上的「火箭隊的寶可夢」數量為4隻以上時，這隻寶可夢才可使用招式。",
-			ja: "自分の場の「ロケット団のポケモン」が4匹以上のときにしか、このポケモンはワザが使えない。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "擦除球",
-			'zh-cn': "擦除球",
-			ja: "イレイザーボール"
+	attacks: [
+		{
+			name: {
+				ja: "イレイザーボール",
+				'zh-tw': "擦除球",
+				'zh-cn': "擦除球",
+			},
+			damage: "160+",
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "のぞむなら、自分のベンチポケモンについているエネルギーを2枚までトラッシュし、その枚数×60ダメージ追加。",
+				'zh-tw': "若希望，將最多2張自己的備戰寶可夢身上附加的能量卡丟棄，增加其張數×60點傷害。",
+				'zh-cn': "若希望，將最多2張自己的備戰寶可夢身上附加的能量卡丟棄，增加其張數×60點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若希望，將最多2張自己的備戰寶可夢身上附加的能量卡丟棄，增加其張數×60點傷害。",
-			'zh-cn': "若希望，將最多2張自己的備戰寶可夢身上附加的能量卡丟棄，增加其張數×60點傷害。",
-			ja: "のぞむなら、自分のベンチポケモンについているエネルギーを2枚までトラッシュし、その枚数×60ダメージ追加。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821871,
+				tcgplayer: 628680,
+			},
 		},
-
-		damage: "160＋",
-		cost: ["Psychic", "Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "－30"
-	}],
+	],
 
 	retreat: 3,
 	regulationMark: "I",
-	rarity: "Double rare"
-}
+	rarity: "Double rare",
+	dexId: [150],
 
-export default card
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV10/040.ts
+++ b/data-asia/SV/SV10/040.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のソーナンス",
 		'zh-tw': "<火箭隊的>果然翁",
 		'zh-cn': "<火箭隊的>果然翁",
-		ja: "ロケット団のソーナンス"
 	},
 
 	illustrator: "Kazumasa Yasukuni",
@@ -16,52 +15,55 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
+		ja: "真っ黒な 尻尾を 隠すため 暗闇で ひっそりと 生きている。 自分からは 攻撃しない。",
 		'zh-tw': "為了隱藏漆黑的尾巴 而悄悄地生活在黑暗之中。 不會主動發動攻擊。",
 		'zh-cn': "為了隱藏漆黑的尾巴 而悄悄地生活在黑暗之中。 不會主動發動攻擊。",
-		ja: "真っ黒な 尻尾を 隠すため 暗闇で ひっそりと 生きている。 自分からは 攻撃しない。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "火箭鏡面",
-			'zh-cn': "火箭鏡面",
-			ja: "ロケットミラー"
+	attacks: [
+		{
+			name: {
+				ja: "ロケットミラー",
+				'zh-tw': "火箭鏡面",
+				'zh-cn': "火箭鏡面",
+			},
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "自分のベンチの「ロケット団のポケモン」を1匹選び、選んだポケモンにのっているダメカンをすべて、相手のバトルポケモンにのせ替える。",
+				'zh-tw': "選擇1隻自己的備戰區的「火箭隊的寶可夢」，將所選的寶可夢身上放置的傷害指示物，全部改放於對手的戰鬥寶可夢身上。",
+				'zh-cn': "選擇1隻自己的備戰區的「火箭隊的寶可夢」，將所選的寶可夢身上放置的傷害指示物，全部改放於對手的戰鬥寶可夢身上。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇1隻自己的備戰區的「火箭隊的寶可夢」，將所選的寶可夢身上放置的傷害指示物，全部改放於對手的戰鬥寶可夢身上。",
-			'zh-cn': "選擇1隻自己的備戰區的「火箭隊的寶可夢」，將所選的寶可夢身上放置的傷害指示物，全部改放於對手的戰鬥寶可夢身上。",
-			ja: "自分のベンチの「ロケット団のポケモン」を1匹選び、選んだポケモンにのっているダメカンをすべて、相手のバトルポケモンにのせ替える。"
+		{
+			name: {
+				ja: "とびだしヘッド",
+				'zh-tw': "魯莽頭擊",
+				'zh-cn': "魯莽頭擊",
+			},
+			damage: 70,
+			cost: ["Psychic", "Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Psychic", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "魯莽頭擊",
-			'zh-cn': "魯莽頭擊",
-			ja: "とびだしヘッド"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821872,
+				tcgplayer: 628681,
+			},
 		},
-
-		damage: 70,
-		cost: ["Psychic", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "－30"
-	}],
+	],
 
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Rare",
-	dexId: [202]
-}
+	dexId: [202],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/041.ts
+++ b/data-asia/SV/SV10/041.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のリーシャン",
 		'zh-tw': "<火箭隊的>鈴鐺響",
 		'zh-cn': "<火箭隊的>鈴鐺響",
-		ja: "ロケット団のリーシャン"
 	},
 
 	illustrator: "Mina Nakai",
@@ -16,51 +15,40 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
+		ja: "飛び跳ねると 口の中にある 玉が あちこちに 反射して 鈴のような 音色と なる。",
 		'zh-tw': "如果跳起來， 嘴裡的珠子就會到處反彈， 發出鈴鐺一般的音色。",
 		'zh-cn': "如果跳起來， 嘴裡的珠子就會到處反彈， 發出鈴鐺一般的音色。",
-		ja: "飛び跳ねると 口の中にある 玉が あちこちに 反射して 鈴のような 音色と なる。"
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "鈴鈴吵鬧",
-			'zh-cn': "鈴鈴吵鬧"
+	attacks: [
+		{
+			name: { ja: "リンリンさわぐ" },
+			cost: [],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、トラッシュする。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在不看正面的情況下，從對手的手牌選擇1張，將其丟棄。",
-			'zh-cn': "在不看正面的情況下，從對手的手牌選擇1張，將其丟棄。"
-		}
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "－30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821873,
+				tcgplayer: 628682,
+			},
+		},
+	],
 
 	retreat: 0,
 	regulationMark: "I",
 	rarity: "Common",
 	dexId: [433],
+};
 
-	attacks: [{
-		name: {
-			ja: "リンリンさわぐ"
-		},
-
-		effect: {
-			ja: "相手の手札からオモテを見ないで1枚選び、トラッシュする。"
-		}
-	}]
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV10/042.ts
+++ b/data-asia/SV/SV10/042.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のミミッキュ",
 		'zh-tw': "<火箭隊的>謎擬Ｑ",
 		'zh-cn': "<火箭隊的>謎擬Ｑ",
-		ja: "ロケット団のミミッキュ"
 	},
 
 	illustrator: "DOM",
@@ -16,43 +15,46 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
+		ja: "陽の 当たらない 暗がりに 棲む。 人前に 出るときは ピカチュウに 似せた 布で 全身を 隠す。",
 		'zh-tw': "棲息在陽光照射不到的陰暗處。 在人們面前現身時會用 看似皮卡丘的布來隱藏全身。",
 		'zh-cn': "棲息在陽光照射不到的陰暗處。 在人們面前現身時會用 看似皮卡丘的布來隱藏全身。",
-		ja: "陽の 当たらない 暗がりに 棲む。 人前に 出るときは ピカチュウに 似せた 布で 全身を 隠す。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "扮晶晶酒",
-			'zh-cn': "扮晶晶酒",
-			ja: "ほうせきごっこ"
+	attacks: [
+		{
+			name: {
+				ja: "ほうせきごっこ",
+				'zh-tw': "扮晶晶酒",
+				'zh-cn': "扮晶晶酒",
+			},
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手のバトル場の「テラスタル」のポケモンが持つワザを1つ選び、このワザとして使う。",
+				'zh-tw': "選擇1個對手的戰鬥場的「太晶」寶可夢持有的招式，作為這個招式使用。",
+				'zh-cn': "選擇1個對手的戰鬥場的「太晶」寶可夢持有的招式，作為這個招式使用。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇1個對手的戰鬥場的「太晶」寶可夢持有的招式，作為這個招式使用。",
-			'zh-cn': "選擇1個對手的戰鬥場的「太晶」寶可夢持有的招式，作為這個招式使用。",
-			ja: "相手のバトル場の「テラスタル」のポケモンが持つワザを1つ選び、このワザとして使う。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821874,
+				tcgplayer: 628683,
+			},
 		},
-
-		cost: ["Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "－30"
-	}],
+	],
 
 	retreat: 0,
 	regulationMark: "I",
 	rarity: "Uncommon",
-	dexId: [778]
-}
+	dexId: [778],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/043.ts
+++ b/data-asia/SV/SV10/043.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のレドームシ",
 		'zh-tw': "<火箭隊的>天罩蟲",
 		'zh-cn': "<火箭隊的>天罩蟲",
-		ja: "ロケット団のレドームシ"
 	},
 
 	illustrator: "Scav",
@@ -16,52 +15,59 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
+		ja: "殻の 中で 成長中。 サイコパワーで 外の 様子を うかがい 進化に 備えている。",
 		'zh-tw': "正在殼裡成長著。 用精神力量掌握外界的 狀況，做好進化的準備。",
 		'zh-cn': "正在殼裡成長著。 用精神力量掌握外界的 狀況，做好進化的準備。",
-		ja: "殻の 中で 成長中。 サイコパワーで 外の 様子を うかがい 進化に 備えている。"
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "攪亂雷達",
-			'zh-cn': "攪亂雷達",
-			ja: "かくらんレーダー"
+	attacks: [
+		{
+			name: {
+				ja: "かくらんレーダー",
+				'zh-tw': "攪亂雷達",
+				'zh-cn': "攪亂雷達",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手の山札を上から5枚見て、好きな順番に入れ替えて、山札の上にもどす。",
+				'zh-tw': "查看對手的牌庫上方5張卡，以任意順序排列，放回牌庫上方。",
+				'zh-cn': "查看對手的牌庫上方5張卡，以任意順序排列，放回牌庫上方。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "查看對手的牌庫上方5張卡，以任意順序排列，放回牌庫上方。",
-			'zh-cn': "查看對手的牌庫上方5張卡，以任意順序排列，放回牌庫上方。",
-			ja: "相手の山札を上から5枚見て、好きな順番に入れ替えて、山札の上にもどす。"
+		{
+			name: {
+				ja: "ちょうねんりき",
+				'zh-tw': "超念力",
+				'zh-cn': "超念力",
+			},
+			damage: 30,
+			cost: ["Psychic", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "超念力",
-			'zh-cn': "超念力",
-			ja: "ちょうねんりき"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821875,
+				tcgplayer: 628684,
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "－30"
-	}],
+	evolveFrom: {
+		ja: "ロケット団のサッチムシ",
+	},
 
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [825]
-}
+	dexId: [825],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/044.ts
+++ b/data-asia/SV/SV10/044.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のイオルブ",
 		'zh-tw': "<火箭隊的>以歐路普",
 		'zh-cn': "<火箭隊的>以歐路普",
-		ja: "ロケット団のイオルブ"
 	},
 
 	illustrator: "Shin Nagasawa",
@@ -16,60 +15,67 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
+		ja: "サイコパワーを 放ち 周囲を 調べている。 観測範囲は 周囲 １０キロにも 達するぞ。",
 		'zh-tw': "釋放出精神力量來調查 周圍的情況。牠的偵測範圍 甚至可以達到方圓１０公里。",
 		'zh-cn': "釋放出精神力量來調查 周圍的情況。牠的偵測範圍 甚至可以達到方圓１０公里。",
-		ja: "サイコパワーを 放ち 周囲を 調べている。 観測範囲は 周囲 １０キロにも 達するぞ。"
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "火箭腦力",
-			'zh-cn': "火箭腦力",
-			ja: "ロケットブレイン"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ロケットブレイン",
+				'zh-tw': "火箭腦力",
+				'zh-cn': "火箭腦力",
+			},
+			effect: {
+				ja: "自分の番に何回でも使える。自分の場の「ロケット団のポケモン」にのっているダメカンを1個選び、自分の別のポケモンにのせ替える。",
+				'zh-tw': "在自己的回合時，可不限次數使用。選擇1個自己的場上的「火箭隊的寶可夢」身上放置的傷害指示物，改放於自己的其他寶可夢身上。",
+				'zh-cn': "在自己的回合時，可不限次數使用。選擇1個自己的場上的「火箭隊的寶可夢」身上放置的傷害指示物，改放於自己的其他寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，可不限次數使用。選擇1個自己的場上的「火箭隊的寶可夢」身上放置的傷害指示物，改放於自己的其他寶可夢身上。",
-			'zh-cn': "在自己的回合時，可不限次數使用。選擇1個自己的場上的「火箭隊的寶可夢」身上放置的傷害指示物，改放於自己的其他寶可夢身上。",
-			ja: "自分の番に何回でも使える。自分の場の「ロケット団のポケモン」にのっているダメカンを1個選び、自分の別のポケモンにのせ替える。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "精神強念",
-			'zh-cn': "精神強念",
-			ja: "サイコキネシス"
+	attacks: [
+		{
+			name: {
+				ja: "サイコキネシス",
+				'zh-tw': "精神強念",
+				'zh-cn': "精神強念",
+			},
+			damage: "40+",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数×40ダメージ追加。",
+				'zh-tw': "增加對手的戰鬥寶可夢身上附加的能量的數量×40點傷害。",
+				'zh-cn': "增加對手的戰鬥寶可夢身上附加的能量的數量×40點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加對手的戰鬥寶可夢身上附加的能量的數量×40點傷害。",
-			'zh-cn': "增加對手的戰鬥寶可夢身上附加的能量的數量×40點傷害。",
-			ja: "相手のバトルポケモンについているエネルギーの数×40ダメージ追加。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821876,
+				tcgplayer: 628685,
+			},
 		},
+	],
 
-		damage: "40＋",
-		cost: ["Psychic", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "－30"
-	}],
+	evolveFrom: {
+		ja: "ロケット団のレドームシ",
+	},
 
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Uncommon",
-	dexId: [826]
-}
+	dexId: [826],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/045.ts
+++ b/data-asia/SV/SV10/045.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "マンキー",
 		'zh-tw': "猴怪",
 		'zh-cn': "猴怪",
-		ja: "マンキー"
 	},
 
 	illustrator: "Ayako Ozaki",
@@ -16,39 +15,47 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
+		ja: "木の上で 群れをつくって 暮らす。 群れから はぐれた マンキーは 寂しくて すぐに 怒りだす。",
 		'zh-tw': "在樹上群居的寶可夢。 和夥伴走散的猴怪會因為 按捺不住寂寞而動不動就生氣。",
 		'zh-cn': "在樹上群居的寶可夢。 和夥伴走散的猴怪會因為 按捺不住寂寞而動不動就生氣。",
-		ja: "木の上で 群れをつくって 暮らす。 群れから はぐれた マンキーは 寂しくて すぐに 怒りだす。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "踹",
-			'zh-cn': "踹",
-			ja: "けりつける"
+	attacks: [
+		{
+			name: {
+				ja: "けりつける",
+				'zh-tw': "踹",
+				'zh-cn': "踹",
+			},
+			damage: 30,
+			cost: ["Fighting"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+				'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。",
+				'zh-cn': "擲1次硬幣若為反面，則這個招式失敗。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。",
-			'zh-cn': "擲1次硬幣若為反面，則這個招式失敗。",
-			ja: "コインを1回投げウラなら、このワザは失敗。"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821877,
+				tcgplayer: 628686,
+			},
 		},
-
-		damage: 30,
-		cost: ["Fighting"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [56]
-}
+	dexId: [56],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/046.ts
+++ b/data-asia/SV/SV10/046.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "オコリザル",
 		'zh-tw': "火爆猴",
 		'zh-cn': "火爆猴",
-		ja: "オコリザル"
 	},
 
 	illustrator: "GOTO minori",
@@ -16,38 +15,50 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
+		ja: "だれかの 視線を 感じただけで 猛烈に 怒りだす。 そして 目が合った ものを 追いかけるのだ。",
 		'zh-tw': "光是感覺到他方的視線 都會暴怒起來，然後去追 和牠對到眼的傢伙。",
 		'zh-cn': "光是感覺到他方的視線 都會暴怒起來，然後去追 和牠對到眼的傢伙。",
-		ja: "だれかの 視線を 感じただけで 猛烈に 怒りだす。 そして 目が合った ものを 追いかけるのだ。"
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "拖出",
-			'zh-cn': "拖出",
-			ja: "ひきずりだす"
+	attacks: [
+		{
+			name: {
+				ja: "ひきずりだす",
+				'zh-tw': "拖出",
+				'zh-cn': "拖出",
+			},
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、新しく出てきたポケモンに30ダメージ。",
+				'zh-tw': "選擇1隻對手的備戰寶可夢，與戰鬥寶可夢互換。然後，新上場的寶可夢受到30點傷害。",
+				'zh-cn': "選擇1隻對手的備戰寶可夢，與戰鬥寶可夢互換。然後，新上場的寶可夢受到30點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇1隻對手的備戰寶可夢，與戰鬥寶可夢互換。然後，新上場的寶可夢受到30點傷害。",
-			'zh-cn': "選擇1隻對手的備戰寶可夢，與戰鬥寶可夢互換。然後，新上場的寶可夢受到30點傷害。",
-			ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、新しく出てきたポケモンに30ダメージ。"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821878,
+				tcgplayer: 628687,
+			},
 		},
+	],
 
-		cost: ["Fighting"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "マンキー",
+	},
 
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [57]
-}
+	dexId: [57],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/047.ts
+++ b/data-asia/SV/SV10/047.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "コノヨザル",
 		'zh-tw': "棄世猴",
 		'zh-cn': "棄世猴",
-		ja: "コノヨザル"
 	},
 
 	illustrator: "Shiburingaru",
@@ -16,55 +15,67 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
+		ja: "怒りのボルテージが 臨界点を 超えたとき 肉体という 枠に 縛られない パワーを 手に入れた。",
 		'zh-tw': "在怒氣突破臨界點時， 獲得了能夠擺脫 肉體束縛的力量。",
 		'zh-cn': "在怒氣突破臨界點時， 獲得了能夠擺脫 肉體束縛的力量。",
-		ja: "怒りのボルテージが 臨界点を 超えたとき 肉体という 枠に 縛られない パワーを 手に入れた。"
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "憤怒穴",
-			'zh-cn': "憤怒穴",
-			ja: "ふんどのつぼ"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ふんどのつぼ",
+				'zh-tw': "憤怒穴",
+				'zh-cn': "憤怒穴",
+			},
+			effect: {
+				ja: "このポケモンにダメカンが2個以上のっているなら、このポケモンが使うワザの、相手のバトルポケモンへのダメージは「+120」される。",
+				'zh-tw': "若這隻寶可夢身上放置有2個以上的傷害指示物，則這隻寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+120」點。",
+				'zh-cn': "若這隻寶可夢身上放置有2個以上的傷害指示物，則這隻寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+120」點。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢身上放置有2個以上的傷害指示物，則這隻寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+120」點。",
-			'zh-cn': "若這隻寶可夢身上放置有2個以上的傷害指示物，則這隻寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+120」點。",
-			ja: "このポケモンにダメカンが2個以上のっているなら、このポケモンが使うワザの、相手のバトルポケモンへのダメージは「+120」される。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "衝擊打擊",
-			'zh-cn': "衝擊打擊",
-			ja: "インパクトブロー"
+	attacks: [
+		{
+			name: {
+				ja: "インパクトブロー",
+				'zh-tw': "衝擊打擊",
+				'zh-cn': "衝擊打擊",
+			},
+			damage: 160,
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「インパクトブロー」が使えない。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「衝擊打擊」。",
+				'zh-cn': "在下個自己的回合，這隻寶可夢無法使用「衝擊打擊」。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「衝擊打擊」。",
-			'zh-cn': "在下個自己的回合，這隻寶可夢無法使用「衝擊打擊」。",
-			ja: "次の自分の番、このポケモンは「インパクトブロー」が使えない。"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821879,
+				tcgplayer: 628688,
+			},
 		},
+	],
 
-		damage: 160,
-		cost: ["Fighting", "Fighting"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "オコリザル",
+	},
 
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Rare",
-	dexId: [979]
-}
+	dexId: [979],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/048.ts
+++ b/data-asia/SV/SV10/048.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のヨーギラス",
 		'zh-tw': "<火箭隊的>幼基拉斯",
 		'zh-cn': "<火箭隊的>幼基拉斯",
-		ja: "ロケット団のヨーギラス"
 	},
 
 	illustrator: "Kuroimori",
@@ -16,39 +15,47 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
+		ja: "地面 深くで 生まれ 山ほどの 土を 食べ終わると 体を つくるため サナギになる。",
 		'zh-tw': "誕生在地底深處。 當牠吃完滿山的土壤後， 就會為了成長而變成蛹。",
 		'zh-cn': "誕生在地底深處。 當牠吃完滿山的土壤後， 就會為了成長而變成蛹。",
-		ja: "地面 深くで 生まれ 山ほどの 土を 食べ終わると 体を つくるため サナギになる。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "嚼山",
-			'zh-cn': "嚼山",
-			ja: "やまかじり"
+	attacks: [
+		{
+			name: {
+				ja: "やまかじり",
+				'zh-tw': "嚼山",
+				'zh-cn': "嚼山",
+			},
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手の山札を上から1枚トラッシュする。",
+				'zh-tw': "將對手的牌庫上方1張卡丟棄。",
+				'zh-cn': "將對手的牌庫上方1張卡丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的牌庫上方1張卡丟棄。",
-			'zh-cn': "將對手的牌庫上方1張卡丟棄。",
-			ja: "相手の山札を上から1枚トラッシュする。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821880,
+				tcgplayer: 628689,
+			},
 		},
-
-		damage: 10,
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [246]
-}
+	dexId: [246],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/049.ts
+++ b/data-asia/SV/SV10/049.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のサナギラス",
 		'zh-tw': "<火箭隊的>沙基拉斯",
 		'zh-cn': "<火箭隊的>沙基拉斯",
-		ja: "ロケット団のサナギラス"
 	},
 
 	illustrator: "Izucch",
@@ -16,39 +15,51 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
+		ja: "体内で 圧縮させた ガスを 勢いよく 噴出させ 飛んで 暴れまわる サナギだ。",
 		'zh-tw': "會以強勁的力道噴出在體內 壓縮好的氣體，好讓自己 能飛在空中大搞破壞的蛹。",
 		'zh-cn': "會以強勁的力道噴出在體內 壓縮好的氣體，好讓自己 能飛在空中大搞破壞的蛹。",
-		ja: "体内で 圧縮させた ガスを 勢いよく 噴出させ 飛んで 暴れまわる サナギだ。"
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "爆裂覺醒",
-			'zh-cn': "爆裂覺醒",
-			ja: "ばくれつかくせい"
+	attacks: [
+		{
+			name: {
+				ja: "ばくれつかくせい",
+				'zh-tw': "爆裂覺醒",
+				'zh-cn': "爆裂覺醒",
+			},
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンから進化するカードを、自分の山札から1枚選び、このポケモンにのせて進化させる。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張從這隻寶可夢進化而來的卡，放置於這隻寶可夢身上完成進化。並且重洗牌庫。",
+				'zh-cn': "從自己的牌庫選擇1張從這隻寶可夢進化而來的卡，放置於這隻寶可夢身上完成進化。並且重洗牌庫。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張從這隻寶可夢進化而來的卡，放置於這隻寶可夢身上完成進化。並且重洗牌庫。",
-			'zh-cn': "從自己的牌庫選擇1張從這隻寶可夢進化而來的卡，放置於這隻寶可夢身上完成進化。並且重洗牌庫。",
-			ja: "このポケモンから進化するカードを、自分の山札から1枚選び、このポケモンにのせて進化させる。そして山札を切る。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821881,
+				tcgplayer: 628690,
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ロケット団のヨーギラス",
+	},
 
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Uncommon",
-	dexId: [247]
-}
+	dexId: [247],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/050.ts
+++ b/data-asia/SV/SV10/050.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のバンギラス",
 		'zh-tw': "<火箭隊的>班基拉斯",
 		'zh-cn': "<火箭隊的>班基拉斯",
-		ja: "ロケット団のバンギラス"
 	},
 
 	illustrator: "Ryuta Fuse",
@@ -16,55 +15,67 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
+		ja: "あたりの 地形を 変えるぐらい 朝飯前の 力持ち。 まわりを 気にしない ふてぶてしさ。",
 		'zh-tw': "即便是改變周圍的地形 也是小事一樁的大力士。 個性狂妄，不顧周遭的感受。",
 		'zh-cn': "即便是改變周圍的地形 也是小事一樁的大力士。 個性狂妄，不顧周遭的感受。",
-		ja: "あたりの 地形を 変えるぐらい 朝飯前の 力持ち。 まわりを 気にしない ふてぶてしさ。"
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "揚沙",
-			'zh-cn': "揚沙",
-			ja: "すなおこし"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "すなおこし",
+				'zh-tw': "揚沙",
+				'zh-cn': "揚沙",
+			},
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、ポケモンチェックのたび、相手のたねポケモン全員に、それぞれダメカンを2個のせる。",
+				'zh-tw': "只要這隻寶可夢在戰鬥場上，每次寶可夢檢查時，在對手的所有【基礎】寶可夢身上各放置2個傷害指示物。",
+				'zh-cn': "只要這隻寶可夢在戰鬥場上，每次寶可夢檢查時，在對手的所有【基礎】寶可夢身上各放置2個傷害指示物。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在戰鬥場上，每次寶可夢檢查時，在對手的所有【基礎】寶可夢身上各放置2個傷害指示物。",
-			'zh-cn': "只要這隻寶可夢在戰鬥場上，每次寶可夢檢查時，在對手的所有【基礎】寶可夢身上各放置2個傷害指示物。",
-			ja: "このポケモンがバトル場にいるかぎり、ポケモンチェックのたび、相手のたねポケモン全員に、それぞれダメカンを2個のせる。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "打穿衝撞",
-			'zh-cn': "打穿衝撞",
-			ja: "ぶちぬきタックル"
+	attacks: [
+		{
+			name: {
+				ja: "ぶちぬきタックル",
+				'zh-tw': "打穿衝撞",
+				'zh-cn': "打穿衝撞",
+			},
+			damage: 180,
+			cost: ["Fighting", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。",
+				'zh-cn': "選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。",
-			'zh-cn': "選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。",
-			ja: "相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821882,
+				tcgplayer: 628691,
+			},
 		},
+	],
 
-		damage: 180,
-		cost: ["Fighting", "Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ロケット団のサナギラス",
+	},
 
 	retreat: 3,
 	regulationMark: "I",
 	rarity: "Rare",
-	dexId: [248]
-}
+	dexId: [248],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/051.ts
+++ b/data-asia/SV/SV10/051.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ノズパス",
 		'zh-tw': "朝北鼻",
 		'zh-cn': "朝北鼻",
-		ja: "ノズパス"
 	},
 
 	illustrator: "Oku",
@@ -16,42 +15,51 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
+		ja: "ノズパスの 鼻の 磁石は 絶対に 狂わないので 旅する トレーナーの 良き パートナーだ。",
 		'zh-tw': "朝北鼻鼻子上的磁鐵 絕對不會失靈，所以是 訓練家旅行時的良伴。",
 		'zh-cn': "朝北鼻鼻子上的磁鐵 絕對不會失靈，所以是 訓練家旅行時的良伴。",
-		ja: "ノズパスの 鼻の 磁石は 絶対に 狂わないので 旅する トレーナーの 良き パートナーだ。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "頭錘",
-			'zh-cn': "頭錘",
-			ja: "ずつき"
+	attacks: [
+		{
+			name: {
+				ja: "ずつき",
+				'zh-tw': "頭錘",
+				'zh-cn': "頭錘",
+			},
+			damage: 20,
+			cost: ["Fighting"],
 		},
-
-		damage: 20,
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "落石",
-			'zh-cn': "落石",
-			ja: "いわおとし"
+		{
+			name: {
+				ja: "いわおとし",
+				'zh-tw': "落石",
+				'zh-cn': "落石",
+			},
+			damage: 40,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 40,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821883,
+				tcgplayer: 628692,
+			},
+		},
+	],
 
 	retreat: 3,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [299]
-}
+	dexId: [299],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/052.ts
+++ b/data-asia/SV/SV10/052.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ダイノーズ",
 		'zh-tw': "大朝北鼻",
 		'zh-cn': "大朝北鼻",
-		ja: "ダイノーズ"
 	},
 
 	illustrator: "sowsow",
@@ -16,48 +15,60 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
+		ja: "３個の チビノーズと 呼ばれる ユニットを 磁力で 操り ３方向から 相手を 仕留める。",
 		'zh-tw': "會以磁力操縱３個 被稱為小朝北鼻的組件， 從３個方向解決對手。",
 		'zh-cn': "會以磁力操縱３個 被稱為小朝北鼻的組件， 從３個方向解決對手。",
-		ja: "３個の チビノーズと 呼ばれる ユニットを 磁力で 操り ３方向から 相手を 仕留める。"
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "力量寶石",
-			'zh-cn': "力量寶石",
-			ja: "パワージェム"
+	attacks: [
+		{
+			name: {
+				ja: "パワージェム",
+				'zh-tw': "力量寶石",
+				'zh-cn': "力量寶石",
+			},
+			damage: 40,
+			cost: ["Fighting"],
 		},
-
-		damage: 40,
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "山岳墜落",
-			'zh-cn': "山岳墜落",
-			ja: "マウンテンフォール"
+		{
+			name: {
+				ja: "マウンテンフォール",
+				'zh-tw': "山岳墜落",
+				'zh-cn': "山岳墜落",
+			},
+			damage: "70+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "場にスタジアムが出ているなら、70ダメージ追加。",
+				'zh-tw': "若場上有競技場卡，則增加70點傷害。",
+				'zh-cn': "若場上有競技場卡，則增加70點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若場上有競技場卡，則增加70點傷害。",
-			'zh-cn': "若場上有競技場卡，則增加70點傷害。",
-			ja: "場にスタジアムが出ているなら、70ダメージ追加。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821884,
+				tcgplayer: 628693,
+			},
 		},
+	],
 
-		damage: "70＋",
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ノズパス",
+	},
 
 	retreat: 3,
 	regulationMark: "I",
 	rarity: "Uncommon",
-	dexId: [476]
-}
+	dexId: [476],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/053.ts
+++ b/data-asia/SV/SV10/053.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "アサナン",
 		'zh-tw': "瑪沙那",
 		'zh-cn': "瑪沙那",
-		ja: "アサナン"
 	},
 
 	illustrator: "MINAMINAMI Take",
@@ -16,39 +15,47 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
+		ja: "毎日 ヨガの 修行を 欠かさない。 瞑想を することで 精神力を 高めている。",
 		'zh-tw': "每天都少不了瑜珈的修行。 會藉著冥想提高 自身的精神力。",
 		'zh-cn': "每天都少不了瑜珈的修行。 會藉著冥想提高 自身的精神力。",
-		ja: "毎日 ヨガの 修行を 欠かさない。 瞑想を することで 精神力を 高めている。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "連續擊拳",
-			'zh-cn': "連續擊拳",
-			ja: "ワンツーパンチ"
+	attacks: [
+		{
+			name: {
+				ja: "ワンツーパンチ",
+				'zh-tw': "連續擊拳",
+				'zh-cn': "連續擊拳",
+			},
+			damage: "10+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+				'zh-tw': "擲1次硬幣若為正面，則增加20點傷害。",
+				'zh-cn': "擲1次硬幣若為正面，則增加20點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則增加20點傷害。",
-			'zh-cn': "擲1次硬幣若為正面，則增加20點傷害。",
-			ja: "コインを1回投げオモテなら、20ダメージ追加。"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821885,
+				tcgplayer: 628694,
+			},
 		},
-
-		damage: "10＋",
-		cost: ["Fighting"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [307]
-}
+	dexId: [307],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/054.ts
+++ b/data-asia/SV/SV10/054.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "チャーレム",
 		'zh-tw': "恰雷姆",
 		'zh-cn': "恰雷姆",
-		ja: "チャーレム"
 	},
 
 	illustrator: "Whisker",
@@ -16,39 +15,51 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
+		ja: "ヨガの 修行で 鍛えられた サイコパワーで 相手の 動きを 予測する ことが できるのだ。",
 		'zh-tw': "可以用藉由瑜珈修行 鍛鍊出來的精神力量， 來預測對手的行動。",
 		'zh-cn': "可以用藉由瑜珈修行 鍛鍊出來的精神力量， 來預測對手的行動。",
-		ja: "ヨガの 修行で 鍛えられた サイコパワーで 相手の 動きを 予測する ことが できるのだ。"
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "合氣掌",
-			'zh-cn': "合氣掌",
-			ja: "あいきしょう"
+	attacks: [
+		{
+			name: {
+				ja: "あいきしょう",
+				'zh-tw': "合氣掌",
+				'zh-cn': "合氣掌",
+			},
+			damage: "50+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "このポケモンと相手のバトルポケモンについているエネルギーの数が同じなら、120ダメージ追加。",
+				'zh-tw': "若這隻寶可夢與對手的戰鬥寶可夢身上附加的能量數量相同，則增加120點傷害。",
+				'zh-cn': "若這隻寶可夢與對手的戰鬥寶可夢身上附加的能量數量相同，則增加120點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢與對手的戰鬥寶可夢身上附加的能量數量相同，則增加120點傷害。",
-			'zh-cn': "若這隻寶可夢與對手的戰鬥寶可夢身上附加的能量數量相同，則增加120點傷害。",
-			ja: "このポケモンと相手のバトルポケモンについているエネルギーの数が同じなら、120ダメージ追加。"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821886,
+				tcgplayer: 628695,
+			},
 		},
+	],
 
-		damage: "50＋",
-		cost: ["Fighting"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "アサナン",
+	},
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Uncommon",
-	dexId: [308]
-}
+	dexId: [308],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/055.ts
+++ b/data-asia/SV/SV10/055.ts
@@ -1,61 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "レジロックex",
 		'zh-tw': "雷吉洛克ex",
 		'zh-cn': "雷吉洛克ex",
-		ja: "レジロックex"
 	},
 
 	illustrator: "Nisota Niso",
 	category: "Pokemon",
 	hp: 230,
 	types: ["Fighting"],
+
 	stage: "Basic",
-	suffix: "EX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "雷吉充能",
-			'zh-cn': "雷吉充能",
-			ja: "レジチャージ"
+	attacks: [
+		{
+			name: {
+				ja: "レジチャージ",
+				'zh-tw': "雷吉充能",
+				'zh-cn': "雷吉充能",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュから「基本[F]エネルギー」を2枚まで選び、このポケモンにつける。",
+				'zh-tw': "從自己的棄牌區選擇最多2張「基本【鬥】能量」卡，附於這隻寶可夢身上。",
+				'zh-cn': "從自己的棄牌區選擇最多2張「基本【鬥】能量」卡，附於這隻寶可夢身上。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的棄牌區選擇最多2張「基本【鬥】能量」卡，附於這隻寶可夢身上。",
-			'zh-cn': "從自己的棄牌區選擇最多2張「基本【鬥】能量」卡，附於這隻寶可夢身上。",
-			ja: "自分のトラッシュから「基本エネルギー」を2枚まで選び、このポケモンにつける。"
+		{
+			name: {
+				ja: "ジャイアントロック",
+				'zh-tw': "巨型岩石",
+				'zh-cn': "巨型岩石",
+			},
+			damage: "140+",
+			cost: ["Fighting", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが2進化ポケモンなら、140ダメージ追加。",
+				'zh-tw': "若對手的戰鬥寶可夢為【2階進化】寶可夢，則增加140點傷害。",
+				'zh-cn': "若對手的戰鬥寶可夢為【2階進化】寶可夢，則增加140點傷害。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "巨型岩石",
-			'zh-cn': "巨型岩石",
-			ja: "ジャイアントロック"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821887,
+				tcgplayer: 628696,
+			},
 		},
-
-		effect: {
-			'zh-tw': "若對手的戰鬥寶可夢為【2階進化】寶可夢，則增加140點傷害。",
-			'zh-cn': "若對手的戰鬥寶可夢為【2階進化】寶可夢，則增加140點傷害。",
-			ja: "相手のバトルポケモンが2進化ポケモンなら、140ダメージ追加。"
-		},
-
-		damage: "140＋",
-		cost: ["Fighting", "Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	],
 
 	retreat: 3,
 	regulationMark: "I",
-	rarity: "Double rare"
-}
+	rarity: "Double rare",
+	dexId: [377],
 
-export default card
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV10/056.ts
+++ b/data-asia/SV/SV10/056.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のアーボ",
 		'zh-tw': "<火箭隊的>阿柏蛇",
 		'zh-cn': "<火箭隊的>阿柏蛇",
-		ja: "ロケット団のアーボ"
 	},
 
 	illustrator: "KEIICHIRO ITO",
@@ -16,47 +15,55 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
+		ja: "自由に あごを 外せるので 大きな 獲物でも 飲みこめるが 重くなって 動けなくなる。",
 		'zh-tw': "能夠自由地讓下顎脫臼，因此 就連體型大的獵物都吞得下去， 但身體會變笨重而無法動彈。",
 		'zh-cn': "能夠自由地讓下顎脫臼，因此 就連體型大的獵物都吞得下去， 但身體會變笨重而無法動彈。",
-		ja: "自由に あごを 外せるので 大きな 獲物でも 飲みこめるが 重くなって 動けなくなる。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "扯後腿",
-			'zh-cn': "扯後腿",
-			ja: "あしをひっぱる"
+	attacks: [
+		{
+			name: {
+				ja: "あしをひっぱる",
+				'zh-tw': "扯後腿",
+				'zh-cn': "扯後腿",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+				'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
+				'zh-cn': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
-			'zh-cn': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
-			ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。"
+		{
+			name: {
+				ja: "かじる",
+				'zh-tw': "咬",
+				'zh-cn': "咬",
+			},
+			damage: 10,
+			cost: ["Darkness"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "咬",
-			'zh-cn': "咬",
-			ja: "かじる"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821888,
+				tcgplayer: 628697,
+			},
 		},
-
-		damage: 10,
-		cost: ["Darkness"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [23]
-}
+	dexId: [23],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/057.ts
+++ b/data-asia/SV/SV10/057.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のアーボック",
 		'zh-tw': "<火箭隊的>阿柏怪",
 		'zh-cn': "<火箭隊的>阿柏怪",
-		ja: "ロケット団のアーボック"
 	},
 
 	illustrator: "Teeziro",
@@ -16,54 +15,66 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
+		ja: "お腹の 模様が 怖い顔に 見える。 弱い敵は その模様を 見ただけで 逃げだしてしまう。",
 		'zh-tw': "腹部的花紋看起來像一張可怕的臉。 弱小的敵人只要看到 這個花紋就會被嚇跑。",
 		'zh-cn': "腹部的花紋看起來像一張可怕的臉。 弱小的敵人只要看到 這個花紋就會被嚇跑。",
-		ja: "お腹の 模様が 怖い顔に 見える。 弱い敵は その模様を 見ただけで 逃げだしてしまう。"
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "瞪眼效用",
-			'zh-cn': "瞪眼效用",
-			ja: "にらみをきかす"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "にらみをきかす",
+				'zh-tw': "瞪眼效用",
+				'zh-cn': "瞪眼效用",
+			},
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手は手札から特性を持つポケモン（「ロケット団のポケモン」をのぞく）を場に出せない。",
+				'zh-tw': "只要這隻寶可夢在戰鬥場上，對手不可從手牌將擁有特性的寶可夢（「火箭隊的寶可夢」除外）放置於場上。",
+				'zh-cn': "只要這隻寶可夢在戰鬥場上，對手不可從手牌將擁有特性的寶可夢（「火箭隊的寶可夢」除外）放置於場上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在戰鬥場上，對手不可從手牌將擁有特性的寶可夢（「火箭隊的寶可夢」除外）放置於場上。",
-			'zh-cn': "只要這隻寶可夢在戰鬥場上，對手不可從手牌將擁有特性的寶可夢（「火箭隊的寶可夢」除外）放置於場上。",
-			ja: "このポケモンがバトル場にいるかぎり、相手は手札から特性を持つポケモン（「ロケット団のポケモン」をのぞく）を場に出せない。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "旋轉之尾",
-			'zh-cn': "旋轉之尾",
-			ja: "スピンテール"
+	attacks: [
+		{
+			name: {
+				ja: "スピンテール",
+				'zh-tw': "旋轉之尾",
+				'zh-cn': "旋轉之尾",
+			},
+			cost: ["Darkness", "Darkness", "Darkness"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的所有寶可夢各受到30點傷害。[在備戰區不計算弱點・抵抗力。]",
+				'zh-cn': "對手的所有寶可夢各受到30點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "對手的所有寶可夢各受到30點傷害。[在備戰區不計算弱點・抵抗力。]",
-			'zh-cn': "對手的所有寶可夢各受到30點傷害。[在備戰區不計算弱點・抵抗力。]",
-			ja: "相手のポケモン全員に、それぞれ30ダメージ。［ベンチは弱点・抵抗力を計算しない。］"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821889,
+				tcgplayer: 628698,
+			},
 		},
+	],
 
-		cost: ["Darkness", "Darkness", "Darkness"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ロケット団のアーボ",
+	},
 
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Uncommon",
-	dexId: [24]
-}
+	dexId: [24],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/058.ts
+++ b/data-asia/SV/SV10/058.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のニドラン♀",
 		'zh-tw': "<火箭隊的>尼多蘭",
 		'zh-cn': "<火箭隊的>尼多蘭",
-		ja: "ロケット団のニドラン♀"
 	},
 
 	illustrator: "REND",
@@ -16,39 +15,47 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
+		ja: "硬い 前歯で 木の実を 砕いて 食べる。 ツノの 先は オスより 少し 丸みを 帯びている。",
 		'zh-tw': "會用堅硬的門牙咬碎 樹果後吃下。角的尖端 會比雄性還要圓一些。",
 		'zh-cn': "會用堅硬的門牙咬碎 樹果後吃下。角的尖端 會比雄性還要圓一些。",
-		ja: "硬い 前歯で 木の実を 砕いて 食べる。 ツノの 先は オスより 少し 丸みを 帯びている。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "偷襲",
-			'zh-cn': "偷襲",
-			ja: "ふいをつく"
+	attacks: [
+		{
+			name: {
+				ja: "ふいをつく",
+				'zh-tw': "偷襲",
+				'zh-cn': "偷襲",
+			},
+			damage: 30,
+			cost: ["Darkness"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+				'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。",
+				'zh-cn': "擲1次硬幣若為反面，則這個招式失敗。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。",
-			'zh-cn': "擲1次硬幣若為反面，則這個招式失敗。",
-			ja: "コインを1回投げウラなら、このワザは失敗。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821890,
+				tcgplayer: 628699,
+			},
 		},
-
-		damage: 30,
-		cost: ["Darkness"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [29]
-}
+	dexId: [29],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/059.ts
+++ b/data-asia/SV/SV10/059.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のニドリーナ",
 		'zh-tw': "<火箭隊的>尼多娜",
 		'zh-cn': "<火箭隊的>尼多娜",
-		ja: "ロケット団のニドリーナ"
 	},
 
 	illustrator: "Taiga Kasai",
@@ -16,47 +15,59 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
+		ja: "群れに 危険が せまると 仲間で 結束して 超音波の 大合唱を おみまいするぞ。",
 		'zh-tw': "有危險逼近群體時， 會與夥伴們團結一致地 用超音波的大合唱來攻擊。",
 		'zh-cn': "有危險逼近群體時， 會與夥伴們團結一致地 用超音波的大合唱來攻擊。",
-		ja: "群れに 危険が せまると 仲間で 結束して 超音波の 大合唱を おみまいするぞ。"
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "惡之覺醒",
-			'zh-cn': "惡之覺醒",
-			ja: "あくのめざめ"
+	attacks: [
+		{
+			name: {
+				ja: "あくのめざめ",
+				'zh-tw': "惡之覺醒",
+				'zh-cn': "惡之覺醒",
+			},
+			cost: ["Darkness"],
+			effect: {
+				ja: "自分の[D]ポケモンを2匹まで選び、そのポケモンから進化するカードを、自分の山札から1枚ずつ選び、それぞれにのせて進化させる。そして山札を切る。",
+				'zh-tw': "選擇最多2隻自己的【惡】寶可夢，從自己的牌庫選擇從那些寶可夢進化而來的卡各1張，放置於各自身上完成進化。並且重洗牌庫。",
+				'zh-cn': "選擇最多2隻自己的【惡】寶可夢，從自己的牌庫選擇從那些寶可夢進化而來的卡各1張，放置於各自身上完成進化。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇最多2隻自己的【惡】寶可夢，從自己的牌庫選擇從那些寶可夢進化而來的卡各1張，放置於各自身上完成進化。並且重洗牌庫。",
-			'zh-cn': "選擇最多2隻自己的【惡】寶可夢，從自己的牌庫選擇從那些寶可夢進化而來的卡各1張，放置於各自身上完成進化。並且重洗牌庫。",
-			ja: "自分のポケモンを2匹まで選び、そのポケモンから進化するカードを、自分の山札から1枚ずつ選び、それぞれにのせて進化させる。そして山札を切る。"
+		{
+			name: {
+				ja: "ひっかく",
+				'zh-tw': "抓",
+				'zh-cn': "抓",
+			},
+			damage: 50,
+			cost: ["Darkness", "Darkness"],
 		},
+	],
 
-		cost: ["Darkness"]
-	}, {
-		name: {
-			'zh-tw': "抓",
-			'zh-cn': "抓",
-			ja: "ひっかく"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821891,
+				tcgplayer: 628700,
+			},
 		},
+	],
 
-		damage: 50,
-		cost: ["Darkness", "Darkness"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ロケット団のニドラン♀",
+	},
 
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [30]
-}
+	dexId: [30],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/060.ts
+++ b/data-asia/SV/SV10/060.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のニドクイン",
 		'zh-tw': "<火箭隊的>尼多后",
 		'zh-cn': "<火箭隊的>尼多后",
-		ja: "ロケット団のニドクイン"
 	},
 
 	illustrator: "hncl",
@@ -16,48 +15,60 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
+		ja: "背中の 棘の 隙間に 子どもを 乗せて あやす。 そのときに 毒が 出ることは けっして ないのだ。",
 		'zh-tw': "會把孩子放在背上的 刺與刺之間來哄牠們。 這時候絕對不會釋放毒素。",
 		'zh-cn': "會把孩子放在背上的 刺與刺之間來哄牠們。 這時候絕對不會釋放毒素。",
-		ja: "背中の 棘の 隙間に 子どもを 乗せて あやす。 そのときに 毒が 出ることは けっして ないのだ。"
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "愛之衝擊",
-			'zh-cn': "愛之衝擊",
-			ja: "ラブインパクト"
+	attacks: [
+		{
+			name: {
+				ja: "ラブインパクト",
+				'zh-tw': "愛之衝擊",
+				'zh-cn': "愛之衝擊",
+			},
+			damage: "60+",
+			cost: ["Darkness"],
+			effect: {
+				ja: "自分のベンチに、名前に「ニドキング」とつくポケモンがいるなら、120ダメージ追加。",
+				'zh-tw': "若自己的備戰區有名稱中有「尼多王」的寶可夢，則增加120點傷害。",
+				'zh-cn': "若自己的備戰區有名稱中有「尼多王」的寶可夢，則增加120點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "若自己的備戰區有名稱中有「尼多王」的寶可夢，則增加120點傷害。",
-			'zh-cn': "若自己的備戰區有名稱中有「尼多王」的寶可夢，則增加120點傷害。",
-			ja: "自分のベンチに、名前に「ニドキング」とつくポケモンがいるなら、120ダメージ追加。"
+		{
+			name: {
+				ja: "メガトンキック",
+				'zh-tw': "百萬噸重踢",
+				'zh-cn': "百萬噸重踢",
+			},
+			damage: 130,
+			cost: ["Darkness", "Darkness"],
 		},
+	],
 
-		damage: "60＋",
-		cost: ["Darkness"]
-	}, {
-		name: {
-			'zh-tw': "百萬噸重踢",
-			'zh-cn': "百萬噸重踢",
-			ja: "メガトンキック"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821892,
+				tcgplayer: 628701,
+			},
 		},
+	],
 
-		damage: 130,
-		cost: ["Darkness", "Darkness"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ロケット団のニドリーナ",
+	},
 
 	retreat: 3,
 	regulationMark: "I",
 	rarity: "Uncommon",
-	dexId: [31]
-}
+	dexId: [31],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/061.ts
+++ b/data-asia/SV/SV10/061.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のニドラン♂",
 		'zh-tw': "<火箭隊的>尼多朗",
 		'zh-cn': "<火箭隊的>尼多朗",
-		ja: "ロケット団のニドラン♂"
 	},
 
 	illustrator: "buchi",
@@ -16,42 +15,51 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
+		ja: "小柄だが 勇ましい 性質。 仲良しの メスを 守るため 身を ていして 果敢に 戦う。",
 		'zh-tw': "體型嬌小，但性情勇猛。 為了保護感情好的雌性， 會奮不顧身地勇敢戰鬥。",
 		'zh-cn': "體型嬌小，但性情勇猛。 為了保護感情好的雌性， 會奮不顧身地勇敢戰鬥。",
-		ja: "小柄だが 勇ましい 性質。 仲良しの メスを 守るため 身を ていして 果敢に 戦う。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "突刺",
-			'zh-cn': "突刺",
-			ja: "つきさす"
+	attacks: [
+		{
+			name: {
+				ja: "つきさす",
+				'zh-tw': "突刺",
+				'zh-cn': "突刺",
+			},
+			damage: 10,
+			cost: ["Darkness"],
 		},
-
-		damage: 10,
-		cost: ["Darkness"]
-	}, {
-		name: {
-			'zh-tw': "頭突",
-			'zh-cn': "頭突",
-			ja: "ぶちかます"
+		{
+			name: {
+				ja: "ぶちかます",
+				'zh-tw': "頭突",
+				'zh-cn': "頭突",
+			},
+			damage: 30,
+			cost: ["Darkness", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Darkness", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821893,
+				tcgplayer: 628702,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [32]
-}
+	dexId: [32],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/062.ts
+++ b/data-asia/SV/SV10/062.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のニドリーノ",
 		'zh-tw': "<火箭隊的>尼多力諾",
 		'zh-cn': "<火箭隊的>尼多力諾",
-		ja: "ロケット団のニドリーノ"
 	},
 
 	illustrator: "KEIICHIRO ITO",
@@ -16,48 +15,60 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
+		ja: "神経質で 喧嘩っ早い。 体内の アドレナリンが 増えると 毒素の 濃度も 高まるぞ。",
 		'zh-tw': "神經質且容易發脾氣打架。 當體內的腎上腺素增加時， 毒素的濃度也會提升。",
 		'zh-cn': "神經質且容易發脾氣打架。 當體內的腎上腺素增加時， 毒素的濃度也會提升。",
-		ja: "神経質で 喧嘩っ早い。 体内の アドレナリンが 増えると 毒素の 濃度も 高まるぞ。"
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "頭突",
-			'zh-cn': "頭突",
-			ja: "ぶちかます"
+	attacks: [
+		{
+			name: {
+				ja: "ぶちかます",
+				'zh-tw': "頭突",
+				'zh-cn': "頭突",
+			},
+			damage: 30,
+			cost: ["Darkness", "Colorless"],
 		},
-
-		damage: 30,
-		cost: ["Darkness", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "角裂",
-			'zh-cn': "角裂",
-			ja: "つのでえぐる"
+		{
+			name: {
+				ja: "つのでえぐる",
+				'zh-tw': "角裂",
+				'zh-cn': "角裂",
+			},
+			damage: "60+",
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにダメカンがのっているなら、60ダメージ追加。",
+				'zh-tw': "若對手的戰鬥寶可夢身上放置有傷害指示物，則增加60點傷害。",
+				'zh-cn': "若對手的戰鬥寶可夢身上放置有傷害指示物，則增加60點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若對手的戰鬥寶可夢身上放置有傷害指示物，則增加60點傷害。",
-			'zh-cn': "若對手的戰鬥寶可夢身上放置有傷害指示物，則增加60點傷害。",
-			ja: "相手のバトルポケモンにダメカンがのっているなら、60ダメージ追加。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821894,
+				tcgplayer: 628703,
+			},
 		},
+	],
 
-		damage: "60＋",
-		cost: ["Darkness", "Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ロケット団のニドラン♂",
+	},
 
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [33]
-}
+	dexId: [33],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/063.ts
+++ b/data-asia/SV/SV10/063.ts
@@ -1,56 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のニドキングex",
 		'zh-tw': "<火箭隊的>尼多王ex",
 		'zh-cn': "<火箭隊的>尼多王ex",
-		ja: "ロケット団のニドキングex"
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Darkness"],
+
 	stage: "Stage2",
-	suffix: "EX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "惡劣角擊",
-			'zh-cn': "惡劣角擊",
-			ja: "ダーティホーン"
+	attacks: [
+		{
+			name: {
+				ja: "ダーティホーン",
+				'zh-tw': "惡劣角擊",
+				'zh-cn': "惡劣角擊",
+			},
+			damage: 100,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。このどくでのせるダメカンの数は8個になる。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】。因這個【中毒】而放置的傷害指示物的數量改為8個。",
+				'zh-cn': "將對手的戰鬥寶可夢【中毒】。因這個【中毒】而放置的傷害指示物的數量改為8個。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。因這個【中毒】而放置的傷害指示物的數量改為8個。",
-			'zh-cn': "將對手的戰鬥寶可夢【中毒】。因這個【中毒】而放置的傷害指示物的數量改為8個。",
-			ja: "相手のバトルポケモンをどくにする。このどくでのせるダメカンの数は8個になる。"
+		{
+			name: {
+				ja: "キングインパクト",
+				'zh-tw': "王者衝擊",
+				'zh-cn': "王者衝擊",
+			},
+			damage: 240,
+			cost: ["Darkness", "Darkness", "Darkness", "Colorless"],
 		},
+	],
 
-		damage: 100,
-		cost: ["Darkness", "Darkness", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "王者衝擊",
-			'zh-cn': "王者衝擊",
-			ja: "キングインパクト"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821895,
+				tcgplayer: 628704,
+			},
 		},
+	],
 
-		damage: 240,
-		cost: ["Darkness", "Darkness", "Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ロケット団のニドリーノ",
+	},
 
 	retreat: 3,
 	regulationMark: "I",
-	rarity: "Double rare"
-}
+	rarity: "Double rare",
+	dexId: [34],
 
-export default card
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV10/064.ts
+++ b/data-asia/SV/SV10/064.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のズバット",
 		'zh-tw': "<火箭隊的>超音蝠",
 		'zh-cn': "<火箭隊的>超音蝠",
-		ja: "ロケット団のズバット"
 	},
 
 	illustrator: "toi8",
@@ -16,43 +15,46 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
+		ja: "陽の 当たらない 洞窟に 棲む。 朝になると 仲間で 集まり 体を 温めあいながら 寝る。",
 		'zh-tw': "棲息在陽光照射不到的洞窟裡。 到了早上就會和夥伴相聚， 一邊互相取暖一邊睡覺。",
 		'zh-cn': "棲息在陽光照射不到的洞窟裡。 到了早上就會和夥伴相聚， 一邊互相取暖一邊睡覺。",
-		ja: "陽の 当たらない 洞窟に 棲む。 朝になると 仲間で 集まり 体を 温めあいながら 寝る。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "噴毒",
-			'zh-cn': "噴毒",
-			ja: "どくをとばす"
+	attacks: [
+		{
+			name: {
+				ja: "どくをとばす",
+				'zh-tw': "噴毒",
+				'zh-cn': "噴毒",
+			},
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】。",
+				'zh-cn': "將對手的戰鬥寶可夢【中毒】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。",
-			'zh-cn': "將對手的戰鬥寶可夢【中毒】。",
-			ja: "相手のバトルポケモンをどくにする。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821896,
+				tcgplayer: 628705,
+			},
 		},
-
-		cost: ["Darkness"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "－30"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [41]
-}
+	dexId: [41],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/065.ts
+++ b/data-asia/SV/SV10/065.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のゴルバット",
 		'zh-tw': "<火箭隊的>大嘴蝠",
 		'zh-cn': "<火箭隊的>大嘴蝠",
-		ja: "ロケット団のゴルバット"
 	},
 
 	illustrator: "AKIRA EGAWA",
@@ -16,60 +15,67 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
+		ja: "小さな 脚で 器用に 歩く。 寝ている 獲物に 忍びより キバを 突きたて 血を すするのだ。",
 		'zh-tw': "能以小小的腳靈巧地步行。 會無聲無息地靠近沉睡中的獵物， 用獠牙咬住對方並且吸食血液。",
 		'zh-cn': "能以小小的腳靈巧地步行。 會無聲無息地靠近沉睡中的獵物， 用獠牙咬住對方並且吸食血液。",
-		ja: "小さな 脚で 器用に 歩く。 寝ている 獲物に 忍びより キバを 突きたて 血を すするのだ。"
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "暗中咬住",
-			'zh-cn': "暗中咬住",
-			ja: "こっそりかみつく"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "こっそりかみつく",
+				'zh-tw': "暗中咬住",
+				'zh-cn': "暗中咬住",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のポケモン1匹に、ダメカンを2個のせる。",
+				'zh-tw': "在自己的回合，從手牌使出這張卡並完成進化時，可使用1次。在對手的1隻寶可夢身上放置2個傷害指示物。",
+				'zh-cn': "在自己的回合，從手牌使出這張卡並完成進化時，可使用1次。在對手的1隻寶可夢身上放置2個傷害指示物。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，從手牌使出這張卡並完成進化時，可使用1次。在對手的1隻寶可夢身上放置2個傷害指示物。",
-			'zh-cn': "在自己的回合，從手牌使出這張卡並完成進化時，可使用1次。在對手的1隻寶可夢身上放置2個傷害指示物。",
-			ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のポケモン1匹に、ダメカンを2個のせる。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "奇異之光",
-			'zh-cn': "奇異之光",
-			ja: "あやしいひかり"
+	attacks: [
+		{
+			name: {
+				ja: "あやしいひかり",
+				'zh-tw': "奇異之光",
+				'zh-cn': "奇異之光",
+			},
+			damage: 30,
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【混亂】。",
+				'zh-cn': "將對手的戰鬥寶可夢【混亂】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【混亂】。",
-			'zh-cn': "將對手的戰鬥寶可夢【混亂】。",
-			ja: "相手のバトルポケモンをこんらんにする。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821897,
+				tcgplayer: 628706,
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Darkness"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "－30"
-	}],
+	evolveFrom: {
+		ja: "ロケット団のズバット",
+	},
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Uncommon",
-	dexId: [42]
-}
+	dexId: [42],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/066.ts
+++ b/data-asia/SV/SV10/066.ts
@@ -1,68 +1,77 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のクロバットex",
 		'zh-tw': "<火箭隊的>叉字蝠ex",
 		'zh-cn': "<火箭隊的>叉字蝠ex",
-		ja: "ロケット団のクロバットex"
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 310,
 	types: ["Darkness"],
+
 	stage: "Stage2",
-	suffix: "EX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "亂咬",
-			'zh-cn': "亂咬",
-			ja: "かみつきまわる"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "かみつきまわる",
+				'zh-tw': "亂咬",
+				'zh-cn': "亂咬",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のポケモン2匹に、それぞれダメカンを2個のせる。",
+				'zh-tw': "在自己的回合，從手牌使出這張卡並完成進化時，可使用1次。在對手的2隻寶可夢身上各放置2個傷害指示物。",
+				'zh-cn': "在自己的回合，從手牌使出這張卡並完成進化時，可使用1次。在對手的2隻寶可夢身上各放置2個傷害指示物。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，從手牌使出這張卡並完成進化時，可使用1次。在對手的2隻寶可夢身上各放置2個傷害指示物。",
-			'zh-cn': "在自己的回合，從手牌使出這張卡並完成進化時，可使用1次。在對手的2隻寶可夢身上各放置2個傷害指示物。",
-			ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のポケモン2匹に、それぞれダメカンを2個のせる。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "刺殺迴旋",
-			'zh-cn': "刺殺迴旋",
-			ja: "アサシンリターン"
+	attacks: [
+		{
+			name: {
+				ja: "アサシンリターン",
+				'zh-tw': "刺殺迴旋",
+				'zh-cn': "刺殺迴旋",
+			},
+			damage: 120,
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "のぞむなら、このポケモンを手札にもどす。（ポケモン以外のカードは、すべてトラッシュする。）",
+				'zh-tw': "若希望，將這隻寶可夢放回手牌。（寶可夢以外的卡全部丟棄。）",
+				'zh-cn': "若希望，將這隻寶可夢放回手牌。（寶可夢以外的卡全部丟棄。）",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若希望，將這隻寶可夢放回手牌。（寶可夢以外的卡全部丟棄。）",
-			'zh-cn': "若希望，將這隻寶可夢放回手牌。（寶可夢以外的卡全部丟棄。）",
-			ja: "のぞむなら、このポケモンを手札にもどす。（ポケモン以外のカードは、すべてトラッシュする。）"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821898,
+				tcgplayer: 628707,
+			},
 		},
+	],
 
-		damage: 120,
-		cost: ["Darkness", "Darkness"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "－30"
-	}],
+	evolveFrom: {
+		ja: "ロケット団のゴルバット",
+	},
 
 	retreat: 1,
 	regulationMark: "I",
-	rarity: "Double rare"
-}
+	rarity: "Double rare",
+	dexId: [169],
 
-export default card
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV10/067.ts
+++ b/data-asia/SV/SV10/067.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のベトベター",
 		'zh-tw': "<火箭隊的>臭泥",
 		'zh-cn': "<火箭隊的>臭泥",
-		ja: "ロケット団のベトベター"
 	},
 
 	illustrator: "Mousho",
@@ -16,38 +15,46 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
+		ja: "ヘドロが ポケモンになった。 汚い 場所に 集まって 体の ばい菌を 増やしていく。",
 		'zh-tw': "污泥變成的寶可夢。 會聚集在骯髒的地方 來繁殖身體的細菌。",
 		'zh-cn': "污泥變成的寶可夢。 會聚集在骯髒的地方 來繁殖身體的細菌。",
-		ja: "ヘドロが ポケモンになった。 汚い 場所に 集まって 体の ばい菌を 増やしていく。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "浸蝕污泥",
-			'zh-cn': "浸蝕污泥",
-			ja: "しんしょくヘドロ"
+	attacks: [
+		{
+			name: {
+				ja: "しんしょくヘドロ",
+				'zh-tw': "浸蝕污泥",
+				'zh-cn': "浸蝕污泥",
+			},
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "次の相手の番の終わりに、このワザを受けたポケモンと、ついているすべてのカードを、トラッシュする。",
+				'zh-tw': "在下個對手的回合結束時，將受到這個招式的寶可夢與附加的卡全部丟棄。",
+				'zh-cn': "在下個對手的回合結束時，將受到這個招式的寶可夢與附加的卡全部丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合結束時，將受到這個招式的寶可夢與附加的卡全部丟棄。",
-			'zh-cn': "在下個對手的回合結束時，將受到這個招式的寶可夢與附加的卡全部丟棄。",
-			ja: "次の相手の番の終わりに、このワザを受けたポケモンと、ついているすべてのカードを、トラッシュする。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821899,
+				tcgplayer: 628708,
+			},
 		},
-
-		cost: ["Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 3,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [88]
-}
+	dexId: [88],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/068.ts
+++ b/data-asia/SV/SV10/068.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のベトベトン",
 		'zh-tw': "<火箭隊的>臭臭泥",
 		'zh-cn': "<火箭隊的>臭臭泥",
-		ja: "ロケット団のベトベトン"
 	},
 
 	illustrator: "Uta",
@@ -16,54 +15,65 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
+		ja: "汚い ヘドロが 全身に まとわりつく。 足跡に 触っただけで 毒に 侵される。",
 		'zh-tw': "全身上下沾滿污泥。 光是碰到牠的足跡， 都會受到毒素的侵襲。",
 		'zh-cn': "全身上下沾滿污泥。 光是碰到牠的足跡， 都會受到毒素的侵襲。",
-		ja: "汚い ヘドロが 全身に まとわりつく。 足跡に 触っただけで 毒に 侵される。"
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "渾身臭臭",
-			'zh-cn': "渾身臭臭",
-			ja: "ベトベトまみれ"
+	attacks: [
+		{
+			name: {
+				ja: "ベトベトまみれ",
+				'zh-tw': "渾身臭臭",
+				'zh-cn': "渾身臭臭",
+			},
+			damage: 40,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。次の相手の番、このワザを受けたポケモンは、にげられない。",
+				'zh-tw': "將對手的戰鬥寶可夢【混亂】。在下個對手的回合，受到這個招式的寶可夢無法撤退。",
+				'zh-cn': "將對手的戰鬥寶可夢【混亂】。在下個對手的回合，受到這個招式的寶可夢無法撤退。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【混亂】。在下個對手的回合，受到這個招式的寶可夢無法撤退。",
-			'zh-cn': "將對手的戰鬥寶可夢【混亂】。在下個對手的回合，受到這個招式的寶可夢無法撤退。",
-			ja: "相手のバトルポケモンをこんらんにする。次の相手の番、このワザを受けたポケモンは、にげられない。"
+		{
+			name: {
+				ja: "ベノムハザード",
+				'zh-tw': "毒液危害",
+				'zh-cn': "毒液危害",
+			},
+			damage: "100×",
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが受けている特殊状態の数×100ダメージ。",
+				'zh-tw': "造成對手的戰鬥寶可夢處於特殊狀態的數量×100點傷害。",
+				'zh-cn': "造成對手的戰鬥寶可夢處於特殊狀態的數量×100點傷害。",
+			},
 		},
+	],
 
-		damage: 40,
-		cost: ["Darkness", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "毒液危害",
-			'zh-cn': "毒液危害",
-			ja: "ベノムハザード"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821900,
+				tcgplayer: 628709,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "造成對手的戰鬥寶可夢處於特殊狀態的數量×100點傷害。",
-			'zh-cn': "造成對手的戰鬥寶可夢處於特殊狀態的數量×100點傷害。",
-			ja: "相手のバトルポケモンが受けている特殊状態の数×100ダメージ。"
-		},
-
-		damage: "100×",
-		cost: ["Darkness", "Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ロケット団のベトベター",
+	},
 
 	retreat: 4,
 	regulationMark: "I",
 	rarity: "Uncommon",
-	dexId: [89]
-}
+	dexId: [89],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/069.ts
+++ b/data-asia/SV/SV10/069.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のドガース",
 		'zh-tw': "<火箭隊的>瓦斯彈",
 		'zh-cn': "<火箭隊的>瓦斯彈",
-		ja: "ロケット団のドガース"
 	},
 
 	illustrator: "kodama",
@@ -16,49 +15,58 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
+		ja: "薄い バルーン状の 体に 猛毒の ガスが 詰まっているので ときどき 大爆発を 起こす。",
 		'zh-tw': "薄薄的氣球狀身體裡 儲滿了劇毒的瓦斯， 所以有時會發生大爆炸。",
 		'zh-cn': "薄薄的氣球狀身體裡 儲滿了劇毒的瓦斯， 所以有時會發生大爆炸。",
-		ja: "薄い バルーン状の 体に 猛毒の ガスが 詰まっているので ときどき 大爆発を 起こす。"
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "警備濁霧",
-			'zh-cn': "警備濁霧",
-			ja: "アラートスモッグ"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "アラートスモッグ",
+				'zh-tw': "警備濁霧",
+				'zh-cn': "警備濁霧",
+			},
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、自分の山札から、名前に「ドガース」とつくポケモンを2枚まで選び、ベンチに出す。そして山札を切る。",
+				'zh-tw': "這隻寶可夢在戰鬥場受到對手的寶可夢招式的傷害時，從自己的牌庫選擇最多2張名稱中有「瓦斯彈」的寶可夢卡，放置於備戰區。並且重洗牌庫。",
+				'zh-cn': "這隻寶可夢在戰鬥場受到對手的寶可夢招式的傷害時，從自己的牌庫選擇最多2張名稱中有「瓦斯彈」的寶可夢卡，放置於備戰區。並且重洗牌庫。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢在戰鬥場受到對手的寶可夢招式的傷害時，從自己的牌庫選擇最多2張名稱中有「瓦斯彈」的寶可夢卡，放置於備戰區。並且重洗牌庫。",
-			'zh-cn': "這隻寶可夢在戰鬥場受到對手的寶可夢招式的傷害時，從自己的牌庫選擇最多2張名稱中有「瓦斯彈」的寶可夢卡，放置於備戰區。並且重洗牌庫。",
-			ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、自分の山札から、名前に「ドガース」とつくポケモンを2枚まで選び、ベンチに出す。そして山札を切る。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "瓦斯漏氣",
-			'zh-cn': "瓦斯漏氣",
-			ja: "ガスもれ"
+	attacks: [
+		{
+			name: {
+				ja: "ガスもれ",
+				'zh-tw': "瓦斯漏氣",
+				'zh-cn': "瓦斯漏氣",
+			},
+			damage: 30,
+			cost: ["Darkness", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Darkness", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821901,
+				tcgplayer: 628710,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [109]
-}
+	dexId: [109],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/070.ts
+++ b/data-asia/SV/SV10/070.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のマタドガス",
 		'zh-tw': "<火箭隊的>雙彈瓦斯",
 		'zh-cn': "<火箭隊的>雙彈瓦斯",
-		ja: "ロケット団のマタドガス"
 	},
 
 	illustrator: "matazo",
@@ -16,39 +15,51 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
+		ja: "体内に 含まれる 毒ガスを ぎりぎりまで 薄めると 最高級の 香水ができる。",
 		'zh-tw': "若將牠體內所含的 毒瓦斯稀釋到極限， 就能做出最高級的香水。",
 		'zh-cn': "若將牠體內所含的 毒瓦斯稀釋到極限， 就能做出最高級的香水。",
-		ja: "体内に 含まれる 毒ガスを ぎりぎりまで 薄めると 最高級の 香水ができる。"
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "一併爆炸",
-			'zh-cn': "一併爆炸",
-			ja: "いっせいばくはつ"
+	attacks: [
+		{
+			name: {
+				ja: "いっせいばくはつ",
+				'zh-tw': "一併爆炸",
+				'zh-cn': "一併爆炸",
+			},
+			damage: "40×",
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "おたがいの場の、名前に「ドガース」または「マタドガス」とつくポケモンの数×40ダメージ。",
+				'zh-tw': "造成雙方的場上的，名稱中有「瓦斯彈」或者「雙彈瓦斯」的寶可夢的數量×40點傷害。",
+				'zh-cn': "造成雙方的場上的，名稱中有「瓦斯彈」或者「雙彈瓦斯」的寶可夢的數量×40點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "造成雙方的場上的，名稱中有「瓦斯彈」或者「雙彈瓦斯」的寶可夢的數量×40點傷害。",
-			'zh-cn': "造成雙方的場上的，名稱中有「瓦斯彈」或者「雙彈瓦斯」的寶可夢的數量×40點傷害。",
-			ja: "おたがいの場の、名前に「ドガース」または「マタドガス」とつくポケモンの数×40ダメージ。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821902,
+				tcgplayer: 628711,
+			},
 		},
+	],
 
-		damage: "40×",
-		cost: ["Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ロケット団のドガース",
+	},
 
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Uncommon",
-	dexId: [110]
-}
+	dexId: [110],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/071.ts
+++ b/data-asia/SV/SV10/071.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のヤミカラス",
 		'zh-tw': "<火箭隊的>黑暗鴉",
 		'zh-cn': "<火箭隊的>黑暗鴉",
-		ja: "ロケット団のヤミカラス"
 	},
 
 	illustrator: "Mugi Hamada",
@@ -16,58 +15,60 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
+		ja: "夜 姿を 見かけると 不吉なことが 起きると 信じられ 忌み嫌われている ポケモン。",
 		'zh-tw': "人們相信晚上看到牠 就會發生不吉利的事， 這讓牠成了人見人厭的寶可夢。",
 		'zh-cn': "人們相信晚上看到牠 就會發生不吉利的事， 這讓牠成了人見人厭的寶可夢。",
-		ja: "夜 姿を 見かけると 不吉なことが 起きると 信じられ 忌み嫌われている ポケモン。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "誑騙",
-			'zh-cn': "誑騙",
-			ja: "たぶらかす"
+	attacks: [
+		{
+			name: {
+				ja: "たぶらかす",
+				'zh-tw': "誑騙",
+				'zh-cn': "誑騙",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からサポートを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張支援者卡，在給對手看過後加入手牌。並且重洗牌庫。",
+				'zh-cn': "從自己的牌庫選擇1張支援者卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張支援者卡，在給對手看過後加入手牌。並且重洗牌庫。",
-			'zh-cn': "從自己的牌庫選擇1張支援者卡，在給對手看過後加入手牌。並且重洗牌庫。",
-			ja: "自分の山札からサポートを1枚選び、相手に見せて、手札に加える。そして山札を切る。"
+		{
+			name: {
+				ja: "いちゃもん",
+				'zh-tw': "無理取鬧",
+				'zh-cn': "無理取鬧",
+			},
+			damage: 30,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが持つワザを1つ選ぶ。次の相手の番、このワザを受けたポケモンは、選ばれたワザが使えない。",
+				'zh-tw': "選擇1個對手的戰鬥寶可夢持有的招式。在下個對手的回合，受到這個招式的寶可夢無法使用被選擇的招式。",
+				'zh-cn': "選擇1個對手的戰鬥寶可夢持有的招式。在下個對手的回合，受到這個招式的寶可夢無法使用被選擇的招式。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "無理取鬧",
-			'zh-cn': "無理取鬧",
-			ja: "いちゃもん"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821903,
+				tcgplayer: 628712,
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇1個對手的戰鬥寶可夢持有的招式。在下個對手的回合，受到這個招式的寶可夢無法使用被選擇的招式。",
-			'zh-cn': "選擇1個對手的戰鬥寶可夢持有的招式。在下個對手的回合，受到這個招式的寶可夢無法使用被選擇的招式。",
-			ja: "相手のバトルポケモンが持つワザを1つ選ぶ。次の相手の番、このワザを受けたポケモンは、選ばれたワザが使えない。"
-		},
-
-		damage: 30,
-		cost: ["Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "－30"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Uncommon",
-	dexId: [198]
-}
+	dexId: [198],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/072.ts
+++ b/data-asia/SV/SV10/072.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のニューラ",
 		'zh-tw': "<火箭隊的>狃拉",
 		'zh-cn': "<火箭隊的>狃拉",
-		ja: "ロケット団のニューラ"
 	},
 
 	illustrator: "GIDORA",
@@ -16,47 +15,55 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
+		ja: "自分が 目立たないよう 暗闇に まぎれて 獲物に 襲いかかる とても ずる賢い ポケモン。",
 		'zh-tw': "會潛藏在黑暗中使自己變得 不起眼，然後伺機襲擊獵物， 是非常狡詐的寶可夢。",
 		'zh-cn': "會潛藏在黑暗中使自己變得 不起眼，然後伺機襲擊獵物， 是非常狡詐的寶可夢。",
-		ja: "自分が 目立たないよう 暗闇に まぎれて 獲物に 襲いかかる とても ずる賢い ポケモン。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "抓",
-			'zh-cn': "抓",
-			ja: "ひっかく"
+	attacks: [
+		{
+			name: {
+				ja: "ひっかく",
+				'zh-tw': "抓",
+				'zh-cn': "抓",
+			},
+			damage: 20,
+			cost: ["Darkness"],
 		},
-
-		damage: 20,
-		cost: ["Darkness"]
-	}, {
-		name: {
-			'zh-tw': "暗算",
-			'zh-cn': "暗算",
-			ja: "ねくびをかく"
+		{
+			name: {
+				ja: "ねくびをかく",
+				'zh-tw': "暗算",
+				'zh-cn': "暗算",
+			},
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "相手のベンチポケモン1匹に、そのポケモンにのっているダメカンの数×20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的1隻備戰寶可夢，受到那隻寶可夢身上放置的傷害指示物的數量×20點傷害。[在備戰區不計算弱點・抵抗力。]",
+				'zh-cn': "對手的1隻備戰寶可夢，受到那隻寶可夢身上放置的傷害指示物的數量×20點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "對手的1隻備戰寶可夢，受到那隻寶可夢身上放置的傷害指示物的數量×20點傷害。[在備戰區不計算弱點・抵抗力。]",
-			'zh-cn': "對手的1隻備戰寶可夢，受到那隻寶可夢身上放置的傷害指示物的數量×20點傷害。[在備戰區不計算弱點・抵抗力。]",
-			ja: "相手のベンチポケモン1匹に、そのポケモンにのっているダメカンの数×20ダメージ。［ベンチは弱点・抵抗力を計算しない。］"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821904,
+				tcgplayer: 628713,
+			},
 		},
-
-		cost: ["Darkness", "Darkness"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Rare",
-	dexId: [215]
-}
+	dexId: [215],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/073.ts
+++ b/data-asia/SV/SV10/073.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "フォレトス",
 		'zh-tw': "佛烈托斯",
 		'zh-cn': "佛烈托斯",
-		ja: "フォレトス"
 	},
 
 	illustrator: "Wintr Wandr",
@@ -16,59 +15,65 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
+		ja: "太い 木の幹に くっついている。 なにかの 気配を 感じるたび 殻の 破片を 撃ち出すのだ。",
 		'zh-tw': "總是貼著在粗大的樹幹上。 一旦察覺到了什麼， 就會射出外殼的碎片。",
 		'zh-cn': "總是貼著在粗大的樹幹上。 一旦察覺到了什麼， 就會射出外殼的碎片。",
-		ja: "太い 木の幹に くっついている。 なにかの 気配を 感じるたび 殻の 破片を 撃ち出すのだ。"
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "鐵之震動",
-			'zh-cn': "鐵之震動",
-			ja: "アイアンシェイク"
+	attacks: [
+		{
+			name: {
+				ja: "アイアンシェイク",
+				'zh-tw': "鐵之震動",
+				'zh-cn': "鐵之震動",
+			},
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[M]エネルギーを好きなだけ選び、自分のポケモンに好きなようにつけ替える。",
+				'zh-tw': "選擇自己的場上寶可夢身上附加的任意數量的【鋼】能量卡，以任意方式改附於自己的寶可夢身上。",
+				'zh-cn': "選擇自己的場上寶可夢身上附加的任意數量的【鋼】能量卡，以任意方式改附於自己的寶可夢身上。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇自己的場上寶可夢身上附加的任意數量的【鋼】能量卡，以任意方式改附於自己的寶可夢身上。",
-			'zh-cn': "選擇自己的場上寶可夢身上附加的任意數量的【鋼】能量卡，以任意方式改附於自己的寶可夢身上。",
-			ja: "自分の場のポケモンについているエネルギーを好きなだけ選び、自分のポケモンに好きなようにつけ替える。"
+		{
+			name: {
+				ja: "ハリケーンニードル",
+				'zh-tw': "颶風尖刺",
+				'zh-cn': "颶風尖刺",
+			},
+			damage: "80×",
+			cost: ["Metal", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを4回投げ、オモテの数×80ダメージ。",
+				'zh-tw': "擲4次硬幣，造成正面出現的次數×80點傷害。",
+				'zh-cn': "擲4次硬幣，造成正面出現的次數×80點傷害。",
+			},
 		},
+	],
 
-		damage: 20,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "颶風尖刺",
-			'zh-cn': "颶風尖刺",
-			ja: "ハリケーンニードル"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821905,
+				tcgplayer: 628714,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲4次硬幣，造成正面出現的次數×80點傷害。",
-			'zh-cn': "擲4次硬幣，造成正面出現的次數×80點傷害。",
-			ja: "コインを4回投げ、オモテの数×80ダメージ。"
-		},
-
-		damage: "80×",
-		cost: ["Metal", "Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "－30"
-	}],
+	evolveFrom: {
+		ja: "クヌギダマ",
+	},
 
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Uncommon",
-	dexId: [205]
-}
+	dexId: [205],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/074.ts
+++ b/data-asia/SV/SV10/074.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "エアームド",
 		'zh-tw': "盔甲鳥",
 		'zh-cn': "盔甲鳥",
-		ja: "エアームド"
 	},
 
 	illustrator: "Shin Nagasawa",
@@ -16,52 +15,55 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
+		ja: "頑丈で 重そうな 鉄の 体だが 薄くて 軽いので 時速３００キロで とべる。",
 		'zh-tw': "鐵的身體雖然看起來結實沉重， 但其實又薄又輕，因此牠的 飛行速度可達時速３００公里。",
 		'zh-cn': "鐵的身體雖然看起來結實沉重， 但其實又薄又輕，因此牠的 飛行速度可達時速３００公里。",
-		ja: "頑丈で 重そうな 鉄の 体だが 薄くて 軽いので 時速３００キロで とべる。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "羽棲",
-			'zh-cn': "羽棲",
-			ja: "はねやすめ"
+	attacks: [
+		{
+			name: {
+				ja: "はねやすめ",
+				'zh-tw': "羽棲",
+				'zh-cn': "羽棲",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「50」回復する。次の自分の番、このポケモンはにげられない。",
+				'zh-tw': "將這隻寶可夢恢復「50」HP。在下個自己的回合，這隻寶可夢無法撤退。",
+				'zh-cn': "將這隻寶可夢恢復「50」HP。在下個自己的回合，這隻寶可夢無法撤退。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將這隻寶可夢恢復「50」HP。在下個自己的回合，這隻寶可夢無法撤退。",
-			'zh-cn': "將這隻寶可夢恢復「50」HP。在下個自己的回合，這隻寶可夢無法撤退。",
-			ja: "このポケモンのHPを「50」回復する。次の自分の番、このポケモンはにげられない。"
+		{
+			name: {
+				ja: "メタルクロー",
+				'zh-tw': "金屬爪",
+				'zh-cn': "金屬爪",
+			},
+			damage: 60,
+			cost: ["Metal", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "金屬爪",
-			'zh-cn': "金屬爪",
-			ja: "メタルクロー"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821906,
+				tcgplayer: 628715,
+			},
 		},
-
-		damage: 60,
-		cost: ["Metal", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "－30"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [227]
-}
+	dexId: [227],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/075.ts
+++ b/data-asia/SV/SV10/075.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ザマゼンタ",
 		'zh-tw': "藏瑪然特",
 		'zh-cn': "藏瑪然特",
-		ja: "ザマゼンタ"
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -16,44 +15,47 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
+		ja: "いかなる 攻撃も 弾き返す 姿は 格闘王の盾 と 呼ばれ 恐れ 崇められた。",
 		'zh-tw': "能夠反彈一切的攻擊， 因此被稱為格鬥王之盾， 受到人們的畏懼與尊崇。",
 		'zh-cn': "能夠反彈一切的攻擊， 因此被稱為格鬥王之盾， 受到人們的畏懼與尊崇。",
-		ja: "いかなる 攻撃も 弾き返す 姿は 格闘王の盾 と 呼ばれ 恐れ 崇められた。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "強大猛擊",
-			'zh-cn': "強大猛擊",
-			ja: "ストロングバッシュ"
+	attacks: [
+		{
+			name: {
+				ja: "ストロングバッシュ",
+				'zh-tw': "強大猛擊",
+				'zh-cn': "強大猛擊",
+			},
+			damage: 70,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンがワザのダメージを受けたとき、受けたダメージぶんのダメカンを、ワザを使ったポケモンにのせる。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害時，將與受到的傷害相同數值的傷害指示物，放置於使用招式的寶可夢身上。",
+				'zh-cn': "在下個對手的回合，這隻寶可夢受到招式的傷害時，將與受到的傷害相同數值的傷害指示物，放置於使用招式的寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害時，將與受到的傷害相同數值的傷害指示物，放置於使用招式的寶可夢身上。",
-			'zh-cn': "在下個對手的回合，這隻寶可夢受到招式的傷害時，將與受到的傷害相同數值的傷害指示物，放置於使用招式的寶可夢身上。",
-			ja: "次の相手の番、このポケモンがワザのダメージを受けたとき、受けたダメージぶんのダメカンを、ワザを使ったポケモンにのせる。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821907,
+				tcgplayer: 628716,
+			},
 		},
-
-		damage: 70,
-		cost: ["Metal", "Metal", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "－30"
-	}],
+	],
 
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Rare",
-	dexId: [889]
-}
+	dexId: [889],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/076.ts
+++ b/data-asia/SV/SV10/076.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のコラッタ",
 		'zh-tw': "<火箭隊的>小拉達",
 		'zh-cn': "<火箭隊的>小拉達",
-		ja: "ロケット団のコラッタ"
 	},
 
 	illustrator: "Dsuke",
@@ -16,39 +15,47 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
+		ja: "ありふれた ポケモンだが 注意。 鋭い 前歯は 堅い 材木さえ 簡単に へしおる。",
 		'zh-tw': "雖然是常見的寶可夢，但還是要小心。 銳利的門牙十分堅硬， 就連木材也能輕易咬斷。",
 		'zh-cn': "雖然是常見的寶可夢，但還是要小心。 銳利的門牙十分堅硬， 就連木材也能輕易咬斷。",
-		ja: "ありふれた ポケモンだが 注意。 鋭い 前歯は 堅い 材木さえ 簡単に へしおる。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "險惡門牙",
-			'zh-cn': "險惡門牙",
-			ja: "あぶないまえば"
+	attacks: [
+		{
+			name: {
+				ja: "あぶないまえば",
+				'zh-tw': "險惡門牙",
+				'zh-cn': "險惡門牙",
+			},
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】。",
+				'zh-cn': "將對手的戰鬥寶可夢【中毒】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。",
-			'zh-cn': "將對手的戰鬥寶可夢【中毒】。",
-			ja: "相手のバトルポケモンをどくにする。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821908,
+				tcgplayer: 628717,
+			},
 		},
-
-		damage: 10,
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [19]
-}
+	dexId: [19],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/077.ts
+++ b/data-asia/SV/SV10/077.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のラッタ",
 		'zh-tw': "<火箭隊的>拉達",
 		'zh-cn': "<火箭隊的>拉達",
-		ja: "ロケット団のラッタ"
 	},
 
 	illustrator: "Uninori",
@@ -16,39 +15,51 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
+		ja: "ヒゲは バランスを とる 大切な 器官。 どんなに 仲良くなっても 触られると 怒って 噛みつく。",
 		'zh-tw': "鬍鬚是用來保持平衡的重要器官。 就算感情再好，如果摸了牠的鬍鬚， 牠都會生氣地咬過來。",
 		'zh-cn': "鬍鬚是用來保持平衡的重要器官。 就算感情再好，如果摸了牠的鬍鬚， 牠都會生氣地咬過來。",
-		ja: "ヒゲは バランスを とる 大切な 器官。 どんなに 仲良くなっても 触られると 怒って 噛みつく。"
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "顧前不顧後",
-			'zh-cn': "顧前不顧後",
-			ja: "むこうみず"
+	attacks: [
+		{
+			name: {
+				ja: "むこうみず",
+				'zh-tw': "顧前不顧後",
+				'zh-cn': "顧前不顧後",
+			},
+			damage: 90,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを2回投げ、すべてウラなら、このポケモンにも90ダメージ。",
+				'zh-tw': "擲2次硬幣，若全部為反面，則這隻寶可夢也受到90點傷害。",
+				'zh-cn': "擲2次硬幣，若全部為反面，則這隻寶可夢也受到90點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲2次硬幣，若全部為反面，則這隻寶可夢也受到90點傷害。",
-			'zh-cn': "擲2次硬幣，若全部為反面，則這隻寶可夢也受到90點傷害。",
-			ja: "コインを2回投げ、すべてウラなら、このポケモンにも90ダメージ。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821909,
+				tcgplayer: 628718,
+			},
 		},
+	],
 
-		damage: 90,
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ロケット団のコラッタ",
+	},
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [20]
-}
+	dexId: [20],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/078.ts
+++ b/data-asia/SV/SV10/078.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のニャース",
 		'zh-tw': "<火箭隊的>喵喵",
 		'zh-cn': "<火箭隊的>喵喵",
-		ja: "ロケット団のニャース"
 	},
 
 	illustrator: "Megumi Mizutani",
@@ -16,53 +15,60 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
+		ja: "昼間は 寝てばかりいる。 夜になると 目が 輝き 縄張りを 歩きまわる。",
 		'zh-tw': "白天一直都在睡覺。 到了晚上眼睛就會發光， 在自己的地盤徘徊。",
 		'zh-cn': "白天一直都在睡覺。 到了晚上眼睛就會發光， 在自己的地盤徘徊。",
-		ja: "昼間は 寝てばかりいる。 夜になると 目が 輝き 縄張りを 歩きまわる。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "占為己有",
-			'zh-cn': "占為己有",
-			ja: "ねこばば"
+	attacks: [
+		{
+			name: {
+				ja: "ねこばば",
+				'zh-tw': "占為己有",
+				'zh-cn': "占為己有",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、そのカードのオモテを見て、相手の山札にもどして切る。",
+				'zh-tw': "在不看正面的情況下，從對手的手牌選擇1張，查看那張卡的正面後放回對手的牌庫並重洗。",
+				'zh-cn': "在不看正面的情況下，從對手的手牌選擇1張，查看那張卡的正面後放回對手的牌庫並重洗。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在不看正面的情況下，從對手的手牌選擇1張，查看那張卡的正面後放回對手的牌庫並重洗。",
-			'zh-cn': "在不看正面的情況下，從對手的手牌選擇1張，查看那張卡的正面後放回對手的牌庫並重洗。",
-			ja: "相手の手札からオモテを見ないで1枚選び、そのカードのオモテを見て、相手の山札にもどして切る。"
+		{
+			name: {
+				ja: "みだれひっかき",
+				'zh-tw': "亂抓",
+				'zh-cn': "亂抓",
+			},
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数×20ダメージ。",
+				'zh-tw': "擲3次硬幣，造成正面出現的次數×20點傷害。",
+				'zh-cn': "擲3次硬幣，造成正面出現的次數×20點傷害。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "亂抓",
-			'zh-cn': "亂抓",
-			ja: "みだれひっかき"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821910,
+				tcgplayer: 628719,
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲3次硬幣，造成正面出現的次數×20點傷害。",
-			'zh-cn': "擲3次硬幣，造成正面出現的次數×20點傷害。",
-			ja: "コインを3回投げ、オモテの数×20ダメージ。"
-		},
-
-		damage: "20×",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [52]
-}
+	dexId: [52],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/079.ts
+++ b/data-asia/SV/SV10/079.ts
@@ -1,61 +1,74 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のペルシアンex",
 		'zh-tw': "<火箭隊的>貓老大ex",
 		'zh-cn': "<火箭隊的>貓老大ex",
-		ja: "ロケット団のペルシアンex"
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 260,
 	types: ["Colorless"],
+
 	stage: "Stage1",
-	suffix: "EX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "高傲指令",
-			'zh-cn': "高傲指令",
-			ja: "こうまんしれい"
+	attacks: [
+		{
+			name: {
+				ja: "こうまんしれい",
+				'zh-tw': "高傲指令",
+				'zh-cn': "高傲指令",
+			},
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手の山札を上から10枚オモテにする。のぞむなら、その中にあるポケモンが持つワザを1つ選び、このワザとして使う。オモテにしたカードは山札にもどして切る。",
+				'zh-tw': "將對手的牌庫上方10張卡翻到正面。若希望，選擇1個其中的寶可夢持有的招式，作為這個招式使用。將翻到正面的卡放回牌庫並重洗。",
+				'zh-cn': "將對手的牌庫上方10張卡翻到正面。若希望，選擇1個其中的寶可夢持有的招式，作為這個招式使用。將翻到正面的卡放回牌庫並重洗。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的牌庫上方10張卡翻到正面。若希望，選擇1個其中的寶可夢持有的招式，作為這個招式使用。將翻到正面的卡放回牌庫並重洗。",
-			'zh-cn': "將對手的牌庫上方10張卡翻到正面。若希望，選擇1個其中的寶可夢持有的招式，作為這個招式使用。將翻到正面的卡放回牌庫並重洗。",
-			ja: "相手の山札を上から10枚オモテにする。のぞむなら、その中にあるポケモンが持つワザを1つ選び、このワザとして使う。オモテにしたカードは山札にもどして切る。"
+		{
+			name: {
+				ja: "クルーエルスラッシュ",
+				'zh-tw': "殘酷斬",
+				'zh-cn': "殘酷斬",
+			},
+			damage: 140,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【混亂】。",
+				'zh-cn': "將對手的戰鬥寶可夢【混亂】。",
+			},
 		},
+	],
 
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "殘酷斬",
-			'zh-cn': "殘酷斬",
-			ja: "クルーエルスラッシュ"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821911,
+				tcgplayer: 628720,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【混亂】。",
-			'zh-cn': "將對手的戰鬥寶可夢【混亂】。",
-			ja: "相手のバトルポケモンをこんらんにする。"
-		},
-
-		damage: 140,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ロケット団のニャース",
+	},
 
 	retreat: 2,
 	regulationMark: "I",
-	rarity: "Double rare"
-}
+	rarity: "Double rare",
+	dexId: [53],
 
-export default card
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV10/080.ts
+++ b/data-asia/SV/SV10/080.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ガルーラ",
 		'zh-tw': "袋獸",
 		'zh-cn': "袋獸",
-		ja: "ガルーラ"
 	},
 
 	illustrator: "Sanosuke Sakuma",
@@ -16,48 +15,56 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
+		ja: "子どもの いない ガルーラが 遭難した 人間の 子を 育てていたという 記録がある。",
 		'zh-tw': "紀錄中記載著， 曾經有沒孩子的袋獸 養育了遇難的人類孩子。",
 		'zh-cn': "紀錄中記載著， 曾經有沒孩子的袋獸 養育了遇難的人類孩子。",
-		ja: "子どもの いない ガルーラが 遭難した 人間の 子を 育てていたという 記録がある。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "重摑",
-			'zh-cn': "重摑",
-			ja: "ひっぱたく"
+	attacks: [
+		{
+			name: {
+				ja: "ひっぱたく",
+				'zh-tw': "重摑",
+				'zh-cn': "重摑",
+			},
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
 		},
-
-		damage: 50,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "迷昏拳",
-			'zh-cn': "迷昏拳",
-			ja: "ピヨピヨパンチ"
+		{
+			name: {
+				ja: "ピヨピヨパンチ",
+				'zh-tw': "迷昏拳",
+				'zh-cn': "迷昏拳",
+			},
+			damage: "90×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×90ダメージ。",
+				'zh-tw': "擲2次硬幣，造成正面出現的次數×90點傷害。",
+				'zh-cn': "擲2次硬幣，造成正面出現的次數×90點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲2次硬幣，造成正面出現的次數×90點傷害。",
-			'zh-cn': "擲2次硬幣，造成正面出現的次數×90點傷害。",
-			ja: "コインを2回投げ、オモテの数×90ダメージ。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821912,
+				tcgplayer: 628721,
+			},
 		},
-
-		damage: "90×",
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [115]
-}
+	dexId: [115],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/081.ts
+++ b/data-asia/SV/SV10/081.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のポリゴン",
 		'zh-tw': "<火箭隊的>多邊獸",
 		'zh-cn': "<火箭隊的>多邊獸",
-		ja: "ロケット団のポリゴン"
 	},
 
 	illustrator: "Oswaldo KATO",
@@ -16,38 +15,46 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
+		ja: "呼吸を していないので どんなところでも 活躍できると 期待される 人工の ポケモン。",
 		'zh-tw': "人工創造的寶可夢。 沒有呼吸，因此被期待在 任何地方都能大展身手。",
 		'zh-cn': "人工創造的寶可夢。 沒有呼吸，因此被期待在 任何地方都能大展身手。",
-		ja: "呼吸を していないので どんなところでも 活躍できると 期待される 人工の ポケモン。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "駭客攻擊",
-			'zh-cn': "駭客攻擊",
-			ja: "ハッキング"
+	attacks: [
+		{
+			name: {
+				ja: "ハッキング",
+				'zh-tw': "駭客攻擊",
+				'zh-cn': "駭客攻擊",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札を1枚選び、トラッシュする。その後、相手は相手自身の手札を1枚選び、トラッシュする。",
+				'zh-tw': "選擇1張自己的手牌，將其丟棄。然後，對手選擇1張對手自己的手牌，將其丟棄。",
+				'zh-cn': "選擇1張自己的手牌，將其丟棄。然後，對手選擇1張對手自己的手牌，將其丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇1張自己的手牌，將其丟棄。然後，對手選擇1張對手自己的手牌，將其丟棄。",
-			'zh-cn': "選擇1張自己的手牌，將其丟棄。然後，對手選擇1張對手自己的手牌，將其丟棄。",
-			ja: "自分の手札を1枚選び、トラッシュする。その後、相手は相手自身の手札を1枚選び、トラッシュする。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821913,
+				tcgplayer: 628722,
+			},
 		},
-
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [137]
-}
+	dexId: [137],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/082.ts
+++ b/data-asia/SV/SV10/082.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のポリゴン2",
 		'zh-tw': "<火箭隊的>多邊獸Ⅱ",
 		'zh-cn': "<火箭隊的>多邊獸Ⅱ",
-		ja: "ロケット団のポリゴン2"
 	},
 
 	illustrator: "Takeshi Nakamura",
@@ -16,39 +15,51 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
+		ja: "最新科学で 進化した 人工の ポケモン。 ときどき プログラムにない 反応をみせる。",
 		'zh-tw': "利用最新科技進化的 人工寶可夢。有時會 表現出程式裡沒有的反應。",
 		'zh-cn': "利用最新科技進化的 人工寶可夢。有時會 表現出程式裡沒有的反應。",
-		ja: "最新科学で 進化した 人工の ポケモン。 ときどき プログラムにない 反応をみせる。"
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "R指令",
-			'zh-cn': "R指令",
-			ja: "Rコマンド"
+	attacks: [
+		{
+			name: {
+				ja: "Rコマンド",
+				'zh-tw': "R指令",
+				'zh-cn': "R指令",
+			},
+			damage: "20×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある、名前に「ロケット団」とつくサポートの枚数×20ダメージ。",
+				'zh-tw': "造成自己的棄牌區的，名稱中有「火箭隊」的支援者卡的張數×20點傷害。",
+				'zh-cn': "造成自己的棄牌區的，名稱中有「火箭隊」的支援者卡的張數×20點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "造成自己的棄牌區的，名稱中有「火箭隊」的支援者卡的張數×20點傷害。",
-			'zh-cn': "造成自己的棄牌區的，名稱中有「火箭隊」的支援者卡的張數×20點傷害。",
-			ja: "自分のトラッシュにある、名前に「ロケット団」とつくサポートの枚数×20ダメージ。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821914,
+				tcgplayer: 628723,
+			},
 		},
+	],
 
-		damage: "20×",
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ロケット団のポリゴン",
+	},
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [233]
-}
+	dexId: [233],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/083.ts
+++ b/data-asia/SV/SV10/083.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のポリゴンZ",
 		'zh-tw': "<火箭隊的>多邊獸Ｚ",
 		'zh-cn': "<火箭隊的>多邊獸Ｚ",
-		ja: "ロケット団のポリゴンZ"
 	},
 
 	illustrator: "Anesaki Dynamic",
@@ -16,55 +15,67 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
+		ja: "さらに 優れた ポケモンを 目指し 追加した プログラムに 不具合が あったらしく 動きが おかしい。",
 		'zh-tw': "以成為更優秀的寶可夢為目標 所新追加的程式好像狀況不佳， 使得動作變得很奇怪。",
 		'zh-cn': "以成為更優秀的寶可夢為目標 所新追加的程式好像狀況不佳， 使得動作變得很奇怪。",
-		ja: "さらに 優れた ポケモンを 目指し 追加した プログラムに 不具合が あったらしく 動きが おかしい。"
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "再構築",
-			'zh-cn': "再構築",
-			ja: "さいこうちく"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "さいこうちく",
+				'zh-tw': "再構築",
+				'zh-cn': "再構築",
+			},
+			effect: {
+				ja: "自分の番に、自分の手札を2枚トラッシュするなら、1回使える。自分の山札を1枚引く。",
+				'zh-tw': "在自己的回合，若將自己的2張手牌丟棄，則可使用1次。從自己的牌庫抽出1張卡。",
+				'zh-cn': "在自己的回合，若將自己的2張手牌丟棄，則可使用1次。從自己的牌庫抽出1張卡。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，若將自己的2張手牌丟棄，則可使用1次。從自己的牌庫抽出1張卡。",
-			'zh-cn': "在自己的回合，若將自己的2張手牌丟棄，則可使用1次。從自己的牌庫抽出1張卡。",
-			ja: "自分の番に、自分の手札を2枚トラッシュするなら、1回使える。自分の山札を1枚引く。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "R指令",
-			'zh-cn': "R指令",
-			ja: "Rコマンド"
+	attacks: [
+		{
+			name: {
+				ja: "Rコマンド",
+				'zh-tw': "R指令",
+				'zh-cn': "R指令",
+			},
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある、名前に「ロケット団」とつくサポートの枚数×20ダメージ。",
+				'zh-tw': "造成自己的棄牌區的，名稱中有「火箭隊」的支援者卡的張數×20點傷害。",
+				'zh-cn': "造成自己的棄牌區的，名稱中有「火箭隊」的支援者卡的張數×20點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "造成自己的棄牌區的，名稱中有「火箭隊」的支援者卡的張數×20點傷害。",
-			'zh-cn': "造成自己的棄牌區的，名稱中有「火箭隊」的支援者卡的張數×20點傷害。",
-			ja: "自分のトラッシュにある、名前に「ロケット団」とつくサポートの枚数×20ダメージ。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821915,
+				tcgplayer: 628724,
+			},
 		},
+	],
 
-		damage: "20×",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ロケット団のポリゴン２",
+	},
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Uncommon",
-	dexId: [474]
-}
+	dexId: [474],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/084.ts
+++ b/data-asia/SV/SV10/084.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "スバメ",
 		'zh-tw': "傲骨燕",
 		'zh-cn': "傲骨燕",
-		ja: "スバメ"
 	},
 
 	illustrator: "Ayako Ozaki",
@@ -16,38 +15,42 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
+		ja: "寒い 季節は 苦手。暖かい 土地を 探し １日 ３００キロの 距離を 飛んで 移動する。",
 		'zh-tw': "不擅長應付寒冷的季節。 為了尋找溫暖的地帶， 會１天飛上３００公里的距離。",
 		'zh-cn': "不擅長應付寒冷的季節。 為了尋找溫暖的地帶， 會１天飛上３００公里的距離。",
-		ja: "寒い 季節は 苦手。暖かい 土地を 探し １日 ３００キロの 距離を 飛んで 移動する。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "翅膀攻擊",
-			'zh-cn': "翅膀攻擊",
-			ja: "つばさでうつ"
+	attacks: [
+		{
+			name: {
+				ja: "つばさでうつ",
+				'zh-tw': "翅膀攻擊",
+				'zh-cn': "翅膀攻擊",
+			},
+			damage: 20,
+			cost: ["Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Colorless"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "－30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821916,
+				tcgplayer: 628725,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [276]
-}
+	dexId: [276],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/085.ts
+++ b/data-asia/SV/SV10/085.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "オオスバメ",
 		'zh-tw': "大王燕",
 		'zh-cn': "大王燕",
-		ja: "オオスバメ"
 	},
 
 	illustrator: "Souichirou Gunjima",
@@ -16,52 +15,59 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
+		ja: "森に 住む 獲物を 見つけると 上空から 急降下。 鋭い ツメで 捕まえる。",
 		'zh-tw': "發現居住在森林裡的獵物時， 會從高空俯衝而下。 用鋒利的爪子捕捉獵物。",
 		'zh-cn': "發現居住在森林裡的獵物時， 會從高空俯衝而下。 用鋒利的爪子捕捉獵物。",
-		ja: "森に 住む 獲物を 見つけると 上空から 急降下。 鋭い ツメで 捕まえる。"
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "叼",
-			'zh-cn': "叼",
-			ja: "くわえる"
+	attacks: [
+		{
+			name: {
+				ja: "くわえる",
+				'zh-tw': "叼",
+				'zh-cn': "叼",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を3枚引く。",
+				'zh-tw': "從自己的牌庫抽出3張卡。",
+				'zh-cn': "從自己的牌庫抽出3張卡。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫抽出3張卡。",
-			'zh-cn': "從自己的牌庫抽出3張卡。",
-			ja: "自分の山札を3枚引く。"
+		{
+			name: {
+				ja: "スピードウイング",
+				'zh-tw': "高速之翼",
+				'zh-cn': "高速之翼",
+			},
+			damage: 70,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "高速之翼",
-			'zh-cn': "高速之翼",
-			ja: "スピードウイング"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821917,
+				tcgplayer: 628726,
+			},
 		},
+	],
 
-		damage: 70,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "－30"
-	}],
+	evolveFrom: {
+		ja: "スバメ",
+	},
 
 	retreat: 0,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [277]
-}
+	dexId: [277],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/086.ts
+++ b/data-asia/SV/SV10/086.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "イキリンコ",
 		'zh-tw': "怒鸚哥",
 		'zh-cn': "怒鸚哥",
-		ja: "イキリンコ"
 	},
 
 	illustrator: "Julie Hang",
@@ -16,44 +15,47 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
+		ja: "街中で 暮らすことを 好む。 羽の 色で グループを 作り 縄張り争いを 繰り広げる。",
 		'zh-tw': "喜歡棲息在街上。 會以羽毛的顏色組隊， 展開爭奪地盤之戰。",
 		'zh-cn': "喜歡棲息在街上。 會以羽毛的顏色組隊， 展開爭奪地盤之戰。",
-		ja: "街中で 暮らすことを 好む。 羽の 色で グループを 作り 縄張り争いを 繰り広げる。"
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "推倒",
-			'zh-cn': "推倒",
-			ja: "つきとばす"
+	attacks: [
+		{
+			name: {
+				ja: "つきとばす",
+				'zh-tw': "推倒",
+				'zh-cn': "推倒",
+			},
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "のぞむなら、相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+				'zh-tw': "若希望，將對手的戰鬥寶可夢與備戰寶可夢互換。[由對手選擇放置於戰鬥場的寶可夢。]",
+				'zh-cn': "若希望，將對手的戰鬥寶可夢與備戰寶可夢互換。[由對手選擇放置於戰鬥場的寶可夢。]",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若希望，將對手的戰鬥寶可夢與備戰寶可夢互換。[由對手選擇放置於戰鬥場的寶可夢。]",
-			'zh-cn': "若希望，將對手的戰鬥寶可夢與備戰寶可夢互換。[由對手選擇放置於戰鬥場的寶可夢。]",
-			ja: "のぞむなら、相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821918,
+				tcgplayer: 628727,
+			},
 		},
-
-		damage: 20,
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "－30"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "I",
 	rarity: "Common",
-	dexId: [931]
-}
+	dexId: [931],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/087.ts
+++ b/data-asia/SV/SV10/087.ts
@@ -1,27 +1,36 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のおじゃまロボ",
 		'zh-tw': "火箭隊的妨礙機器人",
 		'zh-cn': "火箭隊的妨礙機器人",
-		ja: "ロケット団のおじゃまロボ"
 	},
 
 	illustrator: "Toyste Beach",
 	category: "Trainer",
 
 	effect: {
+		ja: "ウラになっている相手のサイド1枚と、相手の手札からオモテを見ないで1枚選び、それぞれオモテを見る。のぞむなら、選んだカードを相手に入れ替えさせる。（対戦が終わるまで、そのサイドはオモテのまま。）",
 		'zh-tw': "選擇1張對手的反面朝上的獎賞卡，並在不看正面的情況下，從對手的手牌選擇1張，查看各自的正面。若希望，令對手互換所選的卡。（在對戰結束前，那張獎賞卡維持正面朝上。）",
 		'zh-cn': "選擇1張對手的反面朝上的獎賞卡，並在不看正面的情況下，從對手的手牌選擇1張，查看各自的正面。若希望，令對手互換所選的卡。（在對戰結束前，那張獎賞卡維持正面朝上。）",
-		ja: "ウラになっている相手のサイド1枚と、相手の手札からオモテを見ないで1枚選び、それぞれオモテを見る。のぞむなら、選んだカードを相手に入れ替えさせる。（対戦が終わるまで、そのサイドはオモテのまま。）"
 	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821919,
+				tcgplayer: 628728,
+			},
+		},
+	],
 
 	trainerType: "Item",
 	regulationMark: "I",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/088.ts
+++ b/data-asia/SV/SV10/088.ts
@@ -1,27 +1,36 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のスーパーボール",
 		'zh-tw': "火箭隊的超級球",
 		'zh-cn': "火箭隊的超級球",
-		ja: "ロケット団のスーパーボール"
 	},
 
 	illustrator: "Toyste Beach",
 	category: "Trainer",
 
 	effect: {
+		ja: "コインを1回投げる。オモテなら進化ポケモンの「ロケット団のポケモン」、ウラならたねポケモンの「ロケット団のポケモン」を自分の山札から1枚選び、相手に見せて、手札に加える。そして山札を切る。",
 		'zh-tw': "擲1次硬幣。若為正面，則從自己的牌庫選擇1張進化寶可夢的「火箭隊的寶可夢」，若為反面，則選擇1張【基礎】寶可夢的「火箭隊的寶可夢」，在給對手看過後加入手牌。並且重洗牌庫。",
 		'zh-cn': "擲1次硬幣。若為正面，則從自己的牌庫選擇1張進化寶可夢的「火箭隊的寶可夢」，若為反面，則選擇1張【基礎】寶可夢的「火箭隊的寶可夢」，在給對手看過後加入手牌。並且重洗牌庫。",
-		ja: "コインを1回投げる。オモテなら進化ポケモンの「ロケット団のポケモン」、ウラならたねポケモンの「ロケット団のポケモン」を自分の山札から1枚選び、相手に見せて、手札に加える。そして山札を切る。"
 	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821920,
+				tcgplayer: 628729,
+			},
+		},
+	],
 
 	trainerType: "Item",
 	regulationMark: "I",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/089.ts
+++ b/data-asia/SV/SV10/089.ts
@@ -1,27 +1,36 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のびっくりボム",
 		'zh-tw': "火箭隊的驚嚇炸彈",
 		'zh-cn': "火箭隊的驚嚇炸彈",
-		ja: "ロケット団のびっくりボム"
 	},
 
 	illustrator: "Toyste Beach",
 	category: "Trainer",
 
 	effect: {
+		ja: "コインを1回投げオモテなら、相手のポケモン1匹に、ダメカンを2個のせる。ウラなら、自分のバトルポケモンに、ダメカンを2個のせる。",
 		'zh-tw': "擲1次硬幣若為正面，則在對手的1隻寶可夢身上放置2個傷害指示物。若為反面，則在自己的戰鬥寶可夢身上放置2個傷害指示物。",
 		'zh-cn': "擲1次硬幣若為正面，則在對手的1隻寶可夢身上放置2個傷害指示物。若為反面，則在自己的戰鬥寶可夢身上放置2個傷害指示物。",
-		ja: "コインを1回投げオモテなら、相手のポケモン1匹に、ダメカンを2個のせる。ウラなら、自分のバトルポケモンに、ダメカンを2個のせる。"
 	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821921,
+				tcgplayer: 628730,
+			},
+		},
+	],
 
 	trainerType: "Item",
 	regulationMark: "I",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/090.ts
+++ b/data-asia/SV/SV10/090.ts
@@ -1,27 +1,36 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のレシーバー",
 		'zh-tw': "火箭隊的接收器",
 		'zh-cn': "火箭隊的接收器",
-		ja: "ロケット団のレシーバー"
 	},
 
 	illustrator: "inose yukie",
 	category: "Trainer",
 
 	effect: {
+		ja: "自分の山札から、名前に「ロケット団」とつくサポートを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
 		'zh-tw': "從自己的牌庫選擇1張名稱中有「火箭隊」的支援者卡，在給對手看過後加入手牌。並且重洗牌庫。",
 		'zh-cn': "從自己的牌庫選擇1張名稱中有「火箭隊」的支援者卡，在給對手看過後加入手牌。並且重洗牌庫。",
-		ja: "自分の山札から、名前に「ロケット団」とつくサポートを1枚選び、相手に見せて、手札に加える。そして山札を切る。"
 	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821922,
+				tcgplayer: 628731,
+			},
+		},
+	],
 
 	trainerType: "Item",
 	regulationMark: "I",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/091.ts
+++ b/data-asia/SV/SV10/091.ts
@@ -1,27 +1,36 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のアテナ",
 		'zh-tw': "火箭隊的雅典娜",
 		'zh-cn': "火箭隊的雅典娜",
-		ja: "ロケット団のアテナ"
 	},
 
 	illustrator: "hncl",
 	category: "Trainer",
 
 	effect: {
+		ja: "自分の手札が5枚になるように、山札を引く。自分の場のポケモン全員が「ロケット団のポケモン」なら、8枚になるように引く。",
 		'zh-tw': "從牌庫抽卡直到自己的手牌滿5張為止。若自己的所有場上寶可夢皆為「火箭隊的寶可夢」，則抽卡直到滿8張為止。",
 		'zh-cn': "從牌庫抽卡直到自己的手牌滿5張為止。若自己的所有場上寶可夢皆為「火箭隊的寶可夢」，則抽卡直到滿8張為止。",
-		ja: "自分の手札が5枚になるように、山札を引く。自分の場のポケモン全員が「ロケット団のポケモン」なら、8枚になるように引く。"
 	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821923,
+				tcgplayer: 628732,
+			},
+		},
+	],
 
 	trainerType: "Supporter",
 	regulationMark: "I",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/092.ts
+++ b/data-asia/SV/SV10/092.ts
@@ -1,27 +1,36 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のアポロ",
 		'zh-tw': "火箭隊的阿波羅",
 		'zh-cn': "火箭隊的阿波羅",
-		ja: "ロケット団のアポロ"
 	},
 
 	illustrator: "Hideki Ishikawa",
 	category: "Trainer",
 
 	effect: {
+		ja: "このカードは、前の相手の番に、自分の「ロケット団のポケモン」がきぜつしていなければ使えない。おたがいのプレイヤーは、それぞれ手札をすべて山札にもどして切る。その後、自分は5枚、相手は3枚、山札を引く。",
 		'zh-tw': "這張卡必須在上個對手的回合自己的「火箭隊的寶可夢」【昏厥】了才可使用。 雙方玩家各將手牌全部放回牌庫並重洗。然後，從牌庫抽卡，自己抽出5張，對手抽出3張。",
 		'zh-cn': "這張卡必須在上個對手的回合自己的「火箭隊的寶可夢」【昏厥】了才可使用。 雙方玩家各將手牌全部放回牌庫並重洗。然後，從牌庫抽卡，自己抽出5張，對手抽出3張。",
-		ja: "このカードは、前の相手の番に、自分の「ロケット団のポケモン」がきぜつしていなければ使えない。\n\nおたがいのプレイヤーは、それぞれ手札をすべて山札にもどして切る。その後、自分は5枚、相手は3枚、山札を引く。"
 	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821924,
+				tcgplayer: 628733,
+			},
+		},
+	],
 
 	trainerType: "Supporter",
 	regulationMark: "I",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/093.ts
+++ b/data-asia/SV/SV10/093.ts
@@ -1,27 +1,36 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のサカキ",
 		'zh-tw': "火箭隊的坂木",
 		'zh-cn': "火箭隊的坂木",
-		ja: "ロケット団のサカキ"
 	},
 
 	illustrator: "akagi",
 	category: "Trainer",
 
 	effect: {
+		ja: "自分のバトル場の「ロケット団のポケモン」を、ベンチの「ロケット団のポケモン」と入れ替える。その後、相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
 		'zh-tw': "將自己的戰鬥場的「火箭隊的寶可夢」與備戰區的「火箭隊的寶可夢」互換。然後，選擇1隻對手的備戰寶可夢，與戰鬥寶可夢互換。",
 		'zh-cn': "將自己的戰鬥場的「火箭隊的寶可夢」與備戰區的「火箭隊的寶可夢」互換。然後，選擇1隻對手的備戰寶可夢，與戰鬥寶可夢互換。",
-		ja: "自分のバトル場の「ロケット団のポケモン」を、ベンチの「ロケット団のポケモン」と入れ替える。その後、相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。"
 	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821925,
+				tcgplayer: 628734,
+			},
+		},
+	],
 
 	trainerType: "Supporter",
 	regulationMark: "I",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/094.ts
+++ b/data-asia/SV/SV10/094.ts
@@ -1,27 +1,36 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のラムダ",
 		'zh-tw': "火箭隊的拉姆達",
 		'zh-cn': "火箭隊的拉姆達",
-		ja: "ロケット団のラムダ"
 	},
 
 	illustrator: "GOSSAN",
 	category: "Trainer",
 
 	effect: {
+		ja: "自分の山札からトレーナーズを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
 		'zh-tw': "從自己的牌庫選擇1張訓練家卡，在給對手看過後加入手牌。並且重洗牌庫。",
 		'zh-cn': "從自己的牌庫選擇1張訓練家卡，在給對手看過後加入手牌。並且重洗牌庫。",
-		ja: "自分の山札からトレーナーズを1枚選び、相手に見せて、手札に加える。そして山札を切る。"
 	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821926,
+				tcgplayer: 628735,
+			},
+		},
+	],
 
 	trainerType: "Supporter",
 	regulationMark: "I",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/095.ts
+++ b/data-asia/SV/SV10/095.ts
@@ -1,27 +1,36 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のランス",
 		'zh-tw': "火箭隊的蘭斯",
 		'zh-cn': "火箭隊的蘭斯",
-		ja: "ロケット団のランス"
 	},
 
 	illustrator: "Naoki Saito",
 	category: "Trainer",
 
 	effect: {
+		ja: "このカードは、先攻プレイヤーの最初の番でも使える。自分の山札からたねポケモンの「ロケット団のポケモン」を3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
 		'zh-tw': "這張卡在先攻玩家的最初回合也可使用。 從自己的牌庫選擇最多3張【基礎】寶可夢的「火箭隊的寶可夢」，在給對手看過後加入手牌。並且重洗牌庫。",
 		'zh-cn': "這張卡在先攻玩家的最初回合也可使用。 從自己的牌庫選擇最多3張【基礎】寶可夢的「火箭隊的寶可夢」，在給對手看過後加入手牌。並且重洗牌庫。",
-		ja: "このカードは、先攻プレイヤーの最初の番でも使える。\n\n自分の山札からたねポケモンの「ロケット団のポケモン」を3枚まで選び、相手に見せて、手札に加える。そして山札を切る。"
 	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821927,
+				tcgplayer: 628736,
+			},
+		},
+	],
 
 	trainerType: "Supporter",
 	regulationMark: "I",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/096.ts
+++ b/data-asia/SV/SV10/096.ts
@@ -1,27 +1,36 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団の監視塔",
 		'zh-tw': "火箭隊的監視塔",
 		'zh-cn': "火箭隊的監視塔",
-		ja: "ロケット団の監視塔"
 	},
 
 	illustrator: "AYUMI ODASHIMA",
 	category: "Trainer",
 
 	effect: {
+		ja: "おたがいの場の[C]ポケモン全員の特性は、すべてなくなる。",
 		'zh-tw': "雙方場上所有【無】寶可夢的特性全部消除。",
 		'zh-cn': "雙方場上所有【無】寶可夢的特性全部消除。",
-		ja: "おたがいの場のポケモン全員の特性は、すべてなくなる。"
 	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821928,
+				tcgplayer: 628737,
+			},
+		},
+	],
 
 	trainerType: "Stadium",
 	regulationMark: "I",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/097.ts
+++ b/data-asia/SV/SV10/097.ts
@@ -1,27 +1,36 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団のファクトリー",
 		'zh-tw': "火箭隊的工廠",
 		'zh-cn': "火箭隊的工廠",
-		ja: "ロケット団のファクトリー"
 	},
 
 	illustrator: "imoniii",
 	category: "Trainer",
 
 	effect: {
+		ja: "この番に、手札から、名前に「ロケット団」とつくサポートを出して使っていたプレイヤーは、自分の番ごとに1回、自分の山札を2枚引いてよい。",
 		'zh-tw': "在每個自己的回合時，可使用1次。在這個回合從手牌使出了名稱中有「火箭隊」的支援者卡的玩家，可從自己的牌庫抽出2張卡。",
 		'zh-cn': "在每個自己的回合時，可使用1次。在這個回合從手牌使出了名稱中有「火箭隊」的支援者卡的玩家，可從自己的牌庫抽出2張卡。",
-		ja: "この番に、手札から、名前に「ロケット団」とつくサポートを出して使っていたプレイヤーは、自分の番ごとに1回、自分の山札を2枚引いてよい。"
 	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821929,
+				tcgplayer: 628738,
+			},
+		},
+	],
 
 	trainerType: "Stadium",
 	regulationMark: "I",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV10/098.ts
+++ b/data-asia/SV/SV10/098.ts
@@ -1,26 +1,36 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV10"
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ロケット団エネルギー",
 		'zh-tw': "火箭隊能量",
 		'zh-cn': "火箭隊能量",
-		ja: "ロケット団エネルギー"
 	},
 
+	illustrator: "",
 	category: "Energy",
+	energyType: "Special",
 
 	effect: {
+		ja: "このカードは「ロケット団のポケモン」にしかつけられず、「ロケット団のポケモン」以外についているなら、トラッシュする。このカードは、ポケモンについているかぎり、[P][D]の2つのタイプのエネルギー2個ぶんとしてはたらく。",
 		'zh-tw': "這張卡只可附於「火箭隊的寶可夢」身上，若附於「火箭隊的寶可夢」以外的寶可夢身上，則將其丟棄。 只要這張卡附於寶可夢身上，視為提供2個【超】【惡】2種屬性的能量。",
 		'zh-cn': "這張卡只可附於「火箭隊的寶可夢」身上，若附於「火箭隊的寶可夢」以外的寶可夢身上，則將其丟棄。 只要這張卡附於寶可夢身上，視為提供2個【超】【惡】2種屬性的能量。",
-		ja: "このカードは「ロケット団のポケモン」にしかつけられず、「ロケット団のポケモン」以外についているなら、トラッシュする。\n\nこのカードは、ポケモンについているかぎり、の2つのタイプのエネルギー2個ぶんとしてはたらく。"
 	},
 
-	energyType: "Special",
-	regulationMark: "I",
-	rarity: "Uncommon"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821930,
+				tcgplayer: 628739,
+			},
+		},
+	],
 
-export default card
+	regulationMark: "I",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SV/SV10/099.ts
+++ b/data-asia/SV/SV10/099.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のワナイダー",
+	},
+
+	illustrator: "NC Empire",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Grass"],
+
+	description: {
+		ja: "木の枝や 天井に 糸で 張りつき 音もなく 行動する。 獲物に 気づかれる前に 倒す。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "チャージアップ" },
+			effect: {
+				ja: "自分の番に1回使える。自分のトラッシュから基本エネルギーを1枚選び、このポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ロケットラッシュ" },
+			damage: "30×",
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "自分の場の「ロケット団のポケモン」の数×30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821931,
+				tcgplayer: 629040,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ロケット団のタマンチュラ",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [918],
+};
+
+export default card;

--- a/data-asia/SV/SV10/100.ts
+++ b/data-asia/SV/SV10/100.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のヘルガー",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fire"],
+
+	description: {
+		ja: "口から 吹き出す 炎で 火傷すると いつまでたっても 傷口が うずいてしまう。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "あくのひだね" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどとこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "バーンアウト" },
+			damage: 120,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821932,
+				tcgplayer: 629041,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ロケット団のデルビル",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [229],
+};
+
+export default card;

--- a/data-asia/SV/SV10/101.ts
+++ b/data-asia/SV/SV10/101.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バシャーモ",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Fire"],
+
+	description: {
+		ja: "強敵に 出会うと 手首から 炎を 噴き出す。 ジャンプで ビルを 跳び越す 脚力。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ヒートブラスト" },
+			damage: 70,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ごうかれんきゃく" },
+			damage: 120,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個トラッシュし、相手のベンチポケモン1匹にも、120ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821933,
+				tcgplayer: 629042,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ワカシャモ",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [257],
+};
+
+export default card;

--- a/data-asia/SV/SV10/102.ts
+++ b/data-asia/SV/SV10/102.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パールル",
+	},
+
+	illustrator: "Mori Yuu",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "パールルの 真珠は とても 貴重。 シェルダーの 真珠の １０倍以上 価値が あるとも。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "シェルプレス" },
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-10」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821934,
+				tcgplayer: 629043,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [366],
+};
+
+export default card;

--- a/data-asia/SV/SV10/103.ts
+++ b/data-asia/SV/SV10/103.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のソーナンス",
+	},
+
+	illustrator: "Saboteri",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Psychic"],
+
+	description: {
+		ja: "真っ黒な 尻尾を 隠すため 暗闇で ひっそりと 生きている。 自分からは 攻撃しない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ロケットミラー" },
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "自分のベンチの「ロケット団のポケモン」を1匹選び、選んだポケモンにのっているダメカンをすべて、相手のバトルポケモンにのせ替える。",
+			},
+		},
+		{
+			name: { ja: "とびだしヘッド" },
+			damage: 70,
+			cost: ["Psychic", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821935,
+				tcgplayer: 629044,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [202],
+};
+
+export default card;

--- a/data-asia/SV/SV10/104.ts
+++ b/data-asia/SV/SV10/104.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のイオルブ",
+	},
+
+	illustrator: "HYOGONOSUKE",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	description: {
+		ja: "サイコパワーを 放ち 周囲を 調べている。 観測範囲は 周囲 １０キロにも 達するぞ。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ロケットブレイン" },
+			effect: {
+				ja: "自分の番に何回でも使える。自分の場の「ロケット団のポケモン」にのっているダメカンを1個選び、自分の別のポケモンにのせ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "サイコキネシス" },
+			damage: "40+",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数×40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821936,
+				tcgplayer: 629045,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ロケット団のレドームシ",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [826],
+};
+
+export default card;

--- a/data-asia/SV/SV10/105.ts
+++ b/data-asia/SV/SV10/105.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のマタドガス",
+	},
+
+	illustrator: "Yukihiro Tada",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Darkness"],
+
+	description: {
+		ja: "体内に 含まれる 毒ガスを ぎりぎりまで 薄めると 最高級の 香水ができる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "いっせいばくはつ" },
+			damage: "40×",
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "おたがいの場の、名前に「ドガース」または「マタドガス」とつくポケモンの数×40ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821937,
+				tcgplayer: 629046,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ロケット団のドガース",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [110],
+};
+
+export default card;

--- a/data-asia/SV/SV10/106.ts
+++ b/data-asia/SV/SV10/106.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のヤミカラス",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Darkness"],
+
+	description: {
+		ja: "夜 姿を 見かけると 不吉なことが 起きると 信じられ 忌み嫌われている ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たぶらかす" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からサポートを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "いちゃもん" },
+			damage: 30,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが持つワザを1つ選ぶ。次の相手の番、このワザを受けたポケモンは、選ばれたワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821938,
+				tcgplayer: 629047,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [198],
+};
+
+export default card;

--- a/data-asia/SV/SV10/107.ts
+++ b/data-asia/SV/SV10/107.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ザマゼンタ",
+	},
+
+	illustrator: "Takumi Wada",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Metal"],
+
+	description: {
+		ja: "いかなる 攻撃も 弾き返す 姿は 格闘王の盾 と 呼ばれ 恐れ 崇められた。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ストロングバッシュ" },
+			damage: 70,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンがワザのダメージを受けたとき、受けたダメージぶんのダメカンを、ワザを使ったポケモンにのせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821939,
+				tcgplayer: 629048,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [889],
+};
+
+export default card;

--- a/data-asia/SV/SV10/108.ts
+++ b/data-asia/SV/SV10/108.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のラッタ",
+	},
+
+	illustrator: "Mékayu",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ヒゲは バランスを とる 大切な 器官。 どんなに 仲良くなっても 触られると 怒って 噛みつく。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "むこうみず" },
+			damage: 90,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを2回投げ、すべてウラなら、このポケモンにも90ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821940,
+				tcgplayer: 629049,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ロケット団のコラッタ",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [20],
+};
+
+export default card;

--- a/data-asia/SV/SV10/109.ts
+++ b/data-asia/SV/SV10/109.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のニャース",
+	},
+
+	illustrator: "Shimaris Yukichi",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "昼間は 寝てばかりいる。 夜になると 目が 輝き 縄張りを 歩きまわる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ねこばば" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、そのカードのオモテを見て、相手の山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "みだれひっかき" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数×20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821941,
+				tcgplayer: 629050,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [52],
+};
+
+export default card;

--- a/data-asia/SV/SV10/110.ts
+++ b/data-asia/SV/SV10/110.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガルーラ",
+	},
+
+	illustrator: "Mékayu",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Colorless"],
+
+	description: {
+		ja: "子どもの いない ガルーラが 遭難した 人間の 子を 育てていたという 記録がある。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっぱたく" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ピヨピヨパンチ" },
+			damage: "90×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×90ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821942,
+				tcgplayer: 629051,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Illustration rare",
+	dexId: [115],
+};
+
+export default card;

--- a/data-asia/SV/SV10/111.ts
+++ b/data-asia/SV/SV10/111.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オリーヴァex",
+	},
+
+	illustrator: "PLANETA Tsuji",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Grass"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "オイルマシンガン" },
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のポケモンを6回選び、選んだポケモン全員に、弱点・抵抗力を計算せず、選んだ回数×20ダメージ。（1匹を2回以上選べる。）",
+			},
+		},
+		{
+			name: { ja: "アロマシュート" },
+			damage: 160,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンの特殊状態を、すべて回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821943,
+				tcgplayer: 629052,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "オリーニョ",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [930],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV10/112.ts
+++ b/data-asia/SV/SV10/112.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のファイヤーex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フレイムバリア" },
+			damage: 110,
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-50」される。",
+			},
+		},
+		{
+			name: { ja: "イビルバーン" },
+			cost: ["Fire", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている「ロケット団エネルギー」を1枚選び、トラッシュする。その場合、相手のバトルポケモンと、ついているすべてのカードを、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821944,
+				tcgplayer: 629053,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [146],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV10/113.ts
+++ b/data-asia/SV/SV10/113.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハルクジラex",
+	},
+
+	illustrator: "PLANETA Tsuji",
+	category: "Pokemon",
+	hp: 300,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ゆきにまぎれる" },
+			effect: {
+				ja: "このポケモンは、相手が手札からグッズまたはサポートを出して使ったとき、その効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "クラッシュプレス" },
+			damage: "140+",
+			cost: ["Water", "Water", "Water", "Colorless"],
+			effect: {
+				ja: "のぞむなら、場に出ているスタジアムをトラッシュする。その場合、140ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821945,
+				tcgplayer: 629054,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アルクジラ",
+	},
+
+	retreat: 4,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [975],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV10/114.ts
+++ b/data-asia/SV/SV10/114.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のミュウツーex",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "パワーセーバー" },
+			effect: {
+				ja: "自分の場の「ロケット団のポケモン」が4匹以上のときにしか、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "イレイザーボール" },
+			damage: "160+",
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "のぞむなら、自分のベンチポケモンについているエネルギーを2枚までトラッシュし、その枚数×60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821946,
+				tcgplayer: 629055,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [150],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV10/115.ts
+++ b/data-asia/SV/SV10/115.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レジロックex",
+	},
+
+	illustrator: "PLANETA Mochizuki",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "レジチャージ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュから「基本[F]エネルギー」を2枚まで選び、このポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "ジャイアントロック" },
+			damage: "140+",
+			cost: ["Fighting", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが2進化ポケモンなら、140ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821947,
+				tcgplayer: 629056,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [377],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV10/116.ts
+++ b/data-asia/SV/SV10/116.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のニドキングex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Darkness"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ダーティホーン" },
+			damage: 100,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。このどくでのせるダメカンの数は8個になる。",
+			},
+		},
+		{
+			name: { ja: "キングインパクト" },
+			damage: 240,
+			cost: ["Darkness", "Darkness", "Darkness", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821948,
+				tcgplayer: 629057,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ロケット団のニドリーノ",
+	},
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [34],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV10/117.ts
+++ b/data-asia/SV/SV10/117.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のクロバットex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Darkness"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かみつきまわる" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のポケモン2匹に、それぞれダメカンを2個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アサシンリターン" },
+			damage: 120,
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "のぞむなら、このポケモンを手札にもどす。（ポケモン以外のカードは、すべてトラッシュする。）",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821949,
+				tcgplayer: 629058,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ロケット団のゴルバット",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [169],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV10/118.ts
+++ b/data-asia/SV/SV10/118.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のペルシアンex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Colorless"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "こうまんしれい" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手の山札を上から10枚オモテにする。のぞむなら、その中にあるポケモンが持つワザを1つ選び、このワザとして使う。オモテにしたカードは山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "クルーエルスラッシュ" },
+			damage: 140,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821950,
+				tcgplayer: 629059,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ロケット団のニャース",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+	dexId: [53],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV10/119.ts
+++ b/data-asia/SV/SV10/119.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のアテナ",
+	},
+
+	illustrator: "hncl",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札が5枚になるように、山札を引く。自分の場のポケモン全員が「ロケット団のポケモン」なら、8枚になるように引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821951,
+				tcgplayer: 629060,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SV/SV10/120.ts
+++ b/data-asia/SV/SV10/120.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のアポロ",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、前の相手の番に、自分の「ロケット団のポケモン」がきぜつしていなければ使えない。おたがいのプレイヤーは、それぞれ手札をすべて山札にもどして切る。その後、自分は5枚、相手は3枚、山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821952,
+				tcgplayer: 629061,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SV/SV10/121.ts
+++ b/data-asia/SV/SV10/121.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のサカキ",
+	},
+
+	illustrator: "akagi",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトル場の「ロケット団のポケモン」を、ベンチの「ロケット団のポケモン」と入れ替える。その後、相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821953,
+				tcgplayer: 629062,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SV/SV10/122.ts
+++ b/data-asia/SV/SV10/122.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のラムダ",
+	},
+
+	illustrator: "GOSSAN",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札からトレーナーズを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821954,
+				tcgplayer: 629063,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SV/SV10/123.ts
+++ b/data-asia/SV/SV10/123.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のランス",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、先攻プレイヤーの最初の番でも使える。自分の山札からたねポケモンの「ロケット団のポケモン」を3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821955,
+				tcgplayer: 629064,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SV/SV10/124.ts
+++ b/data-asia/SV/SV10/124.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のファイヤーex",
+	},
+
+	illustrator: "AKIRA EGAWA",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フレイムバリア" },
+			damage: 110,
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-50」される。",
+			},
+		},
+		{
+			name: { ja: "イビルバーン" },
+			cost: ["Fire", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている「ロケット団エネルギー」を1枚選び、トラッシュする。その場合、相手のバトルポケモンと、ついているすべてのカードを、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821956,
+				tcgplayer: 629065,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+	dexId: [146],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV10/125.ts
+++ b/data-asia/SV/SV10/125.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のミュウツーex",
+	},
+
+	illustrator: "Iwamoto05",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "パワーセーバー" },
+			effect: {
+				ja: "自分の場の「ロケット団のポケモン」が4匹以上のときにしか、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "イレイザーボール" },
+			damage: "160+",
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "のぞむなら、自分のベンチポケモンについているエネルギーを2枚までトラッシュし、その枚数×60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821957,
+				tcgplayer: 629066,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+	dexId: [150],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV10/126.ts
+++ b/data-asia/SV/SV10/126.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のニドキングex",
+	},
+
+	illustrator: "Uninori",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Darkness"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ダーティホーン" },
+			damage: 100,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。このどくでのせるダメカンの数は8個になる。",
+			},
+		},
+		{
+			name: { ja: "キングインパクト" },
+			damage: 240,
+			cost: ["Darkness", "Darkness", "Darkness", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821958,
+				tcgplayer: 629067,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ロケット団のニドリーノ",
+	},
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+	dexId: [34],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV10/127.ts
+++ b/data-asia/SV/SV10/127.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のクロバットex",
+	},
+
+	illustrator: "cochi8i",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Darkness"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かみつきまわる" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のポケモン2匹に、それぞれダメカンを2個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アサシンリターン" },
+			damage: 120,
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "のぞむなら、このポケモンを手札にもどす。（ポケモン以外のカードは、すべてトラッシュする。）",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821959,
+				tcgplayer: 629068,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ロケット団のゴルバット",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+	dexId: [169],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV10/128.ts
+++ b/data-asia/SV/SV10/128.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のアテナ",
+	},
+
+	illustrator: "Yoshioka",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札が5枚になるように、山札を引く。自分の場のポケモン全員が「ロケット団のポケモン」なら、8枚になるように引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821960,
+				tcgplayer: 629069,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+};
+
+export default card;

--- a/data-asia/SV/SV10/129.ts
+++ b/data-asia/SV/SV10/129.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のサカキ",
+	},
+
+	illustrator: "Krgc",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトル場の「ロケット団のポケモン」を、ベンチの「ロケット団のポケモン」と入れ替える。その後、相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821961,
+				tcgplayer: 629070,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Special illustration rare",
+};
+
+export default card;

--- a/data-asia/SV/SV10/130.ts
+++ b/data-asia/SV/SV10/130.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のミュウツーex",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "パワーセーバー" },
+			effect: {
+				ja: "自分の場の「ロケット団のポケモン」が4匹以上のときにしか、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "イレイザーボール" },
+			damage: "160+",
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "のぞむなら、自分のベンチポケモンについているエネルギーを2枚までトラッシュし、その枚数×60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821962,
+				tcgplayer: 629071,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Mega Hyper Rare",
+	dexId: [150],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV10/131.ts
+++ b/data-asia/SV/SV10/131.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のクロバットex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Darkness"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かみつきまわる" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のポケモン2匹に、それぞれダメカンを2個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アサシンリターン" },
+			damage: 120,
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "のぞむなら、このポケモンを手札にもどす。（ポケモン以外のカードは、すべてトラッシュする。）",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821963,
+				tcgplayer: 629072,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ロケット団のゴルバット",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Mega Hyper Rare",
+	dexId: [169],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV10/132.ts
+++ b/data-asia/SV/SV10/132.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV10";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャミングタワー",
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのポケモン全員についている「ポケモンのどうぐ」の効果は、すべてなくなる。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 821964,
+				tcgplayer: 629074,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "H",
+	rarity: "Mega Hyper Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Refreshes the existing Japanese set **SV10 ロケット団の栄光 (Glory of Team Rocket)** from its primary sources. The curated content stays: every card keeps its `zh-tw`/`zh-cn` texts verbatim.

What changes across the 132 card files:

- `thirdParty.cardmarket` moves onto `variants` objects and 98 missing ids are filled in
- per card where missing: `dexId`, `evolveFrom`, `resistances`, the Japanese flavor text and the Japanese effect/attack texts straight from the official database and limitless

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (821832–821964)
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (628642–629074), keyed by the collection number each product carries in `extendedData`

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- All 132 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
