### PR TITLE
(data) Update Japanese S set S11a Incandescent Arcana

### DIFF
--- a/data-asia/S/S11a/001.ts
+++ b/data-asia/S/S11a/001.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "飛天螳螂"
+		ja: "ストライク",
+		'zh-tw': "飛天螳螂",
 	},
 
 	illustrator: "Narumi Sato",
@@ -14,31 +14,51 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "隨著牠歷經越多的對戰，鐮刀也就會變得越鋒利。連大樹也能一刀劈成兩半。"
+		ja: "戦いを 重ねるごとに 鎌の 切れ味は 上がる。 大木も 一刀両断に 切り裂くぞ。",
+		'zh-tw': "隨著牠歷經越多的對戰，鐮刀也就會變得越鋒利。連大樹也能一刀劈成兩半。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "音速斬"
+	attacks: [
+		{
+			name: {
+				ja: "おんそくぎり",
+				'zh-tw': "音速斬",
+			},
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについている特殊エネルギーを1個選び、トラッシュする。",
+				'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的特殊能量，將其丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的特殊能量，將其丟棄。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 672998,
+				tcgplayer: 570764,
+			},
 		},
-
-		damage: 10,
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570858,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [123],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/002.ts
+++ b/data-asia/S/S11a/002.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "蜻蜻蜓"
+		ja: "ヤンヤンマ",
+		'zh-tw': "蜻蜻蜓",
 	},
 
 	illustrator: "Shin Nagasawa",
@@ -14,37 +14,58 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "如果高速拍動翅膀，就會產生衝擊波，把周圍的玻璃一一震碎。"
+		ja: "高速で 羽を 羽ばたかせると 衝撃波が 発生して まわりの 窓ガラスが 割れていく。",
+		'zh-tw': "如果高速拍動翅膀，就會產生衝擊波，把周圍的玻璃一一震碎。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "橫斷飛行"
+	attacks: [
+		{
+			name: {
+				ja: "おうだんひこう",
+				'zh-tw': "橫斷飛行",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的所有寶可夢各受到10點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
-
-		effect: {
-			'zh-tw': "對手的所有寶可夢各受到10點傷害。[在備戰區不計算弱點・抵抗力。]"
+		{
+			name: {
+				ja: "カッターウインド",
+				'zh-tw': "利刃之風",
+			},
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "利刃之風"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 672999,
+				tcgplayer: 570765,
+			},
 		},
-
-		damage: 70,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570859,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [193],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/003.ts
+++ b/data-asia/S/S11a/003.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "遠古巨蜓"
+		ja: "メガヤンマ",
+		'zh-tw': "遠古巨蜓",
 	},
 
 	illustrator: "KIYOTAKA OSHIYAMA",
@@ -14,42 +14,67 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "能以６隻腳攫住成年人並輕鬆地飛行。以尾部的翅膀保持平衡。"
+		ja: "６本の 脚で 大人を 抱えて 楽々と 飛ぶ ことが できる。 尻尾の 羽で バランスを とる。",
+		'zh-tw': "能以６隻腳攫住成年人並輕鬆地飛行。以尾部的翅膀保持平衡。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "穿通"
+	attacks: [
+		{
+			name: {
+				ja: "つきぬける",
+				'zh-tw': "穿通",
+			},
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的1隻備戰寶可夢也受到20點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
-
-		effect: {
-			'zh-tw': "對手的1隻備戰寶可夢也受到20點傷害。[在備戰區不計算弱點・抵抗力。]"
+		{
+			name: {
+				ja: "ジェットウイング",
+				'zh-tw': "噴射之翼",
+			},
+			damage: 160,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。",
+			},
 		},
+	],
 
-		damage: 20,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "噴射之翼"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673000,
+				tcgplayer: 570766,
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。"
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570860,
+			},
 		},
+	],
 
-		damage: 160,
-		cost: ["Grass", "Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ヤンヤンマ",
+	},
 
 	retreat: 0,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [469],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/004.ts
+++ b/data-asia/S/S11a/004.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "尖牙籠"
+		ja: "マスキッパ",
+		'zh-tw': "尖牙籠",
 	},
 
 	illustrator: "Shibuzoh.",
@@ -14,41 +14,62 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "會纏繞在生長於潮濕地帶的樹木上，以散發甜甜香氣的唾液吸引獵物靠近，再一口吃掉。"
+		ja: "湿地帯に 生える 木に巻きつき 甘い香りの だえきで 獲物を 誘き寄せては ひとくちで 食べる。",
+		'zh-tw': "會纏繞在生長於潮濕地帶的樹木上，以散發甜甜香氣的唾液吸引獵物靠近，再一口吃掉。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "潰爛唾液"
+	attacks: [
+		{
+			name: {
+				ja: "ただれるだえき",
+				'zh-tw': "潰爛唾液",
+			},
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンをどくとやけどにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】與【灼傷】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】與【灼傷】。"
+		{
+			name: {
+				ja: "しばりつける",
+				'zh-tw': "束縛",
+			},
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。",
+			},
 		},
+	],
 
-		cost: ["Grass"]
-	}, {
-		name: {
-			'zh-tw': "束縛"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673001,
+				tcgplayer: 570767,
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。"
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570861,
+			},
 		},
-
-		damage: 40,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [455],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/005.ts
+++ b/data-asia/S/S11a/005.ts
@@ -1,46 +1,59 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "君主蛇V"
+		ja: "ジャローダV",
+		'zh-tw': "君主蛇V",
 	},
 
 	illustrator: "Ayaka Yoshida",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Grass"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "高貴之光"
+	attacks: [
+		{
+			name: {
+				ja: "けだかいひかり",
+				'zh-tw': "高貴之光",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "おたがいのポケモン全員のHPを、それぞれ「30」回復する。",
+				'zh-tw': "將雙方的所有寶可夢各恢復「30」HP。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將雙方的所有寶可夢各恢復「30」HP。"
+		{
+			name: {
+				ja: "ソーラービーム",
+				'zh-tw': "日光束",
+			},
+			damage: 120,
+			cost: ["Grass", "Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "日光束"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673002,
+				tcgplayer: 570768,
+			},
 		},
-
-		damage: 120,
-		cost: ["Grass", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Double rare",
+	dexId: [497],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/006.ts
+++ b/data-asia/S/S11a/006.ts
@@ -1,50 +1,68 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "君主蛇VSTAR"
+		ja: "ジャローダVSTAR",
+		'zh-tw': "君主蛇VSTAR",
 	},
 
 	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
 	hp: 270,
 	types: ["Grass"],
-	stage: "VMAX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "皇家攪拌"
+	stage: "VSTAR",
+
+	attacks: [
+		{
+			name: {
+				ja: "ロイヤルミキサー",
+				'zh-tw': "皇家攪拌",
+			},
+			damage: 190,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについているエネルギーを好きなだけ選び、自分のポケモンに好きなようにつけ替える。",
+				'zh-tw': "選擇自己的場上寶可夢身上附加的任意數量的能量，以任意方式改附於自己的寶可夢身上。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇自己的場上寶可夢身上附加的任意數量的能量，以任意方式改附於自己的寶可夢身上。"
+		{
+			name: {
+				ja: "スターワインダー",
+				'zh-tw': "[VSTAR力量]星星旋繞",
+			},
+			damage: "60×",
+			cost: ["Grass"],
+			effect: {
+				ja: "このポケモンについているエネルギーの数×60ダメージ。このポケモンをベンチポケモンと入れ替える。［対戦中、自分はVSTARパワーを1回しか使えない。］",
+				'zh-tw': "造成這隻寶可夢身上附加的能量的數量×60點傷害。將這隻寶可夢與備戰寶可夢互換。[對戰中，己方只可使用1次【VSTAR】力量。]",
+			},
 		},
+	],
 
-		damage: 190,
-		cost: ["Grass", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "[VSTAR力量]星星旋繞"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673003,
+				tcgplayer: 570769,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "造成這隻寶可夢身上附加的能量的數量×60點傷害。將這隻寶可夢與備戰寶可夢互換。[對戰中，己方只可使用1次【VSTAR】力量。]"
-		},
-
-		damage: "60×",
-		cost: ["Grass"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ジャローダV",
+	},
 
 	retreat: 0,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Triple Rare",
+	dexId: [497],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/007.ts
+++ b/data-asia/S/S11a/007.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "百合根娃娃"
+		ja: "チュリネ",
+		'zh-tw': "百合根娃娃",
 	},
 
 	illustrator: "HYOGONOSUKE",
@@ -14,34 +14,55 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "頭上的葉片是人們愛用的藥材。在太陽下曬乾後煎煮服用，雖然味苦但能有效地消除疲勞。"
+		ja: "頭の 葉は 薬として 重宝されたり。 天日で 乾かし 煎じて 飲むと 苦けれども 疲労回復に 効果抜群。",
+		'zh-tw': "頭上的葉片是人們愛用的藥材。在太陽下曬乾後煎煮服用，雖然味苦但能有效地消除疲勞。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "衝撞"
+	attacks: [
+		{
+			name: {
+				ja: "ぶつかる",
+				'zh-tw': "衝撞",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
-
-		damage: 10,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "活蹦亂跳"
+		{
+			name: {
+				ja: "はねまわる",
+				'zh-tw': "活蹦亂跳",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673004,
+				tcgplayer: 570770,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570862,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [548],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/008.ts
+++ b/data-asia/S/S11a/008.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洗翠 裙兒小姐"
+		ja: "ヒスイ ドレディア",
+		'zh-tw': "洗翠 裙兒小姐",
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -14,35 +14,62 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "據考察，雪山深處的棲息環境為其帶來了發達的腳力。會從頭冠般的花中發出鼓舞周遭夥伴的香氣。"
+		ja: "雪深き山に 棲みしゆえに 脚力が 発達したと 考察す。 周囲の者を 鼓舞する 香りを 冠の花より 放つ。",
+		'zh-tw': "據考察，雪山深處的棲息環境為其帶來了發達的腳力。會從頭冠般的花中發出鼓舞周遭夥伴的香氣。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "充溢香氣"
+	attacks: [
+		{
+			name: {
+				ja: "みなぎるかおり",
+				'zh-tw': "充溢香氣",
+			},
+			cost: [],
+			effect: {
+				ja: "自分の山札から[G]エネルギーを2枚まで選び、ベンチポケモンに好きなようにつける。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多2張【草】能量卡，以任意方式附於備戰寶可夢身上。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多2張【草】能量卡，以任意方式附於備戰寶可夢身上。並且重洗牌庫。"
-		}
-	}, {
-		name: {
-			'zh-tw': "迴轉踢"
+		{
+			name: {
+				ja: "かいてんげり",
+				'zh-tw': "迴轉踢",
+			},
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 50,
-		cost: ["Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673005,
+				tcgplayer: 570771,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570863,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チュリネ",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [549],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/009.ts
+++ b/data-asia/S/S11a/009.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "光輝甜冷美后"
+		ja: "かがやくアマージョ",
+		'zh-tw': "光輝甜冷美后",
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -14,43 +14,58 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "讓人畏懼的寶可夢。擁有苗條的雙腿和殘忍的心，會毫不留情地狠踩敵人。"
+		ja: "すらりと 伸びた 脚と 残忍な 心を もち 恐れられている。 敵を 容赦なく 踏みにじる。",
+		'zh-tw': "讓人畏懼的寶可夢。擁有苗條的雙腿和殘忍的心，會毫不留情地狠踩敵人。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "優雅治癒"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "エレガントヒール",
+				'zh-tw': "優雅治癒",
+			},
+			effect: {
+				ja: "自分の番に1回使える。自分のポケモン全員のHPを、それぞれ「20」回復する。",
+				'zh-tw': "在自己的回合時，可使用1次。將自己的所有寶可夢各恢復「20」HP。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，可使用1次。將自己的所有寶可夢各恢復「20」HP。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "芳香射擊"
+	attacks: [
+		{
+			name: {
+				ja: "アロマシュート",
+				'zh-tw': "芳香射擊",
+			},
+			damage: 90,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンの特殊状態をすべて回復する。",
+				'zh-tw': "將這隻寶可夢的特殊狀態全部恢復。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將這隻寶可夢的特殊狀態全部恢復。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673006,
+				tcgplayer: 570772,
+			},
 		},
-
-		damage: 90,
-		cost: ["Grass", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Radiant Rare",
+	dexId: [763],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/010.ts
+++ b/data-asia/S/S11a/010.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "薩戮德"
+		ja: "ザルード",
+		'zh-tw': "薩戮德",
 	},
 
 	illustrator: "Shiburingaru",
@@ -14,41 +14,55 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "集結成群生活在密林裡。攻擊性很強，令棲息在森林的寶可夢們畏懼不已。"
+		ja: "群れを つくり 密林で 暮らす。 とても 攻撃的で 森にすむ ポケモンたちから 恐れられている。",
+		'zh-tw': "集結成群生活在密林裡。攻擊性很強，令棲息在森林的寶可夢們畏懼不已。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "拖出"
+	attacks: [
+		{
+			name: {
+				ja: "ひきずりだす",
+				'zh-tw': "拖出",
+			},
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、新しく出てきたポケモンに20ダメージ。",
+				'zh-tw': "選擇對手的1隻備戰寶可夢，與戰鬥寶可夢互換。然後，新上場的寶可夢受到20點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇對手的1隻備戰寶可夢，與戰鬥寶可夢互換。然後，新上場的寶可夢受到20點傷害。"
+		{
+			name: {
+				ja: "さんれんのムチ",
+				'zh-tw': "三連鞭",
+			},
+			damage: "70×",
+			cost: ["Grass", "Grass"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数×70ダメージ。",
+				'zh-tw': "擲3次硬幣，造成正面出現的次數×70點傷害。",
+			},
 		},
+	],
 
-		cost: ["Grass"]
-	}, {
-		name: {
-			'zh-tw': "三連鞭"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673007,
+				tcgplayer: 570773,
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲3次硬幣，造成正面出現的次數×70點傷害。"
-		},
-
-		damage: "70×",
-		cost: ["Grass", "Grass"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [893],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/011.ts
+++ b/data-asia/S/S11a/011.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "蕾冠王"
+		ja: "バドレックス",
+		'zh-tw': "蕾冠王",
 	},
 
 	illustrator: "Nurikabe",
@@ -14,42 +14,56 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "擁有治癒與賜恩之力，且滿懷慈愛的寶可夢。在遠古時代曾統治伽勒爾。"
+		ja: "癒しと 恵みの 力を もつ 慈愛に 満ちた ポケモン。 はるか むかし ガラルに 君臨していた。",
+		'zh-tw': "擁有治癒與賜恩之力，且滿懷慈愛的寶可夢。在遠古時代曾統治伽勒爾。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "王之號令"
+	attacks: [
+		{
+			name: {
+				ja: "おうのさいはい",
+				'zh-tw': "王之號令",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、自分の山札から好きなカードを2枚まで選び、手札に加える。そして山札を切る。",
+				'zh-tw': "若希望，從自己的牌庫任意選擇最多2張卡加入手牌。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "若希望，從自己的牌庫任意選擇最多2張卡加入手牌。並且重洗牌庫。"
+		{
+			name: {
+				ja: "ブルームシャイン",
+				'zh-tw': "綻放閃耀",
+			},
+			damage: 90,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のポケモン全員のHPを、それぞれ「20」回復する。",
+				'zh-tw': "將自己的所有寶可夢各恢復「20」HP。",
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "綻放閃耀"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673008,
+				tcgplayer: 570774,
+			},
 		},
-
-		effect: {
-			'zh-tw': "將自己的所有寶可夢各恢復「20」HP。"
-		},
-
-		damage: 90,
-		cost: ["Grass", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [898],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/012.ts
+++ b/data-asia/S/S11a/012.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "卡蒂狗"
+		ja: "ガーディ",
+		'zh-tw': "卡蒂狗",
 	},
 
 	illustrator: "sowsow",
@@ -14,34 +14,55 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "能毫不畏懼地去對抗比自己更強更大的對手。性格非常勇敢可靠。"
+		ja: "自分より 強くて 大きな 相手にも 恐れずに 立ち向かう 勇敢で 頼もしい 性格。",
+		'zh-tw': "能毫不畏懼地去對抗比自己更強更大的對手。性格非常勇敢可靠。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "火焰"
+	attacks: [
+		{
+			name: {
+				ja: "ほのお",
+				'zh-tw': "火焰",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
-
-		damage: 10,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "衝撞"
+		{
+			name: {
+				ja: "ぶつかる",
+				'zh-tw': "衝撞",
+			},
+			damage: 20,
+			cost: ["Fire", "Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Fire", "Colorless"]
-	}],
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673009,
+				tcgplayer: 570775,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570866,
+			},
+		},
+	],
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [58],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/013.ts
+++ b/data-asia/S/S11a/013.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "風速狗"
+		ja: "ウインディ",
+		'zh-tw': "風速狗",
 	},
 
 	illustrator: "OKACHEKE",
@@ -14,42 +14,67 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "只需要一晝夜時間就能跑完１００００公里的身影令許多人為之沉醉。"
+		ja: "一昼夜で １００００キロの 距離を 駆けぬける 姿は 多くの 人を 魅了してきた。",
+		'zh-tw': "只需要一晝夜時間就能跑完１００００公里的身影令許多人為之沉醉。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "火焰纏身"
+	attacks: [
+		{
+			name: {
+				ja: "ほのおをまとう",
+				'zh-tw': "火焰纏身",
+			},
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュから[R]エネルギーを1枚選び、このポケモンにつける。",
+				'zh-tw': "從自己的棄牌區選擇1張【火】能量卡，附於這隻寶可夢身上。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的棄牌區選擇1張【火】能量卡，附於這隻寶可夢身上。"
+		{
+			name: {
+				ja: "とうしのタックル",
+				'zh-tw': "鬥志衝撞",
+			},
+			damage: "100+",
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが「ポケモンV」なら、100ダメージ追加。",
+				'zh-tw': "若對手的戰鬥寶可夢為「寶可夢【V】」，則增加100點傷害。",
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "鬥志衝撞"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673010,
+				tcgplayer: 570776,
+			},
 		},
-
-		effect: {
-			'zh-tw': "若對手的戰鬥寶可夢為「寶可夢【V】」，則增加100點傷害。"
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570867,
+			},
 		},
+	],
 
-		damage: "100+",
-		cost: ["Fire", "Fire", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ガーディ",
+	},
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [59],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/014.ts
+++ b/data-asia/S/S11a/014.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "炎帝"
+		ja: "エンテイ",
+		'zh-tw': "炎帝",
 	},
 
 	illustrator: "Nisota Niso",
@@ -14,39 +14,54 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "據說如果炎帝吼叫的話，世界上的某處火山就會爆發。"
+		ja: "エンテイが ほえると 世界の どこかの 火山が 噴火すると 言われている。",
+		'zh-tw': "據說如果炎帝吼叫的話，世界上的某處火山就會爆發。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "爆熱衝刺"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ばくねつダッシュ",
+				'zh-tw': "爆熱衝刺",
+			},
+			effect: {
+				ja: "このポケモンに[R]エネルギーがついているなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+				'zh-tw': "若這隻寶可夢身上附有【火】能量，則這隻寶可夢【撤退】所需的能量全部消除。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢身上附有【火】能量，則這隻寶可夢【撤退】所需的能量全部消除。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "利爪劈擊"
+	attacks: [
+		{
+			name: {
+				ja: "ツメできりさく",
+				'zh-tw': "利爪劈擊",
+			},
+			damage: 90,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 90,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673011,
+				tcgplayer: 570777,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [244],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/015.ts
+++ b/data-asia/S/S11a/015.ts
@@ -1,50 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "萊希拉姆V"
+		ja: "レシラムV",
+		'zh-tw': "萊希拉姆V",
 	},
 
 	illustrator: "N-DESIGN Inc.",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Fire"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "璀璨之翼"
+	attacks: [
+		{
+			name: {
+				ja: "きらめくつばさ",
+				'zh-tw': "璀璨之翼",
+			},
+			cost: ["Fire"],
+			effect: {
+				ja: "自分の山札から基本エネルギーを2枚まで選び、自分のポケモン1匹につける。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多2張基本能量卡，附於自己的1隻寶可夢身上。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多2張基本能量卡，附於自己的1隻寶可夢身上。並且重洗牌庫。"
+		{
+			name: {
+				ja: "ホワイトブレイズ",
+				'zh-tw': "皎白火焰",
+			},
+			damage: 200,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、次の自分の番、このポケモンはワザが使えない。",
+				'zh-tw': "擲1次硬幣若為反面，則在下個自己的回合，這隻寶可夢無法使用招式。",
+			},
 		},
+	],
 
-		cost: ["Fire"]
-	}, {
-		name: {
-			'zh-tw': "皎白火焰"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673012,
+				tcgplayer: 570778,
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為反面，則在下個自己的回合，這隻寶可夢無法使用招式。"
-		},
-
-		damage: 200,
-		cost: ["Fire", "Fire", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Double rare",
+	dexId: [643],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/016.ts
+++ b/data-asia/S/S11a/016.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "火狐狸"
+		ja: "フォッコ",
+		'zh-tw': "火狐狸",
 	},
 
 	illustrator: "ryoma uratsuka",
@@ -14,37 +14,58 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "隨身帶著小樹枝，卡滋卡滋地當零食吃。會從耳朵噴出熱氣來威嚇對手。"
+		ja: "小枝を 持ち歩き おやつがわりに ポリポリ 食べる。 耳から 熱気を 噴き出して 相手を 威嚇する。",
+		'zh-tw': "隨身帶著小樹枝，卡滋卡滋地當零食吃。會從耳朵噴出熱氣來威嚇對手。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "引路"
+	attacks: [
+		{
+			name: {
+				ja: "みちびく",
+				'zh-tw': "引路",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からサポートを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張支援者卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張支援者卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		{
+			name: {
+				ja: "ひだね",
+				'zh-tw': "火種",
+			},
+			damage: 10,
+			cost: ["Fire"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "火種"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673013,
+				tcgplayer: 570779,
+			},
 		},
-
-		damage: 10,
-		cost: ["Fire"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570869,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [653],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/017.ts
+++ b/data-asia/S/S11a/017.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "長尾火狐"
+		ja: "テールナー",
+		'zh-tw': "長尾火狐",
 	},
 
 	illustrator: "Ligton",
@@ -14,38 +14,63 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "將樹枝從尾巴拔出時，會因摩擦而起火。會揮動樹枝，以樹枝上面的火焰向夥伴發送信號。"
+		ja: "木の枝を 尻尾から 引き抜くとき 摩擦で 着火。 枝の 炎を 振って 仲間に 合図を 送る。",
+		'zh-tw': "將樹枝從尾巴拔出時，會因摩擦而起火。會揮動樹枝，以樹枝上面的火焰向夥伴發送信號。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "烈焰"
+	attacks: [
+		{
+			name: {
+				ja: "かえん",
+				'zh-tw': "烈焰",
+			},
+			damage: 30,
+			cost: ["Fire"],
 		},
-
-		damage: 30,
-		cost: ["Fire"]
-	}, {
-		name: {
-			'zh-tw': "閃焰遊行"
+		{
+			name: {
+				ja: "フレアパレード",
+				'zh-tw': "閃焰遊行",
+			},
+			damage: "60×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある「セレナ」の枚数×60ダメージ。",
+				'zh-tw': "造成自己的棄牌區的「莎莉娜」的張數×60點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "造成自己的棄牌區的「莎莉娜」的張數×60點傷害。"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673014,
+				tcgplayer: 570780,
+			},
 		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570870,
+			},
+		},
+	],
 
-		damage: "60×",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "フォッコ",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [654],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/018.ts
+++ b/data-asia/S/S11a/018.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "妖火紅狐"
+		ja: "マフォクシー",
+		'zh-tw': "妖火紅狐",
 	},
 
 	illustrator: "Uta",
@@ -14,42 +14,67 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "能用超能力操控攝氏３０００度的火焰旋渦。用旋渦包圍敵人後將其燒盡。"
+		ja: "摂氏３０００度の 炎の 渦を 超能力で 操る。 敵を 渦で 包み 焼きつくす。",
+		'zh-tw': "能用超能力操控攝氏３０００度的火焰旋渦。用旋渦包圍敵人後將其燒盡。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "閃焰遊行"
+	attacks: [
+		{
+			name: {
+				ja: "フレアパレード",
+				'zh-tw': "閃焰遊行",
+			},
+			damage: "60×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある「セレナ」の枚数×60ダメージ。",
+				'zh-tw': "造成自己的棄牌區的「莎莉娜」的張數×60點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "造成自己的棄牌區的「莎莉娜」的張數×60點傷害。"
+		{
+			name: {
+				ja: "エナジークラッシュ",
+				'zh-tw': "能量粉碎",
+			},
+			damage: "50×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手の場のポケモンについているエネルギーの数×50ダメージ。",
+				'zh-tw': "造成對手的場上寶可夢身上附加的能量的數量×50點傷害。",
+			},
 		},
+	],
 
-		damage: "60×",
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "能量粉碎"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673015,
+				tcgplayer: 570781,
+			},
 		},
-
-		effect: {
-			'zh-tw': "造成對手的場上寶可夢身上附加的能量的數量×50點傷害。"
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570871,
+			},
 		},
+	],
 
-		damage: "50×",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "テールナー",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [655],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/019.ts
+++ b/data-asia/S/S11a/019.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "波爾凱尼恩"
+		ja: "ボルケニオン",
+		'zh-tw': "波爾凱尼恩",
 	},
 
 	illustrator: "Shiburingaru",
@@ -14,38 +14,52 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "從背上的手臂噴出體內的水蒸氣。有著將整座山轟飛的威力。"
+		ja: "背中の アームから 体内の 水蒸気を 噴射する。 山 ひとつ 吹き飛ばす 威力。",
+		'zh-tw': "從背上的手臂噴出體內的水蒸氣。有著將整座山轟飛的威力。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "頭突"
+	attacks: [
+		{
+			name: {
+				ja: "ぶちかます",
+				'zh-tw': "頭突",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
 		},
-
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "水炮灼燒"
+		{
+			name: {
+				ja: "ハイドロバーン",
+				'zh-tw': "水炮灼燒",
+			},
+			damage: "80+",
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンに[W]エネルギーがついているなら、80ダメージ追加。",
+				'zh-tw': "若這隻寶可夢身上附有【水】能量，則增加80點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢身上附有【水】能量，則增加80點傷害。"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673016,
+				tcgplayer: 570782,
+			},
 		},
-
-		damage: "80+",
-		cost: ["Fire", "Fire", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	],
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [721],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/020.ts
+++ b/data-asia/S/S11a/020.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "夜盜火蜥"
+		ja: "ヤトウモリ",
+		'zh-tw': "夜盜火蜥",
 	},
 
 	illustrator: "Sekio",
@@ -14,37 +14,58 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "用尾巴上的火焰燃燒毒囊裡製造出的體液，生成出毒氣。"
+		ja: "毒袋で つくった 体液を しっぽの 炎で 熱して 毒ガスを 発生させる 仕組み。",
+		'zh-tw': "用尾巴上的火焰燃燒毒囊裡製造出的體液，生成出毒氣。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "呼朋引伴"
+	attacks: [
+		{
+			name: {
+				ja: "なかまをよぶ",
+				'zh-tw': "呼朋引伴",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からたねポケモンを1枚選び、ベンチに出す。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。"
+		{
+			name: {
+				ja: "ひっかく",
+				'zh-tw': "抓",
+			},
+			damage: 10,
+			cost: ["Fire"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "抓"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673017,
+				tcgplayer: 570783,
+			},
 		},
-
-		damage: 10,
-		cost: ["Fire"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570873,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [757],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/021.ts
+++ b/data-asia/S/S11a/021.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "焰后蜥"
+		ja: "エンニュート",
+		'zh-tw': "焰后蜥",
 	},
 
 	illustrator: "aoki",
@@ -14,42 +14,67 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "焰后蜥只有雌性。會釋放出費洛蒙氣體，讓雄性的夜盜火蜥為之著迷。"
+		ja: "エンニュートは メスしか いない。 フェロモンガスを 発生させて オスの ヤトウモリを 魅了する。",
+		'zh-tw': "焰后蜥只有雌性。會釋放出費洛蒙氣體，讓雄性的夜盜火蜥為之著迷。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "擺尾蠱惑"
+	attacks: [
+		{
+			name: {
+				ja: "しっぽでまどわす",
+				'zh-tw': "擺尾蠱惑",
+			},
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【混亂】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【混亂】。"
+		{
+			name: {
+				ja: "ほのおでこがす",
+				'zh-tw': "火焰灼燒",
+			},
+			damage: 60,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【灼傷】。",
+			},
 		},
+	],
 
-		damage: 20,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "火焰灼燒"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673018,
+				tcgplayer: 570784,
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【灼傷】。"
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570874,
+			},
 		},
+	],
 
-		damage: 60,
-		cost: ["Fire", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ヤトウモリ",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [758],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/022.ts
+++ b/data-asia/S/S11a/022.ts
@@ -1,46 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "阿羅拉 六尾V"
+		ja: "アローラ ロコンV",
+		'zh-tw': "阿羅拉 六尾V",
 	},
 
 	illustrator: "Ryota Murayama",
 	category: "Pokemon",
 	hp: 190,
 	types: ["Water"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "皎白墜擊"
+	attacks: [
+		{
+			name: {
+				ja: "ホワイトドロップ",
+				'zh-tw': "皎白墜擊",
+			},
+			damage: "10+",
+			cost: [],
+			effect: {
+				ja: "相手のバトルポケモンが「ポケモンV」なら、50ダメージ追加。",
+				'zh-tw': "若對手的戰鬥寶可夢為「寶可夢【V】」，則增加50點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "若對手的戰鬥寶可夢為「寶可夢【V】」，則增加50點傷害。"
+		{
+			name: {
+				ja: "フロストスマッシュ",
+				'zh-tw': "冰霜粉碎",
+			},
+			damage: 110,
+			cost: ["Water", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: "10+"
-	}, {
-		name: {
-			'zh-tw': "冰霜粉碎"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673019,
+				tcgplayer: 570785,
+			},
 		},
-
-		damage: 110,
-		cost: ["Water", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Double rare",
+	dexId: [37],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/023.ts
+++ b/data-asia/S/S11a/023.ts
@@ -1,49 +1,68 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "阿羅拉 六尾VSTAR"
+		ja: "アローラ ロコンVSTAR",
+		'zh-tw': "阿羅拉 六尾VSTAR",
 	},
 
 	illustrator: "PLANETA Hiiragi",
 	category: "Pokemon",
 	hp: 240,
 	types: ["Water"],
-	stage: "VMAX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "雪之幻想"
+	stage: "VSTAR",
+
+	attacks: [
+		{
+			name: {
+				ja: "スノーミラージュ",
+				'zh-tw': "雪之幻想",
+			},
+			damage: 160,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。次の相手の番、このポケモンは特性を持つポケモンからワザのダメージを受けない。",
+				'zh-tw': "這個招式的傷害不計算對手的戰鬥寶可夢身上的附加效果。在下個對手的回合，這隻寶可夢不會受到擁有特性的寶可夢招式的傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "這個招式的傷害不計算對手的戰鬥寶可夢身上的附加效果。在下個對手的回合，這隻寶可夢不會受到擁有特性的寶可夢招式的傷害。"
+		{
+			name: {
+				ja: "ぎんせつスター",
+				'zh-tw': "[VSTAR力量]銀雪星星",
+			},
+			damage: "70×",
+			cost: [],
+			effect: {
+				ja: "相手の場の「ポケモンV」の数×70ダメージ。このワザのダメージは弱点・抵抗力を計算しない。［対戦中、自分はVSTARパワーを1回しか使えない。］",
+				'zh-tw': "造成對手的場上的「寶可夢【V】」的數量×70點傷害。這個招式的傷害不計算弱點・抵抗力。[對戰中，己方只可使用1次【VSTAR】力量。]",
+			},
 		},
+	],
 
-		damage: 160,
-		cost: ["Water", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "[VSTAR力量]銀雪星星"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673020,
+				tcgplayer: 570786,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "造成對手的場上的「寶可夢【V】」的數量×70點傷害。這個招式的傷害不計算弱點・抵抗力。[對戰中，己方只可使用1次【VSTAR】力量。]"
-		},
-
-		damage: "70×"
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "アローラロコンV",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Triple Rare",
+	dexId: [37],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/024.ts
+++ b/data-asia/S/S11a/024.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "急凍鳥"
+		ja: "フリーザー",
+		'zh-tw': "急凍鳥",
 	},
 
 	illustrator: "Naoyo Kimura",
@@ -14,38 +14,52 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "藍色的美麗羽毛據說是由冰構成的。會搖曳著長長的尾巴飛過雪山。"
+		ja: "青く 美しい 羽根は 氷で できていると 言われている。 長い 尾を たなびかせ 雪山を 飛ぶ。",
+		'zh-tw': "藍色的美麗羽毛據說是由冰構成的。會搖曳著長長的尾巴飛過雪山。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "冰之翼"
+	attacks: [
+		{
+			name: {
+				ja: "アイスウイング",
+				'zh-tw': "冰之翼",
+			},
+			damage: 20,
+			cost: ["Water"],
 		},
-
-		damage: 20,
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "狂野冰凍"
+		{
+			name: {
+				ja: "ワイルドフリーズ",
+				'zh-tw': "狂野冰凍",
+			},
+			damage: 70,
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "このポケモンにも50ダメージ。相手のバトルポケモンをマヒにする。",
+				'zh-tw': "這隻寶可夢也受到50點傷害。將對手的戰鬥寶可夢【麻痺】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢也受到50點傷害。將對手的戰鬥寶可夢【麻痺】。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673021,
+				tcgplayer: 570787,
+			},
 		},
-
-		damage: 70,
-		cost: ["Water", "Water"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [144],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/025.ts
+++ b/data-asia/S/S11a/025.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "吼吼鯨"
+		ja: "ホエルコ",
+		'zh-tw': "吼吼鯨",
 	},
 
 	illustrator: "kodama",
@@ -14,37 +14,58 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "把喝入的海水從眼睛上方的鼻孔中噴出來吸引他人。每天要吃１噸弱丁魚。"
+		ja: "飲みこんだ 海水を 目の 上の 鼻の 穴から 噴き出し アピール。 毎日 １トンの ヨワシを 食う。",
+		'zh-tw': "把喝入的海水從眼睛上方的鼻孔中噴出來吸引他人。每天要吃１噸弱丁魚。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "小憩"
+	attacks: [
+		{
+			name: {
+				ja: "ひとやすみ",
+				'zh-tw': "小憩",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+				'zh-tw': "將這隻寶可夢恢復「30」HP。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將這隻寶可夢恢復「30」HP。"
+		{
+			name: {
+				ja: "みずでっぽう",
+				'zh-tw': "水槍",
+			},
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "水槍"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673022,
+				tcgplayer: 570788,
+			},
 		},
-
-		damage: 70,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570876,
+			},
+		},
+	],
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [320],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/026.ts
+++ b/data-asia/S/S11a/026.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "吼鯨王"
+		ja: "ホエルオー",
+		'zh-tw': "吼鯨王",
 	},
 
 	illustrator: "KIYOTAKA OSHIYAMA",
@@ -14,38 +14,63 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "有時會讓大大的身體在波浪上跳躍，藉此製造出衝擊讓對手昏迷。"
+		ja: "大きな 体を 波の上で ジャンプさせ 衝撃を 生みだし 相手を 気絶 させることがある。",
+		'zh-tw': "有時會讓大大的身體在波浪上跳躍，藉此製造出衝擊讓對手昏迷。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "泡沫吸取"
+	attacks: [
+		{
+			name: {
+				ja: "バブルドレイン",
+				'zh-tw': "泡沫吸取",
+			},
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+				'zh-tw': "將這隻寶可夢恢復「30」HP。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將這隻寶可夢恢復「30」HP。"
+		{
+			name: {
+				ja: "ヘビーインパクト",
+				'zh-tw': "重磅衝擊",
+			},
+			damage: 180,
+			cost: ["Water", "Water", "Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 80,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "重磅衝擊"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673023,
+				tcgplayer: 570789,
+			},
 		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570877,
+			},
+		},
+	],
 
-		damage: 180,
-		cost: ["Water", "Water", "Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ホエルコ",
+	},
 
 	retreat: 4,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [321],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/027.ts
+++ b/data-asia/S/S11a/027.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "醜醜魚"
+		ja: "ヒンバス",
+		'zh-tw': "醜醜魚",
 	},
 
 	illustrator: "0313",
@@ -14,37 +14,58 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "外表醜陋，所以不受歡迎。擁有驚人的生命力，因而成為了研究對象。"
+		ja: "見た目が 悪いので 人気はないが 脅威の 生命力が あり 研究対象には なっている。",
+		'zh-tw': "外表醜陋，所以不受歡迎。擁有驚人的生命力，因而成為了研究對象。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "覺醒"
+	attacks: [
+		{
+			name: {
+				ja: "かくせい",
+				'zh-tw': "覺醒",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンから進化するカードを、自分の山札から1枚選び、このポケモンにのせて進化させる。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張從這隻寶可夢進化而來的卡，放置於這隻寶可夢身上完成進化。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張從這隻寶可夢進化而來的卡，放置於這隻寶可夢身上完成進化。並且重洗牌庫。"
+		{
+			name: {
+				ja: "はねる",
+				'zh-tw': "躍起",
+			},
+			damage: 10,
+			cost: ["Water"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "躍起"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673024,
+				tcgplayer: 570790,
+			},
 		},
-
-		damage: 10,
-		cost: ["Water"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570878,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [349],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/028.ts
+++ b/data-asia/S/S11a/028.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "美納斯"
+		ja: "ミロカロス",
+		'zh-tw': "美納斯",
 	},
 
 	illustrator: "KEIICHIRO ITO",
@@ -14,41 +14,66 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "也被稱為是最美的寶可夢。一直以來為無數的藝術家提供了靈感。"
+		ja: "もっとも 美しい ポケモンとも 呼ばれ 多くの 芸術家に インスピレーションを 与えてきた。",
+		'zh-tw': "也被稱為是最美的寶可夢。一直以來為無數的藝術家提供了靈感。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "水箭"
+	attacks: [
+		{
+			name: {
+				ja: "ウォーターアロー",
+				'zh-tw': "水箭",
+			},
+			cost: ["Water"],
+			effect: {
+				ja: "相手のポケモン1匹に、50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的1隻寶可夢受到50點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
-
-		effect: {
-			'zh-tw': "對手的1隻寶可夢受到50點傷害。[在備戰區不計算弱點・抵抗力。]"
+		{
+			name: {
+				ja: "メロウウェーブ",
+				'zh-tw': "柔和波",
+			},
+			damage: 60,
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【睡眠】。",
+			},
 		},
+	],
 
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "柔和波"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673025,
+				tcgplayer: 570791,
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【睡眠】。"
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570879,
+			},
 		},
+	],
 
-		damage: 60,
-		cost: ["Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ヒンバス",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [350],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/029.ts
+++ b/data-asia/S/S11a/029.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "愛心魚"
+		ja: "ラブカス",
+		'zh-tw': "愛心魚",
 	},
 
 	illustrator: "Miki Tanaka",
@@ -14,37 +14,58 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "溫暖海域的珊瑚礁是牠的棲息地。最喜歡在太陽珊瑚的枝條間睡覺。"
+		ja: "暖かい 海の サンゴ礁が 棲み処。 サニーゴの枝の 間で 眠るのが 特に お気に入り。",
+		'zh-tw': "溫暖海域的珊瑚礁是牠的棲息地。最喜歡在太陽珊瑚的枝條間睡覺。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "情緒抽出"
+	attacks: [
+		{
+			name: {
+				ja: "フィーリングドロー",
+				'zh-tw': "情緒抽出",
+			},
+			cost: ["Water"],
+			effect: {
+				ja: "自分の手札をすべて山札にもどして切る。その後、山札を5枚引く。",
+				'zh-tw': "將自己的手牌全部放回牌庫並重洗。然後，從牌庫抽出5張卡。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將自己的手牌全部放回牌庫並重洗。然後，從牌庫抽出5張卡。"
+		{
+			name: {
+				ja: "たいあたり",
+				'zh-tw': "撞擊",
+			},
+			damage: 20,
+			cost: ["Colorless"],
 		},
+	],
 
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "撞擊"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673026,
+				tcgplayer: 570792,
+			},
 		},
-
-		damage: 20,
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570880,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [370],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/030.ts
+++ b/data-asia/S/S11a/030.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "蓋歐卡"
+		ja: "カイオーガ",
+		'zh-tw': "蓋歐卡",
 	},
 
 	illustrator: "Kouki Saitou",
@@ -14,40 +14,54 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "據說會用降下大雨的能力擴張海洋。一直沉睡在海溝的底部。"
+		ja: "大雨を 降らせる 能力で 海を 広げたと 言われている。 海溝の 底で 眠っていた。",
+		'zh-tw': "據說會用降下大雨的能力擴張海洋。一直沉睡在海溝的底部。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "召喚潮漩"
+	attacks: [
+		{
+			name: {
+				ja: "うねりをよぶ",
+				'zh-tw': "召喚潮漩",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から[W]エネルギーを1枚選び、このポケモンにつける。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張【水】能量卡，附於這隻寶可夢身上。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張【水】能量卡，附於這隻寶可夢身上。並且重洗牌庫。"
+		{
+			name: {
+				ja: "ダイナミックウェーブ",
+				'zh-tw': "極限波",
+			},
+			cost: ["Water", "Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを3個手札にもどし、相手のポケモン1匹に、180ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "將這隻寶可夢身上附加的3個能量放回手牌，對手的1隻寶可夢受到180點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "極限波"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673027,
+				tcgplayer: 570793,
+			},
 		},
-
-		effect: {
-			'zh-tw': "將這隻寶可夢身上附加的3個能量放回手牌，對手的1隻寶可夢受到180點傷害。[在備戰區不計算弱點・抵抗力。]"
-		},
-
-		cost: ["Water", "Water", "Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	],
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [382],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/031.ts
+++ b/data-asia/S/S11a/031.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "光輝胡地"
+		ja: "かがやくフーディン",
+		'zh-tw': "光輝胡地",
 	},
 
 	illustrator: "Akira Komayama",
@@ -14,48 +14,58 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "擁有非常高的智商。據說牠能記住從出生到死一輩子發生過的所有事情。"
+		ja: "非常に 高い 知能を 持つ。 生まれてから 死ぬまでの できごとを すべて 覚えている という。",
+		'zh-tw': "擁有非常高的智商。據說牠能記住從出生到死一輩子發生過的所有事情。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "傷痛湯匙"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ペインスプーン",
+				'zh-tw': "傷痛湯匙",
+			},
+			effect: {
+				ja: "自分の番に1回使える。相手の場のポケモン1匹にのっているダメカンを2個まで選び、相手の別のポケモン1匹にのせ替える。",
+				'zh-tw': "在自己的回合時，可使用1次。選擇最多2個對手的1隻場上寶可夢身上放置的傷害指示物，改放於對手的另1隻寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，可使用1次。選擇最多2個對手的1隻場上寶可夢身上放置的傷害指示物，改放於對手的另1隻寶可夢身上。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "意志統治者"
+	attacks: [
+		{
+			name: {
+				ja: "マインドルーラー",
+				'zh-tw': "意志統治者",
+			},
+			damage: "20×",
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手の手札の枚数×20ダメージ。",
+				'zh-tw': "造成對手的手牌的張數×20點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "造成對手的手牌的張數×20點傷害。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673028,
+				tcgplayer: 570794,
+			},
 		},
-
-		damage: "20×",
-		cost: ["Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Radiant Rare",
+	dexId: [65],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/032.ts
+++ b/data-asia/S/S11a/032.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "蛋蛋"
+		ja: "タマタマ",
+		'zh-tw': "蛋蛋",
 	},
 
 	illustrator: "zig",
@@ -14,36 +14,51 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "雖然看起來很像是蛋，但卻是如假包換的寶可夢。似乎會用心靈感應來與夥伴們交流喔。"
+		ja: "タマゴのように 見えるが 立派な ポケモン。 テレパシーで 仲間と 交信している らしいぞ。",
+		'zh-tw': "雖然看起來很像是蛋，但卻是如假包換的寶可夢。似乎會用心靈感應來與夥伴們交流喔。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "念力"
+	attacks: [
+		{
+			name: {
+				ja: "ねんりき",
+				'zh-tw': "念力",
+			},
+			damage: 20,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+				'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673029,
+				tcgplayer: 570795,
+			},
 		},
-
-		damage: 20,
-		cost: ["Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570882,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [102],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/033.ts
+++ b/data-asia/S/S11a/033.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "椰蛋樹"
+		ja: "ナッシー",
+		'zh-tw': "椰蛋樹",
 	},
 
 	illustrator: "Toshinao Aoki",
@@ -14,43 +14,63 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "３顆頭都想著不同的事。對自己以外的事情似乎都沒什麼興趣。"
+		ja: "３つの 頭は べつのことを 考えている。 自分以外は あまり 興味がない ようだ。",
+		'zh-tw': "３顆頭都想著不同的事。對自己以外的事情似乎都沒什麼興趣。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "強力風暴"
+	attacks: [
+		{
+			name: {
+				ja: "パワフルストーム",
+				'zh-tw': "強力風暴",
+			},
+			damage: "20×",
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の場のポケモンについているエネルギーの数×20ダメージ。",
+				'zh-tw': "造成自己的場上寶可夢身上附加的能量的數量×20點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "造成自己的場上寶可夢身上附加的能量的數量×20點傷害。"
+		{
+			name: {
+				ja: "ふむ",
+				'zh-tw': "踩",
+			},
+			damage: 100,
+			cost: ["Psychic", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: "20×",
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "踩"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673031,
+				tcgplayer: 570796,
+			},
 		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570883,
+			},
+		},
+	],
 
-		damage: 100,
-		cost: ["Psychic", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "タマタマ",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [103],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/034.ts
+++ b/data-asia/S/S11a/034.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "迷唇姐"
+		ja: "ルージュラ",
+		'zh-tw': "迷唇姐",
 	},
 
 	illustrator: "Tomokazu Komiya",
@@ -14,48 +14,65 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "在伽勒爾的某個地區，人們稱迷唇姐為冰之女王，並且敬畏崇拜牠。"
+		ja: "ガラルの とある 地域では 氷の 女王と 呼んで ルージュラを 恐れ崇めていた。",
+		'zh-tw': "在伽勒爾的某個地區，人們稱迷唇姐為冰之女王，並且敬畏崇拜牠。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "任性唇"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "わがままリップ",
+				'zh-tw': "任性唇",
+			},
+			effect: {
+				ja: "このポケモンが、相手の「ポケモンV」からワザのダメージを受けてきぜつしても、相手はサイドをとれない。",
+				'zh-tw': "這隻寶可夢就算受到對手的「寶可夢【V】」招式的傷害而【氣絕】，對手也無法獲得獎賞卡。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢就算受到對手的「寶可夢【V】」招式的傷害而【氣絕】，對手也無法獲得獎賞卡。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "精神傷害"
+	attacks: [
+		{
+			name: {
+				ja: "サイコダメージ",
+				'zh-tw': "精神傷害",
+			},
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにのっているダメカンの数×10ダメージ追加。",
+				'zh-tw': "增加對手的戰鬥寶可夢身上放置的傷害指示物的數量×10點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加對手的戰鬥寶可夢身上放置的傷害指示物的數量×10點傷害。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673032,
+				tcgplayer: 570797,
+			},
 		},
-
-		damage: "10+",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570884,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [124],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/035.ts
+++ b/data-asia/S/S11a/035.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "超夢"
+		ja: "ミュウツー",
+		'zh-tw': "超夢",
 	},
 
 	illustrator: "Atsushi Furusawa",
@@ -14,46 +14,55 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "藉著重組夢幻的基因而誕生。據說有著所有寶可夢中最殘暴的心。"
+		ja: "ミュウの 遺伝子を 組み替えて 生み出された。 ポケモンで 一番 凶暴な 心を 持つという。",
+		'zh-tw': "藉著重組夢幻的基因而誕生。據說有著所有寶可夢中最殘暴的心。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "精神充氣"
+	attacks: [
+		{
+			name: {
+				ja: "サイコパンプ",
+				'zh-tw': "精神充氣",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュから[P]エネルギーを2枚まで選び、自分のポケモン1匹につける。",
+				'zh-tw': "從自己的棄牌區選擇最多2張【超】能量卡，附於自己的1隻寶可夢身上。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的棄牌區選擇最多2張【超】能量卡，附於自己的1隻寶可夢身上。"
+		{
+			name: {
+				ja: "リミットブレイク",
+				'zh-tw': "界限破壞",
+			},
+			damage: "90+",
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "相手のサイドの残り枚数が3枚以下なら、90ダメージ追加。",
+				'zh-tw': "若對手剩餘獎賞卡的張數為3張以下，則增加90點傷害。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "界限破壞"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673033,
+				tcgplayer: 570798,
+			},
 		},
-
-		effect: {
-			'zh-tw': "若對手剩餘獎賞卡的張數為3張以下，則增加90點傷害。"
-		},
-
-		damage: "90+",
-		cost: ["Psychic", "Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [150],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/036.ts
+++ b/data-asia/S/S11a/036.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "拉魯拉絲"
+		ja: "ラルトス",
+		'zh-tw': "拉魯拉絲",
 	},
 
 	illustrator: "Nagomi Nijo",
@@ -14,31 +14,51 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "能敏銳地感知人和寶可夢的感情。一旦感受到敵意就會躲進暗處。"
+		ja: "人や ポケモンの 感情を 敏感に キャッチ。 敵意を 感じると 物陰に 隠れる。",
+		'zh-tw': "能敏銳地感知人和寶可夢的感情。一旦感受到敵意就會躲進暗處。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "記憶跳接"
+	attacks: [
+		{
+			name: {
+				ja: "メモリースキップ",
+				'zh-tw': "記憶跳接",
+			},
+			damage: 10,
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンが持っているワザを1つ選ぶ。次の相手の番、このワザを受けたポケモンは、選ばれたワザが使えない。",
+				'zh-tw': "選擇對手的戰鬥寶可夢持有的1個招式。在下個對手的回合，受到這個招式的寶可夢無法使用被選擇的招式。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇對手的戰鬥寶可夢持有的1個招式。在下個對手的回合，受到這個招式的寶可夢無法使用被選擇的招式。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673034,
+				tcgplayer: 570799,
+			},
 		},
-
-		damage: 10,
-		cost: ["Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570886,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [280],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/037.ts
+++ b/data-asia/S/S11a/037.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "奇魯莉安"
+		ja: "キルリア",
+		'zh-tw': "奇魯莉安",
 	},
 
 	illustrator: "Yukiko Baba",
@@ -14,39 +14,65 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "當訓練家高興的時候，奇魯莉安會充滿能量，開心地轉著圈跳舞。"
+		ja: "トレーナーが 喜ぶと キルリアに エネルギーが 満ちあふれ 楽しそうに くるくると 踊る。",
+		'zh-tw': "當訓練家高興的時候，奇魯莉安會充滿能量，開心地轉著圈跳舞。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "洗鍊"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "リファイン",
+				'zh-tw': "洗鍊",
+			},
+			effect: {
+				ja: "自分の番に、自分の手札を1枚トラッシュするなら、1回使える。自分の山札を2枚引く。",
+				'zh-tw': "在自己的回合時，若將自己的1張手牌丟棄，則可使用1次。從自己的牌庫抽出2張卡。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，若將自己的1張手牌丟棄，則可使用1次。從自己的牌庫抽出2張卡。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "巴掌"
+	attacks: [
+		{
+			name: {
+				ja: "ビンタ",
+				'zh-tw': "巴掌",
+			},
+			damage: 30,
+			cost: ["Psychic", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Psychic", "Colorless"]
-	}],
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673035,
+				tcgplayer: 570800,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570887,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ラルトス",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [281],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/038.ts
+++ b/data-asia/S/S11a/038.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "沙奈朵"
+		ja: "サーナイト",
+		'zh-tw': "沙奈朵",
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -14,39 +14,65 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "有著預知未來的能力。在保護訓練家的時候，會發揮出最強的力量。"
+		ja: "未来を 予知する 力を もつ。 トレーナーを 守る ときに 最大 パワーを 発揮する。",
+		'zh-tw': "有著預知未來的能力。在保護訓練家的時候，會發揮出最強的力量。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "洗鍊"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "リファイン",
+				'zh-tw': "洗鍊",
+			},
+			effect: {
+				ja: "自分の番に、自分の手札を1枚トラッシュするなら、1回使える。自分の山札を2枚引く。",
+				'zh-tw': "在自己的回合時，若將自己的1張手牌丟棄，則可使用1次。從自己的牌庫抽出2張卡。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，若將自己的1張手牌丟棄，則可使用1次。從自己的牌庫抽出2張卡。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "魔法射擊"
+	attacks: [
+		{
+			name: {
+				ja: "マジカルショット",
+				'zh-tw': "魔法射擊",
+			},
+			damage: 120,
+			cost: ["Psychic", "Colorless"],
 		},
+	],
 
-		damage: 120,
-		cost: ["Psychic", "Colorless"]
-	}],
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673036,
+				tcgplayer: 570801,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570888,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キルリア",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [282],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/039.ts
+++ b/data-asia/S/S11a/039.ts
@@ -1,51 +1,64 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "大嘴娃V"
+		ja: "クチートV",
+		'zh-tw': "大嘴娃V",
 	},
 
 	illustrator: "takuyoa",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Psychic"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "不爽摑擊"
+	attacks: [
+		{
+			name: {
+				ja: "ふきげんスラップ",
+				'zh-tw': "不爽摑擊",
+			},
+			damage: 30,
+			cost: ["Psychic"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "擲1次硬幣若為正面，則選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。"
+		{
+			name: {
+				ja: "かみおとす",
+				'zh-tw': "咬落",
+			},
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、トラッシュする。",
+				'zh-tw': "在不看正面的情況下，選擇1張對手的手牌，將其丟棄。",
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "咬落"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673037,
+				tcgplayer: 570802,
+			},
 		},
-
-		effect: {
-			'zh-tw': "在不看正面的情況下，選擇1張對手的手牌，將其丟棄。"
-		},
-
-		damage: 100,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Double rare",
+	dexId: [303],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/040.ts
+++ b/data-asia/S/S11a/040.ts
@@ -1,51 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "大嘴娃VSTAR"
+		ja: "クチートVSTAR",
+		'zh-tw': "大嘴娃VSTAR",
 	},
 
 	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
 	hp: 260,
 	types: ["Psychic"],
-	stage: "VMAX",
 
-	abilities: [{
-		type: "Ability",
+	stage: "VSTAR",
 
-		name: {
-			'zh-tw': "星星迴旋曲"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "スターロンド",
+				'zh-tw': "星星迴旋曲",
+			},
+			effect: {
+				ja: "このポケモンがベンチにいるなら、自分の番に使える。このポケモンを自分のバトルポケモンと入れ替える。その後、相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。［対戦中、自分はVSTARパワーを1回しか使えない。］",
+				'zh-tw': "若這隻寶可夢在備戰區，則在自己的回合時可使用。將這隻寶可夢與自己的戰鬥寶可夢互換。然後，選擇對手的1隻備戰寶可夢，與戰鬥寶可夢互換。[對戰中，己方只可使用1次【VSTAR】力量。]",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢在備戰區，則在自己的回合時可使用。將這隻寶可夢與自己的戰鬥寶可夢互換。然後，選擇對手的1隻備戰寶可夢，與戰鬥寶可夢互換。[對戰中，己方只可使用1次【VSTAR】力量。]"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "乍然食客"
+	attacks: [
+		{
+			name: {
+				ja: "サドンイーター",
+				'zh-tw': "乍然食客",
+			},
+			damage: "90+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "この番、このポケモンがベンチからバトル場に出ていたなら、90ダメージ追加。",
+				'zh-tw': "在這個回合，若從備戰區將這隻寶可夢放置於戰鬥場，則增加90點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在這個回合，若從備戰區將這隻寶可夢放置於戰鬥場，則增加90點傷害。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673038,
+				tcgplayer: 570803,
+			},
 		},
+	],
 
-		damage: "90+",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "クチートV",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Triple Rare",
+	dexId: [303],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/041.ts
+++ b/data-asia/S/S11a/041.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "妙喵"
+		ja: "ニャスパー",
+		'zh-tw': "妙喵",
 	},
 
 	illustrator: "Asako Ito",
@@ -14,39 +14,55 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "雖然一直都面無表情，但是那其實是因為牠在努力不讓自己強大的精神力量漏出。"
+		ja: "いつも 無表情だが じつは 強力な サイコパワーが 漏れ出さないように 必死なのだ。",
+		'zh-tw': "雖然一直都面無表情，但是那其實是因為牠在努力不讓自己強大的精神力量漏出。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "囈語"
+	attacks: [
+		{
+			name: {
+				ja: "つぶやく",
+				'zh-tw': "囈語",
+			},
+			damage: 10,
+			cost: ["Psychic"],
 		},
-
-		damage: 10,
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "重摑"
+		{
+			name: {
+				ja: "ひっぱたく",
+				'zh-tw': "重摑",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673039,
+				tcgplayer: 570804,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570889,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [677],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/042.ts
+++ b/data-asia/S/S11a/042.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "超能妙喵"
+		ja: "ニャオニクス",
+		'zh-tw': "超能妙喵",
 	},
 
 	illustrator: "Taira Akitsu",
@@ -14,44 +14,65 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "性格要比雄性更任性一些，而且也更具攻擊性。要是惹得牠不高興，就會被牠用精神力量狠狠教訓。"
+		ja: "オスに 比べて すこし わがままで 攻撃的。 機嫌を 損ねると サイコパワーで 痛めつけられる。",
+		'zh-tw': "性格要比雄性更任性一些，而且也更具攻擊性。要是惹得牠不高興，就會被牠用精神力量狠狠教訓。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "招財耳"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "おまねきイヤー",
+				'zh-tw': "招財耳",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分の山札からサポートを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。從自己的牌庫選擇最多2張支援者卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。從自己的牌庫選擇最多2張支援者卡，在給對手看過後加入手牌。並且重洗牌庫。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "超念力"
+	attacks: [
+		{
+			name: {
+				ja: "ちょうねんりき",
+				'zh-tw': "超念力",
+			},
+			damage: 80,
+			cost: ["Psychic", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 80,
-		cost: ["Psychic", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673040,
+				tcgplayer: 570805,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570890,
+			},
+		},
+	],
 
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ニャスパー",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [678],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/043.ts
+++ b/data-asia/S/S11a/043.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "卡璞・蝶蝶"
+		ja: "カプ・テテフ",
+		'zh-tw': "卡璞・蝶蝶",
 	},
 
 	illustrator: "Saya Tsuruta",
@@ -14,42 +14,56 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "被稱為守護神，卻同時有著天真無邪與殘酷的性格，可說是大自然的化身。"
+		ja: "守り神と 呼ばれるが 無邪気で 残酷な 性質も 併せ持つ 自然の化身と いえる 存在。",
+		'zh-tw': "被稱為守護神，卻同時有著天真無邪與殘酷的性格，可說是大自然的化身。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "能量爆炸"
+	attacks: [
+		{
+			name: {
+				ja: "エネバースト",
+				'zh-tw': "能量爆炸",
+			},
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "おたがいのバトルポケモンについているエネルギーの数×20ダメージ。",
+				'zh-tw': "造成雙方的戰鬥寶可夢身上附加的能量的數量×20點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "造成雙方的戰鬥寶可夢身上附加的能量的數量×20點傷害。"
+		{
+			name: {
+				ja: "スパイラルドレイン",
+				'zh-tw': "螺旋吸取",
+			},
+			damage: 100,
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+				'zh-tw': "將這隻寶可夢恢復「30」HP。",
+			},
 		},
+	],
 
-		damage: "20×",
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "螺旋吸取"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673041,
+				tcgplayer: 570806,
+			},
 		},
-
-		effect: {
-			'zh-tw': "將這隻寶可夢恢復「30」HP。"
-		},
-
-		damage: 100,
-		cost: ["Psychic", "Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [786],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/044.ts
+++ b/data-asia/S/S11a/044.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "巨鉗螳螂"
+		ja: "ハッサム",
+		'zh-tw': "巨鉗螳螂",
 	},
 
 	illustrator: "kodama",
@@ -14,47 +14,67 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "巨大的鉗子重達體重的３分之１。鉗子一揮，就連岩石都能一擊粉碎。"
+		ja: "大きな ハサミは 体重の ３分の１の 重さ。 振り下ろせば 岩石も 一発で 粉々だ。",
+		'zh-tw': "巨大的鉗子重達體重的３分之１。鉗子一揮，就連岩石都能一擊粉碎。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "十字剪"
+	attacks: [
+		{
+			name: {
+				ja: "シザークロス",
+				'zh-tw': "十字剪",
+			},
+			damage: "30+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、30ダメージ追加。",
+				'zh-tw': "擲1次硬幣若為正面，則增加30點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則增加30點傷害。"
+		{
+			name: {
+				ja: "デンジャラスクロー",
+				'zh-tw': "危險爪",
+			},
+			damage: "80+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンがたねポケモンなら、80ダメージ追加。",
+				'zh-tw': "若對手的戰鬥寶可夢為【基礎】寶可夢，則增加80點傷害。",
+			},
 		},
+	],
 
-		damage: "30+",
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "危險爪"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673042,
+				tcgplayer: 570807,
+			},
 		},
-
-		effect: {
-			'zh-tw': "若對手的戰鬥寶可夢為【基礎】寶可夢，則增加80點傷害。"
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570892,
+			},
 		},
+	],
 
-		damage: "80+",
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ストライク",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [212],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/045.ts
+++ b/data-asia/S/S11a/045.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "光輝基拉祈"
+		ja: "かがやくジラーチ",
+		'zh-tw': "光輝基拉祈",
 	},
 
 	illustrator: "Ryuta Fuse",
@@ -14,47 +14,57 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "據說牠在１０００年之中只有７天時間會醒過來，使用能實現任何願望的力量。"
+		ja: "１０００年間で ７日だけ 目を 覚まし どんな 願い事でも かなえる 力を 使うという。",
+		'zh-tw': "據說牠在１０００年之中只有７天時間會醒過來，使用能實現任何願望的力量。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "託付願望"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ねがいをたくす",
+				'zh-tw': "託付願望",
+			},
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けてきぜつしたとき、自分の山札から好きなカードを3枚まで選び、手札に加える。そして山札を切る。",
+				'zh-tw': "當這隻寶可夢在戰鬥場上受到對手的寶可夢招式的傷害而【氣絕】時，從自己的牌庫任意選擇最多3張卡加入手牌。並且重洗牌庫。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "當這隻寶可夢在戰鬥場上受到對手的寶可夢招式的傷害而【氣絕】時，從自己的牌庫任意選擇最多3張卡加入手牌。並且重洗牌庫。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "星星降災"
+	attacks: [
+		{
+			name: {
+				ja: "ほしのわざわい",
+				'zh-tw': "星星降災",
+			},
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、すべてオモテなら、相手のバトルポケモンをきぜつさせる。",
+				'zh-tw': "擲2次硬幣，若全部為正面，則將對手的戰鬥寶可夢【氣絕】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲2次硬幣，若全部為正面，則將對手的戰鬥寶可夢【氣絕】。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673043,
+				tcgplayer: 570808,
+			},
 		},
-
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Radiant Rare",
+	dexId: [385],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/046.ts
+++ b/data-asia/S/S11a/046.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "齒輪兒"
+		ja: "ギアル",
+		'zh-tw': "齒輪兒",
 	},
 
 	illustrator: "Kyoko Umemoto",
@@ -14,35 +14,50 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "２個身體比雙胞胎還要親近。要是換成別的齒輪兒，就沒有辦法好好咬合。"
+		ja: "２つの 体は 双子よりも 近い。 べつの 体同士だと いまいち うまく 噛み合わない。",
+		'zh-tw': "２個身體比雙胞胎還要親近。要是換成別的齒輪兒，就沒有辦法好好咬合。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "呼喚信號"
+	attacks: [
+		{
+			name: {
+				ja: "コールサイン",
+				'zh-tw': "呼喚信號",
+			},
+			cost: ["Metal"],
+			effect: {
+				ja: "自分の山札からポケモンを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673044,
+				tcgplayer: 570809,
+			},
 		},
-
-		cost: ["Metal"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570893,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [599],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/047.ts
+++ b/data-asia/S/S11a/047.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "齒輪組"
+		ja: "ギギアル",
+		'zh-tw': "齒輪組",
 	},
 
 	illustrator: "SATOSHI NAKAI",
@@ -14,36 +14,55 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "如果認真起來，大齒輪外圈的齒輪會和小齒輪完全接合。此時轉速將會大幅提升。"
+		ja: "本気の ときは でかギアの 外の 歯車と ちびギアが 合致。 回転速度が 飛躍 するのだ。",
+		'zh-tw': "如果認真起來，大齒輪外圈的齒輪會和小齒輪完全接合。此時轉速將會大幅提升。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "齒輪飛盤"
+	attacks: [
+		{
+			name: {
+				ja: "ギアソーサー",
+				'zh-tw': "齒輪飛盤",
+			},
+			damage: "80×",
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×80ダメージ。",
+				'zh-tw': "擲2次硬幣，造成正面出現的次數×80點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲2次硬幣，造成正面出現的次數×80點傷害。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673045,
+				tcgplayer: 570810,
+			},
 		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570894,
+			},
+		},
+	],
 
-		damage: "80×",
-		cost: ["Metal", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ギアル",
+	},
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [600],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/048.ts
+++ b/data-asia/S/S11a/048.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "齒輪怪"
+		ja: "ギギギアル",
+		'zh-tw': "齒輪怪",
 	},
 
 	illustrator: "Akira Komayama",
@@ -14,44 +14,65 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "會從尖刺的前端發出強力電擊。紅色核心裡填充著非常多的能量。"
+		ja: "棘の 先から 強い 電撃を 発射。 赤いコアに たくさんの エネルギーを 蓄えている。",
+		'zh-tw': "會從尖刺的前端發出強力電擊。紅色核心裡填充著非常多的能量。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "三重齒輪"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "トリプルギア",
+				'zh-tw': "三重齒輪",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分の山札から基本エネルギーを3枚まで選び、自分のポケモンに好きなようにつける。そして山札を切る。",
+				'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。從自己的牌庫選擇最多3張基本能量卡，以任意方式附於自己的寶可夢身上。並且重洗牌庫。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。從自己的牌庫選擇最多3張基本能量卡，以任意方式附於自己的寶可夢身上。並且重洗牌庫。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "强力光束"
+	attacks: [
+		{
+			name: {
+				ja: "パワービーム",
+				'zh-tw': "强力光束",
+			},
+			damage: 130,
+			cost: ["Metal", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 130,
-		cost: ["Metal", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673046,
+				tcgplayer: 570811,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570895,
+			},
+		},
+	],
 
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ギギアル",
+	},
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [601],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/049.ts
+++ b/data-asia/S/S11a/049.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "駒刀小兵"
+		ja: "コマタナ",
+		'zh-tw': "駒刀小兵",
 	},
 
 	illustrator: "Yuka Morii",
@@ -14,32 +14,47 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "揮舞銳利的刀刃將敵人逼向絕境。會用河灘的石頭來精心保養刀刃。"
+		ja: "鋭い 刃を 操り 敵を 追い詰める。 河原の 石で 体の 刃を 手入れする。",
+		'zh-tw': "揮舞銳利的刀刃將敵人逼向絕境。會用河灘的石頭來精心保養刀刃。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "突刺"
+	attacks: [
+		{
+			name: {
+				ja: "つきさす",
+				'zh-tw': "突刺",
+			},
+			damage: 20,
+			cost: ["Metal"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Metal"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673047,
+				tcgplayer: 570812,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570896,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [624],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/050.ts
+++ b/data-asia/S/S11a/050.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "劈斬司令"
+		ja: "キリキザン",
+		'zh-tw': "劈斬司令",
 	},
 
 	illustrator: "DOM",
@@ -14,43 +14,63 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "率領著一大群駒刀小兵。為了防止手下們背叛自己，總是睜大著眼睛監視牠們。"
+		ja: "大勢の コマタナを 従える。 手下たちが 裏切らない よう 常に 目を 光らせている。",
+		'zh-tw': "率領著一大群駒刀小兵。為了防止手下們背叛自己，總是睜大著眼睛監視牠們。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "扣殺抽出"
+	attacks: [
+		{
+			name: {
+				ja: "スパイクドロー",
+				'zh-tw': "扣殺抽出",
+			},
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を2枚引く。",
+				'zh-tw': "從自己的牌庫抽出2張卡。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫抽出2張卡。"
+		{
+			name: {
+				ja: "パワーエッジ",
+				'zh-tw': "力量刀鋒",
+			},
+			damage: 70,
+			cost: ["Metal", "Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "力量刀鋒"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673048,
+				tcgplayer: 570813,
+			},
 		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570897,
+			},
+		},
+	],
 
-		damage: 70,
-		cost: ["Metal", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "コマタナ",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [625],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/051.ts
+++ b/data-asia/S/S11a/051.ts
@@ -1,55 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "瑪機雅娜V"
+		ja: "マギアナV",
+		'zh-tw': "瑪機雅娜V",
 	},
 
 	illustrator: "N-DESIGN Inc.",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Metal"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "齒輪一投"
+	attacks: [
+		{
+			name: {
+				ja: "ギアスロー",
+				'zh-tw': "齒輪一投",
+			},
+			cost: ["Metal"],
+			effect: {
+				ja: "相手のポケモン1匹に、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的1隻寶可夢受到30點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
-
-		effect: {
-			'zh-tw': "對手的1隻寶可夢受到30點傷害。[在備戰區不計算弱點・抵抗力。]"
+		{
+			name: {
+				ja: "スペシャルレーザー",
+				'zh-tw': "特殊鐳射",
+			},
+			damage: "100+",
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "このポケモンに特殊エネルギーがついているなら、120ダメージ追加。",
+				'zh-tw': "若這隻寶可夢身上附有特殊能量，則增加120點傷害。",
+			},
 		},
+	],
 
-		cost: ["Metal"]
-	}, {
-		name: {
-			'zh-tw': "特殊鐳射"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673049,
+				tcgplayer: 570814,
+			},
 		},
-
-		effect: {
-			'zh-tw': "若這隻寶可夢身上附有特殊能量，則增加120點傷害。"
-		},
-
-		damage: "100+",
-		cost: ["Metal", "Metal", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Double rare",
+	dexId: [801],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/052.ts
+++ b/data-asia/S/S11a/052.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "蒼響"
+		ja: "ザシアン",
+		'zh-tw': "蒼響",
 	},
 
 	illustrator: "nagimiso",
@@ -14,43 +14,52 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "用過去使用的兵器武裝自己。即使是超極巨化寶可夢，也能以一劍將之拿下。"
+		ja: "かつての 得物で 武装した。 キョダイマックスポケモンも 一刀の もとに 切り捨てる。",
+		'zh-tw': "用過去使用的兵器武裝自己。即使是超極巨化寶可夢，也能以一劍將之拿下。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "戰鬥軍團"
+	attacks: [
+		{
+			name: {
+				ja: "バトルレギオン",
+				'zh-tw': "戰鬥軍團",
+			},
+			damage: "20+",
+			cost: ["Metal"],
+			effect: {
+				ja: "自分のベンチポケモンの数×10ダメージ追加。このワザのダメージは、弱点と、相手のバトルポケモンにかかっている効果を計算しない。",
+				'zh-tw': "增加自己的備戰寶可夢的數量×10點傷害。這個招式的傷害不計算弱點與對手的戰鬥寶可夢身上的附加效果。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "增加自己的備戰寶可夢的數量×10點傷害。這個招式的傷害不計算弱點與對手的戰鬥寶可夢身上的附加效果。"
+		{
+			name: {
+				ja: "スライスブレード",
+				'zh-tw': "利刃切割",
+			},
+			damage: 100,
+			cost: ["Metal", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: "20+",
-		cost: ["Metal"]
-	}, {
-		name: {
-			'zh-tw': "利刃切割"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673050,
+				tcgplayer: 570815,
+			},
 		},
-
-		damage: 100,
-		cost: ["Metal", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [888],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/053.ts
+++ b/data-asia/S/S11a/053.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "藏瑪然特"
+		ja: "ザマゼンタ",
+		'zh-tw': "藏瑪然特",
 	},
 
 	illustrator: "GIDORA",
@@ -14,48 +14,58 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "能夠反彈一切的攻擊，因此被稱為格鬥王之盾，受到人們的畏懼與尊崇。"
+		ja: "いかなる 攻撃も 弾き返す 姿は 格闘王の盾 と 呼ばれ 恐れ 崇められた。",
+		'zh-tw': "能夠反彈一切的攻擊，因此被稱為格鬥王之盾，受到人們的畏懼與尊崇。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "金屬盾牌"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "メタルシールド",
+				'zh-tw': "金屬盾牌",
+			},
+			effect: {
+				ja: "このポケモンにエネルギーがついているなら、このポケモンが受けるワザのダメージは「-30」される。",
+				'zh-tw': "若這隻寶可夢身上附有能量，則這隻寶可夢受到招式的傷害「-30」點。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢身上附有能量，則這隻寶可夢受到招式的傷害「-30」點。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "報仇"
+	attacks: [
+		{
+			name: {
+				ja: "かたきうち",
+				'zh-tw': "報仇",
+			},
+			damage: "100+",
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "前の相手の番に、自分のポケモンがきぜつしていたなら、120ダメージ追加。",
+				'zh-tw': "在上個對手的回合，若自己的寶可夢【氣絕】了，則增加120點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在上個對手的回合，若自己的寶可夢【氣絕】了，則增加120點傷害。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673051,
+				tcgplayer: 570816,
+			},
 		},
-
-		damage: "100+",
-		cost: ["Metal", "Metal", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [889],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/054.ts
+++ b/data-asia/S/S11a/054.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "圖圖犬"
+		ja: "ドーブル",
+		'zh-tw': "圖圖犬",
 	},
 
 	illustrator: "Mizue",
@@ -14,37 +14,58 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "會用尾巴前端分泌出的液體畫下標記。其中有些標記會吸引愛好者以高價買賣。"
+		ja: "シッポの 先から でる 体液で マークを えがく。 マークに よっては マニアに 高値で 取引される。",
+		'zh-tw': "會用尾巴前端分泌出的液體畫下標記。其中有些標記會吸引愛好者以高價買賣。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "五顏六色調色盤"
+	attacks: [
+		{
+			name: {
+				ja: "いろいろパレット",
+				'zh-tw': "五顏六色調色盤",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を上から5枚見て、その中から基本エネルギーを好きなだけ選び、自分のポケモン1匹につける。残りのカードは山札にもどして切る。",
+				'zh-tw': "查看自己的牌庫上方5張卡，從其中選擇任意數量的基本能量卡，附於自己的1隻寶可夢身上。將剩餘卡放回牌庫並重洗。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "查看自己的牌庫上方5張卡，從其中選擇任意數量的基本能量卡，附於自己的1隻寶可夢身上。將剩餘卡放回牌庫並重洗。"
+		{
+			name: {
+				ja: "ぶつかる",
+				'zh-tw': "衝撞",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "衝撞"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673052,
+				tcgplayer: 570817,
+			},
 		},
-
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570900,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [235],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/055.ts
+++ b/data-asia/S/S11a/055.ts
@@ -1,57 +1,66 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鳳王V"
+		ja: "ホウオウV",
+		'zh-tw': "鳳王V",
 	},
 
 	illustrator: "AKIRA EGAWA",
 	category: "Pokemon",
 	hp: 230,
 	types: ["Colorless"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "復活火焰"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ふっかつのほのお",
+				'zh-tw': "復活火焰",
+			},
+			effect: {
+				ja: "このカードがトラッシュにあるなら、自分の番に1回使えて、使ったなら、自分の番は終わる。このカードをベンチに出す。その後、自分のトラッシュから基本エネルギーを4枚まで選び、このポケモンにつける。",
+				'zh-tw': "若這張卡在棄牌區，則在自己的回合時可使用1次，若使用，則自己的回合結束。將這張卡放置於備戰區。然後，從自己的棄牌區選擇最多4張基本能量卡，附於這隻寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這張卡在棄牌區，則在自己的回合時可使用1次，若使用，則自己的回合結束。將這張卡放置於備戰區。然後，從自己的棄牌區選擇最多4張基本能量卡，附於這隻寶可夢身上。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "彩虹烈焰"
+	attacks: [
+		{
+			name: {
+				ja: "レインボーバーン",
+				'zh-tw': "彩虹烈焰",
+			},
+			damage: "100+",
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている基本エネルギーのタイプの数×30ダメージ追加。",
+				'zh-tw': "增加這隻寶可夢身上附加的基本能量的屬性種類的數量×30點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加這隻寶可夢身上附加的基本能量的屬性種類的數量×30點傷害。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673053,
+				tcgplayer: 570818,
+			},
 		},
-
-		damage: "100+",
-		cost: ["Colorless", "Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Double rare",
+	dexId: [250],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/056.ts
+++ b/data-asia/S/S11a/056.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "青綿鳥"
+		ja: "チルット",
+		'zh-tw': "青綿鳥",
 	},
 
 	illustrator: "Miki Tanaka",
@@ -14,36 +14,51 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "絲綿般的翅膀會鎖住空氣，呈現蓬蓬鬆鬆的觸感。牠總是會細心地打理翅膀。"
+		ja: "真綿のような 翼は 空気を 含んで ふわふわの 触り心地。 こまめな 手入れを 欠かさない。",
+		'zh-tw': "絲綿般的翅膀會鎖住空氣，呈現蓬蓬鬆鬆的觸感。牠總是會細心地打理翅膀。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "連續旋轉"
+	attacks: [
+		{
+			name: {
+				ja: "れんぞくスピン",
+				'zh-tw': "連續旋轉",
+			},
+			damage: "20×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数×20ダメージ。",
+				'zh-tw': "擲硬幣直到出現反面，造成正面出現的次數×20點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲硬幣直到出現反面，造成正面出現的次數×20點傷害。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673054,
+				tcgplayer: 570819,
+			},
 		},
-
-		damage: "20×",
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570901,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [333],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/057.ts
+++ b/data-asia/S/S11a/057.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "七夕青鳥"
+		ja: "チルタリス",
+		'zh-tw': "七夕青鳥",
 	},
 
 	illustrator: "Sanosuke Sakuma",
@@ -14,42 +14,62 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "會一邊在天空中悠然飛翔，一邊哼唱出令人心醉神迷的美妙旋律。"
+		ja: "大空を ゆったりと 飛びながら 耳にした 者を うっとりさせる 美しい ハミングを 奏でる。",
+		'zh-tw': "會一邊在天空中悠然飛翔，一邊哼唱出令人心醉神迷的美妙旋律。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "魔法迴響"
+	attacks: [
+		{
+			name: {
+				ja: "マジカルエコー",
+				'zh-tw': "魔法迴響",
+			},
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチポケモンを1匹選び、選んだポケモンにのっているダメカンをすべて、相手のバトルポケモンにのせ替える。",
+				'zh-tw': "選擇自己的1隻備戰寶可夢，將所選的寶可夢身上放置的傷害指示物，全部改放於對手的戰鬥寶可夢身上。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇自己的1隻備戰寶可夢，將所選的寶可夢身上放置的傷害指示物，全部改放於對手的戰鬥寶可夢身上。"
+		{
+			name: {
+				ja: "ブラストウインド",
+				'zh-tw': "爆破之風",
+			},
+			damage: 90,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "爆破之風"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673055,
+				tcgplayer: 570820,
+			},
 		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570902,
+			},
+		},
+	],
 
-		damage: 90,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "チルット",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [334],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/058.ts
+++ b/data-asia/S/S11a/058.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "聒噪鳥"
+		ja: "ペラップ",
+		'zh-tw': "聒噪鳥",
 	},
 
 	illustrator: "sui",
@@ -14,42 +14,58 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "學習人類的語言來鳴叫。當夥伴們聚集在同一個地方時，大家就會學會同樣的詞語。"
+		ja: "人の 言葉を 覚えて 鳴く。 仲間が 一か所に 集まると みんな 同じ 言葉を 覚える。",
+		'zh-tw': "學習人類的語言來鳴叫。當夥伴們聚集在同一個地方時，大家就會學會同樣的詞語。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "循環抽出"
+	attacks: [
+		{
+			name: {
+				ja: "サイクルドロー",
+				'zh-tw': "循環抽出",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札を1枚トラッシュする。その後、自分の山札を2枚引く。",
+				'zh-tw': "將自己的1張手牌丟棄。然後，從自己的牌庫抽出2張卡。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將自己的1張手牌丟棄。然後，從自己的牌庫抽出2張卡。"
+		{
+			name: {
+				ja: "はばたく",
+				'zh-tw': "羽擊",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "羽擊"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673056,
+				tcgplayer: 570821,
+			},
 		},
-
-		damage: 10,
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570903,
+			},
+		},
+	],
 
 	retreat: 0,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [441],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11a/059.ts
+++ b/data-asia/S/S11a/059.ts
@@ -1,22 +1,41 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "能量轉移"
+		ja: "エネルギーつけかえ",
+		'zh-tw': "能量轉移",
 	},
 
 	illustrator: "Toyste Beach",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "選擇1個自己的場上寶可夢身上附加的基本能量，改附於自己的其他寶可夢身上。"
+		ja: "自分のポケモンについている基本エネルギーを1個、自分の別のポケモンにつけ替える。",
+		'zh-tw': "選擇1個自己的場上寶可夢身上附加的基本能量，改附於自己的其他寶可夢身上。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673057,
+				tcgplayer: 570822,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570904,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S11a/060.ts
+++ b/data-asia/S/S11a/060.ts
@@ -1,22 +1,41 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "捕獲香氛"
+		ja: "キャプチャーアロマ",
+		'zh-tw': "捕獲香氛",
 	},
 
 	illustrator: "sadaji",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "擲1次硬幣。若為正面，則從自己的牌庫選擇1張進化寶可夢卡，若為反面，則選擇1張【基礎】寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		ja: "コインを1回投げる。オモテなら進化ポケモン、ウラならたねポケモンを自分の山札から1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+		'zh-tw': "擲1次硬幣。若為正面，則從自己的牌庫選擇1張進化寶可夢卡，若為反面，則選擇1張【基礎】寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673058,
+				tcgplayer: 570823,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570905,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S11a/061.ts
+++ b/data-asia/S/S11a/061.ts
@@ -1,22 +1,41 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "寶可夢交替"
+		ja: "ポケモンいれかえ",
+		'zh-tw': "寶可夢交替",
 	},
 
 	illustrator: "Studio Bora Inc.",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "將自己的戰鬥寶可夢與備戰寶可夢互換。"
+		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。",
+		'zh-tw': "將自己的戰鬥寶可夢與備戰寶可夢互換。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673059,
+				tcgplayer: 570824,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570906,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S11a/062.ts
+++ b/data-asia/S/S11a/062.ts
@@ -1,22 +1,41 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "緊急果凍"
+		ja: "きんきゅうゼリー",
+		'zh-tw': "緊急果凍",
 	},
 
 	illustrator: "AYUMI ODASHIMA",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。"
+		ja: "おたがいの番の終わりに、このカードをつけているポケモンの残りHPが「30」以下でダメカンがのっているなら、そのポケモンのHPを「120」回復する。その後、このカードをトラッシュする。",
+		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673060,
+				tcgplayer: 570825,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570907,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Tool",
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S11a/063.ts
+++ b/data-asia/S/S11a/063.ts
@@ -1,22 +1,41 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "裁判"
+		ja: "ジャッジマン",
+		'zh-tw': "裁判",
 	},
 
 	illustrator: "Ryuta Fuse",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "雙方玩家各將手牌全部放回牌庫並重洗。然後，各從牌庫抽出4張。"
+		ja: "おたがいのプレイヤーは、それぞれ、手札をすべて山札にもどし、山札を切る。その後、それぞれの山札を4枚引く。",
+		'zh-tw': "雙方玩家各將手牌全部放回牌庫並重洗。然後，各從牌庫抽出4張。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673061,
+				tcgplayer: 570826,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570908,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S11a/064.ts
+++ b/data-asia/S/S11a/064.ts
@@ -1,22 +1,41 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "莎莉娜"
+		ja: "セレナ",
+		'zh-tw': "莎莉娜",
 	},
 
 	illustrator: "Ken Sugimori",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "這張卡從2種效果中選擇1種使用。 ◆選擇最多3張自己的手牌，將其丟棄。（一定要選擇1張。）然後，從牌庫抽卡直到自己的手牌滿5張為止。◆選擇對手的備戰區的1隻「寶可夢【V】」，與戰鬥寶可夢互換。"
+		ja: "このカードは、2つの効果から1つを選んで使う。◆自分の手札を3枚まで選び、トラッシュする。（必ず1枚は選ぶ。）その後、自分の手札が5枚になるように、山札を引く。◆相手のベンチの「ポケモンV」を1匹選び、バトルポケモンと入れ替える。",
+		'zh-tw': "這張卡從2種效果中選擇1種使用。 ◆選擇最多3張自己的手牌，將其丟棄。（一定要選擇1張。）然後，從牌庫抽卡直到自己的手牌滿5張為止。◆選擇對手的備戰區的1隻「寶可夢【V】」，與戰鬥寶可夢互換。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673062,
+				tcgplayer: 570827,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570909,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S11a/065.ts
+++ b/data-asia/S/S11a/065.ts
@@ -1,22 +1,41 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "長袖和服少女"
+		ja: "ふりそで",
+		'zh-tw': "長袖和服少女",
 	},
 
 	illustrator: "Yusuke Ohmura",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的牌庫選擇1張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。若希望，將剛放置的寶可夢與戰鬥寶可夢互換。"
+		ja: "自分の山札からたねポケモンを1枚選び、ベンチに出す。そして山札を切る。のぞむなら、出したポケモンとバトルポケモンを入れ替える。",
+		'zh-tw': "從自己的牌庫選擇1張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。若希望，將剛放置的寶可夢與戰鬥寶可夢互換。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673063,
+				tcgplayer: 570828,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570910,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/S/S11a/066.ts
+++ b/data-asia/S/S11a/066.ts
@@ -1,22 +1,41 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "米可利"
+		ja: "ミクリ",
+		'zh-tw': "米可利",
 	},
 
 	illustrator: "Megumi Mizutani",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的牌庫抽出3張卡。對手若希望，從牌庫抽出1張卡。這個情況下，自己再從牌庫抽出1張卡。"
+		ja: "自分の山札を3枚引く。相手は、のぞむなら、山札を1枚引く。その場合、自分は、さらに山札を1枚引く。",
+		'zh-tw': "從自己的牌庫抽出3張卡。對手若希望，從牌庫抽出1張卡。這個情況下，自己再從牌庫抽出1張卡。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673064,
+				tcgplayer: 570829,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570911,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/S/S11a/067.ts
+++ b/data-asia/S/S11a/067.ts
@@ -1,21 +1,41 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雙重渦輪能量"
+		ja: "ダブルターボエネルギー",
+		'zh-tw': "雙重渦輪能量",
 	},
 
+	illustrator: "",
 	category: "Energy",
+	energyType: "Special",
 
 	effect: {
-		'zh-tw': "只要這張卡附於寶可夢身上，視為提供2個【無】能量。 附有這張卡的寶可夢使用的招式，對對手的寶可夢造成的傷害「-20」點。"
+		ja: "このカードは、ポケモンについているかぎり、[C]エネルギー2個ぶんとしてはたらく。このカードをつけているポケモンが使うワザの、相手のポケモンへのダメージは「-20」される。",
+		'zh-tw': "只要這張卡附於寶可夢身上，視為提供2個【無】能量。 附有這張卡的寶可夢使用的招式，對對手的寶可夢造成的傷害「-20」點。",
 	},
 
-	energyType: "Special",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673065,
+				tcgplayer: 570830,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570912,
+			},
+		},
+	],
 
-export default card
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S11a/068.ts
+++ b/data-asia/S/S11a/068.ts
@@ -1,21 +1,41 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11a"
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "V防守能量"
+		ja: "Vガードエネルギー",
+		'zh-tw': "V防守能量",
 	},
 
+	illustrator: "",
 	category: "Energy",
+	energyType: "Special",
 
 	effect: {
-		'zh-tw': "只要這張卡附於寶可夢身上，視為提供1個【無】能量。附有這張卡的寶可夢受到對手的「寶可夢【V】」招式的傷害「-30」點。無論附有多少張「V防守能量」卡，這個效果也不會重複。"
+		ja: "このカードは、ポケモンについているかぎり、[C]エネルギー1個ぶんとしてはたらく。このカードをつけているポケモンが、相手の「ポケモンV」から受けるワザのダメージは「-30」される。この効果は、「Vガードエネルギー」が何枚ついていても、重ならない。",
+		'zh-tw': "只要這張卡附於寶可夢身上，視為提供1個【無】能量。附有這張卡的寶可夢受到對手的「寶可夢【V】」招式的傷害「-30」點。無論附有多少張「V防守能量」卡，這個效果也不會重複。",
 	},
 
-	energyType: "Special",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 673066,
+				tcgplayer: 570831,
+			},
+		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			thirdParty: {
+				tcgplayer: 570913,
+			},
+		},
+	],
 
-export default card
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S11a/069.ts
+++ b/data-asia/S/S11a/069.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テールナー",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fire"],
+
+	description: {
+		ja: "木の枝を 尻尾から 引き抜くとき 摩擦で 着火。 枝の 炎を 振って 仲間に 合図を 送る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かえん" },
+			damage: 30,
+			cost: ["Fire"],
+		},
+		{
+			name: { ja: "フレアパレード" },
+			damage: "60×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある「セレナ」の枚数×60ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673386,
+				tcgplayer: 570832,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "フォッコ",
+	},
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Character Rare",
+	dexId: [654],
+};
+
+export default card;

--- a/data-asia/S/S11a/070.ts
+++ b/data-asia/S/S11a/070.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミロカロス",
+	},
+
+	illustrator: "chibi",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Water"],
+
+	description: {
+		ja: "もっとも 美しい ポケモンとも 呼ばれ 多くの 芸術家に インスピレーションを 与えてきた。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ウォーターアロー" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手のポケモン1匹に、50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "メロウウェーブ" },
+			damage: 60,
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673387,
+				tcgplayer: 570833,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒンバス",
+	},
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Character Rare",
+	dexId: [350],
+};
+
+export default card;

--- a/data-asia/S/S11a/071.ts
+++ b/data-asia/S/S11a/071.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルージュラ",
+	},
+
+	illustrator: "HYOGONOSUKE",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Psychic"],
+
+	description: {
+		ja: "ガラルの とある 地域では 氷の 女王と 呼んで ルージュラを 恐れ崇めていた。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "わがままリップ" },
+			effect: {
+				ja: "このポケモンが、相手の「ポケモンV」からワザのダメージを受けてきぜつしても、相手はサイドをとれない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "サイコダメージ" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにのっているダメカンの数×10ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673388,
+				tcgplayer: 570834,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Character Rare",
+	dexId: [124],
+};
+
+export default card;

--- a/data-asia/S/S11a/072.ts
+++ b/data-asia/S/S11a/072.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サーナイト",
+	},
+
+	illustrator: "AKIRA EGAWA",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Psychic"],
+
+	description: {
+		ja: "未来を 予知する 力を もつ。 トレーナーを 守る ときに 最大 パワーを 発揮する。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "リファイン" },
+			effect: {
+				ja: "自分の番に、自分の手札を1枚トラッシュするなら、1回使える。自分の山札を2枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "マジカルショット" },
+			damage: 120,
+			cost: ["Psychic", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673389,
+				tcgplayer: 570835,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キルリア",
+	},
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Character Rare",
+	dexId: [282],
+};
+
+export default card;

--- a/data-asia/S/S11a/073.ts
+++ b/data-asia/S/S11a/073.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドーブル",
+	},
+
+	illustrator: "KIYOTAKA OSHIYAMA",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "シッポの 先から でる 体液で マークを えがく。 マークに よっては マニアに 高値で 取引される。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "いろいろパレット" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を上から5枚見て、その中から基本エネルギーを好きなだけ選び、自分のポケモン1匹につける。残りのカードは山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "ぶつかる" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673390,
+				tcgplayer: 570836,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Character Rare",
+	dexId: [235],
+};
+
+export default card;

--- a/data-asia/S/S11a/074.ts
+++ b/data-asia/S/S11a/074.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チルタリス",
+	},
+
+	illustrator: "Yuu Nishida",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Colorless"],
+
+	description: {
+		ja: "大空を ゆったりと 飛びながら 耳にした 者を うっとりさせる 美しい ハミングを 奏でる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "マジカルエコー" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチポケモンを1匹選び、選んだポケモンにのっているダメカンをすべて、相手のバトルポケモンにのせ替える。",
+			},
+		},
+		{
+			name: { ja: "ブラストウインド" },
+			damage: 90,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673391,
+				tcgplayer: 570837,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チルット",
+	},
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Character Rare",
+	dexId: [334],
+};
+
+export default card;

--- a/data-asia/S/S11a/075.ts
+++ b/data-asia/S/S11a/075.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャローダV",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "けだかいひかり" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "おたがいのポケモン全員のHPを、それぞれ「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "ソーラービーム" },
+			damage: 120,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673392,
+				tcgplayer: 570838,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [497],
+};
+
+export default card;

--- a/data-asia/S/S11a/076.ts
+++ b/data-asia/S/S11a/076.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レシラムV",
+	},
+
+	illustrator: "N-DESIGN Inc.",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きらめくつばさ" },
+			cost: ["Fire"],
+			effect: {
+				ja: "自分の山札から基本エネルギーを2枚まで選び、自分のポケモン1匹につける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ホワイトブレイズ" },
+			damage: 200,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673393,
+				tcgplayer: 570839,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [643],
+};
+
+export default card;

--- a/data-asia/S/S11a/077.ts
+++ b/data-asia/S/S11a/077.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラ ロコンV",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ホワイトドロップ" },
+			damage: "10+",
+			cost: [],
+			effect: {
+				ja: "相手のバトルポケモンが「ポケモンV」なら、50ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "フロストスマッシュ" },
+			damage: 110,
+			cost: ["Water", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673394,
+				tcgplayer: 570840,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [37],
+};
+
+export default card;

--- a/data-asia/S/S11a/078.ts
+++ b/data-asia/S/S11a/078.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クチートV",
+	},
+
+	illustrator: "takuyoa",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふきげんスラップ" },
+			damage: 30,
+			cost: ["Psychic"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "かみおとす" },
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673395,
+				tcgplayer: 570841,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [303],
+};
+
+export default card;

--- a/data-asia/S/S11a/079.ts
+++ b/data-asia/S/S11a/079.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マギアナV",
+	},
+
+	illustrator: "N-DESIGN Inc.",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ギアスロー" },
+			cost: ["Metal"],
+			effect: {
+				ja: "相手のポケモン1匹に、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "スペシャルレーザー" },
+			damage: "100+",
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "このポケモンに特殊エネルギーがついているなら、120ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673396,
+				tcgplayer: 570842,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [801],
+};
+
+export default card;

--- a/data-asia/S/S11a/080.ts
+++ b/data-asia/S/S11a/080.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホウオウV",
+	},
+
+	illustrator: "N-DESIGN Inc.",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ふっかつのほのお" },
+			effect: {
+				ja: "このカードがトラッシュにあるなら、自分の番に1回使えて、使ったなら、自分の番は終わる。このカードをベンチに出す。その後、自分のトラッシュから基本エネルギーを4枚まで選び、このポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "レインボーバーン" },
+			damage: "100+",
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている基本エネルギーのタイプの数×30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673397,
+				tcgplayer: 570843,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [250],
+};
+
+export default card;

--- a/data-asia/S/S11a/081.ts
+++ b/data-asia/S/S11a/081.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "セレナ",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、2つの効果から1つを選んで使う。◆自分の手札を3枚まで選び、トラッシュする。（必ず1枚は選ぶ。）その後、自分の手札が5枚になるように、山札を引く。◆相手のベンチの「ポケモンV」を1匹選び、バトルポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673398,
+				tcgplayer: 570844,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S11a/082.ts
+++ b/data-asia/S/S11a/082.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ふりそで",
+	},
+
+	illustrator: "saino misaki",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札からたねポケモンを1枚選び、ベンチに出す。そして山札を切る。のぞむなら、出したポケモンとバトルポケモンを入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673399,
+				tcgplayer: 570845,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S11a/083.ts
+++ b/data-asia/S/S11a/083.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミクリ",
+	},
+
+	illustrator: "Ryuta Fuse",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を3枚引く。相手は、のぞむなら、山札を1枚引く。その場合、自分は、さらに山札を1枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673400,
+				tcgplayer: 570846,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S11a/084.ts
+++ b/data-asia/S/S11a/084.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャローダV",
+	},
+
+	illustrator: "Teeziro",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "けだかいひかり" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "おたがいのポケモン全員のHPを、それぞれ「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "ソーラービーム" },
+			damage: 120,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673401,
+				tcgplayer: 570847,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Character Super Rare",
+	dexId: [497],
+};
+
+export default card;

--- a/data-asia/S/S11a/085.ts
+++ b/data-asia/S/S11a/085.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クチートV",
+	},
+
+	illustrator: "saino misaki",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふきげんスラップ" },
+			damage: 30,
+			cost: ["Psychic"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "かみおとす" },
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673402,
+				tcgplayer: 570848,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Character Super Rare",
+	dexId: [303],
+};
+
+export default card;

--- a/data-asia/S/S11a/086.ts
+++ b/data-asia/S/S11a/086.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャローダVSTAR",
+	},
+
+	illustrator: "PLANETA Mochizuki",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Grass"],
+
+	stage: "VSTAR",
+
+	attacks: [
+		{
+			name: { ja: "ロイヤルミキサー" },
+			damage: 190,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについているエネルギーを好きなだけ選び、自分のポケモンに好きなようにつけ替える。",
+			},
+		},
+		{
+			name: { ja: "スターワインダー" },
+			damage: "60×",
+			cost: ["Grass"],
+			effect: {
+				ja: "このポケモンについているエネルギーの数×60ダメージ。このポケモンをベンチポケモンと入れ替える。［対戦中、自分はVSTARパワーを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673403,
+				tcgplayer: 570849,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジャローダV",
+	},
+
+	retreat: 0,
+	regulationMark: "F",
+	rarity: "Holo Rare",
+	dexId: [497],
+};
+
+export default card;

--- a/data-asia/S/S11a/087.ts
+++ b/data-asia/S/S11a/087.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラ ロコンVSTAR",
+	},
+
+	illustrator: "PLANETA Hiiragi",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Water"],
+
+	stage: "VSTAR",
+
+	attacks: [
+		{
+			name: { ja: "スノーミラージュ" },
+			damage: 160,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。次の相手の番、このポケモンは特性を持つポケモンからワザのダメージを受けない。",
+			},
+		},
+		{
+			name: { ja: "ぎんせつスター" },
+			damage: "70×",
+			cost: [],
+			effect: {
+				ja: "相手の場の「ポケモンV」の数×70ダメージ。このワザのダメージは弱点・抵抗力を計算しない。［対戦中、自分はVSTARパワーを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673404,
+				tcgplayer: 570850,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラロコンV",
+	},
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Holo Rare",
+	dexId: [37],
+};
+
+export default card;

--- a/data-asia/S/S11a/088.ts
+++ b/data-asia/S/S11a/088.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クチートVSTAR",
+	},
+
+	illustrator: "PLANETA Mochizuki",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Psychic"],
+
+	stage: "VSTAR",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "スターロンド" },
+			effect: {
+				ja: "このポケモンがベンチにいるなら、自分の番に使える。このポケモンを自分のバトルポケモンと入れ替える。その後、相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。［対戦中、自分はVSTARパワーを1回しか使えない。］",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "サドンイーター" },
+			damage: "90+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "この番、このポケモンがベンチからバトル場に出ていたなら、90ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673405,
+				tcgplayer: 570851,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "クチートV",
+	},
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Holo Rare",
+	dexId: [303],
+};
+
+export default card;

--- a/data-asia/S/S11a/089.ts
+++ b/data-asia/S/S11a/089.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "セレナ",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、2つの効果から1つを選んで使う。◆自分の手札を3枚まで選び、トラッシュする。（必ず1枚は選ぶ。）その後、自分の手札が5枚になるように、山札を引く。◆相手のベンチの「ポケモンV」を1匹選び、バトルポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673406,
+				tcgplayer: 570852,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Holo Rare",
+};
+
+export default card;

--- a/data-asia/S/S11a/090.ts
+++ b/data-asia/S/S11a/090.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ふりそで",
+	},
+
+	illustrator: "saino misaki",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札からたねポケモンを1枚選び、ベンチに出す。そして山札を切る。のぞむなら、出したポケモンとバトルポケモンを入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673407,
+				tcgplayer: 570853,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Holo Rare",
+};
+
+export default card;

--- a/data-asia/S/S11a/091.ts
+++ b/data-asia/S/S11a/091.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミクリ",
+	},
+
+	illustrator: "Ryuta Fuse",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を3枚引く。相手は、のぞむなら、山札を1枚引く。その場合、自分は、さらに山札を1枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673408,
+				tcgplayer: 570854,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Holo Rare",
+};
+
+export default card;

--- a/data-asia/S/S11a/092.ts
+++ b/data-asia/S/S11a/092.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャローダVSTAR",
+	},
+
+	illustrator: "PLANETA Mochizuki",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Grass"],
+
+	stage: "VSTAR",
+
+	attacks: [
+		{
+			name: { ja: "ロイヤルミキサー" },
+			damage: 190,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについているエネルギーを好きなだけ選び、自分のポケモンに好きなようにつけ替える。",
+			},
+		},
+		{
+			name: { ja: "スターワインダー" },
+			damage: "60×",
+			cost: ["Grass"],
+			effect: {
+				ja: "このポケモンについているエネルギーの数×60ダメージ。このポケモンをベンチポケモンと入れ替える。［対戦中、自分はVSTARパワーを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673409,
+				tcgplayer: 570855,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジャローダV",
+	},
+
+	retreat: 0,
+	regulationMark: "F",
+	rarity: "Mega Hyper Rare",
+	dexId: [497],
+};
+
+export default card;

--- a/data-asia/S/S11a/093.ts
+++ b/data-asia/S/S11a/093.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エネルギーつけかえ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のポケモンについている基本エネルギーを1個、自分の別のポケモンにつけ替える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673410,
+				tcgplayer: 570856,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "F",
+	rarity: "Mega Hyper Rare",
+};
+
+export default card;

--- a/data-asia/S/S11a/094.ts
+++ b/data-asia/S/S11a/094.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11a";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "Vガードエネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、ポケモンについているかぎり、[C]エネルギー1個ぶんとしてはたらく。このカードをつけているポケモンが、相手の「ポケモンV」から受けるワザのダメージは「-30」される。この効果は、「Vガードエネルギー」が何枚ついていても、重ならない。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 673411,
+				tcgplayer: 570857,
+			},
+		},
+	],
+
+	regulationMark: "F",
+	rarity: "Mega Hyper Rare",
+};
+
+export default card;

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -236,6 +236,7 @@ export interface Card {
 			// Black White rare
 			| 'Black White Rare'
 			| 'Mega Hyper Rare'
+			| 'Triple Rare'
 			// Japanese Character Rares (since SM11b Dream League)
 			| 'Character Rare' | 'Character Super Rare'
 			// Pokémon TCG Pocket Rarities


### PR DESCRIPTION
## What

Refreshes the existing Japanese set **S11a 白熱のアルカナ (Incandescent Arcana)** from its primary sources. The curated content stays: every card keeps its `zh-tw` texts verbatim.

What changes across the 94 card files:

- `thirdParty.cardmarket` moves onto `variants` objects and 68 missing ids are filled in
- per card where missing: `dexId`, `evolveFrom`, `resistances`, the Japanese flavor text and the Japanese effect/attack texts straight from the official database and limitless

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (672998–673411)
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (570764–570857), keyed by the collection number each product carries in `extendedData`

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- All 94 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
