### PR TITLE
(data) ja S9 Star Birth - cardmarket + tcgplayer product ids

### DIFF
--- a/data-asia/S/S9/001.ts
+++ b/data-asia/S/S9/001.ts
@@ -44,14 +44,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605852,
+				tcgplayer: 569629,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [102],
-
-	thirdParty: {
-		cardmarket: 605852
-	}
 }
 
 export default card

--- a/data-asia/S/S9/002.ts
+++ b/data-asia/S/S9/002.ts
@@ -49,14 +49,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605853,
+				tcgplayer: 569630,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [103],
-
-	thirdParty: {
-		cardmarket: 605853
-	}
 }
 
 export default card

--- a/data-asia/S/S9/003.ts
+++ b/data-asia/S/S9/003.ts
@@ -36,14 +36,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605854,
+				tcgplayer: 569631,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [285],
-
-	thirdParty: {
-		cardmarket: 605854
-	}
 }
 
 export default card

--- a/data-asia/S/S9/004.ts
+++ b/data-asia/S/S9/004.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605855,
+				tcgplayer: 569632,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [286],
-
-	thirdParty: {
-		cardmarket: 605855
-	}
 }
 
 export default card

--- a/data-asia/S/S9/005.ts
+++ b/data-asia/S/S9/005.ts
@@ -50,14 +50,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605856,
+				tcgplayer: 569633,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [357],
-
-	thirdParty: {
-		cardmarket: 605856
-	}
 }
 
 export default card

--- a/data-asia/S/S9/006.ts
+++ b/data-asia/S/S9/006.ts
@@ -44,14 +44,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605857,
+				tcgplayer: 569634,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [387],
-
-	thirdParty: {
-		cardmarket: 605857
-	}
 }
 
 export default card

--- a/data-asia/S/S9/007.ts
+++ b/data-asia/S/S9/007.ts
@@ -50,14 +50,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605858,
+				tcgplayer: 569635,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [388],
-
-	thirdParty: {
-		cardmarket: 605858
-	}
 }
 
 export default card

--- a/data-asia/S/S9/008.ts
+++ b/data-asia/S/S9/008.ts
@@ -49,14 +49,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 605859,
+				tcgplayer: 569636,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "F",
 	rarity: "Rare",
 	dexId: [389],
-
-	thirdParty: {
-		cardmarket: 605859
-	}
 }
 
 export default card

--- a/data-asia/S/S9/009.ts
+++ b/data-asia/S/S9/009.ts
@@ -36,14 +36,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605860,
+				tcgplayer: 569637,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [412],
-
-	thirdParty: {
-		cardmarket: 605860
-	}
 }
 
 export default card

--- a/data-asia/S/S9/010.ts
+++ b/data-asia/S/S9/010.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605861,
+				tcgplayer: 569638,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [413],
-
-	thirdParty: {
-		cardmarket: 605861
-	}
 }
 
 export default card

--- a/data-asia/S/S9/011.ts
+++ b/data-asia/S/S9/011.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605862,
+				tcgplayer: 569639,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [414],
-
-	thirdParty: {
-		cardmarket: 605862
-	}
 }
 
 export default card

--- a/data-asia/S/S9/012.ts
+++ b/data-asia/S/S9/012.ts
@@ -44,6 +44,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 605863,
+				tcgplayer: 569640,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Double rare"

--- a/data-asia/S/S9/013.ts
+++ b/data-asia/S/S9/013.ts
@@ -59,12 +59,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 605864,
+				tcgplayer: 569641,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 605864
-	}
 }
 
 export default card

--- a/data-asia/S/S9/014.ts
+++ b/data-asia/S/S9/014.ts
@@ -44,6 +44,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 605865,
+				tcgplayer: 569642,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Double rare"

--- a/data-asia/S/S9/015.ts
+++ b/data-asia/S/S9/015.ts
@@ -48,12 +48,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 605866,
+				tcgplayer: 569643,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 605866
-	}
 }
 
 export default card

--- a/data-asia/S/S9/016.ts
+++ b/data-asia/S/S9/016.ts
@@ -44,14 +44,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605867,
+				tcgplayer: 569644,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [126],
-
-	thirdParty: {
-		cardmarket: 605867
-	}
 }
 
 export default card

--- a/data-asia/S/S9/017.ts
+++ b/data-asia/S/S9/017.ts
@@ -49,14 +49,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605868,
+				tcgplayer: 569645,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [467],
-
-	thirdParty: {
-		cardmarket: 605868
-	}
 }
 
 export default card

--- a/data-asia/S/S9/018.ts
+++ b/data-asia/S/S9/018.ts
@@ -41,14 +41,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 605869,
+				tcgplayer: 569646,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Rare",
 	dexId: [146],
-
-	thirdParty: {
-		cardmarket: 605869
-	}
 }
 
 export default card

--- a/data-asia/S/S9/019.ts
+++ b/data-asia/S/S9/019.ts
@@ -41,14 +41,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605870,
+				tcgplayer: 569647,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [390],
-
-	thirdParty: {
-		cardmarket: 605870
-	}
 }
 
 export default card

--- a/data-asia/S/S9/020.ts
+++ b/data-asia/S/S9/020.ts
@@ -49,14 +49,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605871,
+				tcgplayer: 569648,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [391],
-
-	thirdParty: {
-		cardmarket: 605871
-	}
 }
 
 export default card

--- a/data-asia/S/S9/021.ts
+++ b/data-asia/S/S9/021.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 605872,
+				tcgplayer: 569649,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Rare",
 	dexId: [392],
-
-	thirdParty: {
-		cardmarket: 605872
-	}
 }
 
 export default card

--- a/data-asia/S/S9/022.ts
+++ b/data-asia/S/S9/022.ts
@@ -41,14 +41,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605873,
+				tcgplayer: 569650,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [131],
-
-	thirdParty: {
-		cardmarket: 605873
-	}
 }
 
 export default card

--- a/data-asia/S/S9/023.ts
+++ b/data-asia/S/S9/023.ts
@@ -44,14 +44,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605874,
+				tcgplayer: 569651,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [341],
-
-	thirdParty: {
-		cardmarket: 605874
-	}
 }
 
 export default card

--- a/data-asia/S/S9/024.ts
+++ b/data-asia/S/S9/024.ts
@@ -49,14 +49,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605875,
+				tcgplayer: 569652,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [342],
-
-	thirdParty: {
-		cardmarket: 605875
-	}
 }
 
 export default card

--- a/data-asia/S/S9/025.ts
+++ b/data-asia/S/S9/025.ts
@@ -41,14 +41,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605876,
+				tcgplayer: 569653,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [393],
-
-	thirdParty: {
-		cardmarket: 605876
-	}
 }
 
 export default card

--- a/data-asia/S/S9/026.ts
+++ b/data-asia/S/S9/026.ts
@@ -36,14 +36,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605877,
+				tcgplayer: 569654,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [394],
-
-	thirdParty: {
-		cardmarket: 605877
-	}
 }
 
 export default card

--- a/data-asia/S/S9/027.ts
+++ b/data-asia/S/S9/027.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 605878,
+				tcgplayer: 569655,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Rare",
 	dexId: [395],
-
-	thirdParty: {
-		cardmarket: 605878
-	}
 }
 
 export default card

--- a/data-asia/S/S9/028.ts
+++ b/data-asia/S/S9/028.ts
@@ -41,14 +41,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605879,
+				tcgplayer: 569656,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [418],
-
-	thirdParty: {
-		cardmarket: 605879
-	}
 }
 
 export default card

--- a/data-asia/S/S9/029.ts
+++ b/data-asia/S/S9/029.ts
@@ -48,14 +48,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605880,
+				tcgplayer: 569657,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [419],
-
-	thirdParty: {
-		cardmarket: 605880
-	}
 }
 
 export default card

--- a/data-asia/S/S9/030.ts
+++ b/data-asia/S/S9/030.ts
@@ -50,6 +50,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 605881,
+				tcgplayer: 569658,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Double rare"

--- a/data-asia/S/S9/031.ts
+++ b/data-asia/S/S9/031.ts
@@ -50,14 +50,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605882,
+				tcgplayer: 569659,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [490],
-
-	thirdParty: {
-		cardmarket: 605882
-	}
 }
 
 export default card

--- a/data-asia/S/S9/032.ts
+++ b/data-asia/S/S9/032.ts
@@ -36,14 +36,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605883,
+				tcgplayer: 569660,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [613],
-
-	thirdParty: {
-		cardmarket: 605883
-	}
 }
 
 export default card

--- a/data-asia/S/S9/033.ts
+++ b/data-asia/S/S9/033.ts
@@ -49,14 +49,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605884,
+				tcgplayer: 569661,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [614],
-
-	thirdParty: {
-		cardmarket: 605884
-	}
 }
 
 export default card

--- a/data-asia/S/S9/034.ts
+++ b/data-asia/S/S9/034.ts
@@ -48,6 +48,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 605885,
+				tcgplayer: 569662,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Double rare"

--- a/data-asia/S/S9/035.ts
+++ b/data-asia/S/S9/035.ts
@@ -48,14 +48,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605886,
+				tcgplayer: 569663,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [125],
-
-	thirdParty: {
-		cardmarket: 605886
-	}
 }
 
 export default card

--- a/data-asia/S/S9/036.ts
+++ b/data-asia/S/S9/036.ts
@@ -53,14 +53,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605887,
+				tcgplayer: 569664,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [466],
-
-	thirdParty: {
-		cardmarket: 605887
-	}
 }
 
 export default card

--- a/data-asia/S/S9/037.ts
+++ b/data-asia/S/S9/037.ts
@@ -36,14 +36,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605888,
+				tcgplayer: 569665,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [403],
-
-	thirdParty: {
-		cardmarket: 605888
-	}
 }
 
 export default card

--- a/data-asia/S/S9/038.ts
+++ b/data-asia/S/S9/038.ts
@@ -41,14 +41,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605889,
+				tcgplayer: 569666,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [404],
-
-	thirdParty: {
-		cardmarket: 605889
-	}
 }
 
 export default card

--- a/data-asia/S/S9/039.ts
+++ b/data-asia/S/S9/039.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605890,
+				tcgplayer: 569667,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [405],
-
-	thirdParty: {
-		cardmarket: 605890
-	}
 }
 
 export default card

--- a/data-asia/S/S9/040.ts
+++ b/data-asia/S/S9/040.ts
@@ -41,14 +41,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605891,
+				tcgplayer: 569668,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [417],
-
-	thirdParty: {
-		cardmarket: 605891
-	}
 }
 
 export default card

--- a/data-asia/S/S9/041.ts
+++ b/data-asia/S/S9/041.ts
@@ -44,14 +44,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605892,
+				tcgplayer: 569669,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [35],
-
-	thirdParty: {
-		cardmarket: 605892
-	}
 }
 
 export default card

--- a/data-asia/S/S9/042.ts
+++ b/data-asia/S/S9/042.ts
@@ -48,14 +48,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605893,
+				tcgplayer: 569670,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [36],
-
-	thirdParty: {
-		cardmarket: 605893
-	}
 }
 
 export default card

--- a/data-asia/S/S9/043.ts
+++ b/data-asia/S/S9/043.ts
@@ -46,14 +46,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605894,
+				tcgplayer: 569671,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [343],
-
-	thirdParty: {
-		cardmarket: 605894
-	}
 }
 
 export default card

--- a/data-asia/S/S9/044.ts
+++ b/data-asia/S/S9/044.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605895,
+				tcgplayer: 569672,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [344],
-
-	thirdParty: {
-		cardmarket: 605895
-	}
 }
 
 export default card

--- a/data-asia/S/S9/045.ts
+++ b/data-asia/S/S9/045.ts
@@ -46,14 +46,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605896,
+				tcgplayer: 569673,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [355],
-
-	thirdParty: {
-		cardmarket: 605896
-	}
 }
 
 export default card

--- a/data-asia/S/S9/046.ts
+++ b/data-asia/S/S9/046.ts
@@ -46,14 +46,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605897,
+				tcgplayer: 569674,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [356],
-
-	thirdParty: {
-		cardmarket: 605897
-	}
 }
 
 export default card

--- a/data-asia/S/S9/047.ts
+++ b/data-asia/S/S9/047.ts
@@ -55,14 +55,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 605898,
+				tcgplayer: 569675,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "F",
 	rarity: "Rare",
 	dexId: [477],
-
-	thirdParty: {
-		cardmarket: 605898
-	}
 }
 
 export default card

--- a/data-asia/S/S9/048.ts
+++ b/data-asia/S/S9/048.ts
@@ -53,14 +53,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605899,
+				tcgplayer: 569676,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [358],
-
-	thirdParty: {
-		cardmarket: 605899
-	}
 }
 
 export default card

--- a/data-asia/S/S9/049.ts
+++ b/data-asia/S/S9/049.ts
@@ -49,6 +49,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 605900,
+				tcgplayer: 569677,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Double rare"

--- a/data-asia/S/S9/050.ts
+++ b/data-asia/S/S9/050.ts
@@ -47,12 +47,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 605901,
+				tcgplayer: 569678,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 605901
-	}
 }
 
 export default card

--- a/data-asia/S/S9/051.ts
+++ b/data-asia/S/S9/051.ts
@@ -58,14 +58,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605902,
+				tcgplayer: 569679,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [561],
-
-	thirdParty: {
-		cardmarket: 605902
-	}
 }
 
 export default card

--- a/data-asia/S/S9/052.ts
+++ b/data-asia/S/S9/052.ts
@@ -36,14 +36,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605903,
+				tcgplayer: 569680,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [299],
-
-	thirdParty: {
-		cardmarket: 605903
-	}
 }
 
 export default card

--- a/data-asia/S/S9/053.ts
+++ b/data-asia/S/S9/053.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605904,
+				tcgplayer: 569681,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [413],
-
-	thirdParty: {
-		cardmarket: 605861
-	}
 }
 
 export default card

--- a/data-asia/S/S9/054.ts
+++ b/data-asia/S/S9/054.ts
@@ -36,14 +36,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605905,
+				tcgplayer: 569682,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [447],
-
-	thirdParty: {
-		cardmarket: 605905
-	}
 }
 
 export default card

--- a/data-asia/S/S9/055.ts
+++ b/data-asia/S/S9/055.ts
@@ -55,14 +55,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 605906,
+				tcgplayer: 569683,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Rare",
 	dexId: [448],
-
-	thirdParty: {
-		cardmarket: 605906
-	}
 }
 
 export default card

--- a/data-asia/S/S9/056.ts
+++ b/data-asia/S/S9/056.ts
@@ -44,14 +44,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605907,
+				tcgplayer: 569684,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [538],
-
-	thirdParty: {
-		cardmarket: 605907
-	}
 }
 
 export default card

--- a/data-asia/S/S9/057.ts
+++ b/data-asia/S/S9/057.ts
@@ -41,14 +41,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605908,
+				tcgplayer: 569685,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [539],
-
-	thirdParty: {
-		cardmarket: 605908
-	}
 }
 
 export default card

--- a/data-asia/S/S9/058.ts
+++ b/data-asia/S/S9/058.ts
@@ -44,14 +44,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605909,
+				tcgplayer: 569686,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [622],
-
-	thirdParty: {
-		cardmarket: 605909
-	}
 }
 
 export default card

--- a/data-asia/S/S9/059.ts
+++ b/data-asia/S/S9/059.ts
@@ -49,14 +49,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605910,
+				tcgplayer: 569687,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [623],
-
-	thirdParty: {
-		cardmarket: 605910
-	}
 }
 
 export default card

--- a/data-asia/S/S9/060.ts
+++ b/data-asia/S/S9/060.ts
@@ -40,14 +40,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605911,
+				tcgplayer: 569688,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [88],
-
-	thirdParty: {
-		cardmarket: 605911
-	}
 }
 
 export default card

--- a/data-asia/S/S9/061.ts
+++ b/data-asia/S/S9/061.ts
@@ -55,14 +55,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605912,
+				tcgplayer: 569689,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [89],
-
-	thirdParty: {
-		cardmarket: 605912
-	}
 }
 
 export default card

--- a/data-asia/S/S9/062.ts
+++ b/data-asia/S/S9/062.ts
@@ -44,14 +44,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605913,
+				tcgplayer: 569690,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [215],
-
-	thirdParty: {
-		cardmarket: 605913
-	}
 }
 
 export default card

--- a/data-asia/S/S9/063.ts
+++ b/data-asia/S/S9/063.ts
@@ -48,14 +48,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605914,
+				tcgplayer: 569691,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [461],
-
-	thirdParty: {
-		cardmarket: 605914
-	}
 }
 
 export default card

--- a/data-asia/S/S9/064.ts
+++ b/data-asia/S/S9/064.ts
@@ -55,6 +55,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 605915,
+				tcgplayer: 569692,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Double rare"

--- a/data-asia/S/S9/065.ts
+++ b/data-asia/S/S9/065.ts
@@ -52,14 +52,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605916,
+				tcgplayer: 569693,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [442],
-
-	thirdParty: {
-		cardmarket: 605916
-	}
 }
 
 export default card

--- a/data-asia/S/S9/066.ts
+++ b/data-asia/S/S9/066.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605917,
+				tcgplayer: 569694,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [413],
-
-	thirdParty: {
-		cardmarket: 605861
-	}
 }
 
 export default card

--- a/data-asia/S/S9/067.ts
+++ b/data-asia/S/S9/067.ts
@@ -58,14 +58,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605918,
+				tcgplayer: 569695,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [476],
-
-	thirdParty: {
-		cardmarket: 605918
-	}
 }
 
 export default card

--- a/data-asia/S/S9/068.ts
+++ b/data-asia/S/S9/068.ts
@@ -59,14 +59,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605919,
+				tcgplayer: 569696,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [485],
-
-	thirdParty: {
-		cardmarket: 605919
-	}
 }
 
 export default card

--- a/data-asia/S/S9/069.ts
+++ b/data-asia/S/S9/069.ts
@@ -49,14 +49,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605920,
+				tcgplayer: 569697,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [599],
-
-	thirdParty: {
-		cardmarket: 605920
-	}
 }
 
 export default card

--- a/data-asia/S/S9/070.ts
+++ b/data-asia/S/S9/070.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605921,
+				tcgplayer: 569698,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [600],
-
-	thirdParty: {
-		cardmarket: 605921
-	}
 }
 
 export default card

--- a/data-asia/S/S9/071.ts
+++ b/data-asia/S/S9/071.ts
@@ -60,14 +60,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605922,
+				tcgplayer: 569699,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [601],
-
-	thirdParty: {
-		cardmarket: 605922
-	}
 }
 
 export default card

--- a/data-asia/S/S9/072.ts
+++ b/data-asia/S/S9/072.ts
@@ -39,6 +39,16 @@ const card: Card = {
 		cost: ["Grass", "Fighting", "Fighting", "Colorless"]
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 605923,
+				tcgplayer: 569700,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Double rare"

--- a/data-asia/S/S9/073.ts
+++ b/data-asia/S/S9/073.ts
@@ -31,14 +31,20 @@ const card: Card = {
 		cost: ["Water", "Fighting"]
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605924,
+				tcgplayer: 569701,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [443],
-
-	thirdParty: {
-		cardmarket: 605924
-	}
 }
 
 export default card

--- a/data-asia/S/S9/074.ts
+++ b/data-asia/S/S9/074.ts
@@ -31,14 +31,20 @@ const card: Card = {
 		cost: ["Water", "Fighting"]
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605925,
+				tcgplayer: 569702,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [444],
-
-	thirdParty: {
-		cardmarket: 605925
-	}
 }
 
 export default card

--- a/data-asia/S/S9/075.ts
+++ b/data-asia/S/S9/075.ts
@@ -50,14 +50,20 @@ const card: Card = {
 		cost: ["Water", "Fighting"]
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 605926,
+				tcgplayer: 569703,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Rare",
 	dexId: [445],
-
-	thirdParty: {
-		cardmarket: 605926
-	}
 }
 
 export default card

--- a/data-asia/S/S9/076.ts
+++ b/data-asia/S/S9/076.ts
@@ -46,14 +46,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605927,
+				tcgplayer: 569704,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [83],
-
-	thirdParty: {
-		cardmarket: 605927
-	}
 }
 
 export default card

--- a/data-asia/S/S9/077.ts
+++ b/data-asia/S/S9/077.ts
@@ -53,14 +53,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605928,
+				tcgplayer: 569705,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [351],
-
-	thirdParty: {
-		cardmarket: 605928
-	}
 }
 
 export default card

--- a/data-asia/S/S9/078.ts
+++ b/data-asia/S/S9/078.ts
@@ -46,14 +46,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605929,
+				tcgplayer: 569706,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [396],
-
-	thirdParty: {
-		cardmarket: 605929
-	}
 }
 
 export default card

--- a/data-asia/S/S9/079.ts
+++ b/data-asia/S/S9/079.ts
@@ -41,14 +41,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605930,
+				tcgplayer: 569707,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [397],
-
-	thirdParty: {
-		cardmarket: 605930
-	}
 }
 
 export default card

--- a/data-asia/S/S9/080.ts
+++ b/data-asia/S/S9/080.ts
@@ -58,14 +58,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605931,
+				tcgplayer: 569708,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [398],
-
-	thirdParty: {
-		cardmarket: 605931
-	}
 }
 
 export default card

--- a/data-asia/S/S9/081.ts
+++ b/data-asia/S/S9/081.ts
@@ -36,14 +36,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605932,
+				tcgplayer: 569709,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [399],
-
-	thirdParty: {
-		cardmarket: 605932
-	}
 }
 
 export default card

--- a/data-asia/S/S9/082.ts
+++ b/data-asia/S/S9/082.ts
@@ -55,14 +55,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 605933,
+				tcgplayer: 569710,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Rare",
 	dexId: [400],
-
-	thirdParty: {
-		cardmarket: 605933
-	}
 }
 
 export default card

--- a/data-asia/S/S9/083.ts
+++ b/data-asia/S/S9/083.ts
@@ -47,6 +47,16 @@ const card: Card = {
 		type: "Colorless"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 605934,
+				tcgplayer: 569711,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Double rare"

--- a/data-asia/S/S9/084.ts
+++ b/data-asia/S/S9/084.ts
@@ -59,12 +59,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 605935,
+				tcgplayer: 569712,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 605935
-	}
 }
 
 export default card

--- a/data-asia/S/S9/085.ts
+++ b/data-asia/S/S9/085.ts
@@ -48,14 +48,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605936,
+				tcgplayer: 569713,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [572],
-
-	thirdParty: {
-		cardmarket: 605936
-	}
 }
 
 export default card

--- a/data-asia/S/S9/086.ts
+++ b/data-asia/S/S9/086.ts
@@ -49,14 +49,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605937,
+				tcgplayer: 569714,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [573],
-
-	thirdParty: {
-		cardmarket: 605937
-	}
 }
 
 export default card

--- a/data-asia/S/S9/087.ts
+++ b/data-asia/S/S9/087.ts
@@ -55,14 +55,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605938,
+				tcgplayer: 569715,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [641],
-
-	thirdParty: {
-		cardmarket: 605938
-	}
 }
 
 export default card

--- a/data-asia/S/S9/088.ts
+++ b/data-asia/S/S9/088.ts
@@ -17,6 +17,16 @@ const card: Card = {
 		ja: "自分のポケモン全員のHPを、それぞれ「20」回復する。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605939,
+				tcgplayer: 569716,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "F",
 	rarity: "Uncommon"

--- a/data-asia/S/S9/089.ts
+++ b/data-asia/S/S9/089.ts
@@ -17,6 +17,16 @@ const card: Card = {
 		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。\n\n自分の山札からポケモンを1枚選び、相手に見せて、手札に加える。そして山札を切る。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605940,
+				tcgplayer: 569717,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "F",
 	rarity: "Uncommon"

--- a/data-asia/S/S9/090.ts
+++ b/data-asia/S/S9/090.ts
@@ -17,6 +17,16 @@ const card: Card = {
 		ja: "ポケモンのどうぐは、自分のポケモンにつけて使う。ポケモン1匹につき1枚だけつけられ、つけたままにする。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605941,
+				tcgplayer: 569718,
+			},
+		},
+	],
+
 	trainerType: "Tool",
 	regulationMark: "F",
 	rarity: "Uncommon"

--- a/data-asia/S/S9/091.ts
+++ b/data-asia/S/S9/091.ts
@@ -17,6 +17,16 @@ const card: Card = {
 		ja: "ポケモンのどうぐは、自分のポケモンにつけて使う。ポケモン1匹につき1枚だけつけられ、つけたままにする。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605942,
+				tcgplayer: 569719,
+			},
+		},
+	],
+
 	trainerType: "Tool",
 	regulationMark: "F",
 	rarity: "Uncommon"

--- a/data-asia/S/S9/092.ts
+++ b/data-asia/S/S9/092.ts
@@ -17,6 +17,16 @@ const card: Card = {
 		ja: "このカードは、自分の手札からエネルギーを1枚トラッシュしなければ使えない。\n\n自分の山札を上から7枚見て、その中からカードを2枚まで選び、手札に加える。残りのカードは山札にもどして切る。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605943,
+				tcgplayer: 569720,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "F",
 	rarity: "Uncommon"

--- a/data-asia/S/S9/093.ts
+++ b/data-asia/S/S9/093.ts
@@ -17,6 +17,16 @@ const card: Card = {
 		ja: "自分の手札が5枚になるように、山札を引く。前の相手の番に、自分のポケモンがきぜつしていたなら、8枚になるように引く。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605944,
+				tcgplayer: 569721,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "F",
 	rarity: "Uncommon"

--- a/data-asia/S/S9/094.ts
+++ b/data-asia/S/S9/094.ts
@@ -17,6 +17,16 @@ const card: Card = {
 		ja: "ダメカンがのっている自分のポケモンを1匹選び、そのポケモンと、ついているすべてのカードを、手札にもどす。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605945,
+				tcgplayer: 569722,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "F",
 	rarity: "Uncommon"

--- a/data-asia/S/S9/095.ts
+++ b/data-asia/S/S9/095.ts
@@ -17,6 +17,16 @@ const card: Card = {
 		ja: "自分の手札をすべてトラッシュし、山札を7枚引く。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 605946,
+				tcgplayer: 569723,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "F",
 	rarity: "Rare"

--- a/data-asia/S/S9/096.ts
+++ b/data-asia/S/S9/096.ts
@@ -17,6 +17,16 @@ const card: Card = {
 		ja: "自分のトラッシュから「ポケモン」と「ポケモンのどうぐ」と「スタジアム」と「エネルギー」を、それぞれ1枚まで選び、相手に見せて、山札にもどして切る。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605947,
+				tcgplayer: 569724,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "F",
 	rarity: "Uncommon"

--- a/data-asia/S/S9/097.ts
+++ b/data-asia/S/S9/097.ts
@@ -17,6 +17,16 @@ const card: Card = {
 		ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 605948,
+				tcgplayer: 569725,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "F",
 	rarity: "Rare"

--- a/data-asia/S/S9/098.ts
+++ b/data-asia/S/S9/098.ts
@@ -17,6 +17,16 @@ const card: Card = {
 		ja: "おたがいのプレイヤーがベンチに出せるポケモンの数は、4匹になる。［ベンチの数を変更する効果は、少ない数が優先される。］\n\n（このカードが場に出たとき、ベンチが5匹以上いるプレイヤーは、4匹になるまでトラッシュする。トラッシュするのは、このカードの持ち主から。）"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605949,
+				tcgplayer: 569726,
+			},
+		},
+	],
+
 	trainerType: "Stadium",
 	regulationMark: "F",
 	rarity: "Uncommon"

--- a/data-asia/S/S9/099.ts
+++ b/data-asia/S/S9/099.ts
@@ -17,6 +17,16 @@ const card: Card = {
 		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分のトラッシュからエネルギーを1枚選び、自分のベンチのポケモンにつけてよい。その場合、つけたポケモンにダメカンを2個のせる。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605950,
+				tcgplayer: 569727,
+			},
+		},
+	],
+
 	trainerType: "Stadium",
 	regulationMark: "F",
 	rarity: "Uncommon"

--- a/data-asia/S/S9/100.ts
+++ b/data-asia/S/S9/100.ts
@@ -17,6 +17,16 @@ const card: Card = {
 	},
 
 	energyType: "Special",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605951,
+				tcgplayer: 569728,
+			},
+		},
+	],
+
 	regulationMark: "F",
 	rarity: "Uncommon"
 }

--- a/data-asia/S/S9/101.ts
+++ b/data-asia/S/S9/101.ts
@@ -42,6 +42,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606266,
+				tcgplayer: 569729,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/S/S9/102.ts
+++ b/data-asia/S/S9/102.ts
@@ -42,6 +42,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606267,
+				tcgplayer: 569730,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/S/S9/103.ts
+++ b/data-asia/S/S9/103.ts
@@ -42,6 +42,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606268,
+				tcgplayer: 569731,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/S/S9/104.ts
+++ b/data-asia/S/S9/104.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606269,
+				tcgplayer: 569732,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/S/S9/105.ts
+++ b/data-asia/S/S9/105.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606270,
+				tcgplayer: 569733,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/S/S9/106.ts
+++ b/data-asia/S/S9/106.ts
@@ -44,6 +44,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606271,
+				tcgplayer: 569734,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/S/S9/107.ts
+++ b/data-asia/S/S9/107.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606272,
+				tcgplayer: 569735,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/S/S9/108.ts
+++ b/data-asia/S/S9/108.ts
@@ -51,6 +51,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606273,
+				tcgplayer: 569736,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/S/S9/109.ts
+++ b/data-asia/S/S9/109.ts
@@ -51,6 +51,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606274,
+				tcgplayer: 569737,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/S/S9/110.ts
+++ b/data-asia/S/S9/110.ts
@@ -37,6 +37,16 @@ const card: Card = {
 		}
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606275,
+				tcgplayer: 569738,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/S/S9/111.ts
+++ b/data-asia/S/S9/111.ts
@@ -40,6 +40,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606276,
+				tcgplayer: 569739,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/S/S9/112.ts
+++ b/data-asia/S/S9/112.ts
@@ -40,6 +40,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606277,
+				tcgplayer: 569740,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/S/S9/113.ts
+++ b/data-asia/S/S9/113.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "このカードは、自分の手札からエネルギーを1枚トラッシュしなければ使えない。\n\n自分の山札を上から7枚見て、その中からカードを2枚まで選び、手札に加える。残りのカードは山札にもどして切る。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606278,
+				tcgplayer: 569741,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/S/S9/114.ts
+++ b/data-asia/S/S9/114.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分の手札が5枚になるように、山札を引く。前の相手の番に、自分のポケモンがきぜつしていたなら、8枚になるように引く。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606279,
+				tcgplayer: 569742,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/S/S9/115.ts
+++ b/data-asia/S/S9/115.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "ダメカンがのっている自分のポケモンを1匹選び、そのポケモンと、ついているすべてのカードを、手札にもどす。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606280,
+				tcgplayer: 569743,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/S/S9/116.ts
+++ b/data-asia/S/S9/116.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分のトラッシュから「ポケモン」と「ポケモンのどうぐ」と「スタジアム」と「エネルギー」を、それぞれ1枚まで選び、相手に見せて、山札にもどして切る。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606281,
+				tcgplayer: 569744,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/S/S9/117.ts
+++ b/data-asia/S/S9/117.ts
@@ -45,11 +45,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 1,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606282,
+				tcgplayer: 569745,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 605864
-	}
+	retreat: 1,
 }
 
 export default card

--- a/data-asia/S/S9/118.ts
+++ b/data-asia/S/S9/118.ts
@@ -45,11 +45,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 2,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606283,
+				tcgplayer: 569746,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 605866
-	}
+	retreat: 2,
 }
 
 export default card

--- a/data-asia/S/S9/119.ts
+++ b/data-asia/S/S9/119.ts
@@ -43,11 +43,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 1,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606284,
+				tcgplayer: 569747,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 605901
-	}
+	retreat: 1,
 }
 
 export default card

--- a/data-asia/S/S9/120.ts
+++ b/data-asia/S/S9/120.ts
@@ -45,11 +45,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 2,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606285,
+				tcgplayer: 569748,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 605935
-	}
+	retreat: 2,
 }
 
 export default card

--- a/data-asia/S/S9/121.ts
+++ b/data-asia/S/S9/121.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "このカードは、自分の手札からエネルギーを1枚トラッシュしなければ使えない。\n\n自分の山札を上から7枚見て、その中からカードを2枚まで選び、手札に加える。残りのカードは山札にもどして切る。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606286,
+				tcgplayer: 569749,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/S/S9/122.ts
+++ b/data-asia/S/S9/122.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分の手札が5枚になるように、山札を引く。前の相手の番に、自分のポケモンがきぜつしていたなら、8枚になるように引く。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606287,
+				tcgplayer: 569750,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/S/S9/123.ts
+++ b/data-asia/S/S9/123.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "ダメカンがのっている自分のポケモンを1匹選び、そのポケモンと、ついているすべてのカードを、手札にもどす。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606288,
+				tcgplayer: 569751,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/S/S9/124.ts
+++ b/data-asia/S/S9/124.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分のトラッシュから「ポケモン」と「ポケモンのどうぐ」と「スタジアム」と「エネルギー」を、それぞれ1枚まで選び、相手に見せて、山札にもどして切る。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606289,
+				tcgplayer: 569752,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/S/S9/125.ts
+++ b/data-asia/S/S9/125.ts
@@ -45,11 +45,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 2,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606290,
+				tcgplayer: 569753,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 605935
-	}
+	retreat: 2,
 }
 
 export default card

--- a/data-asia/S/S9/126.ts
+++ b/data-asia/S/S9/126.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。\n\n自分の山札からポケモンを1枚選び、相手に見せて、手札に加える。そして山札を切る。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606291,
+				tcgplayer: 569754,
+			},
+		},
+	],
+
 	trainerType: "Item"
 }
 

--- a/data-asia/S/S9/127.ts
+++ b/data-asia/S/S9/127.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分のトラッシュからエネルギーを1枚選び、自分のベンチのポケモンにつけてよい。その場合、つけたポケモンにダメカンを2個のせる。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606292,
+				tcgplayer: 569755,
+			},
+		},
+	],
+
 	trainerType: "Stadium"
 }
 


### PR DESCRIPTION
## What

Links the cards of the existing Japanese set **S9 スターバース (Star Birth)** to their Cardmarket **and TCGplayer** products, so the API can serve their prices.

- **43** cards carried no product id at all and get both
- **84** carried a card-level `thirdParty.cardmarket`, which is moved onto the card's `variants` entry and joined by its tcgplayer id
- **7** carried the cardmarket id of a different print and are corrected

Afterwards every card of the set carries its id on a `variants` entry and none on the card itself, which is where tcgdex is heading. Nothing else changes: the `zh-tw` texts and the Japanese card data are not rewritten.

7 cards carried the product of **another print** of the same card, so the API served that print's price for them:

| card | was | is | the old id belongs to |
|---|---|---|---|
| 053 | 605861 | 605904 | points at card 010 of this set |
| 066 | 605861 | 605917 | points at card 010 of this set |
| 117 | 605864 | 606282 | points at card 013 of this set |
| 118 | 605866 | 606283 | points at card 015 of this set |
| 119 | 605901 | 606284 | points at card 050 of this set |
| 120 | 605935 | 606285 | points at card 084 of this set |
| 125 | 605935 | 606290 | points at card 084 of this set |

The ids are assigned **by collection number**, not by name: within a Cardmarket expansion the products sorted by `idProduct` follow the collection order, and the assignment is verified against the sample rows pokepricelab renders. That matters because Cardmarket names every print of a card identically inside an expansion, so a name lookup cannot tell a base print from its AR/full-art reprint — which is where the corrected ids above come from. That the 77 ids this set already carried correctly agree with the same assignment is an independent cross-check.

## Data sources

- **Cardmarket** public product catalog (`downloads.s3.cardmarket.com`): the product ids (605852–606292), assigned by collection number
- **pokepricelab.com**: the sample rows that verify that assignment
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (569629–569755), keyed by the collection number each product carries in `extendedData`
- **limitlesstcg.com**: the set's card list — used here for nothing but the rarity per number, which decides whether a variant is `holo` or `normal`

## Notes

- `tsc --noEmit` reports the same 31 pre-existing errors as upstream/master — this change adds none. They are `rarity` being required by `interfaces.d.ts` while these older hand-written files omit it, which is out of scope here.
