### PR TITLE
(data) ja SV8a Terastal Fest ex - cardmarket + tcgplayer product ids

### DIFF
--- a/data-asia/SV/SV8a/001.ts
+++ b/data-asia/SV/SV8a/001.ts
@@ -54,6 +54,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803114,
+				tcgplayer: 602319,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604502,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602320,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/002.ts
+++ b/data-asia/SV/SV8a/002.ts
@@ -66,6 +66,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803115,
+				tcgplayer: 602321,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604503,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602322,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/003.ts
+++ b/data-asia/SV/SV8a/003.ts
@@ -67,6 +67,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803116,
+				tcgplayer: 602323,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/004.ts
+++ b/data-asia/SV/SV8a/004.ts
@@ -56,6 +56,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803117,
+				tcgplayer: 602324,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604504,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602325,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/005.ts
+++ b/data-asia/SV/SV8a/005.ts
@@ -68,6 +68,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803118,
+				tcgplayer: 602326,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604505,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602327,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/006.ts
+++ b/data-asia/SV/SV8a/006.ts
@@ -60,6 +60,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803119,
+				tcgplayer: 602328,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604506,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602329,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/007.ts
+++ b/data-asia/SV/SV8a/007.ts
@@ -68,6 +68,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803120,
+				tcgplayer: 602330,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604507,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602331,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/008.ts
+++ b/data-asia/SV/SV8a/008.ts
@@ -48,6 +48,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803121,
+				tcgplayer: 602332,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604508,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602333,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/009.ts
+++ b/data-asia/SV/SV8a/009.ts
@@ -76,6 +76,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803122,
+				tcgplayer: 602334,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604509,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602335,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/010.ts
+++ b/data-asia/SV/SV8a/010.ts
@@ -67,6 +67,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803123,
+				tcgplayer: 602336,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/011.ts
+++ b/data-asia/SV/SV8a/011.ts
@@ -48,6 +48,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803124,
+				tcgplayer: 602337,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604510,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602338,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/012.ts
+++ b/data-asia/SV/SV8a/012.ts
@@ -76,6 +76,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803125,
+				tcgplayer: 602339,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604511,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602340,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/013.ts
+++ b/data-asia/SV/SV8a/013.ts
@@ -56,6 +56,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803126,
+				tcgplayer: 602341,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604512,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602342,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/014.ts
+++ b/data-asia/SV/SV8a/014.ts
@@ -76,6 +76,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803127,
+				tcgplayer: 602343,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604513,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602344,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/015.ts
+++ b/data-asia/SV/SV8a/015.ts
@@ -74,6 +74,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803128,
+				tcgplayer: 602345,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604514,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602346,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/016.ts
+++ b/data-asia/SV/SV8a/016.ts
@@ -67,6 +67,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803129,
+				tcgplayer: 602347,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/017.ts
+++ b/data-asia/SV/SV8a/017.ts
@@ -68,6 +68,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803130,
+				tcgplayer: 602348,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604515,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602349,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/018.ts
+++ b/data-asia/SV/SV8a/018.ts
@@ -74,6 +74,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803131,
+				tcgplayer: 602350,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604516,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602351,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/019.ts
+++ b/data-asia/SV/SV8a/019.ts
@@ -65,6 +65,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803132,
+				tcgplayer: 602352,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/020.ts
+++ b/data-asia/SV/SV8a/020.ts
@@ -67,6 +67,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803133,
+				tcgplayer: 602353,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/021.ts
+++ b/data-asia/SV/SV8a/021.ts
@@ -76,6 +76,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803134,
+				tcgplayer: 602354,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604517,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602355,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/022.ts
+++ b/data-asia/SV/SV8a/022.ts
@@ -67,6 +67,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803135,
+				tcgplayer: 602356,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/023.ts
+++ b/data-asia/SV/SV8a/023.ts
@@ -60,6 +60,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803136,
+				tcgplayer: 602357,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604518,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602358,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/024.ts
+++ b/data-asia/SV/SV8a/024.ts
@@ -76,6 +76,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803137,
+				tcgplayer: 602359,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604519,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602360,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/025.ts
+++ b/data-asia/SV/SV8a/025.ts
@@ -74,6 +74,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803138,
+				tcgplayer: 602361,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604520,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602362,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/026.ts
+++ b/data-asia/SV/SV8a/026.ts
@@ -67,6 +67,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803139,
+				tcgplayer: 602363,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/027.ts
+++ b/data-asia/SV/SV8a/027.ts
@@ -59,6 +59,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803140,
+				tcgplayer: 602364,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/028.ts
+++ b/data-asia/SV/SV8a/028.ts
@@ -76,6 +76,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803141,
+				tcgplayer: 602365,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604521,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602366,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/029.ts
+++ b/data-asia/SV/SV8a/029.ts
@@ -76,6 +76,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803142,
+				tcgplayer: 602367,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604522,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602368,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/030.ts
+++ b/data-asia/SV/SV8a/030.ts
@@ -76,6 +76,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803143,
+				tcgplayer: 602369,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604523,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602370,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/031.ts
+++ b/data-asia/SV/SV8a/031.ts
@@ -65,6 +65,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803144,
+				tcgplayer: 602371,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/032.ts
+++ b/data-asia/SV/SV8a/032.ts
@@ -56,6 +56,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803145,
+				tcgplayer: 602372,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604524,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602373,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/033.ts
+++ b/data-asia/SV/SV8a/033.ts
@@ -56,6 +56,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803146,
+				tcgplayer: 602374,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604525,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602375,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/034.ts
+++ b/data-asia/SV/SV8a/034.ts
@@ -76,6 +76,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803147,
+				tcgplayer: 602376,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604526,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602377,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/035.ts
+++ b/data-asia/SV/SV8a/035.ts
@@ -56,6 +56,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803148,
+				tcgplayer: 602378,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604527,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602379,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/036.ts
+++ b/data-asia/SV/SV8a/036.ts
@@ -68,6 +68,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803149,
+				tcgplayer: 602380,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604528,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602381,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/037.ts
+++ b/data-asia/SV/SV8a/037.ts
@@ -56,6 +56,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803150,
+				tcgplayer: 602382,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604529,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602383,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/038.ts
+++ b/data-asia/SV/SV8a/038.ts
@@ -68,6 +68,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803151,
+				tcgplayer: 602384,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604530,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602385,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/039.ts
+++ b/data-asia/SV/SV8a/039.ts
@@ -65,6 +65,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803152,
+				tcgplayer: 602386,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/040.ts
+++ b/data-asia/SV/SV8a/040.ts
@@ -68,6 +68,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803153,
+				tcgplayer: 602387,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604531,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602388,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/041.ts
+++ b/data-asia/SV/SV8a/041.ts
@@ -65,6 +65,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803154,
+				tcgplayer: 602389,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/042.ts
+++ b/data-asia/SV/SV8a/042.ts
@@ -74,6 +74,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803155,
+				tcgplayer: 602390,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604532,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602391,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/043.ts
+++ b/data-asia/SV/SV8a/043.ts
@@ -76,6 +76,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803156,
+				tcgplayer: 602392,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604533,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602393,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/044.ts
+++ b/data-asia/SV/SV8a/044.ts
@@ -56,6 +56,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803157,
+				tcgplayer: 602394,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604534,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602395,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/045.ts
+++ b/data-asia/SV/SV8a/045.ts
@@ -68,6 +68,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803158,
+				tcgplayer: 602396,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604535,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602397,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/046.ts
+++ b/data-asia/SV/SV8a/046.ts
@@ -67,6 +67,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803159,
+				tcgplayer: 602398,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/047.ts
+++ b/data-asia/SV/SV8a/047.ts
@@ -76,6 +76,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803160,
+				tcgplayer: 602399,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604536,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602400,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/048.ts
+++ b/data-asia/SV/SV8a/048.ts
@@ -74,6 +74,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803161,
+				tcgplayer: 602401,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604537,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602402,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/049.ts
+++ b/data-asia/SV/SV8a/049.ts
@@ -67,6 +67,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803162,
+				tcgplayer: 602403,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/050.ts
+++ b/data-asia/SV/SV8a/050.ts
@@ -67,6 +67,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803163,
+				tcgplayer: 602404,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/051.ts
+++ b/data-asia/SV/SV8a/051.ts
@@ -74,6 +74,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803164,
+				tcgplayer: 602405,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604538,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602406,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/052.ts
+++ b/data-asia/SV/SV8a/052.ts
@@ -67,6 +67,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803165,
+				tcgplayer: 602407,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/053.ts
+++ b/data-asia/SV/SV8a/053.ts
@@ -56,6 +56,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803166,
+				tcgplayer: 602408,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604539,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602409,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/054.ts
+++ b/data-asia/SV/SV8a/054.ts
@@ -59,6 +59,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803167,
+				tcgplayer: 602410,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/055.ts
+++ b/data-asia/SV/SV8a/055.ts
@@ -68,6 +68,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803168,
+				tcgplayer: 602411,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604540,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602412,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/056.ts
+++ b/data-asia/SV/SV8a/056.ts
@@ -67,6 +67,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803169,
+				tcgplayer: 602413,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/057.ts
+++ b/data-asia/SV/SV8a/057.ts
@@ -73,6 +73,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803170,
+				tcgplayer: 602414,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604541,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602415,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/058.ts
+++ b/data-asia/SV/SV8a/058.ts
@@ -61,6 +61,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803171,
+				tcgplayer: 602416,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604542,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602417,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/059.ts
+++ b/data-asia/SV/SV8a/059.ts
@@ -79,6 +79,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803172,
+				tcgplayer: 602418,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604543,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602419,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/060.ts
+++ b/data-asia/SV/SV8a/060.ts
@@ -61,6 +61,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803173,
+				tcgplayer: 602420,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604544,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602421,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/061.ts
+++ b/data-asia/SV/SV8a/061.ts
@@ -73,6 +73,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803174,
+				tcgplayer: 602422,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604545,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602423,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/062.ts
+++ b/data-asia/SV/SV8a/062.ts
@@ -81,6 +81,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803175,
+				tcgplayer: 602424,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604546,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602425,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/063.ts
+++ b/data-asia/SV/SV8a/063.ts
@@ -70,6 +70,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803176,
+				tcgplayer: 602426,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/064.ts
+++ b/data-asia/SV/SV8a/064.ts
@@ -71,6 +71,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803177,
+				tcgplayer: 602427,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604547,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602428,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/065.ts
+++ b/data-asia/SV/SV8a/065.ts
@@ -73,6 +73,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803178,
+				tcgplayer: 602429,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604548,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602430,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/066.ts
+++ b/data-asia/SV/SV8a/066.ts
@@ -81,6 +81,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803179,
+				tcgplayer: 602431,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604549,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602432,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/067.ts
+++ b/data-asia/SV/SV8a/067.ts
@@ -74,6 +74,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803180,
+				tcgplayer: 602433,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604550,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602434,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/068.ts
+++ b/data-asia/SV/SV8a/068.ts
@@ -74,6 +74,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803181,
+				tcgplayer: 602435,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604551,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602436,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/069.ts
+++ b/data-asia/SV/SV8a/069.ts
@@ -65,6 +65,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803182,
+				tcgplayer: 602437,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/070.ts
+++ b/data-asia/SV/SV8a/070.ts
@@ -81,6 +81,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803183,
+				tcgplayer: 602438,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604552,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602439,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/071.ts
+++ b/data-asia/SV/SV8a/071.ts
@@ -71,6 +71,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803184,
+				tcgplayer: 602440,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604553,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602441,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/072.ts
+++ b/data-asia/SV/SV8a/072.ts
@@ -76,6 +76,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803185,
+				tcgplayer: 602442,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604554,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602443,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/073.ts
+++ b/data-asia/SV/SV8a/073.ts
@@ -61,6 +61,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803186,
+				tcgplayer: 602444,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604555,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602445,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/074.ts
+++ b/data-asia/SV/SV8a/074.ts
@@ -67,6 +67,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803187,
+				tcgplayer: 602446,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/075.ts
+++ b/data-asia/SV/SV8a/075.ts
@@ -81,6 +81,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803188,
+				tcgplayer: 602447,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604556,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602448,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/076.ts
+++ b/data-asia/SV/SV8a/076.ts
@@ -76,6 +76,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803189,
+				tcgplayer: 602449,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604557,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602450,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/077.ts
+++ b/data-asia/SV/SV8a/077.ts
@@ -61,6 +61,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803190,
+				tcgplayer: 602451,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604558,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602452,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/078.ts
+++ b/data-asia/SV/SV8a/078.ts
@@ -70,6 +70,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803191,
+				tcgplayer: 602453,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/079.ts
+++ b/data-asia/SV/SV8a/079.ts
@@ -68,6 +68,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803192,
+				tcgplayer: 602454,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604559,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602455,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/080.ts
+++ b/data-asia/SV/SV8a/080.ts
@@ -74,6 +74,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803193,
+				tcgplayer: 602456,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604560,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602457,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/081.ts
+++ b/data-asia/SV/SV8a/081.ts
@@ -48,6 +48,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803194,
+				tcgplayer: 602458,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604561,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602459,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/082.ts
+++ b/data-asia/SV/SV8a/082.ts
@@ -56,6 +56,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803195,
+				tcgplayer: 602460,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604562,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602461,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/083.ts
+++ b/data-asia/SV/SV8a/083.ts
@@ -68,6 +68,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803196,
+				tcgplayer: 602462,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604563,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602463,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/084.ts
+++ b/data-asia/SV/SV8a/084.ts
@@ -68,6 +68,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803197,
+				tcgplayer: 602464,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604564,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602465,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/085.ts
+++ b/data-asia/SV/SV8a/085.ts
@@ -76,6 +76,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803198,
+				tcgplayer: 602466,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604565,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602467,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/086.ts
+++ b/data-asia/SV/SV8a/086.ts
@@ -66,6 +66,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803199,
+				tcgplayer: 602468,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604566,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602469,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/087.ts
+++ b/data-asia/SV/SV8a/087.ts
@@ -76,6 +76,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803200,
+				tcgplayer: 602470,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604567,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602471,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/088.ts
+++ b/data-asia/SV/SV8a/088.ts
@@ -67,6 +67,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803201,
+				tcgplayer: 602472,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/089.ts
+++ b/data-asia/SV/SV8a/089.ts
@@ -74,6 +74,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803202,
+				tcgplayer: 602473,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604568,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602474,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/090.ts
+++ b/data-asia/SV/SV8a/090.ts
@@ -68,6 +68,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803203,
+				tcgplayer: 602475,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604569,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602476,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/091.ts
+++ b/data-asia/SV/SV8a/091.ts
@@ -67,6 +67,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803204,
+				tcgplayer: 602477,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/092.ts
+++ b/data-asia/SV/SV8a/092.ts
@@ -74,6 +74,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803205,
+				tcgplayer: 602478,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604570,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602479,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/093.ts
+++ b/data-asia/SV/SV8a/093.ts
@@ -65,6 +65,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803206,
+				tcgplayer: 602480,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/094.ts
+++ b/data-asia/SV/SV8a/094.ts
@@ -68,6 +68,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803207,
+				tcgplayer: 602481,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604571,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602482,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/095.ts
+++ b/data-asia/SV/SV8a/095.ts
@@ -76,6 +76,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803208,
+				tcgplayer: 602483,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604572,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602484,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/096.ts
+++ b/data-asia/SV/SV8a/096.ts
@@ -68,6 +68,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803209,
+				tcgplayer: 602485,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604573,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602486,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/097.ts
+++ b/data-asia/SV/SV8a/097.ts
@@ -68,6 +68,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803210,
+				tcgplayer: 602487,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604574,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602488,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/098.ts
+++ b/data-asia/SV/SV8a/098.ts
@@ -76,6 +76,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803211,
+				tcgplayer: 602489,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604575,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602490,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/099.ts
+++ b/data-asia/SV/SV8a/099.ts
@@ -76,6 +76,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803212,
+				tcgplayer: 602491,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604576,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602492,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/100.ts
+++ b/data-asia/SV/SV8a/100.ts
@@ -68,6 +68,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803213,
+				tcgplayer: 602493,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604577,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602494,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/101.ts
+++ b/data-asia/SV/SV8a/101.ts
@@ -65,6 +65,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803214,
+				tcgplayer: 602495,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/102.ts
+++ b/data-asia/SV/SV8a/102.ts
@@ -65,6 +65,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803215,
+				tcgplayer: 602496,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/103.ts
+++ b/data-asia/SV/SV8a/103.ts
@@ -67,6 +67,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803216,
+				tcgplayer: 602497,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/104.ts
+++ b/data-asia/SV/SV8a/104.ts
@@ -65,6 +65,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803217,
+				tcgplayer: 602498,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/105.ts
+++ b/data-asia/SV/SV8a/105.ts
@@ -67,6 +67,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803218,
+				tcgplayer: 602499,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/106.ts
+++ b/data-asia/SV/SV8a/106.ts
@@ -73,6 +73,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803219,
+				tcgplayer: 602500,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604578,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602501,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/107.ts
+++ b/data-asia/SV/SV8a/107.ts
@@ -73,6 +73,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803220,
+				tcgplayer: 602502,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604579,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602503,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/108.ts
+++ b/data-asia/SV/SV8a/108.ts
@@ -79,6 +79,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803221,
+				tcgplayer: 602504,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604580,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602505,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/109.ts
+++ b/data-asia/SV/SV8a/109.ts
@@ -61,6 +61,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803222,
+				tcgplayer: 602506,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604581,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602507,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/110.ts
+++ b/data-asia/SV/SV8a/110.ts
@@ -73,6 +73,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803223,
+				tcgplayer: 602508,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604582,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602509,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/111.ts
+++ b/data-asia/SV/SV8a/111.ts
@@ -81,6 +81,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803224,
+				tcgplayer: 602510,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604583,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602511,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/112.ts
+++ b/data-asia/SV/SV8a/112.ts
@@ -73,6 +73,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803225,
+				tcgplayer: 602512,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604584,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602513,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/113.ts
+++ b/data-asia/SV/SV8a/113.ts
@@ -81,6 +81,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803226,
+				tcgplayer: 602514,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604585,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602515,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/114.ts
+++ b/data-asia/SV/SV8a/114.ts
@@ -71,6 +71,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803227,
+				tcgplayer: 602516,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604586,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602517,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/115.ts
+++ b/data-asia/SV/SV8a/115.ts
@@ -81,6 +81,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803228,
+				tcgplayer: 602518,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604587,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602519,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/116.ts
+++ b/data-asia/SV/SV8a/116.ts
@@ -81,6 +81,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803229,
+				tcgplayer: 602520,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604588,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602521,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/117.ts
+++ b/data-asia/SV/SV8a/117.ts
@@ -72,6 +72,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803230,
+				tcgplayer: 602522,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/118.ts
+++ b/data-asia/SV/SV8a/118.ts
@@ -55,6 +55,29 @@ const card: Card = {
 		damage: 40
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803231,
+				tcgplayer: 602523,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604589,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602524,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/119.ts
+++ b/data-asia/SV/SV8a/119.ts
@@ -63,6 +63,29 @@ const card: Card = {
 		damage: 70
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803232,
+				tcgplayer: 602525,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604590,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602526,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/120.ts
+++ b/data-asia/SV/SV8a/120.ts
@@ -54,6 +54,16 @@ const card: Card = {
 		}
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803233,
+				tcgplayer: 602527,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/121.ts
+++ b/data-asia/SV/SV8a/121.ts
@@ -63,6 +63,29 @@ const card: Card = {
 		damage: 50
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803234,
+				tcgplayer: 602528,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604591,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602529,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/122.ts
+++ b/data-asia/SV/SV8a/122.ts
@@ -71,6 +71,29 @@ const card: Card = {
 		}
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803235,
+				tcgplayer: 602530,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604592,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602531,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/123.ts
+++ b/data-asia/SV/SV8a/123.ts
@@ -63,6 +63,29 @@ const card: Card = {
 		damage: 160
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803236,
+				tcgplayer: 602532,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604593,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602533,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/124.ts
+++ b/data-asia/SV/SV8a/124.ts
@@ -60,6 +60,16 @@ const card: Card = {
 		}
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803237,
+				tcgplayer: 602534,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/125.ts
+++ b/data-asia/SV/SV8a/125.ts
@@ -76,6 +76,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803238,
+				tcgplayer: 602535,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604594,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602536,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/126.ts
+++ b/data-asia/SV/SV8a/126.ts
@@ -59,6 +59,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803239,
+				tcgplayer: 602537,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/127.ts
+++ b/data-asia/SV/SV8a/127.ts
@@ -73,6 +73,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803240,
+				tcgplayer: 602538,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604595,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602539,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/128.ts
+++ b/data-asia/SV/SV8a/128.ts
@@ -73,6 +73,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803241,
+				tcgplayer: 602540,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604596,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602541,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/129.ts
+++ b/data-asia/SV/SV8a/129.ts
@@ -68,6 +68,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803242,
+				tcgplayer: 602542,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604597,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602543,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/130.ts
+++ b/data-asia/SV/SV8a/130.ts
@@ -68,6 +68,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803243,
+				tcgplayer: 602544,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604598,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602545,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/131.ts
+++ b/data-asia/SV/SV8a/131.ts
@@ -81,6 +81,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803244,
+				tcgplayer: 602546,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604599,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602547,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/132.ts
+++ b/data-asia/SV/SV8a/132.ts
@@ -56,6 +56,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803245,
+				tcgplayer: 602548,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604600,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602549,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/133.ts
+++ b/data-asia/SV/SV8a/133.ts
@@ -76,6 +76,29 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803246,
+				tcgplayer: 602550,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604601,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602551,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/134.ts
+++ b/data-asia/SV/SV8a/134.ts
@@ -67,6 +67,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803247,
+				tcgplayer: 602552,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/135.ts
+++ b/data-asia/SV/SV8a/135.ts
@@ -79,6 +79,29 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803248,
+				tcgplayer: 602553,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604602,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602554,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/136.ts
+++ b/data-asia/SV/SV8a/136.ts
@@ -67,6 +67,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 803249,
+				tcgplayer: 602555,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/137.ts
+++ b/data-asia/SV/SV8a/137.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "從自己的棄牌區選擇1張名稱中有「厄鬼椪」的「寶可夢【ex】」卡，與自己的場上的1隻名稱中有「厄鬼椪」的「寶可夢【ex】」互換（所附加的卡・傷害指示物・特殊狀態・效果等全部保留）。將換下的寶可夢丟棄。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803250,
+				tcgplayer: 602556,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602557,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "H",
 	energyType: "Normal"

--- a/data-asia/SV/SV8a/138.ts
+++ b/data-asia/SV/SV8a/138.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "選擇1個對手的場上寶可夢身上附加的特殊能量，將其丟棄。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803251,
+				tcgplayer: 602558,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602559,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/139.ts
+++ b/data-asia/SV/SV8a/139.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "這張卡只有在自己剩餘獎賞卡的張數比對手剩餘獎賞卡的張數多時才可使用。 選擇1隻對手的備戰寶可夢，與戰鬥寶可夢互換。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803252,
+				tcgplayer: 602560,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602561,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/140.ts
+++ b/data-asia/SV/SV8a/140.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "這張卡只有在自己的場上有「太晶」寶可夢時才可使用。 選擇最多2隻自己的備戰區的【無】寶可夢，從棄牌區附給那些寶可夢各1張基本能量卡。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803253,
+				tcgplayer: 602562,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602563,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/141.ts
+++ b/data-asia/SV/SV8a/141.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "這張卡必須將自己的2張手牌丟棄才可使用。 從自己的棄牌區選擇最多4張基本能量卡，在給對手看過後加入手牌。（不可選擇因這張卡的效果而丟棄的能量卡。）"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803254,
+				tcgplayer: 602564,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602565,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/142.ts
+++ b/data-asia/SV/SV8a/142.ts
@@ -24,6 +24,16 @@ const card: Card = {
 		'zh-cn': "從自己的棄牌區選擇寶可夢卡與基本能量卡合計最多5張，在給對手看過後加入手牌。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803255,
+				tcgplayer: 602566,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/143.ts
+++ b/data-asia/SV/SV8a/143.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "這張卡必須將自己的1張手牌丟棄才可使用。 從自己的牌庫選擇最多2張基本能量卡，在給對手看過後加入手牌。並且重洗牌庫。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803256,
+				tcgplayer: 602567,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602568,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/144.ts
+++ b/data-asia/SV/SV8a/144.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "這張卡必須將自己的1張手牌丟棄才可使用。 從自己的牌庫選擇最多2張「未來」寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803257,
+				tcgplayer: 602569,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602570,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/145.ts
+++ b/data-asia/SV/SV8a/145.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "從自己的牌庫選擇1張「太晶」寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803258,
+				tcgplayer: 602571,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602572,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/146.ts
+++ b/data-asia/SV/SV8a/146.ts
@@ -24,6 +24,16 @@ const card: Card = {
 		'zh-cn': "從自己的牌庫選擇最多5張「寶可夢道具」卡，在給對手看過後加入手牌。並且重洗牌庫。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803259,
+				tcgplayer: 602573,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/147.ts
+++ b/data-asia/SV/SV8a/147.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "從自己的牌庫選擇最多2張HP為「70」以下的【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803260,
+				tcgplayer: 602574,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602575,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/148.ts
+++ b/data-asia/SV/SV8a/148.ts
@@ -24,6 +24,16 @@ const card: Card = {
 		'zh-cn': "選擇1隻對手的備戰寶可夢，與戰鬥寶可夢互換。然後，將自己的戰鬥寶可夢與備戰寶可夢互換。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803261,
+				tcgplayer: 602576,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/149.ts
+++ b/data-asia/SV/SV8a/149.ts
@@ -24,6 +24,16 @@ const card: Card = {
 		'zh-cn': "選擇1隻自己的場上寶可夢，將那隻寶可夢與附加的卡，全部放回手牌。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803262,
+				tcgplayer: 602577,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/150.ts
+++ b/data-asia/SV/SV8a/150.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "查看自己的牌庫上方7張卡，從其中選擇【草】寶可夢卡與「基本【草】能量」卡合計最多2張，在給對手看過後加入手牌。將剩餘卡放回牌庫並重洗。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803263,
+				tcgplayer: 602578,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602579,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/151.ts
+++ b/data-asia/SV/SV8a/151.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "從自己的棄牌區選擇1張寶可夢卡或者基本能量卡，在給對手看過後加入手牌。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803264,
+				tcgplayer: 602580,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602581,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/152.ts
+++ b/data-asia/SV/SV8a/152.ts
@@ -24,6 +24,16 @@ const card: Card = {
 		'zh-cn': "附有這張卡的「太晶」寶可夢使用招式時，使用那個招式所需的能量減少1個。（減少的能量任何屬性皆可。）"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803265,
+				tcgplayer: 602582,
+			},
+		},
+	],
+
 	trainerType: "Tool",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/153.ts
+++ b/data-asia/SV/SV8a/153.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "附有這張卡的寶可夢，【撤退】所需的能量減少1個。若那隻寶可夢的剩餘HP為「30」以下，則【撤退】所需的能量全部消除。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803266,
+				tcgplayer: 602583,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602584,
+			},
+		},
+	],
+
 	trainerType: "Tool",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/154.ts
+++ b/data-asia/SV/SV8a/154.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "附有這張卡的【中毒】的寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+40」點。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803267,
+				tcgplayer: 602585,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602586,
+			},
+		},
+	],
+
 	trainerType: "Tool",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/155.ts
+++ b/data-asia/SV/SV8a/155.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "附有這張卡的寶可夢（「擁有規則的寶可夢」除外）的最大HP「+100」，那隻寶可夢受到對手的寶可夢招式的傷害而【昏厥】時，被獲得的獎賞卡的張數增加1張。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803268,
+				tcgplayer: 602587,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602588,
+			},
+		},
+	],
+
 	trainerType: "Tool",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/156.ts
+++ b/data-asia/SV/SV8a/156.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "附有這張卡的寶可夢受到對手的【龍】寶可夢招式的傷害時，那個傷害「-60」點，將這張卡丟棄。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803269,
+				tcgplayer: 602589,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602590,
+			},
+		},
+	],
+
 	trainerType: "Tool",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/157.ts
+++ b/data-asia/SV/SV8a/157.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "附有這張卡的「古代」寶可夢的最大HP「+60」，那隻寶可夢不會陷入特殊狀態，並將受到的特殊狀態全部恢復。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803270,
+				tcgplayer: 602591,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602592,
+			},
+		},
+	],
+
 	trainerType: "Tool",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/158.ts
+++ b/data-asia/SV/SV8a/158.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "附有這張卡的「未來」寶可夢【撤退】所需的能量全部消除，那隻寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+20」點。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803271,
+				tcgplayer: 602593,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602594,
+			},
+		},
+	],
+
 	trainerType: "Tool",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/159.ts
+++ b/data-asia/SV/SV8a/159.ts
@@ -24,6 +24,16 @@ const card: Card = {
 		'zh-cn': "附有這張卡的寶可夢使用的招式，對對手的戰鬥場的「寶可夢【ex】」造成的傷害「+50」點。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803272,
+				tcgplayer: 602595,
+			},
+		},
+	],
+
 	trainerType: "Tool",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/160.ts
+++ b/data-asia/SV/SV8a/160.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "附有這張卡的寶可夢，可使用這張卡上寫的招式。[需要有足夠使用招式的能量。] 將附於寶可夢身上的這張卡，在自己的回合結束時丟棄。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803273,
+				tcgplayer: 602596,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602597,
+			},
+		},
+	],
+
 	trainerType: "Tool",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/161.ts
+++ b/data-asia/SV/SV8a/161.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "附有這張卡的寶可夢，可使用這張卡上寫的招式。[需要有足夠使用招式的能量。] 將附於寶可夢身上的這張卡，在自己的回合結束時丟棄。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803274,
+				tcgplayer: 602598,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602599,
+			},
+		},
+	],
+
 	trainerType: "Tool",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/162.ts
+++ b/data-asia/SV/SV8a/162.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "將自己的手牌全部丟棄，從自己的牌庫選擇「寶可夢」卡「支援者」卡「基本能量」卡各1張，在給對手看過後加入手牌。並且重洗牌庫。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803275,
+				tcgplayer: 602600,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602601,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/163.ts
+++ b/data-asia/SV/SV8a/163.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "從自己的牌庫選擇最多2張各不同屬性的基本能量卡，在給對手看過後，其中1張加入手牌，剩餘的能量卡附於自己的寶可夢身上。並且重洗牌庫。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803276,
+				tcgplayer: 602602,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602603,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/164.ts
+++ b/data-asia/SV/SV8a/164.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "從自己的牌庫選擇競技場卡與能量卡各1張，在給對手看過後加入手牌。並且重洗牌庫。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803277,
+				tcgplayer: 602604,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602605,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/165.ts
+++ b/data-asia/SV/SV8a/165.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "從自己的牌庫任意選擇2張卡。重洗剩餘牌庫，將所選的卡以任意順序排列，放回牌庫上方。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803278,
+				tcgplayer: 602606,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602607,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/166.ts
+++ b/data-asia/SV/SV8a/166.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "選擇最多2隻自己的【惡】寶可夢，從自己的牌庫附給那些寶可夢各1張「基本【惡】能量」卡。並且重洗牌庫。附於戰鬥寶可夢身上的情況下，將那隻寶可夢【中毒】。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803279,
+				tcgplayer: 602608,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602609,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/167.ts
+++ b/data-asia/SV/SV8a/167.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "選擇最多2隻自己的「古代」寶可夢，從棄牌區附給那些寶可夢各1張基本能量卡。然後，從自己的牌庫抽出3張卡。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803280,
+				tcgplayer: 602610,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602611,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/168.ts
+++ b/data-asia/SV/SV8a/168.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "從自己的棄牌區選擇寶可夢卡（「擁有規則的寶可夢」除外）與基本能量卡合計最多3張，在給對手看過後加入手牌。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803281,
+				tcgplayer: 602612,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602613,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/169.ts
+++ b/data-asia/SV/SV8a/169.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "這張卡從2種效果中選擇1種使用。 ◆將自己的戰鬥寶可夢與備戰寶可夢互換。 ◆在這個回合，自己的寶可夢使用的招式，對對手的戰鬥場的「寶可夢【ex】・【V】」造成的傷害「+30」點。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803282,
+				tcgplayer: 602614,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602615,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/170.ts
+++ b/data-asia/SV/SV8a/170.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "這張卡可在先攻玩家的最初回合使用。 將自己的手牌全部丟棄，從牌庫抽出5張卡。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803283,
+				tcgplayer: 602616,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602617,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/171.ts
+++ b/data-asia/SV/SV8a/171.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "將自己的手牌全部放回牌庫並重洗。然後，從牌庫抽出4張卡。若對手剩餘獎賞卡的張數為3張以下，則改爲抽出8張卡。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803284,
+				tcgplayer: 602618,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602619,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/172.ts
+++ b/data-asia/SV/SV8a/172.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "查看自己的牌庫上方6張卡，從其中選擇2張卡加入手牌。將剩餘卡丟棄。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803285,
+				tcgplayer: 602620,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602621,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H",
 	energyType: "Normal"

--- a/data-asia/SV/SV8a/173.ts
+++ b/data-asia/SV/SV8a/173.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "從自己的牌庫抽出4張卡。在使用了這張卡的回合結束時，若自己的手牌有5張以上，則將自己的手牌全部丟棄。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803286,
+				tcgplayer: 602622,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602623,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/174.ts
+++ b/data-asia/SV/SV8a/174.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "從自己的牌庫抽出3張卡。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803287,
+				tcgplayer: 602624,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602625,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/175.ts
+++ b/data-asia/SV/SV8a/175.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "選擇1隻自己的場上寶可夢，放回手牌。（寶可夢以外的卡全部丟棄。）"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803288,
+				tcgplayer: 602626,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602627,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/176.ts
+++ b/data-asia/SV/SV8a/176.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "這張卡只有在對手剩餘獎賞卡的張數為2張時才可使用。 在這個回合，若對手的戰鬥寶可夢因自己的「太晶」寶可夢使用的招式的傷害而【昏厥】了，則多獲得1張獎賞卡。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803289,
+				tcgplayer: 602628,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602629,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/177.ts
+++ b/data-asia/SV/SV8a/177.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "將自己的1隻剩餘HP為「30」以下的寶可夢的HP全部恢復。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803290,
+				tcgplayer: 602630,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602631,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/178.ts
+++ b/data-asia/SV/SV8a/178.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "這張卡必須將自己的1張手牌丟棄才可使用。 從自己的牌庫抽出與對手的備戰寶可夢相同數量的卡。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803291,
+				tcgplayer: 602632,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602633,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/179.ts
+++ b/data-asia/SV/SV8a/179.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "這張卡必須在上個對手的回合自己的寶可夢【昏厥】了才可使用。 從自己的棄牌區選擇1張「基本【火】能量」卡，附於自己的寶可夢身上。然後，從牌庫抽卡直到自己的手牌滿6張為止。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803292,
+				tcgplayer: 602634,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602635,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/180.ts
+++ b/data-asia/SV/SV8a/180.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "雙方的所有身上附有能量卡的寶可夢不會陷入特殊狀態，並將受到的特殊狀態全部恢復。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803293,
+				tcgplayer: 602636,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602637,
+			},
+		},
+	],
+
 	trainerType: "Stadium",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/181.ts
+++ b/data-asia/SV/SV8a/181.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "雙方的所有寶可夢身上附加的「寶可夢道具」卡的效果全部消除。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803294,
+				tcgplayer: 602638,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602639,
+			},
+		},
+	],
+
 	trainerType: "Stadium",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/182.ts
+++ b/data-asia/SV/SV8a/182.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "自己的場上有「太晶」寶可夢的玩家的可放置於備戰區的寶可夢數量改為8隻。 （這張卡被丟棄時，或自己的場上沒有了「太晶」寶可夢時，將備戰區的寶可夢丟棄直到變為5隻為止。若雙方都要丟棄，則這張卡的持有人先丟棄。）"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803295,
+				tcgplayer: 602640,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602641,
+			},
+		},
+	],
+
 	trainerType: "Stadium",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/183.ts
+++ b/data-asia/SV/SV8a/183.ts
@@ -24,6 +24,22 @@ const card: Card = {
 		'zh-cn': "雙方玩家在每個自己的回合時，可使用1次，若從自己的手牌將1張「基本【超】能量」卡丟棄，則可將自己的所有寶可夢各恢復「30」HP。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803296,
+				tcgplayer: 602642,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602643,
+			},
+		},
+	],
+
 	trainerType: "Stadium",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/184.ts
+++ b/data-asia/SV/SV8a/184.ts
@@ -24,6 +24,16 @@ const card: Card = {
 		'zh-cn': "雙方的所有寶可夢（「擁有規則的寶可夢」除外），不會受到對手的「寶可夢【ex】・【V】」招式的傷害。 這張卡只要在棄牌區，無法加入手牌，無法放回牌庫。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803297,
+				tcgplayer: 602644,
+			},
+		},
+	],
+
 	trainerType: "Stadium",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/185.ts
+++ b/data-asia/SV/SV8a/185.ts
@@ -24,6 +24,29 @@ const card: Card = {
 	},
 
 	energyType: "Special",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803298,
+				tcgplayer: 602645,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604644,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602646,
+			},
+		},
+	],
+
 	regulationMark: "G"
 }
 

--- a/data-asia/SV/SV8a/186.ts
+++ b/data-asia/SV/SV8a/186.ts
@@ -24,6 +24,29 @@ const card: Card = {
 	},
 
 	energyType: "Special",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803299,
+				tcgplayer: 602647,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604645,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 602648,
+			},
+		},
+	],
+
 	regulationMark: "H"
 }
 

--- a/data-asia/SV/SV8a/187.ts
+++ b/data-asia/SV/SV8a/187.ts
@@ -24,6 +24,23 @@ const card: Card = {
 	},
 
 	energyType: "Special",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803300,
+				tcgplayer: 602649,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "masterball",
+			thirdParty: {
+				tcgplayer: 604646,
+			},
+		},
+	],
+
 	regulationMark: "H"
 }
 

--- a/data-asia/SV/SV8a/188.ts
+++ b/data-asia/SV/SV8a/188.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		'zh-cn': "將自己的手牌全部丟棄，從自己的牌庫選擇「寶可夢」卡「支援者」卡「基本能量」卡各1張，在給對手看過後加入手牌。並且重洗牌庫。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803301,
+				tcgplayer: 602651,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/189.ts
+++ b/data-asia/SV/SV8a/189.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		'zh-cn': "查看對手的手牌，從其中任意選擇1張卡，放回對手的牌庫下方。然後，對手若希望，從牌庫抽出1張卡。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803302,
+				tcgplayer: 602653,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/190.ts
+++ b/data-asia/SV/SV8a/190.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		'zh-cn': "將自己的所有手牌放回牌庫並重洗。然後，從牌庫抽出比放回張數多1張的卡。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803303,
+				tcgplayer: 602654,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/191.ts
+++ b/data-asia/SV/SV8a/191.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		'zh-cn': "這張卡只有在對手的戰鬥寶可夢【中毒】時才可使用。 將自己的手牌全部放回牌庫並重洗。然後，從牌庫抽出7張卡。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803304,
+				tcgplayer: 602655,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/192.ts
+++ b/data-asia/SV/SV8a/192.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		'zh-cn': "這張卡只有在對手的戰鬥寶可夢【中毒】時才可使用。 將自己的手牌全部放回牌庫並重洗。然後，從牌庫抽出7張卡。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803305,
+				tcgplayer: 602656,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/193.ts
+++ b/data-asia/SV/SV8a/193.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		'zh-cn': "從自己的手牌選擇1張寶可夢卡，向對手宣言那隻寶可夢的名稱後，翻到反面放置。對手回答那隻寶可夢的HP。將翻到反面的寶可夢卡翻到正面，若正確，則對手從牌庫抽出4張卡。若不正確，則自己從牌庫抽出4張卡。然後，將放置的卡放回自己的手牌。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803306,
+				tcgplayer: 602657,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/194.ts
+++ b/data-asia/SV/SV8a/194.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		'zh-cn': "從自己的牌庫抽出4張卡。在使用了這張卡的回合結束時，若自己的手牌有5張以上，則將自己的手牌全部丟棄。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803307,
+				tcgplayer: 602658,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/195.ts
+++ b/data-asia/SV/SV8a/195.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		'zh-cn': "從自己的牌庫抽出3張卡。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803308,
+				tcgplayer: 602659,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/196.ts
+++ b/data-asia/SV/SV8a/196.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		'zh-cn': "選擇對手的所有寶可夢身上各自附加的特殊能量各1個，將其丟棄。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803309,
+				tcgplayer: 602660,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/197.ts
+++ b/data-asia/SV/SV8a/197.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		'zh-cn': "查看對手的手牌，從其中選擇最多2張物品卡，將其丟棄。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803310,
+				tcgplayer: 602661,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/198.ts
+++ b/data-asia/SV/SV8a/198.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		'zh-cn': "這張卡必須在上個對手的回合自己的寶可夢【昏厥】了才可使用。 從自己的棄牌區選擇1張「基本【火】能量」卡，附於自己的寶可夢身上。然後，從牌庫抽卡直到自己的手牌滿6張為止。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803311,
+				tcgplayer: 602662,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/199.ts
+++ b/data-asia/SV/SV8a/199.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		'zh-cn': "查看自己的牌庫上方5張卡，從其中選擇任意數量的卡，將其丟棄。將剩餘卡以任意順序排列，放回牌庫上方。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803312,
+				tcgplayer: 602663,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/200.ts
+++ b/data-asia/SV/SV8a/200.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803313,
+				tcgplayer: 602664,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/201.ts
+++ b/data-asia/SV/SV8a/201.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803314,
+				tcgplayer: 602665,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/202.ts
+++ b/data-asia/SV/SV8a/202.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803315,
+				tcgplayer: 602666,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/203.ts
+++ b/data-asia/SV/SV8a/203.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803316,
+				tcgplayer: 602667,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/204.ts
+++ b/data-asia/SV/SV8a/204.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803317,
+				tcgplayer: 602668,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/205.ts
+++ b/data-asia/SV/SV8a/205.ts
@@ -60,6 +60,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803318,
+				tcgplayer: 602669,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/206.ts
+++ b/data-asia/SV/SV8a/206.ts
@@ -60,6 +60,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803319,
+				tcgplayer: 602670,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/207.ts
+++ b/data-asia/SV/SV8a/207.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803320,
+				tcgplayer: 602671,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/208.ts
+++ b/data-asia/SV/SV8a/208.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803321,
+				tcgplayer: 602672,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/209.ts
+++ b/data-asia/SV/SV8a/209.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803322,
+				tcgplayer: 602673,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/210.ts
+++ b/data-asia/SV/SV8a/210.ts
@@ -55,6 +55,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803323,
+				tcgplayer: 602674,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/211.ts
+++ b/data-asia/SV/SV8a/211.ts
@@ -65,6 +65,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803324,
+				tcgplayer: 602675,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/212.ts
+++ b/data-asia/SV/SV8a/212.ts
@@ -60,6 +60,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803325,
+				tcgplayer: 602676,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/213.ts
+++ b/data-asia/SV/SV8a/213.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803326,
+				tcgplayer: 602677,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/214.ts
+++ b/data-asia/SV/SV8a/214.ts
@@ -65,6 +65,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803327,
+				tcgplayer: 602678,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/215.ts
+++ b/data-asia/SV/SV8a/215.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803328,
+				tcgplayer: 602679,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/216.ts
+++ b/data-asia/SV/SV8a/216.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803329,
+				tcgplayer: 602680,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/217.ts
+++ b/data-asia/SV/SV8a/217.ts
@@ -60,6 +60,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803330,
+				tcgplayer: 602681,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/218.ts
+++ b/data-asia/SV/SV8a/218.ts
@@ -60,6 +60,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803331,
+				tcgplayer: 602682,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/219.ts
+++ b/data-asia/SV/SV8a/219.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803332,
+				tcgplayer: 602683,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/220.ts
+++ b/data-asia/SV/SV8a/220.ts
@@ -67,6 +67,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803333,
+				tcgplayer: 602684,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV8a/221.ts
+++ b/data-asia/SV/SV8a/221.ts
@@ -50,6 +50,16 @@ const card: Card = {
 		}
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803334,
+				tcgplayer: 602685,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/222.ts
+++ b/data-asia/SV/SV8a/222.ts
@@ -55,6 +55,16 @@ const card: Card = {
 		}
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803335,
+				tcgplayer: 602686,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/223.ts
+++ b/data-asia/SV/SV8a/223.ts
@@ -55,6 +55,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803336,
+				tcgplayer: 602687,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/224.ts
+++ b/data-asia/SV/SV8a/224.ts
@@ -55,6 +55,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803337,
+				tcgplayer: 602688,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/225.ts
+++ b/data-asia/SV/SV8a/225.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803338,
+				tcgplayer: 602689,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/226.ts
+++ b/data-asia/SV/SV8a/226.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803339,
+				tcgplayer: 602690,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/227.ts
+++ b/data-asia/SV/SV8a/227.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		'zh-cn': "從自己的牌庫選擇最多2張各不同屬性的基本能量卡，在給對手看過後，其中1張加入手牌，剩餘的能量卡附於自己的寶可夢身上。並且重洗牌庫。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803340,
+				tcgplayer: 602691,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/228.ts
+++ b/data-asia/SV/SV8a/228.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		'zh-cn': "選擇最多2隻自己的【惡】寶可夢，從自己的牌庫附給那些寶可夢各1張「基本【惡】能量」卡。並且重洗牌庫。附於戰鬥寶可夢身上的情況下，將那隻寶可夢【中毒】。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803341,
+				tcgplayer: 602692,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/229.ts
+++ b/data-asia/SV/SV8a/229.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		'zh-cn': "查看自己的牌庫上方7張卡，從其中選擇寶可夢卡與訓練家卡各1張，在給對手看過後加入手牌。將剩餘卡放回牌庫並重洗。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803342,
+				tcgplayer: 602693,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/230.ts
+++ b/data-asia/SV/SV8a/230.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		'zh-cn': "這張卡從2種效果中選擇1種使用。 ◆將自己的戰鬥寶可夢與備戰寶可夢互換。 ◆在這個回合，自己的寶可夢使用的招式，對對手的戰鬥場的「寶可夢【ex】・【V】」造成的傷害「+30」點。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803343,
+				tcgplayer: 602694,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/231.ts
+++ b/data-asia/SV/SV8a/231.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		'zh-cn': "將自己的手牌全部放回牌庫並重洗。然後，從牌庫抽出4張卡。若對手剩餘獎賞卡的張數為3張以下，則改爲抽出8張卡。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803344,
+				tcgplayer: 602695,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/232.ts
+++ b/data-asia/SV/SV8a/232.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		'zh-cn': "從自己的牌庫抽出4張卡。在使用了這張卡的回合結束時，若自己的手牌有5張以上，則將自己的手牌全部丟棄。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803345,
+				tcgplayer: 602696,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/233.ts
+++ b/data-asia/SV/SV8a/233.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803346,
+				tcgplayer: 602697,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/234.ts
+++ b/data-asia/SV/SV8a/234.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803347,
+				tcgplayer: 602698,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/235.ts
+++ b/data-asia/SV/SV8a/235.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803348,
+				tcgplayer: 602699,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/236.ts
+++ b/data-asia/SV/SV8a/236.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803349,
+				tcgplayer: 602700,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H"
 }

--- a/data-asia/SV/SV8a/237.ts
+++ b/data-asia/SV/SV8a/237.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 803350,
+				tcgplayer: 602701,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H"
 }


### PR DESCRIPTION
## What

Links the cards of the existing Japanese set **SV8a テラスタルフェスex (Terastal Fest ex)** to their Cardmarket **and TCGplayer** products, so the API can serve their prices.

- **237** cards carried no product id at all and get both

Afterwards every card of the set carries its id on a `variants` entry and none on the card itself, which is where tcgdex is heading. Nothing else changes: the `zh-tw`/`zh-cn`/`th`/`id` texts and the Japanese card data are not rewritten.

The ids are assigned **by collection number**, not by name: within a Cardmarket expansion the products sorted by `idProduct` follow the collection order, and the assignment is verified against the sample rows pokepricelab renders. That matters because Cardmarket names every print of a card identically inside an expansion, so a name lookup cannot tell a base print from its AR/full-art reprint. This set carried no id yet, so there is nothing in the repository to cross-check the assignment against — it rests on the verified ordering alone.

## Data sources

- **Cardmarket** public product catalog (`downloads.s3.cardmarket.com`): the product ids (803114–803350), assigned by collection number
- **pokepricelab.com**: the sample rows that verify that assignment
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (602319–602701), keyed by the collection number each product carries in `extendedData`
- **limitlesstcg.com**: the set's card list — used here for nothing but the rarity per number, which decides whether a variant is `holo` or `normal`

## Notes

- All 237 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
