### PR TITLE
(data) ja SV9 Battle Partners - cardmarket + tcgplayer product ids

### DIFF
--- a/data-asia/SV/SV9/001.ts
+++ b/data-asia/SV/SV9/001.ts
@@ -42,12 +42,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807588,
+				tcgplayer: 614852,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807588
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/002.ts
+++ b/data-asia/SV/SV9/002.ts
@@ -46,12 +46,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807589,
+				tcgplayer: 614853,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807589
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/003.ts
+++ b/data-asia/SV/SV9/003.ts
@@ -48,12 +48,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807590,
+				tcgplayer: 614854,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807590
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/004.ts
+++ b/data-asia/SV/SV9/004.ts
@@ -48,12 +48,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807591,
+				tcgplayer: 614855,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807591
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/005.ts
+++ b/data-asia/SV/SV9/005.ts
@@ -62,12 +62,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807592,
+				tcgplayer: 614856,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807592
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/006.ts
+++ b/data-asia/SV/SV9/006.ts
@@ -64,12 +64,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807593,
+				tcgplayer: 614857,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807593
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/007.ts
+++ b/data-asia/SV/SV9/007.ts
@@ -48,12 +48,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807594,
+				tcgplayer: 614858,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807594
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/008.ts
+++ b/data-asia/SV/SV9/008.ts
@@ -48,12 +48,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807595,
+				tcgplayer: 614859,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807595
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/009.ts
+++ b/data-asia/SV/SV9/009.ts
@@ -48,12 +48,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807596,
+				tcgplayer: 614860,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807596
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/010.ts
+++ b/data-asia/SV/SV9/010.ts
@@ -48,6 +48,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807597,
+				tcgplayer: 614861,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/011.ts
+++ b/data-asia/SV/SV9/011.ts
@@ -48,6 +48,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807598,
+				tcgplayer: 614862,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/012.ts
+++ b/data-asia/SV/SV9/012.ts
@@ -64,6 +64,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 807599,
+				tcgplayer: 614863,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/013.ts
+++ b/data-asia/SV/SV9/013.ts
@@ -48,12 +48,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807600,
+				tcgplayer: 614864,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807600
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/014.ts
+++ b/data-asia/SV/SV9/014.ts
@@ -64,12 +64,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 807601,
+				tcgplayer: 614865,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807601
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/015.ts
+++ b/data-asia/SV/SV9/015.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807602,
+				tcgplayer: 614866,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/016.ts
+++ b/data-asia/SV/SV9/016.ts
@@ -64,6 +64,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807603,
+				tcgplayer: 614867,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/017.ts
+++ b/data-asia/SV/SV9/017.ts
@@ -57,12 +57,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 807604,
+				tcgplayer: 614868,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807604
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/018.ts
+++ b/data-asia/SV/SV9/018.ts
@@ -61,12 +61,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807605,
+				tcgplayer: 614869,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807605
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/019.ts
+++ b/data-asia/SV/SV9/019.ts
@@ -58,12 +58,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807606,
+				tcgplayer: 614870,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807606
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/020.ts
+++ b/data-asia/SV/SV9/020.ts
@@ -64,12 +64,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807607,
+				tcgplayer: 614871,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807607
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/021.ts
+++ b/data-asia/SV/SV9/021.ts
@@ -42,12 +42,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807608,
+				tcgplayer: 614872,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807608
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/022.ts
+++ b/data-asia/SV/SV9/022.ts
@@ -48,12 +48,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807609,
+				tcgplayer: 614873,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807609
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/023.ts
+++ b/data-asia/SV/SV9/023.ts
@@ -58,12 +58,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807610,
+				tcgplayer: 614874,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807610
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/024.ts
+++ b/data-asia/SV/SV9/024.ts
@@ -42,12 +42,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807611,
+				tcgplayer: 614875,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807611
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/025.ts
+++ b/data-asia/SV/SV9/025.ts
@@ -48,12 +48,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 807612,
+				tcgplayer: 614876,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807612
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/026.ts
+++ b/data-asia/SV/SV9/026.ts
@@ -48,6 +48,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807613,
+				tcgplayer: 614877,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/027.ts
+++ b/data-asia/SV/SV9/027.ts
@@ -56,6 +56,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807614,
+				tcgplayer: 614878,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/028.ts
+++ b/data-asia/SV/SV9/028.ts
@@ -48,6 +48,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807615,
+				tcgplayer: 614879,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/029.ts
+++ b/data-asia/SV/SV9/029.ts
@@ -42,6 +42,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807616,
+				tcgplayer: 614880,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/030.ts
+++ b/data-asia/SV/SV9/030.ts
@@ -57,6 +57,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 807617,
+				tcgplayer: 614881,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/031.ts
+++ b/data-asia/SV/SV9/031.ts
@@ -53,6 +53,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807618,
+				tcgplayer: 614882,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/032.ts
+++ b/data-asia/SV/SV9/032.ts
@@ -63,6 +63,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 807619,
+				tcgplayer: 614883,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/033.ts
+++ b/data-asia/SV/SV9/033.ts
@@ -57,6 +57,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 807620,
+				tcgplayer: 614884,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/034.ts
+++ b/data-asia/SV/SV9/034.ts
@@ -67,12 +67,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807621,
+				tcgplayer: 614885,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807621
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/035.ts
+++ b/data-asia/SV/SV9/035.ts
@@ -47,12 +47,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807622,
+				tcgplayer: 614886,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807622
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/036.ts
+++ b/data-asia/SV/SV9/036.ts
@@ -61,12 +61,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807623,
+				tcgplayer: 614887,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807623
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/037.ts
+++ b/data-asia/SV/SV9/037.ts
@@ -57,12 +57,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807624,
+				tcgplayer: 614888,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807624
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/038.ts
+++ b/data-asia/SV/SV9/038.ts
@@ -57,12 +57,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807625,
+				tcgplayer: 614889,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807625
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/039.ts
+++ b/data-asia/SV/SV9/039.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807626,
+				tcgplayer: 614890,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807626
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/040.ts
+++ b/data-asia/SV/SV9/040.ts
@@ -61,6 +61,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807627,
+				tcgplayer: 614891,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/041.ts
+++ b/data-asia/SV/SV9/041.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807628,
+				tcgplayer: 614892,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/042.ts
+++ b/data-asia/SV/SV9/042.ts
@@ -58,6 +58,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807629,
+				tcgplayer: 614893,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/043.ts
+++ b/data-asia/SV/SV9/043.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807630,
+				tcgplayer: 614894,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/044.ts
+++ b/data-asia/SV/SV9/044.ts
@@ -56,12 +56,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807631,
+				tcgplayer: 614895,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807631
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/045.ts
+++ b/data-asia/SV/SV9/045.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807632,
+				tcgplayer: 614896,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807632
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/046.ts
+++ b/data-asia/SV/SV9/046.ts
@@ -57,12 +57,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 807633,
+				tcgplayer: 614897,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807633
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/047.ts
+++ b/data-asia/SV/SV9/047.ts
@@ -48,12 +48,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807634,
+				tcgplayer: 614898,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807634
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/048.ts
+++ b/data-asia/SV/SV9/048.ts
@@ -48,12 +48,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807635,
+				tcgplayer: 614899,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807635
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/049.ts
+++ b/data-asia/SV/SV9/049.ts
@@ -64,12 +64,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807636,
+				tcgplayer: 614900,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807636
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/050.ts
+++ b/data-asia/SV/SV9/050.ts
@@ -58,12 +58,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807637,
+				tcgplayer: 614901,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807637
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/051.ts
+++ b/data-asia/SV/SV9/051.ts
@@ -56,12 +56,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807638,
+				tcgplayer: 614902,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807638
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/052.ts
+++ b/data-asia/SV/SV9/052.ts
@@ -64,12 +64,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 807639,
+				tcgplayer: 614903,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807639
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/053.ts
+++ b/data-asia/SV/SV9/053.ts
@@ -56,6 +56,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807640,
+				tcgplayer: 614904,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/054.ts
+++ b/data-asia/SV/SV9/054.ts
@@ -64,6 +64,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807641,
+				tcgplayer: 614905,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/055.ts
+++ b/data-asia/SV/SV9/055.ts
@@ -56,6 +56,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807642,
+				tcgplayer: 614906,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/056.ts
+++ b/data-asia/SV/SV9/056.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807643,
+				tcgplayer: 614907,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807643
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/057.ts
+++ b/data-asia/SV/SV9/057.ts
@@ -64,12 +64,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807644,
+				tcgplayer: 614908,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807644
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/058.ts
+++ b/data-asia/SV/SV9/058.ts
@@ -64,12 +64,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 807645,
+				tcgplayer: 614909,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807645
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/059.ts
+++ b/data-asia/SV/SV9/059.ts
@@ -48,6 +48,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807646,
+				tcgplayer: 614910,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/060.ts
+++ b/data-asia/SV/SV9/060.ts
@@ -42,6 +42,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807647,
+				tcgplayer: 614911,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/061.ts
+++ b/data-asia/SV/SV9/061.ts
@@ -55,6 +55,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 807648,
+				tcgplayer: 614912,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/062.ts
+++ b/data-asia/SV/SV9/062.ts
@@ -64,12 +64,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807649,
+				tcgplayer: 614913,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807649
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/063.ts
+++ b/data-asia/SV/SV9/063.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807650,
+				tcgplayer: 614914,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807650
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/064.ts
+++ b/data-asia/SV/SV9/064.ts
@@ -53,6 +53,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807651,
+				tcgplayer: 614915,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/065.ts
+++ b/data-asia/SV/SV9/065.ts
@@ -63,6 +63,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807652,
+				tcgplayer: 614916,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/066.ts
+++ b/data-asia/SV/SV9/066.ts
@@ -63,6 +63,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807653,
+				tcgplayer: 614917,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/067.ts
+++ b/data-asia/SV/SV9/067.ts
@@ -69,12 +69,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 807654,
+				tcgplayer: 614918,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807654
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/068.ts
+++ b/data-asia/SV/SV9/068.ts
@@ -69,6 +69,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807655,
+				tcgplayer: 614919,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/069.ts
+++ b/data-asia/SV/SV9/069.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 807656,
+				tcgplayer: 614920,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/070.ts
+++ b/data-asia/SV/SV9/070.ts
@@ -53,12 +53,18 @@ const card: Card = {
 		}
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807657,
+				tcgplayer: 614921,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807657
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/071.ts
+++ b/data-asia/SV/SV9/071.ts
@@ -53,12 +53,18 @@ const card: Card = {
 		damage: 80
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807658,
+				tcgplayer: 614922,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807658
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/072.ts
+++ b/data-asia/SV/SV9/072.ts
@@ -50,12 +50,18 @@ const card: Card = {
 		}
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 807659,
+				tcgplayer: 614923,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807659
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/073.ts
+++ b/data-asia/SV/SV9/073.ts
@@ -53,12 +53,18 @@ const card: Card = {
 		damage: 120
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807660,
+				tcgplayer: 614924,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807660
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/074.ts
+++ b/data-asia/SV/SV9/074.ts
@@ -53,6 +53,16 @@ const card: Card = {
 		damage: 170
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 807661,
+				tcgplayer: 614925,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/075.ts
+++ b/data-asia/SV/SV9/075.ts
@@ -64,6 +64,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 807662,
+				tcgplayer: 614926,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/076.ts
+++ b/data-asia/SV/SV9/076.ts
@@ -42,12 +42,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807663,
+				tcgplayer: 614927,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807663
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/077.ts
+++ b/data-asia/SV/SV9/077.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807664,
+				tcgplayer: 614928,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807664
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/078.ts
+++ b/data-asia/SV/SV9/078.ts
@@ -56,12 +56,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807665,
+				tcgplayer: 614929,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807665
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/079.ts
+++ b/data-asia/SV/SV9/079.ts
@@ -57,6 +57,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 807666,
+				tcgplayer: 614930,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/080.ts
+++ b/data-asia/SV/SV9/080.ts
@@ -53,12 +53,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807667,
+				tcgplayer: 614931,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807667
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/081.ts
+++ b/data-asia/SV/SV9/081.ts
@@ -69,12 +69,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807668,
+				tcgplayer: 614932,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807668
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/082.ts
+++ b/data-asia/SV/SV9/082.ts
@@ -48,12 +48,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807669,
+				tcgplayer: 614933,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I",
-
-	thirdParty: {
-		cardmarket: 807669
-	}
 }
 
 export default card

--- a/data-asia/SV/SV9/083.ts
+++ b/data-asia/SV/SV9/083.ts
@@ -61,6 +61,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807670,
+				tcgplayer: 614934,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/084.ts
+++ b/data-asia/SV/SV9/084.ts
@@ -57,6 +57,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807671,
+				tcgplayer: 614935,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/085.ts
+++ b/data-asia/SV/SV9/085.ts
@@ -42,6 +42,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807672,
+				tcgplayer: 614936,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/086.ts
+++ b/data-asia/SV/SV9/086.ts
@@ -58,6 +58,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 807673,
+				tcgplayer: 614937,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/087.ts
+++ b/data-asia/SV/SV9/087.ts
@@ -53,6 +53,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807674,
+				tcgplayer: 614938,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/088.ts
+++ b/data-asia/SV/SV9/088.ts
@@ -20,6 +20,16 @@ const card: Card = {
 		'zh-cn': "將自己的1隻寶可夢恢復「60」HP。然後，選擇1個恢復的寶可夢身上附加的能量，將其丟棄。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807675,
+				tcgplayer: 614939,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/089.ts
+++ b/data-asia/SV/SV9/089.ts
@@ -20,6 +20,16 @@ const card: Card = {
 		'zh-cn': "從自己的棄牌區選擇1張基本能量卡，附於備戰區的「N的寶可夢」身上。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807676,
+				tcgplayer: 614940,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/090.ts
+++ b/data-asia/SV/SV9/090.ts
@@ -20,6 +20,16 @@ const card: Card = {
 		'zh-cn': "數過自己的獎賞卡張數後，全部翻回反面並重洗，放回牌庫下方。然後，從牌庫上方抽出與放回張數相同數量的卡，作為獎賞卡放置。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807677,
+				tcgplayer: 614941,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/091.ts
+++ b/data-asia/SV/SV9/091.ts
@@ -20,6 +20,16 @@ const card: Card = {
 		'zh-cn': "從自己的牌庫選擇最多2張【基礎】寶可夢的「赫普的寶可夢」，放置於備戰區。並且重洗牌庫。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807678,
+				tcgplayer: 614942,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/092.ts
+++ b/data-asia/SV/SV9/092.ts
@@ -20,6 +20,16 @@ const card: Card = {
 		'zh-cn': "附有這張卡的「赫普的寶可夢」，使用招式所需的能量減少1個【無】能量，那隻寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+30」點。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807679,
+				tcgplayer: 614943,
+			},
+		},
+	],
+
 	trainerType: "Tool",
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/093.ts
+++ b/data-asia/SV/SV9/093.ts
@@ -20,6 +20,16 @@ const card: Card = {
 		'zh-cn': "附有這張卡的「莉莉艾的寶可夢」受到對手的寶可夢招式的傷害而【昏厥】時，被獲得的獎賞卡減少1張。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807680,
+				tcgplayer: 614944,
+			},
+		},
+	],
+
 	trainerType: "Tool",
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/094.ts
+++ b/data-asia/SV/SV9/094.ts
@@ -20,6 +20,16 @@ const card: Card = {
 		'zh-cn': "這張卡必須將自己的1張手牌丟棄才可使用。 從牌庫抽卡直到自己的手牌滿6張為止。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807681,
+				tcgplayer: 614945,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/095.ts
+++ b/data-asia/SV/SV9/095.ts
@@ -20,6 +20,16 @@ const card: Card = {
 		'zh-cn': "選擇1隻對手的寶可夢，將那隻寶可夢身上附加的「寶可夢道具」卡與「特殊能量」卡各丟棄1張。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807682,
+				tcgplayer: 614946,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/096.ts
+++ b/data-asia/SV/SV9/096.ts
@@ -20,6 +20,16 @@ const card: Card = {
 		'zh-cn': "從自己的牌庫選擇最多2張【基礎】寶可夢卡，或者1張進化寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807683,
+				tcgplayer: 614947,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/097.ts
+++ b/data-asia/SV/SV9/097.ts
@@ -20,6 +20,16 @@ const card: Card = {
 		'zh-cn': "雙方場上所有「N的寶可夢」【撤退】所需的能量全部消除。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807684,
+				tcgplayer: 614948,
+			},
+		},
+	],
+
 	trainerType: "Stadium",
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/098.ts
+++ b/data-asia/SV/SV9/098.ts
@@ -20,6 +20,16 @@ const card: Card = {
 		'zh-cn': "雙方玩家在每個自己的回合時，可使用1次，可從自己的棄牌區選擇最多2張「基本【雷】能量」卡，在給對手看過後加入手牌。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807685,
+				tcgplayer: 614949,
+			},
+		},
+	],
+
 	trainerType: "Stadium",
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/099.ts
+++ b/data-asia/SV/SV9/099.ts
@@ -20,6 +20,16 @@ const card: Card = {
 		'zh-cn': "雙方的「赫普的寶可夢」使用的招式，對對手的戰鬥寶可夢造成的傷害「+30」點。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807686,
+				tcgplayer: 614950,
+			},
+		},
+	],
+
 	trainerType: "Stadium",
 	regulationMark: "I"
 }

--- a/data-asia/SV/SV9/100.ts
+++ b/data-asia/SV/SV9/100.ts
@@ -20,6 +20,16 @@ const card: Card = {
 	},
 
 	energyType: "Special",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807687,
+				tcgplayer: 614951,
+			},
+		},
+	],
+
 	regulationMark: "I"
 }
 

--- a/data-asia/SV/SV9/101.ts
+++ b/data-asia/SV/SV9/101.ts
@@ -52,11 +52,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 2,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807688,
+				tcgplayer: 614977,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 807593
-	}
+	retreat: 2,
 }
 
 export default card

--- a/data-asia/SV/SV9/102.ts
+++ b/data-asia/SV/SV9/102.ts
@@ -51,11 +51,17 @@ const card: Card = {
 		value: "－30"
 	}],
 
-	retreat: 1,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807689,
+				tcgplayer: 614978,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 807605
-	}
+	retreat: 1,
 }
 
 export default card

--- a/data-asia/SV/SV9/103.ts
+++ b/data-asia/SV/SV9/103.ts
@@ -40,11 +40,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 4,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807690,
+				tcgplayer: 614979,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 807612
-	}
+	retreat: 4,
 }
 
 export default card

--- a/data-asia/SV/SV9/104.ts
+++ b/data-asia/SV/SV9/104.ts
@@ -53,6 +53,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807691,
+				tcgplayer: 614980,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV9/105.ts
+++ b/data-asia/SV/SV9/105.ts
@@ -48,6 +48,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807692,
+				tcgplayer: 614981,
+			},
+		},
+	],
+
 	retreat: 0
 }
 

--- a/data-asia/SV/SV9/106.ts
+++ b/data-asia/SV/SV9/106.ts
@@ -46,11 +46,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 2,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807693,
+				tcgplayer: 614982,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 807631
-	}
+	retreat: 2,
 }
 
 export default card

--- a/data-asia/SV/SV9/107.ts
+++ b/data-asia/SV/SV9/107.ts
@@ -52,11 +52,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 2,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807694,
+				tcgplayer: 614983,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 807639
-	}
+	retreat: 2,
 }
 
 export default card

--- a/data-asia/SV/SV9/108.ts
+++ b/data-asia/SV/SV9/108.ts
@@ -36,6 +36,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807695,
+				tcgplayer: 614984,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV9/109.ts
+++ b/data-asia/SV/SV9/109.ts
@@ -43,6 +43,16 @@ const card: Card = {
 		damage: 170
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807696,
+				tcgplayer: 614985,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV9/110.ts
+++ b/data-asia/SV/SV9/110.ts
@@ -44,11 +44,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 1,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807697,
+				tcgplayer: 614986,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 807664
-	}
+	retreat: 1,
 }
 
 export default card

--- a/data-asia/SV/SV9/111.ts
+++ b/data-asia/SV/SV9/111.ts
@@ -45,11 +45,17 @@ const card: Card = {
 		value: "－30"
 	}],
 
-	retreat: 1,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807698,
+				tcgplayer: 614987,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 807667
-	}
+	retreat: 1,
 }
 
 export default card

--- a/data-asia/SV/SV9/112.ts
+++ b/data-asia/SV/SV9/112.ts
@@ -36,6 +36,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807699,
+				tcgplayer: 614988,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV9/113.ts
+++ b/data-asia/SV/SV9/113.ts
@@ -47,11 +47,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 3,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807700,
+				tcgplayer: 614989,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 807604
-	}
+	retreat: 3,
 }
 
 export default card

--- a/data-asia/SV/SV9/114.ts
+++ b/data-asia/SV/SV9/114.ts
@@ -47,6 +47,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807701,
+				tcgplayer: 614990,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV9/115.ts
+++ b/data-asia/SV/SV9/115.ts
@@ -47,6 +47,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807702,
+				tcgplayer: 614991,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV9/116.ts
+++ b/data-asia/SV/SV9/116.ts
@@ -47,11 +47,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 4,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807703,
+				tcgplayer: 614992,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 807633
-	}
+	retreat: 4,
 }
 
 export default card

--- a/data-asia/SV/SV9/117.ts
+++ b/data-asia/SV/SV9/117.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807704,
+				tcgplayer: 614993,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV9/118.ts
+++ b/data-asia/SV/SV9/118.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807705,
+				tcgplayer: 614994,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV9/119.ts
+++ b/data-asia/SV/SV9/119.ts
@@ -40,11 +40,17 @@ const card: Card = {
 		}
 	}],
 
-	retreat: 2,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807706,
+				tcgplayer: 614995,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 807659
-	}
+	retreat: 2,
 }
 
 export default card

--- a/data-asia/SV/SV9/120.ts
+++ b/data-asia/SV/SV9/120.ts
@@ -47,6 +47,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807707,
+				tcgplayer: 614996,
+			},
+		},
+	],
+
 	retreat: 3
 }
 

--- a/data-asia/SV/SV9/121.ts
+++ b/data-asia/SV/SV9/121.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		ja: "このカードは、自分の手札を1枚トラッシュしなければ使えない。\n\n自分の手札が6枚になるように、山札を引く。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807708,
+				tcgplayer: 614997,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV9/122.ts
+++ b/data-asia/SV/SV9/122.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		ja: "相手のポケモンを1匹選び、そのポケモンについている「ポケモンのどうぐ」と「特殊エネルギー」を1枚ずつトラッシュする。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807709,
+				tcgplayer: 614998,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV9/123.ts
+++ b/data-asia/SV/SV9/123.ts
@@ -16,6 +16,16 @@ const card: Card = {
 		ja: "自分の山札からたねポケモンを2枚まで、または進化ポケモンを1枚選び、相手に見せて、手札に加える。そして山札を切る。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807710,
+				tcgplayer: 614999,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV9/124.ts
+++ b/data-asia/SV/SV9/124.ts
@@ -47,11 +47,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 3,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807711,
+				tcgplayer: 615000,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 807604
-	}
+	retreat: 3,
 }
 
 export default card

--- a/data-asia/SV/SV9/125.ts
+++ b/data-asia/SV/SV9/125.ts
@@ -47,6 +47,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807712,
+				tcgplayer: 615001,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV9/126.ts
+++ b/data-asia/SV/SV9/126.ts
@@ -47,6 +47,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807713,
+				tcgplayer: 615002,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV9/127.ts
+++ b/data-asia/SV/SV9/127.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807714,
+				tcgplayer: 615003,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV9/128.ts
+++ b/data-asia/SV/SV9/128.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807715,
+				tcgplayer: 615004,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV9/129.ts
+++ b/data-asia/SV/SV9/129.ts
@@ -40,11 +40,17 @@ const card: Card = {
 		}
 	}],
 
-	retreat: 2,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807716,
+				tcgplayer: 615005,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 807659
-	}
+	retreat: 2,
 }
 
 export default card

--- a/data-asia/SV/SV9/130.ts
+++ b/data-asia/SV/SV9/130.ts
@@ -47,6 +47,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807717,
+				tcgplayer: 615006,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV9/131.ts
+++ b/data-asia/SV/SV9/131.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807718,
+				tcgplayer: 615007,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV9/132.ts
+++ b/data-asia/SV/SV9/132.ts
@@ -8,6 +8,16 @@ const card: Card = {
 		ja: "スパイクエネルギー"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807719,
+				tcgplayer: 615008,
+			},
+		},
+	],
+
 	rarity: "None",
 	category: "Energy",
 


### PR DESCRIPTION
## What

Links the cards of the existing Japanese set **SV9 バトルパートナーズ (Battle Partners)** to their Cardmarket **and TCGplayer** products, so the API can serve their prices.

- **69** cards carried no product id at all and get both
- **63** carried a card-level `thirdParty.cardmarket`, which is moved onto the card's `variants` entry and joined by its tcgplayer id
- **12** carried the cardmarket id of a different print and are corrected

Afterwards every card of the set carries its id on a `variants` entry and none on the card itself, which is where tcgdex is heading. Nothing else changes: the `zh-tw`/`zh-cn` texts and the Japanese card data are not rewritten.

12 cards carried the product of **another print** of the same card, so the API served that print's price for them:

| card | was | is | the old id belongs to |
|---|---|---|---|
| 101 | 807593 | 807688 | points at card 006 of this set |
| 102 | 807605 | 807689 | points at card 018 of this set |
| 103 | 807612 | 807690 | points at card 025 of this set |
| 106 | 807631 | 807693 | points at card 044 of this set |
| 107 | 807639 | 807694 | points at card 052 of this set |
| 110 | 807664 | 807697 | points at card 077 of this set |
| 111 | 807667 | 807698 | points at card 080 of this set |
| 113 | 807604 | 807700 | points at card 017 of this set |
| 116 | 807633 | 807703 | points at card 046 of this set |
| 119 | 807659 | 807706 | points at card 072 of this set |
| 124 | 807604 | 807711 | points at card 017 of this set |
| 129 | 807659 | 807716 | points at card 072 of this set |

The ids are assigned **by collection number**, not by name: within a Cardmarket expansion the products sorted by `idProduct` follow the collection order, and the assignment is verified against the sample rows pokepricelab renders. That matters because Cardmarket names every print of a card identically inside an expansion, so a name lookup cannot tell a base print from its AR/full-art reprint — which is where the corrected ids above come from. That the 51 ids this set already carried correctly agree with the same assignment is an independent cross-check.

## Data sources

- **Cardmarket** public product catalog (`downloads.s3.cardmarket.com`): the product ids (807588–807719), assigned by collection number
- **pokepricelab.com**: the sample rows that verify that assignment
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (614852–615008), keyed by the collection number each product carries in `extendedData`
- **limitlesstcg.com**: the set's card list — used here for nothing but the rarity per number, which decides whether a variant is `holo` or `normal`

## Notes

- All 132 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
