### PR TITLE
(data) ja SV1a Triplet Beat - cardmarket + tcgplayer product ids

### DIFF
--- a/data-asia/SV/SV1a/001.ts
+++ b/data-asia/SV/SV1a/001.ts
@@ -70,12 +70,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701036,
+				tcgplayer: 568124,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701036
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/002.ts
+++ b/data-asia/SV/SV1a/002.ts
@@ -61,12 +61,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701038,
+				tcgplayer: 568125,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701038
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/003.ts
+++ b/data-asia/SV/SV1a/003.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701039,
+				tcgplayer: 568126,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701039
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/004.ts
+++ b/data-asia/SV/SV1a/004.ts
@@ -61,6 +61,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701040,
+				tcgplayer: 568127,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/005.ts
+++ b/data-asia/SV/SV1a/005.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701041,
+				tcgplayer: 568128,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/006.ts
+++ b/data-asia/SV/SV1a/006.ts
@@ -63,6 +63,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701043,
+				tcgplayer: 568129,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/007.ts
+++ b/data-asia/SV/SV1a/007.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701046,
+				tcgplayer: 568130,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/008.ts
+++ b/data-asia/SV/SV1a/008.ts
@@ -61,6 +61,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701049,
+				tcgplayer: 568131,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/009.ts
+++ b/data-asia/SV/SV1a/009.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701051,
+				tcgplayer: 568132,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/010.ts
+++ b/data-asia/SV/SV1a/010.ts
@@ -63,6 +63,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701054,
+				tcgplayer: 568133,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/011.ts
+++ b/data-asia/SV/SV1a/011.ts
@@ -70,6 +70,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701058,
+				tcgplayer: 568134,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/012.ts
+++ b/data-asia/SV/SV1a/012.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701060,
+				tcgplayer: 568135,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701060
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/013.ts
+++ b/data-asia/SV/SV1a/013.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701062,
+				tcgplayer: 568136,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701062
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/014.ts
+++ b/data-asia/SV/SV1a/014.ts
@@ -61,12 +61,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701063,
+				tcgplayer: 568137,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701063
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/015.ts
+++ b/data-asia/SV/SV1a/015.ts
@@ -68,12 +68,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701065,
+				tcgplayer: 568138,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701065
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/016.ts
+++ b/data-asia/SV/SV1a/016.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701068,
+				tcgplayer: 568139,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701068
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/017.ts
+++ b/data-asia/SV/SV1a/017.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701070,
+				tcgplayer: 568140,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/018.ts
+++ b/data-asia/SV/SV1a/018.ts
@@ -61,6 +61,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701072,
+				tcgplayer: 568141,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/019.ts
+++ b/data-asia/SV/SV1a/019.ts
@@ -56,6 +56,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701073,
+				tcgplayer: 568142,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/020.ts
+++ b/data-asia/SV/SV1a/020.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701074,
+				tcgplayer: 568143,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/021.ts
+++ b/data-asia/SV/SV1a/021.ts
@@ -68,6 +68,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701075,
+				tcgplayer: 568144,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/022.ts
+++ b/data-asia/SV/SV1a/022.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701076,
+				tcgplayer: 568145,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701076
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/023.ts
+++ b/data-asia/SV/SV1a/023.ts
@@ -70,12 +70,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701077,
+				tcgplayer: 568146,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701077
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/024.ts
+++ b/data-asia/SV/SV1a/024.ts
@@ -61,12 +61,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701078,
+				tcgplayer: 568147,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701078
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/025.ts
+++ b/data-asia/SV/SV1a/025.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701079,
+				tcgplayer: 568148,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701079
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/026.ts
+++ b/data-asia/SV/SV1a/026.ts
@@ -61,12 +61,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701080,
+				tcgplayer: 568149,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701080
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/027.ts
+++ b/data-asia/SV/SV1a/027.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701081,
+				tcgplayer: 568150,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/028.ts
+++ b/data-asia/SV/SV1a/028.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701082,
+				tcgplayer: 568151,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/029.ts
+++ b/data-asia/SV/SV1a/029.ts
@@ -56,6 +56,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701083,
+				tcgplayer: 568152,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/030.ts
+++ b/data-asia/SV/SV1a/030.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701084,
+				tcgplayer: 568153,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/031.ts
+++ b/data-asia/SV/SV1a/031.ts
@@ -68,6 +68,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701085,
+				tcgplayer: 568154,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/032.ts
+++ b/data-asia/SV/SV1a/032.ts
@@ -66,6 +66,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701086,
+				tcgplayer: 568155,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/033.ts
+++ b/data-asia/SV/SV1a/033.ts
@@ -68,6 +68,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701087,
+				tcgplayer: 568156,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/034.ts
+++ b/data-asia/SV/SV1a/034.ts
@@ -57,12 +57,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701088,
+				tcgplayer: 568157,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701088
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/035.ts
+++ b/data-asia/SV/SV1a/035.ts
@@ -68,12 +68,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701089,
+				tcgplayer: 568158,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701089
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/036.ts
+++ b/data-asia/SV/SV1a/036.ts
@@ -61,12 +61,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701090,
+				tcgplayer: 568159,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701090
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/037.ts
+++ b/data-asia/SV/SV1a/037.ts
@@ -66,12 +66,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701091,
+				tcgplayer: 568160,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701091
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/038.ts
+++ b/data-asia/SV/SV1a/038.ts
@@ -60,12 +60,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701092,
+				tcgplayer: 568161,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701092
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/039.ts
+++ b/data-asia/SV/SV1a/039.ts
@@ -68,12 +68,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701093,
+				tcgplayer: 568162,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701093
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/040.ts
+++ b/data-asia/SV/SV1a/040.ts
@@ -61,6 +61,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701094,
+				tcgplayer: 568163,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/041.ts
+++ b/data-asia/SV/SV1a/041.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701095,
+				tcgplayer: 568164,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/042.ts
+++ b/data-asia/SV/SV1a/042.ts
@@ -63,6 +63,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701096,
+				tcgplayer: 568165,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/043.ts
+++ b/data-asia/SV/SV1a/043.ts
@@ -70,6 +70,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701097,
+				tcgplayer: 568166,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/044.ts
+++ b/data-asia/SV/SV1a/044.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701098,
+				tcgplayer: 568167,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701098
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/045.ts
+++ b/data-asia/SV/SV1a/045.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701099,
+				tcgplayer: 568168,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701099
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/046.ts
+++ b/data-asia/SV/SV1a/046.ts
@@ -70,6 +70,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701100,
+				tcgplayer: 568169,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/047.ts
+++ b/data-asia/SV/SV1a/047.ts
@@ -45,12 +45,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701101,
+				tcgplayer: 568170,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701101
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/048.ts
+++ b/data-asia/SV/SV1a/048.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701102,
+				tcgplayer: 568171,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701102
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/049.ts
+++ b/data-asia/SV/SV1a/049.ts
@@ -56,12 +56,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701103,
+				tcgplayer: 568172,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701103
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/050.ts
+++ b/data-asia/SV/SV1a/050.ts
@@ -55,12 +55,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701104,
+				tcgplayer: 568173,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701104
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/051.ts
+++ b/data-asia/SV/SV1a/051.ts
@@ -63,6 +63,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701105,
+				tcgplayer: 568174,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/052.ts
+++ b/data-asia/SV/SV1a/052.ts
@@ -56,6 +56,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701106,
+				tcgplayer: 568175,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/053.ts
+++ b/data-asia/SV/SV1a/053.ts
@@ -61,6 +61,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701107,
+				tcgplayer: 568176,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/054.ts
+++ b/data-asia/SV/SV1a/054.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701108,
+				tcgplayer: 568177,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/055.ts
+++ b/data-asia/SV/SV1a/055.ts
@@ -68,12 +68,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701109,
+				tcgplayer: 568178,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701109
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/056.ts
+++ b/data-asia/SV/SV1a/056.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701110,
+				tcgplayer: 568179,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701110
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/057.ts
+++ b/data-asia/SV/SV1a/057.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701111,
+				tcgplayer: 568180,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701111
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/058.ts
+++ b/data-asia/SV/SV1a/058.ts
@@ -61,12 +61,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701112,
+				tcgplayer: 568181,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701112
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/059.ts
+++ b/data-asia/SV/SV1a/059.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701113,
+				tcgplayer: 568182,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701113
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/060.ts
+++ b/data-asia/SV/SV1a/060.ts
@@ -56,12 +56,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701114,
+				tcgplayer: 568183,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701114
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/061.ts
+++ b/data-asia/SV/SV1a/061.ts
@@ -56,12 +56,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701115,
+				tcgplayer: 568184,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701115
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/062.ts
+++ b/data-asia/SV/SV1a/062.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701116,
+				tcgplayer: 568185,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701116
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/063.ts
+++ b/data-asia/SV/SV1a/063.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701117,
+				tcgplayer: 568186,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 701117
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1a/064.ts
+++ b/data-asia/SV/SV1a/064.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Kartu ini dapat digunakan jika pemain membuang 2 lembar Kartu Pegangan sendiri ke Trash. Pilih paling banyak 4 lembar Energi Dasar dari Trash sendiri, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan. (Tidak dapat memilih Energi yang dibuang ke Trash akibat efek kartu ini.)"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701118,
+				tcgplayer: 568187,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/065.ts
+++ b/data-asia/SV/SV1a/065.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Lihat 7 kartu dari atas Deck sendiri, pilih 1 lembar Pokémon di antaranya, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan. Kocok kembali sisa kartu ke Deck."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701119,
+				tcgplayer: 568188,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/066.ts
+++ b/data-asia/SV/SV1a/066.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Pilih 1 lembar Kartu Pegangan sendiri, lalu kembalikan ke bawah Deck. Setelah itu, ambil kartu dari atas Deck hingga jumlah Kartu Pegangan sendiri menjadi 5 lembar. (Jika Kartu Pegangan sendiri hanya 1 kartu ini saja, kartu ini tidak dapat digunakan.)"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701120,
+				tcgplayer: 568189,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/067.ts
+++ b/data-asia/SV/SV1a/067.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Pilih paling banyak 3 lembar Pokémon Basic dengan HP 120 atau kurang dari Deck sendiri, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan. Kemudian, kocok Deck."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701121,
+				tcgplayer: 568190,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/068.ts
+++ b/data-asia/SV/SV1a/068.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Ambil 2 kartu dari atas Deck sendiri. Jika ada Stadium sendiri di Arena, ambil lagi 2 kartu tambahan."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701122,
+				tcgplayer: 568191,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/069.ts
+++ b/data-asia/SV/SV1a/069.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Pilih 1 Pokémon Cadangan lawan, lalu tukar dengan Pokémon Bertarung."
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701123,
+				tcgplayer: 568192,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/070.ts
+++ b/data-asia/SV/SV1a/070.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Kedua pemain 1 kali pada tiap gilirannya sendiri dapat memilih 1 lembar Pokémon Basic (selain Pokémon yang memiliki Peraturan) dari Deck sendiri, lalu memasukkannya ke Cadangan. Kemudian, kocok Deck."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701124,
+				tcgplayer: 568193,
+			},
+		},
+	],
+
 	trainerType: "Stadium",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/071.ts
+++ b/data-asia/SV/SV1a/071.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Kerusakan akibat serangan yang digunakan oleh Pokémon Stage 1 kedua pemain kepada Pokémon Bertarung lawan bertambah sejumlah 10."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701125,
+				tcgplayer: 568194,
+			},
+		},
+	],
+
 	trainerType: "Stadium",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1a/072.ts
+++ b/data-asia/SV/SV1a/072.ts
@@ -22,6 +22,16 @@ const card: Card = {
 	},
 
 	energyType: "Special",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701126,
+				tcgplayer: 568195,
+			},
+		},
+	],
+
 	regulationMark: "G"
 }
 

--- a/data-asia/SV/SV1a/073.ts
+++ b/data-asia/SV/SV1a/073.ts
@@ -22,6 +22,16 @@ const card: Card = {
 	},
 
 	energyType: "Special",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 701127,
+				tcgplayer: 568196,
+			},
+		},
+	],
+
 	regulationMark: "G"
 }
 

--- a/data-asia/SV/SV1a/074.ts
+++ b/data-asia/SV/SV1a/074.ts
@@ -51,11 +51,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 1,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701530,
+				tcgplayer: 568197,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 701036
-	}
+	retreat: 1,
 }
 
 export default card

--- a/data-asia/SV/SV1a/075.ts
+++ b/data-asia/SV/SV1a/075.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701531,
+				tcgplayer: 568198,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV1a/076.ts
+++ b/data-asia/SV/SV1a/076.ts
@@ -47,6 +47,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701532,
+				tcgplayer: 568199,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV1a/077.ts
+++ b/data-asia/SV/SV1a/077.ts
@@ -49,11 +49,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 2,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701533,
+				tcgplayer: 568200,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 701065
-	}
+	retreat: 2,
 }
 
 export default card

--- a/data-asia/SV/SV1a/078.ts
+++ b/data-asia/SV/SV1a/078.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701534,
+				tcgplayer: 568201,
+			},
+		},
+	],
+
 	retreat: 3
 }
 

--- a/data-asia/SV/SV1a/079.ts
+++ b/data-asia/SV/SV1a/079.ts
@@ -43,6 +43,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701535,
+				tcgplayer: 568202,
+			},
+		},
+	],
+
 	retreat: 3
 }
 

--- a/data-asia/SV/SV1a/080.ts
+++ b/data-asia/SV/SV1a/080.ts
@@ -39,11 +39,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 1,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701536,
+				tcgplayer: 568203,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 701076
-	}
+	retreat: 1,
 }
 
 export default card

--- a/data-asia/SV/SV1a/081.ts
+++ b/data-asia/SV/SV1a/081.ts
@@ -39,6 +39,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701538,
+				tcgplayer: 568204,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV1a/082.ts
+++ b/data-asia/SV/SV1a/082.ts
@@ -43,6 +43,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701540,
+				tcgplayer: 568205,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV1a/083.ts
+++ b/data-asia/SV/SV1a/083.ts
@@ -52,11 +52,17 @@ const card: Card = {
 		value: "－30"
 	}],
 
-	retreat: 1,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701541,
+				tcgplayer: 568206,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 701089
-	}
+	retreat: 1,
 }
 
 export default card

--- a/data-asia/SV/SV1a/084.ts
+++ b/data-asia/SV/SV1a/084.ts
@@ -51,6 +51,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701543,
+				tcgplayer: 568207,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV1a/085.ts
+++ b/data-asia/SV/SV1a/085.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701544,
+				tcgplayer: 568208,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV1a/086.ts
+++ b/data-asia/SV/SV1a/086.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701546,
+				tcgplayer: 568209,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV1a/087.ts
+++ b/data-asia/SV/SV1a/087.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701547,
+				tcgplayer: 568210,
+			},
+		},
+	],
+
 	retreat: 3
 }
 

--- a/data-asia/SV/SV1a/088.ts
+++ b/data-asia/SV/SV1a/088.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701548,
+				tcgplayer: 568211,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV1a/089.ts
+++ b/data-asia/SV/SV1a/089.ts
@@ -44,11 +44,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 1,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701549,
+				tcgplayer: 568212,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 701092
-	}
+	retreat: 1,
 }
 
 export default card

--- a/data-asia/SV/SV1a/090.ts
+++ b/data-asia/SV/SV1a/090.ts
@@ -42,11 +42,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 2,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701550,
+				tcgplayer: 568213,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 701104
-	}
+	retreat: 2,
 }
 
 export default card

--- a/data-asia/SV/SV1a/091.ts
+++ b/data-asia/SV/SV1a/091.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701551,
+				tcgplayer: 568214,
+			},
+		},
+	],
+
 	retreat: 3
 }
 

--- a/data-asia/SV/SV1a/092.ts
+++ b/data-asia/SV/SV1a/092.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分の手札を1枚選び、山札の下にもどす。その後、自分の手札が5枚になるように、山札を引く。（自分の手札がこのカード1枚だけなら、このカードは使えない。）"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701553,
+				tcgplayer: 568215,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV1a/093.ts
+++ b/data-asia/SV/SV1a/093.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分の山札から、HPが「120」以下のたねポケモンを3枚まで選び、相手に見せて、手札に加える。そして山札を切る。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701555,
+				tcgplayer: 568216,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV1a/094.ts
+++ b/data-asia/SV/SV1a/094.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分の山札を2枚引く。場に自分のスタジアムが出ているなら、さらに2枚引く。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701557,
+				tcgplayer: 568217,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV1a/095.ts
+++ b/data-asia/SV/SV1a/095.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701559,
+				tcgplayer: 568218,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV1a/096.ts
+++ b/data-asia/SV/SV1a/096.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701560,
+				tcgplayer: 568219,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV1a/097.ts
+++ b/data-asia/SV/SV1a/097.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701561,
+				tcgplayer: 568220,
+			},
+		},
+	],
+
 	retreat: 3
 }
 

--- a/data-asia/SV/SV1a/098.ts
+++ b/data-asia/SV/SV1a/098.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701562,
+				tcgplayer: 568221,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV1a/099.ts
+++ b/data-asia/SV/SV1a/099.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分の手札を1枚選び、山札の下にもどす。その後、自分の手札が5枚になるように、山札を引く。（自分の手札がこのカード1枚だけなら、このカードは使えない。）"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701563,
+				tcgplayer: 568222,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV1a/100.ts
+++ b/data-asia/SV/SV1a/100.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701564,
+				tcgplayer: 568223,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV1a/101.ts
+++ b/data-asia/SV/SV1a/101.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701565,
+				tcgplayer: 568224,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV1a/102.ts
+++ b/data-asia/SV/SV1a/102.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701566,
+				tcgplayer: 568225,
+			},
+		},
+	],
+
 	retreat: 3
 }
 

--- a/data-asia/SV/SV1a/103.ts
+++ b/data-asia/SV/SV1a/103.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 701567,
+				tcgplayer: 568226,
+			},
+		},
+	],
+
 	retreat: 2
 }
 


### PR DESCRIPTION
## What

Links the cards of the existing Japanese set **SV1a トリプレットビート (Triplet Beat)** to their Cardmarket **and TCGplayer** products, so the API can serve their prices.

- **63** cards carried no product id at all and get both
- **40** carried a card-level `thirdParty.cardmarket`, which is moved onto the card's `variants` entry and joined by its tcgplayer id
- **6** carried the cardmarket id of a different print and are corrected

Afterwards every card of the set carries its id on a `variants` entry and none on the card itself, which is where tcgdex is heading. Nothing else changes: the `zh-tw`/`th`/`id` texts and the Japanese card data are not rewritten.

6 cards carried the product of **another print** of the same card, so the API served that print's price for them:

| card | was | is | the old id belongs to |
|---|---|---|---|
| 074 | 701036 | 701530 | points at card 001 of this set |
| 077 | 701065 | 701533 | points at card 015 of this set |
| 080 | 701076 | 701536 | points at card 022 of this set |
| 083 | 701089 | 701541 | points at card 035 of this set |
| 089 | 701092 | 701549 | points at card 038 of this set |
| 090 | 701104 | 701550 | points at card 050 of this set |

The ids are assigned **by collection number**, not by name: within a Cardmarket expansion the products sorted by `idProduct` follow the collection order, and the assignment is verified against the sample rows pokepricelab renders. That matters because Cardmarket names every print of a card identically inside an expansion, so a name lookup cannot tell a base print from its AR/full-art reprint — which is where the corrected ids above come from. That the 34 ids this set already carried correctly agree with the same assignment is an independent cross-check.

## Data sources

- **Cardmarket** public product catalog (`downloads.s3.cardmarket.com`): the product ids (701036–701567), assigned by collection number
- **pokepricelab.com**: the sample rows that verify that assignment
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (568124–568226), keyed by the collection number each product carries in `extendedData`
- **limitlesstcg.com**: the set's card list — used here for nothing but the rarity per number, which decides whether a variant is `holo` or `normal`

## Notes

- `tsc --noEmit` reports the same 30 pre-existing errors as upstream/master — this change adds none. They are `rarity` being required by `interfaces.d.ts` while these older hand-written files omit it, which is out of scope here.
