### PR TITLE
(data) Update Japanese SV set SV6a Night Wanderer

### DIFF
--- a/data-asia/SV/SV6a/001.ts
+++ b/data-asia/SV/SV6a/001.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "電電蟲"
+		ja: "バチュル",
+		'zh-tw': "電電蟲",
 	},
 
 	illustrator: "Naoyo Kimura",
@@ -14,32 +14,44 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "會附在寶可夢的身上 吸收靜電。自身並沒有 製造電的能力。"
+		ja: "ポケモンの 体に くっついて 静電気を 吸い取る。 自分では 電気を つくることが できない。",
+		'zh-tw': "會附在寶可夢的身上 吸收靜電。自身並沒有 製造電的能力。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "躍起閃避"
+	attacks: [
+		{
+			name: {
+				ja: "はねてかわす",
+				'zh-tw': "躍起閃避",
+			},
+			damage: 10,
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+				'zh-tw': "擲1次硬幣若為正面，則在下個對手的回合，這隻寶可夢不會受到招式的傷害與效果的影響。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則在下個對手的回合，這隻寶可夢不會受到招式的傷害與效果的影響。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773750,
+				tcgplayer: 566252,
+			},
 		},
-
-		damage: 10,
-		cost: ["Grass"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Common"
-}
+	rarity: "Common",
+	dexId: [595],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/002.ts
+++ b/data-asia/SV/SV6a/002.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "電蜘蛛"
+		ja: "デンチュラ",
+		'zh-tw': "電蜘蛛",
 	},
 
 	illustrator: "mashu",
@@ -14,40 +14,58 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "發射腹部帶電的毛來攻擊。 要是被牠的毛刺中， 就會全身麻痺三天三夜。"
+		ja: "電気を 帯びた お腹の 毛を 飛ばして 攻撃。 毛が 刺さると 三日三晩 全身が 痺れる。",
+		'zh-tw': "發射腹部帶電的毛來攻擊。 要是被牠的毛刺中， 就會全身麻痺三天三夜。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "‌[特性]複眼"
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ふくがん" },
+			effect: {
+				ja: "このポケモンが使うワザの、相手のバトル場の特性を持つポケモンへのダメージは「+50」される。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢使用的招式，對對手的戰鬥場的擁有特性的寶可夢造成的傷害「+50」點。"
-		}
-	}, {
-		name: {
-			'zh-tw': "麻麻羅網"
+	attacks: [
+		{
+			name: {
+				ja: "ビリビリウェブ",
+				'zh-tw': "‌[特性]複眼",
+			},
+			damage: "50+",
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンに[L]エネルギーがついているなら、80ダメージ追加。",
+				'zh-tw': "這隻寶可夢使用的招式，對對手的戰鬥場的擁有特性的寶可夢造成的傷害「+50」點。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢身上附有【雷】能量卡，則增加80點傷害。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773751,
+				tcgplayer: 566253,
+			},
 		},
+	],
 
-		damage: "50+",
-		cost: ["Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "バチュル",
+	},
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+	dexId: [596],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/003.ts
+++ b/data-asia/SV/SV6a/003.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "木木梟"
+		ja: "モクロー",
+		'zh-tw': "木木梟",
 	},
 
 	illustrator: "Yoshimi Miyoshi",
@@ -14,38 +14,51 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "一邊飛行一邊射出 刀刃般銳利的羽毛， 距離近時會使出猛烈的踢擊。"
+		ja: "飛行しながら 切れ味 鋭い 羽根を 飛ばし 近距離では 強烈な キックを 叩きこむ。",
+		'zh-tw': "一邊飛行一邊射出 刀刃般銳利的羽毛， 距離近時會使出猛烈的踢擊。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "叼"
+	attacks: [
+		{
+			name: {
+				ja: "くわえる",
+				'zh-tw': "叼",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+				'zh-tw': "從自己的牌庫抽出1張卡。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫抽出1張卡。"
+		{
+			name: {
+				ja: "このは",
+				'zh-tw': "樹葉",
+			},
+			damage: 10,
+			cost: ["Grass"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "樹葉"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773752,
+				tcgplayer: 566254,
+			},
 		},
-
-		damage: 10,
-		cost: ["Grass"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Common"
-}
+	rarity: "Common",
+	dexId: [722],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/004.ts
+++ b/data-asia/SV/SV6a/004.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "投羽梟"
+		ja: "フクスロー",
+		'zh-tw': "投羽梟",
 	},
 
 	illustrator: "Tetsu Kayama",
@@ -14,39 +14,56 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "連續投出被稱為是 刃羽的刀般銳利羽毛， 能精準地貫穿敵人要害。"
+		ja: "刃羽根 と 呼ばれる ナイフのような 羽根を 立て続けに 投げて 敵の 急所を 確実に つらぬく。",
+		'zh-tw': "連續投出被稱為是 刃羽的刀般銳利羽毛， 能精準地貫穿敵人要害。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "團結之翼"
+	attacks: [
+		{
+			name: {
+				ja: "だんけつのつばさ",
+				'zh-tw': "團結之翼",
+			},
+			damage: "20×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある、ワザ「だんけつのつばさ」を持つポケモンの枚数×20ダメージ。",
+				'zh-tw': "造成自己的棄牌區的，持有「團結之翼」招式的寶可夢卡的張數×20點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "造成自己的棄牌區的，持有「團結之翼」招式的寶可夢卡的張數×20點傷害。"
+		{
+			name: {
+				ja: "カッターウインド",
+				'zh-tw': "利刃之風",
+			},
+			damage: 30,
+			cost: ["Grass"],
 		},
+	],
 
-		damage: "20×",
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "利刃之風"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773753,
+				tcgplayer: 566255,
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Grass"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "モクロー",
+	},
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Common"
-}
+	rarity: "Common",
+	dexId: [723],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/005.ts
+++ b/data-asia/SV/SV6a/005.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "狙射樹梟"
+		ja: "ジュナイパー",
+		'zh-tw': "狙射樹梟",
 	},
 
 	illustrator: "DOM",
@@ -14,42 +14,59 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "會像射箭那樣射出 藏在自己翅膀裡的箭羽。 只要瞄準目標就絕不會射偏。"
+		ja: "翼に 仕込まれた 矢羽根を 弓矢のように つがえて 放つ。 狙った 的は 外さない。",
+		'zh-tw': "會像射箭那樣射出 藏在自己翅膀裡的箭羽。 只要瞄準目標就絕不會射偏。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "羽毛庫存"
+	attacks: [
+		{
+			name: {
+				ja: "フェザーストック",
+				'zh-tw': "羽毛庫存",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札が7枚になるように、山札を引く。",
+				'zh-tw': "從牌庫抽卡直到自己的手牌滿7張為止。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從牌庫抽卡直到自己的手牌滿7張為止。"
+		{
+			name: {
+				ja: "ストロングショット",
+				'zh-tw': "強力射擊",
+			},
+			damage: 170,
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の手札から「基本[G]エネルギー」を1枚トラッシュする。トラッシュできないなら、このワザは失敗。",
+				'zh-tw': "從自己的手牌將1張「基本【草】能量」卡丟棄。若無法丟棄，則這個招式失敗。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "強力射擊"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773754,
+				tcgplayer: 566256,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的手牌將1張「基本【草】能量」卡丟棄。若無法丟棄，則這個招式失敗。"
-		},
-
-		damage: 170,
-		cost: ["Grass"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "フクスロー",
+	},
 
 	retreat: 2,
 	regulationMark: "H",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+	dexId: [724],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/006.ts
+++ b/data-asia/SV/SV6a/006.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "卡璞・哞哞"
+		ja: "カプ・ブルル",
+		'zh-tw': "卡璞・哞哞",
 	},
 
 	illustrator: "GOSSAN",
@@ -14,32 +14,44 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "拔出巨大的樹木，轟轟地來回揮舞。 會讓草木茂盛生長，再吸收其中的能量。"
+		ja: "大木を 引き抜き ブンブン 振り回す。 草木を 茂らせて そのエネルギーを 吸収する。",
+		'zh-tw': "拔出巨大的樹木，轟轟地來回揮舞。 會讓草木茂盛生長，再吸收其中的能量。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "木槌"
+	attacks: [
+		{
+			name: {
+				ja: "ウッドハンマー",
+				'zh-tw': "木槌",
+			},
+			damage: 220,
+			cost: ["Grass", "Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+				'zh-tw': "這隻寶可夢也受到30點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢也受到30點傷害。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773755,
+				tcgplayer: 566257,
+			},
 		},
-
-		damage: 220,
-		cost: ["Grass", "Grass", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 3,
 	regulationMark: "H",
-	rarity: "Rare"
-}
+	rarity: "Rare",
+	dexId: [787],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/007.ts
+++ b/data-asia/SV/SV6a/007.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "戴魯比"
+		ja: "デルビル",
+		'zh-tw': "戴魯比",
 	},
 
 	illustrator: "REND",
@@ -14,35 +14,48 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "聯絡夥伴和追趕獵物 的時候，會分別發出 不同種類的叫聲。"
+		ja: "仲間に 連絡するときと 獲物を 追いつめるときでは 鳴き声の 種類が 違うのだ。",
+		'zh-tw': "聯絡夥伴和追趕獵物 的時候，會分別發出 不同種類的叫聲。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "咬"
+	attacks: [
+		{
+			name: {
+				ja: "かじる",
+				'zh-tw': "咬",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
-
-		damage: 20,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "後踢"
+		{
+			name: {
+				ja: "うしろげり",
+				'zh-tw': "後踢",
+			},
+			damage: 50,
+			cost: ["Fire", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 50,
-		cost: ["Fire", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773756,
+				tcgplayer: 566258,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Common"
-}
+	rarity: "Common",
+	dexId: [228],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/008.ts
+++ b/data-asia/SV/SV6a/008.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "黑魯加"
+		ja: "ヘルガー",
+		'zh-tw': "黑魯加",
 	},
 
 	illustrator: "burari",
@@ -14,39 +14,56 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "聽見牠恐怖長嚎的 寶可夢會渾身發抖， 一溜煙地回到自己的巢裡。"
+		ja: "不気味な 遠吠えを 聞いた ポケモンは 震え 一目散に 自分の 巣に 戻る。",
+		'zh-tw': "聽見牠恐怖長嚎的 寶可夢會渾身發抖， 一溜煙地回到自己的巢裡。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "咬住"
+	attacks: [
+		{
+			name: {
+				ja: "かみつく",
+				'zh-tw': "咬住",
+			},
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
 		},
-
-		damage: 50,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "大聲咆哮"
+		{
+			name: {
+				ja: "バークアウト",
+				'zh-tw': "大聲咆哮",
+			},
+			damage: 100,
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-100」される。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢使用招式的傷害「-100」點。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢使用招式的傷害「-100」點。"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773757,
+				tcgplayer: 566259,
+			},
 		},
+	],
 
-		damage: 100,
-		cost: ["Fire", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "デルビル",
+	},
 
 	retreat: 2,
 	regulationMark: "H",
-	rarity: "Common"
-}
+	rarity: "Common",
+	dexId: [229],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/009.ts
+++ b/data-asia/SV/SV6a/009.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鐵毒蛾"
+		ja: "テツノドクガ",
+		'zh-tw': "鐵毒蛾",
 	},
 
 	illustrator: "Shinji Kanda",
@@ -14,43 +14,56 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "無捕獲紀錄。資料不足。 其特徵與古書裡 所記載的物體一致。"
+		ja: "捕獲例は ゼロ。 データ不足。 古い 書物に 記された 物体と 特徴が 一致。",
+		'zh-tw': "無捕獲紀錄。資料不足。 其特徵與古書裡 所記載的物體一致。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "吸納"
+	attacks: [
+		{
+			name: {
+				ja: "きゅういん",
+				'zh-tw': "吸納",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンに与えたダメージぶん、このポケモンのHPを回復する。",
+				'zh-tw': "將這隻寶可夢恢復對對手的戰鬥寶可夢造成的傷害相同數值的HP。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將這隻寶可夢恢復對對手的戰鬥寶可夢造成的傷害相同數值的HP。"
+		{
+			name: {
+				ja: "ワイルドリジェクター",
+				'zh-tw': "瘋狂拒絕",
+			},
+			damage: 120,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンは「古代」のポケモンからワザのダメージを受けない。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢不會受到「古代」寶可夢招式的傷害。",
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "瘋狂拒絕"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773758,
+				tcgplayer: 566260,
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，這隻寶可夢不會受到「古代」寶可夢招式的傷害。"
-		},
-
-		damage: 120,
-		cost: ["Fire", "Fire", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
 	regulationMark: "H",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+	dexId: [994],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/010.ts
+++ b/data-asia/SV/SV6a/010.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "墨海馬"
+		ja: "タッツー",
+		'zh-tw': "墨海馬",
 	},
 
 	illustrator: "Shimaris Yukichi",
@@ -14,38 +14,51 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "棲息在海流平穩的海域。 被襲擊時會吐出漆黑的 墨汁，然後趁機逃走。"
+		ja: "潮の 流れが 穏やかな 海に 棲む。 襲われると 真っ黒な 墨を吐いて その隙に 逃げだす。",
+		'zh-tw': "棲息在海流平穩的海域。 被襲擊時會吐出漆黑的 墨汁，然後趁機逃走。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "紋絲不動"
+	attacks: [
+		{
+			name: {
+				ja: "じっとする",
+				'zh-tw': "紋絲不動",
+			},
+			cost: ["Water"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+				'zh-tw': "將這隻寶可夢恢復「30」HP。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將這隻寶可夢恢復「30」HP。"
+		{
+			name: {
+				ja: "ひれカッター",
+				'zh-tw': "鰭快刀",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "鰭快刀"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773759,
+				tcgplayer: 566261,
+			},
 		},
-
-		damage: 20,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Common"
-}
+	rarity: "Common",
+	dexId: [116],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/011.ts
+++ b/data-asia/SV/SV6a/011.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "海刺龍"
+		ja: "シードラ",
+		'zh-tw': "海刺龍",
 	},
 
 	illustrator: "Yuya Oka",
@@ -14,38 +14,55 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "是由雄性來養育孩子。 在育兒時，背上刺的 毒素會變得更強更濃。"
+		ja: "オスが 子どもを 育てる。 子育て中は 背中の トゲの 毒素が 強く 濃くなるのだ。",
+		'zh-tw': "是由雄性來養育孩子。 在育兒時，背上刺的 毒素會變得更強更濃。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "援軍"
+	attacks: [
+		{
+			name: {
+				ja: "えんぐん",
+				'zh-tw': "援軍",
+			},
+			cost: ["Water"],
+			effect: {
+				ja: "自分の山札からポケモンを3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多3張寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多3張寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		{
+			name: {
+				ja: "するどいひれ",
+				'zh-tw': "銳利鰭",
+			},
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "銳利鰭"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773760,
+				tcgplayer: 566262,
+			},
 		},
+	],
 
-		damage: 40,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "タッツー",
+	},
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Common"
-}
+	rarity: "Common",
+	dexId: [117],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/012.ts
+++ b/data-asia/SV/SV6a/012.ts
@@ -1,51 +1,69 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "刺龍王ex"
+		ja: "キングドラex",
+		'zh-tw': "刺龍王ex",
 	},
 
 	illustrator: "toriyufu",
 	category: "Pokemon",
 	hp: 310,
 	types: ["Water"],
+
 	stage: "Stage2",
-	suffix: "EX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "王之號召"
+	attacks: [
+		{
+			name: {
+				ja: "おうのごうれい",
+				'zh-tw': "王之號召",
+			},
+			cost: ["Water"],
+			effect: {
+				ja: "自分のトラッシュから[W]ポケモンを3枚まで選び、ベンチに出す。",
+				'zh-tw': "從自己的棄牌區選擇最多3張【水】寶可夢卡，放置於備戰區。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的棄牌區選擇最多3張【水】寶可夢卡，放置於備戰區。"
+		{
+			name: {
+				ja: "ハイドロポンプ",
+				'zh-tw': "水炮",
+			},
+			damage: "50+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[W]エネルギーの数×50ダメージ追加。",
+				'zh-tw': "增加這隻寶可夢身上附加的【水】能量的數量×50點傷害。",
+			},
 		},
+	],
 
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "水炮"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773761,
+				tcgplayer: 566263,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加這隻寶可夢身上附加的【水】能量的數量×50點傷害。"
-		},
-
-		damage: "50+",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "シードラ",
+	},
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Double rare"
-}
+	rarity: "Double rare",
+	dexId: [230],
 
-export default card
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV6a/013.ts
+++ b/data-asia/SV/SV6a/013.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "狃拉"
+		ja: "ニューラ",
+		'zh-tw': "狃拉",
 	},
 
 	illustrator: "Krgc",
@@ -14,39 +14,52 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "會透過團隊合作，一隻負責 引開雙親的注意，一隻負責 偷走蛋，非常地狡猾奸詐。"
+		ja: "ずる賢く １匹が 親を 誘き寄せ もう１匹が タマゴを 取るという チームプレーも 見せる。",
+		'zh-tw': "會透過團隊合作，一隻負責 引開雙親的注意，一隻負責 偷走蛋，非常地狡猾奸詐。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "居合斬"
+	attacks: [
+		{
+			name: {
+				ja: "いあいぎり",
+				'zh-tw': "居合斬",
+			},
+			damage: 10,
+			cost: ["Water"],
 		},
-
-		damage: 10,
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "逼近"
+		{
+			name: {
+				ja: "つめよる",
+				'zh-tw': "逼近",
+			},
+			damage: 30,
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773762,
+				tcgplayer: 566264,
+			},
 		},
-
-		damage: 30,
-		cost: ["Water", "Water"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Common"
-}
+	rarity: "Common",
+	dexId: [215],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/014.ts
+++ b/data-asia/SV/SV6a/014.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "瑪狃拉"
+		ja: "マニューラ",
+		'zh-tw': "瑪狃拉",
 	},
 
 	illustrator: "aspara",
@@ -14,39 +14,56 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "４～５隻一組行動。 在岩石和樹木上留下記號， 以團隊合作捕殺獵物。"
+		ja: "４～５匹の グループで 行動。 岩や 樹木に サインを 残し 連係して 獲物を 仕留める。",
+		'zh-tw': "４～５隻一組行動。 在岩石和樹木上留下記號， 以團隊合作捕殺獵物。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "劈開"
+	attacks: [
+		{
+			name: {
+				ja: "きりさく",
+				'zh-tw': "劈開",
+			},
+			damage: 40,
+			cost: ["Water"],
 		},
-
-		damage: 40,
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "冰雹爪"
+		{
+			name: {
+				ja: "ヘイルクロー",
+				'zh-tw': "冰雹爪",
+			},
+			damage: 70,
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "このポケモンについているエネルギーをすべてトラッシュし、相手のバトルポケモンをマヒにする。",
+				'zh-tw': "將這隻寶可夢身上附加的能量卡全部丟棄，將對手的戰鬥寶可夢【麻痺】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將這隻寶可夢身上附加的能量卡全部丟棄，將對手的戰鬥寶可夢【麻痺】。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773763,
+				tcgplayer: 566265,
+			},
 		},
+	],
 
-		damage: 70,
-		cost: ["Water", "Water"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ニューラ",
+	},
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+	dexId: [461],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/015.ts
+++ b/data-asia/SV/SV6a/015.ts
@@ -1,52 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "普隆隆姆ex"
+		ja: "ブロロロームex",
+		'zh-tw': "普隆隆姆ex",
 	},
 
 	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
 	hp: 280,
 	types: ["Lightning"],
+
 	stage: "Stage1",
-	suffix: "EX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "暴衝閃光"
+	attacks: [
+		{
+			name: {
+				ja: "アクセルフラッシュ",
+				'zh-tw': "暴衝閃光",
+			},
+			damage: "20+",
+			cost: ["Metal"],
+			effect: {
+				ja: "この番、このポケモンがベンチからバトル場に出ていたなら、120ダメージ追加。",
+				'zh-tw': "在這個回合，若從備戰區將這隻寶可夢放置於戰鬥場，則增加120點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在這個回合，若從備戰區將這隻寶可夢放置於戰鬥場，則增加120點傷害。"
+		{
+			name: {
+				ja: "スピードブレイク",
+				'zh-tw': "高速破壞",
+			},
+			damage: 250,
+			cost: ["Metal", "Metal", "Metal"],
+			effect: {
+				ja: "このポケモンと、ついているすべてのカードを、トラッシュする。",
+				'zh-tw': "將這隻寶可夢與附加的卡全部丟棄。",
+			},
 		},
+	],
 
-		damage: "20+",
-		cost: ["Metal"]
-	}, {
-		name: {
-			'zh-tw': "高速破壞"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773764,
+				tcgplayer: 566266,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將這隻寶可夢與附加的卡全部丟棄。"
-		},
-
-		damage: 250,
-		cost: ["Metal", "Metal", "Metal"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ブロロン",
+	},
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Double rare"
-}
+	rarity: "Double rare",
+	dexId: [966],
 
-export default card
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV6a/016.ts
+++ b/data-asia/SV/SV6a/016.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "催眠貘"
+		ja: "スリープ",
+		'zh-tw': "催眠貘",
 	},
 
 	illustrator: "OKUBO",
@@ -14,37 +14,44 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "據說當牠抽動凸出的鼻子， 無論是誰在哪裡做著什麼夢， 都會被牠知道得一清二楚。"
+		ja: "突き出た 鼻を ひくひくさせると どこの だれが どんな 夢を 見ているのか 全部 わかるという。",
+		'zh-tw': "據說當牠抽動凸出的鼻子， 無論是誰在哪裡做著什麼夢， 都會被牠知道得一清二楚。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "不祥視線"
+	attacks: [
+		{
+			name: {
+				ja: "ぶきみなしせん",
+				'zh-tw': "不祥視線",
+			},
+			damage: 10,
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手の手札を見る。",
+				'zh-tw': "查看對手的手牌。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "查看對手的手牌。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773765,
+				tcgplayer: 566267,
+			},
 		},
-
-		damage: 10,
-		cost: ["Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 2,
 	regulationMark: "H",
-	rarity: "Common"
-}
+	rarity: "Common",
+	dexId: [96],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/017.ts
+++ b/data-asia/SV/SV6a/017.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "引夢貘人"
+		ja: "スリーパー",
+		'zh-tw': "引夢貘人",
 	},
 
 	illustrator: "Masako Tomii",
@@ -14,37 +14,48 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "會以固定的節奏擺動著 形影不離的鐘擺。一靠近牠 就會不由自主地昏昏欲睡。"
+		ja: "どんなときでも 持っている 振り子を 決まったリズムで 揺らしている。 近寄ると なぜか 眠くなる。",
+		'zh-tw': "會以固定的節奏擺動著 形影不離的鐘擺。一靠近牠 就會不由自主地昏昏欲睡。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "白日夢"
+	attacks: [
+		{
+			name: {
+				ja: "はくちゅうむ",
+				'zh-tw': "白日夢",
+			},
+			damage: 80,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンに、相手が手札からエネルギーをつけたなら、相手の番は終わる。",
+				'zh-tw': "在下個對手的回合，若對手從手牌將能量卡附於受到這個招式的寶可夢身上，則對手的回合結束。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，若對手從手牌將能量卡附於受到這個招式的寶可夢身上，則對手的回合結束。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773766,
+				tcgplayer: 566268,
+			},
 		},
+	],
 
-		damage: 80,
-		cost: ["Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "スリープ",
+	},
 
 	retreat: 2,
 	regulationMark: "H",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+	dexId: [97],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/018.ts
+++ b/data-asia/SV/SV6a/018.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "夜巡靈"
+		ja: "ヨマワル",
+		'zh-tw': "夜巡靈",
 	},
 
 	illustrator: "IKEDA Saki",
@@ -14,43 +14,51 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "遭到牠鮮紅的獨眼瞪視 並且被吸取生物能量時， 會受到嚴重的寒氣侵襲。"
+		ja: "真っ赤な ひとつ目で 睨みつけられ 生体エネルギーを 吸われるとき ひどい 寒気に 襲われる。",
+		'zh-tw': "遭到牠鮮紅的獨眼瞪視 並且被吸取生物能量時， 會受到嚴重的寒氣侵襲。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "前往渡魂"
+	attacks: [
+		{
+			name: {
+				ja: "むかえにいく",
+				'zh-tw': "前往渡魂",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のトラッシュから「ヨマワル」を3枚まで選び、ベンチに出す。",
+				'zh-tw': "從自己的棄牌區選擇最多3張「夜巡靈」，放置於備戰區。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的棄牌區選擇最多3張「夜巡靈」，放置於備戰區。"
+		{
+			name: {
+				ja: "つぶやく",
+				'zh-tw': "囈語",
+			},
+			damage: 30,
+			cost: ["Psychic", "Psychic"],
 		},
+	],
 
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "囈語"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773767,
+				tcgplayer: 566269,
+			},
 		},
-
-		damage: 30,
-		cost: ["Psychic", "Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Common"
-}
+	rarity: "Common",
+	dexId: [355],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/019.ts
+++ b/data-asia/SV/SV6a/019.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "彷徨夜靈"
+		ja: "サマヨール",
+		'zh-tw': "彷徨夜靈",
 	},
 
 	illustrator: "Aya Kusube",
@@ -14,41 +14,54 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "據說在體內燃燒著的鮮紅獨眼 是彷徨夜靈的本體， 但沒有人親眼見過。"
+		ja: "体の中で 燃えている 真っ赤な ひとつ目が サマヨールの 本体と いわれるが 誰も 見ていない。",
+		'zh-tw': "據說在體內燃燒著的鮮紅獨眼 是彷徨夜靈的本體， 但沒有人親眼見過。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "‌[特性]咒詛炸彈"
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "カースドボム" },
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、このポケモンをきぜつさせる。相手のポケモン1匹に、ダメカンを5個のせる。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時可使用1次，若使用，則將這隻寶可夢【昏厥】。在對手的1隻寶可夢身上放置5個傷害指示物。"
-		}
-	}, {
-		name: {
-			'zh-tw': "鬼火"
+	attacks: [
+		{
+			name: {
+				ja: "おにび",
+				'zh-tw': "‌[特性]咒詛炸彈",
+			},
+			damage: 50,
+			cost: ["Psychic", "Psychic"],
 		},
+	],
 
-		damage: 50,
-		cost: ["Psychic", "Psychic"]
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773768,
+				tcgplayer: 566270,
+			},
+		},
+	],
 
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ヨマワル",
+	},
 
 	retreat: 2,
 	regulationMark: "H",
-	rarity: "Common"
-}
+	rarity: "Common",
+	dexId: [356],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/020.ts
+++ b/data-asia/SV/SV6a/020.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "黑夜魔靈"
+		ja: "ヨノワール",
+		'zh-tw': "黑夜魔靈",
 	},
 
 	illustrator: "danciao",
@@ -14,45 +14,58 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "在這個世界與另一個世界間往返。 據說會吸入並帶走遊蕩的靈魂， 因此遭到人們畏懼。"
+		ja: "この世と あの世を 行ったり来たり。 さまよう 魂を 吸い込んで 運ぶと いわれ 恐れられている。",
+		'zh-tw': "在這個世界與另一個世界間往返。 據說會吸入並帶走遊蕩的靈魂， 因此遭到人們畏懼。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "‌[特性]咒詛炸彈"
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "カースドボム" },
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、このポケモンをきぜつさせる。相手のポケモン1匹に、ダメカンを13個のせる。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時可使用1次，若使用，則將這隻寶可夢【昏厥】。在對手的1隻寶可夢身上放置13個傷害指示物。"
-		}
-	}, {
-		name: {
-			'zh-tw': "影子束縛"
+	attacks: [
+		{
+			name: {
+				ja: "かげしばり",
+				'zh-tw': "‌[特性]咒詛炸彈",
+			},
+			damage: 150,
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+				'zh-tw': "在自己的回合時可使用1次，若使用，則將這隻寶可夢【昏厥】。在對手的1隻寶可夢身上放置13個傷害指示物。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773769,
+				tcgplayer: 566271,
+			},
 		},
+	],
 
-		damage: 150,
-		cost: ["Psychic", "Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "サマヨール",
+	},
 
 	retreat: 3,
 	regulationMark: "H",
-	rarity: "Rare"
-}
+	rarity: "Rare",
+	dexId: [477],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/021.ts
+++ b/data-asia/SV/SV6a/021.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "克雷色利亞"
+		ja: "クレセリア",
+		'zh-tw': "克雷色利亞",
 	},
 
 	illustrator: "matazo",
@@ -14,47 +14,55 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "飛行時，會從薄紗般的翅膀 發出閃亮的粒子。 被稱為新月的化身。"
+		ja: "飛行するときは ベールのような 羽から 光る 粒子を 出す。 三日月の化身と 呼ばれている。",
+		'zh-tw': "飛行時，會從薄紗般的翅膀 發出閃亮的粒子。 被稱為新月的化身。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "治癒之舞"
+	attacks: [
+		{
+			name: {
+				ja: "いやしのまい",
+				'zh-tw': "治癒之舞",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のポケモン全員のHPを、それぞれ「20」回復する。",
+				'zh-tw': "將自己的所有寶可夢各恢復「20」HP。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將自己的所有寶可夢各恢復「20」HP。"
+		{
+			name: {
+				ja: "クレセントパージ",
+				'zh-tw': "弦月光芒",
+			},
+			damage: "80+",
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "のぞむなら、ウラになっている自分のサイドを1枚選び、オモテにする。その場合、80ダメージ追加。（対戦が終わるまで、そのサイドはオモテのまま。）",
+				'zh-tw': "若希望，選擇1張自己的反面朝上的獎賞卡，翻到正面。這個情況下，增加80點傷害。（在對戰結束前，那張獎賞卡維持正面朝上。）",
+			},
 		},
+	],
 
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "弦月光芒"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773770,
+				tcgplayer: 566272,
+			},
 		},
-
-		effect: {
-			'zh-tw': "若希望，選擇1張自己的反面朝上的獎賞卡，翻到正面。這個情況下，增加80點傷害。（在對戰結束前，那張獎賞卡維持正面朝上。）"
-		},
-
-		damage: "80+",
-		cost: ["Psychic", "Psychic", "Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Rare"
-}
+	rarity: "Rare",
+	dexId: [488],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/022.ts
+++ b/data-asia/SV/SV6a/022.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "仙子伊布"
+		ja: "ニンフィア",
+		'zh-tw': "仙子伊布",
 	},
 
 	illustrator: "Kuroimori",
@@ -14,42 +14,59 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "搖曳著觸角跳著輕快 舞蹈的樣子相當優雅， 但招式卻會直搗對手要害。"
+		ja: "触角を なびかせ 軽やかに 舞う 姿は 優雅だが 技は 鋭く 急所を 狙う。",
+		'zh-tw': "搖曳著觸角跳著輕快 舞蹈的樣子相當優雅， 但招式卻會直搗對手要害。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "奧密迴旋"
+	attacks: [
+		{
+			name: {
+				ja: "ミスティックリターン",
+				'zh-tw': "奧密迴旋",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のベンチポケモンを1匹選び、そのポケモンと、ついているすべてのカードを、相手の山札にもどして切る。",
+				'zh-tw': "擲1次硬幣若為正面，則選擇1隻對手的備戰寶可夢，將那隻寶可夢與附加的卡全部放回對手的牌庫並重洗。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則選擇1隻對手的備戰寶可夢，將那隻寶可夢與附加的卡全部放回對手的牌庫並重洗。"
+		{
+			name: {
+				ja: "チャームボイス",
+				'zh-tw': "魅惑之聲",
+			},
+			damage: 90,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【混亂】。",
+			},
 		},
+	],
 
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "魅惑之聲"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773771,
+				tcgplayer: 566273,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【混亂】。"
-		},
-
-		damage: 90,
-		cost: ["Psychic", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "イーブイ",
+	},
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+	dexId: [700],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/023.ts
+++ b/data-asia/SV/SV6a/023.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "不良蛙"
+		ja: "グレッグル",
+		'zh-tw': "不良蛙",
 	},
 
 	illustrator: "Aliya Chen",
@@ -14,39 +14,52 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "很少會堂堂正正地戰鬥， 但那都是為了要生存下去。 作為吉祥物非常受歡迎。"
+		ja: "正々堂々と 戦うことは 少ないが それも 生き延びるため。 マスコットとして 人気が 高い。",
+		'zh-tw': "很少會堂堂正正地戰鬥， 但那都是為了要生存下去。 作為吉祥物非常受歡迎。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "打擊"
+	attacks: [
+		{
+			name: {
+				ja: "なぐる",
+				'zh-tw': "打擊",
+			},
+			damage: 10,
+			cost: ["Fighting"],
 		},
-
-		damage: 10,
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "蛙跳"
+		{
+			name: {
+				ja: "かえるとび",
+				'zh-tw': "蛙跳",
+			},
+			damage: "20+",
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+				'zh-tw': "擲1次硬幣若為正面，則增加20點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則增加20點傷害。"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773772,
+				tcgplayer: 566274,
+			},
 		},
-
-		damage: "20+",
-		cost: ["Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Common"
-}
+	rarity: "Common",
+	dexId: [453],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/024.ts
+++ b/data-asia/SV/SV6a/024.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "毒骷蛙"
+		ja: "ドクロッグ",
+		'zh-tw': "毒骷蛙",
 	},
 
 	illustrator: "Anesaki Dynamic",
@@ -14,39 +14,56 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "喉嚨處有著毒囊。 從喉嚨發出鳴叫時， 積存的毒素就會被煉製得更加強勁。"
+		ja: "のど元に 毒袋を 持つ。 のどを 鳴らすと 溜まった 毒は 練りこまれ 強力になる。",
+		'zh-tw': "喉嚨處有著毒囊。 從喉嚨發出鳴叫時， 積存的毒素就會被煉製得更加強勁。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "推擊"
+	attacks: [
+		{
+			name: {
+				ja: "どつく",
+				'zh-tw': "推擊",
+			},
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
 		},
-
-		damage: 50,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "俐落一擊"
+		{
+			name: {
+				ja: "クリーンヒット",
+				'zh-tw': "俐落一擊",
+			},
+			damage: "90+",
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが進化ポケモンなら、90ダメージ追加。",
+				'zh-tw': "若對手的戰鬥寶可夢為進化寶可夢，則增加90點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若對手的戰鬥寶可夢為進化寶可夢，則增加90點傷害。"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773773,
+				tcgplayer: 566275,
+			},
 		},
+	],
 
-		damage: "90+",
-		cost: ["Fighting", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "グレッグル",
+	},
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Common"
-}
+	rarity: "Common",
+	dexId: [454],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/025.ts
+++ b/data-asia/SV/SV6a/025.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "月月熊 赫月"
+		ja: "ガチグマ アカツキ",
+		'zh-tw': "月月熊 赫月",
 	},
 
 	illustrator: "Souichirou Gunjima",
@@ -14,44 +14,58 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "會用堅硬如鐵的泥巴保護身體， 且擁有能夠看穿黑暗的左眼。 是特別的月月熊。"
+		ja: "鉄のように 硬い 泥で 身を 守り 闇を 見通す 左目を 持つ 特別な ガチグマ。",
+		'zh-tw': "會用堅硬如鐵的泥巴保護身體， 且擁有能夠看穿黑暗的左眼。 是特別的月月熊。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "經驗法則"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "けいけんそく",
+				'zh-tw': "經驗法則",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の手札から「基本[F]エネルギー」を2枚まで選び、このポケモンにつける。",
+				'zh-tw': "在自己的回合，從手牌將這張卡放置於備戰區時，可使用1次。從自己的手牌選擇最多2張「基本【鬥】能量」卡，附於這隻寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，從手牌將這張卡放置於備戰區時，可使用1次。從自己的手牌選擇最多2張「基本【鬥】能量」卡，附於這隻寶可夢身上。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "瘋狂啃咬"
+	attacks: [
+		{
+			name: {
+				ja: "マッドバイト",
+				'zh-tw': "瘋狂啃咬",
+			},
+			damage: "100+",
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにのっているダメカンの数×30ダメージ追加。",
+				'zh-tw': "增加對手的戰鬥寶可夢身上放置的傷害指示物的數量×30點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加對手的戰鬥寶可夢身上放置的傷害指示物的數量×30點傷害。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773774,
+				tcgplayer: 566276,
+			},
 		},
-
-		damage: "100+",
-		cost: ["Fighting", "Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	],
 
 	retreat: 4,
 	regulationMark: "H",
-	rarity: "Rare"
-}
+	rarity: "Rare",
+	dexId: [901],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/026.ts
+++ b/data-asia/SV/SV6a/026.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "爬地翅"
+		ja: "チヲハウハネ",
+		'zh-tw': "爬地翅",
 	},
 
 	illustrator: "Shinji Kanda",
@@ -14,43 +14,56 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "與古老書籍裡介紹的一種 叫做爬地翅的生物有著 相似點的神秘寶可夢。"
+		ja: "古い 本で チヲハウハネと 紹介されている 生物に 似た点が ある 謎のポケモン。",
+		'zh-tw': "與古老書籍裡介紹的一種 叫做爬地翅的生物有著 相似點的神秘寶可夢。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "鐵碎"
+	attacks: [
+		{
+			name: {
+				ja: "てつつぶし",
+				'zh-tw': "鐵碎",
+			},
+			damage: "20+",
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "相手の場に「未来」のポケモンがいるなら、120ダメージ追加。",
+				'zh-tw': "若對手的場上有「未來」寶可夢，則增加120點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "若對手的場上有「未來」寶可夢，則增加120點傷害。"
+		{
+			name: {
+				ja: "スマッシュウイング",
+				'zh-tw': "粉碎之翼",
+			},
+			damage: 130,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+				'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		damage: "20+",
-		cost: ["Fighting", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "粉碎之翼"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773775,
+				tcgplayer: 566277,
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。"
-		},
-
-		damage: 130,
-		cost: ["Fighting", "Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	],
 
 	retreat: 3,
 	regulationMark: "H",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+	dexId: [988],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/027.ts
+++ b/data-asia/SV/SV6a/027.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "超音蝠"
+		ja: "ズバット",
+		'zh-tw': "超音蝠",
 	},
 
 	illustrator: "osare",
@@ -14,43 +14,51 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "會利用從口中發出的超音波 探查周圍的狀況。在狹窄的 洞窟裡也能靈巧地飛來飛去。"
+		ja: "口から 出す 超音波で まわりの 様子を 探る。 狭い 洞窟も 器用に 飛びまわる。",
+		'zh-tw': "會利用從口中發出的超音波 探查周圍的狀況。在狹窄的 洞窟裡也能靈巧地飛來飛去。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "引路"
+	attacks: [
+		{
+			name: {
+				ja: "みちびく",
+				'zh-tw': "引路",
+			},
+			cost: ["Darkness"],
+			effect: {
+				ja: "自分の山札からサポートを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張支援者卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張支援者卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		{
+			name: {
+				ja: "やみのキバ",
+				'zh-tw': "暗之牙",
+			},
+			damage: 10,
+			cost: ["Darkness"],
 		},
+	],
 
-		cost: ["Darkness"]
-	}, {
-		name: {
-			'zh-tw': "暗之牙"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773776,
+				tcgplayer: 566278,
+			},
 		},
-
-		damage: 10,
-		cost: ["Darkness"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Common"
-}
+	rarity: "Common",
+	dexId: [41],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/028.ts
+++ b/data-asia/SV/SV6a/028.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "大嘴蝠"
+		ja: "ゴルバット",
+		'zh-tw': "大嘴蝠",
 	},
 
 	illustrator: "Teeziro",
@@ -14,44 +14,56 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "喜歡吸食生物的血液。 據說還會將吸來的血 分給空腹的夥伴。"
+		ja: "生き物の 血液が 好物。 腹ペコの 仲間に 吸った 血を 分け与えることも あるという。",
+		'zh-tw': "喜歡吸食生物的血液。 據說還會將吸來的血 分給空腹的夥伴。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "高速飛行"
+	attacks: [
+		{
+			name: {
+				ja: "スピードひこう",
+				'zh-tw': "高速飛行",
+			},
+			damage: 30,
+			cost: ["Darkness"],
 		},
-
-		damage: 30,
-		cost: ["Darkness"]
-	}, {
-		name: {
-			'zh-tw': "漆黑利刃"
+		{
+			name: {
+				ja: "しっこくのやいば",
+				'zh-tw': "漆黑利刃",
+			},
+			damage: 80,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773777,
+				tcgplayer: 566279,
+			},
 		},
+	],
 
-		damage: 80,
-		cost: ["Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ズバット",
+	},
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Common"
-}
+	rarity: "Common",
+	dexId: [42],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/029.ts
+++ b/data-asia/SV/SV6a/029.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "叉字蝠"
+		ja: "クロバット",
+		'zh-tw': "叉字蝠",
 	},
 
 	illustrator: "Nisota Niso",
@@ -14,49 +14,62 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "雙腳變成了翅膀。 能夠無聲無息地高速飛行， 用獠牙咬住獵物的後頸。"
+		ja: "両足が 羽に 変化。 音を たてずに 高速で 飛び 獲物の うなじに キバを たてる。",
+		'zh-tw': "雙腳變成了翅膀。 能夠無聲無息地高速飛行， 用獠牙咬住獵物的後頸。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "怨影使者"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "かげのつかい",
+				'zh-tw': "怨影使者",
+			},
+			effect: {
+				ja: "この番、手札から「アンズの秘技」を出して使っていたなら、自分の番に1回使える。自分の手札が8枚になるように、山札を引く。",
+				'zh-tw': "在這個回合，若從手牌使出了「‌阿杏的秘招」，則在自己的回合時可使用1次。從牌庫抽卡直到自己的手牌滿8張為止。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在這個回合，若從手牌使出了「‌阿杏的秘招」，則在自己的回合時可使用1次。從牌庫抽卡直到自己的手牌滿8張為止。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "劇毒牙"
+	attacks: [
+		{
+			name: {
+				ja: "どくどくのキバ",
+				'zh-tw': "劇毒牙",
+			},
+			damage: 120,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。このどくでのせるダメカンの数は2個になる。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】。因這個【中毒】而放置的傷害指示物的數量改為2個。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。因這個【中毒】而放置的傷害指示物的數量改為2個。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773778,
+				tcgplayer: 566280,
+			},
 		},
+	],
 
-		damage: 120,
-		cost: ["Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ゴルバット",
+	},
 
 	retreat: 0,
 	regulationMark: "H",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+	dexId: [169],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/030.ts
+++ b/data-asia/SV/SV6a/030.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "阿勃梭魯"
+		ja: "アブソル",
+		'zh-tw': "阿勃梭魯",
 	},
 
 	illustrator: "rika",
@@ -14,32 +14,44 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "如風般地奔馳在山野中。 形狀如弓的角能夠敏銳 感應到自然災害的預兆。"
+		ja: "風のように 野山を 駆けぬける。 弓なりの ツノは 自然災害の 予兆を 敏感に 感じとる。",
+		'zh-tw': "如風般地奔馳在山野中。 形狀如弓的角能夠敏銳 感應到自然災害的預兆。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "惡棍墜落"
+	attacks: [
+		{
+			name: {
+				ja: "バッドフォール",
+				'zh-tw': "惡棍墜落",
+			},
+			damage: "20+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の場に[D]エネルギーが3個以上あるなら、50ダメージ追加。",
+				'zh-tw': "若自己的場上的【惡】能量有3個以上，則增加50點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若自己的場上的【惡】能量有3個以上，則增加50點傷害。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773779,
+				tcgplayer: 566281,
+			},
 		},
-
-		damage: "20+",
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Common"
-}
+	rarity: "Common",
+	dexId: [359],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/031.ts
+++ b/data-asia/SV/SV6a/031.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "索羅亞"
+		ja: "ゾロア",
+		'zh-tw': "索羅亞",
 	},
 
 	illustrator: "Yuu Nishida",
@@ -14,39 +14,52 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "會化為人類或其他的寶可夢。 透過隱藏自己原本的面貌， 保護自己不遇危險。"
+		ja: "人や ほかの ポケモンに 化ける。 自分の 正体を 隠すことで 危険から 身を 守っているのだ。",
+		'zh-tw': "會化為人類或其他的寶可夢。 透過隱藏自己原本的面貌， 保護自己不遇危險。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "踩"
+	attacks: [
+		{
+			name: {
+				ja: "ふむ",
+				'zh-tw': "踩",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
-
-		damage: 10,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "雙重抓"
+		{
+			name: {
+				ja: "ダブルひっかき",
+				'zh-tw': "雙重抓",
+			},
+			damage: "20×",
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×20ダメージ。",
+				'zh-tw': "擲2次硬幣，造成正面出現的次數×20點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲2次硬幣，造成正面出現的次數×20點傷害。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773780,
+				tcgplayer: 566282,
+			},
 		},
-
-		damage: "20×",
-		cost: ["Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Common"
-}
+	rarity: "Common",
+	dexId: [570],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/032.ts
+++ b/data-asia/SV/SV6a/032.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "索羅亞克"
+		ja: "ゾロアーク",
+		'zh-tw': "索羅亞克",
 	},
 
 	illustrator: "nagimiso",
@@ -14,39 +14,56 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "有著一口氣迷惑許多人的力量。 會讓人看見虛幻的景色， 以保護自己的居所。"
+		ja: "いっぺんに 大勢の 人を 化かす 力を 持つ。 幻の 景色を 見せて 棲み処を 守る。",
+		'zh-tw': "有著一口氣迷惑許多人的力量。 會讓人看見虛幻的景色， 以保護自己的居所。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "幻影劫持"
+	attacks: [
+		{
+			name: {
+				ja: "げんえいジャック",
+				'zh-tw': "幻影劫持",
+			},
+			damage: "60×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手の場の「ポケモンex・V」の数×60ダメージ。",
+				'zh-tw': "造成對手的場上的「寶可夢【ex】・【V】」的數量×60點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "造成對手的場上的「寶可夢【ex】・【V】」的數量×60點傷害。"
+		{
+			name: {
+				ja: "ツメできりさく",
+				'zh-tw': "利爪劈擊",
+			},
+			damage: 110,
+			cost: ["Darkness", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: "60×",
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "利爪劈擊"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773781,
+				tcgplayer: 566283,
+			},
 		},
+	],
 
-		damage: 110,
-		cost: ["Darkness", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ゾロア",
+	},
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Rare"
-}
+	rarity: "Rare",
+	dexId: [571],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/033.ts
+++ b/data-asia/SV/SV6a/033.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "好啦魷"
+		ja: "マーイーカ",
+		'zh-tw': "好啦魷",
 	},
 
 	illustrator: "Mori Yuu",
@@ -14,38 +14,51 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "旋轉著閃爍自己的發光體。 透過改變閃爍的方式 來和其他夥伴交流。"
+		ja: "回転しながら 発光体を 点滅。 光の パターンで 仲間と コミュニケーションする。",
+		'zh-tw': "旋轉著閃爍自己的發光體。 透過改變閃爍的方式 來和其他夥伴交流。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "惡作劇觸手"
+	attacks: [
+		{
+			name: {
+				ja: "いたずらしょくしゅ",
+				'zh-tw': "惡作劇觸手",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手の山札を上から1枚見て、もとにもどす。のぞむなら、その山札を切る。",
+				'zh-tw': "查看對手的牌庫上方1張卡，回復原樣。若希望，重洗那個牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "查看對手的牌庫上方1張卡，回復原樣。若希望，重洗那個牌庫。"
+		{
+			name: {
+				ja: "つつく",
+				'zh-tw': "啄",
+			},
+			damage: 10,
+			cost: ["Darkness"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "啄"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773782,
+				tcgplayer: 566284,
+			},
 		},
-
-		damage: 10,
-		cost: ["Darkness"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Common"
-}
+	rarity: "Common",
+	dexId: [686],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/034.ts
+++ b/data-asia/SV/SV6a/034.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "烏賊王"
+		ja: "カラマネロ",
+		'zh-tw': "烏賊王",
 	},
 
 	illustrator: "akagi",
@@ -14,38 +14,55 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "要是盯著牠的發光體看， 就會馬上陷入催眠狀態， 並且受到牠的控制。"
+		ja: "発光体の 光を 見つめると たちまち 催眠状態になり カラマネロに 操られてしまう。",
+		'zh-tw': "要是盯著牠的發光體看， 就會馬上陷入催眠狀態， 並且受到牠的控制。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "勾結觸手"
+	attacks: [
+		{
+			name: {
+				ja: "けったくテンタクル",
+				'zh-tw': "勾結觸手",
+			},
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、新しく出てきたポケモンに120ダメージ。この番、手札から「クセロシキのたくらみ」を出して使っていないなら、このワザは失敗。",
+				'zh-tw': "選擇1隻對手的備戰寶可夢，與戰鬥寶可夢互換。然後，新上場的寶可夢受到120點傷害。在這個回合，若沒有從手牌使出「‌‌庫瑟洛斯奇的企圖」，則這個招式失敗。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇1隻對手的備戰寶可夢，與戰鬥寶可夢互換。然後，新上場的寶可夢受到120點傷害。在這個回合，若沒有從手牌使出「‌‌庫瑟洛斯奇的企圖」，則這個招式失敗。"
+		{
+			name: {
+				ja: "かいてんアタック",
+				'zh-tw': "迴轉攻擊",
+			},
+			damage: 90,
+			cost: ["Darkness", "Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Darkness"]
-	}, {
-		name: {
-			'zh-tw': "迴轉攻擊"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773783,
+				tcgplayer: 566285,
+			},
 		},
+	],
 
-		damage: 90,
-		cost: ["Darkness", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "マーイーカ",
+	},
 
 	retreat: 3,
 	regulationMark: "H",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+	dexId: [687],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/035.ts
+++ b/data-asia/SV/SV6a/035.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伊裴爾塔爾"
+		ja: "イベルタル",
+		'zh-tw': "伊裴爾塔爾",
 	},
 
 	illustrator: "SIE NANAHARA",
@@ -14,47 +14,55 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "傳說的寶可夢。據說當牠 展開的翅膀與尾羽閃耀紅色光芒時， 就會吸走生物的生命。"
+		ja: "翼と 尾羽を 広げて 赤く 輝くとき 生き物の 命を 吸い取る 伝説の ポケモン。",
+		'zh-tw': "傳說的寶可夢。據說當牠 展開的翅膀與尾羽閃耀紅色光芒時， 就會吸走生物的生命。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "侵蝕之風"
+	attacks: [
+		{
+			name: {
+				ja: "むしばむかぜ",
+				'zh-tw': "侵蝕之風",
+			},
+			cost: ["Darkness"],
+			effect: {
+				ja: "ダメカンがのっている相手のポケモン全員に、それぞれダメカンを2個のせる。",
+				'zh-tw': "在對手的身上放置有傷害指示物的所有寶可夢身上，各放置2個傷害指示物。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在對手的身上放置有傷害指示物的所有寶可夢身上，各放置2個傷害指示物。"
+		{
+			name: {
+				ja: "はかいビーム",
+				'zh-tw': "破壞光束",
+			},
+			damage: 100,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "擲1次硬幣若為正面，則選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		cost: ["Darkness"]
-	}, {
-		name: {
-			'zh-tw': "破壞光束"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773784,
+				tcgplayer: 566286,
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。"
-		},
-
-		damage: 100,
-		cost: ["Darkness", "Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+	dexId: [717],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/036.ts
+++ b/data-asia/SV/SV6a/036.ts
@@ -1,51 +1,65 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "夠讚狗ex"
+		ja: "イイネイヌex",
+		'zh-tw': "夠讚狗ex",
 	},
 
 	illustrator: "takuyoa",
 	category: "Pokemon",
 	hp: 250,
 	types: ["Darkness"],
+
 	stage: "Basic",
-	suffix: "EX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "猛毒筋力"
+	attacks: [
+		{
+			name: {
+				ja: "ポイズンマッスル",
+				'zh-tw': "猛毒筋力",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から「基本[D]エネルギー」を2枚まで選び、このポケモンにつける。そして山札を切る。つけた場合、このポケモンをどくにする。",
+				'zh-tw': "從自己的牌庫選擇最多2張「基本【惡】能量」卡，附於這隻寶可夢身上。並且重洗牌庫。附上卡的情況下，將這隻寶可夢【中毒】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多2張「基本【惡】能量」卡，附於這隻寶可夢身上。並且重洗牌庫。附上卡的情況下，將這隻寶可夢【中毒】。"
+		{
+			name: {
+				ja: "クレイジーチェーン",
+				'zh-tw': "瘋狂連鎖",
+			},
+			damage: "130+",
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "このポケモンがどくなら、130ダメージ追加。",
+				'zh-tw': "若這隻寶可夢【中毒】，則增加130點傷害。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "瘋狂連鎖"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773785,
+				tcgplayer: 566287,
+			},
 		},
-
-		effect: {
-			'zh-tw': "若這隻寶可夢【中毒】，則增加130點傷害。"
-		},
-
-		damage: "130+",
-		cost: ["Darkness", "Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 3,
 	regulationMark: "H",
-	rarity: "Double rare"
-}
+	rarity: "Double rare",
+	dexId: [1014],
 
-export default card
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV6a/037.ts
+++ b/data-asia/SV/SV6a/037.ts
@@ -1,49 +1,64 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "願增猿ex"
+		ja: "マシマシラex",
+		'zh-tw': "願增猿ex",
 	},
 
 	illustrator: "takuyoa",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Darkness"],
+
 	stage: "Basic",
-	suffix: "EX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "‌[特性]鬆口氣"
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひょうしぬけ" },
+			effect: {
+				ja: "このポケモンが、相手のポケモンからワザのダメージを受けてきぜつしたとき、自分の場に「モモワロウex」がいるなら、とられるサイドは1枚少なくなる。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢受到對手的寶可夢招式的傷害而【昏厥】時，若自己的場上有「桃歹郎ex」，則被獲得的獎賞卡減少1張。"
-		}
-	}, {
-		name: {
-			'zh-tw': "惡劣頭擊"
+	attacks: [
+		{
+			name: {
+				ja: "ダーティヘッド",
+				'zh-tw': "‌[特性]鬆口氣",
+			},
+			damage: 190,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「ダーティヘッド」が使えない。",
+				'zh-tw': "這隻寶可夢受到對手的寶可夢招式的傷害而【昏厥】時，若自己的場上有「桃歹郎ex」，則被獲得的獎賞卡減少1張。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「惡劣頭擊」。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773786,
+				tcgplayer: 566288,
+			},
 		},
-
-		damage: 190,
-		cost: ["Darkness", "Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Double rare"
-}
+	rarity: "Double rare",
+	dexId: [1015],
 
-export default card
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV6a/038.ts
+++ b/data-asia/SV/SV6a/038.ts
@@ -1,48 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "吉雉雞ex"
+		ja: "キチキギスex",
+		'zh-tw': "吉雉雞ex",
 	},
 
 	illustrator: "takuyoa",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Darkness"],
+
 	stage: "Basic",
-	suffix: "EX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "‌‌[特性]扭轉乾坤"
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "さかてにとる" },
+			effect: {
+				ja: "前の相手の番に、自分のポケモンがきぜつしていたなら、自分の番に1回使える。自分の山札を3枚引く。この番、すでに別の「さかてにとる」を使っていたなら、この特性は使えない。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在上個對手的回合，若自己的寶可夢【昏厥】了，則在自己的回合時可使用1次。從自己的牌庫抽出3張卡。在這個回合，若已經使出了其他的「扭轉乾坤」，則這個特性無法使用。"
-		}
-	}, {
-		name: {
-			'zh-tw': "殘酷箭"
+	attacks: [
+		{
+			name: {
+				ja: "クルーエルアロー",
+				'zh-tw': "‌‌[特性]扭轉乾坤",
+			},
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、100ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "在上個對手的回合，若自己的寶可夢【昏厥】了，則在自己的回合時可使用1次。從自己的牌庫抽出3張卡。在這個回合，若已經使出了其他的「扭轉乾坤」，則這個特性無法使用。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "對手的1隻寶可夢受到100點傷害。[在備戰區不計算弱點・抵抗力。]"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773787,
+				tcgplayer: 566289,
+			},
 		},
-
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Double rare"
-}
+	rarity: "Double rare",
+	dexId: [1016],
 
-export default card
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV6a/039.ts
+++ b/data-asia/SV/SV6a/039.ts
@@ -1,49 +1,64 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "桃歹郎ex"
+		ja: "モモワロウex",
+		'zh-tw': "桃歹郎ex",
 	},
 
 	illustrator: "aky CG Works",
 	category: "Pokemon",
 	hp: 190,
 	types: ["Darkness"],
+
 	stage: "Basic",
-	suffix: "EX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "‌‌[特性]支配鎖鏈"
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しはいのくさり" },
+			effect: {
+				ja: "自分の番に1回使える。自分のベンチの[D]ポケモン（「モモワロウex」をのぞく）を1匹選び、バトルポケモンと入れ替える。その後、新しいバトルポケモンをどくにする。この番、すでに別の「しはいのくさり」を使っていたなら、この特性は使えない。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時可使用1次。選擇1隻自己的備戰區的【惡】寶可夢（「桃歹郎ex」除外），與戰鬥寶可夢互換。然後，將新的戰鬥寶可夢【中毒】。在這個回合，若已經使出了其他的「支配鎖鏈」，則這個特性無法使用。"
-		}
-	}, {
-		name: {
-			'zh-tw': "煩煩爆炸"
+	attacks: [
+		{
+			name: {
+				ja: "イライラバースト",
+				'zh-tw': "‌‌[特性]支配鎖鏈",
+			},
+			damage: "60×",
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "相手がすでにとったサイドの枚数×60ダメージ。",
+				'zh-tw': "在自己的回合時可使用1次。選擇1隻自己的備戰區的【惡】寶可夢（「桃歹郎ex」除外），與戰鬥寶可夢互換。然後，將新的戰鬥寶可夢【中毒】。在這個回合，若已經使出了其他的「支配鎖鏈」，則這個特性無法使用。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "造成對手已經獲得的獎賞卡的張數×60點傷害。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773788,
+				tcgplayer: 566290,
+			},
 		},
-
-		damage: "60×",
-		cost: ["Darkness", "Darkness"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Double rare"
-}
+	rarity: "Double rare",
+	dexId: [1025],
 
-export default card
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV6a/040.ts
+++ b/data-asia/SV/SV6a/040.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "蓋諾賽克特"
+		ja: "ゲノセクト",
+		'zh-tw': "蓋諾賽克特",
 	},
 
 	illustrator: "Kazumasa Yasukuni",
@@ -14,41 +14,50 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "被等離子隊改造過的 古代的蟲寶可夢。 背上的大砲力量得到了提升。"
+		ja: "プラズマ団によって 改造された 古代の むしポケモン。 背中の 大砲が パワーアップした。",
+		'zh-tw': "被等離子隊改造過的 古代的蟲寶可夢。 背上的大砲力量得到了提升。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "‌‌[特性]ACE消弭"
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エースキャンセラー" },
+			effect: {
+				ja: "このポケモンに「ポケモンのどうぐ」がついているなら、相手は手札から「ACE SPEC」のカードを出して使えない。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢附有「寶可夢道具」卡，則對手無法從手牌使出「【ACE SPEC】」卡。"
-		}
-	}, {
-		name: {
-			'zh-tw': "磁力爆破"
+	attacks: [
+		{
+			name: {
+				ja: "マグネブラスト",
+				'zh-tw': "‌‌[特性]ACE消弭",
+			},
+			damage: 100,
+			cost: ["Metal", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 100,
-		cost: ["Metal", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773789,
+				tcgplayer: 566291,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+	dexId: [649],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/041.ts
+++ b/data-asia/SV/SV6a/041.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "銅象"
+		ja: "ゾウドウ",
+		'zh-tw': "銅象",
 	},
 
 	illustrator: "Shinya Mizuno",
@@ -14,40 +14,48 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "能夠舉起重達５噸的貨物。 天一亮就會成群結隊 前往洞窟找礦石來吃。"
+		ja: "５トンの 荷物を 持ち上げられる。 朝になると 群れで 洞窟へと 向かい エサの 鉱石を 探す。",
+		'zh-tw': "能夠舉起重達５噸的貨物。 天一亮就會成群結隊 前往洞窟找礦石來吃。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "撞擊"
+	attacks: [
+		{
+			name: {
+				ja: "たいあたり",
+				'zh-tw': "撞擊",
+			},
+			damage: 30,
+			cost: ["Metal", "Colorless"],
 		},
-
-		damage: 30,
-		cost: ["Metal", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "正面對決"
+		{
+			name: {
+				ja: "がちんこ",
+				'zh-tw': "正面對決",
+			},
+			damage: 70,
+			cost: ["Metal", "Metal", "Colorless"],
 		},
+	],
 
-		damage: 70,
-		cost: ["Metal", "Metal", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773790,
+				tcgplayer: 566292,
+			},
+		},
+	],
 
 	retreat: 3,
 	regulationMark: "H",
-	rarity: "Common"
-}
+	rarity: "Common",
+	dexId: [878],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/042.ts
+++ b/data-asia/SV/SV6a/042.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "大王銅象"
+		ja: "ダイオウドウ",
+		'zh-tw': "大王銅象",
 	},
 
 	illustrator: "kawayoo",
@@ -14,45 +14,58 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "自尊心強，脾氣刁鑽。 皮膚的綠色越是鮮豔， 就越受到同伴的尊敬。"
+		ja: "プライドが 高く 気難しい。 鮮やかな 緑の 皮膚の ものが 仲間の 尊敬を 集める。",
+		'zh-tw': "自尊心強，脾氣刁鑽。 皮膚的綠色越是鮮豔， 就越受到同伴的尊敬。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "‌‌[特性]爆大身軀"
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "どでかいからだ" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手は手札からスタジアムを出せない。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在戰鬥場上，對手無法從手牌使出競技場卡。"
-		}
-	}, {
-		name: {
-			'zh-tw': "鼻之金勾臂"
+	attacks: [
+		{
+			name: {
+				ja: "ノーズラリアット",
+				'zh-tw': "‌‌[特性]爆大身軀",
+			},
+			damage: "130+",
+			cost: ["Metal", "Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "のぞむなら、100ダメージ追加。その場合、次の自分の番、このポケモンはワザが使えない。",
+				'zh-tw': "只要這隻寶可夢在戰鬥場上，對手無法從手牌使出競技場卡。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若希望，增加100點傷害。這個情況下，在下個自己的回合，這隻寶可夢無法使用招式。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773791,
+				tcgplayer: 566293,
+			},
 		},
+	],
 
-		damage: "130+",
-		cost: ["Metal", "Metal", "Metal", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ゾウドウ",
+	},
 
 	retreat: 4,
 	regulationMark: "H",
-	rarity: "Rare"
-}
+	rarity: "Rare",
+	dexId: [879],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/043.ts
+++ b/data-asia/SV/SV6a/043.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "噗隆隆"
+		ja: "ブロロン",
+		'zh-tw': "噗隆隆",
 	},
 
 	illustrator: "HAGIYA Kaoru",
@@ -14,43 +14,51 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "鋼鐵身軀才是本體。 會貼在岩石上將其成分 轉換成活動用的能量。"
+		ja: "鋼の 体が 本体。 岩に 張りつき その成分を エネルギーに 変えて 活動する。",
+		'zh-tw': "鋼鐵身軀才是本體。 會貼在岩石上將其成分 轉換成活動用的能量。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "硬化"
+	attacks: [
+		{
+			name: {
+				ja: "こうちょく",
+				'zh-tw': "硬化",
+			},
+			cost: ["Metal"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-30」點。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-30」點。"
+		{
+			name: {
+				ja: "とびだしヘッド",
+				'zh-tw': "魯莽頭擊",
+			},
+			damage: 20,
+			cost: ["Metal", "Metal"],
 		},
+	],
 
-		cost: ["Metal"]
-	}, {
-		name: {
-			'zh-tw': "魯莽頭擊"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773792,
+				tcgplayer: 566294,
+			},
 		},
-
-		damage: 20,
-		cost: ["Metal", "Metal"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Common"
-}
+	rarity: "Common",
+	dexId: [965],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/044.ts
+++ b/data-asia/SV/SV6a/044.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "牙牙"
+		ja: "キバゴ",
+		'zh-tw': "牙牙",
 	},
 
 	illustrator: "Orca",
@@ -14,30 +14,48 @@ const card: Card = {
 	types: ["Dragon"],
 
 	description: {
-		'zh-tw': "如果在岩石或樹木上 發現了獨特的齒痕， 附近一定棲息著牙牙。"
+		ja: "岩や 樹木に 独特の 歯形を 見かけたら 近くに キバゴが 棲んでいるはずだ。",
+		'zh-tw': "如果在岩石或樹木上 發現了獨特的齒痕， 附近一定棲息著牙牙。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "抓"
+	attacks: [
+		{
+			name: {
+				ja: "ひっかく",
+				'zh-tw': "抓",
+			},
+			damage: 10,
+			cost: ["Fighting"],
 		},
-
-		damage: 10,
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "銳利之牙"
+		{
+			name: {
+				ja: "するどいキバ",
+				'zh-tw': "銳利之牙",
+			},
+			damage: 30,
+			cost: ["Fighting", "Metal"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Fighting", "Metal"]
-	}],
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773793,
+				tcgplayer: 566295,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "H",
-	rarity: "Common"
-}
+	rarity: "Common",
+	dexId: [610],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/045.ts
+++ b/data-asia/SV/SV6a/045.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "斧牙龍"
+		ja: "オノンド",
+		'zh-tw': "斧牙龍",
 	},
 
 	illustrator: "Uninori",
@@ -14,39 +14,62 @@ const card: Card = {
 	types: ["Dragon"],
 
 	description: {
-		'zh-tw': "會使用粗壯的牙齒俐落地 分解獵物，然後把當下 要吃的份與存糧的份分開。"
+		ja: "太い キバを 使って 獲物を きれいに 捌いて 食べるものと 保存する ものに 分けるのだ。",
+		'zh-tw': "會使用粗壯的牙齒俐落地 分解獵物，然後把當下 要吃的份與存糧的份分開。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "緊張感"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "きんちょうかん",
+				'zh-tw': "緊張感",
+			},
+			effect: {
+				ja: "このポケモンは、相手が手札からグッズまたはサポートを出して使ったとき、その効果を受けない。",
+				'zh-tw': "對手從手牌使出物品卡或者支援者卡時，這隻寶可夢不會受到那個效果的影響。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "對手從手牌使出物品卡或者支援者卡時，這隻寶可夢不會受到那個效果的影響。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "龍之波動"
+	attacks: [
+		{
+			name: {
+				ja: "りゅうのはどう",
+				'zh-tw': "龍之波動",
+			},
+			damage: 80,
+			cost: ["Fighting", "Metal"],
+			effect: {
+				ja: "自分の山札を上から1枚トラッシュする。",
+				'zh-tw': "將自己的牌庫上方1張卡丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將自己的牌庫上方1張卡丟棄。"
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773794,
+				tcgplayer: 566296,
+			},
 		},
+	],
 
-		damage: 80,
-		cost: ["Fighting", "Metal"]
-	}],
+	evolveFrom: {
+		ja: "キバゴ",
+	},
 
 	retreat: 2,
 	regulationMark: "H",
-	rarity: "Common"
-}
+	rarity: "Common",
+	dexId: [611],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/046.ts
+++ b/data-asia/SV/SV6a/046.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雙斧戰龍"
+		ja: "オノノクス",
+		'zh-tw': "雙斧戰龍",
 	},
 
 	illustrator: "Tsuyoshi Nagano",
@@ -14,37 +14,59 @@ const card: Card = {
 	types: ["Dragon"],
 
 	description: {
-		'zh-tw': "會以自傲的牙齒壓制敵人。 牙齒的鋒利程度無與倫比， 就連鐵塔都能夠一斬而斷。"
+		ja: "自慢の キバで 敵を 圧倒。 鉄塔を 一刀のもとに 切り捨てる 切れ味を 誇る。",
+		'zh-tw': "會以自傲的牙齒壓制敵人。 牙齒的鋒利程度無與倫比， 就連鐵塔都能夠一斬而斷。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "斧擊在地"
+	attacks: [
+		{
+			name: {
+				ja: "アックスダウン",
+				'zh-tw': "斧擊在地",
+			},
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のバトルポケモンに特殊エネルギーがついているなら、そのポケモンをきぜつさせる。",
+				'zh-tw': "若對手的戰鬥寶可夢身上附有特殊能量卡，則將那隻寶可夢【昏厥】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "若對手的戰鬥寶可夢身上附有特殊能量卡，則將那隻寶可夢【昏厥】。"
+		{
+			name: {
+				ja: "りゅうのはどう",
+				'zh-tw': "龍之波動",
+			},
+			damage: 230,
+			cost: ["Fighting", "Metal"],
+			effect: {
+				ja: "自分の山札を上から3枚トラッシュする。",
+				'zh-tw': "將自己的牌庫上方3張卡丟棄。",
+			},
 		},
+	],
 
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "龍之波動"
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773795,
+				tcgplayer: 566297,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將自己的牌庫上方3張卡丟棄。"
-		},
-
-		damage: 230,
-		cost: ["Fighting", "Metal"]
-	}],
+	evolveFrom: {
+		ja: "オノンド",
+	},
 
 	retreat: 2,
 	regulationMark: "H",
-	rarity: "Rare"
-}
+	rarity: "Rare",
+	dexId: [612],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/047.ts
+++ b/data-asia/SV/SV6a/047.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "酋雷姆"
+		ja: "キュレム",
+		'zh-tw': "酋雷姆",
 	},
 
 	illustrator: "Shiburingaru",
@@ -14,34 +14,53 @@ const card: Card = {
 	types: ["Dragon"],
 
 	description: {
-		'zh-tw': "雖然擁有凌駕於萊希拉姆和 捷克羅姆之上的力量，但是那 力量已被極低溫冷氣封住了。"
+		ja: "レシラムと ゼクロムを 凌ぐほどの 力を もつが 極低温の 冷気で 封じられてしまっている。",
+		'zh-tw': "雖然擁有凌駕於萊希拉姆和 捷克羅姆之上的力量，但是那 力量已被極低溫冷氣封住了。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "‌‌[特性]反等離子"
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "アンチプラズマ" },
+			effect: {
+				ja: "相手のトラッシュに、名前に「アクロマ」とつくカードがあるなら、このポケモンが「トライフロスト」を使うためのエネルギーは、[C]エネルギー1個になる。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若對手的棄牌區有‌名稱中有「‌阿克羅瑪」的卡，則這隻寶可夢使用「‌三重冰霜」所需的能量，改為1個【無】能量。"
-		}
-	}, {
-		name: {
-			'zh-tw': "三重冰霜"
+	attacks: [
+		{
+			name: {
+				ja: "トライフロスト",
+				'zh-tw': "‌‌[特性]反等離子",
+			},
+			cost: ["Water", "Water", "Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーをすべてトラッシュし、相手のポケモン3匹に、それぞれ110ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "若對手的棄牌區有‌名稱中有「‌阿克羅瑪」的卡，則這隻寶可夢使用「‌三重冰霜」所需的能量，改為1個【無】能量。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將這隻寶可夢身上附加的能量卡全部丟棄，對手的3隻寶可夢各受到110點傷害。[在備戰區不計算弱點・抵抗力。]"
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773796,
+				tcgplayer: 566298,
+			},
 		},
-
-		cost: ["Water", "Water", "Metal", "Metal", "Colorless"]
-	}],
+	],
 
 	retreat: 2,
 	regulationMark: "H",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+	dexId: [646],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/048.ts
+++ b/data-asia/SV/SV6a/048.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "喵喵"
+		ja: "ニャース",
+		'zh-tw': "喵喵",
 	},
 
 	illustrator: "sui",
@@ -14,32 +14,44 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "非常喜歡耀眼的發光物。 找到發光物時，不知為何 額頭的金幣也會跟著發光。"
+		ja: "眩しく 光るものが 大好き。 光るものを 見つけたとき なぜか 額の小判も 輝く。",
+		'zh-tw': "非常喜歡耀眼的發光物。 找到發光物時，不知為何 額頭的金幣也會跟著發光。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "亂抓"
+	attacks: [
+		{
+			name: {
+				ja: "みだれひっかき",
+				'zh-tw': "亂抓",
+			},
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数×20ダメージ。",
+				'zh-tw': "擲3次硬幣，造成正面出現的次數×20點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲3次硬幣，造成正面出現的次數×20點傷害。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773797,
+				tcgplayer: 566299,
+			},
 		},
-
-		damage: "20×",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Common"
-}
+	rarity: "Common",
+	dexId: [52],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/049.ts
+++ b/data-asia/SV/SV6a/049.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "貓老大"
+		ja: "ペルシアン",
+		'zh-tw': "貓老大",
 	},
 
 	illustrator: "NC Empire",
@@ -14,39 +14,56 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "性情凶暴，豎起尾巴時 要多加小心。那是牠將 飛撲過來咬你的前兆。"
+		ja: "気性が 激しく 尻尾を まっすぐ 立てたら 要注意。 とびかかって 噛みつく 前触れだ。",
+		'zh-tw': "性情凶暴，豎起尾巴時 要多加小心。那是牠將 飛撲過來咬你的前兆。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "亂抓"
+	attacks: [
+		{
+			name: {
+				ja: "みだれひっかき",
+				'zh-tw': "亂抓",
+			},
+			damage: "50×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数×50ダメージ。",
+				'zh-tw': "擲3次硬幣，造成正面出現的次數×50點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲3次硬幣，造成正面出現的次數×50點傷害。"
+		{
+			name: {
+				ja: "スラッシュクロー",
+				'zh-tw': "利爪揮砍",
+			},
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: "50×",
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "利爪揮砍"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773798,
+				tcgplayer: 566300,
+			},
 		},
+	],
 
-		damage: 100,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ニャース",
+	},
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Common"
-}
+	rarity: "Common",
+	dexId: [53],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/050.ts
+++ b/data-asia/SV/SV6a/050.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伊布"
+		ja: "イーブイ",
+		'zh-tw': "伊布",
 	},
 
 	illustrator: "Susumu Maeya",
@@ -14,38 +14,51 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "有著不規則的基因。 石頭散發出的放射線， 會使牠的身體發生突變。"
+		ja: "不規則な 遺伝子を 持つ。 石から出る 放射線によって 体が 突然変異を 起こす。",
+		'zh-tw': "有著不規則的基因。 石頭散發出的放射線， 會使牠的身體發生突變。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "鮮豔捕捉"
+	attacks: [
+		{
+			name: {
+				ja: "カラフルキャッチ",
+				'zh-tw': "鮮豔捕捉",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から、それぞれちがうタイプの基本エネルギーを3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多3張各不同屬性的基本能量卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多3張各不同屬性的基本能量卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		{
+			name: {
+				ja: "ずつき",
+				'zh-tw': "頭錘",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "頭錘"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773799,
+				tcgplayer: 566301,
+			},
 		},
-
-		damage: 20,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Common"
-}
+	rarity: "Common",
+	dexId: [133],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/051.ts
+++ b/data-asia/SV/SV6a/051.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "多麗米亞"
+		ja: "トリミアン",
+		'zh-tw': "多麗米亞",
 	},
 
 	illustrator: "Shinya Komatsu",
@@ -14,32 +14,44 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "修整好蓬亂的體毛後， 不只是模樣變得美麗， 就連身體也會變得更敏捷。"
+		ja: "ボサボサの 体毛を 刈りこむと 姿が 美しくなる だけでなく 身体の キレが 良くなるのだ。",
+		'zh-tw': "修整好蓬亂的體毛後， 不只是模樣變得美麗， 就連身體也會變得更敏捷。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "能量支援"
+	attacks: [
+		{
+			name: {
+				ja: "エネアシスト",
+				'zh-tw': "能量支援",
+			},
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュから基本エネルギーを1枚選び、ベンチポケモンにつける。",
+				'zh-tw': "從自己的棄牌區選擇1張基本能量卡，附於備戰寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的棄牌區選擇1張基本能量卡，附於備戰寶可夢身上。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773800,
+				tcgplayer: 566302,
+			},
 		},
-
-		damage: 30,
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
 	regulationMark: "H",
-	rarity: "Common"
-}
+	rarity: "Common",
+	dexId: [676],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/052.ts
+++ b/data-asia/SV/SV6a/052.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "童偶熊"
+		ja: "ヌイコグマ",
+		'zh-tw': "童偶熊",
 	},
 
 	illustrator: "ryoma uratsuka",
@@ -14,32 +14,44 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "毛茸茸的毛皮摸起來觸感超群， 但粗心大意地向牠伸出手的人 基本上都會遭到牠的劇烈反擊。"
+		ja: "ふわふわの 毛並みは 触り心地が 抜群だが うかつに 手を だすと 手痛い 反撃を 受けてしまう。",
+		'zh-tw': "毛茸茸的毛皮摸起來觸感超群， 但粗心大意地向牠伸出手的人 基本上都會遭到牠的劇烈反擊。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "猛撞"
+	attacks: [
+		{
+			name: {
+				ja: "とっしん",
+				'zh-tw': "猛撞",
+			},
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンにも10ダメージ。",
+				'zh-tw': "這隻寶可夢也受到10點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢也受到10點傷害。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773801,
+				tcgplayer: 566303,
+			},
 		},
-
-		damage: 30,
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
 	regulationMark: "H",
-	rarity: "Common"
-}
+	rarity: "Common",
+	dexId: [759],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/053.ts
+++ b/data-asia/SV/SV6a/053.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "穿著熊"
+		ja: "キテルグマ",
+		'zh-tw': "穿著熊",
 	},
 
 	illustrator: "Takeshi Nakamura",
@@ -14,39 +14,56 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "如果牠認定你是牠的夥伴， 便會試著擁抱你來表示喜愛。 但這會弄碎你的骨頭，非常危險。"
+		ja: "仲間と 認めると 愛情を 示すために 抱きしめようとするが 骨を 砕かれるので 危険。",
+		'zh-tw': "如果牠認定你是牠的夥伴， 便會試著擁抱你來表示喜愛。 但這會弄碎你的骨頭，非常危險。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "力量充能"
+	attacks: [
+		{
+			name: {
+				ja: "パワーチャージ",
+				'zh-tw': "力量充能",
+			},
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から基本エネルギーを1枚選び、このポケモンにつける。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張基本能量卡，附於這隻寶可夢身上。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張基本能量卡，附於這隻寶可夢身上。並且重洗牌庫。"
+		{
+			name: {
+				ja: "ぶちかます",
+				'zh-tw': "頭突",
+			},
+			damage: 130,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "頭突"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773802,
+				tcgplayer: 566304,
+			},
 		},
+	],
 
-		damage: 130,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ヌイコグマ",
+	},
 
 	retreat: 3,
 	regulationMark: "H",
-	rarity: "Common"
-}
+	rarity: "Common",
+	dexId: [760],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/054.ts
+++ b/data-asia/SV/SV6a/054.ts
@@ -1,23 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "危險光線"
+		ja: "デンジャラス光線",
+		'zh-tw': "危險光線",
 	},
 
 	illustrator: "inose yukie",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "將對手的戰鬥寶可夢【灼傷】與【混亂】。"
+		ja: "相手のバトルポケモンをやけどとこんらんにする。",
+		'zh-tw': "將對手的戰鬥寶可夢【灼傷】與【混亂】。",
 	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773803,
+				tcgplayer: 566305,
+			},
+		},
+	],
 
 	trainerType: "Item",
 	regulationMark: "H",
-	rarity: "ACE SPEC Rare"
-}
+	rarity: "ACE SPEC Rare",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/055.ts
+++ b/data-asia/SV/SV6a/055.ts
@@ -1,23 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "寶可生機劑A"
+		ja: "ポケバイタルA",
+		'zh-tw': "寶可生機劑A",
 	},
 
 	illustrator: "Toyste Beach",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "將自己的1隻寶可夢恢復「150」HP。 這張卡只要在棄牌區，無法加入手牌，無法放回牌庫。"
+		ja: "自分のポケモン1匹のHPを「150」回復する。このカードは、トラッシュにあるかぎり、手札に加えられず、山札にもどせない。",
+		'zh-tw': "將自己的1隻寶可夢恢復「150」HP。 這張卡只要在棄牌區，無法加入手牌，無法放回牌庫。",
 	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773804,
+				tcgplayer: 566306,
+			},
+		},
+	],
 
 	trainerType: "Item",
 	regulationMark: "H",
-	rarity: "ACE SPEC Rare"
-}
+	rarity: "ACE SPEC Rare",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/056.ts
+++ b/data-asia/SV/SV6a/056.ts
@@ -1,23 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "夜間擔架"
+		ja: "夜のタンカ",
+		'zh-tw': "夜間擔架",
 	},
 
 	illustrator: "Toyste Beach",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的棄牌區選擇1張寶可夢卡或者基本能量卡，在給對手看過後加入手牌。"
+		ja: "自分のトラッシュからポケモンまたは基本エネルギーを1枚選び、相手に見せて、手札に加える。",
+		'zh-tw': "從自己的棄牌區選擇1張寶可夢卡或者基本能量卡，在給對手看過後加入手牌。",
 	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773805,
+				tcgplayer: 566307,
+			},
+		},
+	],
 
 	trainerType: "Item",
 	regulationMark: "H",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/057.ts
+++ b/data-asia/SV/SV6a/057.ts
@@ -1,23 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鎖鏈糬"
+		ja: "くさりもち",
+		'zh-tw': "鎖鏈糬",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "附有這張卡的【中毒】的寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+40」點。"
+		ja: "このカードをつけているどくのポケモンが使うワザの、相手のバトルポケモンへのダメージは「+40」される。",
+		'zh-tw': "附有這張卡的【中毒】的寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+40」點。",
 	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773806,
+				tcgplayer: 566308,
+			},
+		},
+	],
 
 	trainerType: "Tool",
 	regulationMark: "H",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/058.ts
+++ b/data-asia/SV/SV6a/058.ts
@@ -1,23 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "力之沙漏"
+		ja: "力の砂時計",
+		'zh-tw': "力之沙漏",
 	},
 
 	illustrator: "Studio Bora Inc.",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "在自己的回合結束時，若附有這張卡的寶可夢在戰鬥場上，則可從自己的棄牌區選擇1張基本能量卡，附於那隻寶可夢身上。"
+		ja: "自分の番の終わりに、このカードをつけているポケモンがバトル場にいるなら、自分のトラッシュから基本エネルギーを1枚選び、そのポケモンにつけてよい。",
+		'zh-tw': "在自己的回合結束時，若附有這張卡的寶可夢在戰鬥場上，則可從自己的棄牌區選擇1張基本能量卡，附於那隻寶可夢身上。",
 	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773807,
+				tcgplayer: 566309,
+			},
+		},
+	],
 
 	trainerType: "Tool",
 	regulationMark: "H",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/059.ts
+++ b/data-asia/SV/SV6a/059.ts
@@ -1,23 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "阿克羅瑪的執著"
+		ja: "アクロマの執念",
+		'zh-tw': "阿克羅瑪的執著",
 	},
 
 	illustrator: "hncl",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的牌庫選擇競技場卡與能量卡各1張，在給對手看過後加入手牌。並且重洗牌庫。"
+		ja: "自分の山札からスタジアムとエネルギーを1枚ずつ選び、相手に見せて、手札に加える。そして山札を切る。",
+		'zh-tw': "從自己的牌庫選擇競技場卡與能量卡各1張，在給對手看過後加入手牌。並且重洗牌庫。",
 	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773808,
+				tcgplayer: 566310,
+			},
+		},
+	],
 
 	trainerType: "Supporter",
 	regulationMark: "H",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/060.ts
+++ b/data-asia/SV/SV6a/060.ts
@@ -1,23 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "阿杏的秘招"
+		ja: "アンズの秘技",
+		'zh-tw': "阿杏的秘招",
 	},
 
 	illustrator: "Taira Akitsu",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "選擇最多2隻自己的【惡】寶可夢，從自己的牌庫附給那些寶可夢各1張「基本【惡】能量」卡。並且重洗牌庫。附於戰鬥寶可夢身上的情況下，將那隻寶可夢【中毒】。"
+		ja: "自分の[D]ポケモンを2匹まで選び、自分の山札から「基本[D]エネルギー」を1枚ずつつける。そして山札を切る。バトルポケモンにつけた場合、そのポケモンをどくにする。",
+		'zh-tw': "選擇最多2隻自己的【惡】寶可夢，從自己的牌庫附給那些寶可夢各1張「基本【惡】能量」卡。並且重洗牌庫。附於戰鬥寶可夢身上的情況下，將那隻寶可夢【中毒】。",
 	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773809,
+				tcgplayer: 566311,
+			},
+		},
+	],
 
 	trainerType: "Supporter",
 	regulationMark: "H",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/061.ts
+++ b/data-asia/SV/SV6a/061.ts
@@ -1,23 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "仙后"
+		ja: "カシオペア",
+		'zh-tw': "仙后",
 	},
 
 	illustrator: "Atsushi Furusawa",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "這張卡只有在自己的手牌只有這1張時才可使用。 從自己的牌庫任意選擇最多2張卡加入手牌。並且重洗牌庫。"
+		ja: "このカードは、自分の手札がこのカード1枚だけのときにしか使えない。自分の山札から好きなカードを2枚まで選び、手札に加える。そして山札を切る。",
+		'zh-tw': "這張卡只有在自己的手牌只有這1張時才可使用。 從自己的牌庫任意選擇最多2張卡加入手牌。並且重洗牌庫。",
 	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773810,
+				tcgplayer: 566312,
+			},
+		},
+	],
 
 	trainerType: "Supporter",
 	regulationMark: "H",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/062.ts
+++ b/data-asia/SV/SV6a/062.ts
@@ -1,23 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "庫瑟洛斯奇的企圖"
+		ja: "クセロシキのたくらみ",
+		'zh-tw': "庫瑟洛斯奇的企圖",
 	},
 
 	illustrator: "GOSSAN",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "對手將對手自己的手牌丟棄直到變為3張為止。"
+		ja: "相手は相手自身の手札を、3枚になるようにトラッシュする。",
+		'zh-tw': "對手將對手自己的手牌丟棄直到變為3張為止。",
 	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773811,
+				tcgplayer: 566313,
+			},
+		},
+	],
 
 	trainerType: "Supporter",
 	regulationMark: "H",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/063.ts
+++ b/data-asia/SV/SV6a/063.ts
@@ -1,23 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "中立中心"
+		ja: "ニュートラルセンター",
+		'zh-tw': "中立中心",
 	},
 
 	illustrator: "imoniii",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "雙方的所有寶可夢（「擁有規則的寶可夢」除外），不會受到對手的「寶可夢【ex】・【V】」招式的傷害。 這張卡只要在棄牌區，無法加入手牌，無法放回牌庫。"
+		ja: "おたがいのポケモン（「ルールを持つポケモン」をのぞく）全員は、相手の「ポケモンex・V」からワザのダメージを受けない。このカードは、トラッシュにあるかぎり、手札に加えられず、山札にもどせない。",
+		'zh-tw': "雙方的所有寶可夢（「擁有規則的寶可夢」除外），不會受到對手的「寶可夢【ex】・【V】」招式的傷害。 這張卡只要在棄牌區，無法加入手牌，無法放回牌庫。",
 	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773812,
+				tcgplayer: 566314,
+			},
+		},
+	],
 
 	trainerType: "Stadium",
 	regulationMark: "H",
-	rarity: "ACE SPEC Rare"
-}
+	rarity: "ACE SPEC Rare",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/064.ts
+++ b/data-asia/SV/SV6a/064.ts
@@ -1,23 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV6a"
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "夜間學院"
+		ja: "夜のアカデミー",
+		'zh-tw': "夜間學院",
 	},
 
 	illustrator: "AYUMI ODASHIMA",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "雙方玩家在每個自己的回合時，可使用1次，可選擇1張自己的手牌，放回牌庫上方。"
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の手札を1枚選び、山札の上にもどしてよい。",
+		'zh-tw': "雙方玩家在每個自己的回合時，可使用1次，可選擇1張自己的手牌，放回牌庫上方。",
 	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 773813,
+				tcgplayer: 566315,
+			},
+		},
+	],
 
 	trainerType: "Stadium",
 	regulationMark: "H",
-	rarity: "Uncommon"
-}
+	rarity: "Uncommon",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV6a/065.ts
+++ b/data-asia/SV/SV6a/065.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・ブルル",
+	},
+
+	illustrator: "IKEDA Saki",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Grass"],
+
+	description: {
+		ja: "大木を 引き抜き ブンブン 振り回す。 草木を 茂らせて そのエネルギーを 吸収する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ウッドハンマー" },
+			damage: 220,
+			cost: ["Grass", "Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773814,
+				tcgplayer: 566316,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [787],
+};
+
+export default card;

--- a/data-asia/SV/SV6a/066.ts
+++ b/data-asia/SV/SV6a/066.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヘルガー",
+	},
+
+	illustrator: "Taiga Kasai",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fire"],
+
+	description: {
+		ja: "不気味な 遠吠えを 聞いた ポケモンは 震え 一目散に 自分の 巣に 戻る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かみつく" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "バークアウト" },
+			damage: 100,
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-100」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773815,
+				tcgplayer: 566317,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "デルビル",
+	},
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [229],
+};
+
+export default card;

--- a/data-asia/SV/SV6a/067.ts
+++ b/data-asia/SV/SV6a/067.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タッツー",
+	},
+
+	illustrator: "Shinya Komatsu",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "潮の 流れが 穏やかな 海に 棲む。 襲われると 真っ黒な 墨を吐いて その隙に 逃げだす。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "じっとする" },
+			cost: ["Water"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "ひれカッター" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773816,
+				tcgplayer: 566318,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [116],
+};
+
+export default card;

--- a/data-asia/SV/SV6a/068.ts
+++ b/data-asia/SV/SV6a/068.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨマワル",
+	},
+
+	illustrator: "James Turner",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "真っ赤な ひとつ目で 睨みつけられ 生体エネルギーを 吸われるとき ひどい 寒気に 襲われる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "むかえにいく" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のトラッシュから「ヨマワル」を3枚まで選び、ベンチに出す。",
+			},
+		},
+		{
+			name: { ja: "つぶやく" },
+			damage: 30,
+			cost: ["Psychic", "Psychic"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773817,
+				tcgplayer: 566319,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [355],
+};
+
+export default card;

--- a/data-asia/SV/SV6a/069.ts
+++ b/data-asia/SV/SV6a/069.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サマヨール",
+	},
+
+	illustrator: "James Turner",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "体の中で 燃えている 真っ赤な ひとつ目が サマヨールの 本体と いわれるが 誰も 見ていない。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "カースドボム" },
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、このポケモンをきぜつさせる。相手のポケモン1匹に、ダメカンを5個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "おにび" },
+			damage: 50,
+			cost: ["Psychic", "Psychic"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773818,
+				tcgplayer: 566320,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヨマワル",
+	},
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [356],
+};
+
+export default card;

--- a/data-asia/SV/SV6a/070.ts
+++ b/data-asia/SV/SV6a/070.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨノワール",
+	},
+
+	illustrator: "James Turner",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Psychic"],
+
+	description: {
+		ja: "この世と あの世を 行ったり来たり。 さまよう 魂を 吸い込んで 運ぶと いわれ 恐れられている。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "カースドボム" },
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、このポケモンをきぜつさせる。相手のポケモン1匹に、ダメカンを13個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かげしばり" },
+			damage: 150,
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773819,
+				tcgplayer: 566321,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "サマヨール",
+	},
+
+	retreat: 3,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [477],
+};
+
+export default card;

--- a/data-asia/SV/SV6a/071.ts
+++ b/data-asia/SV/SV6a/071.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クレセリア",
+	},
+
+	illustrator: "satoma",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "飛行するときは ベールのような 羽から 光る 粒子を 出す。 三日月の化身と 呼ばれている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "いやしのまい" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のポケモン全員のHPを、それぞれ「20」回復する。",
+			},
+		},
+		{
+			name: { ja: "クレセントパージ" },
+			damage: "80+",
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "のぞむなら、ウラになっている自分のサイドを1枚選び、オモテにする。その場合、80ダメージ追加。（対戦が終わるまで、そのサイドはオモテのまま。）",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773820,
+				tcgplayer: 566322,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [488],
+};
+
+export default card;

--- a/data-asia/SV/SV6a/072.ts
+++ b/data-asia/SV/SV6a/072.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゾロア",
+	},
+
+	illustrator: "REND",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "人や ほかの ポケモンに 化ける。 自分の 正体を 隠すことで 危険から 身を 守っているのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふむ" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "ダブルひっかき" },
+			damage: "20×",
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773821,
+				tcgplayer: 566323,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [570],
+};
+
+export default card;

--- a/data-asia/SV/SV6a/073.ts
+++ b/data-asia/SV/SV6a/073.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゾウドウ",
+	},
+
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Metal"],
+
+	description: {
+		ja: "５トンの 荷物を 持ち上げられる。 朝になると 群れで 洞窟へと 向かい エサの 鉱石を 探す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 30,
+			cost: ["Metal", "Colorless"],
+		},
+		{
+			name: { ja: "がちんこ" },
+			damage: 70,
+			cost: ["Metal", "Metal", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773822,
+				tcgplayer: 566324,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [878],
+};
+
+export default card;

--- a/data-asia/SV/SV6a/074.ts
+++ b/data-asia/SV/SV6a/074.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オノンド",
+	},
+
+	illustrator: "MINAMINAMI Take",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Dragon"],
+
+	description: {
+		ja: "太い キバを 使って 獲物を きれいに 捌いて 食べるものと 保存する ものに 分けるのだ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "きんちょうかん" },
+			effect: {
+				ja: "このポケモンは、相手が手札からグッズまたはサポートを出して使ったとき、その効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "りゅうのはどう" },
+			damage: 80,
+			cost: ["Fighting", "Metal"],
+			effect: {
+				ja: "自分の山札を上から1枚トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773823,
+				tcgplayer: 566325,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キバゴ",
+	},
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [611],
+};
+
+export default card;

--- a/data-asia/SV/SV6a/075.ts
+++ b/data-asia/SV/SV6a/075.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ペルシアン",
+	},
+
+	illustrator: "Whisker",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Colorless"],
+
+	description: {
+		ja: "気性が 激しく 尻尾を まっすぐ 立てたら 要注意。 とびかかって 噛みつく 前触れだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "みだれひっかき" },
+			damage: "50×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数×50ダメージ。",
+			},
+		},
+		{
+			name: { ja: "スラッシュクロー" },
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773824,
+				tcgplayer: 566326,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャース",
+	},
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [53],
+};
+
+export default card;

--- a/data-asia/SV/SV6a/076.ts
+++ b/data-asia/SV/SV6a/076.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キテルグマ",
+	},
+
+	illustrator: "Takeshi Nakamura",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "仲間と 認めると 愛情を 示すために 抱きしめようとするが 骨を 砕かれるので 危険。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "パワーチャージ" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から基本エネルギーを1枚選び、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ぶちかます" },
+			damage: 130,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773825,
+				tcgplayer: 566327,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヌイコグマ",
+	},
+
+	retreat: 3,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [760],
+};
+
+export default card;

--- a/data-asia/SV/SV6a/077.ts
+++ b/data-asia/SV/SV6a/077.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キングドラex",
+	},
+
+	illustrator: "PLANETA Igarashi",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Water"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "おうのごうれい" },
+			cost: ["Water"],
+			effect: {
+				ja: "自分のトラッシュから[W]ポケモンを3枚まで選び、ベンチに出す。",
+			},
+		},
+		{
+			name: { ja: "ハイドロポンプ" },
+			damage: "50+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[W]エネルギーの数×50ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773826,
+				tcgplayer: 566328,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シードラ",
+	},
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Ultra Rare",
+	dexId: [230],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV6a/078.ts
+++ b/data-asia/SV/SV6a/078.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブロロロームex",
+	},
+
+	illustrator: "PLANETA Mochizuki",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Lightning"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "アクセルフラッシュ" },
+			damage: "20+",
+			cost: ["Metal"],
+			effect: {
+				ja: "この番、このポケモンがベンチからバトル場に出ていたなら、120ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "スピードブレイク" },
+			damage: 250,
+			cost: ["Metal", "Metal", "Metal"],
+			effect: {
+				ja: "このポケモンと、ついているすべてのカードを、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773827,
+				tcgplayer: 566329,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ブロロン",
+	},
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Ultra Rare",
+	dexId: [966],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV6a/079.ts
+++ b/data-asia/SV/SV6a/079.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イイネイヌex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ポイズンマッスル" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から「基本[D]エネルギー」を2枚まで選び、このポケモンにつける。そして山札を切る。つけた場合、このポケモンをどくにする。",
+			},
+		},
+		{
+			name: { ja: "クレイジーチェーン" },
+			damage: "130+",
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "このポケモンがどくなら、130ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773828,
+				tcgplayer: 566330,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "H",
+	rarity: "Ultra Rare",
+	dexId: [1014],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV6a/080.ts
+++ b/data-asia/SV/SV6a/080.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マシマシラex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひょうしぬけ" },
+			effect: {
+				ja: "このポケモンが、相手のポケモンからワザのダメージを受けてきぜつしたとき、自分の場に「モモワロウex」がいるなら、とられるサイドは1枚少なくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ダーティヘッド" },
+			damage: 190,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「ダーティヘッド」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773829,
+				tcgplayer: 566331,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Ultra Rare",
+	dexId: [1015],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV6a/081.ts
+++ b/data-asia/SV/SV6a/081.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キチキギスex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "さかてにとる" },
+			effect: {
+				ja: "前の相手の番に、自分のポケモンがきぜつしていたなら、自分の番に1回使える。自分の山札を3枚引く。この番、すでに別の「さかてにとる」を使っていたなら、この特性は使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "クルーエルアロー" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、100ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773830,
+				tcgplayer: 566332,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Ultra Rare",
+	dexId: [1016],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV6a/082.ts
+++ b/data-asia/SV/SV6a/082.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モモワロウex",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しはいのくさり" },
+			effect: {
+				ja: "自分の番に1回使える。自分のベンチの[D]ポケモン（「モモワロウex」をのぞく）を1匹選び、バトルポケモンと入れ替える。その後、新しいバトルポケモンをどくにする。この番、すでに別の「しはいのくさり」を使っていたなら、この特性は使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "イライラバースト" },
+			damage: "60×",
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "相手がすでにとったサイドの枚数×60ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773831,
+				tcgplayer: 566333,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Ultra Rare",
+	dexId: [1025],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV6a/083.ts
+++ b/data-asia/SV/SV6a/083.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクロマの執念",
+	},
+
+	illustrator: "hncl",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札からスタジアムとエネルギーを1枚ずつ選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773832,
+				tcgplayer: 566334,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "H",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SV/SV6a/084.ts
+++ b/data-asia/SV/SV6a/084.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アンズの秘技",
+	},
+
+	illustrator: "Taira Akitsu",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の[D]ポケモンを2匹まで選び、自分の山札から「基本[D]エネルギー」を1枚ずつつける。そして山札を切る。バトルポケモンにつけた場合、そのポケモンをどくにする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773833,
+				tcgplayer: 566335,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "H",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SV/SV6a/085.ts
+++ b/data-asia/SV/SV6a/085.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カシオペア",
+	},
+
+	illustrator: "Atsushi Furusawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札がこのカード1枚だけのときにしか使えない。自分の山札から好きなカードを2枚まで選び、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773834,
+				tcgplayer: 566336,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "H",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SV/SV6a/086.ts
+++ b/data-asia/SV/SV6a/086.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クセロシキのたくらみ",
+	},
+
+	illustrator: "GOSSAN",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手は相手自身の手札を、3枚になるようにトラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773835,
+				tcgplayer: 566337,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "H",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SV/SV6a/087.ts
+++ b/data-asia/SV/SV6a/087.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イイネイヌex",
+	},
+
+	illustrator: "kantaro",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ポイズンマッスル" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から「基本[D]エネルギー」を2枚まで選び、このポケモンにつける。そして山札を切る。つけた場合、このポケモンをどくにする。",
+			},
+		},
+		{
+			name: { ja: "クレイジーチェーン" },
+			damage: "130+",
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "このポケモンがどくなら、130ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773836,
+				tcgplayer: 566338,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "H",
+	rarity: "Special illustration rare",
+	dexId: [1014],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV6a/088.ts
+++ b/data-asia/SV/SV6a/088.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マシマシラex",
+	},
+
+	illustrator: "kantaro",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひょうしぬけ" },
+			effect: {
+				ja: "このポケモンが、相手のポケモンからワザのダメージを受けてきぜつしたとき、自分の場に「モモワロウex」がいるなら、とられるサイドは1枚少なくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ダーティヘッド" },
+			damage: 190,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「ダーティヘッド」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773837,
+				tcgplayer: 566339,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Special illustration rare",
+	dexId: [1015],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV6a/089.ts
+++ b/data-asia/SV/SV6a/089.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キチキギスex",
+	},
+
+	illustrator: "kantaro",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "さかてにとる" },
+			effect: {
+				ja: "前の相手の番に、自分のポケモンがきぜつしていたなら、自分の番に1回使える。自分の山札を3枚引く。この番、すでに別の「さかてにとる」を使っていたなら、この特性は使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "クルーエルアロー" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、100ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773838,
+				tcgplayer: 566340,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Special illustration rare",
+	dexId: [1016],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV6a/090.ts
+++ b/data-asia/SV/SV6a/090.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モモワロウex",
+	},
+
+	illustrator: "kantaro",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しはいのくさり" },
+			effect: {
+				ja: "自分の番に1回使える。自分のベンチの[D]ポケモン（「モモワロウex」をのぞく）を1匹選び、バトルポケモンと入れ替える。その後、新しいバトルポケモンをどくにする。この番、すでに別の「しはいのくさり」を使っていたなら、この特性は使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "イライラバースト" },
+			damage: "60×",
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "相手がすでにとったサイドの枚数×60ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773839,
+				tcgplayer: 566341,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Special illustration rare",
+	dexId: [1025],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV6a/091.ts
+++ b/data-asia/SV/SV6a/091.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カシオペア",
+	},
+
+	illustrator: "burari",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札がこのカード1枚だけのときにしか使えない。自分の山札から好きなカードを2枚まで選び、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773840,
+				tcgplayer: 566342,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "H",
+	rarity: "Special illustration rare",
+};
+
+export default card;

--- a/data-asia/SV/SV6a/092.ts
+++ b/data-asia/SV/SV6a/092.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モモワロウex",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しはいのくさり" },
+			effect: {
+				ja: "自分の番に1回使える。自分のベンチの[D]ポケモン（「モモワロウex」をのぞく）を1匹選び、バトルポケモンと入れ替える。その後、新しいバトルポケモンをどくにする。この番、すでに別の「しはいのくさり」を使っていたなら、この特性は使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "イライラバースト" },
+			damage: "60×",
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "相手がすでにとったサイドの枚数×60ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773841,
+				tcgplayer: 566343,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Mega Hyper Rare",
+	dexId: [1025],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV6a/093.ts
+++ b/data-asia/SV/SV6a/093.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "大地の器",
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を1枚トラッシュしなければ使えない。自分の山札から基本エネルギーを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773842,
+				tcgplayer: 566344,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Mega Hyper Rare",
+};
+
+export default card;

--- a/data-asia/SV/SV6a/094.ts
+++ b/data-asia/SV/SV6a/094.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV6a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "力の砂時計",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の番の終わりに、このカードをつけているポケモンがバトル場にいるなら、自分のトラッシュから基本エネルギーを1枚選び、そのポケモンにつけてよい。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 773843,
+				tcgplayer: 566345,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "H",
+	rarity: "Mega Hyper Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Refreshes the existing Japanese set **SV6a ナイトワンダラー (Night Wanderer)** from its primary sources. The curated content stays: every card keeps its `zh-tw` texts verbatim.

What changes across the 94 card files:

- `thirdParty.cardmarket` moves onto `variants` objects and 64 missing ids are filled in
- per card where missing: `dexId`, `evolveFrom`, `resistances`, the Japanese flavor text and the Japanese effect/attack texts straight from the official database and limitless

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (773750–773843)
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (566252–566345), keyed by the collection number each product carries in `extendedData`

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- All 94 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
