### PR TITLE
(data) ja S12 Paradigm Trigger - cardmarket + tcgplayer product ids

### DIFF
--- a/data-asia/S/S12/001.ts
+++ b/data-asia/S/S12/001.ts
@@ -45,14 +45,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680140,
+				tcgplayer: 570059,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [43],
-
-	thirdParty: {
-		cardmarket: 680140
-	}
 }
 
 export default card

--- a/data-asia/S/S12/002.ts
+++ b/data-asia/S/S12/002.ts
@@ -45,14 +45,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680141,
+				tcgplayer: 570060,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [44],
-
-	thirdParty: {
-		cardmarket: 680141
-	}
 }
 
 export default card

--- a/data-asia/S/S12/003.ts
+++ b/data-asia/S/S12/003.ts
@@ -45,14 +45,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680142,
+				tcgplayer: 570061,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [182],
-
-	thirdParty: {
-		cardmarket: 680142
-	}
 }
 
 export default card

--- a/data-asia/S/S12/004.ts
+++ b/data-asia/S/S12/004.ts
@@ -48,14 +48,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680143,
+				tcgplayer: 570062,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [114],
-
-	thirdParty: {
-		cardmarket: 680143
-	}
 }
 
 export default card

--- a/data-asia/S/S12/005.ts
+++ b/data-asia/S/S12/005.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680144,
+				tcgplayer: 570063,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [465],
-
-	thirdParty: {
-		cardmarket: 680144
-	}
 }
 
 export default card

--- a/data-asia/S/S12/006.ts
+++ b/data-asia/S/S12/006.ts
@@ -39,14 +39,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680145,
+				tcgplayer: 570064,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [167],
-
-	thirdParty: {
-		cardmarket: 680145
-	}
 }
 
 export default card

--- a/data-asia/S/S12/007.ts
+++ b/data-asia/S/S12/007.ts
@@ -55,14 +55,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680146,
+				tcgplayer: 570065,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Rare",
 	dexId: [168],
-
-	thirdParty: {
-		cardmarket: 680146
-	}
 }
 
 export default card

--- a/data-asia/S/S12/008.ts
+++ b/data-asia/S/S12/008.ts
@@ -60,14 +60,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680147,
+				tcgplayer: 570066,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [640],
-
-	thirdParty: {
-		cardmarket: 680147
-	}
 }
 
 export default card

--- a/data-asia/S/S12/009.ts
+++ b/data-asia/S/S12/009.ts
@@ -55,6 +55,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680148,
+				tcgplayer: 570067,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "F",
 	rarity: "Double rare"

--- a/data-asia/S/S12/010.ts
+++ b/data-asia/S/S12/010.ts
@@ -45,14 +45,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680149,
+				tcgplayer: 570068,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [77],
-
-	thirdParty: {
-		cardmarket: 680149
-	}
 }
 
 export default card

--- a/data-asia/S/S12/011.ts
+++ b/data-asia/S/S12/011.ts
@@ -55,14 +55,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680150,
+				tcgplayer: 570069,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Rare",
 	dexId: [78],
-
-	thirdParty: {
-		cardmarket: 680150
-	}
 }
 
 export default card

--- a/data-asia/S/S12/012.ts
+++ b/data-asia/S/S12/012.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680151,
+				tcgplayer: 570070,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [494],
-
-	thirdParty: {
-		cardmarket: 680151
-	}
 }
 
 export default card

--- a/data-asia/S/S12/013.ts
+++ b/data-asia/S/S12/013.ts
@@ -39,14 +39,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680152,
+				tcgplayer: 570071,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [636],
-
-	thirdParty: {
-		cardmarket: 680152
-	}
 }
 
 export default card

--- a/data-asia/S/S12/014.ts
+++ b/data-asia/S/S12/014.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680153,
+				tcgplayer: 570072,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [637],
-
-	thirdParty: {
-		cardmarket: 680153
-	}
 }
 
 export default card

--- a/data-asia/S/S12/015.ts
+++ b/data-asia/S/S12/015.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680154,
+				tcgplayer: 570073,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [725],
-
-	thirdParty: {
-		cardmarket: 680154
-	}
 }
 
 export default card

--- a/data-asia/S/S12/016.ts
+++ b/data-asia/S/S12/016.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680155,
+				tcgplayer: 570074,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [726],
-
-	thirdParty: {
-		cardmarket: 680155
-	}
 }
 
 export default card

--- a/data-asia/S/S12/017.ts
+++ b/data-asia/S/S12/017.ts
@@ -59,14 +59,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680156,
+				tcgplayer: 570075,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [727],
-
-	thirdParty: {
-		cardmarket: 680156
-	}
 }
 
 export default card

--- a/data-asia/S/S12/018.ts
+++ b/data-asia/S/S12/018.ts
@@ -53,6 +53,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680157,
+				tcgplayer: 570076,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Double rare"

--- a/data-asia/S/S12/019.ts
+++ b/data-asia/S/S12/019.ts
@@ -53,14 +53,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680158,
+				tcgplayer: 570077,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [361],
-
-	thirdParty: {
-		cardmarket: 680158
-	}
 }
 
 export default card

--- a/data-asia/S/S12/020.ts
+++ b/data-asia/S/S12/020.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680159,
+				tcgplayer: 570078,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [362],
-
-	thirdParty: {
-		cardmarket: 680159
-	}
 }
 
 export default card

--- a/data-asia/S/S12/021.ts
+++ b/data-asia/S/S12/021.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680160,
+				tcgplayer: 570079,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [478],
-
-	thirdParty: {
-		cardmarket: 680160
-	}
 }
 
 export default card

--- a/data-asia/S/S12/022.ts
+++ b/data-asia/S/S12/022.ts
@@ -59,14 +59,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680161,
+				tcgplayer: 570080,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [369],
-
-	thirdParty: {
-		cardmarket: 680161
-	}
 }
 
 export default card

--- a/data-asia/S/S12/023.ts
+++ b/data-asia/S/S12/023.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680162,
+				tcgplayer: 570081,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [647],
-
-	thirdParty: {
-		cardmarket: 680162
-	}
 }
 
 export default card

--- a/data-asia/S/S12/024.ts
+++ b/data-asia/S/S12/024.ts
@@ -45,14 +45,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680163,
+				tcgplayer: 570082,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [25],
-
-	thirdParty: {
-		cardmarket: 680163
-	}
 }
 
 export default card

--- a/data-asia/S/S12/025.ts
+++ b/data-asia/S/S12/025.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680164,
+				tcgplayer: 570083,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [26],
-
-	thirdParty: {
-		cardmarket: 680164
-	}
 }
 
 export default card

--- a/data-asia/S/S12/026.ts
+++ b/data-asia/S/S12/026.ts
@@ -45,14 +45,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680165,
+				tcgplayer: 570084,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [403],
-
-	thirdParty: {
-		cardmarket: 680165
-	}
 }
 
 export default card

--- a/data-asia/S/S12/027.ts
+++ b/data-asia/S/S12/027.ts
@@ -53,14 +53,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680166,
+				tcgplayer: 570085,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [404],
-
-	thirdParty: {
-		cardmarket: 680166
-	}
 }
 
 export default card

--- a/data-asia/S/S12/028.ts
+++ b/data-asia/S/S12/028.ts
@@ -61,14 +61,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680167,
+				tcgplayer: 570086,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [405],
-
-	thirdParty: {
-		cardmarket: 680167
-	}
 }
 
 export default card

--- a/data-asia/S/S12/029.ts
+++ b/data-asia/S/S12/029.ts
@@ -53,14 +53,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680168,
+				tcgplayer: 570087,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [618],
-
-	thirdParty: {
-		cardmarket: 680168
-	}
 }
 
 export default card

--- a/data-asia/S/S12/030.ts
+++ b/data-asia/S/S12/030.ts
@@ -48,14 +48,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680169,
+				tcgplayer: 570088,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [694],
-
-	thirdParty: {
-		cardmarket: 680169
-	}
 }
 
 export default card

--- a/data-asia/S/S12/031.ts
+++ b/data-asia/S/S12/031.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680170,
+				tcgplayer: 570089,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [695],
-
-	thirdParty: {
-		cardmarket: 680170
-	}
 }
 
 export default card

--- a/data-asia/S/S12/032.ts
+++ b/data-asia/S/S12/032.ts
@@ -54,6 +54,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680171,
+				tcgplayer: 570090,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "F",
 	rarity: "Uncommon",

--- a/data-asia/S/S12/033.ts
+++ b/data-asia/S/S12/033.ts
@@ -54,6 +54,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680172,
+				tcgplayer: 570091,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Double rare"

--- a/data-asia/S/S12/034.ts
+++ b/data-asia/S/S12/034.ts
@@ -54,6 +54,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680173,
+				tcgplayer: 570092,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "F"
 }

--- a/data-asia/S/S12/035.ts
+++ b/data-asia/S/S12/035.ts
@@ -58,6 +58,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680174,
+				tcgplayer: 570093,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Double rare"

--- a/data-asia/S/S12/036.ts
+++ b/data-asia/S/S12/036.ts
@@ -57,12 +57,18 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680175,
+				tcgplayer: 570094,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 680175
-	}
 }
 
 export default card

--- a/data-asia/S/S12/037.ts
+++ b/data-asia/S/S12/037.ts
@@ -60,14 +60,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680176,
+				tcgplayer: 570095,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [307],
-
-	thirdParty: {
-		cardmarket: 680176
-	}
 }
 
 export default card

--- a/data-asia/S/S12/038.ts
+++ b/data-asia/S/S12/038.ts
@@ -66,14 +66,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680177,
+				tcgplayer: 570096,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Rare",
 	dexId: [308],
-
-	thirdParty: {
-		cardmarket: 680177
-	}
 }
 
 export default card

--- a/data-asia/S/S12/039.ts
+++ b/data-asia/S/S12/039.ts
@@ -58,14 +58,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680178,
+				tcgplayer: 570097,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [561],
-
-	thirdParty: {
-		cardmarket: 680178
-	}
 }
 
 export default card

--- a/data-asia/S/S12/040.ts
+++ b/data-asia/S/S12/040.ts
@@ -44,14 +44,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680179,
+				tcgplayer: 570098,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [577],
-
-	thirdParty: {
-		cardmarket: 680179
-	}
 }
 
 export default card

--- a/data-asia/S/S12/041.ts
+++ b/data-asia/S/S12/041.ts
@@ -50,14 +50,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680180,
+				tcgplayer: 570099,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [578],
-
-	thirdParty: {
-		cardmarket: 680180
-	}
 }
 
 export default card

--- a/data-asia/S/S12/042.ts
+++ b/data-asia/S/S12/042.ts
@@ -66,14 +66,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680181,
+				tcgplayer: 570100,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Rare",
 	dexId: [579],
-
-	thirdParty: {
-		cardmarket: 680181
-	}
 }
 
 export default card

--- a/data-asia/S/S12/043.ts
+++ b/data-asia/S/S12/043.ts
@@ -44,14 +44,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680182,
+				tcgplayer: 570101,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [605],
-
-	thirdParty: {
-		cardmarket: 680182
-	}
 }
 
 export default card

--- a/data-asia/S/S12/044.ts
+++ b/data-asia/S/S12/044.ts
@@ -58,14 +58,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680183,
+				tcgplayer: 570102,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [606],
-
-	thirdParty: {
-		cardmarket: 680183
-	}
 }
 
 export default card

--- a/data-asia/S/S12/045.ts
+++ b/data-asia/S/S12/045.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680184,
+				tcgplayer: 570103,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [702],
-
-	thirdParty: {
-		cardmarket: 680184
-	}
 }
 
 export default card

--- a/data-asia/S/S12/046.ts
+++ b/data-asia/S/S12/046.ts
@@ -55,6 +55,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680185,
+				tcgplayer: 570104,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "F",
 	rarity: "Double rare"

--- a/data-asia/S/S12/047.ts
+++ b/data-asia/S/S12/047.ts
@@ -53,14 +53,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680186,
+				tcgplayer: 570105,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [343],
-
-	thirdParty: {
-		cardmarket: 680186
-	}
 }
 
 export default card

--- a/data-asia/S/S12/048.ts
+++ b/data-asia/S/S12/048.ts
@@ -55,14 +55,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680187,
+				tcgplayer: 570106,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [344],
-
-	thirdParty: {
-		cardmarket: 680187
-	}
 }
 
 export default card

--- a/data-asia/S/S12/049.ts
+++ b/data-asia/S/S12/049.ts
@@ -45,14 +45,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680188,
+				tcgplayer: 570107,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [347],
-
-	thirdParty: {
-		cardmarket: 680188
-	}
 }
 
 export default card

--- a/data-asia/S/S12/050.ts
+++ b/data-asia/S/S12/050.ts
@@ -53,14 +53,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680189,
+				tcgplayer: 570108,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [348],
-
-	thirdParty: {
-		cardmarket: 680189
-	}
 }
 
 export default card

--- a/data-asia/S/S12/051.ts
+++ b/data-asia/S/S12/051.ts
@@ -45,14 +45,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680190,
+				tcgplayer: 570109,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "F",
 	rarity: "Rare",
 	dexId: [639],
-
-	thirdParty: {
-		cardmarket: 680190
-	}
 }
 
 export default card

--- a/data-asia/S/S12/052.ts
+++ b/data-asia/S/S12/052.ts
@@ -39,14 +39,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680191,
+				tcgplayer: 570110,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [674],
-
-	thirdParty: {
-		cardmarket: 680191
-	}
 }
 
 export default card

--- a/data-asia/S/S12/053.ts
+++ b/data-asia/S/S12/053.ts
@@ -53,14 +53,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680192,
+				tcgplayer: 570111,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [744],
-
-	thirdParty: {
-		cardmarket: 680192
-	}
 }
 
 export default card

--- a/data-asia/S/S12/054.ts
+++ b/data-asia/S/S12/054.ts
@@ -45,14 +45,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680193,
+				tcgplayer: 570112,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [745],
-
-	thirdParty: {
-		cardmarket: 680193
-	}
 }
 
 export default card

--- a/data-asia/S/S12/055.ts
+++ b/data-asia/S/S12/055.ts
@@ -54,6 +54,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680194,
+				tcgplayer: 570113,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "F",
 	rarity: "Uncommon",

--- a/data-asia/S/S12/056.ts
+++ b/data-asia/S/S12/056.ts
@@ -53,6 +53,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680195,
+				tcgplayer: 570114,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Double rare"

--- a/data-asia/S/S12/057.ts
+++ b/data-asia/S/S12/057.ts
@@ -45,14 +45,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680196,
+				tcgplayer: 570115,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [509],
-
-	thirdParty: {
-		cardmarket: 680196
-	}
 }
 
 export default card

--- a/data-asia/S/S12/058.ts
+++ b/data-asia/S/S12/058.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680197,
+				tcgplayer: 570116,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [510],
-
-	thirdParty: {
-		cardmarket: 680197
-	}
 }
 
 export default card

--- a/data-asia/S/S12/059.ts
+++ b/data-asia/S/S12/059.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680198,
+				tcgplayer: 570117,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [675],
-
-	thirdParty: {
-		cardmarket: 680198
-	}
 }
 
 export default card

--- a/data-asia/S/S12/060.ts
+++ b/data-asia/S/S12/060.ts
@@ -48,14 +48,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680199,
+				tcgplayer: 570118,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [690],
-
-	thirdParty: {
-		cardmarket: 680199
-	}
 }
 
 export default card

--- a/data-asia/S/S12/061.ts
+++ b/data-asia/S/S12/061.ts
@@ -53,14 +53,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680200,
+				tcgplayer: 570119,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [691],
-
-	thirdParty: {
-		cardmarket: 680200
-	}
 }
 
 export default card

--- a/data-asia/S/S12/062.ts
+++ b/data-asia/S/S12/062.ts
@@ -44,6 +44,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680201,
+				tcgplayer: 570120,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",

--- a/data-asia/S/S12/063.ts
+++ b/data-asia/S/S12/063.ts
@@ -50,6 +50,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680202,
+				tcgplayer: 570121,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",

--- a/data-asia/S/S12/064.ts
+++ b/data-asia/S/S12/064.ts
@@ -59,6 +59,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680203,
+				tcgplayer: 570122,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Uncommon",

--- a/data-asia/S/S12/065.ts
+++ b/data-asia/S/S12/065.ts
@@ -59,14 +59,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680204,
+				tcgplayer: 570123,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [304],
-
-	thirdParty: {
-		cardmarket: 680204
-	}
 }
 
 export default card

--- a/data-asia/S/S12/066.ts
+++ b/data-asia/S/S12/066.ts
@@ -59,14 +59,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680205,
+				tcgplayer: 570124,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [305],
-
-	thirdParty: {
-		cardmarket: 680205
-	}
 }
 
 export default card

--- a/data-asia/S/S12/067.ts
+++ b/data-asia/S/S12/067.ts
@@ -59,14 +59,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680206,
+				tcgplayer: 570125,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "F",
 	rarity: "Rare",
 	dexId: [306],
-
-	thirdParty: {
-		cardmarket: 680206
-	}
 }
 
 export default card

--- a/data-asia/S/S12/068.ts
+++ b/data-asia/S/S12/068.ts
@@ -66,14 +66,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680207,
+				tcgplayer: 570126,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [638],
-
-	thirdParty: {
-		cardmarket: 680207
-	}
 }
 
 export default card

--- a/data-asia/S/S12/069.ts
+++ b/data-asia/S/S12/069.ts
@@ -50,14 +50,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680208,
+				tcgplayer: 570127,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [777],
-
-	thirdParty: {
-		cardmarket: 680208
-	}
 }
 
 export default card

--- a/data-asia/S/S12/070.ts
+++ b/data-asia/S/S12/070.ts
@@ -40,14 +40,20 @@ const card: Card = {
 		cost: ["Colorless", "Colorless"]
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680209,
+				tcgplayer: 570128,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [147],
-
-	thirdParty: {
-		cardmarket: 680209
-	}
 }
 
 export default card

--- a/data-asia/S/S12/071.ts
+++ b/data-asia/S/S12/071.ts
@@ -49,14 +49,20 @@ const card: Card = {
 		cost: ["Water", "Lightning", "Colorless"]
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680210,
+				tcgplayer: 570129,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [148],
-
-	thirdParty: {
-		cardmarket: 680210
-	}
 }
 
 export default card

--- a/data-asia/S/S12/072.ts
+++ b/data-asia/S/S12/072.ts
@@ -49,14 +49,20 @@ const card: Card = {
 		cost: ["Water", "Lightning", "Colorless", "Colorless"]
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680211,
+				tcgplayer: 570130,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Rare",
 	dexId: [149],
-
-	thirdParty: {
-		cardmarket: 680211
-	}
 }
 
 export default card

--- a/data-asia/S/S12/073.ts
+++ b/data-asia/S/S12/073.ts
@@ -43,14 +43,20 @@ const card: Card = {
 		cost: ["Psychic", "Darkness"]
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680212,
+				tcgplayer: 570131,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [714],
-
-	thirdParty: {
-		cardmarket: 680212
-	}
 }
 
 export default card

--- a/data-asia/S/S12/074.ts
+++ b/data-asia/S/S12/074.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		cost: ["Psychic", "Darkness"]
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680213,
+				tcgplayer: 570132,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [715],
-
-	thirdParty: {
-		cardmarket: 680213
-	}
 }
 
 export default card

--- a/data-asia/S/S12/075.ts
+++ b/data-asia/S/S12/075.ts
@@ -49,14 +49,20 @@ const card: Card = {
 		cost: ["Grass", "Fighting"]
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680214,
+				tcgplayer: 570133,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [718],
-
-	thirdParty: {
-		cardmarket: 680214
-	}
 }
 
 export default card

--- a/data-asia/S/S12/076.ts
+++ b/data-asia/S/S12/076.ts
@@ -48,6 +48,16 @@ const card: Card = {
 		cost: ["Grass", "Grass", "Fire"]
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680215,
+				tcgplayer: 570134,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "F",
 	rarity: "Double rare"

--- a/data-asia/S/S12/077.ts
+++ b/data-asia/S/S12/077.ts
@@ -58,6 +58,16 @@ const card: Card = {
 		}
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680216,
+				tcgplayer: 570135,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "F"
 }

--- a/data-asia/S/S12/078.ts
+++ b/data-asia/S/S12/078.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680217,
+				tcgplayer: 570136,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [128],
-
-	thirdParty: {
-		cardmarket: 680217
-	}
 }
 
 export default card

--- a/data-asia/S/S12/079.ts
+++ b/data-asia/S/S12/079.ts
@@ -58,6 +58,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680218,
+				tcgplayer: 570137,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Double rare"

--- a/data-asia/S/S12/080.ts
+++ b/data-asia/S/S12/080.ts
@@ -69,12 +69,18 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680219,
+				tcgplayer: 570138,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 680219
-	}
 }
 
 export default card

--- a/data-asia/S/S12/081.ts
+++ b/data-asia/S/S12/081.ts
@@ -58,14 +58,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680220,
+				tcgplayer: 570139,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [492],
-
-	thirdParty: {
-		cardmarket: 680220
-	}
 }
 
 export default card

--- a/data-asia/S/S12/082.ts
+++ b/data-asia/S/S12/082.ts
@@ -53,14 +53,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680221,
+				tcgplayer: 570140,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [566],
-
-	thirdParty: {
-		cardmarket: 680221
-	}
 }
 
 export default card

--- a/data-asia/S/S12/083.ts
+++ b/data-asia/S/S12/083.ts
@@ -60,14 +60,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680222,
+				tcgplayer: 570141,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Rare",
 	dexId: [567],
-
-	thirdParty: {
-		cardmarket: 680222
-	}
 }
 
 export default card

--- a/data-asia/S/S12/084.ts
+++ b/data-asia/S/S12/084.ts
@@ -50,14 +50,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680223,
+				tcgplayer: 570142,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [627],
-
-	thirdParty: {
-		cardmarket: 680223
-	}
 }
 
 export default card

--- a/data-asia/S/S12/085.ts
+++ b/data-asia/S/S12/085.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680224,
+				tcgplayer: 570143,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Uncommon",

--- a/data-asia/S/S12/086.ts
+++ b/data-asia/S/S12/086.ts
@@ -39,14 +39,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680225,
+				tcgplayer: 570144,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [734],
-
-	thirdParty: {
-		cardmarket: 680225
-	}
 }
 
 export default card

--- a/data-asia/S/S12/087.ts
+++ b/data-asia/S/S12/087.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680226,
+				tcgplayer: 570145,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [735],
-
-	thirdParty: {
-		cardmarket: 680226
-	}
 }
 
 export default card

--- a/data-asia/S/S12/088.ts
+++ b/data-asia/S/S12/088.ts
@@ -53,14 +53,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680227,
+				tcgplayer: 570146,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [765],
-
-	thirdParty: {
-		cardmarket: 680227
-	}
 }
 
 export default card

--- a/data-asia/S/S12/089.ts
+++ b/data-asia/S/S12/089.ts
@@ -19,6 +19,16 @@ const card: Card = {
 		ja: "「クワッドストーン」は、1枚または4枚同時に使え、使った枚数によって効果が変わる。\n\n◆1枚使ったなら、自分のバトルポケモンのHPを「10」回復する。\n\n◆4枚同時に使ったなら、自分のポケモン全員のHPを、すべて回復する。（この効果は、4枚で1回はたらく。）"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680228,
+				tcgplayer: 570147,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "F",
 	rarity: "Uncommon"

--- a/data-asia/S/S12/090.ts
+++ b/data-asia/S/S12/090.ts
@@ -19,6 +19,16 @@ const card: Card = {
 		ja: "このカードは、HP60のタイプのたねポケモンとして、場に出すことができる。\n自分の番の中でなら、場に出ているこのカードをトラッシュしてよい。\n\nこのカードは、にげられない。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680229,
+				tcgplayer: 570148,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "F",
 	rarity: "Common"

--- a/data-asia/S/S12/091.ts
+++ b/data-asia/S/S12/091.ts
@@ -19,6 +19,16 @@ const card: Card = {
 		ja: "ポケモンのどうぐは、自分のポケモンにつけて使う。ポケモン1匹につき1枚だけつけられ、つけたままにする。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680230,
+				tcgplayer: 570149,
+			},
+		},
+	],
+
 	trainerType: "Tool",
 	regulationMark: "F",
 	rarity: "Rare"

--- a/data-asia/S/S12/092.ts
+++ b/data-asia/S/S12/092.ts
@@ -19,6 +19,16 @@ const card: Card = {
 		ja: "ポケモンのどうぐは、自分のポケモンにつけて使う。ポケモン1匹につき1枚だけつけられ、つけたままにする。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680231,
+				tcgplayer: 570150,
+			},
+		},
+	],
+
 	trainerType: "Tool",
 	regulationMark: "F",
 	rarity: "Rare"

--- a/data-asia/S/S12/093.ts
+++ b/data-asia/S/S12/093.ts
@@ -19,6 +19,16 @@ const card: Card = {
 		ja: "自分の山札を3枚引く。場に出ているスタジアムをトラッシュする。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680232,
+				tcgplayer: 570151,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "F",
 	rarity: "Uncommon"

--- a/data-asia/S/S12/094.ts
+++ b/data-asia/S/S12/094.ts
@@ -19,6 +19,16 @@ const card: Card = {
 		ja: "このカードは、自分の手札がこのカード1枚だけのときにしか使えない。\n\nおたがいのベンチポケモンの数ぶん、自分の山札を引く。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680233,
+				tcgplayer: 570152,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "F",
 	rarity: "Uncommon"

--- a/data-asia/S/S12/095.ts
+++ b/data-asia/S/S12/095.ts
@@ -19,6 +19,16 @@ const card: Card = {
 		ja: "自分の山札を上から7枚見て、その中からポケモンとエネルギーを好きなだけ選び、相手に見せて、手札に加える。残りのカードは山札にもどして切る。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680234,
+				tcgplayer: 570153,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "F",
 	rarity: "Uncommon"

--- a/data-asia/S/S12/096.ts
+++ b/data-asia/S/S12/096.ts
@@ -19,6 +19,16 @@ const card: Card = {
 		ja: "自分の山札からポケモンを3枚まで選び、相手に見せて、手札に加える。そして山札を切る。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680235,
+				tcgplayer: 570154,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "F",
 	rarity: "Uncommon"

--- a/data-asia/S/S12/097.ts
+++ b/data-asia/S/S12/097.ts
@@ -19,6 +19,16 @@ const card: Card = {
 		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の山札を上から1枚見て、もとにもどしてよい。のぞむなら、そのカードをトラッシュする。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680237,
+				tcgplayer: 570155,
+			},
+		},
+	],
+
 	trainerType: "Stadium",
 	regulationMark: "F",
 	rarity: "Uncommon"

--- a/data-asia/S/S12/098.ts
+++ b/data-asia/S/S12/098.ts
@@ -20,6 +20,16 @@ const card: Card = {
 	},
 
 	energyType: "Special",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 680238,
+				tcgplayer: 570156,
+			},
+		},
+	],
+
 	regulationMark: "F",
 	rarity: "Uncommon"
 }

--- a/data-asia/S/S12/099.ts
+++ b/data-asia/S/S12/099.ts
@@ -50,6 +50,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680833,
+				tcgplayer: 570157,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "F"
 }

--- a/data-asia/S/S12/100.ts
+++ b/data-asia/S/S12/100.ts
@@ -48,6 +48,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680834,
+				tcgplayer: 570158,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F"
 }

--- a/data-asia/S/S12/101.ts
+++ b/data-asia/S/S12/101.ts
@@ -49,6 +49,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680835,
+				tcgplayer: 570159,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F"
 }

--- a/data-asia/S/S12/102.ts
+++ b/data-asia/S/S12/102.ts
@@ -53,6 +53,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680836,
+				tcgplayer: 570160,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F"
 }

--- a/data-asia/S/S12/103.ts
+++ b/data-asia/S/S12/103.ts
@@ -53,6 +53,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680837,
+				tcgplayer: 570161,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F"
 }

--- a/data-asia/S/S12/104.ts
+++ b/data-asia/S/S12/104.ts
@@ -50,6 +50,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680838,
+				tcgplayer: 570162,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "F"
 }

--- a/data-asia/S/S12/105.ts
+++ b/data-asia/S/S12/105.ts
@@ -48,6 +48,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680839,
+				tcgplayer: 570163,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F"
 }

--- a/data-asia/S/S12/106.ts
+++ b/data-asia/S/S12/106.ts
@@ -48,6 +48,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680840,
+				tcgplayer: 570164,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F"
 }

--- a/data-asia/S/S12/107.ts
+++ b/data-asia/S/S12/107.ts
@@ -43,6 +43,16 @@ const card: Card = {
 		cost: ["Grass", "Grass", "Fire"]
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680841,
+				tcgplayer: 570165,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "F"
 }

--- a/data-asia/S/S12/108.ts
+++ b/data-asia/S/S12/108.ts
@@ -43,6 +43,16 @@ const card: Card = {
 		cost: ["Grass", "Grass", "Fire"]
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680842,
+				tcgplayer: 570166,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "F"
 }

--- a/data-asia/S/S12/109.ts
+++ b/data-asia/S/S12/109.ts
@@ -53,6 +53,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680843,
+				tcgplayer: 570167,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F"
 }

--- a/data-asia/S/S12/110.ts
+++ b/data-asia/S/S12/110.ts
@@ -53,6 +53,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680844,
+				tcgplayer: 570168,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F"
 }

--- a/data-asia/S/S12/111.ts
+++ b/data-asia/S/S12/111.ts
@@ -17,6 +17,16 @@ const card: Card = {
 		ja: "自分の山札を3枚引く。場に出ているスタジアムをトラッシュする。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680845,
+				tcgplayer: 570169,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "F"
 }

--- a/data-asia/S/S12/112.ts
+++ b/data-asia/S/S12/112.ts
@@ -17,6 +17,16 @@ const card: Card = {
 		ja: "このカードは、自分の手札がこのカード1枚だけのときにしか使えない。\n\nおたがいのベンチポケモンの数ぶん、自分の山札を引く。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680846,
+				tcgplayer: 570170,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "F"
 }

--- a/data-asia/S/S12/113.ts
+++ b/data-asia/S/S12/113.ts
@@ -17,6 +17,16 @@ const card: Card = {
 		ja: "自分の山札を上から7枚見て、その中からポケモンとエネルギーを好きなだけ選び、相手に見せて、手札に加える。残りのカードは山札にもどして切る。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680847,
+				tcgplayer: 570171,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "F"
 }

--- a/data-asia/S/S12/114.ts
+++ b/data-asia/S/S12/114.ts
@@ -17,6 +17,16 @@ const card: Card = {
 		ja: "自分の山札からポケモンを3枚まで選び、相手に見せて、手札に加える。そして山札を切る。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680848,
+				tcgplayer: 570172,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "F"
 }

--- a/data-asia/S/S12/115.ts
+++ b/data-asia/S/S12/115.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680849,
+				tcgplayer: 570173,
+			},
+		},
+	],
+
 	retreat: 0
 }
 

--- a/data-asia/S/S12/116.ts
+++ b/data-asia/S/S12/116.ts
@@ -48,11 +48,17 @@ const card: Card = {
 		value: "－30"
 	}],
 
-	retreat: 1,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680850,
+				tcgplayer: 570174,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 680175
-	}
+	retreat: 1,
 }
 
 export default card

--- a/data-asia/S/S12/117.ts
+++ b/data-asia/S/S12/117.ts
@@ -38,6 +38,16 @@ const card: Card = {
 		}
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680851,
+				tcgplayer: 570175,
+			},
+		},
+	],
+
 	retreat: 3
 }
 

--- a/data-asia/S/S12/118.ts
+++ b/data-asia/S/S12/118.ts
@@ -50,11 +50,17 @@ const card: Card = {
 		value: "－30"
 	}],
 
-	retreat: 2,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680852,
+				tcgplayer: 570176,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 680219
-	}
+	retreat: 2,
 }
 
 export default card

--- a/data-asia/S/S12/119.ts
+++ b/data-asia/S/S12/119.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分の山札を3枚引く。場に出ているスタジアムをトラッシュする。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680853,
+				tcgplayer: 570177,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/S/S12/120.ts
+++ b/data-asia/S/S12/120.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "このカードは、自分の手札がこのカード1枚だけのときにしか使えない。\n\nおたがいのベンチポケモンの数ぶん、自分の山札を引く。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680854,
+				tcgplayer: 570178,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/S/S12/121.ts
+++ b/data-asia/S/S12/121.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分の山札を上から7枚見て、その中からポケモンとエネルギーを好きなだけ選び、相手に見せて、手札に加える。残りのカードは山札にもどして切る。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680855,
+				tcgplayer: 570179,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/S/S12/122.ts
+++ b/data-asia/S/S12/122.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分の山札からポケモンを3枚まで選び、相手に見せて、手札に加える。そして山札を切る。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680856,
+				tcgplayer: 570180,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/S/S12/123.ts
+++ b/data-asia/S/S12/123.ts
@@ -50,11 +50,17 @@ const card: Card = {
 		value: "－30"
 	}],
 
-	retreat: 2,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680857,
+				tcgplayer: 570181,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 680219
-	}
+	retreat: 2,
 }
 
 export default card

--- a/data-asia/S/S12/124.ts
+++ b/data-asia/S/S12/124.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "ポケモンのどうぐは、自分のポケモンにつけて使う。ポケモン1匹につき1枚だけつけられ、つけたままにする。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680858,
+				tcgplayer: 570182,
+			},
+		},
+	],
+
 	trainerType: "Tool"
 }
 

--- a/data-asia/S/S12/125.ts
+++ b/data-asia/S/S12/125.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "おたがいのプレイヤーは、それぞれ、手札からたねポケモンをベンチに出すたび、そのポケモンにダメカンを2個のせる。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 680859,
+				tcgplayer: 570183,
+			},
+		},
+	],
+
 	trainerType: "Stadium"
 }
 


### PR DESCRIPTION
## What

Links the cards of the existing Japanese set **S12 パラダイムトリガー (Paradigm Trigger)** to their Cardmarket **and TCGplayer** products, so the API can serve their prices.

- **50** cards carried no product id at all and get both
- **75** carried a card-level `thirdParty.cardmarket`, which is moved onto the card's `variants` entry and joined by its tcgplayer id
- **3** carried the cardmarket id of a different print and are corrected

Afterwards every card of the set carries its id on a `variants` entry and none on the card itself, which is where tcgdex is heading. Nothing else changes: the `zh-tw`/`th` texts and the Japanese card data are not rewritten.

3 cards carried the product of **another print** of the same card, so the API served that print's price for them:

| card | was | is | the old id belongs to |
|---|---|---|---|
| 116 | 680175 | 680850 | points at card 036 of this set |
| 118 | 680219 | 680852 | points at card 080 of this set |
| 123 | 680219 | 680857 | points at card 080 of this set |

The ids are assigned **by collection number**, not by name: within a Cardmarket expansion the products sorted by `idProduct` follow the collection order, and the assignment is verified against the sample rows pokepricelab renders. That matters because Cardmarket names every print of a card identically inside an expansion, so a name lookup cannot tell a base print from its AR/full-art reprint — which is where the corrected ids above come from. That the 72 ids this set already carried correctly agree with the same assignment is an independent cross-check.

## Data sources

- **Cardmarket** public product catalog (`downloads.s3.cardmarket.com`): the product ids (680140–680859), assigned by collection number
- **pokepricelab.com**: the sample rows that verify that assignment
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (570059–570183), keyed by the collection number each product carries in `extendedData`
- **limitlesstcg.com**: the set's card list — used here for nothing but the rarity per number, which decides whether a variant is `holo` or `normal`

## Notes

- `tsc --noEmit` reports the same 31 pre-existing errors as upstream/master — this change adds none. They are `rarity` being required by `interfaces.d.ts` while these older hand-written files omit it, which is out of scope here.
