### PR TITLE
(data) ja SV1S Scarlet ex - cardmarket + tcgplayer product ids

### DIFF
--- a/data-asia/SV/SV1S/001.ts
+++ b/data-asia/SV/SV1S/001.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692967,
+				tcgplayer: 567118,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 692967
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/002.ts
+++ b/data-asia/SV/SV1S/002.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692968,
+				tcgplayer: 567119,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 692968
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/003.ts
+++ b/data-asia/SV/SV1S/003.ts
@@ -56,12 +56,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692969,
+				tcgplayer: 567120,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 692969
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/004.ts
+++ b/data-asia/SV/SV1S/004.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692970,
+				tcgplayer: 567121,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 692970
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/005.ts
+++ b/data-asia/SV/SV1S/005.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692971,
+				tcgplayer: 567122,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/006.ts
+++ b/data-asia/SV/SV1S/006.ts
@@ -61,6 +61,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692972,
+				tcgplayer: 567123,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/007.ts
+++ b/data-asia/SV/SV1S/007.ts
@@ -63,6 +63,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692973,
+				tcgplayer: 567124,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/008.ts
+++ b/data-asia/SV/SV1S/008.ts
@@ -63,6 +63,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 692974,
+				tcgplayer: 567125,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/009.ts
+++ b/data-asia/SV/SV1S/009.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692975,
+				tcgplayer: 567126,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 692975
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/010.ts
+++ b/data-asia/SV/SV1S/010.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692976,
+				tcgplayer: 567127,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/011.ts
+++ b/data-asia/SV/SV1S/011.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692977,
+				tcgplayer: 567128,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/012.ts
+++ b/data-asia/SV/SV1S/012.ts
@@ -70,6 +70,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 692978,
+				tcgplayer: 567129,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/013.ts
+++ b/data-asia/SV/SV1S/013.ts
@@ -50,12 +50,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692979,
+				tcgplayer: 567130,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 692979
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/014.ts
+++ b/data-asia/SV/SV1S/014.ts
@@ -55,12 +55,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 692980,
+				tcgplayer: 567131,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 692980
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/015.ts
+++ b/data-asia/SV/SV1S/015.ts
@@ -56,12 +56,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692981,
+				tcgplayer: 567132,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 692981
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/016.ts
+++ b/data-asia/SV/SV1S/016.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692982,
+				tcgplayer: 567133,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 692982
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/017.ts
+++ b/data-asia/SV/SV1S/017.ts
@@ -61,12 +61,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692983,
+				tcgplayer: 567134,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 692983
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/018.ts
+++ b/data-asia/SV/SV1S/018.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692984,
+				tcgplayer: 567135,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/019.ts
+++ b/data-asia/SV/SV1S/019.ts
@@ -61,6 +61,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692985,
+				tcgplayer: 567136,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/020.ts
+++ b/data-asia/SV/SV1S/020.ts
@@ -61,6 +61,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692986,
+				tcgplayer: 567137,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/021.ts
+++ b/data-asia/SV/SV1S/021.ts
@@ -63,6 +63,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 692987,
+				tcgplayer: 567138,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/022.ts
+++ b/data-asia/SV/SV1S/022.ts
@@ -68,6 +68,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692988,
+				tcgplayer: 567139,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/023.ts
+++ b/data-asia/SV/SV1S/023.ts
@@ -66,6 +66,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692989,
+				tcgplayer: 567140,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/024.ts
+++ b/data-asia/SV/SV1S/024.ts
@@ -50,6 +50,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692990,
+				tcgplayer: 567141,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/025.ts
+++ b/data-asia/SV/SV1S/025.ts
@@ -73,6 +73,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692991,
+				tcgplayer: 567142,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/026.ts
+++ b/data-asia/SV/SV1S/026.ts
@@ -50,12 +50,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692992,
+				tcgplayer: 567143,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 692992
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/027.ts
+++ b/data-asia/SV/SV1S/027.ts
@@ -68,12 +68,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692993,
+				tcgplayer: 567144,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 692993
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/028.ts
+++ b/data-asia/SV/SV1S/028.ts
@@ -67,12 +67,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 692994,
+				tcgplayer: 567145,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 692994
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/029.ts
+++ b/data-asia/SV/SV1S/029.ts
@@ -68,12 +68,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692995,
+				tcgplayer: 567146,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 692995
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/030.ts
+++ b/data-asia/SV/SV1S/030.ts
@@ -66,12 +66,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692996,
+				tcgplayer: 567147,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 692996
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/031.ts
+++ b/data-asia/SV/SV1S/031.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692997,
+				tcgplayer: 567148,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 692997
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/032.ts
+++ b/data-asia/SV/SV1S/032.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692998,
+				tcgplayer: 567149,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/033.ts
+++ b/data-asia/SV/SV1S/033.ts
@@ -61,6 +61,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692999,
+				tcgplayer: 567150,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/034.ts
+++ b/data-asia/SV/SV1S/034.ts
@@ -63,6 +63,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693000,
+				tcgplayer: 567151,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/035.ts
+++ b/data-asia/SV/SV1S/035.ts
@@ -50,6 +50,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693001,
+				tcgplayer: 567152,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/036.ts
+++ b/data-asia/SV/SV1S/036.ts
@@ -57,6 +57,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693002,
+				tcgplayer: 567153,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/037.ts
+++ b/data-asia/SV/SV1S/037.ts
@@ -75,6 +75,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693003,
+				tcgplayer: 567154,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/038.ts
+++ b/data-asia/SV/SV1S/038.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693004,
+				tcgplayer: 567155,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693004
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/039.ts
+++ b/data-asia/SV/SV1S/039.ts
@@ -70,12 +70,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693005,
+				tcgplayer: 567156,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693005
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/040.ts
+++ b/data-asia/SV/SV1S/040.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693006,
+				tcgplayer: 567157,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693006
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/041.ts
+++ b/data-asia/SV/SV1S/041.ts
@@ -70,12 +70,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693008,
+				tcgplayer: 567158,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693008
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/042.ts
+++ b/data-asia/SV/SV1S/042.ts
@@ -56,12 +56,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693009,
+				tcgplayer: 567159,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693009
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/043.ts
+++ b/data-asia/SV/SV1S/043.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693010,
+				tcgplayer: 567160,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693010
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/044.ts
+++ b/data-asia/SV/SV1S/044.ts
@@ -70,12 +70,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693011,
+				tcgplayer: 567161,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693011
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/045.ts
+++ b/data-asia/SV/SV1S/045.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693012,
+				tcgplayer: 567162,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693012
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/046.ts
+++ b/data-asia/SV/SV1S/046.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693013,
+				tcgplayer: 567163,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/047.ts
+++ b/data-asia/SV/SV1S/047.ts
@@ -61,6 +61,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693014,
+				tcgplayer: 567164,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/048.ts
+++ b/data-asia/SV/SV1S/048.ts
@@ -63,6 +63,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693015,
+				tcgplayer: 567165,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/049.ts
+++ b/data-asia/SV/SV1S/049.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693016,
+				tcgplayer: 567166,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/050.ts
+++ b/data-asia/SV/SV1S/050.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693017,
+				tcgplayer: 567167,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/051.ts
+++ b/data-asia/SV/SV1S/051.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693018,
+				tcgplayer: 567168,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693018
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/052.ts
+++ b/data-asia/SV/SV1S/052.ts
@@ -70,12 +70,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693019,
+				tcgplayer: 567169,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693019
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/053.ts
+++ b/data-asia/SV/SV1S/053.ts
@@ -68,12 +68,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693020,
+				tcgplayer: 567170,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693020
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/054.ts
+++ b/data-asia/SV/SV1S/054.ts
@@ -56,12 +56,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693021,
+				tcgplayer: 567171,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693021
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/055.ts
+++ b/data-asia/SV/SV1S/055.ts
@@ -60,12 +60,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693022,
+				tcgplayer: 567172,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693022
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/056.ts
+++ b/data-asia/SV/SV1S/056.ts
@@ -56,12 +56,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693023,
+				tcgplayer: 567173,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693023
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/057.ts
+++ b/data-asia/SV/SV1S/057.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693024,
+				tcgplayer: 567174,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693024
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/058.ts
+++ b/data-asia/SV/SV1S/058.ts
@@ -63,6 +63,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693025,
+				tcgplayer: 567175,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/059.ts
+++ b/data-asia/SV/SV1S/059.ts
@@ -55,6 +55,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693026,
+				tcgplayer: 567176,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/060.ts
+++ b/data-asia/SV/SV1S/060.ts
@@ -50,6 +50,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693027,
+				tcgplayer: 567177,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/061.ts
+++ b/data-asia/SV/SV1S/061.ts
@@ -75,6 +75,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693028,
+				tcgplayer: 567178,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/062.ts
+++ b/data-asia/SV/SV1S/062.ts
@@ -61,12 +61,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693029,
+				tcgplayer: 567179,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693029
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/063.ts
+++ b/data-asia/SV/SV1S/063.ts
@@ -50,12 +50,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693030,
+				tcgplayer: 567180,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693030
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/064.ts
+++ b/data-asia/SV/SV1S/064.ts
@@ -61,12 +61,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693031,
+				tcgplayer: 567181,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693031
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/065.ts
+++ b/data-asia/SV/SV1S/065.ts
@@ -75,12 +75,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693032,
+				tcgplayer: 567182,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 693032
-	}
 }
 
 export default card

--- a/data-asia/SV/SV1S/066.ts
+++ b/data-asia/SV/SV1S/066.ts
@@ -61,6 +61,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693033,
+				tcgplayer: 567183,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/067.ts
+++ b/data-asia/SV/SV1S/067.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693034,
+				tcgplayer: 567184,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/068.ts
+++ b/data-asia/SV/SV1S/068.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693035,
+				tcgplayer: 567185,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/069.ts
+++ b/data-asia/SV/SV1S/069.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Pilih paling banyak 2 lembar Supporter dari Trash sendiri, perlihatkan ke lawan, lalu kocok kembali ke Deck."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693036,
+				tcgplayer: 567186,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/070.ts
+++ b/data-asia/SV/SV1S/070.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Pilih 1 lembar Pokémon Basic dari Deck sendiri, lalu masukkan ke Cadangan. Kemudian, kocok Deck."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693037,
+				tcgplayer: 567187,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/071.ts
+++ b/data-asia/SV/SV1S/071.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Kerusakan akibat serangan dari Pokémon lawan yang diterima Pokémon {Petarung} yang mengenakan kartu ini berkurang sejumlah 30."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693038,
+				tcgplayer: 567188,
+			},
+		},
+	],
+
 	trainerType: "Tool",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/072.ts
+++ b/data-asia/SV/SV1S/072.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Tiap kali Pokémon Bertarung sendiri KO karena menerima kerusakan akibat serangan dari Pokémon lawan, pemain dapat memilih 1 lembar Energi Dasar yang dikenakan pada Pokémon tersebut, lalu memindahkannya ke Pokémon yang mengenakan kartu ini."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693039,
+				tcgplayer: 567189,
+			},
+		},
+	],
+
 	trainerType: "Tool",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/073.ts
+++ b/data-asia/SV/SV1S/073.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Jika sisa Kartu Point sendiri lebih banyak dari sisa Kartu Point lawan, kerusakan akibat serangan yang digunakan oleh Pokémon yang mengenakan kartu ini kepada Pokémon Bertarung lawan bertambah sejumlah 30."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693040,
+				tcgplayer: 567190,
+			},
+		},
+	],
+
 	trainerType: "Tool",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/074.ts
+++ b/data-asia/SV/SV1S/074.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Pilih paling banyak 2 lembar Pokémon Evolusi dari Deck sendiri, perlihatkan ke lawan, lalu tambahkan ke Kartu Pegangan. Kemudian, kocok Deck."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693041,
+				tcgplayer: 567191,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/075.ts
+++ b/data-asia/SV/SV1S/075.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Pilih 1 Energi yang dikenakan pada Pokémon Bertarung lawan, lalu kembalikan ke atas Deck lawan."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693042,
+				tcgplayer: 567192,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/076.ts
+++ b/data-asia/SV/SV1S/076.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Buang semua Kartu Pegangan sendiri ke Trash, lalu ambil 7 kartu dari atas Deck."
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693043,
+				tcgplayer: 567193,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/077.ts
+++ b/data-asia/SV/SV1S/077.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Pilih 1 Pokémon {Basic} di Arena sendiri, lalu kembalikan Pokémon tersebut dan semua kartu yang dikenakannya ke Kartu Pegangan."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693044,
+				tcgplayer: 567194,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/078.ts
+++ b/data-asia/SV/SV1S/078.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Energi yang dibutuhkan oleh semua Pokémon Basic kedua pemain untuk Mundur masing-masing berkurang 1."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693045,
+				tcgplayer: 567195,
+			},
+		},
+	],
+
 	trainerType: "Stadium",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV1S/079.ts
+++ b/data-asia/SV/SV1S/079.ts
@@ -47,6 +47,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693046,
+				tcgplayer: 567196,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV1S/080.ts
+++ b/data-asia/SV/SV1S/080.ts
@@ -51,6 +51,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693047,
+				tcgplayer: 567197,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV1S/081.ts
+++ b/data-asia/SV/SV1S/081.ts
@@ -39,6 +39,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693048,
+				tcgplayer: 567198,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV1S/082.ts
+++ b/data-asia/SV/SV1S/082.ts
@@ -47,6 +47,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693096,
+				tcgplayer: 567199,
+			},
+		},
+	],
+
 	retreat: 4
 }
 

--- a/data-asia/SV/SV1S/083.ts
+++ b/data-asia/SV/SV1S/083.ts
@@ -40,11 +40,17 @@ const card: Card = {
 		value: "－30"
 	}],
 
-	retreat: 1,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693049,
+				tcgplayer: 567200,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 692992
-	}
+	retreat: 1,
 }
 
 export default card

--- a/data-asia/SV/SV1S/084.ts
+++ b/data-asia/SV/SV1S/084.ts
@@ -52,11 +52,17 @@ const card: Card = {
 		value: "－30"
 	}],
 
-	retreat: 1,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693050,
+				tcgplayer: 567201,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 692993
-	}
+	retreat: 1,
 }
 
 export default card

--- a/data-asia/SV/SV1S/085.ts
+++ b/data-asia/SV/SV1S/085.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693051,
+				tcgplayer: 567202,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV1S/086.ts
+++ b/data-asia/SV/SV1S/086.ts
@@ -47,11 +47,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 1,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693052,
+				tcgplayer: 567203,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 693006
-	}
+	retreat: 1,
 }
 
 export default card

--- a/data-asia/SV/SV1S/087.ts
+++ b/data-asia/SV/SV1S/087.ts
@@ -43,11 +43,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 2,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693053,
+				tcgplayer: 567204,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 693009
-	}
+	retreat: 2,
 }
 
 export default card

--- a/data-asia/SV/SV1S/088.ts
+++ b/data-asia/SV/SV1S/088.ts
@@ -47,6 +47,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693054,
+				tcgplayer: 567205,
+			},
+		},
+	],
+
 	retreat: 3
 }
 

--- a/data-asia/SV/SV1S/089.ts
+++ b/data-asia/SV/SV1S/089.ts
@@ -47,6 +47,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693055,
+				tcgplayer: 567206,
+			},
+		},
+	],
+
 	retreat: 3
 }
 

--- a/data-asia/SV/SV1S/090.ts
+++ b/data-asia/SV/SV1S/090.ts
@@ -40,11 +40,17 @@ const card: Card = {
 		value: "－30"
 	}],
 
-	retreat: 1,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693056,
+				tcgplayer: 567207,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 693030
-	}
+	retreat: 1,
 }
 
 export default card

--- a/data-asia/SV/SV1S/091.ts
+++ b/data-asia/SV/SV1S/091.ts
@@ -42,11 +42,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 4,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693057,
+				tcgplayer: 567208,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 692980
-	}
+	retreat: 4,
 }
 
 export default card

--- a/data-asia/SV/SV1S/092.ts
+++ b/data-asia/SV/SV1S/092.ts
@@ -51,11 +51,17 @@ const card: Card = {
 		value: "－30"
 	}],
 
-	retreat: 2,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693058,
+				tcgplayer: 567209,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 692994
-	}
+	retreat: 2,
 }
 
 export default card

--- a/data-asia/SV/SV1S/093.ts
+++ b/data-asia/SV/SV1S/093.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693059,
+				tcgplayer: 567210,
+			},
+		},
+	],
+
 	retreat: 4
 }
 

--- a/data-asia/SV/SV1S/094.ts
+++ b/data-asia/SV/SV1S/094.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693060,
+				tcgplayer: 567211,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV1S/095.ts
+++ b/data-asia/SV/SV1S/095.ts
@@ -44,11 +44,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 2,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693061,
+				tcgplayer: 567212,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 693022
-	}
+	retreat: 2,
 }
 
 export default card

--- a/data-asia/SV/SV1S/096.ts
+++ b/data-asia/SV/SV1S/096.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693062,
+				tcgplayer: 567213,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV1S/097.ts
+++ b/data-asia/SV/SV1S/097.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分の山札から進化ポケモンを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693063,
+				tcgplayer: 567214,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV1S/098.ts
+++ b/data-asia/SV/SV1S/098.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "相手のバトルポケモンについているエネルギーを1個選び、相手の山札の上にもどす。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693064,
+				tcgplayer: 567215,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV1S/099.ts
+++ b/data-asia/SV/SV1S/099.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分の手札をすべてトラッシュし、山札を7枚引く。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693065,
+				tcgplayer: 567216,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV1S/100.ts
+++ b/data-asia/SV/SV1S/100.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分の場のたねポケモンを1匹選び、そのポケモンと、ついているすべてのカードを、手札にもどす。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693066,
+				tcgplayer: 567217,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV1S/101.ts
+++ b/data-asia/SV/SV1S/101.ts
@@ -51,11 +51,17 @@ const card: Card = {
 		value: "－30"
 	}],
 
-	retreat: 2,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693067,
+				tcgplayer: 567218,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 692994
-	}
+	retreat: 2,
 }
 
 export default card

--- a/data-asia/SV/SV1S/102.ts
+++ b/data-asia/SV/SV1S/102.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693068,
+				tcgplayer: 567219,
+			},
+		},
+	],
+
 	retreat: 4
 }
 

--- a/data-asia/SV/SV1S/103.ts
+++ b/data-asia/SV/SV1S/103.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693069,
+				tcgplayer: 567220,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV1S/104.ts
+++ b/data-asia/SV/SV1S/104.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分の山札から進化ポケモンを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693070,
+				tcgplayer: 567221,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV1S/105.ts
+++ b/data-asia/SV/SV1S/105.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分の場のたねポケモンを1匹選び、そのポケモンと、ついているすべてのカードを、手札にもどす。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693071,
+				tcgplayer: 567222,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV1S/106.ts
+++ b/data-asia/SV/SV1S/106.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693072,
+				tcgplayer: 567223,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV1S/107.ts
+++ b/data-asia/SV/SV1S/107.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分の山札からたねポケモンを1枚選び、ベンチに出す。そして山札を切る。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693073,
+				tcgplayer: 567224,
+			},
+		},
+	],
+
 	trainerType: "Item"
 }
 

--- a/data-asia/SV/SV1S/108.ts
+++ b/data-asia/SV/SV1S/108.ts
@@ -9,7 +9,17 @@ const card: Card = {
 	},
 
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 693074,
+				tcgplayer: 567225,
+			},
+		},
+	],
 }
 
 export default card


### PR DESCRIPTION
## What

Links the cards of the existing Japanese set **SV1S スカーレットex (Scarlet ex)** to their Cardmarket **and TCGplayer** products, so the API can serve their prices.

- **64** cards carried no product id at all and get both
- **44** carried a card-level `thirdParty.cardmarket`, which is moved onto the card's `variants` entry and joined by its tcgplayer id
- **9** carried the cardmarket id of a different print and are corrected

Afterwards every card of the set carries its id on a `variants` entry and none on the card itself, which is where tcgdex is heading. Nothing else changes: the `zh-tw`/`th`/`id` texts and the Japanese card data are not rewritten.

9 cards carried the product of **another print** of the same card, so the API served that print's price for them:

| card | was | is | the old id belongs to |
|---|---|---|---|
| 083 | 692992 | 693049 | points at card 026 of this set |
| 084 | 692993 | 693050 | points at card 027 of this set |
| 086 | 693006 | 693052 | points at card 040 of this set |
| 087 | 693009 | 693053 | points at card 042 of this set |
| 090 | 693030 | 693056 | points at card 063 of this set |
| 091 | 692980 | 693057 | points at card 014 of this set |
| 092 | 692994 | 693058 | points at card 028 of this set |
| 095 | 693022 | 693061 | points at card 055 of this set |
| 101 | 692994 | 693067 | points at card 028 of this set |

The ids are assigned **by collection number**, not by name: within a Cardmarket expansion the products sorted by `idProduct` follow the collection order, and the assignment is verified against the sample rows pokepricelab renders. That matters because Cardmarket names every print of a card identically inside an expansion, so a name lookup cannot tell a base print from its AR/full-art reprint — which is where the corrected ids above come from. That the 35 ids this set already carried correctly agree with the same assignment is an independent cross-check.

## Data sources

- **Cardmarket** public product catalog (`downloads.s3.cardmarket.com`): the product ids (692241–698994), assigned by collection number
- **pokepricelab.com**: the sample rows that verify that assignment
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (567118–567225), keyed by the collection number each product carries in `extendedData`
- **limitlesstcg.com**: the set's card list — used here for nothing but the rarity per number, which decides whether a variant is `holo` or `normal`

## Notes

- `tsc --noEmit` reports the same 30 pre-existing errors as upstream/master — this change adds none. They are `rarity` being required by `interfaces.d.ts` while these older hand-written files omit it, which is out of scope here.
