### PR TITLE
(data) ja SV4M Future Flash - cardmarket + tcgplayer product ids

### DIFF
--- a/data-asia/SV/SV4M/001.ts
+++ b/data-asia/SV/SV4M/001.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741809,
+				tcgplayer: 565961,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741809
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/002.ts
+++ b/data-asia/SV/SV4M/002.ts
@@ -60,12 +60,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741813,
+				tcgplayer: 565962,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741813
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/003.ts
+++ b/data-asia/SV/SV4M/003.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741815,
+				tcgplayer: 565963,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/004.ts
+++ b/data-asia/SV/SV4M/004.ts
@@ -61,6 +61,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741818,
+				tcgplayer: 565964,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/005.ts
+++ b/data-asia/SV/SV4M/005.ts
@@ -70,6 +70,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741821,
+				tcgplayer: 565965,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/006.ts
+++ b/data-asia/SV/SV4M/006.ts
@@ -61,6 +61,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741825,
+				tcgplayer: 565966,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/007.ts
+++ b/data-asia/SV/SV4M/007.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741827,
+				tcgplayer: 565967,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/008.ts
+++ b/data-asia/SV/SV4M/008.ts
@@ -70,6 +70,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741830,
+				tcgplayer: 565968,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/009.ts
+++ b/data-asia/SV/SV4M/009.ts
@@ -68,6 +68,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741833,
+				tcgplayer: 565969,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/010.ts
+++ b/data-asia/SV/SV4M/010.ts
@@ -68,12 +68,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741836,
+				tcgplayer: 565970,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741836
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/011.ts
+++ b/data-asia/SV/SV4M/011.ts
@@ -70,12 +70,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741838,
+				tcgplayer: 565971,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741838
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/012.ts
+++ b/data-asia/SV/SV4M/012.ts
@@ -70,6 +70,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741839,
+				tcgplayer: 565972,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/013.ts
+++ b/data-asia/SV/SV4M/013.ts
@@ -50,12 +50,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741840,
+				tcgplayer: 565973,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741840
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/014.ts
+++ b/data-asia/SV/SV4M/014.ts
@@ -70,12 +70,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741841,
+				tcgplayer: 565974,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741841
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/015.ts
+++ b/data-asia/SV/SV4M/015.ts
@@ -68,12 +68,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741842,
+				tcgplayer: 565975,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741842
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/016.ts
+++ b/data-asia/SV/SV4M/016.ts
@@ -70,12 +70,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741843,
+				tcgplayer: 565976,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741843
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/017.ts
+++ b/data-asia/SV/SV4M/017.ts
@@ -45,12 +45,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741844,
+				tcgplayer: 565977,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741844
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/018.ts
+++ b/data-asia/SV/SV4M/018.ts
@@ -45,12 +45,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741845,
+				tcgplayer: 565978,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741845
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/019.ts
+++ b/data-asia/SV/SV4M/019.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741846,
+				tcgplayer: 565979,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741846
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/020.ts
+++ b/data-asia/SV/SV4M/020.ts
@@ -70,6 +70,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741847,
+				tcgplayer: 565980,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/021.ts
+++ b/data-asia/SV/SV4M/021.ts
@@ -68,6 +68,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741848,
+				tcgplayer: 565981,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/022.ts
+++ b/data-asia/SV/SV4M/022.ts
@@ -50,12 +50,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741849,
+				tcgplayer: 565982,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741849
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/023.ts
+++ b/data-asia/SV/SV4M/023.ts
@@ -62,12 +62,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741850,
+				tcgplayer: 565983,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741850
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/024.ts
+++ b/data-asia/SV/SV4M/024.ts
@@ -68,12 +68,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741851,
+				tcgplayer: 565984,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741851
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/025.ts
+++ b/data-asia/SV/SV4M/025.ts
@@ -68,12 +68,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741852,
+				tcgplayer: 565985,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741852
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/026.ts
+++ b/data-asia/SV/SV4M/026.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741853,
+				tcgplayer: 565986,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/027.ts
+++ b/data-asia/SV/SV4M/027.ts
@@ -54,6 +54,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741854,
+				tcgplayer: 565987,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/028.ts
+++ b/data-asia/SV/SV4M/028.ts
@@ -65,12 +65,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741855,
+				tcgplayer: 565988,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741855
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/029.ts
+++ b/data-asia/SV/SV4M/029.ts
@@ -67,12 +67,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741856,
+				tcgplayer: 565989,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741856
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/030.ts
+++ b/data-asia/SV/SV4M/030.ts
@@ -75,12 +75,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741857,
+				tcgplayer: 565990,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741857
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/031.ts
+++ b/data-asia/SV/SV4M/031.ts
@@ -57,6 +57,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741858,
+				tcgplayer: 565991,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/032.ts
+++ b/data-asia/SV/SV4M/032.ts
@@ -57,6 +57,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741859,
+				tcgplayer: 565992,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/033.ts
+++ b/data-asia/SV/SV4M/033.ts
@@ -75,6 +75,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741860,
+				tcgplayer: 565993,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/034.ts
+++ b/data-asia/SV/SV4M/034.ts
@@ -60,6 +60,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741861,
+				tcgplayer: 565994,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/035.ts
+++ b/data-asia/SV/SV4M/035.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741862,
+				tcgplayer: 565995,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/036.ts
+++ b/data-asia/SV/SV4M/036.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741863,
+				tcgplayer: 565996,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/037.ts
+++ b/data-asia/SV/SV4M/037.ts
@@ -70,6 +70,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741864,
+				tcgplayer: 565997,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/038.ts
+++ b/data-asia/SV/SV4M/038.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741865,
+				tcgplayer: 565998,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/039.ts
+++ b/data-asia/SV/SV4M/039.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741866,
+				tcgplayer: 565999,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741866
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/040.ts
+++ b/data-asia/SV/SV4M/040.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741867,
+				tcgplayer: 566000,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/041.ts
+++ b/data-asia/SV/SV4M/041.ts
@@ -68,12 +68,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741868,
+				tcgplayer: 566001,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741868
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/042.ts
+++ b/data-asia/SV/SV4M/042.ts
@@ -75,12 +75,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741869,
+				tcgplayer: 566002,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741869
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/043.ts
+++ b/data-asia/SV/SV4M/043.ts
@@ -57,12 +57,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741870,
+				tcgplayer: 566003,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741870
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/044.ts
+++ b/data-asia/SV/SV4M/044.ts
@@ -66,12 +66,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741871,
+				tcgplayer: 566004,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741871
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/045.ts
+++ b/data-asia/SV/SV4M/045.ts
@@ -67,12 +67,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741872,
+				tcgplayer: 566005,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741872
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/046.ts
+++ b/data-asia/SV/SV4M/046.ts
@@ -57,12 +57,18 @@ const card: Card = {
 		}
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741873,
+				tcgplayer: 566006,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741873
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/047.ts
+++ b/data-asia/SV/SV4M/047.ts
@@ -55,6 +55,16 @@ const card: Card = {
 		}
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741874,
+				tcgplayer: 566007,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/048.ts
+++ b/data-asia/SV/SV4M/048.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741875,
+				tcgplayer: 566008,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741875
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/049.ts
+++ b/data-asia/SV/SV4M/049.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741876,
+				tcgplayer: 566009,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741876
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/050.ts
+++ b/data-asia/SV/SV4M/050.ts
@@ -70,12 +70,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741877,
+				tcgplayer: 566010,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741877
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/051.ts
+++ b/data-asia/SV/SV4M/051.ts
@@ -61,12 +61,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741878,
+				tcgplayer: 566011,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741878
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/052.ts
+++ b/data-asia/SV/SV4M/052.ts
@@ -68,12 +68,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741879,
+				tcgplayer: 566012,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741879
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/053.ts
+++ b/data-asia/SV/SV4M/053.ts
@@ -52,12 +52,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741880,
+				tcgplayer: 566013,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741880
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/054.ts
+++ b/data-asia/SV/SV4M/054.ts
@@ -65,12 +65,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741881,
+				tcgplayer: 566014,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741881
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/055.ts
+++ b/data-asia/SV/SV4M/055.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741882,
+				tcgplayer: 566015,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/056.ts
+++ b/data-asia/SV/SV4M/056.ts
@@ -52,6 +52,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741883,
+				tcgplayer: 566016,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/057.ts
+++ b/data-asia/SV/SV4M/057.ts
@@ -62,6 +62,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741884,
+				tcgplayer: 566017,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/058.ts
+++ b/data-asia/SV/SV4M/058.ts
@@ -73,6 +73,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741885,
+				tcgplayer: 566018,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/059.ts
+++ b/data-asia/SV/SV4M/059.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		ko: "이 카드는 자신의 남은 프라이즈 장수가 상대의 남은 프라이즈 장수보다 많을 때만 사용할 수 있다. 상대의 벤치 포켓몬을 1마리 선택해서 배틀 포켓몬과 교체한다."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741886,
+				tcgplayer: 566019,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/060.ts
+++ b/data-asia/SV/SV4M/060.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		ko: "이 카드는 자신의 패를 1장 트래쉬하지 않으면 사용할 수 없다. 자신의 덱에서 「미래」의 포켓몬을 2장까지 선택해서 상대에게 보여주고 패로 가져온다. 그리고 덱을 섞는다."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741887,
+				tcgplayer: 566020,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/061.ts
+++ b/data-asia/SV/SV4M/061.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		ko: "이 카드를 붙이고 있는 포켓몬은 이 카드에 적혀 있는 기술을 사용할 수 있다. (기술을 사용하기 위한 에너지는 필요하다.) 포켓몬에게 붙어 있는 이 카드는 자신의 차례의 마지막에 트래쉬한다."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741888,
+				tcgplayer: 566021,
+			},
+		},
+	],
+
 	trainerType: "Tool",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/062.ts
+++ b/data-asia/SV/SV4M/062.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		ko: "이 카드를 붙이고 있는 「미래」의 포켓몬은 후퇴에 필요한 에너지가 모두 없어지고 그 포켓몬이 사용하는 기술이 상대의 배틀 포켓몬에게 주는 데미지는 「+20」이 된다."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741889,
+				tcgplayer: 566022,
+			},
+		},
+	],
+
 	trainerType: "Tool",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/063.ts
+++ b/data-asia/SV/SV4M/063.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		ko: "이 카드를 붙이고 있는 포켓몬이 상대의 포켓몬으로부터 기술의 데미지를 받아 기절했을 때 상대의 패에서 앞면을 보지 않고 1장 선택해서 트래쉬한다."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741890,
+				tcgplayer: 566023,
+			},
+		},
+	],
+
 	trainerType: "Tool",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/064.ts
+++ b/data-asia/SV/SV4M/064.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		ko: "자신의 덱을 2장 뽑는다. 자신의 트래쉬에서 기본 에너지를 1장 선택해서 상대에게 보여주고 패로 가져온다."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741891,
+				tcgplayer: 566024,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/065.ts
+++ b/data-asia/SV/SV4M/065.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		ko: "자신의 트래쉬에서 (초) 포켓몬과 「기본 (초) 에너지」를 합계 4장까지 선택해서 상대에게 보여주고 패로 가져온다."
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741892,
+				tcgplayer: 566025,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/066.ts
+++ b/data-asia/SV/SV4M/066.ts
@@ -22,6 +22,16 @@ const card: Card = {
 		ko: "자신의 필드의 포켓몬을 1마리 선택해서 패로 되돌린다. (포켓몬 이외의 카드는 모두 트래쉬한다.)"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 741893,
+				tcgplayer: 566026,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/067.ts
+++ b/data-asia/SV/SV4M/067.ts
@@ -54,6 +54,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741894,
+				tcgplayer: 566027,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/068.ts
+++ b/data-asia/SV/SV4M/068.ts
@@ -63,6 +63,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741895,
+				tcgplayer: 566028,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/069.ts
+++ b/data-asia/SV/SV4M/069.ts
@@ -63,6 +63,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741896,
+				tcgplayer: 566029,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/070.ts
+++ b/data-asia/SV/SV4M/070.ts
@@ -41,12 +41,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741897,
+				tcgplayer: 566030,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741845
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/071.ts
+++ b/data-asia/SV/SV4M/071.ts
@@ -63,6 +63,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741898,
+				tcgplayer: 566031,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/072.ts
+++ b/data-asia/SV/SV4M/072.ts
@@ -56,12 +56,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741899,
+				tcgplayer: 566032,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741850
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/073.ts
+++ b/data-asia/SV/SV4M/073.ts
@@ -68,6 +68,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741900,
+				tcgplayer: 566033,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/074.ts
+++ b/data-asia/SV/SV4M/074.ts
@@ -61,12 +61,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741901,
+				tcgplayer: 566034,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741868
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/075.ts
+++ b/data-asia/SV/SV4M/075.ts
@@ -55,12 +55,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741902,
+				tcgplayer: 566035,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741878
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/076.ts
+++ b/data-asia/SV/SV4M/076.ts
@@ -59,12 +59,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741903,
+				tcgplayer: 566036,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741881
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/077.ts
+++ b/data-asia/SV/SV4M/077.ts
@@ -63,12 +63,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741904,
+				tcgplayer: 566037,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741877
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/078.ts
+++ b/data-asia/SV/SV4M/078.ts
@@ -66,6 +66,16 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741905,
+				tcgplayer: 566038,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/079.ts
+++ b/data-asia/SV/SV4M/079.ts
@@ -49,6 +49,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741906,
+				tcgplayer: 566039,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/080.ts
+++ b/data-asia/SV/SV4M/080.ts
@@ -56,6 +56,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741907,
+				tcgplayer: 566040,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/081.ts
+++ b/data-asia/SV/SV4M/081.ts
@@ -56,6 +56,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741908,
+				tcgplayer: 566041,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/082.ts
+++ b/data-asia/SV/SV4M/082.ts
@@ -61,12 +61,18 @@ const card: Card = {
 		value: "-30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741909,
+				tcgplayer: 566042,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741872
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/083.ts
+++ b/data-asia/SV/SV4M/083.ts
@@ -51,12 +51,18 @@ const card: Card = {
 		}
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741910,
+				tcgplayer: 566043,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741873
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/084.ts
+++ b/data-asia/SV/SV4M/084.ts
@@ -56,6 +56,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741911,
+				tcgplayer: 566044,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/085.ts
+++ b/data-asia/SV/SV4M/085.ts
@@ -19,6 +19,16 @@ const card: Card = {
 		ko: "자신의 덱을 2장 뽑는다. 자신의 트래쉬에서 기본 에너지를 1장 선택해서 상대에게 보여주고 패로 가져온다."
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741912,
+				tcgplayer: 566045,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/086.ts
+++ b/data-asia/SV/SV4M/086.ts
@@ -19,6 +19,16 @@ const card: Card = {
 		ko: "자신의 트래쉬에서 (초) 포켓몬과 「기본 (초) 에너지」를 합계 4장까지 선택해서 상대에게 보여주고 패로 가져온다."
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741913,
+				tcgplayer: 566046,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/087.ts
+++ b/data-asia/SV/SV4M/087.ts
@@ -19,6 +19,16 @@ const card: Card = {
 		ko: "자신의 필드의 포켓몬을 1마리 선택해서 패로 되돌린다. (포켓몬 이외의 카드는 모두 트래쉬한다.)"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741914,
+				tcgplayer: 566047,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/088.ts
+++ b/data-asia/SV/SV4M/088.ts
@@ -49,6 +49,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741915,
+				tcgplayer: 566048,
+			},
+		},
+	],
+
 	retreat: 4,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/089.ts
+++ b/data-asia/SV/SV4M/089.ts
@@ -56,6 +56,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741916,
+				tcgplayer: 566049,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/090.ts
+++ b/data-asia/SV/SV4M/090.ts
@@ -51,12 +51,18 @@ const card: Card = {
 		}
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741918,
+				tcgplayer: 566050,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "G",
-
-	thirdParty: {
-		cardmarket: 741873
-	}
 }
 
 export default card

--- a/data-asia/SV/SV4M/091.ts
+++ b/data-asia/SV/SV4M/091.ts
@@ -19,6 +19,16 @@ const card: Card = {
 		ko: "자신의 필드의 포켓몬을 1마리 선택해서 패로 되돌린다. (포켓몬 이외의 카드는 모두 트래쉬한다.)"
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741919,
+				tcgplayer: 566051,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/092.ts
+++ b/data-asia/SV/SV4M/092.ts
@@ -19,6 +19,16 @@ const card: Card = {
 		ko: "자신의 트래쉬에서 (초) 포켓몬과 「기본 (초) 에너지」를 합계 4장까지 선택해서 상대에게 보여주고 패로 가져온다."
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741920,
+				tcgplayer: 566052,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "G"
 }

--- a/data-asia/SV/SV4M/093.ts
+++ b/data-asia/SV/SV4M/093.ts
@@ -51,6 +51,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741922,
+				tcgplayer: 566053,
+			},
+		},
+	],
+
 	retreat: 2
 }
 

--- a/data-asia/SV/SV4M/094.ts
+++ b/data-asia/SV/SV4M/094.ts
@@ -17,6 +17,16 @@ const card: Card = {
 		ko: "이 카드는 자신의 남은 프라이즈 장수가 상대의 남은 프라이즈 장수보다 많을 때만 사용할 수 있다. 상대의 벤치 포켓몬을 1마리 선택해서 배틀 포켓몬과 교체한다."
 	},
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741923,
+				tcgplayer: 566054,
+			},
+		},
+	],
+
 	trainerType: "Item"
 }
 

--- a/data-asia/SV/SV4M/095.ts
+++ b/data-asia/SV/SV4M/095.ts
@@ -10,7 +10,17 @@ const card: Card = {
 	},
 
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 741924,
+				tcgplayer: 566055,
+			},
+		},
+	],
 }
 
 export default card


### PR DESCRIPTION
## What

Links the cards of the existing Japanese set **SV4M 未来の一閃 (Future Flash)** to their Cardmarket **and TCGplayer** products, so the API can serve their prices.

- **54** cards carried no product id at all and get both
- **41** carried a card-level `thirdParty.cardmarket`, which is moved onto the card's `variants` entry and joined by its tcgplayer id
- **9** carried the cardmarket id of a different print and are corrected

Afterwards every card of the set carries its id on a `variants` entry and none on the card itself, which is where tcgdex is heading. Nothing else changes: the `ko`/`zh-tw`/`th` texts and the Japanese card data are not rewritten.

9 cards carried the product of **another print** of the same card, so the API served that print's price for them:

| card | was | is | the old id belongs to |
|---|---|---|---|
| 070 | 741845 | 741897 | points at card 018 of this set |
| 072 | 741850 | 741899 | points at card 023 of this set |
| 074 | 741868 | 741901 | points at card 041 of this set |
| 075 | 741878 | 741902 | points at card 051 of this set |
| 076 | 741881 | 741903 | points at card 054 of this set |
| 077 | 741877 | 741904 | points at card 050 of this set |
| 082 | 741872 | 741909 | points at card 045 of this set |
| 083 | 741873 | 741910 | points at card 046 of this set |
| 090 | 741873 | 741918 | points at card 046 of this set |

The ids are assigned **by collection number**, not by name: within a Cardmarket expansion the products sorted by `idProduct` follow the collection order, and the assignment is verified against the sample rows pokepricelab renders. That matters because Cardmarket names every print of a card identically inside an expansion, so a name lookup cannot tell a base print from its AR/full-art reprint — which is where the corrected ids above come from. That the 32 ids this set already carried correctly agree with the same assignment is an independent cross-check.

## Data sources

- **Cardmarket** public product catalog (`downloads.s3.cardmarket.com`): the product ids (741809–741924), assigned by collection number
- **pokepricelab.com**: the sample rows that verify that assignment
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (565961–566055), keyed by the collection number each product carries in `extendedData`
- **limitlesstcg.com**: the set's card list — used here for nothing but the rarity per number, which decides whether a variant is `holo` or `normal`

## Notes

- `tsc --noEmit` reports the same 29 pre-existing errors as upstream/master — this change adds none. They are `rarity` being required by `interfaces.d.ts` while these older hand-written files omit it, which is out of scope here.
