### PR TITLE
(data) ja SV2D Clay Burst - cardmarket + tcgplayer product ids

### DIFF
--- a/data-asia/SV/SV2D/001.ts
+++ b/data-asia/SV/SV2D/001.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705305,
+				tcgplayer: 565863,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705305
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/002.ts
+++ b/data-asia/SV/SV2D/002.ts
@@ -70,12 +70,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705306,
+				tcgplayer: 565864,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705306
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/003.ts
+++ b/data-asia/SV/SV2D/003.ts
@@ -70,12 +70,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 705307,
+				tcgplayer: 565865,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705307
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/004.ts
+++ b/data-asia/SV/SV2D/004.ts
@@ -45,12 +45,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705308,
+				tcgplayer: 565866,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705308
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/005.ts
+++ b/data-asia/SV/SV2D/005.ts
@@ -62,12 +62,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 705309,
+				tcgplayer: 565867,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705309
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/006.ts
+++ b/data-asia/SV/SV2D/006.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705310,
+				tcgplayer: 565868,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705310
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/007.ts
+++ b/data-asia/SV/SV2D/007.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705311,
+				tcgplayer: 565869,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/008.ts
+++ b/data-asia/SV/SV2D/008.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705312,
+				tcgplayer: 565870,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/009.ts
+++ b/data-asia/SV/SV2D/009.ts
@@ -61,6 +61,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705313,
+				tcgplayer: 565871,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/010.ts
+++ b/data-asia/SV/SV2D/010.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705314,
+				tcgplayer: 565872,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705314
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/011.ts
+++ b/data-asia/SV/SV2D/011.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705315,
+				tcgplayer: 565873,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705315
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/012.ts
+++ b/data-asia/SV/SV2D/012.ts
@@ -57,12 +57,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705316,
+				tcgplayer: 565874,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705316
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/013.ts
+++ b/data-asia/SV/SV2D/013.ts
@@ -75,12 +75,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705317,
+				tcgplayer: 565875,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705317
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/014.ts
+++ b/data-asia/SV/SV2D/014.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705318,
+				tcgplayer: 565876,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/015.ts
+++ b/data-asia/SV/SV2D/015.ts
@@ -56,6 +56,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705319,
+				tcgplayer: 565877,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/016.ts
+++ b/data-asia/SV/SV2D/016.ts
@@ -60,6 +60,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 705320,
+				tcgplayer: 565878,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/017.ts
+++ b/data-asia/SV/SV2D/017.ts
@@ -61,12 +61,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705321,
+				tcgplayer: 565879,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705321
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/018.ts
+++ b/data-asia/SV/SV2D/018.ts
@@ -68,12 +68,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705322,
+				tcgplayer: 565880,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705322
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/019.ts
+++ b/data-asia/SV/SV2D/019.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705323,
+				tcgplayer: 565881,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705323
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/020.ts
+++ b/data-asia/SV/SV2D/020.ts
@@ -56,12 +56,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705324,
+				tcgplayer: 565882,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705324
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/021.ts
+++ b/data-asia/SV/SV2D/021.ts
@@ -70,12 +70,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 705325,
+				tcgplayer: 565883,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705325
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/022.ts
+++ b/data-asia/SV/SV2D/022.ts
@@ -70,6 +70,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705326,
+				tcgplayer: 565884,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/023.ts
+++ b/data-asia/SV/SV2D/023.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705327,
+				tcgplayer: 565885,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/024.ts
+++ b/data-asia/SV/SV2D/024.ts
@@ -56,6 +56,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705328,
+				tcgplayer: 565886,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/025.ts
+++ b/data-asia/SV/SV2D/025.ts
@@ -60,6 +60,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 705329,
+				tcgplayer: 565887,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/026.ts
+++ b/data-asia/SV/SV2D/026.ts
@@ -61,12 +61,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705330,
+				tcgplayer: 565888,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705330
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/027.ts
+++ b/data-asia/SV/SV2D/027.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 705331,
+				tcgplayer: 565889,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705331
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/028.ts
+++ b/data-asia/SV/SV2D/028.ts
@@ -75,12 +75,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 705332,
+				tcgplayer: 565890,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705332
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/029.ts
+++ b/data-asia/SV/SV2D/029.ts
@@ -61,12 +61,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705333,
+				tcgplayer: 565891,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705333
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/030.ts
+++ b/data-asia/SV/SV2D/030.ts
@@ -68,12 +68,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705334,
+				tcgplayer: 565892,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705334
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/031.ts
+++ b/data-asia/SV/SV2D/031.ts
@@ -75,6 +75,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 705335,
+				tcgplayer: 565893,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/032.ts
+++ b/data-asia/SV/SV2D/032.ts
@@ -61,6 +61,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705336,
+				tcgplayer: 565894,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/033.ts
+++ b/data-asia/SV/SV2D/033.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705337,
+				tcgplayer: 565895,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/034.ts
+++ b/data-asia/SV/SV2D/034.ts
@@ -70,6 +70,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705338,
+				tcgplayer: 565896,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/035.ts
+++ b/data-asia/SV/SV2D/035.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 705339,
+				tcgplayer: 565897,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/036.ts
+++ b/data-asia/SV/SV2D/036.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705340,
+				tcgplayer: 565898,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705340
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/037.ts
+++ b/data-asia/SV/SV2D/037.ts
@@ -45,12 +45,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705341,
+				tcgplayer: 565899,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705341
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/038.ts
+++ b/data-asia/SV/SV2D/038.ts
@@ -61,12 +61,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705342,
+				tcgplayer: 565900,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705342
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/039.ts
+++ b/data-asia/SV/SV2D/039.ts
@@ -61,12 +61,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705343,
+				tcgplayer: 565901,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705343
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/040.ts
+++ b/data-asia/SV/SV2D/040.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705344,
+				tcgplayer: 565902,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705344
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/041.ts
+++ b/data-asia/SV/SV2D/041.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705345,
+				tcgplayer: 565903,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705345
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/042.ts
+++ b/data-asia/SV/SV2D/042.ts
@@ -56,12 +56,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705346,
+				tcgplayer: 565904,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705346
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/043.ts
+++ b/data-asia/SV/SV2D/043.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705347,
+				tcgplayer: 565905,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705347
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/044.ts
+++ b/data-asia/SV/SV2D/044.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705348,
+				tcgplayer: 565906,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705348
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/045.ts
+++ b/data-asia/SV/SV2D/045.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705349,
+				tcgplayer: 565907,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/046.ts
+++ b/data-asia/SV/SV2D/046.ts
@@ -61,6 +61,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705350,
+				tcgplayer: 565908,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/047.ts
+++ b/data-asia/SV/SV2D/047.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705351,
+				tcgplayer: 565909,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/048.ts
+++ b/data-asia/SV/SV2D/048.ts
@@ -70,6 +70,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 705352,
+				tcgplayer: 565910,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/049.ts
+++ b/data-asia/SV/SV2D/049.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 705353,
+				tcgplayer: 565911,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/050.ts
+++ b/data-asia/SV/SV2D/050.ts
@@ -45,12 +45,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705354,
+				tcgplayer: 565912,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705354
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/051.ts
+++ b/data-asia/SV/SV2D/051.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 705355,
+				tcgplayer: 565913,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705355
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/052.ts
+++ b/data-asia/SV/SV2D/052.ts
@@ -70,12 +70,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 705356,
+				tcgplayer: 565914,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705356
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/053.ts
+++ b/data-asia/SV/SV2D/053.ts
@@ -61,6 +61,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705357,
+				tcgplayer: 565915,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/054.ts
+++ b/data-asia/SV/SV2D/054.ts
@@ -50,6 +50,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705358,
+				tcgplayer: 565916,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/055.ts
+++ b/data-asia/SV/SV2D/055.ts
@@ -68,6 +68,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705359,
+				tcgplayer: 565917,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/056.ts
+++ b/data-asia/SV/SV2D/056.ts
@@ -73,6 +73,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705360,
+				tcgplayer: 565918,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/057.ts
+++ b/data-asia/SV/SV2D/057.ts
@@ -40,12 +40,18 @@ const card: Card = {
 		damage: 40
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705361,
+				tcgplayer: 565919,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705361
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/058.ts
+++ b/data-asia/SV/SV2D/058.ts
@@ -57,12 +57,18 @@ const card: Card = {
 		}
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 705362,
+				tcgplayer: 565920,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705362
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/059.ts
+++ b/data-asia/SV/SV2D/059.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705363,
+				tcgplayer: 565921,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705363
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/060.ts
+++ b/data-asia/SV/SV2D/060.ts
@@ -61,6 +61,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705364,
+				tcgplayer: 565922,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/061.ts
+++ b/data-asia/SV/SV2D/061.ts
@@ -57,12 +57,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705365,
+				tcgplayer: 565923,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705365
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2D/062.ts
+++ b/data-asia/SV/SV2D/062.ts
@@ -61,6 +61,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705366,
+				tcgplayer: 565924,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/063.ts
+++ b/data-asia/SV/SV2D/063.ts
@@ -56,6 +56,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705367,
+				tcgplayer: 565925,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/064.ts
+++ b/data-asia/SV/SV2D/064.ts
@@ -61,6 +61,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705368,
+				tcgplayer: 565926,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/065.ts
+++ b/data-asia/SV/SV2D/065.ts
@@ -75,6 +75,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705369,
+				tcgplayer: 565927,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/066.ts
+++ b/data-asia/SV/SV2D/066.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Lempar koin 2 kali. Jika semuanya sisi depan, pilih 1 kartu sesukanya dari Deck sendiri, lalu tambahkan ke Kartu Pegangan. Kemudian, kocok Deck."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705370,
+				tcgplayer: 565928,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/067.ts
+++ b/data-asia/SV/SV2D/067.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "HP maksimal Pokémon Basic yang mengenakan kartu ini bertambah sejumlah 50."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705371,
+				tcgplayer: 565929,
+			},
+		},
+	],
+
 	trainerType: "Tool",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/068.ts
+++ b/data-asia/SV/SV2D/068.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Pilih paling banyak 2 Pokémon sendiri, lalu pulihkan HP masing-masing sejumlah 50."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705372,
+				tcgplayer: 565930,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/069.ts
+++ b/data-asia/SV/SV2D/069.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Kedua pemain masing-masing mengocok semua Kartu Pegangan sendiri dengan sisi depan menghadap ke bawah, lalu mengembalikannya ke bawah Deck. Setelah itu, kedua pemain masing-masing mengambil kartu dari atas Deck untuk tiap lembar sisa Kartu Point sendiri."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705373,
+				tcgplayer: 565931,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/070.ts
+++ b/data-asia/SV/SV2D/070.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Energi yang dibutuhkan oleh semua Pokémon Basic (selain Pokémon {Petarung}) kedua pemain untuk Mundur masing-masing bertambah 1."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705374,
+				tcgplayer: 565932,
+			},
+		},
+	],
+
 	trainerType: "Stadium",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2D/071.ts
+++ b/data-asia/SV/SV2D/071.ts
@@ -22,6 +22,16 @@ const card: Card = {
 	},
 
 	energyType: "Special",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705375,
+				tcgplayer: 565933,
+			},
+		},
+	],
+
 	regulationMark: "G"
 }
 

--- a/data-asia/SV/SV2D/072.ts
+++ b/data-asia/SV/SV2D/072.ts
@@ -47,11 +47,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 3,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707668,
+				tcgplayer: 565934,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 705310
-	}
+	retreat: 3,
 }
 
 export default card

--- a/data-asia/SV/SV2D/073.ts
+++ b/data-asia/SV/SV2D/073.ts
@@ -44,11 +44,17 @@ const card: Card = {
 		value: "－30"
 	}],
 
-	retreat: 1,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707669,
+				tcgplayer: 565935,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 705316
-	}
+	retreat: 1,
 }
 
 export default card

--- a/data-asia/SV/SV2D/074.ts
+++ b/data-asia/SV/SV2D/074.ts
@@ -49,11 +49,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 1,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707670,
+				tcgplayer: 565936,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 705322
-	}
+	retreat: 1,
 }
 
 export default card

--- a/data-asia/SV/SV2D/075.ts
+++ b/data-asia/SV/SV2D/075.ts
@@ -48,11 +48,17 @@ const card: Card = {
 		value: "－30"
 	}],
 
-	retreat: 3,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707671,
+				tcgplayer: 565937,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 705333
-	}
+	retreat: 3,
 }
 
 export default card

--- a/data-asia/SV/SV2D/076.ts
+++ b/data-asia/SV/SV2D/076.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707672,
+				tcgplayer: 565938,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV2D/077.ts
+++ b/data-asia/SV/SV2D/077.ts
@@ -51,6 +51,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707673,
+				tcgplayer: 565939,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV2D/078.ts
+++ b/data-asia/SV/SV2D/078.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707674,
+				tcgplayer: 565940,
+			},
+		},
+	],
+
 	retreat: 3
 }
 

--- a/data-asia/SV/SV2D/079.ts
+++ b/data-asia/SV/SV2D/079.ts
@@ -51,11 +51,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 3,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707675,
+				tcgplayer: 565941,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 705356
-	}
+	retreat: 3,
 }
 
 export default card

--- a/data-asia/SV/SV2D/080.ts
+++ b/data-asia/SV/SV2D/080.ts
@@ -49,6 +49,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707676,
+				tcgplayer: 565942,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV2D/081.ts
+++ b/data-asia/SV/SV2D/081.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707677,
+				tcgplayer: 565943,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV2D/082.ts
+++ b/data-asia/SV/SV2D/082.ts
@@ -56,6 +56,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707678,
+				tcgplayer: 565944,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV2D/083.ts
+++ b/data-asia/SV/SV2D/083.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707679,
+				tcgplayer: 565945,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV2D/084.ts
+++ b/data-asia/SV/SV2D/084.ts
@@ -46,11 +46,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 3,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707680,
+				tcgplayer: 565946,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 705309
-	}
+	retreat: 3,
 }
 
 export default card

--- a/data-asia/SV/SV2D/085.ts
+++ b/data-asia/SV/SV2D/085.ts
@@ -44,6 +44,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707681,
+				tcgplayer: 565947,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV2D/086.ts
+++ b/data-asia/SV/SV2D/086.ts
@@ -44,6 +44,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707682,
+				tcgplayer: 565948,
+			},
+		},
+	],
+
 	retreat: 3
 }
 

--- a/data-asia/SV/SV2D/087.ts
+++ b/data-asia/SV/SV2D/087.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707683,
+				tcgplayer: 565949,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV2D/088.ts
+++ b/data-asia/SV/SV2D/088.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707684,
+				tcgplayer: 565950,
+			},
+		},
+	],
+
 	retreat: 4
 }
 

--- a/data-asia/SV/SV2D/089.ts
+++ b/data-asia/SV/SV2D/089.ts
@@ -41,11 +41,17 @@ const card: Card = {
 		}
 	}],
 
-	retreat: 0,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707685,
+				tcgplayer: 565951,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 705362
-	}
+	retreat: 0,
 }
 
 export default card

--- a/data-asia/SV/SV2D/090.ts
+++ b/data-asia/SV/SV2D/090.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分のポケモンを2匹まで選び、HPをそれぞれ「50」回復する。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707700,
+				tcgplayer: 565952,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV2D/091.ts
+++ b/data-asia/SV/SV2D/091.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "おたがいのプレイヤーは、それぞれ自分の手札をすべてウラにして切り、山札の下にもどす。その後、それぞれ自分のサイドの残り枚数ぶん、山札を引く。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707701,
+				tcgplayer: 565953,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV2D/092.ts
+++ b/data-asia/SV/SV2D/092.ts
@@ -44,6 +44,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707703,
+				tcgplayer: 565954,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV2D/093.ts
+++ b/data-asia/SV/SV2D/093.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707704,
+				tcgplayer: 565955,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV2D/094.ts
+++ b/data-asia/SV/SV2D/094.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707705,
+				tcgplayer: 565956,
+			},
+		},
+	],
+
 	retreat: 4
 }
 

--- a/data-asia/SV/SV2D/095.ts
+++ b/data-asia/SV/SV2D/095.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分のポケモンを2匹まで選び、HPをそれぞれ「50」回復する。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707708,
+				tcgplayer: 565957,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV2D/096.ts
+++ b/data-asia/SV/SV2D/096.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "おたがいのプレイヤーは、それぞれ自分の手札をすべてウラにして切り、山札の下にもどす。その後、それぞれ自分のサイドの残り枚数ぶん、山札を引く。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707709,
+				tcgplayer: 565958,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV2D/097.ts
+++ b/data-asia/SV/SV2D/097.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707711,
+				tcgplayer: 565959,
+			},
+		},
+	],
+
 	retreat: 4
 }
 

--- a/data-asia/SV/SV2D/098.ts
+++ b/data-asia/SV/SV2D/098.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。\n\n自分のトラッシュから基本エネルギーを4枚まで選び、相手に見せて、手札に加える。（このカードの効果でトラッシュしたエネルギーは選べない。）"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707712,
+				tcgplayer: 565960,
+			},
+		},
+	],
+
 	trainerType: "Item"
 }
 

--- a/data-asia/SV/SV2D/099.ts
+++ b/data-asia/SV/SV2D/099.ts
@@ -9,7 +9,17 @@ const card: Card = {
 	},
 
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707714,
+				tcgplayer: 577562,
+			},
+		},
+	],
 }
 
 export default card


### PR DESCRIPTION
## What

Links the cards of the existing Japanese set **SV2D クレイバースト (Clay Burst)** to their Cardmarket **and TCGplayer** products, so the API can serve their prices.

- **56** cards carried no product id at all and get both
- **43** carried a card-level `thirdParty.cardmarket`, which is moved onto the card's `variants` entry and joined by its tcgplayer id
- **7** carried the cardmarket id of a different print and are corrected

Afterwards every card of the set carries its id on a `variants` entry and none on the card itself, which is where tcgdex is heading. Nothing else changes: the `zh-tw`/`th`/`id` texts and the Japanese card data are not rewritten.

7 cards carried the product of **another print** of the same card, so the API served that print's price for them:

| card | was | is | the old id belongs to |
|---|---|---|---|
| 072 | 705310 | 707668 | points at card 006 of this set |
| 073 | 705316 | 707669 | points at card 012 of this set |
| 074 | 705322 | 707670 | points at card 018 of this set |
| 075 | 705333 | 707671 | points at card 029 of this set |
| 079 | 705356 | 707675 | points at card 052 of this set |
| 084 | 705309 | 707680 | points at card 005 of this set |
| 089 | 705362 | 707685 | points at card 058 of this set |

The ids are assigned **by collection number**, not by name: within a Cardmarket expansion the products sorted by `idProduct` follow the collection order, and the assignment is verified against the sample rows pokepricelab renders. That matters because Cardmarket names every print of a card identically inside an expansion, so a name lookup cannot tell a base print from its AR/full-art reprint — which is where the corrected ids above come from. That the 36 ids this set already carried correctly agree with the same assignment is an independent cross-check.

## Data sources

- **Cardmarket** public product catalog (`downloads.s3.cardmarket.com`): the product ids (705305–707714), assigned by collection number
- **pokepricelab.com**: the sample rows that verify that assignment
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (565863–577562), keyed by the collection number each product carries in `extendedData`
- **limitlesstcg.com**: the set's card list — used here for nothing but the rarity per number, which decides whether a variant is `holo` or `normal`

## Notes

- `tsc --noEmit` reports the same 28 pre-existing errors as upstream/master — this change adds none. They are `rarity` being required by `interfaces.d.ts` while these older hand-written files omit it, which is out of scope here.
