### PR TITLE
(data) ja S9a Battle Region - cardmarket + tcgplayer product ids

### DIFF
--- a/data-asia/S/S9a/001.ts
+++ b/data-asia/S/S9a/001.ts
@@ -36,14 +36,27 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609710,
+				tcgplayer: 570570,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577601,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [43],
-
-	thirdParty: {
-		cardmarket: 609710
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/002.ts
+++ b/data-asia/S/S9a/002.ts
@@ -41,14 +41,27 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609711,
+				tcgplayer: 570571,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577602,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [44],
-
-	thirdParty: {
-		cardmarket: 609711
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/003.ts
+++ b/data-asia/S/S9a/003.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609712,
+				tcgplayer: 570572,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Rare",
 	dexId: [45],
-
-	thirdParty: {
-		cardmarket: 609712
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/004.ts
+++ b/data-asia/S/S9a/004.ts
@@ -41,14 +41,27 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609713,
+				tcgplayer: 570573,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577603,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [123],
-
-	thirdParty: {
-		cardmarket: 609713
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/005.ts
+++ b/data-asia/S/S9a/005.ts
@@ -49,14 +49,27 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609714,
+				tcgplayer: 570574,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577604,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [214],
-
-	thirdParty: {
-		cardmarket: 609714
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/006.ts
+++ b/data-asia/S/S9a/006.ts
@@ -40,14 +40,27 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609715,
+				tcgplayer: 570575,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577605,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [315],
-
-	thirdParty: {
-		cardmarket: 609715
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/007.ts
+++ b/data-asia/S/S9a/007.ts
@@ -54,14 +54,27 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609716,
+				tcgplayer: 570576,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577606,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [407],
-
-	thirdParty: {
-		cardmarket: 609716
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/008.ts
+++ b/data-asia/S/S9a/008.ts
@@ -48,14 +48,27 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609717,
+				tcgplayer: 570577,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577607,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [415],
-
-	thirdParty: {
-		cardmarket: 609717
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/009.ts
+++ b/data-asia/S/S9a/009.ts
@@ -49,14 +49,27 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609718,
+				tcgplayer: 570578,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577608,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [416],
-
-	thirdParty: {
-		cardmarket: 609718
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/010.ts
+++ b/data-asia/S/S9a/010.ts
@@ -50,6 +50,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609719,
+				tcgplayer: 570579,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Double rare"

--- a/data-asia/S/S9a/011.ts
+++ b/data-asia/S/S9a/011.ts
@@ -41,6 +41,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609720,
+				tcgplayer: 570580,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "F",
 	dexId: [485]

--- a/data-asia/S/S9a/012.ts
+++ b/data-asia/S/S9a/012.ts
@@ -40,14 +40,27 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609721,
+				tcgplayer: 570581,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577609,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [607],
-
-	thirdParty: {
-		cardmarket: 609721
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/013.ts
+++ b/data-asia/S/S9a/013.ts
@@ -41,14 +41,27 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609722,
+				tcgplayer: 570582,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577610,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [608],
-
-	thirdParty: {
-		cardmarket: 609722
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/014.ts
+++ b/data-asia/S/S9a/014.ts
@@ -50,14 +50,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609723,
+				tcgplayer: 570583,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Rare",
 	dexId: [609],
-
-	thirdParty: {
-		cardmarket: 609723
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/015.ts
+++ b/data-asia/S/S9a/015.ts
@@ -40,14 +40,27 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609724,
+				tcgplayer: 570584,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577611,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [667],
-
-	thirdParty: {
-		cardmarket: 609724
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/016.ts
+++ b/data-asia/S/S9a/016.ts
@@ -55,14 +55,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609725,
+				tcgplayer: 570585,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Rare",
 	dexId: [668],
-
-	thirdParty: {
-		cardmarket: 609725
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/017.ts
+++ b/data-asia/S/S9a/017.ts
@@ -49,6 +49,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609726,
+				tcgplayer: 570586,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "F",
 	rarity: "Double rare"

--- a/data-asia/S/S9a/018.ts
+++ b/data-asia/S/S9a/018.ts
@@ -49,14 +49,27 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609727,
+				tcgplayer: 570587,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577612,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [220],
-
-	thirdParty: {
-		cardmarket: 609727
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/019.ts
+++ b/data-asia/S/S9a/019.ts
@@ -49,14 +49,27 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609728,
+				tcgplayer: 570588,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577613,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [221],
-
-	thirdParty: {
-		cardmarket: 609728
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/020.ts
+++ b/data-asia/S/S9a/020.ts
@@ -54,14 +54,27 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609729,
+				tcgplayer: 570589,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577614,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [473],
-
-	thirdParty: {
-		cardmarket: 609729
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/021.ts
+++ b/data-asia/S/S9a/021.ts
@@ -36,14 +36,27 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609730,
+				tcgplayer: 570590,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577615,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [339],
-
-	thirdParty: {
-		cardmarket: 609730
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/022.ts
+++ b/data-asia/S/S9a/022.ts
@@ -49,14 +49,27 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609731,
+				tcgplayer: 570591,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577616,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [340],
-
-	thirdParty: {
-		cardmarket: 609731
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/023.ts
+++ b/data-asia/S/S9a/023.ts
@@ -46,6 +46,23 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609732,
+				tcgplayer: 570592,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577617,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",

--- a/data-asia/S/S9a/024.ts
+++ b/data-asia/S/S9a/024.ts
@@ -49,6 +49,23 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609733,
+				tcgplayer: 570593,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577618,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Uncommon",

--- a/data-asia/S/S9a/025.ts
+++ b/data-asia/S/S9a/025.ts
@@ -49,14 +49,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609734,
+				tcgplayer: 570594,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Rare",
 	dexId: [647],
-
-	thirdParty: {
-		cardmarket: 609734
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/026.ts
+++ b/data-asia/S/S9a/026.ts
@@ -54,6 +54,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609735,
+				tcgplayer: 570595,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	dexId: [658]

--- a/data-asia/S/S9a/027.ts
+++ b/data-asia/S/S9a/027.ts
@@ -53,14 +53,27 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609736,
+				tcgplayer: 570596,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577619,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [124],
-
-	thirdParty: {
-		cardmarket: 609736
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/028.ts
+++ b/data-asia/S/S9a/028.ts
@@ -51,6 +51,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609737,
+				tcgplayer: 570597,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Double rare"

--- a/data-asia/S/S9a/029.ts
+++ b/data-asia/S/S9a/029.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609738,
+				tcgplayer: 570598,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F"
 }

--- a/data-asia/S/S9a/030.ts
+++ b/data-asia/S/S9a/030.ts
@@ -41,14 +41,27 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609740,
+				tcgplayer: 570599,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577620,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [200],
-
-	thirdParty: {
-		cardmarket: 609740
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/031.ts
+++ b/data-asia/S/S9a/031.ts
@@ -58,14 +58,27 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609741,
+				tcgplayer: 570600,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577621,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [429],
-
-	thirdParty: {
-		cardmarket: 609741
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/032.ts
+++ b/data-asia/S/S9a/032.ts
@@ -46,14 +46,27 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609742,
+				tcgplayer: 570601,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577622,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [280],
-
-	thirdParty: {
-		cardmarket: 609742
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/033.ts
+++ b/data-asia/S/S9a/033.ts
@@ -46,14 +46,27 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609743,
+				tcgplayer: 570602,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577623,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [281],
-
-	thirdParty: {
-		cardmarket: 609743
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/034.ts
+++ b/data-asia/S/S9a/034.ts
@@ -60,14 +60,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609744,
+				tcgplayer: 570603,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Rare",
 	dexId: [475],
-
-	thirdParty: {
-		cardmarket: 609744
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/035.ts
+++ b/data-asia/S/S9a/035.ts
@@ -55,14 +55,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609745,
+				tcgplayer: 570605,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Rare",
 	dexId: [719],
-
-	thirdParty: {
-		cardmarket: 609745
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/036.ts
+++ b/data-asia/S/S9a/036.ts
@@ -60,6 +60,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609804,
+				tcgplayer: 570606,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Rare",

--- a/data-asia/S/S9a/037.ts
+++ b/data-asia/S/S9a/037.ts
@@ -41,14 +41,27 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609805,
+				tcgplayer: 570607,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577624,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [111],
-
-	thirdParty: {
-		cardmarket: 609805
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/038.ts
+++ b/data-asia/S/S9a/038.ts
@@ -49,14 +49,27 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609806,
+				tcgplayer: 570608,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577625,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [112],
-
-	thirdParty: {
-		cardmarket: 609806
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/039.ts
+++ b/data-asia/S/S9a/039.ts
@@ -54,14 +54,27 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609807,
+				tcgplayer: 570609,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577626,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [464],
-
-	thirdParty: {
-		cardmarket: 609807
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/040.ts
+++ b/data-asia/S/S9a/040.ts
@@ -48,14 +48,27 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609808,
+				tcgplayer: 570610,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577627,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [369],
-
-	thirdParty: {
-		cardmarket: 609808
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/041.ts
+++ b/data-asia/S/S9a/041.ts
@@ -44,14 +44,27 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609809,
+				tcgplayer: 570611,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577628,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [449],
-
-	thirdParty: {
-		cardmarket: 609809
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/042.ts
+++ b/data-asia/S/S9a/042.ts
@@ -49,14 +49,27 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609810,
+				tcgplayer: 570612,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577629,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [450],
-
-	thirdParty: {
-		cardmarket: 609810
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/043.ts
+++ b/data-asia/S/S9a/043.ts
@@ -50,6 +50,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609811,
+				tcgplayer: 570613,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	dexId: [701]

--- a/data-asia/S/S9a/044.ts
+++ b/data-asia/S/S9a/044.ts
@@ -48,6 +48,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609812,
+				tcgplayer: 570614,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Double rare"

--- a/data-asia/S/S9a/045.ts
+++ b/data-asia/S/S9a/045.ts
@@ -59,6 +59,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609813,
+				tcgplayer: 570615,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F"
 }

--- a/data-asia/S/S9a/046.ts
+++ b/data-asia/S/S9a/046.ts
@@ -53,6 +53,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609814,
+				tcgplayer: 570616,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Rare",

--- a/data-asia/S/S9a/047.ts
+++ b/data-asia/S/S9a/047.ts
@@ -40,6 +40,23 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609815,
+				tcgplayer: 570617,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577630,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Common",

--- a/data-asia/S/S9a/048.ts
+++ b/data-asia/S/S9a/048.ts
@@ -51,6 +51,23 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609816,
+				tcgplayer: 570618,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577631,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Uncommon",

--- a/data-asia/S/S9a/049.ts
+++ b/data-asia/S/S9a/049.ts
@@ -49,14 +49,27 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609817,
+				tcgplayer: 570619,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577632,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [261],
-
-	thirdParty: {
-		cardmarket: 609817
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/050.ts
+++ b/data-asia/S/S9a/050.ts
@@ -55,14 +55,27 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609818,
+				tcgplayer: 570620,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577633,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [262],
-
-	thirdParty: {
-		cardmarket: 609818
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/051.ts
+++ b/data-asia/S/S9a/051.ts
@@ -53,14 +53,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609819,
+				tcgplayer: 570621,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Rare",
 	dexId: [359],
-
-	thirdParty: {
-		cardmarket: 609819
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/052.ts
+++ b/data-asia/S/S9a/052.ts
@@ -48,6 +48,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609820,
+				tcgplayer: 570622,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Double rare"

--- a/data-asia/S/S9a/053.ts
+++ b/data-asia/S/S9a/053.ts
@@ -59,6 +59,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609821,
+				tcgplayer: 570623,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F"
 }

--- a/data-asia/S/S9a/054.ts
+++ b/data-asia/S/S9a/054.ts
@@ -38,6 +38,16 @@ const card: Card = {
 		cost: ["Water", "Fighting", "Fighting", "Colorless"]
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609822,
+				tcgplayer: 570624,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "F",
 	rarity: "Double rare"

--- a/data-asia/S/S9a/055.ts
+++ b/data-asia/S/S9a/055.ts
@@ -55,14 +55,27 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609823,
+				tcgplayer: 570625,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577634,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [163],
-
-	thirdParty: {
-		cardmarket: 609823
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/056.ts
+++ b/data-asia/S/S9a/056.ts
@@ -59,14 +59,27 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609824,
+				tcgplayer: 570626,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577635,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [164],
-
-	thirdParty: {
-		cardmarket: 609824
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/057.ts
+++ b/data-asia/S/S9a/057.ts
@@ -41,14 +41,27 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609825,
+				tcgplayer: 570627,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577636,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [234],
-
-	thirdParty: {
-		cardmarket: 609825
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/058.ts
+++ b/data-asia/S/S9a/058.ts
@@ -55,14 +55,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609826,
+				tcgplayer: 570628,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Rare",
 	dexId: [241],
-
-	thirdParty: {
-		cardmarket: 609826
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/059.ts
+++ b/data-asia/S/S9a/059.ts
@@ -41,14 +41,27 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609827,
+				tcgplayer: 570629,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577637,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "F",
 	rarity: "Common",
 	dexId: [431],
-
-	thirdParty: {
-		cardmarket: 609827
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/060.ts
+++ b/data-asia/S/S9a/060.ts
@@ -49,14 +49,27 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609828,
+				tcgplayer: 570630,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577638,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "F",
 	rarity: "Uncommon",
 	dexId: [432],
-
-	thirdParty: {
-		cardmarket: 609828
-	}
 }
 
 export default card

--- a/data-asia/S/S9a/061.ts
+++ b/data-asia/S/S9a/061.ts
@@ -17,6 +17,23 @@ const card: Card = {
 		ja: "このカードは、後攻プレイヤーの最初の番しか使えず、使ったら、自分の番は終わる。\n\n自分の山札から基本エネルギーを1枚選び、自分のポケモンにつける。そして山札を切る。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609829,
+				tcgplayer: 570631,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577639,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "F",
 	rarity: "Uncommon"

--- a/data-asia/S/S9a/062.ts
+++ b/data-asia/S/S9a/062.ts
@@ -17,6 +17,23 @@ const card: Card = {
 		ja: "自分のポケモンを1匹選ぶ。ウラが出るまでコインを投げ、オモテの数×40ダメージぶん、そのポケモンのHPを回復する。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609830,
+				tcgplayer: 570632,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577640,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "F",
 	rarity: "Uncommon"

--- a/data-asia/S/S9a/063.ts
+++ b/data-asia/S/S9a/063.ts
@@ -17,6 +17,23 @@ const card: Card = {
 		ja: "この番の終わりまで、相手のバトルポケモンの特性は、すべてなくなる。（新しくバトル場に出したポケモンもふくむ。）"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609831,
+				tcgplayer: 570633,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577641,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "F",
 	rarity: "Uncommon"

--- a/data-asia/S/S9a/064.ts
+++ b/data-asia/S/S9a/064.ts
@@ -17,6 +17,23 @@ const card: Card = {
 		ja: "コインを2回投げ、オモテの数ぶんまで、自分のトラッシュから好きなカードを選び、相手に見せて、好きな順番に入れ替えて、山札の上にもどす。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609832,
+				tcgplayer: 570634,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577642,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "F",
 	rarity: "Uncommon"

--- a/data-asia/S/S9a/065.ts
+++ b/data-asia/S/S9a/065.ts
@@ -17,6 +17,23 @@ const card: Card = {
 		ja: "このカードは、相手のサイドの残り枚数が3枚以下のときにしか使えない。\n\nおたがいのプレイヤーは、それぞれ手札をすべて山札にもどして切る。その後、自分は6枚、相手は2枚、山札を引く。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609833,
+				tcgplayer: 570635,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577643,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "F",
 	rarity: "Uncommon"

--- a/data-asia/S/S9a/066.ts
+++ b/data-asia/S/S9a/066.ts
@@ -17,6 +17,23 @@ const card: Card = {
 		ja: "自分の手札を1枚選び、残りの手札をすべてトラッシュする。その後、山札を4枚引く。（自分の手札がこのカード1枚だけなら、このカードは使えない。）"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609834,
+				tcgplayer: 570636,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577644,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "F",
 	rarity: "Uncommon"

--- a/data-asia/S/S9a/067.ts
+++ b/data-asia/S/S9a/067.ts
@@ -17,6 +17,23 @@ const card: Card = {
 		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の手札をすべて山札にもどして切ってよい。その場合、自分の山札を5枚引く。この効果を使ったなら、自分の番は終わる。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609835,
+				tcgplayer: 570637,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 577645,
+			},
+		},
+	],
+
 	trainerType: "Stadium",
 	regulationMark: "F",
 	rarity: "Uncommon"

--- a/data-asia/S/S9a/068.ts
+++ b/data-asia/S/S9a/068.ts
@@ -51,11 +51,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 1,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609836,
+				tcgplayer: 570638,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 609716
-	}
+	retreat: 1,
 }
 
 export default card

--- a/data-asia/S/S9a/069.ts
+++ b/data-asia/S/S9a/069.ts
@@ -47,11 +47,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 2,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609837,
+				tcgplayer: 570639,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 609723
-	}
+	retreat: 2,
 }
 
 export default card

--- a/data-asia/S/S9a/070.ts
+++ b/data-asia/S/S9a/070.ts
@@ -56,6 +56,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609838,
+				tcgplayer: 570640,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/S/S9a/071.ts
+++ b/data-asia/S/S9a/071.ts
@@ -49,6 +49,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609839,
+				tcgplayer: 570641,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/S/S9a/072.ts
+++ b/data-asia/S/S9a/072.ts
@@ -51,11 +51,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 2,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609840,
+				tcgplayer: 570642,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 609818
-	}
+	retreat: 2,
 }
 
 export default card

--- a/data-asia/S/S9a/073.ts
+++ b/data-asia/S/S9a/073.ts
@@ -52,11 +52,17 @@ const card: Card = {
 		value: "－30"
 	}],
 
-	retreat: 1,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609841,
+				tcgplayer: 570643,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 609823
-	}
+	retreat: 1,
 }
 
 export default card

--- a/data-asia/S/S9a/074.ts
+++ b/data-asia/S/S9a/074.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609842,
+				tcgplayer: 570644,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/S/S9a/075.ts
+++ b/data-asia/S/S9a/075.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609843,
+				tcgplayer: 570645,
+			},
+		},
+	],
+
 	retreat: 0
 }
 

--- a/data-asia/S/S9a/076.ts
+++ b/data-asia/S/S9a/076.ts
@@ -47,6 +47,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609844,
+				tcgplayer: 570646,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/S/S9a/077.ts
+++ b/data-asia/S/S9a/077.ts
@@ -44,6 +44,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609845,
+				tcgplayer: 570647,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/S/S9a/078.ts
+++ b/data-asia/S/S9a/078.ts
@@ -44,6 +44,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609846,
+				tcgplayer: 570648,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/S/S9a/079.ts
+++ b/data-asia/S/S9a/079.ts
@@ -35,6 +35,16 @@ const card: Card = {
 		}
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609847,
+				tcgplayer: 570649,
+			},
+		},
+	],
+
 	retreat: 0
 }
 

--- a/data-asia/S/S9a/080.ts
+++ b/data-asia/S/S9a/080.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "コインを2回投げ、オモテの数ぶんまで、自分のトラッシュから好きなカードを選び、相手に見せて、好きな順番に入れ替えて、山札の上にもどす。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609848,
+				tcgplayer: 570650,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/S/S9a/081.ts
+++ b/data-asia/S/S9a/081.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "このカードは、相手のサイドの残り枚数が3枚以下のときにしか使えない。\n\nおたがいのプレイヤーは、それぞれ手札をすべて山札にもどして切る。その後、自分は6枚、相手は2枚、山札を引く。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609849,
+				tcgplayer: 570651,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/S/S9a/082.ts
+++ b/data-asia/S/S9a/082.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分の手札を1枚選び、残りの手札をすべてトラッシュする。その後、山札を4枚引く。（自分の手札がこのカード1枚だけなら、このカードは使えない。）"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609850,
+				tcgplayer: 570652,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/S/S9a/083.ts
+++ b/data-asia/S/S9a/083.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609851,
+				tcgplayer: 570653,
+			},
+		},
+	],
+
 	retreat: 0
 }
 

--- a/data-asia/S/S9a/084.ts
+++ b/data-asia/S/S9a/084.ts
@@ -35,6 +35,16 @@ const card: Card = {
 		}
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609852,
+				tcgplayer: 570654,
+			},
+		},
+	],
+
 	retreat: 0
 }
 

--- a/data-asia/S/S9a/085.ts
+++ b/data-asia/S/S9a/085.ts
@@ -48,6 +48,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609853,
+				tcgplayer: 570655,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/S/S9a/086.ts
+++ b/data-asia/S/S9a/086.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609854,
+				tcgplayer: 570656,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/S/S9a/087.ts
+++ b/data-asia/S/S9a/087.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609855,
+				tcgplayer: 570657,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/S/S9a/088.ts
+++ b/data-asia/S/S9a/088.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "コインを2回投げ、オモテの数ぶんまで、自分のトラッシュから好きなカードを選び、相手に見せて、好きな順番に入れ替えて、山札の上にもどす。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609856,
+				tcgplayer: 570658,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/S/S9a/089.ts
+++ b/data-asia/S/S9a/089.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "このカードは、相手のサイドの残り枚数が3枚以下のときにしか使えない。\n\nおたがいのプレイヤーは、それぞれ手札をすべて山札にもどして切る。その後、自分は6枚、相手は2枚、山札を引く。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609857,
+				tcgplayer: 570659,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/S/S9a/090.ts
+++ b/data-asia/S/S9a/090.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分の手札を1枚選び、残りの手札をすべてトラッシュする。その後、山札を4枚引く。（自分の手札がこのカード1枚だけなら、このカードは使えない。）"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609858,
+				tcgplayer: 570660,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/S/S9a/091.ts
+++ b/data-asia/S/S9a/091.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609859,
+				tcgplayer: 570661,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/S/S9a/092.ts
+++ b/data-asia/S/S9a/092.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "ポケモンのどうぐは、自分のポケモンにつけて使う。ポケモン1匹につき1枚だけつけられ、つけたままにする。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609860,
+				tcgplayer: 570662,
+			},
+		},
+	],
+
 	trainerType: "Tool"
 }
 

--- a/data-asia/S/S9a/093.ts
+++ b/data-asia/S/S9a/093.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の手札をすべて山札にもどして切ってよい。その場合、自分の山札を5枚引く。この効果を使ったなら、自分の番は終わる。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609861,
+				tcgplayer: 570663,
+			},
+		},
+	],
+
 	trainerType: "Stadium"
 }
 


### PR DESCRIPTION
## What

Links the cards of the existing Japanese set **S9a バトルリージョン (Battle Region)** to their Cardmarket **and TCGplayer** products, so the API can serve their prices.

- **47** cards carried no product id at all and get both
- **46** carried a card-level `thirdParty.cardmarket`, which is moved onto the card's `variants` entry and joined by its tcgplayer id
- **4** carried the cardmarket id of a different print and are corrected

Afterwards every card of the set carries its id on a `variants` entry and none on the card itself, which is where tcgdex is heading. Nothing else changes: the `zh-tw` texts and the Japanese card data are not rewritten.

4 cards carried the product of **another print** of the same card, so the API served that print's price for them:

| card | was | is | the old id belongs to |
|---|---|---|---|
| 068 | 609716 | 609836 | points at card 007 of this set |
| 069 | 609723 | 609837 | points at card 014 of this set |
| 072 | 609818 | 609840 | points at card 050 of this set |
| 073 | 609823 | 609841 | points at card 055 of this set |

The ids are assigned **by collection number**, not by name: within a Cardmarket expansion the products sorted by `idProduct` follow the collection order, and the assignment is verified against the sample rows pokepricelab renders. That matters because Cardmarket names every print of a card identically inside an expansion, so a name lookup cannot tell a base print from its AR/full-art reprint — which is where the corrected ids above come from. That the 42 ids this set already carried correctly agree with the same assignment is an independent cross-check.

## Data sources

- **Cardmarket** public product catalog (`downloads.s3.cardmarket.com`): the product ids (609710–609861), assigned by collection number
- **pokepricelab.com**: the sample rows that verify that assignment
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (570570–570663), keyed by the collection number each product carries in `extendedData`
- **limitlesstcg.com**: the set's card list — used here for nothing but the rarity per number, which decides whether a variant is `holo` or `normal`

## Notes

- `tsc --noEmit` reports the same 32 pre-existing errors as upstream/master — this change adds none. They are `rarity` being required by `interfaces.d.ts` while these older hand-written files omit it, which is out of scope here.
