### PR TITLE
(data) Update Japanese S set S10a Dark Phantasma

### DIFF
--- a/data-asia/S/S10a/001.ts
+++ b/data-asia/S/S10a/001.ts
@@ -1,12 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "パラス",
 		th: "พารัส",
-		'zh-tw': "派拉斯"
+		'zh-tw': "派拉斯",
 	},
 
 	illustrator: "Mizue",
@@ -15,34 +15,53 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
+		ja: "冬虫夏草と いう キノコが 虫を 操っているのだ。 虫の 意思は 無視される。",
 		th: "เห็ดที่ชื่อโทจูคะโซจะคอยบงการแมลง โดยไม่สนใจความต้องการของแมลง",
-		'zh-tw': "控制蟲子的是一種叫做冬蟲夏草的蕈類。蟲子的意志會被忽視。"
+		'zh-tw': "控制蟲子的是一種叫做冬蟲夏草的蕈類。蟲子的意志會被忽視。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			th: "ดูดซับ",
-			'zh-tw': "吸取"
+	attacks: [
+		{
+			name: {
+				ja: "すいとる",
+				th: "ดูดซับ",
+				'zh-tw': "吸取",
+			},
+			damage: 20,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「10」回復する。",
+				th: "ฟื้นฟู HP ของโปเกมอนนี้ [10]",
+				'zh-tw': "將這隻寶可夢恢復「10」HP。",
+			},
 		},
+	],
 
-		effect: {
-			th: "ฟื้นฟู HP ของโปเกมอนนี้ [10]",
-			'zh-tw': "將這隻寶可夢恢復「10」HP。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656180,
+				tcgplayer: 570664,
+			},
 		},
-
-		damage: 20,
-		cost: ["Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577090,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [46],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/002.ts
+++ b/data-asia/S/S10a/002.ts
@@ -1,12 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "パラセクト",
 		th: "พาราเซ็คท์",
-		'zh-tw': "派拉斯特"
+		'zh-tw': "派拉斯特",
 	},
 
 	illustrator: "Pani Kobayashi",
@@ -15,48 +15,73 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
+		ja: "ムシの 方は ほぼ 死んでいて 本体は 背中の キノコだ。 もげると もう 動かなくなる。",
 		th: "ส่วนที่เป็นแมลงเกือบจะตายแล้วส่วนตัวจริงของมันคือเห็ดที่อยู่บนหลัง ถ้าเด็ดออกจะเคลื่อนไหวไม่ได้อีก",
-		'zh-tw': "本體是背上的蘑菇，底下的蟲子幾乎已經死亡。 一旦蘑菇脫落，牠就再也不會動了。"
+		'zh-tw': "本體是背上的蘑菇，底下的蟲子幾乎已經死亡。 一旦蘑菇脫落，牠就再也不會動了。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			th: "สปอร์หมดกำลัง",
-			'zh-tw': "力竭孢子"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ぐったりほうし",
+				th: "สปอร์หมดกำลัง",
+				'zh-tw': "力竭孢子",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。おたがいのバトルポケモンを、それぞれどくとねむりにする。",
+				th: "ในเทิร์นฝ่ายเรา เมื่อนำการ์ดนี้จากบนมือออกมาวิวัฒนาการแล้ว ใช้ได้ 1 ครั้ง ทำให้โปเกมอนบนตำแหน่งต่อสู้ของทั้งสองฝ่ายแต่ละตัวเป็นสภาวะ[พิษ]และ[หลับ]",
+				'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。將雙方的戰鬥寶可夢【中毒】與【睡眠】。",
+			},
 		},
+	],
 
-		effect: {
-			th: "ในเทิร์นฝ่ายเรา เมื่อนำการ์ดนี้จากบนมือออกมาวิวัฒนาการแล้ว ใช้ได้ 1 ครั้ง ทำให้โปเกมอนบนตำแหน่งต่อสู้ของทั้งสองฝ่ายแต่ละตัวเป็นสภาวะ[พิษ]และ[หลับ]",
-			'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。將雙方的戰鬥寶可夢【中毒】與【睡眠】。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			th: "ซิสเซอร์ครอส",
-			'zh-tw': "十字剪"
+	attacks: [
+		{
+			name: {
+				ja: "シザークロス",
+				th: "ซิสเซอร์ครอส",
+				'zh-tw': "十字剪",
+			},
+			damage: "50+",
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、50ダメージ追加。",
+				th: "ทอยเหรียญ 1 ครั้ง ถ้าออกหัว การโจมตีนี้จะเพิ่มแดเมจอีก 50",
+				'zh-tw': "擲1次硬幣若為正面，則增加50點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			th: "ทอยเหรียญ 1 ครั้ง ถ้าออกหัว การโจมตีนี้จะเพิ่มแดเมจอีก 50",
-			'zh-tw': "擲1次硬幣若為正面，則增加50點傷害。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656181,
+				tcgplayer: 570665,
+			},
 		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577091,
+			},
+		},
+	],
 
-		damage: "50+",
-		cost: ["Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "パラス",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [47],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/003.ts
+++ b/data-asia/S/S10a/003.ts
@@ -1,55 +1,69 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ヒスイ マルマインV",
 		th: "ฮิซุย มารุมายน์V",
-		'zh-tw': "洗翠 頑皮雷彈V"
+		'zh-tw': "洗翠 頑皮雷彈V",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Grass"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			th: "ระเบิดหัวร้อน",
-			'zh-tw': "煩躁炸彈"
+	attacks: [
+		{
+			name: {
+				ja: "かんしゃくボム",
+				th: "ระเบิดหัวร้อน",
+				'zh-tw': "煩躁炸彈",
+			},
+			damage: "100×",
+			cost: [],
+			effect: {
+				ja: "このポケモンが受けている特殊状態の数×100ダメージ。",
+				th: "แดเมจจะเท่ากับจำนวนสภาวะผิดปกติที่โปเกมอนนี้ได้รับอยู่ x100",
+				'zh-tw': "造成這隻寶可夢處於特殊狀態的數量×100點傷害。",
+			},
 		},
-
-		effect: {
-			th: "แดเมจจะเท่ากับจำนวนสภาวะผิดปกติที่โปเกมอนนี้ได้รับอยู่ x100",
-			'zh-tw': "造成這隻寶可夢處於特殊狀態的數量×100點傷害。"
+		{
+			name: {
+				ja: "ソーラーシュート",
+				th: "โซลาร์ชูต",
+				'zh-tw': "日光射擊",
+			},
+			damage: 120,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、すべてトラッシュする。",
+				th: "ทิ้งพลังงานที่ติดอยู่กับโปเกมอนนี้ทั้งหมดที่ตำแหน่งทิ้งการ์ด",
+				'zh-tw': "將這隻寶可夢身上附加的能量全部丟棄。",
+			},
 		},
+	],
 
-		damage: "100×"
-	}, {
-		name: {
-			th: "โซลาร์ชูต",
-			'zh-tw': "日光射擊"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 656182,
+				tcgplayer: 570666,
+			},
 		},
-
-		effect: {
-			th: "ทิ้งพลังงานที่ติดอยู่กับโปเกมอนนี้ทั้งหมดที่ตำแหน่งทิ้งการ์ด",
-			'zh-tw': "將這隻寶可夢身上附加的能量全部丟棄。"
-		},
-
-		damage: 120,
-		cost: ["Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Double rare",
+	dexId: [101],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/004.ts
+++ b/data-asia/S/S10a/004.ts
@@ -1,12 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ケムッソ",
 		th: "เคมุตโสะ",
-		'zh-tw': "刺尾蟲"
+		'zh-tw': "刺尾蟲",
 	},
 
 	illustrator: "ryoma uratsuka",
@@ -15,41 +15,61 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
+		ja: "森や 草むらに 生息。 敵に 襲われた ときは お尻の 毒の トゲで 対抗する。",
 		th: "อาศัยอยู่ตามป่าและพุ่มไม้ เวลาถูกศัตรูโจมตีเข้ามา จะแทงกลับด้วยเข็มพิษจากก้น",
-		'zh-tw': "棲息在森林和草叢裡。受到敵人的襲擊時， 會用尾部的毒刺來對抗。"
+		'zh-tw': "棲息在森林和草叢裡。受到敵人的襲擊時， 會用尾部的毒刺來對抗。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			th: "แทงฉึกฉึก",
-			'zh-tw': "刺刺痛痛"
+	attacks: [
+		{
+			name: {
+				ja: "チクチクさす",
+				th: "แทงฉึกฉึก",
+				'zh-tw': "刺刺痛痛",
+			},
+			damage: 10,
+			cost: ["Grass"],
 		},
-
-		damage: 10,
-		cost: ["Grass"]
-	}, {
-		name: {
-			th: "แห่รวมตัว",
-			'zh-tw': "綿綿集聚"
+		{
+			name: {
+				ja: "わらわらあつまる",
+				th: "แห่รวมตัว",
+				'zh-tw': "綿綿集聚",
+			},
+			cost: ["Grass", "Grass", "Grass"],
+			effect: {
+				ja: "自分の山札から「ケムッソ」「カラサリス」「アゲハント」「マユルド」「ドクケイル」を好きなだけ選び、相手に見せて、手札に加える。そして山札を切る。",
+				th: "เลือกการ์ด [เคมุตโสะ] [คาราซาลิส] [อาเกฮันท์] [มายูลด์] [โดคุเคล] จากสำรับการ์ดฝ่ายเราตามจำนวนที่ชอบ ให้ฝ่ายตรงข้ามดู นำขึ้นมือ แล้วสับสำรับการ์ด",
+				'zh-tw': "從自己的牌庫選擇任意數量的「刺尾蟲」「甲殼繭」「狩獵鳳蝶」「盾甲繭」「毒粉蛾」卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
+	],
 
-		effect: {
-			th: "เลือกการ์ด [เคมุตโสะ] [คาราซาลิส] [อาเกฮันท์] [มายูลด์] [โดคุเคล] จากสำรับการ์ดฝ่ายเราตามจำนวนที่ชอบ ให้ฝ่ายตรงข้ามดู นำขึ้นมือ แล้วสับสำรับการ์ด",
-			'zh-tw': "從自己的牌庫選擇任意數量的「刺尾蟲」「甲殼繭」「狩獵鳳蝶」「盾甲繭」「毒粉蛾」卡，在給對手看過後加入手牌。並且重洗牌庫。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656185,
+				tcgplayer: 570667,
+			},
 		},
-
-		cost: ["Grass", "Grass", "Grass"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577092,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [265],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/005.ts
+++ b/data-asia/S/S10a/005.ts
@@ -1,12 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "カラサリス",
 		th: "คาราซาลิส",
-		'zh-tw': "甲殼繭"
+		'zh-tw': "甲殼繭",
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -15,41 +15,65 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
+		ja: "糸に ついた 朝露を 飲んで 進化の ときを 待ち続ける。 硬い 繭が 攻撃を 防ぐ。",
 		th: "ดูดน้ำค้างที่ติดอยู่บนใย แล้วรอคอยเวลาที่จะวิวัฒนาการ รังไหมแข็ง ๆ ของมันคอยปกป้องการโจมตี",
-		'zh-tw': "會喝絲線上掛著的朝露，持續等待進化的時刻來臨。 堅硬的繭能夠防禦攻擊。"
+		'zh-tw': "會喝絲線上掛著的朝露，持續等待進化的時刻來臨。 堅硬的繭能夠防禦攻擊。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			th: "ใยพันตัว",
-			'zh-tw': "纏繞線"
+	attacks: [
+		{
+			name: {
+				ja: "からむいと",
+				th: "ใยพันตัว",
+				'zh-tw': "纏繞線",
+			},
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このワザを受けたポケモンは、ワザが使えない。",
+				th: "ทอยเหรียญ 1 ครั้ง ถ้าออกหัว เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนที่ได้รับท่าต่อสู้นี้จะใช้ท่าต่อสู้ไม่ได้",
+				'zh-tw': "擲1次硬幣若為正面，則在下個對手的回合，受到這個招式的寶可夢無法使用招式。",
+			},
 		},
-
-		effect: {
-			th: "ทอยเหรียญ 1 ครั้ง ถ้าออกหัว เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนที่ได้รับท่าต่อสู้นี้จะใช้ท่าต่อสู้ไม่ได้",
-			'zh-tw': "擲1次硬幣若為正面，則在下個對手的回合，受到這個招式的寶可夢無法使用招式。"
+		{
+			name: {
+				ja: "ぶつかる",
+				th: "กระแทก",
+				'zh-tw': "衝撞",
+			},
+			damage: 30,
+			cost: ["Grass", "Colorless"],
 		},
+	],
 
-		cost: ["Grass"]
-	}, {
-		name: {
-			th: "กระแทก",
-			'zh-tw': "衝撞"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656187,
+				tcgplayer: 570668,
+			},
 		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577093,
+			},
+		},
+	],
 
-		damage: 30,
-		cost: ["Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ケムッソ",
+	},
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [266],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/006.ts
+++ b/data-asia/S/S10a/006.ts
@@ -1,12 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "アゲハント",
 		th: "อาเกฮันท์",
-		'zh-tw': "狩獵鳳蝶"
+		'zh-tw': "狩獵鳳蝶",
 	},
 
 	illustrator: "Yuu Nishida",
@@ -15,48 +15,67 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
+		ja: "長細い 口を 突き刺して 相手の 体液を 吸い取る。 攻撃的な 性格。",
 		th: "จะแทงปากอันเรียวเล็กไปที่ฝ่ายตรงข้าม และดูดเอาของเหลวในร่างกายออกมา มีนิสัยก้าวร้าว",
-		'zh-tw': "會用細長的嘴刺向對手，吸取對手的體液。 具有很強的攻擊性。"
+		'zh-tw': "會用細長的嘴刺向對手，吸取對手的體液。 具有很強的攻擊性。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			th: "หลอดดูดคึกคัก",
-			'zh-tw': "洋洋吸管"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "アゲアゲストロー",
+				th: "หลอดดูดคึกคัก",
+				'zh-tw': "洋洋吸管",
+			},
+			effect: {
+				ja: "自分の番に1回使える。自分の手札が6枚になるように、山札を引く。",
+				th: "ใช้ได้ 1 ครั้งในเทิร์นฝ่ายเรา จั่วการ์ดจากสำรับการ์ด จนได้การ์ดบนมือฝ่ายเราเป็น 6 ใบ",
+				'zh-tw': "在自己的回合時，可使用1次。從牌庫抽卡直到自己的手牌滿6張為止。",
+			},
 		},
+	],
 
-		effect: {
-			th: "ใช้ได้ 1 ครั้งในเทิร์นฝ่ายเรา จั่วการ์ดจากสำรับการ์ด จนได้การ์ดบนมือฝ่ายเราเป็น 6 ใบ",
-			'zh-tw': "在自己的回合時，可使用1次。從牌庫抽卡直到自己的手牌滿6張為止。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			th: "เมกาเดรน",
-			'zh-tw': "超級吸取"
+	attacks: [
+		{
+			name: {
+				ja: "メガドレイン",
+				th: "เมกาเดรน",
+				'zh-tw': "超級吸取",
+			},
+			damage: 70,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+				th: "ฟื้นฟู HP ของโปเกมอนนี้ [30]",
+				'zh-tw': "將這隻寶可夢恢復「30」HP。",
+			},
 		},
+	],
 
-		effect: {
-			th: "ฟื้นฟู HP ของโปเกมอนนี้ [30]",
-			'zh-tw': "將這隻寶可夢恢復「30」HP。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 656221,
+				tcgplayer: 570669,
+			},
 		},
+	],
 
-		damage: 70,
-		cost: ["Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "カラサリス",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [267],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/007.ts
+++ b/data-asia/S/S10a/007.ts
@@ -1,12 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "マユルド",
 		th: "มายูลด์",
-		'zh-tw': "盾甲繭"
+		'zh-tw': "盾甲繭",
 	},
 
 	illustrator: "GOSSAN",
@@ -15,41 +15,65 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
+		ja: "マユに こもっている あいだに 受けた 攻撃は 進化しても 忘れずに かならず 仕返しする。",
 		th: "มันจะไม่มีวันลืมการโจมตีที่เข้ามาในขณะที่กำลังเก็บตัวอยู่ในรังไหมเลย แม้จะวิวัฒนาการไปแล้วก็ตาม และจะตามล้างแค้นให้จงได้",
-		'zh-tw': "就算進化了也不會忘記待在繭中時受到的攻擊。 一定會設法進行報復。"
+		'zh-tw': "就算進化了也不會忘記待在繭中時受到的攻擊。 一定會設法進行報復。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			th: "แข็งขึ้น",
-			'zh-tw': "變硬"
+	attacks: [
+		{
+			name: {
+				ja: "かたくなる",
+				th: "แข็งขึ้น",
+				'zh-tw': "變硬",
+			},
+			cost: ["Grass"],
+			effect: {
+				ja: "次の相手の番、このポケモンは「60」以下のワザのダメージを受けない。",
+				th: "เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนนี้จะไม่ได้รับแดเมจของท่าต่อสู้ที่น้อยกว่าหรือเท่ากับ [60]",
+				'zh-tw': "在下個對手的回合，這隻寶可夢不會受到「60」以下的招式的傷害。",
+			},
 		},
-
-		effect: {
-			th: "เทิร์นถัดไปของฝ่ายตรงข้าม โปเกมอนนี้จะไม่ได้รับแดเมจของท่าต่อสู้ที่น้อยกว่าหรือเท่ากับ [60]",
-			'zh-tw': "在下個對手的回合，這隻寶可夢不會受到「60」以下的招式的傷害。"
+		{
+			name: {
+				ja: "ころがりタックル",
+				th: "กลิ้งโจมตี",
+				'zh-tw': "滾動衝撞",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Grass"]
-	}, {
-		name: {
-			th: "กลิ้งโจมตี",
-			'zh-tw': "滾動衝撞"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656225,
+				tcgplayer: 570670,
+			},
 		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577094,
+			},
+		},
+	],
 
-		damage: 20,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ケムッソ",
+	},
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [268],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/008.ts
+++ b/data-asia/S/S10a/008.ts
@@ -1,12 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ドクケイル",
 		th: "โดคุเคล",
-		'zh-tw': "毒粉蛾"
+		'zh-tw': "毒粉蛾",
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -15,41 +15,65 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
+		ja: "闇夜の かがり火に 誘われる 習性。 毒性の強き 鱗粉 ばら撒くゆえ 集落より 追い払うのに 難儀す。",
 		th: "มีนิสัยชอบเข้าใกล้กองไฟในยามค่ำคืนอันมืดมิด โปรยเกล็ดปีกที่มีพิษรุนแรง จนต้องลำบากในการไล่มันออกไปจากหมู่บ้าน",
-		'zh-tw': "有著被黑暗中的篝火吸引的習性。會散布毒性猛烈的鱗粉，令人們 為了將牠們驅離村落而煞費苦心。"
+		'zh-tw': "有著被黑暗中的篝火吸引的習性。會散布毒性猛烈的鱗粉，令人們 為了將牠們驅離村落而煞費苦心。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			th: "ผงย่ำแย่",
-			'zh-tw': "谷底粉"
+	attacks: [
+		{
+			name: {
+				ja: "どんぞこパウダー",
+				th: "ผงย่ำแย่",
+				'zh-tw': "谷底粉",
+			},
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとこんらんにする。このどくでのせるダメカンの数は8個になる。",
+				th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[พิษ]และ[สับสน] ด้วย[พิษ]นี้ จำนวนตัวนับแดเมจที่วางจะเป็น 8 ตัว",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】與【混亂】。因這個【中毒】而放置的傷害指示物的數量改為8個。",
+			},
 		},
-
-		effect: {
-			th: "ทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[พิษ]และ[สับสน] ด้วย[พิษ]นี้ จำนวนตัวนับแดเมจที่วางจะเป็น 8 ตัว",
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】與【混亂】。因這個【中毒】而放置的傷害指示物的數量改為8個。"
+		{
+			name: {
+				ja: "カッターウインド",
+				th: "คัตเตอร์วินด์",
+				'zh-tw': "利刃之風",
+			},
+			damage: 110,
+			cost: ["Grass", "Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			th: "คัตเตอร์วินด์",
-			'zh-tw': "利刃之風"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656229,
+				tcgplayer: 570671,
+			},
 		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577095,
+			},
+		},
+	],
 
-		damage: 110,
-		cost: ["Grass", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "マユルド",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [269],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/009.ts
+++ b/data-asia/S/S10a/009.ts
@@ -1,42 +1,66 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雪笠怪"
+		ja: "ユキカブリ",
+		'zh-tw': "雪笠怪",
 	},
 
 	illustrator: "Mitsuhiro Arita",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Water"],
+
+	description: {
+		ja: "雪中にて 遭遇する 可能性 高し。 人里に 現れるも 害は なさず 童の 良き友となると 伝わる。",
+	},
+
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "推擊"
+	attacks: [
+		{
+			name: {
+				ja: "どつく",
+				'zh-tw': "推擊",
+			},
+			damage: 10,
+			cost: ["Water"],
 		},
-
-		damage: 10,
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "冰柱飛彈"
+		{
+			name: {
+				ja: "つららミサイル",
+				'zh-tw': "冰柱飛彈",
+			},
+			damage: 60,
+			cost: ["Water", "Water", "Colorless"],
 		},
+	],
 
-		damage: 60,
-		cost: ["Water", "Water", "Colorless"]
-	}],
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656233,
+				tcgplayer: 570672,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577096,
+			},
+		},
+	],
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [459],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/010.ts
+++ b/data-asia/S/S10a/010.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "暴雪王"
+		ja: "ユキノオー",
+		'zh-tw': "暴雪王",
 	},
 
 	illustrator: "kodama",
@@ -14,38 +14,62 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "會像揮動鎚子般揮下自己大大的手臂，趕走要襲擊 雪笠怪的火紅不倒翁群體。"
+		ja: "大きな 腕を ハンマーの ように 振り下ろし ユキカブリを 狙う ダルマッカの 群れを 追い払う。",
+		'zh-tw': "會像揮動鎚子般揮下自己大大的手臂，趕走要襲擊 雪笠怪的火紅不倒翁群體。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "冰柱拳"
+	attacks: [
+		{
+			name: {
+				ja: "つららパンチ",
+				'zh-tw': "冰柱拳",
+			},
+			damage: 50,
+			cost: ["Water", "Colorless"],
 		},
-
-		damage: 50,
-		cost: ["Water", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "捨身衝撞"
+		{
+			name: {
+				ja: "すてみタックル",
+				'zh-tw': "捨身衝撞",
+			},
+			damage: 160,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+				'zh-tw': "這隻寶可夢也受到30點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢也受到30點傷害。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656237,
+				tcgplayer: 570673,
+			},
 		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577097,
+			},
+		},
+	],
 
-		damage: 160,
-		cost: ["Water", "Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ユキカブリ",
+	},
 
 	retreat: 4,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [460],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/011.ts
+++ b/data-asia/S/S10a/011.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "霏歐納"
+		ja: "フィオネ",
+		'zh-tw': "霏歐納",
 	},
 
 	illustrator: "Jiro Sasumo",
@@ -14,37 +14,57 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "在溫暖的海面上漂流。不論被沖得多遠， 都能夠回到出生的地方。"
+		ja: "暖かい 海を 漂っている。 どんな 遠くに 流されても 生まれた 場所に かならず戻る。",
+		'zh-tw': "在溫暖的海面上漂流。不論被沖得多遠， 都能夠回到出生的地方。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "海之宴"
+	attacks: [
+		{
+			name: {
+				ja: "うみのうたげ",
+				'zh-tw': "海之宴",
+			},
+			cost: ["Water"],
+			effect: {
+				ja: "自分の山札から[W]タイプのたねポケモンを3枚まで選び、ベンチに出す。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多3張【水】屬性的【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多3張【水】屬性的【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。"
+		{
+			name: {
+				ja: "スプラッシュ",
+				'zh-tw': "飛濺",
+			},
+			damage: 20,
+			cost: ["Water"],
 		},
+	],
 
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "飛濺"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656243,
+				tcgplayer: 570674,
+			},
 		},
-
-		damage: 20,
-		cost: ["Water"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577098,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [489],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/012.ts
+++ b/data-asia/S/S10a/012.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洗翠 野蠻鱸魚"
+		ja: "ヒスイ バスラオ",
+		'zh-tw': "洗翠 野蠻鱸魚",
 	},
 
 	illustrator: "Oswaldo KATO",
@@ -14,30 +14,50 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "此寶可夢具有多項野蠻鱸魚的特徵，雖然有性情溫馴等不同點存在， 吾人仍將其定義為野蠻鱸魚的地區形態。"
+		ja: "温厚な 気質など 相違点 あれども バスラオの 特徴を 多く 有すゆえ そのリージョンフォームと 定義す。",
+		'zh-tw': "此寶可夢具有多項野蠻鱸魚的特徵，雖然有性情溫馴等不同點存在， 吾人仍將其定義為野蠻鱸魚的地區形態。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "偷襲"
+	attacks: [
+		{
+			name: {
+				ja: "ふいをつく",
+				'zh-tw': "偷襲",
+			},
+			damage: 40,
+			cost: [],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+				'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656246,
+				tcgplayer: 570675,
+			},
 		},
-
-		damage: 40
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577099,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [550],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/013.ts
+++ b/data-asia/S/S10a/013.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洗翠 幽尾玄魚"
+		ja: "ヒスイ イダイトウ",
+		'zh-tw': "洗翠 幽尾玄魚",
 	},
 
 	illustrator: "AKIRA EGAWA",
@@ -14,41 +14,60 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "在溯河而上的旅程中半途喪命者的靈魂纏繞其身。在流經洗翠地區 的河川裡可謂所向無敵。"
+		ja: "遡上の旅路にて 志半ばに 散った 輩の魂を まとう。 ヒスイ 流れし 河川においては 敵うもの 皆無なり。",
+		'zh-tw': "在溯河而上的旅程中半途喪命者的靈魂纏繞其身。在流經洗翠地區 的河川裡可謂所向無敵。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "攀聖靈"
+	attacks: [
+		{
+			name: {
+				ja: "みたまのぼり",
+				'zh-tw': "攀聖靈",
+			},
+			damage: "20×",
+			cost: [],
+			effect: {
+				ja: "自分のトラッシュにある基本エネルギーをすべて相手に見せ、その枚数×20ダメージ。その後、見せたエネルギーを山札にもどして切る。",
+				'zh-tw': "在給對手看過自己的棄牌區的所有基本能量卡後，造成其張數×20點傷害。然後，將給對手看過的能量卡放回牌庫並重洗。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在給對手看過自己的棄牌區的所有基本能量卡後，造成其張數×20點傷害。然後，將給對手看過的能量卡放回牌庫並重洗。"
+		{
+			name: {
+				ja: "ウォーターショット",
+				'zh-tw': "水射擊",
+			},
+			damage: 70,
+			cost: ["Water"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		damage: "20×"
-	}, {
-		name: {
-			'zh-tw': "水射擊"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 656251,
+				tcgplayer: 570676,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。"
-		},
-
-		damage: 70,
-		cost: ["Water"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ヒスイ バスラオ",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [902],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/014.ts
+++ b/data-asia/S/S10a/014.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "皮卡丘"
+		ja: "ピカチュウ",
+		'zh-tw': "皮卡丘",
 	},
 
 	illustrator: "kurumitsu",
@@ -14,43 +14,64 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "越是能製造出強大電流的皮卡丘，臉頰上的囊就越 柔軟，同時也越有伸展性。"
+		ja: "つくる 電気が 強力な ピカチュウほど ほっぺの 袋は 軟らかく よく 伸びるぞ。",
+		'zh-tw': "越是能製造出強大電流的皮卡丘，臉頰上的囊就越 柔軟，同時也越有伸展性。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "皮卡衝刺"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ピカダッシュ",
+				'zh-tw': "皮卡衝刺",
+			},
+			effect: {
+				ja: "このポケモンにエネルギーがついているなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+				'zh-tw': "若這隻寶可夢身上附有能量，則這隻寶可夢【撤退】所需的能量全部消除。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢身上附有能量，則這隻寶可夢【撤退】所需的能量全部消除。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "胡思亂撞"
+	attacks: [
+		{
+			name: {
+				ja: "きまぐれタックル",
+				'zh-tw': "胡思亂撞",
+			},
+			damage: 50,
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+				'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656253,
+				tcgplayer: 570677,
+			},
 		},
-
-		damage: 50,
-		cost: ["Lightning", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577100,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [25],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/015.ts
+++ b/data-asia/S/S10a/015.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雷丘"
+		ja: "ライチュウ",
+		'zh-tw': "雷丘",
 	},
 
 	illustrator: "GIDORA",
@@ -14,42 +14,66 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "長長的尾巴能夠像接地線一樣保護自己，因此即使 是高壓電也不會讓牠麻痺。"
+		ja: "長い しっぽが アースになって 身を 守るため 自分自身は 高電圧にも 痺れないのだ。",
+		'zh-tw': "長長的尾巴能夠像接地線一樣保護自己，因此即使 是高壓電也不會讓牠麻痺。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "電擊"
+	attacks: [
+		{
+			name: {
+				ja: "でんきショック",
+				'zh-tw': "電擊",
+			},
+			damage: 30,
+			cost: ["Lightning"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+				'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。"
+		{
+			name: {
+				ja: "きりふだスパーク",
+				'zh-tw': "王牌電光",
+			},
+			damage: "100+",
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分がすでにVSTARパワーを使っていたなら、120ダメージ追加。",
+				'zh-tw': "若自己已經使出了【VSTAR】力量，則增加120點傷害。",
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Lightning"]
-	}, {
-		name: {
-			'zh-tw': "王牌電光"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656256,
+				tcgplayer: 570678,
+			},
 		},
-
-		effect: {
-			'zh-tw': "若自己已經使出了【VSTAR】力量，則增加120點傷害。"
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577101,
+			},
 		},
+	],
 
-		damage: "100+",
-		cost: ["Lightning", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ピカチュウ",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [26],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/016.ts
+++ b/data-asia/S/S10a/016.ts
@@ -1,50 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "自爆磁怪V"
+		ja: "ジバコイルV",
+		'zh-tw': "自爆磁怪V",
 	},
 
 	illustrator: "N-DESIGN Inc.",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Lightning"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "拉鋸磁力"
+	attacks: [
+		{
+			name: {
+				ja: "ひっぱりじりょく",
+				'zh-tw': "拉鋸磁力",
+			},
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、新しく出てきたポケモンに40ダメージ。",
+				'zh-tw': "選擇對手的1隻備戰寶可夢，與戰鬥寶可夢互換。然後，新上場的寶可夢受到40點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇對手的1隻備戰寶可夢，與戰鬥寶可夢互換。然後，新上場的寶可夢受到40點傷害。"
+		{
+			name: {
+				ja: "スプリットビーム",
+				'zh-tw': "分岔光束",
+			},
+			damage: 90,
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン2匹にも、それぞれ30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的2隻備戰寶可夢也各受到30點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		cost: ["Lightning", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "分岔光束"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 656262,
+				tcgplayer: 570679,
+			},
 		},
-
-		effect: {
-			'zh-tw': "對手的2隻備戰寶可夢也各受到30點傷害。[在備戰區不計算弱點・抵抗力。]"
-		},
-
-		damage: 90,
-		cost: ["Lightning", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Double rare",
+	dexId: [462],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/017.ts
+++ b/data-asia/S/S10a/017.ts
@@ -1,49 +1,67 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "自爆磁怪VSTAR"
+		ja: "ジバコイルVSTAR",
+		'zh-tw': "自爆磁怪VSTAR",
 	},
 
 	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
 	hp: 270,
 	types: ["Lightning"],
-	stage: "VMAX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "磁力緊握"
+	stage: "VSTAR",
+
+	attacks: [
+		{
+			name: {
+				ja: "マグネグリップ",
+				'zh-tw': "磁力緊握",
+			},
+			damage: 180,
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札からグッズを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多2張物品卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多2張物品卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		{
+			name: {
+				ja: "エレクトロスター",
+				'zh-tw': "[VSTAR力量]電子星星",
+			},
+			cost: ["Lightning", "Lightning"],
+			effect: {
+				ja: "相手のベンチポケモン2匹に、それぞれ90ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はVSTARパワーを1回しか使えない。］",
+				'zh-tw': "對手的2隻備戰寶可夢各受到90點傷害。[在備戰區不計算弱點・抵抗力。][對戰中，己方只可使用1次【VSTAR】力量。]",
+			},
 		},
+	],
 
-		damage: 180,
-		cost: ["Lightning", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "[VSTAR力量]電子星星"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 656272,
+				tcgplayer: 570680,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "對手的2隻備戰寶可夢各受到90點傷害。[在備戰區不計算弱點・抵抗力。][對戰中，己方只可使用1次【VSTAR】力量。]"
-		},
-
-		cost: ["Lightning", "Lightning"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ジバコイルV",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Triple Rare",
+	dexId: [462],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/018.ts
+++ b/data-asia/S/S10a/018.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洛托姆"
+		ja: "ロトム",
+		'zh-tw': "洛托姆",
 	},
 
 	illustrator: "Taira Akitsu",
@@ -14,37 +14,57 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "某位少年的發明促使人們開始製造 各種活用洛托姆的機器。"
+		ja: "ある 少年の 発明から ロトムを 活かした いろいろな 機械が 作られ始めたのだ。",
+		'zh-tw': "某位少年的發明促使人們開始製造 各種活用洛托姆的機器。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "翻修"
+	attacks: [
+		{
+			name: {
+				ja: "オーバーホール",
+				'zh-tw': "翻修",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札をすべて山札にもどして切る。その後、山札を6枚引く。",
+				'zh-tw': "將自己的手牌全部放回牌庫並重洗。然後，從牌庫抽出6張。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將自己的手牌全部放回牌庫並重洗。然後，從牌庫抽出6張。"
+		{
+			name: {
+				ja: "マッハボルト",
+				'zh-tw': "音速伏特",
+			},
+			damage: 80,
+			cost: ["Lightning", "Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "音速伏特"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656277,
+				tcgplayer: 570681,
+			},
 		},
-
-		damage: 80,
-		cost: ["Lightning", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577102,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [479],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/019.ts
+++ b/data-asia/S/S10a/019.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "皮皮"
+		ja: "ピッピ",
+		'zh-tw': "皮皮",
 	},
 
 	illustrator: "Kouki Saitou",
@@ -14,43 +14,64 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "能夠在滿月夜裡的靜謐山間遇見牠。小小翅膀綻放著微光，那舞動的 身姿如同妖精般惹人憐愛。"
+		ja: "満月の夜 静かなる 山間にて 遭遇。 小さき翼 ほのかに光り 舞う姿は まさに 妖精の如き 愛くるしさなり。",
+		'zh-tw': "能夠在滿月夜裡的靜謐山間遇見牠。小小翅膀綻放著微光，那舞動的 身姿如同妖精般惹人憐愛。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "月見派對"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "おつきみパーティ",
+				'zh-tw': "月見派對",
+			},
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。自分のベンチの「ピッピ」全員に、山札から[P]エネルギーを1枚ずつつける。そして山札を切る。",
+				'zh-tw': "若這隻寶可夢在戰鬥場上，則在自己的回合時可使用1次。附給自己的備戰區的所有「皮皮」各1張牌庫的【超】能量卡。並且重洗牌庫。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢在戰鬥場上，則在自己的回合時可使用1次。附給自己的備戰區的所有「皮皮」各1張牌庫的【超】能量卡。並且重洗牌庫。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "奇跡風暴"
+	attacks: [
+		{
+			name: {
+				ja: "ワンダーストーム",
+				'zh-tw': "奇跡風暴",
+			},
+			damage: "20×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[P]エネルギーの数×20ダメージ。",
+				'zh-tw': "造成自己的場上寶可夢身上附加的【超】能量的數量×20點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "造成自己的場上寶可夢身上附加的【超】能量的數量×20點傷害。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656286,
+				tcgplayer: 570682,
+			},
 		},
-
-		damage: "20×",
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577103,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [35],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/020.ts
+++ b/data-asia/S/S10a/020.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "皮可西"
+		ja: "ピクシー",
+		'zh-tw': "皮可西",
 	},
 
 	illustrator: "Sekio",
@@ -14,39 +14,64 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "妖精的一種。極少出現在人類面前。一感覺到有人 就會立刻逃走。"
+		ja: "妖精の 仲間で めったに 人前に 出てこない。 気配を 感じて すぐに 逃げてしまうようだ。",
+		'zh-tw': "妖精的一種。極少出現在人類面前。一感覺到有人 就會立刻逃走。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "妖精守護"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "せいれいのまもり",
+				'zh-tw': "妖精守護",
+			},
+			effect: {
+				ja: "このポケモンがいるかぎり、自分のポケモン全員が、相手の[N]ポケモンから受けるワザのダメージは「-30」される。この効果は、この特性を持つポケモンが何匹いても、重ならない。",
+				'zh-tw': "只要這隻寶可夢在場上，自己的所有寶可夢受到對手的【龍】寶可夢招式的傷害「-30」點。無論有多少隻擁有這個特性的寶可夢，這個效果也不會重複。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在場上，自己的所有寶可夢受到對手的【龍】寶可夢招式的傷害「-30」點。無論有多少隻擁有這個特性的寶可夢，這個效果也不會重複。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "月亮衝擊"
+	attacks: [
+		{
+			name: {
+				ja: "ムーンインパクト",
+				'zh-tw': "月亮衝擊",
+			},
+			damage: 90,
+			cost: ["Psychic", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 90,
-		cost: ["Psychic", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656290,
+				tcgplayer: 570683,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577104,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ピッピ",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [36],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/021.ts
+++ b/data-asia/S/S10a/021.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鬼斯"
+		ja: "ゴース",
+		'zh-tw': "鬼斯",
 	},
 
 	illustrator: "Tika Matsuno",
@@ -14,35 +14,49 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "從氣體中誕生的生命體。若被牠那有毒氣體形成的身體裹住， 不管是誰都會昏迷。"
+		ja: "ガスから 生まれた 生命体。 毒を含んだ ガスの 体に 包まれると だれでも 気絶する。",
+		'zh-tw': "從氣體中誕生的生命體。若被牠那有毒氣體形成的身體裹住， 不管是誰都會昏迷。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "無聲加害"
+	attacks: [
+		{
+			name: {
+				ja: "ひっそりのせる",
+				'zh-tw': "無聲加害",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンに、ダメカンを1個のせる。",
+				'zh-tw': "在對手的戰鬥寶可夢身上放置1個傷害指示物。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在對手的戰鬥寶可夢身上放置1個傷害指示物。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656320,
+				tcgplayer: 570684,
+			},
 		},
-
-		cost: ["Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577105,
+			},
+		},
+	],
 
 	retreat: 0,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [92],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/022.ts
+++ b/data-asia/S/S10a/022.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鬼斯通"
+		ja: "ゴースト",
+		'zh-tw': "鬼斯通",
 	},
 
 	illustrator: "Kouki Saitou",
@@ -14,35 +14,53 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "能夠穿牆透壁，出現在任何地方的恐怖惡靈。傳說被牠的舌頭舔過的人 將會日漸衰弱，最後喪命。"
+		ja: "壁をすり抜け 何処にでも 姿 現す 恐ろしき悪霊。 舌で 舐められし者 日に日に 衰弱し 死に至るとの噂。",
+		'zh-tw': "能夠穿牆透壁，出現在任何地方的恐怖惡靈。傳說被牠的舌頭舔過的人 將會日漸衰弱，最後喪命。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "詛咒水滴"
+	attacks: [
+		{
+			name: {
+				ja: "のろいのしずく",
+				'zh-tw': "詛咒水滴",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "ダメカン3個を、相手のポケモンに好きなようにのせる。",
+				'zh-tw': "將3個傷害指示物以任意方式放置於對手的寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將3個傷害指示物以任意方式放置於對手的寶可夢身上。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656321,
+				tcgplayer: 570685,
+			},
 		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577106,
+			},
+		},
+	],
 
-		cost: ["Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ゴース",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [93],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/023.ts
+++ b/data-asia/S/S10a/023.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "耿鬼"
+		ja: "ゲンガー",
+		'zh-tw': "耿鬼",
 	},
 
 	illustrator: "Narumi Sato",
@@ -14,47 +14,61 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "滿月的夜晚，如果影子自己動起來並露出笑容， 那肯定是耿鬼搞的鬼。"
+		ja: "満月の夜 影が 勝手に 動きだして 笑うのは ゲンガーの しわざに 違いない。",
+		'zh-tw': "滿月的夜晚，如果影子自己動起來並露出笑容， 那肯定是耿鬼搞的鬼。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "奈落後門"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ならくのうらもん",
+				'zh-tw': "奈落後門",
+			},
+			effect: {
+				ja: "このカードがトラッシュにあるなら、自分の番に1回使える。このカードをベンチに出す。その後、このポケモンにダメカンを3個のせる。",
+				'zh-tw': "若這張卡在棄牌區，則在自己的回合時可使用1次。將這張卡放置於備戰區。然後，在這隻寶可夢身上放置3個傷害指示物。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這張卡在棄牌區，則在自己的回合時可使用1次。將這張卡放置於備戰區。然後，在這隻寶可夢身上放置3個傷害指示物。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "尖嘯陣"
+	attacks: [
+		{
+			name: {
+				ja: "スクリームサークル",
+				'zh-tw': "尖嘯陣",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のベンチポケモンの数×2個ぶんのダメカンを、相手のバトルポケモンにのせる。",
+				'zh-tw': "將與對手的備戰寶可夢的數量×2個的相同數量的傷害指示物，放置於對手的戰鬥寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將與對手的備戰寶可夢的數量×2個的相同數量的傷害指示物，放置於對手的戰鬥寶可夢身上。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 656323,
+				tcgplayer: 570686,
+			},
 		},
+	],
 
-		cost: ["Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ゴースト",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [94],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/024.ts
+++ b/data-asia/S/S10a/024.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "魔牆人偶"
+		ja: "バリヤード",
+		'zh-tw': "魔牆人偶",
 	},
 
 	illustrator: "Souichirou Gunjima",
@@ -14,43 +14,58 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "行為舉止如同默劇表演，外貌則與小丑無異。能從指尖發出 氣場，造出透明的牆壁。"
+		ja: "振る舞い パントマイムが如く。 道化師 思い起こす 姿にて 指先より 発す 気力 用いて 透明な壁を作る。",
+		'zh-tw': "行為舉止如同默劇表演，外貌則與小丑無異。能從指尖發出 氣場，造出透明的牆壁。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "拍擊"
+	attacks: [
+		{
+			name: {
+				ja: "はたく",
+				'zh-tw': "拍擊",
+			},
+			damage: 20,
+			cost: ["Colorless"],
 		},
-
-		damage: 20,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "戲法巴掌"
+		{
+			name: {
+				ja: "トリックビンタ",
+				'zh-tw': "戲法巴掌",
+			},
+			damage: 90,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手プレイヤーとジャンケンをし、自分が勝ったなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+				'zh-tw': "與對手玩家猜拳，若己方獲勝，則在下個對手的回合，這隻寶可夢不會受到招式的傷害與效果的影響。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "與對手玩家猜拳，若己方獲勝，則在下個對手的回合，這隻寶可夢不會受到招式的傷害與效果的影響。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656325,
+				tcgplayer: 570687,
+			},
 		},
-
-		damage: 90,
-		cost: ["Psychic", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577107,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [122],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/025.ts
+++ b/data-asia/S/S10a/025.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "夢妖"
+		ja: "ムウマ",
+		'zh-tw': "夢妖",
 	},
 
 	illustrator: "HYOGONOSUKE",
@@ -14,36 +14,50 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "會藉由模仿人哭叫的聲音嚇唬大家來取樂。 不擅長應付膽大的對手。"
+		ja: "人が 泣き叫ぶ 声を 真似て みんなを おびえさせ 喜ぶ。 肝が 据わった 相手は 苦手。",
+		'zh-tw': "會藉由模仿人哭叫的聲音嚇唬大家來取樂。 不擅長應付膽大的對手。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "奇異之光"
+	attacks: [
+		{
+			name: {
+				ja: "あやしいひかり",
+				'zh-tw': "奇異之光",
+			},
+			damage: 10,
+			cost: ["Psychic"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをこんらんにする。",
+				'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【混亂】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【混亂】。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656326,
+				tcgplayer: 570688,
+			},
 		},
-
-		damage: 10,
-		cost: ["Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577108,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [200],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/026.ts
+++ b/data-asia/S/S10a/026.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "夢妖魔"
+		ja: "ムウマージ",
+		'zh-tw': "夢妖魔",
 	},
 
 	illustrator: "kawayoo",
@@ -14,47 +14,67 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "會喃喃唸誦詛咒的話語，使對手激烈頭痛，或是看見 恐怖的幻覺，藉此折磨對手。"
+		ja: "呪いの 言葉を つぶやいて ひどい 頭痛や 恐ろしい 幻を 見せて 苦しめる。",
+		'zh-tw': "會喃喃唸誦詛咒的話語，使對手激烈頭痛，或是看見 恐怖的幻覺，藉此折磨對手。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "怨恨咒語"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "うらみのまじない",
+				'zh-tw': "怨恨咒語",
+			},
+			effect: {
+				ja: "このポケモンのHPがまんたんの状態で、相手のポケモンからワザのダメージを受けてきぜつしたとき、ワザを使ったポケモンにダメカンを8個のせる。",
+				'zh-tw': "這隻寶可夢的HP是全滿的狀態下，受到對手的寶可夢招式的傷害而【氣絕】時，在使用招式的寶可夢身上放置8個傷害指示物。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢的HP是全滿的狀態下，受到對手的寶可夢招式的傷害而【氣絕】時，在使用招式的寶可夢身上放置8個傷害指示物。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "不祥歌聲"
+	attacks: [
+		{
+			name: {
+				ja: "ぶきみなうたごえ",
+				'zh-tw': "不祥歌聲",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれダメカンを2個のせる。",
+				'zh-tw': "在對手的所有寶可夢身上各放置2個傷害指示物。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在對手的所有寶可夢身上各放置2個傷害指示物。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656327,
+				tcgplayer: 570689,
+			},
 		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577109,
+			},
+		},
+	],
 
-		cost: ["Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ムウマ",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [429],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/027.ts
+++ b/data-asia/S/S10a/027.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "光輝沙奈朵"
+		ja: "かがやくサーナイト",
+		'zh-tw': "光輝沙奈朵",
 	},
 
 	illustrator: "Ryuta Fuse",
@@ -14,43 +14,58 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "有著預知未來的能力。在保護訓練家的時候， 會發揮出最強的力量。"
+		ja: "未来を 予知する 力を もつ。 トレーナーを 守る ときに 最大 パワーを 発揮する。",
+		'zh-tw': "有著預知未來的能力。在保護訓練家的時候， 會發揮出最強的力量。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "慈藹之幕"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "じあいのヴェール",
+				'zh-tw': "慈藹之幕",
+			},
+			effect: {
+				ja: "このポケモンがいるかぎり、自分のポケモン全員が、相手の「ポケモンV」から受けるワザのダメージは「-20」される。",
+				'zh-tw': "只要這隻寶可夢在場上，自己的所有寶可夢受到對手的「寶可夢【V】」招式的傷害「-20」點。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在場上，自己的所有寶可夢受到對手的「寶可夢【V】」招式的傷害「-20」點。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "精神強念"
+	attacks: [
+		{
+			name: {
+				ja: "サイコキネシス",
+				'zh-tw': "精神強念",
+			},
+			damage: "70+",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数×20ダメージ追加。",
+				'zh-tw': "增加對手的戰鬥寶可夢身上附加的能量的數量×20點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加對手的戰鬥寶可夢身上附加的能量的數量×20點傷害。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 656328,
+				tcgplayer: 570690,
+			},
 		},
-
-		damage: "70+",
-		cost: ["Psychic", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Radiant Rare",
+	dexId: [282],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/028.ts
+++ b/data-asia/S/S10a/028.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "風鈴鈴"
+		ja: "チリーン",
+		'zh-tw': "風鈴鈴",
 	},
 
 	illustrator: "Naoyo Kimura",
@@ -14,42 +14,57 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "擁有超音波的叫聲。輕飄飄地浮起來， 乘著風旅行到遠方。"
+		ja: "超音波の 鳴き声を 持つ。 ふわふわと 浮かび 風に 乗って 長い 距離を 旅する。",
+		'zh-tw': "擁有超音波的叫聲。輕飄飄地浮起來， 乘著風旅行到遠方。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "美夢音色"
+	attacks: [
+		{
+			name: {
+				ja: "ゆめみのねいろ",
+				'zh-tw': "美夢音色",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンに、相手が手札からエネルギーをつけたなら、そのポケモンをねむりにする。",
+				'zh-tw': "在下個對手的回合，若對手從手牌將能量卡附於受到這個招式的寶可夢身上，則將那隻寶可夢【睡眠】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，若對手從手牌將能量卡附於受到這個招式的寶可夢身上，則將那隻寶可夢【睡眠】。"
+		{
+			name: {
+				ja: "ぶらさがる",
+				'zh-tw': "垂吊",
+			},
+			damage: 30,
+			cost: ["Psychic", "Colorless"],
 		},
+	],
 
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "垂吊"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656329,
+				tcgplayer: 570691,
+			},
 		},
-
-		damage: 30,
-		cost: ["Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577110,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [358],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/029.ts
+++ b/data-asia/S/S10a/029.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洗翠 索羅亞"
+		ja: "ヒスイ ゾロア",
+		'zh-tw': "洗翠 索羅亞",
 	},
 
 	illustrator: "Akira Komayama",
@@ -14,40 +14,57 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "死後靈魂在洗翠地區復甦。怨恨化為力量，從其頭部冉冉飄升。 會化成對手的樣貌去洗刷仇恨。"
+		ja: "死した魂 ヒスイの地にて 蘇る。 怨嗟は 力となり 頭より 立ち昇り 相手の姿に 変じ 恨み 晴らしたり。",
+		'zh-tw': "死後靈魂在洗翠地區復甦。怨恨化為力量，從其頭部冉冉飄升。 會化成對手的樣貌去洗刷仇恨。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "呼喚"
+	attacks: [
+		{
+			name: {
+				ja: "もってくる",
+				'zh-tw': "呼喚",
+			},
+			cost: [],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+				'zh-tw': "從自己的牌庫抽出1張卡。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫抽出1張卡。"
-		}
-	}, {
-		name: {
-			'zh-tw': "囈語"
+		{
+			name: {
+				ja: "つぶやく",
+				'zh-tw': "囈語",
+			},
+			damage: 10,
+			cost: ["Psychic"],
 		},
+	],
 
-		damage: 10,
-		cost: ["Psychic"]
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656333,
+				tcgplayer: 570692,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577111,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [570],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/030.ts
+++ b/data-asia/S/S10a/030.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洗翠 索羅亞克"
+		ja: "ヒスイ ゾロアーク",
+		'zh-tw': "洗翠 索羅亞克",
 	},
 
 	illustrator: "Kouki Saitou",
@@ -14,43 +14,58 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "瘋狂舞動白髮的姿態如同死神。在足以撕裂己身的深刻仇怨驅使下， 抱定同歸於盡之心襲殺仇敵。"
+		ja: "白髪 振り乱し姿 死神の如く。 我が身をも 切り裂く 激しき怨讐にて 仇 襲い 道連れ覚悟で 仕留めたり。",
+		'zh-tw': "瘋狂舞動白髮的姿態如同死神。在足以撕裂己身的深刻仇怨驅使下， 抱定同歸於盡之心襲殺仇敵。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "破滅詛咒"
+	attacks: [
+		{
+			name: {
+				ja: "はめつののろい",
+				'zh-tw': "破滅詛咒",
+			},
+			cost: [],
+			effect: {
+				ja: "次の相手の番の終わりに、このワザを受けたポケモンはきぜつする。",
+				'zh-tw': "在下個對手的回合結束時，將受到這個招式的寶可夢【氣絕】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合結束時，將受到這個招式的寶可夢【氣絕】。"
-		}
-	}, {
-		name: {
-			'zh-tw': "喚回"
+		{
+			name: {
+				ja: "よびもどす",
+				'zh-tw': "喚回",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のトラッシュから好きなカードを1枚選び、相手に見せて、手札に加える。",
+				'zh-tw': "從自己的棄牌區任意選擇1張卡，在給對手看過後加入手牌。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的棄牌區任意選擇1張卡，在給對手看過後加入手牌。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 656334,
+				tcgplayer: 570693,
+			},
 		},
+	],
 
-		cost: ["Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ヒスイ ゾロア",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [571],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/031.ts
+++ b/data-asia/S/S10a/031.ts
@@ -1,52 +1,66 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "眷戀雲V"
+		ja: "ラブトロスV",
+		'zh-tw': "眷戀雲V",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Psychic"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "愛之守護神"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "あいのしゅごしん",
+				'zh-tw': "愛之守護神",
+			},
+			effect: {
+				ja: "このポケモンがいるかぎり、[P]エネルギーがついている自分のポケモン（「ラブトロスV」をのぞく）全員は、相手のポケモンから特性の効果を受けない。",
+				'zh-tw': "只要這隻寶可夢在場上，自己的所有身上附有【超】能量的寶可夢（「眷戀雲V」 除外），不會受到對手的寶可夢的特性效果影響。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在場上，自己的所有身上附有【超】能量的寶可夢（「眷戀雲V」 除外），不會受到對手的寶可夢的特性效果影響。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "花開之尾"
+	attacks: [
+		{
+			name: {
+				ja: "ブロッサムテール",
+				'zh-tw': "花開之尾",
+			},
+			damage: 100,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュから基本エネルギーを2枚まで選び、ベンチポケモンに好きなようにつける。",
+				'zh-tw': "從自己的棄牌區選擇最多2張基本能量卡，以任意方式附於備戰寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的棄牌區選擇最多2張基本能量卡，以任意方式附於備戰寶可夢身上。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 656336,
+				tcgplayer: 570694,
+			},
 		},
-
-		damage: 100,
-		cost: ["Psychic", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Double rare",
+	dexId: [905],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/032.ts
+++ b/data-asia/S/S10a/032.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洗翠 卡蒂狗"
+		ja: "ヒスイ ガーディ",
+		'zh-tw': "洗翠 卡蒂狗",
 	},
 
 	illustrator: "Kouki Saitou",
@@ -14,28 +14,49 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "兩隻一組共同負責地盤的警戒工作。體毛中混有火成岩的成分，可以 推想這是受到火山活動的影響。"
+		ja: "対になりて 縄張りを 哨戒す。 体毛に 火成岩なる 成分 混ざるは 火山活動の 影響と 推察す。",
+		'zh-tw': "兩隻一組共同負責地盤的警戒工作。體毛中混有火成岩的成分，可以 推想這是受到火山活動的影響。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "灼熱"
+	attacks: [
+		{
+			name: {
+				ja: "こがす",
+				'zh-tw': "灼熱",
+			},
+			cost: [],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【灼傷】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【灼傷】。"
-		}
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656337,
+				tcgplayer: 570695,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577112,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [58],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/033.ts
+++ b/data-asia/S/S10a/033.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洗翠 風速狗"
+		ja: "ヒスイ ウインディ",
+		'zh-tw': "洗翠 風速狗",
 	},
 
 	illustrator: "Oswaldo KATO",
@@ -14,37 +14,56 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "將猛烈燃燒的火焰纏繞在牙齒上撲向獵物。雖然體型很大，卻能以靈巧的假動作戲弄敵手，那姿態就像是舞蹈一般。"
+		ja: "燃え盛る炎 牙に纏わせ 食らい付く。 体躯 大柄なれど 陽動 鮮やかなりて 敵 翻弄せしむる姿 演舞の如し。",
+		'zh-tw': "將猛烈燃燒的火焰纏繞在牙齒上撲向獵物。雖然體型很大，卻能以靈巧的假動作戲弄敵手，那姿態就像是舞蹈一般。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "城破突圍"
+	attacks: [
+		{
+			name: {
+				ja: "はっぽうやぶれ",
+				'zh-tw': "城破突圍",
+			},
+			damage: "10+",
+			cost: [],
+			effect: {
+				ja: "自分の手札が1枚もないなら、150ダメージ追加。",
+				'zh-tw': "若自己1張手牌都沒有，則增加150點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "若自己1張手牌都沒有，則增加150點傷害。"
+		{
+			name: {
+				ja: "するどいキバ",
+				'zh-tw': "銳利之牙",
+			},
+			damage: 100,
+			cost: ["Fighting", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: "10+"
-	}, {
-		name: {
-			'zh-tw': "銳利之牙"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 656340,
+				tcgplayer: 570696,
+			},
 		},
+	],
 
-		damage: 100,
-		cost: ["Fighting", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ヒスイ ガーディ",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [59],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/034.ts
+++ b/data-asia/S/S10a/034.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "腕力"
+		ja: "ワンリキー",
+		'zh-tw': "腕力",
 	},
 
 	illustrator: "Yuka Morii",
@@ -14,27 +14,46 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "全身都是肌肉，雖然體型只有小孩那麼大， 卻可以扔飛１００個大人。"
+		ja: "全身が 筋肉になっており 子どもほどの 大きさしかないのに 大人 １００人を 投げ飛ばせる。",
+		'zh-tw': "全身都是肌肉，雖然體型只有小孩那麼大， 卻可以扔飛１００個大人。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "出拳"
+	attacks: [
+		{
+			name: {
+				ja: "パンチ",
+				'zh-tw': "出拳",
+			},
+			damage: 20,
+			cost: ["Fighting"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Fighting"]
-	}],
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656342,
+				tcgplayer: 570697,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577113,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [66],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/035.ts
+++ b/data-asia/S/S10a/035.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "豪力"
+		ja: "ゴーリキー",
+		'zh-tw': "豪力",
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -14,34 +14,58 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "兼具強健肉體與持久耐力的強者。熱愛鍛鍊，會主動 協助進行開墾、建築等工作。"
+		ja: "強靭な 肉体と 持久力 兼ね備えし 剛の者。 鍛錬を 何より 好み 開墾 普請など 進んで 手伝う。",
+		'zh-tw': "兼具強健肉體與持久耐力的強者。熱愛鍛鍊，會主動 協助進行開墾、建築等工作。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "怪力"
+	attacks: [
+		{
+			name: {
+				ja: "かいりき",
+				'zh-tw': "怪力",
+			},
+			damage: 30,
+			cost: ["Fighting"],
 		},
-
-		damage: 30,
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "地球上投"
+		{
+			name: {
+				ja: "ちきゅうなげ",
+				'zh-tw': "地球上投",
+			},
+			damage: 50,
+			cost: ["Fighting", "Fighting"],
 		},
+	],
 
-		damage: 50,
-		cost: ["Fighting", "Fighting"]
-	}],
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656343,
+				tcgplayer: 570698,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577114,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ワンリキー",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [67],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/036.ts
+++ b/data-asia/S/S10a/036.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "怪力"
+		ja: "カイリキー",
+		'zh-tw': "怪力",
 	},
 
 	illustrator: "Nisota Niso",
@@ -14,43 +14,62 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "能夠迅速活動４隻手臂，從各種角度毫不停歇地 使出拳擊或手刀。"
+		ja: "４本の腕を すばやく 動かし あらゆる 角度から 休むことなく パンチや チョップを 叩きこむ。",
+		'zh-tw': "能夠迅速活動４隻手臂，從各種角度毫不停歇地 使出拳擊或手刀。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "火場筋力"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "かじばのマッスル",
+				'zh-tw': "火場筋力",
+			},
+			effect: {
+				ja: "相手のサイドの残り枚数が3枚以下なら、このポケモンの最大HPは「150」大きくなる。",
+				'zh-tw': "若對手剩餘獎賞卡的張數為3張以下，則這隻寶可夢的最大HP增加「150」。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若對手剩餘獎賞卡的張數為3張以下，則這隻寶可夢的最大HP增加「150」。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "剛腕金勾臂"
+	attacks: [
+		{
+			name: {
+				ja: "ごうわんラリアット",
+				'zh-tw': "剛腕金勾臂",
+			},
+			damage: "100+",
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "のぞむなら、100ダメージ追加。その場合、次の自分の番、このポケモンはワザが使えない。",
+				'zh-tw': "若希望，增加100點傷害。這個情況下，在下個自己的回合，這隻寶可夢無法使用招式。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若希望，增加100點傷害。這個情況下，在下個自己的回合，這隻寶可夢無法使用招式。"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 656344,
+				tcgplayer: 570699,
+			},
 		},
+	],
 
-		damage: "100+",
-		cost: ["Fighting", "Fighting"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ゴーリキー",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [68],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/037.ts
+++ b/data-asia/S/S10a/037.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "樹才怪"
+		ja: "ウソッキー",
+		'zh-tw': "樹才怪",
 	},
 
 	illustrator: "AKIRA EGAWA",
@@ -14,42 +14,62 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "偽裝成樹木，卻連幼童也難以騙過。體表並非樹皮，觸感彷若岩石。 值得一提的是，此寶可夢極其怕水。"
+		ja: "樹木の素振りするも 幼子も 欺けず。 その体は 樹皮ならず 岩の手触り。 水を ひどく嫌う習性 特記に値す。",
+		'zh-tw': "偽裝成樹木，卻連幼童也難以騙過。體表並非樹皮，觸感彷若岩石。 值得一提的是，此寶可夢極其怕水。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "狙落"
+	attacks: [
+		{
+			name: {
+				ja: "ねらいおとす",
+				'zh-tw': "狙落",
+			},
+			damage: 20,
+			cost: ["Fighting"],
+			effect: {
+				ja: "ダメージを与える前に、相手のバトルポケモンについている「ポケモンのどうぐ」をトラッシュする。",
+				'zh-tw': "在造成傷害前，將對手的戰鬥寶可夢身上附加的「寶可夢道具」丟棄。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在造成傷害前，將對手的戰鬥寶可夢身上附加的「寶可夢道具」丟棄。"
+		{
+			name: {
+				ja: "かこいこむ",
+				'zh-tw': "圍困",
+			},
+			damage: 50,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。",
+			},
 		},
+	],
 
-		damage: 20,
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "圍困"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656345,
+				tcgplayer: 570700,
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。"
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577115,
+			},
 		},
-
-		damage: 50,
-		cost: ["Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [185],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/038.ts
+++ b/data-asia/S/S10a/038.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "天蠍"
+		ja: "グライガー",
+		'zh-tw': "天蠍",
 	},
 
 	illustrator: "Miki Tanaka",
@@ -14,31 +14,50 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "會朝著獵物迎面飛來，然後趁著被纏上的獵物 驚慌失措時刺入毒針。"
+		ja: "顔面 めがけて 飛んでくる。 張りつかれた 獲物が 驚く あいだに 毒針を 刺しこむ。",
+		'zh-tw': "會朝著獵物迎面飛來，然後趁著被纏上的獵物 驚慌失措時刺入毒針。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "旋風鉗"
+	attacks: [
+		{
+			name: {
+				ja: "せんぷうバサミ",
+				'zh-tw': "旋風鉗",
+			},
+			damage: "10×",
+			cost: ["Fighting"],
+			effect: {
+				ja: "コインを4回投げ、オモテの数×10ダメージ。",
+				'zh-tw': "擲4次硬幣，造成正面出現的次數×10點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲4次硬幣，造成正面出現的次數×10點傷害。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656347,
+				tcgplayer: 570701,
+			},
 		},
-
-		damage: "10×",
-		cost: ["Fighting"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577116,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [207],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/039.ts
+++ b/data-asia/S/S10a/039.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "天蠍王"
+		ja: "グライオン",
+		'zh-tw': "天蠍王",
 	},
 
 	illustrator: "Shiburingaru",
@@ -14,31 +14,54 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "可不發出振翅聲而在空中飛行。先用長長的尾巴攫住獵物， 再用牙齒朝弱點給予一刺。"
+		ja: "羽音を 立てずに 空を 飛ぶ。 長い 尻尾で 獲物を 捕まえ キバで 急所を 一突き。",
+		'zh-tw': "可不發出振翅聲而在空中飛行。先用長長的尾巴攫住獵物， 再用牙齒朝弱點給予一刺。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "颶風衝擊"
+	attacks: [
+		{
+			name: {
+				ja: "ハリケーンショック",
+				'zh-tw': "颶風衝擊",
+			},
+			damage: "50×",
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "コインを4回投げ、オモテの数×50ダメージ。オモテが2回以上なら、相手のバトルポケモンをマヒにする。",
+				'zh-tw': "擲4次硬幣，造成正面出現的次數×50點傷害。若出現2次以上正面，則將對手的戰鬥寶可夢【麻痺】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲4次硬幣，造成正面出現的次數×50點傷害。若出現2次以上正面，則將對手的戰鬥寶可夢【麻痺】。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656348,
+				tcgplayer: 570702,
+			},
 		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577117,
+			},
+		},
+	],
 
-		damage: "50×",
-		cost: ["Fighting", "Fighting"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "グライガー",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [472],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/040.ts
+++ b/data-asia/S/S10a/040.ts
@@ -1,51 +1,64 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "艾路雷朵V"
+		ja: "エルレイドV",
+		'zh-tw': "艾路雷朵V",
 	},
 
 	illustrator: "Ryota Murayama",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Fighting"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "璀璨之劍"
+	attacks: [
+		{
+			name: {
+				ja: "ライジングソード",
+				'zh-tw': "璀璨之劍",
+			},
+			damage: "20+",
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "自分がすでにとったサイドの枚数×50ダメージ追加。",
+				'zh-tw': "增加自己已經獲得的獎賞卡的張數×50點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "增加自己已經獲得的獎賞卡的張數×50點傷害。"
+		{
+			name: {
+				ja: "バスタースイング",
+				'zh-tw': "粗暴橫掃",
+			},
+			damage: 130,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+				'zh-tw': "這個招式的傷害不計算抵抗力。",
+			},
 		},
+	],
 
-		damage: "20+",
-		cost: ["Fighting", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "粗暴橫掃"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 656350,
+				tcgplayer: 570703,
+			},
 		},
-
-		effect: {
-			'zh-tw': "這個招式的傷害不計算抵抗力。"
-		},
-
-		damage: 130,
-		cost: ["Fighting", "Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Double rare",
+	dexId: [475],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/041.ts
+++ b/data-asia/S/S10a/041.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "超音蝠"
+		ja: "ズバット",
+		'zh-tw': "超音蝠",
 	},
 
 	illustrator: "Shigenori Negishi",
@@ -14,27 +14,46 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "會利用從口中發出的超音波探查周圍的狀況。在狹窄的 洞窟裡也能靈巧地飛來飛去。"
+		ja: "口から 出す 超音波で まわりの 様子を 探る。 狭い 洞窟も 器用に 飛びまわる。",
+		'zh-tw': "會利用從口中發出的超音波探查周圍的狀況。在狹窄的 洞窟裡也能靈巧地飛來飛去。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "咬住"
+	attacks: [
+		{
+			name: {
+				ja: "かみつく",
+				'zh-tw': "咬住",
+			},
+			damage: 10,
+			cost: ["Darkness"],
 		},
+	],
 
-		damage: 10,
-		cost: ["Darkness"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656351,
+				tcgplayer: 570704,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577118,
+			},
+		},
+	],
 
 	retreat: 0,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [41],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/042.ts
+++ b/data-asia/S/S10a/042.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "大嘴蝠"
+		ja: "ゴルバット",
+		'zh-tw': "大嘴蝠",
 	},
 
 	illustrator: "Anesaki Dynamic",
@@ -14,27 +14,50 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "喜歡吸食生物的血液。據說還會將吸來的血 分給空腹的夥伴。"
+		ja: "生き物の 血液が 好物。 腹ペコの 仲間に 吸った 血を 分け与えることも あるという。",
+		'zh-tw': "喜歡吸食生物的血液。據說還會將吸來的血 分給空腹的夥伴。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "咬住"
+	attacks: [
+		{
+			name: {
+				ja: "かみつく",
+				'zh-tw': "咬住",
+			},
+			damage: 30,
+			cost: ["Darkness"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Darkness"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656354,
+				tcgplayer: 570705,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577119,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ズバット",
+	},
 
 	retreat: 0,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [42],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/043.ts
+++ b/data-asia/S/S10a/043.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "叉字蝠"
+		ja: "クロバット",
+		'zh-tw': "叉字蝠",
 	},
 
 	illustrator: "Yuya Oka",
@@ -14,41 +14,59 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "雙腳變成了翅膀。能夠無聲無息地高速飛行， 用獠牙咬住獵物的後頸。"
+		ja: "両足が 羽に 変化。 音を たてずに 高速で 飛び 獲物の うなじに キバを たてる。",
+		'zh-tw': "雙腳變成了翅膀。能夠無聲無息地高速飛行， 用獠牙咬住獵物的後頸。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "毒牙"
+	attacks: [
+		{
+			name: {
+				ja: "どくのキバ",
+				'zh-tw': "毒牙",
+			},
+			damage: 50,
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。"
+		{
+			name: {
+				ja: "クリティカルバイト",
+				'zh-tw': "關鍵啃咬",
+			},
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、30ダメージ。このワザのダメージで、相手のポケモンがきぜつしたなら、サイドを2枚多くとる。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的1隻寶可夢受到30點傷害。若對手的寶可夢因這個招式的傷害而【氣絕】，則多獲得2張獎賞卡。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		damage: 50,
-		cost: ["Darkness"]
-	}, {
-		name: {
-			'zh-tw': "關鍵啃咬"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 656357,
+				tcgplayer: 570706,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "對手的1隻寶可夢受到30點傷害。若對手的寶可夢因這個招式的傷害而【氣絕】，則多獲得2張獎賞卡。[在備戰區不計算弱點・抵抗力。]"
-		},
-
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ゴルバット",
+	},
 
 	retreat: 0,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [169],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/044.ts
+++ b/data-asia/S/S10a/044.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "黑暗鴉"
+		ja: "ヤミカラス",
+		'zh-tw': "黑暗鴉",
 	},
 
 	illustrator: "Ligton",
@@ -14,42 +14,57 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "會為了老大尋找閃閃發亮的東西。被人們視為不吉利的象徵， 厭惡牠的人也很多。"
+		ja: "ボスのために キラキラ 光るものを 探している。 不吉な 存在と いわれ 忌み嫌う 人も 多い。",
+		'zh-tw': "會為了老大尋找閃閃發亮的東西。被人們視為不吉利的象徵， 厭惡牠的人也很多。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "群聚"
+	attacks: [
+		{
+			name: {
+				ja: "むれる",
+				'zh-tw': "群聚",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から「ヤミカラス」を2枚まで選び、ベンチに出す。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多2張「黑暗鴉」卡，放置於備戰區。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多2張「黑暗鴉」卡，放置於備戰區。並且重洗牌庫。"
+		{
+			name: {
+				ja: "つつく",
+				'zh-tw': "啄",
+			},
+			damage: 10,
+			cost: ["Darkness"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "啄"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656358,
+				tcgplayer: 570707,
+			},
 		},
-
-		damage: 10,
-		cost: ["Darkness"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577120,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [198],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/045.ts
+++ b/data-asia/S/S10a/045.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "烏鴉頭頭"
+		ja: "ドンカラス",
+		'zh-tw': "烏鴉頭頭",
 	},
 
 	illustrator: "aoki",
@@ -14,46 +14,65 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "與敵人的戰鬥幾乎全由手下來應付。只有在最後給對手致命一擊的時候， 才會弄髒自己的手。"
+		ja: "敵と 戦うのは ほぼ 子分。 自分の 手を 汚すのは 相手に 最後の 止めを 刺すときだけ。",
+		'zh-tw': "與敵人的戰鬥幾乎全由手下來應付。只有在最後給對手致命一擊的時候， 才會弄髒自己的手。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "三重抽出"
+	attacks: [
+		{
+			name: {
+				ja: "トリプルドロー",
+				'zh-tw': "三重抽出",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を3枚引く。",
+				'zh-tw': "從自己的牌庫抽出3張卡。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫抽出3張卡。"
+		{
+			name: {
+				ja: "ひじょうのつばさ",
+				'zh-tw': "無情之翼",
+			},
+			damage: 120,
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンをベンチの「ヤミカラス」と入れ替える。",
+				'zh-tw': "若希望，將這隻寶可夢與備戰區的「黑暗鴉」互換。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "無情之翼"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656359,
+				tcgplayer: 570708,
+			},
 		},
-
-		effect: {
-			'zh-tw': "若希望，將這隻寶可夢與備戰區的「黑暗鴉」互換。"
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577121,
+			},
 		},
+	],
 
-		damage: 120,
-		cost: ["Darkness", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ヤミカラス",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [430],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/046.ts
+++ b/data-asia/S/S10a/046.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "光輝洗翠 大狃拉"
+		ja: "かがやくヒスイ オオニューラ",
+		'zh-tw': "光輝洗翠 大狃拉",
 	},
 
 	illustrator: "Akira Komayama",
@@ -14,43 +14,58 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "擁有凌駕其他物種之上的身體能力以及劇毒。在寒冷的高地上所向無敵。 偏好獨自行動，而不會集結成群。"
+		ja: "他種圧倒する 身体能力と 猛毒 有し 寒冷なる 高地においては 敵なし。 群れ成さず 単独を良しとする 性質。",
+		'zh-tw': "擁有凌駕其他物種之上的身體能力以及劇毒。在寒冷的高地上所向無敵。 偏好獨自行動，而不會集結成群。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "巔峰毒性"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ポイズンピーク",
+				'zh-tw': "巔峰毒性",
+			},
+			effect: {
+				ja: "このポケモンがいるかぎり、相手のバトルポケモンは、どくでのせるダメカンの数が2個多くなる。",
+				'zh-tw': "只要這隻寶可夢在場上，對手的戰鬥寶可夢因【中毒】而放置的傷害指示物的數量增加2個。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在場上，對手的戰鬥寶可夢因【中毒】而放置的傷害指示物的數量增加2個。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "毒擊"
+	attacks: [
+		{
+			name: {
+				ja: "どくづき",
+				'zh-tw': "毒擊",
+			},
+			damage: 90,
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 656361,
+				tcgplayer: 570709,
+			},
 		},
-
-		damage: 90,
-		cost: ["Darkness", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Radiant Rare",
+	dexId: [903],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/047.ts
+++ b/data-asia/S/S10a/047.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "花岩怪"
+		ja: "ミカルゲ",
+		'zh-tw': "花岩怪",
 	},
 
 	illustrator: "sui",
@@ -14,43 +14,64 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "１０８個靈魂聚集在一起成為了寶可夢，但其中 似乎混進了壞心眼的靈魂。"
+		ja: "１０８個の 魂が 集まり ポケモンになったが 性悪の 魂が 混じってしまったらしい。",
+		'zh-tw': "１０８個靈魂聚集在一起成為了寶可夢，但其中 似乎混進了壞心眼的靈魂。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "詛咒遺言"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "のろいのことづけ",
+				'zh-tw': "詛咒遺言",
+			},
+			effect: {
+				ja: "このポケモンが、相手のポケモンからワザのダメージを受けてきぜつしたとき、自分の山札から好きなカードを1枚選び、手札に加える。そして山札を切る。",
+				'zh-tw': "當這隻寶可夢受到對手的寶可夢招式的傷害而【氣絕】時，從自己的牌庫任意選擇1張卡加入手牌。並且重洗牌庫。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "當這隻寶可夢受到對手的寶可夢招式的傷害而【氣絕】時，從自己的牌庫任意選擇1張卡加入手牌。並且重洗牌庫。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "孤魂連鎖"
+	attacks: [
+		{
+			name: {
+				ja: "ひとだまれんさ",
+				'zh-tw': "孤魂連鎖",
+			},
+			damage: "10+",
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "自分のトラッシュにある「ミカルゲ」の枚数×60ダメージ追加。",
+				'zh-tw': "增加自己的棄牌區的「花岩怪」的張數×60點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加自己的棄牌區的「花岩怪」的張數×60點傷害。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656363,
+				tcgplayer: 570710,
+			},
 		},
-
-		damage: "10+",
-		cost: ["Darkness", "Darkness"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577122,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [442],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/048.ts
+++ b/data-asia/S/S10a/048.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "不良蛙"
+		ja: "グレッグル",
+		'zh-tw': "不良蛙",
 	},
 
 	illustrator: "Shin Nagasawa",
@@ -14,27 +14,46 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "會從自己臉頰上的毒囊發出聲音來威嚇對手， 趁對手畏懼的時候使出毒擊。"
+		ja: "頬の 毒袋を 鳴らして 敵を 威嚇。 ひるんだ 隙に 毒突きを おみまいする。",
+		'zh-tw': "會從自己臉頰上的毒囊發出聲音來威嚇對手， 趁對手畏懼的時候使出毒擊。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "推擊"
+	attacks: [
+		{
+			name: {
+				ja: "どつく",
+				'zh-tw': "推擊",
+			},
+			damage: 30,
+			cost: ["Darkness", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Darkness", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656366,
+				tcgplayer: 570711,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577123,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [453],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/049.ts
+++ b/data-asia/S/S10a/049.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "毒骷蛙"
+		ja: "ドクロッグ",
+		'zh-tw': "毒骷蛙",
 	},
 
 	illustrator: "Uta",
@@ -14,38 +14,62 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "一躍而起接近敵人，用有毒的爪子狠抓對方！ 光是擦傷就能將對手ＫＯ。"
+		ja: "跳ねるように 敵に 近づくと 毒のツメで えぐるように 打つ！ かすり傷でも 相手は ＫＯだ。",
+		'zh-tw': "一躍而起接近敵人，用有毒的爪子狠抓對方！ 光是擦傷就能將對手ＫＯ。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "突刺"
+	attacks: [
+		{
+			name: {
+				ja: "つきさす",
+				'zh-tw': "突刺",
+			},
+			damage: 30,
+			cost: ["Darkness"],
 		},
-
-		damage: 30,
-		cost: ["Darkness"]
-	}, {
-		name: {
-			'zh-tw': "衝天跳水"
+		{
+			name: {
+				ja: "とびこみアッパー",
+				'zh-tw': "衝天跳水",
+			},
+			damage: 120,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「+50」される。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「+50」點。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「+50」點。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656372,
+				tcgplayer: 570712,
+			},
 		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577124,
+			},
+		},
+	],
 
-		damage: 120,
-		cost: ["Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "グレッグル",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [454],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/050.ts
+++ b/data-asia/S/S10a/050.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "光輝大鋼蛇"
+		ja: "かがやくハガネール",
+		'zh-tw': "光輝大鋼蛇",
 	},
 
 	illustrator: "Sanosuke Sakuma",
@@ -14,47 +14,56 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "據說當大岩蛇活到了１００年以上，身體的成分 就會變得如同鑽石一般。"
+		ja: "イワークが １００年 以上 生きると 体の 成分が ダイヤのように 変化する という。",
+		'zh-tw': "據說當大岩蛇活到了１００年以上，身體的成分 就會變得如同鑽石一般。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "能量湍流"
+	attacks: [
+		{
+			name: {
+				ja: "エナジーストリーム",
+				'zh-tw': "能量湍流",
+			},
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュから[M]エネルギーを2枚まで選び、このポケモンにつける。",
+				'zh-tw': "從自己的棄牌區選擇最多2張【鋼】能量卡，附於這隻寶可夢身上。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的棄牌區選擇最多2張【鋼】能量卡，附於這隻寶可夢身上。"
+		{
+			name: {
+				ja: "フィニッシュブレイク",
+				'zh-tw': "終結破壞",
+			},
+			damage: "60+",
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "自分の山札の残り枚数が1枚になるように上からトラッシュし、その中にあるエネルギーの枚数×30ダメージ追加。",
+				'zh-tw': "將自己的牌庫上方的卡丟棄直到剩餘張數變為1張為止，增加其中的能量卡的張數×30點傷害。",
+			},
 		},
+	],
 
-		damage: 20,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "終結破壞"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 656373,
+				tcgplayer: 570713,
+			},
 		},
-
-		effect: {
-			'zh-tw': "將自己的牌庫上方的卡丟棄直到剩餘張數變為1張為止，增加其中的能量卡的張數×30點傷害。"
-		},
-
-		damage: "60+",
-		cost: ["Metal", "Metal", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	],
 
 	retreat: 4,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Radiant Rare",
+	dexId: [208],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/051.ts
+++ b/data-asia/S/S10a/051.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "銅鏡怪"
+		ja: "ドーミラー",
+		'zh-tw': "銅鏡怪",
 	},
 
 	illustrator: "Tomokazu Komiya",
@@ -14,32 +14,46 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "會在古老的遺跡出現。身上的紋路不屬於伽勒爾文化， 因此至今仍然謎團重重。"
+		ja: "古い 遺跡に 現れる。 体の 模様は ガラルには ない 文化の もので 謎。",
+		'zh-tw': "會在古老的遺跡出現。身上的紋路不屬於伽勒爾文化， 因此至今仍然謎團重重。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "迴轉攻擊"
+	attacks: [
+		{
+			name: {
+				ja: "かいてんアタック",
+				'zh-tw': "迴轉攻擊",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
+	],
 
-		damage: 10,
-		cost: ["Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656374,
+				tcgplayer: 570714,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577125,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [436],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/052.ts
+++ b/data-asia/S/S10a/052.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "青銅鐘"
+		ja: "ドータクン",
+		'zh-tw': "青銅鐘",
 	},
 
 	illustrator: "AKIRA EGAWA",
@@ -14,43 +14,62 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "據說當牠發出鐘聲般的音色時，通往異界的洞穴便會開啟。 自古就被視為神而受到供奉。"
+		ja: "鐘の音の如き 声色にて 鳴けば 異界へと 通じる 穴 開くと 言われ 古来より 神として 奉られたり。",
+		'zh-tw': "據說當牠發出鐘聲般的音色時，通往異界的洞穴便會開啟。 自古就被視為神而受到供奉。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "衝撞"
+	attacks: [
+		{
+			name: {
+				ja: "ぶつかる",
+				'zh-tw': "衝撞",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
 		},
-
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "重力墜擊"
+		{
+			name: {
+				ja: "じゅうりょくおとし",
+				'zh-tw': "重力墜擊",
+			},
+			damage: "40+",
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンのにげるためのエネルギーの数×40ダメージ追加。",
+				'zh-tw': "增加對手的戰鬥寶可夢【撤退】所需的能量的數量×40點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加對手的戰鬥寶可夢【撤退】所需的能量的數量×40點傷害。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656375,
+				tcgplayer: 570715,
+			},
 		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577126,
+			},
+		},
+	],
 
-		damage: "40+",
-		cost: ["Metal", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ドーミラー",
+	},
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [437],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/053.ts
+++ b/data-asia/S/S10a/053.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "黏黏寶"
+		ja: "ヌメラ",
+		'zh-tw': "黏黏寶",
 	},
 
 	illustrator: "Oswaldo KATO",
@@ -14,29 +14,54 @@ const card: Card = {
 	types: ["Dragon"],
 
 	description: {
-		'zh-tw': "藏身在濕度較高的樹蔭下。覆蓋著身體的黏糊液體一旦 乾枯，就會立刻失去生命力。"
+		ja: "湿度 高き 木陰に 身を 潜める。 体表を覆う ぬめりとした 液体が 乾くと たちどころに 生気を 失う。",
+		'zh-tw': "藏身在濕度較高的樹蔭下。覆蓋著身體的黏糊液體一旦 乾枯，就會立刻失去生命力。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "撞擊"
+	attacks: [
+		{
+			name: {
+				ja: "たいあたり",
+				'zh-tw': "撞擊",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
-
-		damage: 10,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "溶解"
+		{
+			name: {
+				ja: "とかす",
+				'zh-tw': "溶解",
+			},
+			damage: 30,
+			cost: ["Water", "Metal"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Water", "Metal"]
-	}],
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656376,
+				tcgplayer: 570716,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577127,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [704],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/054.ts
+++ b/data-asia/S/S10a/054.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洗翠 黏美兒"
+		ja: "ヒスイ ヌメイル",
+		'zh-tw': "洗翠 黏美兒",
 	},
 
 	illustrator: "Kouki Saitou",
@@ -14,30 +14,61 @@ const card: Card = {
 	types: ["Dragon"],
 
 	description: {
-		'zh-tw': "性情陰沉。據考察，洗翠地區的水中含有的鐵質對皮膚的黏液產生作用， 使其變化成了金屬外殼。"
+		ja: "陰気な 性質。 ヒスイの地の 水に 含有する 鉄が 皮膚の粘液に 作用し 金属の殻へ 変容させたと 考察す。",
+		'zh-tw': "性情陰沉。據考察，洗翠地區的水中含有的鐵質對皮膚的黏液產生作用， 使其變化成了金屬外殼。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "硬化"
+	attacks: [
+		{
+			name: {
+				ja: "こうちょく",
+				'zh-tw': "硬化",
+			},
+			cost: [],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-50」される。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-50」點。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-50」點。"
-		}
-	}, {
-		name: {
-			'zh-tw': "重摑"
+		{
+			name: {
+				ja: "ひっぱたく",
+				'zh-tw': "重摑",
+			},
+			damage: 40,
+			cost: ["Water", "Metal"],
 		},
+	],
 
-		damage: 40,
-		cost: ["Water", "Metal"]
-	}],
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656377,
+				tcgplayer: 570717,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577128,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヌメラ",
+	},
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [705],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/055.ts
+++ b/data-asia/S/S10a/055.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洗翠 黏美龍"
+		ja: "ヒスイ ヌメルゴン",
+		'zh-tw': "洗翠 黏美龍",
 	},
 
 	illustrator: "Akira Komayama",
@@ -14,34 +14,58 @@ const card: Card = {
 	types: ["Dragon"],
 
 	description: {
-		'zh-tw': "能自在操縱可剛可柔的金屬外殼。性情執著且厭惡孤獨，一旦喜愛的 對象離開自己便會怒不可遏。"
+		ja: "金属の殻の 剛柔を 自在に 操る。 孤独を 厭い 執念深く 好いた者が 己から 離れると 怒り 荒ぶる。",
+		'zh-tw': "能自在操縱可剛可柔的金屬外殼。性情執著且厭惡孤獨，一旦喜愛的 對象離開自己便會怒不可遏。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "鋼之歸宿"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "はがねのおやど",
+				'zh-tw': "鋼之歸宿",
+			},
+			effect: {
+				ja: "このポケモンがいるかぎり、[M]エネルギーがついている自分のたねポケモン全員は、相手の「ポケモンV」からワザのダメージを受けない。",
+				'zh-tw': "只要這隻寶可夢在場上，自己的所有身上附有【鋼】能量的【基礎】寶可夢，不會受到對手的「寶可夢【V】」招式的傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在場上，自己的所有身上附有【鋼】能量的【基礎】寶可夢，不會受到對手的「寶可夢【V】」招式的傷害。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "重磅衝擊"
+	attacks: [
+		{
+			name: {
+				ja: "ヘビーインパクト",
+				'zh-tw': "重磅衝擊",
+			},
+			damage: 140,
+			cost: ["Water", "Metal", "Colorless"],
 		},
+	],
 
-		damage: 140,
-		cost: ["Water", "Metal", "Colorless"]
-	}],
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 656378,
+				tcgplayer: 570718,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒスイ ヌメイル",
+	},
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [706],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/056.ts
+++ b/data-asia/S/S10a/056.ts
@@ -1,46 +1,64 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洗翠 黏美龍V"
+		ja: "ヒスイ ヌメルゴンV",
+		'zh-tw': "洗翠 黏美龍V",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Dragon"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "滑溜打滾"
+	attacks: [
+		{
+			name: {
+				ja: "ぬるりところばす",
+				'zh-tw': "滑溜打滾",
+			},
+			damage: 60,
+			cost: ["Water", "Metal"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+				'zh-tw': "將對手的戰鬥寶可夢與備戰寶可夢互換。[由對手選擇放置於戰鬥場的寶可夢。]",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢與備戰寶可夢互換。[由對手選擇放置於戰鬥場的寶可夢。]"
+		{
+			name: {
+				ja: "シェルローリング",
+				'zh-tw': "硬殼回轉",
+			},
+			damage: 140,
+			cost: ["Water", "Metal", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-30」點。",
+			},
 		},
+	],
 
-		damage: 60,
-		cost: ["Water", "Metal"]
-	}, {
-		name: {
-			'zh-tw': "硬殼回轉"
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 656379,
+				tcgplayer: 570719,
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-30」點。"
-		},
-
-		damage: 140,
-		cost: ["Water", "Metal", "Colorless"]
-	}],
+	],
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Double rare",
+	dexId: [706],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/057.ts
+++ b/data-asia/S/S10a/057.ts
@@ -1,46 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洗翠 黏美龍VSTAR"
+		ja: "ヒスイ ヌメルゴンVSTAR",
+		'zh-tw': "洗翠 黏美龍VSTAR",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 270,
 	types: ["Dragon"],
-	stage: "VMAX",
 
-	abilities: [{
-		type: "Ability",
+	stage: "VSTAR",
 
-		name: {
-			'zh-tw': "潤濕星星"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "モイストスター",
+				'zh-tw': "潤濕星星",
+			},
+			effect: {
+				ja: "自分の番に使える。このポケモンのHPを、すべて回復する。［対戦中、自分はVSTARパワーを1回しか使えない。］",
+				'zh-tw': "在自己的回合時可使用。將這隻寶可夢的HP全部恢復。[對戰中，己方只可使用1次【VSTAR】力量。]",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時可使用。將這隻寶可夢的HP全部恢復。[對戰中，己方只可使用1次【VSTAR】力量。]"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "鐵之回轉"
+	attacks: [
+		{
+			name: {
+				ja: "アイアンローリング",
+				'zh-tw': "鐵之回轉",
+			},
+			damage: 200,
+			cost: ["Water", "Metal", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-80」される。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-80」點。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-80」點。"
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 656381,
+				tcgplayer: 570720,
+			},
 		},
+	],
 
-		damage: 200,
-		cost: ["Water", "Metal", "Colorless"]
-	}],
+	evolveFrom: {
+		ja: "ヒスイ ヌメルゴンV",
+	},
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Triple Rare",
+	dexId: [706],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/058.ts
+++ b/data-asia/S/S10a/058.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "卡比獸"
+		ja: "カビゴン",
+		'zh-tw': "卡比獸",
 	},
 
 	illustrator: "0313",
@@ -14,43 +14,58 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "每天不吃下４００公斤的食物絕不會善罷甘休。 吃飽了就會開始睡覺。"
+		ja: "１日に 食べ物を ４００キロ 食べないと 気がすまない。 食べ終わると 眠ってしまう。",
+		'zh-tw': "每天不吃下４００公斤的食物絕不會善罷甘休。 吃飽了就會開始睡覺。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "無畏脂肪"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "へいきなしぼう",
+				'zh-tw': "無畏脂肪",
+			},
+			effect: {
+				ja: "このポケモンは、相手のポケモンが使うワザの効果を受けない。",
+				'zh-tw': "這隻寶可夢不會受到對手的寶可夢使用招式的效果的影響。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢不會受到對手的寶可夢使用招式的效果的影響。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "轟隆打呼"
+	attacks: [
+		{
+			name: {
+				ja: "どっすんグースカ",
+				'zh-tw': "轟隆打呼",
+			},
+			damage: 180,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをねむりにする。このねむりで投げるコインは2回になり、すべてオモテが出ないと回復しない。",
+				'zh-tw': "將這隻寶可夢【睡眠】。因這個【睡眠】的擲硬幣次數改為2次，若沒有全部為正面則無法恢復。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將這隻寶可夢【睡眠】。因這個【睡眠】的擲硬幣次數改為2次，若沒有全部為正面則無法恢復。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 656382,
+				tcgplayer: 570721,
+			},
 		},
-
-		damage: 180,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 4,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [143],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/059.ts
+++ b/data-asia/S/S10a/059.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "長尾怪手"
+		ja: "エイパム",
+		'zh-tw': "長尾怪手",
 	},
 
 	illustrator: "Kouki Saitou",
@@ -14,37 +14,57 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "擁有如同手掌般靈活的尾巴。棲息在樹上，有古書將其敘述為 只有一隻手的奇妙寶可夢。"
+		ja: "掌の如く 器用に 働く 尻尾 持ち 樹上に 暮らす。 古文書に 腕一本の 珍妙なポケモンとの 記述 残る。",
+		'zh-tw': "擁有如同手掌般靈活的尾巴。棲息在樹上，有古書將其敘述為 只有一隻手的奇妙寶可夢。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "惡作劇之尾"
+	attacks: [
+		{
+			name: {
+				ja: "いたずらテール",
+				'zh-tw': "惡作劇之尾",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手の山札を上から1枚見て、もとにもどす。のぞむなら、その山札を切る。",
+				'zh-tw': "查看對手的牌庫上方1張卡，回復原樣。若希望，重洗那個牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "查看對手的牌庫上方1張卡，回復原樣。若希望，重洗那個牌庫。"
+		{
+			name: {
+				ja: "ひっかく",
+				'zh-tw': "抓",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "抓"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656383,
+				tcgplayer: 570722,
+			},
 		},
-
-		damage: 10,
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577129,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [190],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/060.ts
+++ b/data-asia/S/S10a/060.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雙尾怪手"
+		ja: "エテボース",
+		'zh-tw': "雙尾怪手",
 	},
 
 	illustrator: "Atsushi Furusawa",
@@ -14,41 +14,65 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "不管做什麼事都會用到尾巴。如果牠用２根尾巴抱緊你， 就代表牠真的和你很親近。"
+		ja: "なにを するにも シッポを 使う。 ２本の シッポで 抱きしめられたら 本当に 懐かれた 証。",
+		'zh-tw': "不管做什麼事都會用到尾巴。如果牠用２根尾巴抱緊你， 就代表牠真的和你很親近。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "抓到飽"
+	attacks: [
+		{
+			name: {
+				ja: "つかみほうだい",
+				'zh-tw': "抓到飽",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数ぶんまで、自分の山札から好きなカードを選び、手札に加える。そして山札を切る。",
+				'zh-tw': "擲硬幣直到出現反面，從自己的牌庫任意選擇最多與正面出現的次數相同數量的卡，加入手牌。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲硬幣直到出現反面，從自己的牌庫任意選擇最多與正面出現的次數相同數量的卡，加入手牌。並且重洗牌庫。"
+		{
+			name: {
+				ja: "はたきおとす",
+				'zh-tw': "拍落",
+			},
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、トラッシュする。",
+				'zh-tw': "在不看正面的情況下，選擇1張對手的手牌，將其丟棄。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "拍落"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656384,
+				tcgplayer: 570723,
+			},
 		},
-
-		effect: {
-			'zh-tw': "在不看正面的情況下，選擇1張對手的手牌，將其丟棄。"
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577130,
+			},
 		},
+	],
 
-		damage: 50,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "エイパム",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [424],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/061.ts
+++ b/data-asia/S/S10a/061.ts
@@ -1,50 +1,64 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洗翠 索羅亞克V"
+		ja: "ヒスイ ゾロアークV",
+		'zh-tw': "洗翠 索羅亞克V",
 	},
 
 	illustrator: "aky CG Works",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Colorless"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "虛無折返"
+	attacks: [
+		{
+			name: {
+				ja: "うつろがえり",
+				'zh-tw': "虛無折返",
+			},
+			damage: 30,
+			cost: [],
+			effect: {
+				ja: "のぞむなら、このポケモンをベンチポケモンと入れ替える。",
+				'zh-tw': "若希望，將這隻寶可夢與備戰寶可夢互換。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "若希望，將這隻寶可夢與備戰寶可夢互換。"
+		{
+			name: {
+				ja: "シャドーサイクロン",
+				'zh-tw': "暗影旋風",
+			},
+			damage: 130,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、ベンチポケモンにつけ替える。",
+				'zh-tw': "選擇1個這隻寶可夢身上附加的能量，改附於備戰寶可夢身上。",
+			},
 		},
+	],
 
-		damage: 30
-	}, {
-		name: {
-			'zh-tw': "暗影旋風"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 656385,
+				tcgplayer: 570724,
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇1個這隻寶可夢身上附加的能量，改附於備戰寶可夢身上。"
-		},
-
-		damage: 130,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Double rare",
+	dexId: [571],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/062.ts
+++ b/data-asia/S/S10a/062.ts
@@ -1,51 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洗翠 索羅亞克VSTAR"
+		ja: "ヒスイ ゾロアークVSTAR",
+		'zh-tw': "洗翠 索羅亞克VSTAR",
 	},
 
 	illustrator: "aky CG Works",
 	category: "Pokemon",
 	hp: 270,
 	types: ["Colorless"],
-	stage: "VMAX",
 
-	abilities: [{
-		type: "Ability",
+	stage: "VSTAR",
 
-		name: {
-			'zh-tw': "幻影星星"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ファントムスター",
+				'zh-tw': "幻影星星",
+			},
+			effect: {
+				ja: "自分の番に使える。自分の手札をすべてトラッシュし、山札を7枚引く。［対戦中、自分はVSTARパワーを1回しか使えない。］",
+				'zh-tw': "在自己的回合時可使用。將自己的手牌全部丟棄，從牌庫抽出7張卡。[對戰中，己方只可使用1次【VSTAR】力量。]",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時可使用。將自己的手牌全部丟棄，從牌庫抽出7張卡。[對戰中，己方只可使用1次【VSTAR】力量。]"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "牢記詛咒"
+	attacks: [
+		{
+			name: {
+				ja: "のろいをきざむ",
+				'zh-tw': "牢記詛咒",
+			},
+			damage: "50×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のダメカンがのっているポケモンの数×50ダメージ。",
+				'zh-tw': "造成自己的場上身上放置有傷害指示物的寶可夢的數量×50點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "造成自己的場上身上放置有傷害指示物的寶可夢的數量×50點傷害。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 656386,
+				tcgplayer: 570725,
+			},
 		},
+	],
 
-		damage: "50×",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ヒスイ ゾロアークV",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Triple Rare",
+	dexId: [571],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10a/063.ts
+++ b/data-asia/S/S10a/063.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "阿爾宙斯手機"
+		ja: "アルセウスフォン",
+		'zh-tw': "阿爾宙斯手機",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "查看自己的牌庫上方1張卡，回復原樣。若希望，選擇1張自己的反面朝上的獎賞卡，與自己的牌庫上方的卡維持反面朝上互換。"
+		ja: "自分の山札を上から1枚見て、もとにもどす。のぞむなら、ウラになっている自分のサイドを1枚選び、自分の山札の上のカードと、ウラのまま入れ替える。",
+		'zh-tw': "查看自己的牌庫上方1張卡，回復原樣。若希望，選擇1張自己的反面朝上的獎賞卡，與自己的牌庫上方的卡維持反面朝上互換。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656387,
+				tcgplayer: 570726,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577131,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S10a/064.ts
+++ b/data-asia/S/S10a/064.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "傷害水泵"
+		ja: "ダメージポンプ",
+		'zh-tw': "傷害水泵",
 	},
 
 	illustrator: "sadaji",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "選擇最多2個自己的1隻場上寶可夢身上放置的傷害指示物，以任意方式改放於自己的其他寶可夢身上。"
+		ja: "自分の場のポケモン1匹にのっているダメカンを2個まで選び、自分の別のポケモンに好きなようにのせ替える。",
+		'zh-tw': "選擇最多2個自己的1隻場上寶可夢身上放置的傷害指示物，以任意方式改放於自己的其他寶可夢身上。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656388,
+				tcgplayer: 570727,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577132,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S10a/065.ts
+++ b/data-asia/S/S10a/065.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "機關臂"
+		ja: "からくりアーム",
+		'zh-tw': "機關臂",
 	},
 
 	illustrator: "Toyste Beach",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。"
+		ja: "このカードをつけているポケモンは、ねむりまたはマヒでも、ワザが使える。",
+		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656389,
+				tcgplayer: 570728,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577133,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Tool",
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S10a/066.ts
+++ b/data-asia/S/S10a/066.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "災禍箱"
+		ja: "災いの箱",
+		'zh-tw': "災禍箱",
 	},
 
 	illustrator: "Toyste Beach",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。"
+		ja: "このカードをつけている「ポケモンV」のHPがまんたんの状態で、相手のポケモンからワザのダメージを受けてきぜつしたとき、ワザを使ったポケモンにダメカンを8個のせる。",
+		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656390,
+				tcgplayer: 570729,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577134,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Tool",
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S10a/067.ts
+++ b/data-asia/S/S10a/067.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "望羅"
+		ja: "ウォロ",
+		'zh-tw': "望羅",
 	},
 
 	illustrator: "kirisAki",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "選擇1隻自己的備戰區的「寶可夢【V】」，將那隻寶可夢與附加的卡全部丟棄。"
+		ja: "自分のベンチの「ポケモンV」を1匹選び、そのポケモンと、ついているすべてのカードを、トラッシュする。",
+		'zh-tw': "選擇1隻自己的備戰區的「寶可夢【V】」，將那隻寶可夢與附加的卡全部丟棄。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 656391,
+				tcgplayer: 570730,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Rare",
+};
+
+export default card;

--- a/data-asia/S/S10a/068.ts
+++ b/data-asia/S/S10a/068.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "阿芒"
+		ja: "ススキ",
+		'zh-tw': "阿芒",
 	},
 
 	illustrator: "Akira Komayama",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的牌庫抽出2張卡。若自己的戰鬥寶可夢為名稱中有「洗翠」的寶可夢，則再抽出2張卡。"
+		ja: "自分の山札を2枚引く。自分のバトルポケモンが名前に「ヒスイ」とつくポケモンなら、さらに2枚引く。",
+		'zh-tw': "從自己的牌庫抽出2張卡。若自己的戰鬥寶可夢為名稱中有「洗翠」的寶可夢，則再抽出2張卡。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656392,
+				tcgplayer: 570731,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577135,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S10a/069.ts
+++ b/data-asia/S/S10a/069.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "火夏"
+		ja: "ヒナツ",
+		'zh-tw': "火夏",
 	},
 
 	illustrator: "kirisAki",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的牌庫選擇最多3張進化寶可夢卡（「擁有規則的寶可夢」除外），在給對手看過後加入手牌。並且重洗牌庫。"
+		ja: "自分の山札から進化ポケモン（「ルールを持つポケモン」をのぞく）を3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+		'zh-tw': "從自己的牌庫選擇最多3張進化寶可夢卡（「擁有規則的寶可夢」除外），在給對手看過後加入手牌。並且重洗牌庫。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656393,
+				tcgplayer: 570732,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577136,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S10a/070.ts
+++ b/data-asia/S/S10a/070.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "野賊三姐妹"
+		ja: "野盗三姉妹",
+		'zh-tw': "野賊三姐妹",
 	},
 
 	illustrator: "Souichirou Gunjima",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "查看對手的牌庫上方5張卡，從其中選擇任意數量的物品卡，將其丟棄。將剩餘卡放回牌庫並重洗。"
+		ja: "相手の山札を上から5枚見て、その中からグッズを好きなだけ選び、トラッシュする。残りのカードは山札にもどして切る。",
+		'zh-tw': "查看對手的牌庫上方5張卡，從其中選擇任意數量的物品卡，將其丟棄。將剩餘卡放回牌庫並重洗。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656394,
+				tcgplayer: 570733,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577137,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S10a/071.ts
+++ b/data-asia/S/S10a/071.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10a"
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "睿智湖"
+		ja: "エイチ湖",
+		'zh-tw': "睿智湖",
 	},
 
 	illustrator: "Oswaldo KATO",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "雙方的身上附有【水】或者【鬥】能量的寶可夢，受到對手的寶可夢招式的傷害「-20」點。"
+		ja: "おたがいの[W]または[F]エネルギーがついているポケモンが、相手のポケモンから受けるワザのダメージは「-20」される。",
+		'zh-tw': "雙方的身上附有【水】或者【鬥】能量的寶可夢，受到對手的寶可夢招式的傷害「-20」點。",
 	},
 
-	trainerType: "Stadium",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 656395,
+				tcgplayer: 570734,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 577138,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Stadium",
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S10a/072.ts
+++ b/data-asia/S/S10a/072.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パラセクト",
+	},
+
+	illustrator: "Oswaldo KATO",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Grass"],
+
+	description: {
+		ja: "森にて 背の茸が 外れ 動かぬ 個体あり。 大きな茸こそ本体 との 学説を 証明する サンプルなり。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ぐったりほうし" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。おたがいのバトルポケモンを、それぞれどくとねむりにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "シザークロス" },
+			damage: "50+",
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、50ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 657051,
+				tcgplayer: 570735,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "パラス",
+	},
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Character Rare",
+	dexId: [47],
+};
+
+export default card;

--- a/data-asia/S/S10a/073.ts
+++ b/data-asia/S/S10a/073.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウ",
+	},
+
+	illustrator: "Atsushi Furusawa",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "頬に 電気を溜めし 袋を 有す。 森林を 棲み処とし 硬き 木の実は 電撃で 焼き 食べる 知恵者なり。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ピカダッシュ" },
+			effect: {
+				ja: "このポケモンにエネルギーがついているなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "きまぐれタックル" },
+			damage: 50,
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 657052,
+				tcgplayer: 570736,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Character Rare",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/S/S10a/074.ts
+++ b/data-asia/S/S10a/074.ts
@@ -1,0 +1,64 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲンガー",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "影に憑きて 命 狙いし ポケモン。 己が影 ひとりでに 笑いしときは 一刻も早く 清めの札 握るべし。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ならくのうらもん" },
+			effect: {
+				ja: "このカードがトラッシュにあるなら、自分の番に1回使える。このカードをベンチに出す。その後、このポケモンにダメカンを3個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スクリームサークル" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のベンチポケモンの数×2個ぶんのダメカンを、相手のバトルポケモンにのせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 657053,
+				tcgplayer: 570737,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴースト",
+	},
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Character Rare",
+	dexId: [94],
+};
+
+export default card;

--- a/data-asia/S/S10a/075.ts
+++ b/data-asia/S/S10a/075.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒスイ ウインディ",
+	},
+
+	illustrator: "You Iribi",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+
+	description: {
+		ja: "燃え盛る炎 牙に纏わせ 食らい付く。 体躯 大柄なれど 陽動 鮮やかなりて 敵 翻弄せしむる姿 演舞の如し。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "はっぽうやぶれ" },
+			damage: "10+",
+			cost: [],
+			effect: {
+				ja: "自分の手札が1枚もないなら、150ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "するどいキバ" },
+			damage: 100,
+			cost: ["Fighting", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 657054,
+				tcgplayer: 570738,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒスイ ガーディ",
+	},
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Character Rare",
+	dexId: [59],
+};
+
+export default card;

--- a/data-asia/S/S10a/076.ts
+++ b/data-asia/S/S10a/076.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミカルゲ",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "邪悪なる 念にて 祟り もたらす。 百と八つの 悪しき 魂 集いて 生じたと 記されし ポケモン。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "のろいのことづけ" },
+			effect: {
+				ja: "このポケモンが、相手のポケモンからワザのダメージを受けてきぜつしたとき、自分の山札から好きなカードを1枚選び、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ひとだまれんさ" },
+			damage: "10+",
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "自分のトラッシュにある「ミカルゲ」の枚数×60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 657055,
+				tcgplayer: 570739,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Character Rare",
+	dexId: [442],
+};
+
+export default card;

--- a/data-asia/S/S10a/077.ts
+++ b/data-asia/S/S10a/077.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カビゴン",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Colorless"],
+
+	description: {
+		ja: "出し抜けに 村に現れ たちまち 米蔵を 空にする 大食漢。 古より 災厄のひとつと 数えられし行為なり。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "へいきなしぼう" },
+			effect: {
+				ja: "このポケモンは、相手のポケモンが使うワザの効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "どっすんグースカ" },
+			damage: 180,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをねむりにする。このねむりで投げるコインは2回になり、すべてオモテが出ないと回復しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 657056,
+				tcgplayer: 570740,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "F",
+	rarity: "Character Rare",
+	dexId: [143],
+};
+
+export default card;

--- a/data-asia/S/S10a/078.ts
+++ b/data-asia/S/S10a/078.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒスイ マルマインV",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かんしゃくボム" },
+			damage: "100×",
+			cost: [],
+			effect: {
+				ja: "このポケモンが受けている特殊状態の数×100ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ソーラーシュート" },
+			damage: 120,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、すべてトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 657057,
+				tcgplayer: 570741,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [101],
+};
+
+export default card;

--- a/data-asia/S/S10a/079.ts
+++ b/data-asia/S/S10a/079.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジバコイルV",
+	},
+
+	illustrator: "N-DESIGN Inc.",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっぱりじりょく" },
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、新しく出てきたポケモンに40ダメージ。",
+			},
+		},
+		{
+			name: { ja: "スプリットビーム" },
+			damage: 90,
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン2匹にも、それぞれ30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 657058,
+				tcgplayer: 570742,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [462],
+};
+
+export default card;

--- a/data-asia/S/S10a/080.ts
+++ b/data-asia/S/S10a/080.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラブトロスV",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "あいのしゅごしん" },
+			effect: {
+				ja: "このポケモンがいるかぎり、[P]エネルギーがついている自分のポケモン（「ラブトロスV」をのぞく）全員は、相手のポケモンから特性の効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ブロッサムテール" },
+			damage: 100,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュから基本エネルギーを2枚まで選び、ベンチポケモンに好きなようにつける。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 657059,
+				tcgplayer: 570743,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [905],
+};
+
+export default card;

--- a/data-asia/S/S10a/081.ts
+++ b/data-asia/S/S10a/081.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エルレイドV",
+	},
+
+	illustrator: "takuyoa",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ライジングソード" },
+			damage: "20+",
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "自分がすでにとったサイドの枚数×50ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "バスタースイング" },
+			damage: 130,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 657060,
+				tcgplayer: 570744,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [475],
+};
+
+export default card;

--- a/data-asia/S/S10a/082.ts
+++ b/data-asia/S/S10a/082.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒスイ ヌメルゴンV",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぬるりところばす" },
+			damage: 60,
+			cost: ["Water", "Metal"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+		{
+			name: { ja: "シェルローリング" },
+			damage: 140,
+			cost: ["Water", "Metal", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 657061,
+				tcgplayer: 570745,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [706],
+};
+
+export default card;

--- a/data-asia/S/S10a/083.ts
+++ b/data-asia/S/S10a/083.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒスイ ゾロアークV",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "うつろがえり" },
+			damage: 30,
+			cost: [],
+			effect: {
+				ja: "のぞむなら、このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "シャドーサイクロン" },
+			damage: 130,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、ベンチポケモンにつけ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 657062,
+				tcgplayer: 570746,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [571],
+};
+
+export default card;

--- a/data-asia/S/S10a/084.ts
+++ b/data-asia/S/S10a/084.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウォロ",
+	},
+
+	illustrator: "kirisAki",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のベンチの「ポケモンV」を1匹選び、そのポケモンと、ついているすべてのカードを、トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 657063,
+				tcgplayer: 570747,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S10a/085.ts
+++ b/data-asia/S/S10a/085.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ススキ",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を2枚引く。自分のバトルポケモンが名前に「ヒスイ」とつくポケモンなら、さらに2枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 657064,
+				tcgplayer: 570748,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S10a/086.ts
+++ b/data-asia/S/S10a/086.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒナツ",
+	},
+
+	illustrator: "You Iribi",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から進化ポケモン（「ルールを持つポケモン」をのぞく）を3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 657065,
+				tcgplayer: 570749,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S10a/087.ts
+++ b/data-asia/S/S10a/087.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "野盗三姉妹",
+	},
+
+	illustrator: "Souichirou Gunjima",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手の山札を上から5枚見て、その中からグッズを好きなだけ選び、トラッシュする。残りのカードは山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 657066,
+				tcgplayer: 570750,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S10a/088.ts
+++ b/data-asia/S/S10a/088.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラブトロスV",
+	},
+
+	illustrator: "AKIRA EGAWA",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "あいのしゅごしん" },
+			effect: {
+				ja: "このポケモンがいるかぎり、[P]エネルギーがついている自分のポケモン（「ラブトロスV」をのぞく）全員は、相手のポケモンから特性の効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ブロッサムテール" },
+			damage: 100,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュから基本エネルギーを2枚まで選び、ベンチポケモンに好きなようにつける。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 657067,
+				tcgplayer: 570751,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Character Super Rare",
+	dexId: [905],
+};
+
+export default card;

--- a/data-asia/S/S10a/089.ts
+++ b/data-asia/S/S10a/089.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エルレイドV",
+	},
+
+	illustrator: "Souichirou Gunjima",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ライジングソード" },
+			damage: "20+",
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "自分がすでにとったサイドの枚数×50ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "バスタースイング" },
+			damage: 130,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 657068,
+				tcgplayer: 570752,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Character Super Rare",
+	dexId: [475],
+};
+
+export default card;

--- a/data-asia/S/S10a/090.ts
+++ b/data-asia/S/S10a/090.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジバコイルVSTAR",
+	},
+
+	illustrator: "PLANETA Mochizuki",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Lightning"],
+
+	stage: "VSTAR",
+
+	attacks: [
+		{
+			name: { ja: "マグネグリップ" },
+			damage: 180,
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札からグッズを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "エレクトロスター" },
+			cost: ["Lightning", "Lightning"],
+			effect: {
+				ja: "相手のベンチポケモン2匹に、それぞれ90ダメージ。［ベンチは弱点・抵抗力を計算しない。］［対戦中、自分はVSTARパワーを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 657069,
+				tcgplayer: 570753,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジバコイルV",
+	},
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Holo Rare",
+	dexId: [462],
+};
+
+export default card;

--- a/data-asia/S/S10a/091.ts
+++ b/data-asia/S/S10a/091.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒスイ ヌメルゴンVSTAR",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Dragon"],
+
+	stage: "VSTAR",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "モイストスター" },
+			effect: {
+				ja: "自分の番に使える。このポケモンのHPを、すべて回復する。［対戦中、自分はVSTARパワーを1回しか使えない。］",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アイアンローリング" },
+			damage: 200,
+			cost: ["Water", "Metal", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-80」される。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 657070,
+				tcgplayer: 570754,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒスイ ヌメルゴンV",
+	},
+
+	retreat: 3,
+	regulationMark: "F",
+	rarity: "Holo Rare",
+	dexId: [706],
+};
+
+export default card;

--- a/data-asia/S/S10a/092.ts
+++ b/data-asia/S/S10a/092.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒスイ ゾロアークVSTAR",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Colorless"],
+
+	stage: "VSTAR",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ファントムスター" },
+			effect: {
+				ja: "自分の番に使える。自分の手札をすべてトラッシュし、山札を7枚引く。［対戦中、自分はVSTARパワーを1回しか使えない。］",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "のろいをきざむ" },
+			damage: "50×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のダメカンがのっているポケモンの数×50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 657071,
+				tcgplayer: 570755,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒスイ ゾロアークV",
+	},
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Holo Rare",
+	dexId: [571],
+};
+
+export default card;

--- a/data-asia/S/S10a/093.ts
+++ b/data-asia/S/S10a/093.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウォロ",
+	},
+
+	illustrator: "kirisAki",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のベンチの「ポケモンV」を1匹選び、そのポケモンと、ついているすべてのカードを、トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 657072,
+				tcgplayer: 570756,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Holo Rare",
+};
+
+export default card;

--- a/data-asia/S/S10a/094.ts
+++ b/data-asia/S/S10a/094.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ススキ",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を2枚引く。自分のバトルポケモンが名前に「ヒスイ」とつくポケモンなら、さらに2枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 657073,
+				tcgplayer: 570757,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Holo Rare",
+};
+
+export default card;

--- a/data-asia/S/S10a/095.ts
+++ b/data-asia/S/S10a/095.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒナツ",
+	},
+
+	illustrator: "You Iribi",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から進化ポケモン（「ルールを持つポケモン」をのぞく）を3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 657074,
+				tcgplayer: 570758,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Holo Rare",
+};
+
+export default card;

--- a/data-asia/S/S10a/096.ts
+++ b/data-asia/S/S10a/096.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "野盗三姉妹",
+	},
+
+	illustrator: "Souichirou Gunjima",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手の山札を上から5枚見て、その中からグッズを好きなだけ選び、トラッシュする。残りのカードは山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 657075,
+				tcgplayer: 570759,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Holo Rare",
+};
+
+export default card;

--- a/data-asia/S/S10a/097.ts
+++ b/data-asia/S/S10a/097.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒスイ ゾロアークVSTAR",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Colorless"],
+
+	stage: "VSTAR",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ファントムスター" },
+			effect: {
+				ja: "自分の番に使える。自分の手札をすべてトラッシュし、山札を7枚引く。［対戦中、自分はVSTARパワーを1回しか使えない。］",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "のろいをきざむ" },
+			damage: "50×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のダメカンがのっているポケモンの数×50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 657076,
+				tcgplayer: 570760,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒスイ ゾロアークV",
+	},
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Mega Hyper Rare",
+	dexId: [571],
+};
+
+export default card;

--- a/data-asia/S/S10a/098.ts
+++ b/data-asia/S/S10a/098.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダークパッチ",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュから「基本[悪]エネルギー」を1枚選び、ベンチの[悪]ポケモンにつける。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 657077,
+				tcgplayer: 570761,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "F",
+	rarity: "Mega Hyper Rare",
+};
+
+export default card;

--- a/data-asia/S/S10a/099.ts
+++ b/data-asia/S/S10a/099.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "災いの箱",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけている「ポケモンV」のHPがまんたんの状態で、相手のポケモンからワザのダメージを受けてきぜつしたとき、ワザを使ったポケモンにダメカンを8個のせる。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 657078,
+				tcgplayer: 570762,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "F",
+	rarity: "Mega Hyper Rare",
+};
+
+export default card;

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -236,6 +236,7 @@ export interface Card {
 			// Black White rare
 			| 'Black White Rare'
 			| 'Mega Hyper Rare'
+			| 'Triple Rare'
 			// Japanese Character Rares (since SM11b Dream League)
 			| 'Character Rare' | 'Character Super Rare'
 			// Pokémon TCG Pocket Rarities


### PR DESCRIPTION
## What

Refreshes the existing Japanese set **S10a ダークファンタズマ (Dark Phantasma)** from its primary sources. The curated content stays: every card keeps its `zh-tw`/`th` texts verbatim.

What changes across the 99 card files:

- `thirdParty.cardmarket` moves onto `variants` objects and 71 missing ids are filled in
- per card where missing: `dexId`, `evolveFrom`, `resistances`, the Japanese flavor text and the Japanese effect/attack texts straight from the official database and limitless

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (656180–657078)
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (570664–570762), keyed by the collection number each product carries in `extendedData`

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- All 99 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
