### PR TITLE
(data) ja SV2P Snow Hazard - cardmarket + tcgplayer product ids

### DIFF
--- a/data-asia/SV/SV2P/001.ts
+++ b/data-asia/SV/SV2P/001.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705234,
+				tcgplayer: 567758,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705234
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/002.ts
+++ b/data-asia/SV/SV2P/002.ts
@@ -61,12 +61,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705235,
+				tcgplayer: 567759,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705235
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/003.ts
+++ b/data-asia/SV/SV2P/003.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705236,
+				tcgplayer: 567760,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705236
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/004.ts
+++ b/data-asia/SV/SV2P/004.ts
@@ -70,12 +70,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705237,
+				tcgplayer: 567761,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705237
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/005.ts
+++ b/data-asia/SV/SV2P/005.ts
@@ -45,12 +45,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705238,
+				tcgplayer: 567762,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705238
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/006.ts
+++ b/data-asia/SV/SV2P/006.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 705239,
+				tcgplayer: 567763,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705239
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/007.ts
+++ b/data-asia/SV/SV2P/007.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705240,
+				tcgplayer: 567764,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705240
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/008.ts
+++ b/data-asia/SV/SV2P/008.ts
@@ -61,12 +61,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705241,
+				tcgplayer: 567765,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705241
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/009.ts
+++ b/data-asia/SV/SV2P/009.ts
@@ -70,12 +70,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705242,
+				tcgplayer: 567766,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705242
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/010.ts
+++ b/data-asia/SV/SV2P/010.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705243,
+				tcgplayer: 567767,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/011.ts
+++ b/data-asia/SV/SV2P/011.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705244,
+				tcgplayer: 567768,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/012.ts
+++ b/data-asia/SV/SV2P/012.ts
@@ -70,6 +70,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705245,
+				tcgplayer: 567769,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/013.ts
+++ b/data-asia/SV/SV2P/013.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705246,
+				tcgplayer: 567770,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/014.ts
+++ b/data-asia/SV/SV2P/014.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705247,
+				tcgplayer: 567771,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/015.ts
+++ b/data-asia/SV/SV2P/015.ts
@@ -53,6 +53,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 705248,
+				tcgplayer: 567772,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/016.ts
+++ b/data-asia/SV/SV2P/016.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705249,
+				tcgplayer: 567773,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705249
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/017.ts
+++ b/data-asia/SV/SV2P/017.ts
@@ -70,12 +70,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705250,
+				tcgplayer: 567774,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705250
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/018.ts
+++ b/data-asia/SV/SV2P/018.ts
@@ -68,12 +68,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705251,
+				tcgplayer: 567775,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705251
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/019.ts
+++ b/data-asia/SV/SV2P/019.ts
@@ -63,6 +63,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705252,
+				tcgplayer: 567776,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/020.ts
+++ b/data-asia/SV/SV2P/020.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705253,
+				tcgplayer: 567777,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/021.ts
+++ b/data-asia/SV/SV2P/021.ts
@@ -68,6 +68,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705254,
+				tcgplayer: 567778,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/022.ts
+++ b/data-asia/SV/SV2P/022.ts
@@ -63,6 +63,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705255,
+				tcgplayer: 567779,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/023.ts
+++ b/data-asia/SV/SV2P/023.ts
@@ -63,6 +63,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 705256,
+				tcgplayer: 567780,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/024.ts
+++ b/data-asia/SV/SV2P/024.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705257,
+				tcgplayer: 567781,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/025.ts
+++ b/data-asia/SV/SV2P/025.ts
@@ -56,6 +56,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705258,
+				tcgplayer: 567782,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/026.ts
+++ b/data-asia/SV/SV2P/026.ts
@@ -56,6 +56,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705259,
+				tcgplayer: 567783,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/027.ts
+++ b/data-asia/SV/SV2P/027.ts
@@ -63,6 +63,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 705260,
+				tcgplayer: 567784,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/028.ts
+++ b/data-asia/SV/SV2P/028.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 705261,
+				tcgplayer: 567785,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/029.ts
+++ b/data-asia/SV/SV2P/029.ts
@@ -66,12 +66,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705262,
+				tcgplayer: 567786,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705262
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/030.ts
+++ b/data-asia/SV/SV2P/030.ts
@@ -67,12 +67,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 705263,
+				tcgplayer: 567787,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705263
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/031.ts
+++ b/data-asia/SV/SV2P/031.ts
@@ -68,12 +68,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705264,
+				tcgplayer: 567788,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705264
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/032.ts
+++ b/data-asia/SV/SV2P/032.ts
@@ -68,12 +68,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705265,
+				tcgplayer: 567789,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705265
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/033.ts
+++ b/data-asia/SV/SV2P/033.ts
@@ -75,12 +75,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705266,
+				tcgplayer: 567790,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705266
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/034.ts
+++ b/data-asia/SV/SV2P/034.ts
@@ -68,12 +68,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 705267,
+				tcgplayer: 567791,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705267
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/035.ts
+++ b/data-asia/SV/SV2P/035.ts
@@ -57,6 +57,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705268,
+				tcgplayer: 567792,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/036.ts
+++ b/data-asia/SV/SV2P/036.ts
@@ -71,6 +71,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705269,
+				tcgplayer: 567793,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/037.ts
+++ b/data-asia/SV/SV2P/037.ts
@@ -73,6 +73,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 705270,
+				tcgplayer: 567794,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/038.ts
+++ b/data-asia/SV/SV2P/038.ts
@@ -56,12 +56,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705271,
+				tcgplayer: 567795,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705271
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/039.ts
+++ b/data-asia/SV/SV2P/039.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705272,
+				tcgplayer: 567796,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705272
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/040.ts
+++ b/data-asia/SV/SV2P/040.ts
@@ -55,6 +55,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 705273,
+				tcgplayer: 567797,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/041.ts
+++ b/data-asia/SV/SV2P/041.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705274,
+				tcgplayer: 567798,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705274
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/042.ts
+++ b/data-asia/SV/SV2P/042.ts
@@ -50,6 +50,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705275,
+				tcgplayer: 567799,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/043.ts
+++ b/data-asia/SV/SV2P/043.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705276,
+				tcgplayer: 567800,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/044.ts
+++ b/data-asia/SV/SV2P/044.ts
@@ -68,6 +68,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 705277,
+				tcgplayer: 567801,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/045.ts
+++ b/data-asia/SV/SV2P/045.ts
@@ -75,12 +75,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705278,
+				tcgplayer: 567802,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705278
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/046.ts
+++ b/data-asia/SV/SV2P/046.ts
@@ -68,12 +68,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705279,
+				tcgplayer: 567803,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705279
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/047.ts
+++ b/data-asia/SV/SV2P/047.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705280,
+				tcgplayer: 567804,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/048.ts
+++ b/data-asia/SV/SV2P/048.ts
@@ -56,6 +56,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705281,
+				tcgplayer: 567805,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/049.ts
+++ b/data-asia/SV/SV2P/049.ts
@@ -63,6 +63,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705282,
+				tcgplayer: 567806,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/050.ts
+++ b/data-asia/SV/SV2P/050.ts
@@ -66,12 +66,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705283,
+				tcgplayer: 567807,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705283
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/051.ts
+++ b/data-asia/SV/SV2P/051.ts
@@ -75,12 +75,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705284,
+				tcgplayer: 567808,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705284
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/052.ts
+++ b/data-asia/SV/SV2P/052.ts
@@ -75,6 +75,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705285,
+				tcgplayer: 567809,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/053.ts
+++ b/data-asia/SV/SV2P/053.ts
@@ -50,6 +50,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705286,
+				tcgplayer: 567810,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/054.ts
+++ b/data-asia/SV/SV2P/054.ts
@@ -67,6 +67,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 705287,
+				tcgplayer: 567811,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/055.ts
+++ b/data-asia/SV/SV2P/055.ts
@@ -75,6 +75,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 705288,
+				tcgplayer: 567812,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/056.ts
+++ b/data-asia/SV/SV2P/056.ts
@@ -61,12 +61,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705289,
+				tcgplayer: 567813,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705289
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/057.ts
+++ b/data-asia/SV/SV2P/057.ts
@@ -63,6 +63,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705290,
+				tcgplayer: 567814,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/058.ts
+++ b/data-asia/SV/SV2P/058.ts
@@ -50,12 +50,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705291,
+				tcgplayer: 567815,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705291
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/059.ts
+++ b/data-asia/SV/SV2P/059.ts
@@ -68,12 +68,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705292,
+				tcgplayer: 567816,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705292
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/060.ts
+++ b/data-asia/SV/SV2P/060.ts
@@ -50,12 +50,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705293,
+				tcgplayer: 567817,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705293
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/061.ts
+++ b/data-asia/SV/SV2P/061.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705294,
+				tcgplayer: 567818,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705294
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/062.ts
+++ b/data-asia/SV/SV2P/062.ts
@@ -70,12 +70,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 705295,
+				tcgplayer: 567819,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 705295
-	}
 }
 
 export default card

--- a/data-asia/SV/SV2P/063.ts
+++ b/data-asia/SV/SV2P/063.ts
@@ -57,6 +57,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705296,
+				tcgplayer: 567820,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/064.ts
+++ b/data-asia/SV/SV2P/064.ts
@@ -68,6 +68,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705297,
+				tcgplayer: 567821,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/065.ts
+++ b/data-asia/SV/SV2P/065.ts
@@ -67,6 +67,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 705298,
+				tcgplayer: 567822,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/066.ts
+++ b/data-asia/SV/SV2P/066.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Pilih paling banyak total 3 lembar Pokémon dan Energi Dasar dari Trash sendiri, perlihatkan ke lawan, lalu kocok kembali ke Deck."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705299,
+				tcgplayer: 567823,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/067.ts
+++ b/data-asia/SV/SV2P/067.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Kartu ini hanya dapat digunakan saat sisa Kartu Point sendiri lebih banyak dari sisa Kartu Point lawan. Pulihkan HP 1 Pokémon sendiri sejumlah 60."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705300,
+				tcgplayer: 567824,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/068.ts
+++ b/data-asia/SV/SV2P/068.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Ambil kartu dari atas Deck hingga jumlah Kartu Pegangan sendiri menjadi 5 lembar. Jika Pokémon di Arena sendiri tidak mengenakan Energi 1 lembar pun, ambil kartu hingga jumlah Kartu Pegangan sendiri menjadi 7 lembar."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705301,
+				tcgplayer: 567825,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/069.ts
+++ b/data-asia/SV/SV2P/069.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Pilih Energi Spesial yang dikenakan pada semua Pokémon lawan masing-masing 1, lalu buang ke Trash."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705302,
+				tcgplayer: 567826,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/070.ts
+++ b/data-asia/SV/SV2P/070.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		id: "Tiap kali kedua pemain mengenakan Energi dari Kartu Pegangan sendiri pada Pokémon Basic (selain Pokémon {Air}) masing-masing, letakkan 2 Token Kerusakan pada Pokémon tersebut untuk tiap lembar Energi."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705303,
+				tcgplayer: 567827,
+			},
+		},
+	],
+
 	trainerType: "Stadium",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV2P/071.ts
+++ b/data-asia/SV/SV2P/071.ts
@@ -22,6 +22,16 @@ const card: Card = {
 	},
 
 	energyType: "Special",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705304,
+				tcgplayer: 567828,
+			},
+		},
+	],
+
 	regulationMark: "G"
 }
 

--- a/data-asia/SV/SV2P/072.ts
+++ b/data-asia/SV/SV2P/072.ts
@@ -39,6 +39,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707639,
+				tcgplayer: 567829,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV2P/073.ts
+++ b/data-asia/SV/SV2P/073.ts
@@ -39,11 +39,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 1,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707640,
+				tcgplayer: 567830,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 705249
-	}
+	retreat: 1,
 }
 
 export default card

--- a/data-asia/SV/SV2P/074.ts
+++ b/data-asia/SV/SV2P/074.ts
@@ -47,6 +47,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707641,
+				tcgplayer: 567831,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV2P/075.ts
+++ b/data-asia/SV/SV2P/075.ts
@@ -35,6 +35,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707642,
+				tcgplayer: 567832,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV2P/076.ts
+++ b/data-asia/SV/SV2P/076.ts
@@ -43,6 +43,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707643,
+				tcgplayer: 567833,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV2P/077.ts
+++ b/data-asia/SV/SV2P/077.ts
@@ -47,6 +47,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707644,
+				tcgplayer: 567834,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV2P/078.ts
+++ b/data-asia/SV/SV2P/078.ts
@@ -52,11 +52,17 @@ const card: Card = {
 		value: "－30"
 	}],
 
-	retreat: 1,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707645,
+				tcgplayer: 567835,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 705265
-	}
+	retreat: 1,
 }
 
 export default card

--- a/data-asia/SV/SV2P/079.ts
+++ b/data-asia/SV/SV2P/079.ts
@@ -54,6 +54,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707646,
+				tcgplayer: 567836,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV2P/080.ts
+++ b/data-asia/SV/SV2P/080.ts
@@ -47,11 +47,17 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	retreat: 1,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707647,
+				tcgplayer: 567837,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 705274
-	}
+	retreat: 1,
 }
 
 export default card

--- a/data-asia/SV/SV2P/081.ts
+++ b/data-asia/SV/SV2P/081.ts
@@ -56,6 +56,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707648,
+				tcgplayer: 567838,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV2P/082.ts
+++ b/data-asia/SV/SV2P/082.ts
@@ -44,6 +44,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707649,
+				tcgplayer: 567839,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV2P/083.ts
+++ b/data-asia/SV/SV2P/083.ts
@@ -47,6 +47,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707650,
+				tcgplayer: 567840,
+			},
+		},
+	],
+
 	retreat: 3
 }
 

--- a/data-asia/SV/SV2P/084.ts
+++ b/data-asia/SV/SV2P/084.ts
@@ -40,6 +40,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707651,
+				tcgplayer: 567841,
+			},
+		},
+	],
+
 	retreat: 4
 }
 

--- a/data-asia/SV/SV2P/085.ts
+++ b/data-asia/SV/SV2P/085.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707652,
+				tcgplayer: 567842,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV2P/086.ts
+++ b/data-asia/SV/SV2P/086.ts
@@ -51,11 +51,17 @@ const card: Card = {
 		value: "－30"
 	}],
 
-	retreat: 3,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707653,
+				tcgplayer: 567843,
+			},
+		},
+	],
 
-	thirdParty: {
-		cardmarket: 705263
-	}
+	retreat: 3,
 }
 
 export default card

--- a/data-asia/SV/SV2P/087.ts
+++ b/data-asia/SV/SV2P/087.ts
@@ -42,6 +42,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707654,
+				tcgplayer: 567844,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV2P/088.ts
+++ b/data-asia/SV/SV2P/088.ts
@@ -51,6 +51,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707655,
+				tcgplayer: 567845,
+			},
+		},
+	],
+
 	retreat: 4
 }
 

--- a/data-asia/SV/SV2P/089.ts
+++ b/data-asia/SV/SV2P/089.ts
@@ -51,6 +51,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707656,
+				tcgplayer: 567846,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV2P/090.ts
+++ b/data-asia/SV/SV2P/090.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分の手札が5枚になるように、山札を引く。自分の場のポケモンにエネルギーが1枚もついていないなら、7枚になるように引く。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707657,
+				tcgplayer: 567847,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV2P/091.ts
+++ b/data-asia/SV/SV2P/091.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "相手のポケモン全員についている特殊エネルギーをそれぞれ1個ずつ選び、トラッシュする。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707658,
+				tcgplayer: 567848,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV2P/092.ts
+++ b/data-asia/SV/SV2P/092.ts
@@ -40,6 +40,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707659,
+				tcgplayer: 567849,
+			},
+		},
+	],
+
 	retreat: 4
 }
 

--- a/data-asia/SV/SV2P/093.ts
+++ b/data-asia/SV/SV2P/093.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707660,
+				tcgplayer: 567850,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV2P/094.ts
+++ b/data-asia/SV/SV2P/094.ts
@@ -51,6 +51,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707661,
+				tcgplayer: 567851,
+			},
+		},
+	],
+
 	retreat: 1
 }
 

--- a/data-asia/SV/SV2P/095.ts
+++ b/data-asia/SV/SV2P/095.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分の手札が5枚になるように、山札を引く。自分の場のポケモンにエネルギーが1枚もついていないなら、7枚になるように引く。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707662,
+				tcgplayer: 567852,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV2P/096.ts
+++ b/data-asia/SV/SV2P/096.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "相手のポケモン全員についている特殊エネルギーをそれぞれ1個ずつ選び、トラッシュする。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707663,
+				tcgplayer: 567853,
+			},
+		},
+	],
+
 	trainerType: "Supporter"
 }
 

--- a/data-asia/SV/SV2P/097.ts
+++ b/data-asia/SV/SV2P/097.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707664,
+				tcgplayer: 567854,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV2P/098.ts
+++ b/data-asia/SV/SV2P/098.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分のトラッシュからポケモンと基本エネルギーを合計3枚まで選び、相手に見せて、山札にもどして切る。"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707665,
+				tcgplayer: 567855,
+			},
+		},
+	],
+
 	trainerType: "Item"
 }
 

--- a/data-asia/SV/SV2P/099.ts
+++ b/data-asia/SV/SV2P/099.ts
@@ -9,7 +9,17 @@ const card: Card = {
 	},
 
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 707666,
+				tcgplayer: 577563,
+			},
+		},
+	],
 }
 
 export default card


### PR DESCRIPTION
## What

Links the cards of the existing Japanese set **SV2P スノーハザード (Snow Hazard)** to their Cardmarket **and TCGplayer** products, so the API can serve their prices.

- **64** cards carried no product id at all and get both
- **35** carried a card-level `thirdParty.cardmarket`, which is moved onto the card's `variants` entry and joined by its tcgplayer id
- **4** carried the cardmarket id of a different print and are corrected

Afterwards every card of the set carries its id on a `variants` entry and none on the card itself, which is where tcgdex is heading. Nothing else changes: the `zh-tw`/`th`/`id` texts and the Japanese card data are not rewritten.

4 cards carried the product of **another print** of the same card, so the API served that print's price for them:

| card | was | is | the old id belongs to |
|---|---|---|---|
| 073 | 705249 | 707640 | points at card 016 of this set |
| 078 | 705265 | 707645 | points at card 032 of this set |
| 080 | 705274 | 707647 | points at card 041 of this set |
| 086 | 705263 | 707653 | points at card 030 of this set |

The ids are assigned **by collection number**, not by name: within a Cardmarket expansion the products sorted by `idProduct` follow the collection order, and the assignment is verified against the sample rows pokepricelab renders. That matters because Cardmarket names every print of a card identically inside an expansion, so a name lookup cannot tell a base print from its AR/full-art reprint — which is where the corrected ids above come from. That the 31 ids this set already carried correctly agree with the same assignment is an independent cross-check.

## Data sources

- **Cardmarket** public product catalog (`downloads.s3.cardmarket.com`): the product ids (705234–707666), assigned by collection number
- **pokepricelab.com**: the sample rows that verify that assignment
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (567758–577563), keyed by the collection number each product carries in `extendedData`
- **limitlesstcg.com**: the set's card list — used here for nothing but the rarity per number, which decides whether a variant is `holo` or `normal`

## Notes

- `tsc --noEmit` reports the same 28 pre-existing errors as upstream/master — this change adds none. They are `rarity` being required by `interfaces.d.ts` while these older hand-written files omit it, which is out of scope here.
