### PR TITLE
(data) ja SV7a Paradise Dragona - cardmarket + tcgplayer product ids

### DIFF
--- a/data-asia/SV/SV7a/001.ts
+++ b/data-asia/SV/SV7a/001.ts
@@ -44,14 +44,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787561,
+				tcgplayer: 579383,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H",
 	rarity: "Common",
 	dexId: [102],
-
-	thirdParty: {
-		cardmarket: 787561
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/002.ts
+++ b/data-asia/SV/SV7a/002.ts
@@ -39,14 +39,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787562,
+				tcgplayer: 579384,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H",
 	rarity: "Common",
 	dexId: [755],
-
-	thirdParty: {
-		cardmarket: 787562
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/003.ts
+++ b/data-asia/SV/SV7a/003.ts
@@ -61,14 +61,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787563,
+				tcgplayer: 579385,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H",
 	rarity: "Uncommon",
 	dexId: [756],
-
-	thirdParty: {
-		cardmarket: 787563
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/004.ts
+++ b/data-asia/SV/SV7a/004.ts
@@ -59,14 +59,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787564,
+				tcgplayer: 579386,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "H",
 	rarity: "Common",
 	dexId: [781],
-
-	thirdParty: {
-		cardmarket: 787564
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/005.ts
+++ b/data-asia/SV/SV7a/005.ts
@@ -60,6 +60,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 787565,
+				tcgplayer: 579387,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H",
 	rarity: "Rare",

--- a/data-asia/SV/SV7a/006.ts
+++ b/data-asia/SV/SV7a/006.ts
@@ -59,14 +59,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787566,
+				tcgplayer: 579388,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "H",
 	rarity: "Common",
 	dexId: [351],
-
-	thirdParty: {
-		cardmarket: 787566
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/007.ts
+++ b/data-asia/SV/SV7a/007.ts
@@ -39,14 +39,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787567,
+				tcgplayer: 579389,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H",
 	rarity: "Common",
 	dexId: [513],
-
-	thirdParty: {
-		cardmarket: 787567
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/008.ts
+++ b/data-asia/SV/SV7a/008.ts
@@ -45,14 +45,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787568,
+				tcgplayer: 579390,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H",
 	rarity: "Common",
 	dexId: [514],
-
-	thirdParty: {
-		cardmarket: 787568
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/009.ts
+++ b/data-asia/SV/SV7a/009.ts
@@ -54,6 +54,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 787569,
+				tcgplayer: 579391,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H",
 	rarity: "Rare",

--- a/data-asia/SV/SV7a/010.ts
+++ b/data-asia/SV/SV7a/010.ts
@@ -59,14 +59,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787570,
+				tcgplayer: 579392,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H",
 	rarity: "Common",
 	dexId: [615],
-
-	thirdParty: {
-		cardmarket: 787570
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/011.ts
+++ b/data-asia/SV/SV7a/011.ts
@@ -54,6 +54,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 787571,
+				tcgplayer: 579393,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "H",
 	rarity: "Double rare"

--- a/data-asia/SV/SV7a/012.ts
+++ b/data-asia/SV/SV7a/012.ts
@@ -61,14 +61,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787572,
+				tcgplayer: 579394,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H",
 	rarity: "Uncommon",
 	dexId: [779],
-
-	thirdParty: {
-		cardmarket: 787572
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/013.ts
+++ b/data-asia/SV/SV7a/013.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787573,
+				tcgplayer: 579395,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H",
 	rarity: "Common",

--- a/data-asia/SV/SV7a/014.ts
+++ b/data-asia/SV/SV7a/014.ts
@@ -39,6 +39,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787574,
+				tcgplayer: 579396,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H",
 	rarity: "Common",

--- a/data-asia/SV/SV7a/015.ts
+++ b/data-asia/SV/SV7a/015.ts
@@ -39,6 +39,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787575,
+				tcgplayer: 579397,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H",
 	rarity: "Uncommon",

--- a/data-asia/SV/SV7a/016.ts
+++ b/data-asia/SV/SV7a/016.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787576,
+				tcgplayer: 579398,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "H",
 	rarity: "Common",

--- a/data-asia/SV/SV7a/017.ts
+++ b/data-asia/SV/SV7a/017.ts
@@ -55,6 +55,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787577,
+				tcgplayer: 579399,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "H",
 	rarity: "Common",

--- a/data-asia/SV/SV7a/018.ts
+++ b/data-asia/SV/SV7a/018.ts
@@ -47,14 +47,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787578,
+				tcgplayer: 579400,
+			},
+		},
+	],
+
 	retreat: 0,
 	regulationMark: "H",
 	rarity: "Common",
 	dexId: [238],
-
-	thirdParty: {
-		cardmarket: 787578
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/019.ts
+++ b/data-asia/SV/SV7a/019.ts
@@ -44,6 +44,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 787579,
+				tcgplayer: 579401,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H",
 	rarity: "Double rare",
@@ -63,10 +73,6 @@ const card: Card = {
 			ja: "このポケモンがいるかぎり、自分のたねポケモン全員のにげるためのエネルギーは、すべてなくなる。"
 		}
 	}],
-
-	thirdParty: {
-		cardmarket: 787579
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/020.ts
+++ b/data-asia/SV/SV7a/020.ts
@@ -58,14 +58,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787580,
+				tcgplayer: 579402,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H",
 	rarity: "Uncommon",
 	dexId: [381],
-
-	thirdParty: {
-		cardmarket: 787580
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/021.ts
+++ b/data-asia/SV/SV7a/021.ts
@@ -60,14 +60,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 787581,
+				tcgplayer: 579403,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H",
 	rarity: "Rare",
 	dexId: [786],
-
-	thirdParty: {
-		cardmarket: 787581
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/022.ts
+++ b/data-asia/SV/SV7a/022.ts
@@ -50,6 +50,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787582,
+				tcgplayer: 579404,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H",
 	rarity: "Common",

--- a/data-asia/SV/SV7a/023.ts
+++ b/data-asia/SV/SV7a/023.ts
@@ -64,6 +64,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787583,
+				tcgplayer: 579405,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H",
 	rarity: "Uncommon",

--- a/data-asia/SV/SV7a/024.ts
+++ b/data-asia/SV/SV7a/024.ts
@@ -58,6 +58,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787584,
+				tcgplayer: 579406,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H",
 	rarity: "Common",

--- a/data-asia/SV/SV7a/025.ts
+++ b/data-asia/SV/SV7a/025.ts
@@ -53,14 +53,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787585,
+				tcgplayer: 579407,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H",
 	rarity: "Common",
 	dexId: [328],
-
-	thirdParty: {
-		cardmarket: 787585
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/026.ts
+++ b/data-asia/SV/SV7a/026.ts
@@ -53,14 +53,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787586,
+				tcgplayer: 579408,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H",
 	rarity: "Common",
 	dexId: [329],
-
-	thirdParty: {
-		cardmarket: 787586
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/027.ts
+++ b/data-asia/SV/SV7a/027.ts
@@ -53,13 +53,19 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 787587,
+				tcgplayer: 579409,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H",
 	rarity: "Double rare",
-
-	thirdParty: {
-		cardmarket: 787587
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/028.ts
+++ b/data-asia/SV/SV7a/028.ts
@@ -53,14 +53,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787588,
+				tcgplayer: 579410,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H",
 	rarity: "Common",
 	dexId: [529],
-
-	thirdParty: {
-		cardmarket: 787588
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/029.ts
+++ b/data-asia/SV/SV7a/029.ts
@@ -60,14 +60,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787589,
+				tcgplayer: 579411,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H",
 	rarity: "Common",
 	dexId: [530],
-
-	thirdParty: {
-		cardmarket: 787589
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/030.ts
+++ b/data-asia/SV/SV7a/030.ts
@@ -60,14 +60,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 787590,
+				tcgplayer: 579412,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H",
 	rarity: "Rare",
 	dexId: [645],
-
-	thirdParty: {
-		cardmarket: 787590
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/031.ts
+++ b/data-asia/SV/SV7a/031.ts
@@ -45,14 +45,20 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787591,
+				tcgplayer: 579413,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H",
 	rarity: "Uncommon",
 	dexId: [766],
-
-	thirdParty: {
-		cardmarket: 787591
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/032.ts
+++ b/data-asia/SV/SV7a/032.ts
@@ -45,6 +45,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787592,
+				tcgplayer: 579414,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H",
 	rarity: "Common",

--- a/data-asia/SV/SV7a/033.ts
+++ b/data-asia/SV/SV7a/033.ts
@@ -54,6 +54,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787593,
+				tcgplayer: 579415,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "H",
 	rarity: "Common",

--- a/data-asia/SV/SV7a/034.ts
+++ b/data-asia/SV/SV7a/034.ts
@@ -50,14 +50,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787594,
+				tcgplayer: 579416,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H",
 	rarity: "Common",
 	dexId: [227],
-
-	thirdParty: {
-		cardmarket: 787594
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/035.ts
+++ b/data-asia/SV/SV7a/035.ts
@@ -58,14 +58,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787595,
+				tcgplayer: 579417,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H",
 	rarity: "Common",
 	dexId: [707],
-
-	thirdParty: {
-		cardmarket: 787595
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/036.ts
+++ b/data-asia/SV/SV7a/036.ts
@@ -59,6 +59,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787596,
+				tcgplayer: 579418,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H",
 	rarity: "Common",

--- a/data-asia/SV/SV7a/037.ts
+++ b/data-asia/SV/SV7a/037.ts
@@ -44,6 +44,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 787597,
+				tcgplayer: 579419,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H",
 	rarity: "Double rare",

--- a/data-asia/SV/SV7a/038.ts
+++ b/data-asia/SV/SV7a/038.ts
@@ -65,6 +65,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787598,
+				tcgplayer: 579420,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H",
 	rarity: "Uncommon",

--- a/data-asia/SV/SV7a/039.ts
+++ b/data-asia/SV/SV7a/039.ts
@@ -59,6 +59,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 787599,
+				tcgplayer: 579421,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H",
 	rarity: "Rare",

--- a/data-asia/SV/SV7a/040.ts
+++ b/data-asia/SV/SV7a/040.ts
@@ -48,6 +48,16 @@ const card: Card = {
 		cost: ["Grass", "Water", "Fighting"]
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 787600,
+				tcgplayer: 579422,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "H",
 	rarity: "Double rare"

--- a/data-asia/SV/SV7a/041.ts
+++ b/data-asia/SV/SV7a/041.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		cost: ["Water", "Metal"]
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787601,
+				tcgplayer: 579423,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H",
 	rarity: "Uncommon",
 	dexId: [334],
-
-	thirdParty: {
-		cardmarket: 787601
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/042.ts
+++ b/data-asia/SV/SV7a/042.ts
@@ -48,14 +48,20 @@ const card: Card = {
 		cost: ["Psychic", "Metal", "Colorless"]
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 787602,
+				tcgplayer: 579424,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H",
 	rarity: "Rare",
 	dexId: [483],
-
-	thirdParty: {
-		cardmarket: 787602
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/043.ts
+++ b/data-asia/SV/SV7a/043.ts
@@ -40,14 +40,20 @@ const card: Card = {
 		cost: ["Grass", "Water"]
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 787603,
+				tcgplayer: 579425,
+			},
+		},
+	],
+
 	retreat: 2,
 	regulationMark: "H",
 	rarity: "Rare",
 	dexId: [484],
-
-	thirdParty: {
-		cardmarket: 787603
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/044.ts
+++ b/data-asia/SV/SV7a/044.ts
@@ -48,14 +48,20 @@ const card: Card = {
 		cost: ["Fighting", "Colorless", "Colorless"]
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787604,
+				tcgplayer: 579426,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "H",
 	rarity: "Uncommon",
 	dexId: [776],
-
-	thirdParty: {
-		cardmarket: 787604
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/045.ts
+++ b/data-asia/SV/SV7a/045.ts
@@ -54,14 +54,20 @@ const card: Card = {
 		cost: ["Grass", "Fire"]
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787605,
+				tcgplayer: 579427,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H",
 	rarity: "Common",
 	dexId: [840],
-
-	thirdParty: {
-		cardmarket: 787605
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/046.ts
+++ b/data-asia/SV/SV7a/046.ts
@@ -49,14 +49,20 @@ const card: Card = {
 		cost: ["Grass", "Fire"]
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787606,
+				tcgplayer: 579428,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H",
 	rarity: "Uncommon",
 	dexId: [841],
-
-	thirdParty: {
-		cardmarket: 787606
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/047.ts
+++ b/data-asia/SV/SV7a/047.ts
@@ -55,14 +55,20 @@ const card: Card = {
 		cost: ["Grass", "Fire"]
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787607,
+				tcgplayer: 579429,
+			},
+		},
+	],
+
 	retreat: 3,
 	regulationMark: "H",
 	rarity: "Uncommon",
 	dexId: [842],
-
-	thirdParty: {
-		cardmarket: 787607
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/048.ts
+++ b/data-asia/SV/SV7a/048.ts
@@ -50,14 +50,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787608,
+				tcgplayer: 579430,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H",
 	rarity: "Common",
 	dexId: [333],
-
-	thirdParty: {
-		cardmarket: 787608
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/049.ts
+++ b/data-asia/SV/SV7a/049.ts
@@ -44,14 +44,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787609,
+				tcgplayer: 579431,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H",
 	rarity: "Common",
 	dexId: [627],
-
-	thirdParty: {
-		cardmarket: 787609
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/050.ts
+++ b/data-asia/SV/SV7a/050.ts
@@ -58,14 +58,20 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787610,
+				tcgplayer: 579432,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H",
 	rarity: "Uncommon",
 	dexId: [628],
-
-	thirdParty: {
-		cardmarket: 787610
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/051.ts
+++ b/data-asia/SV/SV7a/051.ts
@@ -54,13 +54,19 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 787611,
+				tcgplayer: 579433,
+			},
+		},
+	],
+
 	retreat: 1,
 	regulationMark: "H",
 	rarity: "Double rare",
-
-	thirdParty: {
-		cardmarket: 787611
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/052.ts
+++ b/data-asia/SV/SV7a/052.ts
@@ -19,13 +19,19 @@ const card: Card = {
 		ja: "自分の山札から、それぞれちがうタイプの基本エネルギーを好きなだけ選び、相手に見せて、手札に加える。そして山札を切る。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787612,
+				tcgplayer: 579434,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "H",
 	rarity: "None",
-
-	thirdParty: {
-		cardmarket: 787612
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/053.ts
+++ b/data-asia/SV/SV7a/053.ts
@@ -19,13 +19,19 @@ const card: Card = {
 		ja: "このカードは、後攻プレイヤーの最初の番しか使えない。\n\n自分の山札からサポートを1枚選び、相手に見せて、手札に加える。そして山札を切る。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787613,
+				tcgplayer: 579435,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "H",
 	rarity: "Uncommon",
-
-	thirdParty: {
-		cardmarket: 787613
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/054.ts
+++ b/data-asia/SV/SV7a/054.ts
@@ -19,13 +19,19 @@ const card: Card = {
 		ja: "自分の山札を下から7枚見て、その中からポケモンを1枚選び、相手に見せて、手札に加える。残りのカードは山札にもどして切る。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787614,
+				tcgplayer: 579436,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "H",
 	rarity: "Uncommon",
-
-	thirdParty: {
-		cardmarket: 787614
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/055.ts
+++ b/data-asia/SV/SV7a/055.ts
@@ -19,13 +19,19 @@ const card: Card = {
 		ja: "相手は相手自身の手札を数えたあと、すべてウラにして切り、山札の下にもどす。その後、相手はもどした枚数ぶん、山札を引く。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787615,
+				tcgplayer: 579437,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "H",
 	rarity: "Uncommon",
-
-	thirdParty: {
-		cardmarket: 787615
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/056.ts
+++ b/data-asia/SV/SV7a/056.ts
@@ -19,13 +19,19 @@ const card: Card = {
 		ja: "相手のポケモン全員についている「ポケモンのどうぐ」と「特殊エネルギー」と、場に出ている「スタジアム」を、すべてトラッシュする。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787616,
+				tcgplayer: 579438,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "H",
 	rarity: "None",
-
-	thirdParty: {
-		cardmarket: 787616
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/057.ts
+++ b/data-asia/SV/SV7a/057.ts
@@ -19,13 +19,19 @@ const card: Card = {
 		ja: "自分のバトル場のポケモンのHPを「60」回復する。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787617,
+				tcgplayer: 579439,
+			},
+		},
+	],
+
 	trainerType: "Item",
 	regulationMark: "H",
 	rarity: "Uncommon",
-
-	thirdParty: {
-		cardmarket: 787617
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/058.ts
+++ b/data-asia/SV/SV7a/058.ts
@@ -19,13 +19,19 @@ const card: Card = {
 		ja: "このカードをつけているポケモンが、相手のポケモンからワザのダメージを受けるとき、そのダメージは「-60」され、このカードをトラッシュする。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787618,
+				tcgplayer: 579440,
+			},
+		},
+	],
+
 	trainerType: "Tool",
 	regulationMark: "H",
 	rarity: "Uncommon",
-
-	thirdParty: {
-		cardmarket: 787618
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/059.ts
+++ b/data-asia/SV/SV7a/059.ts
@@ -19,13 +19,19 @@ const card: Card = {
 		ja: "自分のサイドの残り枚数が、相手のサイドの残り枚数より多いなら、このカードをつけているポケモンがワザを使うためのエネルギーは、エネルギー1個ぶん少なくなる。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787619,
+				tcgplayer: 579441,
+			},
+		},
+	],
+
 	trainerType: "Tool",
 	regulationMark: "H",
 	rarity: "Uncommon",
-
-	thirdParty: {
-		cardmarket: 787619
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/060.ts
+++ b/data-asia/SV/SV7a/060.ts
@@ -19,13 +19,19 @@ const card: Card = {
 		ja: "自分の山札を上から7枚見て、その中からポケモンとトレーナーズを1枚ずつ選び、相手に見せて、手札に加える。残りのカードは山札にもどして切る。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787620,
+				tcgplayer: 579442,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H",
 	rarity: "Uncommon",
-
-	thirdParty: {
-		cardmarket: 787620
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/061.ts
+++ b/data-asia/SV/SV7a/061.ts
@@ -19,6 +19,16 @@ const card: Card = {
 		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。その後、自分の手札が5枚になるように、山札を引く。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787621,
+				tcgplayer: 579443,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H",
 	rarity: "Uncommon"

--- a/data-asia/SV/SV7a/062.ts
+++ b/data-asia/SV/SV7a/062.ts
@@ -19,6 +19,16 @@ const card: Card = {
 		ja: "自分の手札をすべて山札にもどして切る。その後、コインを1回投げ、オモテなら8枚、ウラなら3枚、山札を引く。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787622,
+				tcgplayer: 579444,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H",
 	rarity: "Common"

--- a/data-asia/SV/SV7a/063.ts
+++ b/data-asia/SV/SV7a/063.ts
@@ -19,6 +19,16 @@ const card: Card = {
 		ja: "相手のベンチのたねポケモンを1匹選び、バトルポケモンと入れ替える。その後、新しく出てきたポケモンをこんらんにする。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787623,
+				tcgplayer: 579445,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	regulationMark: "H",
 	rarity: "Uncommon"

--- a/data-asia/SV/SV7a/064.ts
+++ b/data-asia/SV/SV7a/064.ts
@@ -20,6 +20,16 @@ const card: Card = {
 	},
 
 	energyType: "Special",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 787624,
+				tcgplayer: 579446,
+			},
+		},
+	],
+
 	regulationMark: "H",
 	rarity: "None"
 }

--- a/data-asia/SV/SV7a/065.ts
+++ b/data-asia/SV/SV7a/065.ts
@@ -37,12 +37,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788038,
+				tcgplayer: 579447,
+			},
+		},
+	],
+
 	retreat: 1,
 	rarity: "None",
-
-	thirdParty: {
-		cardmarket: 787561
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/066.ts
+++ b/data-asia/SV/SV7a/066.ts
@@ -51,12 +51,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788039,
+				tcgplayer: 579448,
+			},
+		},
+	],
+
 	retreat: 2,
 	rarity: "None",
-
-	thirdParty: {
-		cardmarket: 787563
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/067.ts
+++ b/data-asia/SV/SV7a/067.ts
@@ -49,12 +49,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788040,
+				tcgplayer: 579449,
+			},
+		},
+	],
+
 	retreat: 0,
 	rarity: "None",
-
-	thirdParty: {
-		cardmarket: 787566
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/068.ts
+++ b/data-asia/SV/SV7a/068.ts
@@ -51,12 +51,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788041,
+				tcgplayer: 579450,
+			},
+		},
+	],
+
 	retreat: 1,
 	rarity: "None",
-
-	thirdParty: {
-		cardmarket: 787572
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/069.ts
+++ b/data-asia/SV/SV7a/069.ts
@@ -47,6 +47,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788042,
+				tcgplayer: 579451,
+			},
+		},
+	],
+
 	retreat: 3,
 	rarity: "None"
 }

--- a/data-asia/SV/SV7a/070.ts
+++ b/data-asia/SV/SV7a/070.ts
@@ -50,12 +50,18 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788043,
+				tcgplayer: 579452,
+			},
+		},
+	],
+
 	retreat: 2,
 	rarity: "None",
-
-	thirdParty: {
-		cardmarket: 787580
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/071.ts
+++ b/data-asia/SV/SV7a/071.ts
@@ -45,12 +45,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788044,
+				tcgplayer: 579453,
+			},
+		},
+	],
+
 	retreat: 1,
 	rarity: "None",
-
-	thirdParty: {
-		cardmarket: 787586
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/072.ts
+++ b/data-asia/SV/SV7a/072.ts
@@ -39,6 +39,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788045,
+				tcgplayer: 579454,
+			},
+		},
+	],
+
 	retreat: 2,
 	rarity: "None"
 }

--- a/data-asia/SV/SV7a/073.ts
+++ b/data-asia/SV/SV7a/073.ts
@@ -44,12 +44,18 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788046,
+				tcgplayer: 579455,
+			},
+		},
+	],
+
 	retreat: 1,
 	rarity: "None",
-
-	thirdParty: {
-		cardmarket: 787594
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/074.ts
+++ b/data-asia/SV/SV7a/074.ts
@@ -42,12 +42,18 @@ const card: Card = {
 		damage: 70
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788047,
+				tcgplayer: 579456,
+			},
+		},
+	],
+
 	retreat: 1,
 	rarity: "None",
-
-	thirdParty: {
-		cardmarket: 787606
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/075.ts
+++ b/data-asia/SV/SV7a/075.ts
@@ -46,12 +46,18 @@ const card: Card = {
 		}
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788048,
+				tcgplayer: 579457,
+			},
+		},
+	],
+
 	retreat: 3,
 	rarity: "None",
-
-	thirdParty: {
-		cardmarket: 787607
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/076.ts
+++ b/data-asia/SV/SV7a/076.ts
@@ -50,12 +50,18 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788049,
+				tcgplayer: 579458,
+			},
+		},
+	],
+
 	retreat: 1,
 	rarity: "None",
-
-	thirdParty: {
-		cardmarket: 787610
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/077.ts
+++ b/data-asia/SV/SV7a/077.ts
@@ -46,6 +46,16 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788050,
+				tcgplayer: 579459,
+			},
+		},
+	],
+
 	retreat: 3,
 	rarity: "None"
 }

--- a/data-asia/SV/SV7a/078.ts
+++ b/data-asia/SV/SV7a/078.ts
@@ -51,12 +51,18 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788051,
+				tcgplayer: 579460,
+			},
+		},
+	],
+
 	retreat: 2,
 	rarity: "None",
-
-	thirdParty: {
-		cardmarket: 787579
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/079.ts
+++ b/data-asia/SV/SV7a/079.ts
@@ -44,12 +44,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788052,
+				tcgplayer: 579461,
+			},
+		},
+	],
+
 	retreat: 1,
 	rarity: "None",
-
-	thirdParty: {
-		cardmarket: 787587
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/080.ts
+++ b/data-asia/SV/SV7a/080.ts
@@ -51,6 +51,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788053,
+				tcgplayer: 579462,
+			},
+		},
+	],
+
 	retreat: 2,
 	rarity: "None"
 }

--- a/data-asia/SV/SV7a/081.ts
+++ b/data-asia/SV/SV7a/081.ts
@@ -39,6 +39,16 @@ const card: Card = {
 		}
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788054,
+				tcgplayer: 579463,
+			},
+		},
+	],
+
 	retreat: 3,
 	rarity: "None"
 }

--- a/data-asia/SV/SV7a/082.ts
+++ b/data-asia/SV/SV7a/082.ts
@@ -46,12 +46,18 @@ const card: Card = {
 		value: "×2"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788055,
+				tcgplayer: 579464,
+			},
+		},
+	],
+
 	retreat: 1,
 	rarity: "None",
-
-	thirdParty: {
-		cardmarket: 787611
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/083.ts
+++ b/data-asia/SV/SV7a/083.ts
@@ -15,12 +15,18 @@ const card: Card = {
 		ja: "自分の山札を上から7枚見て、その中からポケモンとトレーナーズを1枚ずつ選び、相手に見せて、手札に加える。残りのカードは山札にもどして切る。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788056,
+				tcgplayer: 579465,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	rarity: "None",
-
-	thirdParty: {
-		cardmarket: 787620
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/084.ts
+++ b/data-asia/SV/SV7a/084.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。その後、自分の手札が5枚になるように、山札を引く。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788057,
+				tcgplayer: 579466,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	rarity: "None"
 }

--- a/data-asia/SV/SV7a/085.ts
+++ b/data-asia/SV/SV7a/085.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "自分の手札をすべて山札にもどして切る。その後、コインを1回投げ、オモテなら8枚、ウラなら3枚、山札を引く。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788058,
+				tcgplayer: 579467,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	rarity: "None"
 }

--- a/data-asia/SV/SV7a/086.ts
+++ b/data-asia/SV/SV7a/086.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "相手のベンチのたねポケモンを1匹選び、バトルポケモンと入れ替える。その後、新しく出てきたポケモンをこんらんにする。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788059,
+				tcgplayer: 579468,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	rarity: "None"
 }

--- a/data-asia/SV/SV7a/087.ts
+++ b/data-asia/SV/SV7a/087.ts
@@ -51,12 +51,18 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788060,
+				tcgplayer: 579469,
+			},
+		},
+	],
+
 	retreat: 2,
 	rarity: "None",
-
-	thirdParty: {
-		cardmarket: 787579
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/088.ts
+++ b/data-asia/SV/SV7a/088.ts
@@ -51,6 +51,16 @@ const card: Card = {
 		value: "－30"
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788061,
+				tcgplayer: 579470,
+			},
+		},
+	],
+
 	retreat: 2,
 	rarity: "None"
 }

--- a/data-asia/SV/SV7a/089.ts
+++ b/data-asia/SV/SV7a/089.ts
@@ -39,6 +39,16 @@ const card: Card = {
 		}
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788062,
+				tcgplayer: 579471,
+			},
+		},
+	],
+
 	retreat: 3,
 	rarity: "None"
 }

--- a/data-asia/SV/SV7a/090.ts
+++ b/data-asia/SV/SV7a/090.ts
@@ -15,12 +15,18 @@ const card: Card = {
 		ja: "自分の山札を上から7枚見て、その中からポケモンとトレーナーズを1枚ずつ選び、相手に見せて、手札に加える。残りのカードは山札にもどして切る。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788063,
+				tcgplayer: 579472,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	rarity: "None",
-
-	thirdParty: {
-		cardmarket: 787620
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/091.ts
+++ b/data-asia/SV/SV7a/091.ts
@@ -15,6 +15,16 @@ const card: Card = {
 		ja: "相手のベンチのたねポケモンを1匹選び、バトルポケモンと入れ替える。その後、新しく出てきたポケモンをこんらんにする。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788064,
+				tcgplayer: 579473,
+			},
+		},
+	],
+
 	trainerType: "Supporter",
 	rarity: "None"
 }

--- a/data-asia/SV/SV7a/092.ts
+++ b/data-asia/SV/SV7a/092.ts
@@ -39,6 +39,16 @@ const card: Card = {
 		}
 	}],
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788065,
+				tcgplayer: 579474,
+			},
+		},
+	],
+
 	retreat: 3,
 	rarity: "None"
 }

--- a/data-asia/SV/SV7a/093.ts
+++ b/data-asia/SV/SV7a/093.ts
@@ -15,12 +15,18 @@ const card: Card = {
 		ja: "自分のサイドの残り枚数が、相手のサイドの残り枚数より多いなら、このカードをつけているポケモンがワザを使うためのエネルギーは、エネルギー1個ぶん少なくなる。"
 	},
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788066,
+				tcgplayer: 579475,
+			},
+		},
+	],
+
 	trainerType: "Tool",
 	rarity: "None",
-
-	thirdParty: {
-		cardmarket: 787619
-	}
 }
 
 export default card

--- a/data-asia/SV/SV7a/094.ts
+++ b/data-asia/SV/SV7a/094.ts
@@ -15,6 +15,16 @@ const card: Card = {
 	},
 
 	energyType: "Special",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 788067,
+				tcgplayer: 579476,
+			},
+		},
+	],
+
 	rarity: "None"
 }
 


### PR DESCRIPTION
## What

Links the cards of the existing Japanese set **SV7a 楽園ドラゴーナ (Paradise Dragona)** to their Cardmarket **and TCGplayer** products, so the API can serve their prices.

- **35** cards carried no product id at all and get both
- **59** carried a card-level `thirdParty.cardmarket`, which is moved onto the card's `variants` entry and joined by its tcgplayer id
- **17** carried the cardmarket id of a different print and are corrected

Afterwards every card of the set carries its id on a `variants` entry and none on the card itself, which is where tcgdex is heading. Nothing else changes: the `zh-tw`/`zh-cn` texts and the Japanese card data are not rewritten.

17 cards carried the product of **another print** of the same card, so the API served that print's price for them:

| card | was | is | the old id belongs to |
|---|---|---|---|
| 065 | 787561 | 788038 | points at card 001 of this set |
| 066 | 787563 | 788039 | points at card 003 of this set |
| 067 | 787566 | 788040 | points at card 006 of this set |
| 068 | 787572 | 788041 | points at card 012 of this set |
| 070 | 787580 | 788043 | points at card 020 of this set |
| 071 | 787586 | 788044 | points at card 026 of this set |
| 073 | 787594 | 788046 | points at card 034 of this set |
| 074 | 787606 | 788047 | points at card 046 of this set |
| 075 | 787607 | 788048 | points at card 047 of this set |
| 076 | 787610 | 788049 | points at card 050 of this set |
| 078 | 787579 | 788051 | points at card 019 of this set |
| 079 | 787587 | 788052 | points at card 027 of this set |
| 082 | 787611 | 788055 | points at card 051 of this set |
| 083 | 787620 | 788056 | points at card 060 of this set |
| 087 | 787579 | 788060 | points at card 019 of this set |
| 090 | 787620 | 788063 | points at card 060 of this set |
| 093 | 787619 | 788066 | points at card 059 of this set |

The ids are assigned **by collection number**, not by name: within a Cardmarket expansion the products sorted by `idProduct` follow the collection order, and the assignment is verified against the sample rows pokepricelab renders. That matters because Cardmarket names every print of a card identically inside an expansion, so a name lookup cannot tell a base print from its AR/full-art reprint — which is where the corrected ids above come from. That the 42 ids this set already carried correctly agree with the same assignment is an independent cross-check.

## Data sources

- **Cardmarket** public product catalog (`downloads.s3.cardmarket.com`): the product ids (787561–788067), assigned by collection number
- **pokepricelab.com**: the sample rows that verify that assignment
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (579383–579476), keyed by the collection number each product carries in `extendedData`
- **limitlesstcg.com**: the set's card list — used here for nothing but the rarity per number, which decides whether a variant is `holo` or `normal`

## Notes

- All 94 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
