### PR TITLE
(data) Update Japanese S set S11 Lost Abyss

### DIFF
--- a/data-asia/S/S11/001.ts
+++ b/data-asia/S/S11/001.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "毛球"
+		ja: "コンパン",
+		'zh-tw': "毛球",
 	},
 
 	illustrator: "Sekio",
@@ -14,27 +14,40 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "似乎住在大樹下，吃蟲子之類的東西。 夜裡會到有亮光的地方去。"
+		ja: "大きな 木の下に 住んでいて 虫などを 食べているらしい。 夜は 明かりのそばに やってくる。",
+		'zh-tw': "似乎住在大樹下，吃蟲子之類的東西。 夜裡會到有亮光的地方去。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "撞擊"
+	attacks: [
+		{
+			name: {
+				ja: "たいあたり",
+				'zh-tw': "撞擊",
+			},
+			damage: 20,
+			cost: ["Grass"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Grass"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667561,
+				tcgplayer: 569932,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [48],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/002.ts
+++ b/data-asia/S/S11/002.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "摩魯蛾"
+		ja: "モルフォン",
+		'zh-tw': "摩魯蛾",
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -14,38 +14,56 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "翅膀上附著鱗粉，每次翩翩拍動翅膀， 就會散播劇毒的粉末。"
+		ja: "羽に りんぷんが ついていて ヒラヒラと 羽ばたくたびに 猛毒の 粉を ばらまく。",
+		'zh-tw': "翅膀上附著鱗粉，每次翩翩拍動翅膀， 就會散播劇毒的粉末。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "奇跡粉"
+	attacks: [
+		{
+			name: {
+				ja: "ミラクルパウダー",
+				'zh-tw': "奇跡粉",
+			},
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを1回投げオモテなら、特殊状態の中から1つを選び、相手のバトルポケモンをその状態にする。",
+				'zh-tw': "擲1次硬幣若為正面，則從特殊狀態中選擇1種，將對手的戰鬥寶可夢處於那個狀態。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則從特殊狀態中選擇1種，將對手的戰鬥寶可夢處於那個狀態。"
+		{
+			name: {
+				ja: "かぜおこし",
+				'zh-tw': "起風",
+			},
+			damage: 70,
+			cost: ["Grass", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Grass"]
-	}, {
-		name: {
-			'zh-tw': "起風"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667565,
+				tcgplayer: 569933,
+			},
 		},
+	],
 
-		damage: 70,
-		cost: ["Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "コンパン",
+	},
 
 	retreat: 0,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [49],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/003.ts
+++ b/data-asia/S/S11/003.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "向日種子"
+		ja: "ヒマナッツ",
+		'zh-tw': "向日種子",
 	},
 
 	illustrator: "Saya Tsuruta",
@@ -14,27 +14,40 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "只飲用積在葉子背面的朝露來過活。據說除此之外什麼都不吃。"
+		ja: "葉っぱの 裏側に たまった 朝露だけを 飲んで 暮らす。 他には なにも 食べないという。",
+		'zh-tw': "只飲用積在葉子背面的朝露來過活。據說除此之外什麼都不吃。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "種子炸彈"
+	attacks: [
+		{
+			name: {
+				ja: "タネばくだん",
+				'zh-tw': "種子炸彈",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667591,
+				tcgplayer: 569934,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [191],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/004.ts
+++ b/data-asia/S/S11/004.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "向日花怪"
+		ja: "キマワリ",
+		'zh-tw': "向日花怪",
 	},
 
 	illustrator: "zig",
@@ -14,31 +14,48 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "溫暖的陽光就是牠的能量。以追著太陽移動的習性聞名。"
+		ja: "暖かい 日差しが エネルギー。 太陽を 追いかけて 移動する 習性で 知られている。",
+		'zh-tw': "溫暖的陽光就是牠的能量。以追著太陽移動的習性聞名。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "燦燦光束"
+	attacks: [
+		{
+			name: {
+				ja: "サンサンビーム",
+				'zh-tw': "燦燦光束",
+			},
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、自分の手札からエネルギーを3枚までトラッシュし、その枚数×70ダメージ追加。",
+				'zh-tw': "若希望，從自己的手牌將最多3張能量卡丟棄，增加其張數×70點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若希望，從自己的手牌將最多3張能量卡丟棄，增加其張數×70點傷害。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667607,
+				tcgplayer: 569935,
+			},
 		},
+	],
 
-		damage: "10+",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ヒマナッツ",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [192],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/005.ts
+++ b/data-asia/S/S11/005.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "橡實果"
+		ja: "タネボー",
+		'zh-tw': "橡實果",
 	},
 
 	illustrator: "Yuka Morii",
@@ -14,31 +14,44 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "在牠一動也不動的時候，看起來和樹果一模一樣， 以嚇唬來啄食自己的寶可夢為樂。"
+		ja: "じっと 動かずに いると 木の実と そっくり。 ついばみに やって来た ポケモンを 驚かせて 遊ぶ。",
+		'zh-tw': "在牠一動也不動的時候，看起來和樹果一模一樣， 以嚇唬來啄食自己的寶可夢為樂。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "吸取"
+	attacks: [
+		{
+			name: {
+				ja: "すいとる",
+				'zh-tw': "吸取",
+			},
+			damage: 10,
+			cost: ["Grass"],
+			effect: {
+				ja: "このポケモンのHPを「10」回復する。",
+				'zh-tw': "將這隻寶可夢恢復「10」HP。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將這隻寶可夢恢復「10」HP。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667608,
+				tcgplayer: 569936,
+			},
 		},
-
-		damage: 10,
-		cost: ["Grass"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [273],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/006.ts
+++ b/data-asia/S/S11/006.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "長鼻葉"
+		ja: "コノハナ",
+		'zh-tw': "長鼻葉",
 	},
 
 	illustrator: "Mizue",
@@ -14,31 +14,48 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "棲息在森林深處。會用頭上的葉子做成笛子， 吹出令人感到不安的音色。"
+		ja: "森の 奥深くに 生息。 頭の 葉っぱで 笛を 作り 不安に させる 音色を 出す。",
+		'zh-tw': "棲息在森林深處。會用頭上的葉子做成笛子， 吹出令人感到不安的音色。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "推倒"
+	attacks: [
+		{
+			name: {
+				ja: "つきとばす",
+				'zh-tw': "推倒",
+			},
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "のぞむなら、相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+				'zh-tw': "若希望，將對手的戰鬥寶可夢與備戰寶可夢互換。[由對手選擇放置於戰鬥場的寶可夢。]",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若希望，將對手的戰鬥寶可夢與備戰寶可夢互換。[由對手選擇放置於戰鬥場的寶可夢。]"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667609,
+				tcgplayer: 569937,
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Grass"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "タネボー",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [274],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/007.ts
+++ b/data-asia/S/S11/007.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "狡猾天狗"
+		ja: "ダーテング",
+		'zh-tw': "狡猾天狗",
 	},
 
 	illustrator: "kawayoo",
@@ -14,42 +14,60 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "過去被視為森林之神而受到畏懼的寶可夢。有著讀取對手想法並 搶先一步行動的能力。"
+		ja: "森の 神様と 恐れられていた ポケモン。 相手の 考えを 読み 先回りする 能力を もつ。",
+		'zh-tw': "過去被視為森林之神而受到畏懼的寶可夢。有著讀取對手想法並 搶先一步行動的能力。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "圓扇龍捲風"
+	attacks: [
+		{
+			name: {
+				ja: "うちわトルネード",
+				'zh-tw': "圓扇龍捲風",
+			},
+			damage: 50,
+			cost: ["Grass"],
+			effect: {
+				ja: "のぞむなら、相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+				'zh-tw': "若希望，將對手的戰鬥寶可夢與備戰寶可夢互換。[由對手選擇放置於戰鬥場的寶可夢。]",
+			},
 		},
-
-		effect: {
-			'zh-tw': "若希望，將對手的戰鬥寶可夢與備戰寶可夢互換。[由對手選擇放置於戰鬥場的寶可夢。]"
+		{
+			name: {
+				ja: "やぶれとっぷう",
+				'zh-tw': "毀壞陣風",
+			},
+			damage: 210,
+			cost: ["Grass"],
+			effect: {
+				ja: "このポケモンと、ついているすべてのカードを、ロストゾーンに置く。",
+				'zh-tw': "將這隻寶可夢與附加的卡，全部放置於放逐區。",
+			},
 		},
+	],
 
-		damage: 50,
-		cost: ["Grass"]
-	}, {
-		name: {
-			'zh-tw': "毀壞陣風"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 667610,
+				tcgplayer: 569938,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將這隻寶可夢與附加的卡，全部放置於放逐區。"
-		},
-
-		damage: 210,
-		cost: ["Grass"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "コノハナ",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [275],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/008.ts
+++ b/data-asia/S/S11/008.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "哎呀球菇"
+		ja: "タマゲタケ",
+		'zh-tw': "哎呀球菇",
 	},
 
 	illustrator: "Saya Tsuruta",
@@ -14,27 +14,40 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "酷似精靈球的花紋究竟有什麼意義和理由， 至今仍沒有人能了解。"
+		ja: "モンスターボールに よく 似た 模様の 意味や 理由は いまだに だれも わからない。",
+		'zh-tw': "酷似精靈球的花紋究竟有什麼意義和理由， 至今仍沒有人能了解。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "衝撞"
+	attacks: [
+		{
+			name: {
+				ja: "ぶつかる",
+				'zh-tw': "衝撞",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
+	],
 
-		damage: 10,
-		cost: ["Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667611,
+				tcgplayer: 569939,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [590],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/009.ts
+++ b/data-asia/S/S11/009.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "敗露球菇"
+		ja: "モロバレル",
+		'zh-tw': "敗露球菇",
 	},
 
 	illustrator: "GOSSAN",
@@ -14,43 +14,62 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "會噴出帶有毒性的孢子。如果不盡快洗掉的話， 就會從那裡長出蘑菇來喔。"
+		ja: "毒の 胞子を 噴きつける。 はやく 洗い流さないと そこに キノコが 生えてくるぞ。",
+		'zh-tw': "會噴出帶有毒性的孢子。如果不盡快洗掉的話， 就會從那裡長出蘑菇來喔。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "整人孢子"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "どっきりほうし",
+				'zh-tw': "整人孢子",
+			},
+			effect: {
+				ja: "相手の番に、このカードが相手のワザ・特性・グッズ・サポートの効果で手札からトラッシュされたとき、相手の手札をすべてトラッシュする。",
+				'zh-tw': "在對手的回合，當這張卡因對手的招式・特性・物品卡・支援者卡的效果而從手牌被丟棄時，將對手的手牌全部丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在對手的回合，當這張卡因對手的招式・特性・物品卡・支援者卡的效果而從手牌被丟棄時，將對手的手牌全部丟棄。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "昏睡之錘"
+	attacks: [
+		{
+			name: {
+				ja: "ヒプノハンマー",
+				'zh-tw': "昏睡之錘",
+			},
+			damage: 50,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【睡眠】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【睡眠】。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667612,
+				tcgplayer: 569940,
+			},
 		},
+	],
 
-		damage: 50,
-		cost: ["Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "タマゲタケ",
+	},
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [591],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/010.ts
+++ b/data-asia/S/S11/010.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鐵蟻"
+		ja: "アイアント",
+		'zh-tw': "鐵蟻",
 	},
 
 	illustrator: "Yuya Oka",
@@ -14,37 +14,51 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "在巢穴的深處產卵。受到熔蟻獸的襲擊時會用 大大的顎部咬住對方進行反擊。"
+		ja: "巣の 奥深くに タマゴを 産む。 クイタランに 襲われると 大きな 顎で 噛みついて 反撃。",
+		'zh-tw': "在巢穴的深處產卵。受到熔蟻獸的襲擊時會用 大大的顎部咬住對方進行反擊。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "挖能量"
+	attacks: [
+		{
+			name: {
+				ja: "エネほり",
+				'zh-tw': "挖能量",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から基本エネルギーを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多2張基本能量卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多2張基本能量卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		{
+			name: {
+				ja: "かみつく",
+				'zh-tw': "咬住",
+			},
+			damage: 50,
+			cost: ["Grass", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "咬住"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667613,
+				tcgplayer: 569941,
+			},
 		},
-
-		damage: 50,
-		cost: ["Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [632],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/011.ts
+++ b/data-asia/S/S11/011.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "小木靈"
+		ja: "ボクレー",
+		'zh-tw': "小木靈",
 	},
 
 	illustrator: "AKIRA EGAWA",
@@ -14,27 +14,40 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "在森林中迷路死去的孩子的魂魄附在樹樁上， 轉生成了寶可夢。"
+		ja: "森で さまよい 命を 落とした 子どもの 魂が 切り株に 宿り ポケモンに 生まれ変わった。",
+		'zh-tw': "在森林中迷路死去的孩子的魂魄附在樹樁上， 轉生成了寶可夢。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "鉤住"
+	attacks: [
+		{
+			name: {
+				ja: "ひっかける",
+				'zh-tw': "鉤住",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
+	],
 
-		damage: 10,
-		cost: ["Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667614,
+				tcgplayer: 569942,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [708],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/012.ts
+++ b/data-asia/S/S11/012.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "朽木妖"
+		ja: "オーロット",
+		'zh-tw': "朽木妖",
 	},
 
 	illustrator: "Yuya Oka",
@@ -14,43 +14,62 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "人們懼怕牠，因為牠據說會吃掉砍倒森林裡樹木的人。 但牠對住在森林裡的寶可夢很親切。"
+		ja: "森の 木を 伐り倒す 人間を 食べると 恐れられているが 森で 暮らす ポケモンたちには 優しい。",
+		'zh-tw': "人們懼怕牠，因為牠據說會吃掉砍倒森林裡樹木的人。 但牠對住在森林裡的寶可夢很親切。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "老樹結界"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ろうぼくのけっかい",
+				'zh-tw': "老樹結界",
+			},
+			effect: {
+				ja: "このポケモンが、相手の「ポケモンV」からワザのダメージを受けてきぜつしても、相手はサイドをとれない。",
+				'zh-tw': "這隻寶可夢就算受到對手的「寶可夢【V】」招式的傷害而【氣絕】，對手也無法獲得獎賞卡。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢就算受到對手的「寶可夢【V】」招式的傷害而【氣絕】，對手也無法獲得獎賞卡。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "終極衝擊"
+	attacks: [
+		{
+			name: {
+				ja: "ギガインパクト",
+				'zh-tw': "終極衝擊",
+			},
+			damage: 150,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 667615,
+				tcgplayer: 569943,
+			},
 		},
+	],
 
-		damage: 150,
-		cost: ["Grass", "Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ボクレー",
+	},
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [709],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/013.ts
+++ b/data-asia/S/S11/013.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "六尾"
+		ja: "ロコン",
+		'zh-tw': "六尾",
 	},
 
 	illustrator: "ryoma uratsuka",
@@ -14,31 +14,44 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "雖然還是孩子，但已擁有美麗的６根尾巴。 長大後尾巴會變得更多。"
+		ja: "子どもだが ６本の しっぽが 美しい。 成長すると さらに しっぽが 増える。",
+		'zh-tw': "雖然還是孩子，但已擁有美麗的６根尾巴。 長大後尾巴會變得更多。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "飛撲"
+	attacks: [
+		{
+			name: {
+				ja: "とびつく",
+				'zh-tw': "飛撲",
+			},
+			damage: "10+",
+			cost: ["Fire"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+				'zh-tw': "擲1次硬幣若為正面，則增加20點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則增加20點傷害。"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667616,
+				tcgplayer: 569944,
+			},
 		},
-
-		damage: "10+",
-		cost: ["Fire"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [37],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/014.ts
+++ b/data-asia/S/S11/014.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "九尾"
+		ja: "キュウコン",
+		'zh-tw': "九尾",
 	},
 
 	illustrator: "Shiburingaru",
@@ -14,41 +14,59 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "每一根尾巴裡都蘊含著神通力。據說牠的壽命 長達１０００年。"
+		ja: "しっぽの １本 １本に 神通力が 込められている。 １０００年 生きると 言われる。",
+		'zh-tw': "每一根尾巴裡都蘊含著神通力。據說牠的壽命 長達１０００年。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "目不轉睛"
+	attacks: [
+		{
+			name: {
+				ja: "みつめる",
+				'zh-tw': "目不轉睛",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【睡眠】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【睡眠】。"
+		{
+			name: {
+				ja: "しゃくねつのいぶき",
+				'zh-tw': "灼熱氣息",
+			},
+			damage: 120,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "灼熱氣息"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667617,
+				tcgplayer: 569945,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。"
-		},
-
-		damage: 120,
-		cost: ["Fire", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ロコン",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [38],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/015.ts
+++ b/data-asia/S/S11/015.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "熔岩蟲"
+		ja: "マグマッグ",
+		'zh-tw': "熔岩蟲",
 	},
 
 	illustrator: "Scav",
@@ -14,37 +14,51 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "有著由熔岩構成的身體。如果不持續運動， 身體就會因變冷而凝固。"
+		ja: "溶岩で できた 体を 持つ。 絶えず 動いていないと 体が 冷えて 固まってしまうのだ。",
+		'zh-tw': "有著由熔岩構成的身體。如果不持續運動， 身體就會因變冷而凝固。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "吸入"
+	attacks: [
+		{
+			name: {
+				ja: "すいこむ",
+				'zh-tw': "吸入",
+			},
+			cost: ["Fire"],
+			effect: {
+				ja: "自分のトラッシュから[R]エネルギーを1枚選び、このポケモンにつける。",
+				'zh-tw': "從自己的棄牌區選擇1張【火】能量卡，附於這隻寶可夢身上。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的棄牌區選擇1張【火】能量卡，附於這隻寶可夢身上。"
+		{
+			name: {
+				ja: "かえん",
+				'zh-tw': "烈焰",
+			},
+			damage: 50,
+			cost: ["Fire", "Fire", "Colorless"],
 		},
+	],
 
-		cost: ["Fire"]
-	}, {
-		name: {
-			'zh-tw': "烈焰"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667890,
+				tcgplayer: 569946,
+			},
 		},
-
-		damage: 50,
-		cost: ["Fire", "Fire", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [218],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/016.ts
+++ b/data-asia/S/S11/016.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "熔岩蝸牛"
+		ja: "マグカルゴ",
+		'zh-tw': "熔岩蝸牛",
 	},
 
 	illustrator: "Pani Kobayashi",
@@ -14,38 +14,56 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "身體總是不斷起伏著，像熔岩一樣灼熱。 會不時從殼裡冒出火花。"
+		ja: "体は いつも 波打っていて 溶岩のように 熱い。 ときどき 殻から 火の粉が漏れる。",
+		'zh-tw': "身體總是不斷起伏著，像熔岩一樣灼熱。 會不時從殼裡冒出火花。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "火焰"
+	attacks: [
+		{
+			name: {
+				ja: "ほのお",
+				'zh-tw': "火焰",
+			},
+			damage: 30,
+			cost: ["Fire"],
 		},
-
-		damage: 30,
-		cost: ["Fire"]
-	}, {
-		name: {
-			'zh-tw': "放逐火山"
+		{
+			name: {
+				ja: "ロストボルケーノ",
+				'zh-tw': "放逐火山",
+			},
+			damage: 220,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーをすべて、ロストゾーンに置く。",
+				'zh-tw': "將這隻寶可夢身上附加的所有能量放置於放逐區。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將這隻寶可夢身上附加的所有能量放置於放逐區。"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667891,
+				tcgplayer: 569947,
+			},
 		},
+	],
 
-		damage: 220,
-		cost: ["Fire", "Fire", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "マグマッグ",
+	},
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [219],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/017.ts
+++ b/data-asia/S/S11/017.ts
@@ -1,50 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "妖火紅狐V"
+		ja: "マフォクシーV",
+		'zh-tw': "妖火紅狐V",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Fire"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "奇異燈火"
+	attacks: [
+		{
+			name: {
+				ja: "あやしいともしび",
+				'zh-tw': "奇異燈火",
+			},
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどとこんらんにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【灼傷】與【混亂】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【灼傷】與【混亂】。"
+		{
+			name: {
+				ja: "マジカルファイヤー",
+				'zh-tw': "魔法之火",
+			},
+			damage: 120,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個、ロストゾーンに置き、相手のベンチポケモン1匹にも、120ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "將這隻寶可夢身上附加的2個能量放置於放逐區，對手的1隻備戰寶可夢也受到120點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		cost: ["Fire"]
-	}, {
-		name: {
-			'zh-tw': "魔法之火"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 667892,
+				tcgplayer: 569948,
+			},
 		},
-
-		effect: {
-			'zh-tw': "將這隻寶可夢身上附加的2個能量放置於放逐區，對手的1隻備戰寶可夢也受到120點傷害。[在備戰區不計算弱點・抵抗力。]"
-		},
-
-		damage: 120,
-		cost: ["Fire", "Fire", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Double rare",
+	dexId: [655],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/018.ts
+++ b/data-asia/S/S11/018.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "火箭雀"
+		ja: "ヒノヤコマ",
+		'zh-tw': "火箭雀",
 	},
 
 	illustrator: "Narumi Sato",
@@ -14,27 +14,44 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "會朝著獵物的巢穴中噴射火花，再用銳利的爪子解決掉 受驚嚇而跑出來的獵物。"
+		ja: "巣穴の中に 火の粉を 飛ばし 驚いて 出てきた 獲物を 鋭い ツメで しとめるのだ。",
+		'zh-tw': "會朝著獵物的巢穴中噴射火花，再用銳利的爪子解決掉 受驚嚇而跑出來的獵物。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "吐火"
+	attacks: [
+		{
+			name: {
+				ja: "ひをはく",
+				'zh-tw': "吐火",
+			},
+			damage: 30,
+			cost: ["Fire"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Fire"]
-	}],
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667893,
+				tcgplayer: 569949,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤヤコマ",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [662],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/019.ts
+++ b/data-asia/S/S11/019.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "烈箭鷹"
+		ja: "ファイアロー",
+		'zh-tw': "烈箭鷹",
 	},
 
 	illustrator: "KEIICHIRO ITO",
@@ -14,41 +14,59 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "主要的獵物是鳥寶可夢。會從羽毛的縫隙裡噴出 火花威嚇對手。"
+		ja: "鳥ポケモンが おもな 獲物。 羽毛の あいだから 火の粉を 噴き出し 相手を 威嚇する。",
+		'zh-tw': "主要的獵物是鳥寶可夢。會從羽毛的縫隙裡噴出 火花威嚇對手。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "快速俯衝"
+	attacks: [
+		{
+			name: {
+				ja: "クイックダイブ",
+				'zh-tw': "快速俯衝",
+			},
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のポケモン1匹に、50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的1隻寶可夢受到50點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
-
-		effect: {
-			'zh-tw': "對手的1隻寶可夢受到50點傷害。[在備戰區不計算弱點・抵抗力。]"
+		{
+			name: {
+				ja: "むじひないちげき",
+				'zh-tw': "狠心一擊",
+			},
+			damage: "80+",
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンにダメカンがのっているなら、80ダメージ追加。",
+				'zh-tw': "若對手的戰鬥寶可夢身上放置有傷害指示物，則增加80點傷害。",
+			},
 		},
+	],
 
-		cost: ["Fire"]
-	}, {
-		name: {
-			'zh-tw': "狠心一擊"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667894,
+				tcgplayer: 569950,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若對手的戰鬥寶可夢身上放置有傷害指示物，則增加80點傷害。"
-		},
-
-		damage: "80+",
-		cost: ["Fire"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ヒノヤコマ",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [663],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/020.ts
+++ b/data-asia/S/S11/020.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "小海獅"
+		ja: "パウワウ",
+		'zh-tw': "小海獅",
 	},
 
 	illustrator: "GIDORA",
@@ -14,34 +14,48 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "因為有著厚厚的脂肪，所以完全不怕寒冷的海域， 但在溫暖的海裡就有點容易中暑。"
+		ja: "分厚い 脂肪の おかげで 寒い 海も へっちゃらだけど 暖かい 海では ちょっと バテやすいのだ。",
+		'zh-tw': "因為有著厚厚的脂肪，所以完全不怕寒冷的海域， 但在溫暖的海裡就有點容易中暑。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "頭錘"
+	attacks: [
+		{
+			name: {
+				ja: "ずつき",
+				'zh-tw': "頭錘",
+			},
+			damage: 10,
+			cost: ["Water"],
 		},
-
-		damage: 10,
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "潑水"
+		{
+			name: {
+				ja: "みずかけ",
+				'zh-tw': "潑水",
+			},
+			damage: 20,
+			cost: ["Water", "Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Water", "Colorless"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667895,
+				tcgplayer: 569951,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [86],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/021.ts
+++ b/data-asia/S/S11/021.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "白海獅"
+		ja: "ジュゴン",
+		'zh-tw': "白海獅",
 	},
 
 	illustrator: "chibi",
@@ -14,42 +14,60 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "進食之後會在沙灘上做日光浴，藉此提高體溫 來幫助消化。"
+		ja: "食事の 後は 砂浜で 日光浴を している。 体温を あげて 消化を よく するのだ。",
+		'zh-tw': "進食之後會在沙灘上做日光浴，藉此提高體溫 來幫助消化。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "隨興游水"
+	attacks: [
+		{
+			name: {
+				ja: "きままにおよぐ",
+				'zh-tw': "隨興游水",
+			},
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+				'zh-tw': "擲1次硬幣若為正面，則在下個對手的回合，這隻寶可夢不會受到招式的傷害與效果的影響。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則在下個對手的回合，這隻寶可夢不會受到招式的傷害與效果的影響。"
+		{
+			name: {
+				ja: "ひょうかいリターン",
+				'zh-tw': "冰塊迴旋",
+			},
+			damage: "40×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[W]エネルギーを好きなだけ山札にもどし、その枚数×40ダメージ。その場合、山札を切る。",
+				'zh-tw': "將自己的場上寶可夢身上附加的任意數量的【水】能量卡放回牌庫，造成其張數×40點傷害。這個情況下，重洗牌庫。",
+			},
 		},
+	],
 
-		damage: 10,
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "冰塊迴旋"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667896,
+				tcgplayer: 569952,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將自己的場上寶可夢身上附加的任意數量的【水】能量卡放回牌庫，造成其張數×40點傷害。這個情況下，重洗牌庫。"
-		},
-
-		damage: "40×",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "パウワウ",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [87],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/022.ts
+++ b/data-asia/S/S11/022.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "墨海馬"
+		ja: "タッツー",
+		'zh-tw': "墨海馬",
 	},
 
 	illustrator: "Tika Matsuno",
@@ -14,31 +14,44 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "棲息在海流平穩的海域。被襲擊時會吐出漆黑的 墨汁，然後趁機逃走。"
+		ja: "潮の 流れが 穏やかな 海に 棲む。 襲われると 真っ黒な 墨を吐いて その隙に 逃げだす。",
+		'zh-tw': "棲息在海流平穩的海域。被襲擊時會吐出漆黑的 墨汁，然後趁機逃走。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "逆向噴射"
+	attacks: [
+		{
+			name: {
+				ja: "ぎゃくふんしゃ",
+				'zh-tw': "逆向噴射",
+			},
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+				'zh-tw': "將這隻寶可夢與備戰寶可夢互換。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將這隻寶可夢與備戰寶可夢互換。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667897,
+				tcgplayer: 569953,
+			},
 		},
-
-		damage: 10,
-		cost: ["Water"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [116],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/023.ts
+++ b/data-asia/S/S11/023.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "海刺龍"
+		ja: "シードラ",
+		'zh-tw': "海刺龍",
 	},
 
 	illustrator: "sui",
@@ -14,41 +14,59 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "是由雄性來養育孩子。在育兒時，背上刺的 毒素會變得更強更濃。"
+		ja: "オスが 子どもを 育てる。 子育て中は 背中の トゲの 毒素が 強く 濃くなるのだ。",
+		'zh-tw': "是由雄性來養育孩子。在育兒時，背上刺的 毒素會變得更強更濃。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "隨興游水"
+	attacks: [
+		{
+			name: {
+				ja: "きままにおよぐ",
+				'zh-tw': "隨興游水",
+			},
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+				'zh-tw': "擲1次硬幣若為正面，則在下個對手的回合，這隻寶可夢不會受到招式的傷害與效果的影響。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則在下個對手的回合，這隻寶可夢不會受到招式的傷害與效果的影響。"
+		{
+			name: {
+				ja: "ハイドロショット",
+				'zh-tw': "水炮射",
+			},
+			cost: ["Water"],
+			effect: {
+				ja: "相手のポケモン1匹に、このポケモンについている[W]エネルギーの数×20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的1隻寶可夢受到這隻寶可夢，身上附加的【水】能量的數量×20點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		damage: 10,
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "水炮射"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667898,
+				tcgplayer: 569954,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "對手的1隻寶可夢受到這隻寶可夢，身上附加的【水】能量的數量×20點傷害。[在備戰區不計算弱點・抵抗力。]"
-		},
-
-		cost: ["Water"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "タッツー",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [117],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/024.ts
+++ b/data-asia/S/S11/024.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "刺龍王"
+		ja: "キングドラ",
+		'zh-tw': "刺龍王",
 	},
 
 	illustrator: "AKIRA EGAWA",
@@ -14,39 +14,58 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "暴風雨來襲時會在海面上現身。如果撞見了快龍， 就會展開激烈的爭鬥。"
+		ja: "嵐が来ると 海面に 姿を 見せる。 カイリューに 出くわすと 激しい 争いが はじまる。",
+		'zh-tw': "暴風雨來襲時會在海面上現身。如果撞見了快龍， 就會展開激烈的爭鬥。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "翻騰海流"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "さかまくかいりゅう",
+				'zh-tw': "翻騰海流",
+			},
+			effect: {
+				ja: "自分の番に1回使える。自分または相手のどちらかを選び、選ばれたプレイヤーは、手札をすべてウラにして切り、山札の下にもどす。その後、選ばれたプレイヤーは山札を4枚引く。",
+				'zh-tw': "在自己的回合時，可使用1次。選擇自己或者對手任一方，被選擇的玩家將手牌全部翻回反面並重洗，放回牌庫下方。然後，被選擇的玩家從牌庫抽出4張卡。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，可使用1次。選擇自己或者對手任一方，被選擇的玩家將手牌全部翻回反面並重洗，放回牌庫下方。然後，被選擇的玩家從牌庫抽出4張卡。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "水炮濺射"
+	attacks: [
+		{
+			name: {
+				ja: "ハイドロスプラッシュ",
+				'zh-tw': "水炮濺射",
+			},
+			damage: 130,
+			cost: ["Water", "Colorless"],
 		},
+	],
 
-		damage: 130,
-		cost: ["Water", "Colorless"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 667899,
+				tcgplayer: 569955,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シードラ",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [230],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/025.ts
+++ b/data-asia/S/S11/025.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "吼吼鯨"
+		ja: "ホエルコ",
+		'zh-tw': "吼吼鯨",
 	},
 
 	illustrator: "Jiro Sasumo",
@@ -14,38 +14,52 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "把喝入的海水從眼睛上方的鼻孔中噴出來吸引他人。 每天要吃１噸弱丁魚。"
+		ja: "飲みこんだ 海水を 目の 上の 鼻の 穴から 噴き出し アピール。 毎日 １トンの ヨワシを 食う。",
+		'zh-tw': "把喝入的海水從眼睛上方的鼻孔中噴出來吸引他人。 每天要吃１噸弱丁魚。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "咕嘟咕嘟喝水"
+	attacks: [
+		{
+			name: {
+				ja: "ゴクゴクのむ",
+				'zh-tw': "咕嘟咕嘟喝水",
+			},
+			damage: 30,
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンに与えたダメージぶん、このポケモンのHPを回復する。",
+				'zh-tw': "將這隻寶可夢恢復對對手的戰鬥寶可夢造成的傷害相同數值的HP。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將這隻寶可夢恢復對對手的戰鬥寶可夢造成的傷害相同數值的HP。"
+		{
+			name: {
+				ja: "スプラッシュ",
+				'zh-tw': "飛濺",
+			},
+			damage: 60,
+			cost: ["Water", "Water", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Water", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "飛濺"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667900,
+				tcgplayer: 569956,
+			},
 		},
-
-		damage: 60,
-		cost: ["Water", "Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	],
 
 	retreat: 4,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [320],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/026.ts
+++ b/data-asia/S/S11/026.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "吼鯨王"
+		ja: "ホエルオー",
+		'zh-tw': "吼鯨王",
 	},
 
 	illustrator: "Shinya Komatsu",
@@ -14,43 +14,62 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "有時會讓大大的身體在波浪上跳躍，藉此 製造出衝擊讓對手昏迷。"
+		ja: "大きな 体を 波の上で ジャンプさせ 衝撃を 生みだし 相手を 気絶 させることがある。",
+		'zh-tw': "有時會讓大大的身體在波浪上跳躍，藉此 製造出衝擊讓對手昏迷。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "超大尺寸"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ジャンボサイズ",
+				'zh-tw': "超大尺寸",
+			},
+			effect: {
+				ja: "このポケモンが受けるワザのダメージは「-30」される。",
+				'zh-tw': "這隻寶可夢受到招式的傷害「-30」點。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢受到招式的傷害「-30」點。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "特殊波"
+	attacks: [
+		{
+			name: {
+				ja: "スペシャルウェーブ",
+				'zh-tw': "特殊波",
+			},
+			damage: "120+",
+			cost: ["Water", "Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンに特殊エネルギーがついているなら、120ダメージ追加。",
+				'zh-tw': "若這隻寶可夢身上附有特殊能量，則增加120點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢身上附有特殊能量，則增加120點傷害。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667901,
+				tcgplayer: 569957,
+			},
 		},
+	],
 
-		damage: "120+",
-		cost: ["Water", "Water", "Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ホエルコ",
+	},
 
 	retreat: 4,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [321],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/027.ts
+++ b/data-asia/S/S11/027.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "螢光魚"
+		ja: "ケイコウオ",
+		'zh-tw': "螢光魚",
 	},
 
 	illustrator: "Taira Akitsu",
@@ -14,39 +14,54 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "會用發光的尾鰭引誘獵物。白天會待在海面附近， 到了夜裡就會向深海移動。"
+		ja: "光る 尾びれで 獲物を 誘う。 昼は 海面 近くに いて 夜に なると 深みに 移動。",
+		'zh-tw': "會用發光的尾鰭引誘獵物。白天會待在海面附近， 到了夜裡就會向深海移動。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "海之伴奏"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "うみのばんそう",
+				'zh-tw': "海之伴奏",
+			},
+			effect: {
+				ja: "自分の番に何回でも使える。自分の手札から[W]エネルギーを1枚選び、自分の場にいるワザ「きままにおよぐ」を持つポケモンにつける。",
+				'zh-tw': "在自己的回合時，可不限次數使用。從自己的手牌選擇1張【水】能量卡，附於自己的場上持有「隨興游水」招式的寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，可不限次數使用。從自己的手牌選擇1張【水】能量卡，附於自己的場上持有「隨興游水」招式的寶可夢身上。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "水槍"
+	attacks: [
+		{
+			name: {
+				ja: "みずでっぽう",
+				'zh-tw': "水槍",
+			},
+			damage: 10,
+			cost: ["Water"],
 		},
+	],
 
-		damage: 10,
-		cost: ["Water"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667902,
+				tcgplayer: 569958,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [456],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/028.ts
+++ b/data-asia/S/S11/028.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "霓虹魚"
+		ja: "ネオラント",
+		'zh-tw': "霓虹魚",
 	},
 
 	illustrator: "zig",
@@ -14,38 +14,56 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "像爬行般地在海底游動。鰭發出的光充滿奇幻氣氛， 就像夜空中的星星一樣。"
+		ja: "深海の 海底を はうように 泳ぐ。 幻想的な ヒレの 光は 夜空の 星の よう。",
+		'zh-tw': "像爬行般地在海底游動。鰭發出的光充滿奇幻氣氛， 就像夜空中的星星一樣。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "隨興游水"
+	attacks: [
+		{
+			name: {
+				ja: "きままにおよぐ",
+				'zh-tw': "隨興游水",
+			},
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+				'zh-tw': "擲1次硬幣若為正面，則在下個對手的回合，這隻寶可夢不會受到招式的傷害與效果的影響。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則在下個對手的回合，這隻寶可夢不會受到招式的傷害與效果的影響。"
+		{
+			name: {
+				ja: "たきのぼり",
+				'zh-tw': "攀瀑",
+			},
+			damage: 120,
+			cost: ["Water", "Water", "Colorless"],
 		},
+	],
 
-		damage: 10,
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "攀瀑"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667903,
+				tcgplayer: 569959,
+			},
 		},
+	],
 
-		damage: 120,
-		cost: ["Water", "Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ケイコウオ",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [457],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/029.ts
+++ b/data-asia/S/S11/029.ts
@@ -1,46 +1,59 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "酋雷姆V"
+		ja: "キュレムV",
+		'zh-tw': "酋雷姆V",
 	},
 
 	illustrator: "takuyoa",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Water"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "急遽冰凍"
+	attacks: [
+		{
+			name: {
+				ja: "きゅうげきれいとう",
+				'zh-tw': "急遽冰凍",
+			},
+			cost: ["Water"],
+			effect: {
+				ja: "自分の手札から[W]エネルギーを好きなだけ選び、自分のポケモンに好きなようにつける。",
+				'zh-tw': "從自己的手牌選擇任意數量的【水】能量卡，以任意方式附於自己的寶可夢身上。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的手牌選擇任意數量的【水】能量卡，以任意方式附於自己的寶可夢身上。"
+		{
+			name: {
+				ja: "フロストスマッシュ",
+				'zh-tw': "冰霜粉碎",
+			},
+			damage: 140,
+			cost: ["Water", "Water", "Water"],
 		},
+	],
 
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "冰霜粉碎"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 667904,
+				tcgplayer: 569960,
+			},
 		},
-
-		damage: 140,
-		cost: ["Water", "Water", "Water"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	],
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Double rare",
+	dexId: [646],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/030.ts
+++ b/data-asia/S/S11/030.ts
@@ -1,51 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "酋雷姆VMAX"
+		ja: "キュレムVMAX",
+		'zh-tw': "酋雷姆VMAX",
 	},
 
 	illustrator: "N-DESIGN Inc.",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Water"],
+
 	stage: "VMAX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "白銀世界"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "はくぎんせかい",
+				'zh-tw': "白銀世界",
+			},
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を上から1枚トラッシュし、そのカードが[W]エネルギーなら、自分のポケモンにつける。",
+				'zh-tw': "在自己的回合時，可使用1次。將自己的牌庫上方1張卡丟棄，若那張卡為【水】能量卡，則附於自己的寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，可使用1次。將自己的牌庫上方1張卡丟棄，若那張卡為【水】能量卡，則附於自己的寶可夢身上。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "極巨冰霜"
+	attacks: [
+		{
+			name: {
+				ja: "ダイフロスト",
+				'zh-tw': "極巨冰霜",
+			},
+			damage: "120+",
+			cost: ["Water", "Water", "Water"],
+			effect: {
+				ja: "このポケモンについている[W]エネルギーを好きなだけトラッシュし、その枚数×50ダメージ追加。",
+				'zh-tw': "將這隻寶可夢身上附加的任意數量的【水】能量卡丟棄，增加其張數×50點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將這隻寶可夢身上附加的任意數量的【水】能量卡丟棄，增加其張數×50點傷害。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 667905,
+				tcgplayer: 569961,
+			},
 		},
+	],
 
-		damage: "120+",
-		cost: ["Water", "Water", "Water"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "キュレムV",
+	},
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Triple Rare",
+	dexId: [646],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/031.ts
+++ b/data-asia/S/S11/031.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "滴蛛"
+		ja: "シズクモ",
+		'zh-tw': "滴蛛",
 	},
 
 	illustrator: "Naoyo Kimura",
@@ -14,27 +14,40 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "用臀部讓水泡膨脹，並包裹住自己的頭部。 會和同類比拼水泡的大小。"
+		ja: "お尻で 水泡を 膨らませて 頭を 包む。 仲間同士で 水泡の 大きさを 比べる。",
+		'zh-tw': "用臀部讓水泡膨脹，並包裹住自己的頭部。 會和同類比拼水泡的大小。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "鉤住"
+	attacks: [
+		{
+			name: {
+				ja: "ひっかける",
+				'zh-tw': "鉤住",
+			},
+			damage: 30,
+			cost: ["Water", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Water", "Colorless"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667906,
+				tcgplayer: 569962,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [751],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/032.ts
+++ b/data-asia/S/S11/032.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "滴蛛霸"
+		ja: "オニシズクモ",
+		'zh-tw': "滴蛛霸",
 	},
 
 	illustrator: "DOM",
@@ -14,38 +14,56 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "會用腳發射水泡，包住獵物讓其溺水， 然後花時間慢慢品嚐。"
+		ja: "脚で 水泡を 飛ばして 獲物を 包みこみ 溺れさせる。 時間を かけて 味わうのだ。",
+		'zh-tw': "會用腳發射水泡，包住獵物讓其溺水， 然後花時間慢慢品嚐。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "溺水彈"
+	attacks: [
+		{
+			name: {
+				ja: "おぼれだま",
+				'zh-tw': "溺水彈",
+			},
+			damage: 20,
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。さらに、そのポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。再選擇1個那隻寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。再選擇1個那隻寶可夢身上附加的能量，將其丟棄。"
+		{
+			name: {
+				ja: "とびだしヘッド",
+				'zh-tw': "魯莽頭擊",
+			},
+			damage: 60,
+			cost: ["Water", "Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "魯莽頭擊"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667907,
+				tcgplayer: 569963,
+			},
 		},
+	],
 
-		damage: 60,
-		cost: ["Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "シズクモ",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [752],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/033.ts
+++ b/data-asia/S/S11/033.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "古月鳥"
+		ja: "ウッウ",
+		'zh-tw': "古月鳥",
 	},
 
 	illustrator: "Midori Harada",
@@ -14,43 +14,58 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "雖然擁有一擊定勝負的威力，但因為記性實在太差， 對戰還沒結束就會忘記對手是誰。"
+		ja: "相手を 一撃で 打ち負かすほど パワフルだが 忘れっぽいので 戦っている 相手を 忘れる。",
+		'zh-tw': "雖然擁有一擊定勝負的威力，但因為記性實在太差， 對戰還沒結束就會忘記對手是誰。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "放逐供應"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ロストプロバイド",
+				'zh-tw': "放逐供應",
+			},
+			effect: {
+				ja: "自分のロストゾーンにカードが4枚以上あるなら、このポケモンがワザを使うためのエネルギーは、すべてなくなる。",
+				'zh-tw': "若自己的放逐區有4張以上的卡，則這隻寶可夢使用招式所需的能量全部消除。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若自己的放逐區有4張以上的卡，則這隻寶可夢使用招式所需的能量全部消除。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "裝傻噴吐"
+	attacks: [
+		{
+			name: {
+				ja: "おとぼけスピット",
+				'zh-tw': "裝傻噴吐",
+			},
+			damage: 110,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは弱点を計算しない。",
+				'zh-tw': "這個招式的傷害不計算弱點。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這個招式的傷害不計算弱點。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667908,
+				tcgplayer: 569964,
+			},
 		},
-
-		damage: 110,
-		cost: ["Water", "Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [845],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/034.ts
+++ b/data-asia/S/S11/034.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雪暴馬"
+		ja: "ブリザポス",
+		'zh-tw': "雪暴馬",
 	},
 
 	illustrator: "Jiro Sasumo",
@@ -14,42 +14,56 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "會從蹄子釋放出強烈的寒氣。性情暴躁，只要是自己想要 的東西，就會強行去搶奪。"
+		ja: "蹄から 強力な 冷気を 放つ。 欲しいものは なんでも 力尽くで 奪う 暴れん坊。",
+		'zh-tw': "會從蹄子釋放出強烈的寒氣。性情暴躁，只要是自己想要 的東西，就會強行去搶奪。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "冰凍在地"
+	attacks: [
+		{
+			name: {
+				ja: "フリーズダウン",
+				'zh-tw': "冰凍在地",
+			},
+			damage: 40,
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたたねポケモンは、ワザが使えない。",
+				'zh-tw': "在下個對手的回合，受到這個招式的【基礎】寶可夢，無法使用招式。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的【基礎】寶可夢，無法使用招式。"
+		{
+			name: {
+				ja: "ワイルドタックル",
+				'zh-tw': "狂野衝撞",
+			},
+			damage: 130,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+				'zh-tw': "這隻寶可夢也受到30點傷害。",
+			},
 		},
+	],
 
-		damage: 40,
-		cost: ["Water", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "狂野衝撞"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 667909,
+				tcgplayer: 569965,
+			},
 		},
-
-		effect: {
-			'zh-tw': "這隻寶可夢也受到30點傷害。"
-		},
-
-		damage: 130,
-		cost: ["Water", "Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [896],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/035.ts
+++ b/data-asia/S/S11/035.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "燈籠魚"
+		ja: "チョンチー",
+		'zh-tw': "燈籠魚",
 	},
 
 	illustrator: "Miki Tanaka",
@@ -14,34 +14,48 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "從鰭變化而來的觸手之中，分別流通著 正電以及負電。"
+		ja: "ひれが 変化して できた 触手は それぞれが プラスと マイナスの 電気が 流れている。",
+		'zh-tw': "從鰭變化而來的觸手之中，分別流通著 正電以及負電。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "光彈"
+	attacks: [
+		{
+			name: {
+				ja: "ピッカリだま",
+				'zh-tw': "光彈",
+			},
+			damage: 10,
+			cost: ["Lightning"],
 		},
-
-		damage: 10,
-		cost: ["Lightning"]
-	}, {
-		name: {
-			'zh-tw': "重摑"
+		{
+			name: {
+				ja: "ひっぱたく",
+				'zh-tw': "重摑",
+			},
+			damage: 20,
+			cost: ["Lightning", "Lightning"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Lightning", "Lightning"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667910,
+				tcgplayer: 569966,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [170],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/036.ts
+++ b/data-asia/S/S11/036.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "電燈怪"
+		ja: "ランターン",
+		'zh-tw': "電燈怪",
 	},
 
 	illustrator: "aoki",
@@ -14,38 +14,56 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "電燈怪發出的光有著極高的亮度，甚至可以從５０００公尺 深的水底照亮水面。"
+		ja: "ランターンのだす 光は ５０００メートルの 深さ からでも 水面まで 届くほど 明るい。",
+		'zh-tw': "電燈怪發出的光有著極高的亮度，甚至可以從５０００公尺 深的水底照亮水面。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "衝撞"
+	attacks: [
+		{
+			name: {
+				ja: "ぶつかる",
+				'zh-tw': "衝撞",
+			},
+			damage: 30,
+			cost: ["Lightning"],
 		},
-
-		damage: 30,
-		cost: ["Lightning"]
-	}, {
-		name: {
-			'zh-tw': "強力伏特"
+		{
+			name: {
+				ja: "ストロングボルト",
+				'zh-tw': "強力伏特",
+			},
+			damage: 160,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+				'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667911,
+				tcgplayer: 569967,
+			},
 		},
+	],
 
-		damage: 160,
-		cost: ["Lightning", "Lightning", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "チョンチー",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [171],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/037.ts
+++ b/data-asia/S/S11/037.ts
@@ -1,52 +1,66 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洛托姆V"
+		ja: "ロトムV",
+		'zh-tw': "洛托姆V",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 190,
 	types: ["Lightning"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "即刻充電"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "そくせきじゅうでん",
+				'zh-tw': "即刻充電",
+			},
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、自分の番は終わる。自分の山札を3枚引く。",
+				'zh-tw': "在自己的回合時可使用1次，若使用，則自己的回合結束。從自己的牌庫抽出3張卡。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時可使用1次，若使用，則自己的回合結束。從自己的牌庫抽出3張卡。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "廢鐵短路"
+	attacks: [
+		{
+			name: {
+				ja: "スクラップショート",
+				'zh-tw': "廢鐵短路",
+			},
+			damage: "40+",
+			cost: ["Lightning", "Lightning"],
+			effect: {
+				ja: "自分のトラッシュにある「ポケモンのどうぐ」を好きなだけロストゾーンに置き、その枚数×40ダメージ追加。",
+				'zh-tw': "將自己的棄牌區的任意數量的「寶可夢道具」放置於放逐區，增加其張數×40點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將自己的棄牌區的任意數量的「寶可夢道具」放置於放逐區，增加其張數×40點傷害。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 667912,
+				tcgplayer: 569968,
+			},
 		},
-
-		damage: "40+",
-		cost: ["Lightning", "Lightning"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Double rare",
+	dexId: [479],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/038.ts
+++ b/data-asia/S/S11/038.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "電飛鼠"
+		ja: "エモンガ",
+		'zh-tw': "電飛鼠",
 	},
 
 	illustrator: "sowsow",
@@ -14,37 +14,51 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "會一邊放電一邊像是在空中跳舞般地飛行。 雖然可愛，但很難纏。"
+		ja: "電気を ほとばしらせながら 空を 舞うように 飛ぶ。 可愛いが やっかいなのだ。",
+		'zh-tw': "會一邊放電一邊像是在空中跳舞般地飛行。 雖然可愛，但很難纏。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "挖到寶"
+	attacks: [
+		{
+			name: {
+				ja: "ほりだしもの",
+				'zh-tw': "挖到寶",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からグッズを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張物品卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張物品卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		{
+			name: {
+				ja: "バチバチ",
+				'zh-tw': "劈哩啪啦",
+			},
+			damage: 40,
+			cost: ["Lightning", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "劈哩啪啦"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667913,
+				tcgplayer: 569969,
+			},
 		},
-
-		damage: 40,
-		cost: ["Lightning", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 0,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [587],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/039.ts
+++ b/data-asia/S/S11/039.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "麻麻小魚"
+		ja: "シビシラス",
+		'zh-tw': "麻麻小魚",
 	},
 
 	illustrator: "Yukiko Baba",
@@ -14,37 +14,51 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "由於只能放出微弱的電，所以會由許多麻麻小魚聚集起來， 放出強大的電流。"
+		ja: "弱い 電気しか だせないので たくさんの シビシラスで 集まり 強力な 電気を 放つ。",
+		'zh-tw': "由於只能放出微弱的電，所以會由許多麻麻小魚聚集起來， 放出強大的電流。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "呼喚信號"
+	attacks: [
+		{
+			name: {
+				ja: "コールサイン",
+				'zh-tw': "呼喚信號",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から[L]ポケモンを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張【雷】寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張【雷】寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		{
+			name: {
+				ja: "プチでんき",
+				'zh-tw': "小電氣",
+			},
+			damage: 10,
+			cost: ["Lightning"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "小電氣"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667914,
+				tcgplayer: 569970,
+			},
 		},
-
-		damage: 10,
-		cost: ["Lightning"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [602],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/040.ts
+++ b/data-asia/S/S11/040.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "麻麻鰻"
+		ja: "シビビール",
+		'zh-tw': "麻麻鰻",
 	},
 
 	illustrator: "Uta",
@@ -14,39 +14,58 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "食慾旺盛的寶可夢。一發現獵物就會發動襲擊， 用電流使其麻痺後大快朵頤。"
+		ja: "食欲 旺盛な ポケモン。 獲物を 見つけると 襲いかかり 電気で しびれさせてから 食べる。",
+		'zh-tw': "食慾旺盛的寶可夢。一發現獵物就會發動襲擊， 用電流使其麻痺後大快朵頤。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "臨場衝擊"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "でたとこショック",
+				'zh-tw': "臨場衝擊",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+				'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "劈哩啪啦"
+	attacks: [
+		{
+			name: {
+				ja: "バチバチ",
+				'zh-tw': "劈哩啪啦",
+			},
+			damage: 30,
+			cost: ["Lightning"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Lightning"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667915,
+				tcgplayer: 569971,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シビシラス",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [603],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/041.ts
+++ b/data-asia/S/S11/041.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "麻麻鰻魚王"
+		ja: "シビルドン",
+		'zh-tw': "麻麻鰻魚王",
 	},
 
 	illustrator: "Shin Nagasawa",
@@ -14,42 +14,60 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "用手臂的力量從大海裡爬出，襲擊水邊的獵物。 會瞬間將獵物拖入海中。"
+		ja: "腕の 力で 海から はい出し 水辺の 獲物に 襲いかかる。 一瞬で 海へ 引きずりこむ。",
+		'zh-tw': "用手臂的力量從大海裡爬出，襲擊水邊的獵物。 會瞬間將獵物拖入海中。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "盤蜷"
+	attacks: [
+		{
+			name: {
+				ja: "とぐろをまく",
+				'zh-tw': "盤蜷",
+			},
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンが使うワザの、相手のバトルポケモンへのダメージは「+120」される。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+120」點。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+120」點。"
+		{
+			name: {
+				ja: "げきでんりゅう",
+				'zh-tw': "激電流",
+			},
+			damage: 160,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+				'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		damage: 10,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "激電流"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667916,
+				tcgplayer: 569972,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。"
-		},
-
-		damage: 160,
-		cost: ["Lightning", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "シビビール",
+	},
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [604],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/042.ts
+++ b/data-asia/S/S11/042.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "催眠貘"
+		ja: "スリープ",
+		'zh-tw': "催眠貘",
 	},
 
 	illustrator: "Souichirou Gunjima",
@@ -14,43 +14,52 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "會讓獵物睡著，吃掉對方所做的夢。惡夢的味道是酸的， 所以牠似乎不怎麼愛吃。"
+		ja: "獲物を 眠らせ 見ている ユメを 喰らう。 悪いユメは すっぱくて あまり 好んで 食べないらしい。",
+		'zh-tw': "會讓獵物睡著，吃掉對方所做的夢。惡夢的味道是酸的， 所以牠似乎不怎麼愛吃。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "精神拳"
+	attacks: [
+		{
+			name: {
+				ja: "サイコパンチ",
+				'zh-tw': "精神拳",
+			},
+			damage: 10,
+			cost: ["Psychic"],
 		},
-
-		damage: 10,
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "催眠光線"
+		{
+			name: {
+				ja: "さいみんこうせん",
+				'zh-tw': "催眠光線",
+			},
+			damage: 20,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【睡眠】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【睡眠】。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667917,
+				tcgplayer: 569973,
+			},
 		},
-
-		damage: 20,
-		cost: ["Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [96],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/043.ts
+++ b/data-asia/S/S11/043.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "引夢貘人"
+		ja: "スリーパー",
+		'zh-tw': "引夢貘人",
 	},
 
 	illustrator: "Shinji Kanda",
@@ -14,42 +14,55 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "為了幫助那些晚上失眠的人，也有些引夢貘人會到 醫院去協助醫生。"
+		ja: "夜に 眠れない 人の ために 病院で お医者さんの 手伝いをする スリーパーも いる。",
+		'zh-tw': "為了幫助那些晚上失眠的人，也有些引夢貘人會到 醫院去協助醫生。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "幻迷呼喚"
+	attacks: [
+		{
+			name: {
+				ja: "サイケデリックコール",
+				'zh-tw': "幻迷呼喚",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の山札から1進化ポケモンを2枚まで選び、ベンチに出す。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多2張【1階進化】寶可夢卡，放置於備戰區。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多2張【1階進化】寶可夢卡，放置於備戰區。並且重洗牌庫。"
+		{
+			name: {
+				ja: "しねんのずつき",
+				'zh-tw': "意念頭錘",
+			},
+			damage: 90,
+			cost: ["Psychic", "Psychic", "Colorless"],
 		},
+	],
 
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "意念頭錘"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667918,
+				tcgplayer: 569974,
+			},
 		},
+	],
 
-		damage: 90,
-		cost: ["Psychic", "Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "スリープ",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [97],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/044.ts
+++ b/data-asia/S/S11/044.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "勾魂眼"
+		ja: "ヤミラミ",
+		'zh-tw': "勾魂眼",
 	},
 
 	illustrator: "Shibuzoh.",
@@ -14,42 +14,51 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "寶石的眼睛發出詭異光芒時，就會攝取人的魂魄。 是令人恐懼的寶可夢。"
+		ja: "宝石の 瞳が 怪しく 輝くとき 人の 魂を 奪うと 恐れられる ポケモン。",
+		'zh-tw': "寶石的眼睛發出詭異光芒時，就會攝取人的魂魄。 是令人恐懼的寶可夢。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "抓"
+	attacks: [
+		{
+			name: {
+				ja: "ひっかく",
+				'zh-tw': "抓",
+			},
+			damage: 20,
+			cost: ["Colorless"],
 		},
-
-		damage: 20,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "放逐礦山"
+		{
+			name: {
+				ja: "ロストマイン",
+				'zh-tw': "放逐礦山",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "このワザは、自分のロストゾーンにカードが10枚以上あるときにしか使えない。ダメカン12個を、相手のポケモンに好きなようにのせる。",
+				'zh-tw': "這個招式只有在自己的放逐區有10張以上的卡時才可使用。將12個傷害指示物以任意方式放置於對手的寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這個招式只有在自己的放逐區有10張以上的卡時才可使用。將12個傷害指示物以任意方式放置於對手的寶可夢身上。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 667919,
+				tcgplayer: 569975,
+			},
 		},
-
-		cost: ["Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [302],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/045.ts
+++ b/data-asia/S/S11/045.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "怨影娃娃"
+		ja: "カゲボウズ",
+		'zh-tw': "怨影娃娃",
 	},
 
 	illustrator: "Kouki Saitou",
@@ -14,32 +14,40 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "不要去跟那些在黃昏時有怨影娃娃在排隊的人家來往。 這是自古流傳下來的諺語。"
+		ja: "日暮れに カゲボウズが 並ぶような 家とは 付き合うな と いう 古い ことわざが 残っている。",
+		'zh-tw': "不要去跟那些在黃昏時有怨影娃娃在排隊的人家來往。 這是自古流傳下來的諺語。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "舌擊"
+	attacks: [
+		{
+			name: {
+				ja: "ベロではたく",
+				'zh-tw': "舌擊",
+			},
+			damage: 30,
+			cost: ["Psychic", "Psychic"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Psychic", "Psychic"]
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667920,
+				tcgplayer: 569976,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [353],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/046.ts
+++ b/data-asia/S/S11/046.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "詛咒娃娃"
+		ja: "ジュペッタ",
+		'zh-tw': "詛咒娃娃",
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -14,44 +14,58 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "誕生自遭到捨棄時的怨念。據說只要讓牠感覺自己受到重視， 牠就會滿意地變回原本的玩偶。"
+		ja: "捨てられた 怨念で 生まれる。 大切に されると 満足して 元の ヌイグルミに 戻るという。",
+		'zh-tw': "誕生自遭到捨棄時的怨念。據說只要讓牠感覺自己受到重視， 牠就會滿意地變回原本的玩偶。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "玩偶供養"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "にんぎょうくよう",
+				'zh-tw': "玩偶供養",
+			},
+			effect: {
+				ja: "自分の番に1回使える。自分のトラッシュからサポートを1枚選び、相手に見せて、手札に加える。その後、このポケモンをロストゾーンに置く。（ポケモン以外のカードは、すべてトラッシュする。）",
+				'zh-tw': "在自己的回合時，可使用1次。從自己的棄牌區選擇1張支援者卡，在給對手看過後加入手牌。然後，將這隻寶可夢放置於放逐區。（寶可夢以外的卡全部丟棄。）",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，可使用1次。從自己的棄牌區選擇1張支援者卡，在給對手看過後加入手牌。然後，將這隻寶可夢放置於放逐區。（寶可夢以外的卡全部丟棄。）"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "陰森射擊"
+	attacks: [
+		{
+			name: {
+				ja: "ホロウショット",
+				'zh-tw': "陰森射擊",
+			},
+			damage: 50,
+			cost: ["Psychic", "Psychic"],
 		},
+	],
 
-		damage: 50,
-		cost: ["Psychic", "Psychic"]
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667921,
+				tcgplayer: 569977,
+			},
+		},
+	],
 
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "カゲボウズ",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [354],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/047.ts
+++ b/data-asia/S/S11/047.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "綿綿泡芙"
+		ja: "ペロッパフ",
+		'zh-tw': "綿綿泡芙",
 	},
 
 	illustrator: "Asako Ito",
@@ -14,34 +14,48 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "每天要吃掉與自己體重相同重量的砂糖， 糖分不夠就會鬧脾氣。"
+		ja: "１日に 食べる 砂糖は 自分の 体重と 同じ。 糖分が 足りないと ひどく 不機嫌になる。",
+		'zh-tw': "每天要吃掉與自己體重相同重量的砂糖， 糖分不夠就會鬧脾氣。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "活蹦亂跳"
+	attacks: [
+		{
+			name: {
+				ja: "はねまわる",
+				'zh-tw': "活蹦亂跳",
+			},
+			damage: 10,
+			cost: ["Psychic"],
 		},
-
-		damage: 10,
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "撞擊"
+		{
+			name: {
+				ja: "たいあたり",
+				'zh-tw': "撞擊",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667922,
+				tcgplayer: 569978,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [684],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/048.ts
+++ b/data-asia/S/S11/048.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "胖甜妮"
+		ja: "ペロリーム",
+		'zh-tw': "胖甜妮",
 	},
 
 	illustrator: "Mizue",
@@ -14,38 +14,56 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "能從人們身上的氣味裡嗅出他們的身心狀態。 在醫療領域的實際應用備受矚目。"
+		ja: "体臭から 心と 体の 調子を 嗅ぎとる。 医療への 応用が 期待されている。",
+		'zh-tw': "能從人們身上的氣味裡嗅出他們的身心狀態。 在醫療領域的實際應用備受矚目。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "吸取之吻"
+	attacks: [
+		{
+			name: {
+				ja: "ドレインキッス",
+				'zh-tw': "吸取之吻",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+				'zh-tw': "將這隻寶可夢恢復「30」HP。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將這隻寶可夢恢復「30」HP。"
+		{
+			name: {
+				ja: "マジカルショット",
+				'zh-tw': "魔法射擊",
+			},
+			damage: 100,
+			cost: ["Psychic", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "魔法射擊"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667923,
+				tcgplayer: 569979,
+			},
 		},
+	],
 
-		damage: 100,
-		cost: ["Psychic", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ペロッパフ",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [685],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/049.ts
+++ b/data-asia/S/S11/049.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "花療環環"
+		ja: "キュワワー",
+		'zh-tw': "花療環環",
 	},
 
 	illustrator: "Aya Kusube",
@@ -14,39 +14,54 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "會用藤蔓摘花來裝飾自己。不知為何，黏在牠身上的 花朵都不會枯萎。"
+		ja: "ツルを 使って 花を 摘み 自分を 飾る。 体に ついた 花は なぜか 枯れない。",
+		'zh-tw': "會用藤蔓摘花來裝飾自己。不知為何，黏在牠身上的 花朵都不會枯萎。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "選花"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "はなえらび",
+				'zh-tw': "選花",
+			},
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。自分の山札を上から2枚見て、どちらか1枚を選び、手札に加える。残りのカードはロストゾーンに置く。",
+				'zh-tw': "若這隻寶可夢在戰鬥場上，則在自己的回合時可使用1次。查看自己的牌庫上方2張卡，選擇其中1張，加入手牌。將剩餘卡放置於放逐區。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢在戰鬥場上，則在自己的回合時可使用1次。查看自己的牌庫上方2張卡，選擇其中1張，加入手牌。將剩餘卡放置於放逐區。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "迴轉攻擊"
+	attacks: [
+		{
+			name: {
+				ja: "かいてんアタック",
+				'zh-tw': "迴轉攻擊",
+			},
+			damage: 30,
+			cost: ["Psychic", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Psychic", "Colorless"]
-	}],
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667924,
+				tcgplayer: 569980,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [764],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/050.ts
+++ b/data-asia/S/S11/050.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "謎擬Ｑ"
+		ja: "ミミッキュ",
+		'zh-tw': "謎擬Ｑ",
 	},
 
 	illustrator: "Ligton",
@@ -14,46 +14,55 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "為了讓別人不要害怕自己，特意穿上了看似皮卡丘的破布， 結果卻變得更加令人毛骨悚然。"
+		ja: "怖がられないように ピカチュウに 似せた ボロ布を かぶっているが 余計に 不気味に なってしまった。",
+		'zh-tw': "為了讓別人不要害怕自己，特意穿上了看似皮卡丘的破布， 結果卻變得更加令人毛骨悚然。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "蠱惑"
+	attacks: [
+		{
+			name: {
+				ja: "まどわす",
+				'zh-tw': "蠱惑",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【混亂】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【混亂】。"
+		{
+			name: {
+				ja: "ワーストギフト",
+				'zh-tw': "極惡之禮",
+			},
+			damage: "10×",
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手の場のポケモンにのっているダメカンの数×10ダメージ。",
+				'zh-tw': "造成對手的場上寶可夢身上放置的傷害指示物的數量×10點傷害。",
+			},
 		},
+	],
 
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "極惡之禮"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667925,
+				tcgplayer: 569981,
+			},
 		},
-
-		effect: {
-			'zh-tw': "造成對手的場上寶可夢身上放置的傷害指示物的數量×10點傷害。"
-		},
-
-		damage: "10×",
-		cost: ["Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [778],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/051.ts
+++ b/data-asia/S/S11/051.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "愛管侍"
+		ja: "イエッサン",
+		'zh-tw': "愛管侍",
 	},
 
 	illustrator: "kodama",
@@ -14,42 +14,51 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "擁有高度智能的寶可夢，能透過夥伴間角與角的互碰 來彼此交換訊息。"
+		ja: "高い 知能を もつ ポケモン。 仲間同士で ツノを 寄せあい 情報 交換を する。",
+		'zh-tw': "擁有高度智能的寶可夢，能透過夥伴間角與角的互碰 來彼此交換訊息。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "伶俐服務"
+	attacks: [
+		{
+			name: {
+				ja: "スマートサーブ",
+				'zh-tw': "伶俐服務",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "このワザは、先攻プレイヤーの最初の番でも使える。自分の山札から好きなカードを1枚選び、手札に加える。そして山札を切る。",
+				'zh-tw': "這個招式在先攻玩家的最初回合也可使用。從自己的牌庫任意選擇1張卡加入手牌。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "這個招式在先攻玩家的最初回合也可使用。從自己的牌庫任意選擇1張卡加入手牌。並且重洗牌庫。"
+		{
+			name: {
+				ja: "ひらてうち",
+				'zh-tw': "掌擊",
+			},
+			damage: 40,
+			cost: ["Psychic", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "掌擊"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667926,
+				tcgplayer: 569982,
+			},
 		},
-
-		damage: 40,
-		cost: ["Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [876],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/052.ts
+++ b/data-asia/S/S11/052.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "多龍梅西亞"
+		ja: "ドラメシヤ",
+		'zh-tw': "多龍梅西亞",
 	},
 
 	illustrator: "Tomokazu Komiya",
@@ -14,36 +14,44 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "曾經棲息在古代的大海。在重生為幽靈寶可夢後， 會在昔日的住處徘徊。"
+		ja: "古代の 海で 暮らしていた。 ゴーストポケモンとして よみがえり かつての すみかを さまよっている。",
+		'zh-tw': "曾經棲息在古代的大海。在重生為幽靈寶可夢後， 會在昔日的住處徘徊。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "突擊"
+	attacks: [
+		{
+			name: {
+				ja: "とつげき",
+				'zh-tw': "突擊",
+			},
+			damage: 30,
+			cost: ["Psychic"],
+			effect: {
+				ja: "このポケモンにも10ダメージ。",
+				'zh-tw': "這隻寶可夢也受到10點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢也受到10點傷害。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667927,
+				tcgplayer: 569983,
+			},
 		},
-
-		damage: 30,
-		cost: ["Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [885],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/053.ts
+++ b/data-asia/S/S11/053.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "多龍奇"
+		ja: "ドロンチ",
+		'zh-tw': "多龍奇",
 	},
 
 	illustrator: "kurumitsu",
@@ -14,32 +14,44 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "飛行速度為每小時２００公里。與多龍梅西亞一起戰鬥， 到牠進化為止都會細心照顧。"
+		ja: "飛行速度は 時速２００キロ。 ドラメシヤと いっしょに 戦い 無事に 進化するまで 世話をする。",
+		'zh-tw': "飛行速度為每小時２００公里。與多龍梅西亞一起戰鬥， 到牠進化為止都會細心照顧。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "陰森射擊"
+	attacks: [
+		{
+			name: {
+				ja: "ホロウショット",
+				'zh-tw': "陰森射擊",
+			},
+			damage: 40,
+			cost: ["Psychic"],
 		},
+	],
 
-		damage: 40,
-		cost: ["Psychic"]
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667928,
+				tcgplayer: 569984,
+			},
+		},
+	],
 
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ドラメシヤ",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [886],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/054.ts
+++ b/data-asia/S/S11/054.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "多龍巴魯托"
+		ja: "ドラパルト",
+		'zh-tw': "多龍巴魯托",
 	},
 
 	illustrator: "Teeziro",
@@ -14,42 +14,55 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "讓多龍梅西亞住在自己角上的洞裡。戰鬥開始後會用音速 將多龍梅西亞發射出去。"
+		ja: "ツノの 穴に ドラメシヤを 入れて 暮らす。 戦いになると マッハの スピードで ドラメシヤを 飛ばす。",
+		'zh-tw': "讓多龍梅西亞住在自己角上的洞裡。戰鬥開始後會用音速 將多龍梅西亞發射出去。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "龍之發射器"
+	attacks: [
+		{
+			name: {
+				ja: "ドラゴンランチャー",
+				'zh-tw': "龍之發射器",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のベンチの「ドラメシヤ」を、相手の場のポケモンの数ぶんまでトラッシュし、トラッシュした数ぶん、相手のポケモンを選ぶ。その後、選んだポケモン全員に、弱点・抵抗力を計算せず、それぞれ100ダメージ。",
+				'zh-tw': "將最多與對手的場上寶可夢相同數量的自己的備戰區的「多龍梅西亞」卡丟棄，選擇與丟棄的數量相同數量的對手的寶可夢。然後，對所選的所有寶可夢不計算弱點・抵抗力，各造成100點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將最多與對手的場上寶可夢相同數量的自己的備戰區的「多龍梅西亞」卡丟棄，選擇與丟棄的數量相同數量的對手的寶可夢。然後，對所選的所有寶可夢不計算弱點・抵抗力，各造成100點傷害。"
+		{
+			name: {
+				ja: "ホロウショット",
+				'zh-tw': "陰森射擊",
+			},
+			damage: 120,
+			cost: ["Psychic", "Colorless"],
 		},
+	],
 
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "陰森射擊"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 667929,
+				tcgplayer: 569985,
+			},
 		},
+	],
 
-		damage: 120,
-		cost: ["Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ドロンチ",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [887],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/055.ts
+++ b/data-asia/S/S11/055.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "靈幽馬"
+		ja: "レイスポス",
+		'zh-tw': "靈幽馬",
 	},
 
 	illustrator: "Narumi Sato",
@@ -14,46 +14,55 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "會利用視覺之外的感官去探測周圍的狀況。據說 被牠踢到時靈魂就會出竅。"
+		ja: "視覚 以外の 五感を 使い 様子を 探る。 蹴られたものは 魂を 抜かれてしまうという。",
+		'zh-tw': "會利用視覺之外的感官去探測周圍的狀況。據說 被牠踢到時靈魂就會出竅。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "夜之足音"
+	attacks: [
+		{
+			name: {
+				ja: "よるのあしおと",
+				'zh-tw': "夜之足音",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のポケモン2匹に、それぞれダメカンを2個のせる。",
+				'zh-tw': "在對手的2隻寶可夢身上各放置2個傷害指示物。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在對手的2隻寶可夢身上各放置2個傷害指示物。"
+		{
+			name: {
+				ja: "ファントムストライク",
+				'zh-tw': "幻影強襲",
+			},
+			damage: 120,
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「ファントムストライク」が使えない。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「幻影強襲」。",
+			},
 		},
+	],
 
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "幻影強襲"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 667930,
+				tcgplayer: 569986,
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「幻影強襲」。"
-		},
-
-		damage: 120,
-		cost: ["Psychic", "Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [897],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/056.ts
+++ b/data-asia/S/S11/056.ts
@@ -1,47 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "化石翼龍V"
+		ja: "プテラV",
+		'zh-tw': "化石翼龍V",
 	},
 
 	illustrator: "N-DESIGN Inc.",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Fighting"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "咬住"
+	attacks: [
+		{
+			name: {
+				ja: "かみつく",
+				'zh-tw': "咬住",
+			},
+			damage: 40,
+			cost: ["Fighting", "Colorless"],
 		},
-
-		damage: 40,
-		cost: ["Fighting", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "岩石細碎"
+		{
+			name: {
+				ja: "ロッククラッシュ",
+				'zh-tw': "岩石細碎",
+			},
+			damage: 120,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 667931,
+				tcgplayer: 569987,
+			},
 		},
-
-		damage: 120,
-		cost: ["Fighting", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Double rare",
+	dexId: [142],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/057.ts
+++ b/data-asia/S/S11/057.ts
@@ -1,49 +1,67 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "化石翼龍VSTAR"
+		ja: "プテラVSTAR",
+		'zh-tw': "化石翼龍VSTAR",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 260,
 	types: ["Fighting"],
-	stage: "VMAX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "放逐奇襲"
+	stage: "VSTAR",
+
+	attacks: [
+		{
+			name: {
+				ja: "ロストダイブ",
+				'zh-tw': "放逐奇襲",
+			},
+			damage: 240,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札を上から3枚、ロストゾーンに置く。",
+				'zh-tw': "將自己的牌庫上方3張卡放置於放逐區。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將自己的牌庫上方3張卡放置於放逐區。"
+		{
+			name: {
+				ja: "エンシェントスター",
+				'zh-tw': "[VSTAR力量]古時星星",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンは、場をはなれるまで「相手の場の『ポケモンV』（『プテラVSTAR』をのぞく）の特性は、すべてなくなる。」という効果の特性を持つ。［対戦中、自分はVSTARパワーを1回しか使えない。］",
+				'zh-tw': "這隻寶可夢離場前，擁有「對手的場上的『寶可夢【V】』（『化石翼龍【VSTAR】』 除外）的特性全部消除。」效果的特性。[對戰中，己方只可使用1次【VSTAR】力量。]",
+			},
 		},
+	],
 
-		damage: 240,
-		cost: ["Fighting", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "[VSTAR力量]古時星星"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 667932,
+				tcgplayer: 569988,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢離場前，擁有「對手的場上的『寶可夢【V】』（『化石翼龍【VSTAR】』 除外）的特性全部消除。」效果的特性。[對戰中，己方只可使用1次【VSTAR】力量。]"
-		},
-
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "プテラV",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Triple Rare",
+	dexId: [142],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/058.ts
+++ b/data-asia/S/S11/058.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "小小象"
+		ja: "ゴマゾウ",
+		'zh-tw': "小小象",
 	},
 
 	illustrator: "Naoyo Kimura",
@@ -14,31 +14,44 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "身體雖小卻很有力氣。能輕鬆地讓成年人 騎在牠背上移動。"
+		ja: "体は 小さいが 力持ち。 大人の 人を 軽々と 背中に 乗せて 歩いてしまう。",
+		'zh-tw': "身體雖小卻很有力氣。能輕鬆地讓成年人 騎在牠背上移動。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "擊飛"
+	attacks: [
+		{
+			name: {
+				ja: "はねとばす",
+				'zh-tw': "擊飛",
+			},
+			damage: "10+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+				'zh-tw': "擲1次硬幣若為正面，則增加20點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則增加20點傷害。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667933,
+				tcgplayer: 569989,
+			},
 		},
-
-		damage: "10+",
-		cost: ["Fighting"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [231],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/059.ts
+++ b/data-asia/S/S11/059.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "頓甲"
+		ja: "ドンファン",
+		'zh-tw': "頓甲",
 	},
 
 	illustrator: "Anesaki Dynamic",
@@ -14,38 +14,56 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "牙齒越大越長，在族群裡的地位就越高。 牙齒的生長需要很長的時間。"
+		ja: "キバが 長くて 大きいほど 群れの中での ランクが 高い。 キバが 伸びるには 時間が かかる。",
+		'zh-tw': "牙齒越大越長，在族群裡的地位就越高。 牙齒的生長需要很長的時間。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "超頻旋轉"
+	attacks: [
+		{
+			name: {
+				ja: "オーバースピン",
+				'zh-tw': "超頻旋轉",
+			},
+			damage: 110,
+			cost: ["Fighting"],
+			effect: {
+				ja: "この番、このポケモンに進化していたなら、このワザは失敗。",
+				'zh-tw': "在這個回合，若進化成這隻寶可夢，則這個招式失敗。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在這個回合，若進化成這隻寶可夢，則這個招式失敗。"
+		{
+			name: {
+				ja: "きょだいなキバ",
+				'zh-tw': "巨大之牙",
+			},
+			damage: 170,
+			cost: ["Fighting", "Fighting", "Fighting", "Colorless"],
 		},
+	],
 
-		damage: 110,
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "巨大之牙"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667934,
+				tcgplayer: 569990,
+			},
 		},
+	],
 
-		damage: 170,
-		cost: ["Fighting", "Fighting", "Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ゴマゾウ",
+	},
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [232],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/060.ts
+++ b/data-asia/S/S11/060.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "龜腳腳"
+		ja: "カメテテ",
+		'zh-tw': "龜腳腳",
 	},
 
 	illustrator: "Scav",
@@ -14,34 +14,48 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "２隻龜腳腳會在海邊找一塊大小合適的岩石，附在上面一起生活。 漲潮的時候會互相合作尋找食物。"
+		ja: "２匹が 海辺の 手ごろな 岩に くっついて 暮らす。 満潮時 協力して エサを 集める。",
+		'zh-tw': "２隻龜腳腳會在海邊找一塊大小合適的岩石，附在上面一起生活。 漲潮的時候會互相合作尋找食物。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "擲泥"
+	attacks: [
+		{
+			name: {
+				ja: "どろかけ",
+				'zh-tw': "擲泥",
+			},
+			damage: 10,
+			cost: ["Fighting"],
 		},
-
-		damage: 10,
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "劈開"
+		{
+			name: {
+				ja: "きりさく",
+				'zh-tw': "劈開",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667935,
+				tcgplayer: 569991,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [688],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/061.ts
+++ b/data-asia/S/S11/061.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "龜足巨鎧"
+		ja: "ガメノデス",
+		'zh-tw': "龜足巨鎧",
 	},
 
 	illustrator: "KEIICHIRO ITO",
@@ -14,39 +14,58 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "７隻龜腳腳組成了１隻龜足巨鎧的身體。 由頭部對手腳發號施令。"
+		ja: "７匹の カメテテが １匹分の 体を つくっている。 頭が 手足に 命令する 仕組み。",
+		'zh-tw': "７隻龜腳腳組成了１隻龜足巨鎧的身體。 由頭部對手腳發號施令。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "放逐區障礙"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ロストブロック",
+				'zh-tw': "放逐區障礙",
+			},
+			effect: {
+				ja: "このポケモンがいるかぎり、相手がとるサイドは、手札には加えず、ロストゾーンに置く。",
+				'zh-tw': "只要這隻寶可夢在場上，對手獲得的獎賞卡不加入手牌，而是放置於放逐區。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在場上，對手獲得的獎賞卡不加入手牌，而是放置於放逐區。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "爆裂劈"
+	attacks: [
+		{
+			name: {
+				ja: "ばくれつチョップ",
+				'zh-tw': "爆裂劈",
+			},
+			damage: 100,
+			cost: ["Fighting", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 100,
-		cost: ["Fighting", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 667936,
+				tcgplayer: 569992,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カメテテ",
+	},
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [689],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/062.ts
+++ b/data-asia/S/S11/062.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "摔角鷹人"
+		ja: "ルチャブル",
+		'zh-tw': "摔角鷹人",
 	},
 
 	illustrator: "Teeziro",
@@ -14,46 +14,55 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "利用發揮輕盈體型優勢的戰法，在消耗了對手的體力之後 使用華麗的絕招分出勝負。"
+		ja: "身軽さを 活かした 戦法で 相手の 体力を 奪ってから 華麗な 大技を 決める。",
+		'zh-tw': "利用發揮輕盈體型優勢的戰法，在消耗了對手的體力之後 使用華麗的絕招分出勝負。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "吸引"
+	attacks: [
+		{
+			name: {
+				ja: "ひきつける",
+				'zh-tw': "吸引",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を2枚引く。",
+				'zh-tw': "從自己的牌庫抽出2張卡。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫抽出2張卡。"
+		{
+			name: {
+				ja: "アクロバット",
+				'zh-tw': "雜技",
+			},
+			damage: "30+",
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×20ダメージ追加。",
+				'zh-tw': "擲2次硬幣，增加正面出現的次數×20點傷害。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "雜技"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667937,
+				tcgplayer: 569993,
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲2次硬幣，增加正面出現的次數×20點傷害。"
-		},
-
-		damage: "30+",
-		cost: ["Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [701],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/063.ts
+++ b/data-asia/S/S11/063.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "沙丘娃"
+		ja: "スナバァ",
+		'zh-tw': "沙丘娃",
 	},
 
 	illustrator: "Sekio",
@@ -14,31 +14,44 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "死者的怨念附在沙丘上，從而變成的寶可夢。 很喜歡頭上的鏟子。"
+		ja: "砂山に 死者の 怨念が 宿り ポケモンに なった。 頭の スコップは お気に入り。",
+		'zh-tw': "死者的怨念附在沙丘上，從而變成的寶可夢。 很喜歡頭上的鏟子。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "窮追不捨"
+	attacks: [
+		{
+			name: {
+				ja: "おいつめる",
+				'zh-tw': "窮追不捨",
+			},
+			damage: 10,
+			cost: ["Fighting"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667938,
+				tcgplayer: 569994,
+			},
 		},
-
-		damage: 10,
-		cost: ["Fighting"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	],
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [769],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/064.ts
+++ b/data-asia/S/S11/064.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "噬沙堡爺"
+		ja: "シロデスナ",
+		'zh-tw': "噬沙堡爺",
 	},
 
 	illustrator: "sui",
@@ -14,37 +14,55 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "也被稱為「海灘惡夢」。會操控沙子淹沒獵物， 然後吸取對方的靈魂。"
+		ja: "ビーチの 悪夢とも 呼ばれる。 砂を 操って 獲物を 沈め 魂を 吸い取る。",
+		'zh-tw': "也被稱為「海灘惡夢」。會操控沙子淹沒獵物， 然後吸取對方的靈魂。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "沙壺地獄"
+	attacks: [
+		{
+			name: {
+				ja: "すなつぼじごく",
+				'zh-tw': "沙壺地獄",
+			},
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的所有寶可夢各受到30點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
-
-		effect: {
-			'zh-tw': "對手的所有寶可夢各受到30點傷害。[在備戰區不計算弱點・抵抗力。]"
+		{
+			name: {
+				ja: "ランドクラッシュ",
+				'zh-tw': "大地粉碎",
+			},
+			damage: 120,
+			cost: ["Fighting", "Fighting", "Colorless"],
 		},
+	],
 
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "大地粉碎"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667939,
+				tcgplayer: 569995,
+			},
 		},
+	],
 
-		damage: 120,
-		cost: ["Fighting", "Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "スナバァ",
+	},
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [770],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/065.ts
+++ b/data-asia/S/S11/065.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "巨石丁"
+		ja: "イシヘンジン",
+		'zh-tw': "巨石丁",
 	},
 
 	illustrator: "HYOGONOSUKE",
@@ -14,41 +14,55 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "佇立在大草原上，每天眺望著日升日落。 擅長強而有力的踢技。"
+		ja: "大草原の 中で たたずみ 陽の 傾きを 眺めて 暮らす。 ダイナミックな 蹴り技が 得意。",
+		'zh-tw': "佇立在大草原上，每天眺望著日升日落。 擅長強而有力的踢技。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "力量尖石"
+	attacks: [
+		{
+			name: {
+				ja: "パワーストーン",
+				'zh-tw': "力量尖石",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札から[F]エネルギーを2枚まで選び、自分のポケモンに好きなようにつける。",
+				'zh-tw': "從自己的手牌選擇最多2張【鬥】能量卡，以任意方式附於自己的寶可夢身上。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的手牌選擇最多2張【鬥】能量卡，以任意方式附於自己的寶可夢身上。"
+		{
+			name: {
+				ja: "ロストシュート",
+				'zh-tw': "放逐射擊",
+			},
+			damage: 120,
+			cost: ["Fighting", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の山札を上から1枚、ロストゾーンに置く。",
+				'zh-tw': "將對手的牌庫上方1張卡放置於放逐區。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "放逐射擊"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667940,
+				tcgplayer: 569996,
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的牌庫上方1張卡放置於放逐區。"
-		},
-
-		damage: 120,
-		cost: ["Fighting", "Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	],
 
 	retreat: 4,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [874],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/066.ts
+++ b/data-asia/S/S11/066.ts
@@ -1,52 +1,66 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "龍王蠍V"
+		ja: "ドラピオンV",
+		'zh-tw': "龍王蠍V",
 	},
 
 	illustrator: "N-DESIGN Inc.",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Darkness"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "狂野風格"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ワイルドスタイル",
+				'zh-tw': "狂野風格",
+			},
+			effect: {
+				ja: "相手の場の「いちげき」「れんげき」「フュージョン」のポケモンの数ぶん、このポケモンがワザを使うための[C]エネルギーは少なくなる。",
+				'zh-tw': "這隻寶可夢使用招式所需的【無】能量，減少對手的場上「一擊」「連擊」「匯流」寶可夢的數量。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢使用招式所需的【無】能量，減少對手的場上「一擊」「連擊」「匯流」寶可夢的數量。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "極限之尾"
+	attacks: [
+		{
+			name: {
+				ja: "ダイナミックテール",
+				'zh-tw': "極限之尾",
+			},
+			damage: 190,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のポケモン1匹にも、60ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "自己的1隻寶可夢也受到60點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "自己的1隻寶可夢也受到60點傷害。[在備戰區不計算弱點・抵抗力。]"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 667941,
+				tcgplayer: 569997,
+			},
 		},
-
-		damage: 190,
-		cost: ["Colorless", "Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Double rare",
+	dexId: [452],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/067.ts
+++ b/data-asia/S/S11/067.ts
@@ -1,51 +1,69 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "龍王蠍VSTAR"
+		ja: "ドラピオンVSTAR",
+		'zh-tw': "龍王蠍VSTAR",
 	},
 
 	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
 	hp: 270,
 	types: ["Darkness"],
-	stage: "VMAX",
 
-	abilities: [{
-		type: "Ability",
+	stage: "VSTAR",
 
-		name: {
-			'zh-tw': "危害星星"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ハザードスター",
+				'zh-tw': "危害星星",
+			},
+			effect: {
+				ja: "自分の番に使える。相手のバトルポケモンをどくとマヒにする。このどくでのせるダメカンの数は3個になる。［対戦中、自分はVSTARパワーを1回しか使えない。］",
+				'zh-tw': "在自己的回合時可使用。將對手的戰鬥寶可夢【中毒】與【麻痺】。因這個【中毒】而放置的傷害指示物的數量改為3個。[對戰中，己方只可使用1次【VSTAR】力量。]",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時可使用。將對手的戰鬥寶可夢【中毒】與【麻痺】。因這個【中毒】而放置的傷害指示物的數量改為3個。[對戰中，己方只可使用1次【VSTAR】力量。]"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "大爆炸之臂"
+	attacks: [
+		{
+			name: {
+				ja: "ビッグバンアーム 250-",
+				'zh-tw': "大爆炸之臂",
+			},
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数×10ダメージぶん、このワザのダメージは小さくなる。",
+				'zh-tw': "減少這隻寶可夢身上放置的傷害指示物的數量×10點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "減少這隻寶可夢身上放置的傷害指示物的數量×10點傷害。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 667942,
+				tcgplayer: 569998,
+			},
 		},
+	],
 
-		damage: "250-",
-		cost: ["Darkness", "Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ドラピオンV",
+	},
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Triple Rare",
+	dexId: [452],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/068.ts
+++ b/data-asia/S/S11/068.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "黑眼鱷"
+		ja: "メグロコ",
+		'zh-tw': "黑眼鱷",
 	},
 
 	illustrator: "0313",
@@ -14,27 +14,40 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "沙漠的夜晚比較寒冷，因此牠會潛到沙子深處， 一直睡到太陽出來。"
+		ja: "砂漠の 夜は 冷えるので 砂の 奥深くに 潜り 陽が 出るまで 眠って 過ごす。",
+		'zh-tw': "沙漠的夜晚比較寒冷，因此牠會潛到沙子深處， 一直睡到太陽出來。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "咬住"
+	attacks: [
+		{
+			name: {
+				ja: "かみつく",
+				'zh-tw': "咬住",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667943,
+				tcgplayer: 569999,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [551],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/069.ts
+++ b/data-asia/S/S11/069.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "混混鱷"
+		ja: "ワルビル",
+		'zh-tw': "混混鱷",
 	},
 
 	illustrator: "Pani Kobayashi",
@@ -14,31 +14,48 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "有一雙在漆黑環境也能看見四周的特殊眼睛，讓牠即使 在半夜也能不受影響地去打獵。"
+		ja: "暗闇でも 見える 特殊な 両目の おかげで 真夜中でも 迷わず 狩りが できるのだ。",
+		'zh-tw': "有一雙在漆黑環境也能看見四周的特殊眼睛，讓牠即使 在半夜也能不受影響地去打獵。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "咬碎"
+	attacks: [
+		{
+			name: {
+				ja: "かみくだく",
+				'zh-tw': "咬碎",
+			},
+			damage: 60,
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "擲1次硬幣若為正面，則選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667944,
+				tcgplayer: 570000,
+			},
 		},
+	],
 
-		damage: 60,
-		cost: ["Darkness", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "メグロコ",
+	},
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [552],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/070.ts
+++ b/data-asia/S/S11/070.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "流氓鱷"
+		ja: "ワルビアル",
+		'zh-tw': "流氓鱷",
 	},
 
 	illustrator: "Shiburingaru",
@@ -14,43 +14,62 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "又被稱為沙之惡霸。就連厚厚的鐵板也能被牠 用強力的下顎輕鬆咬爛。"
+		ja: "砂の ギャングとも 呼ばれる。 強力な 顎で ぶ厚い 鉄板も たやすく 食いちぎる。",
+		'zh-tw': "又被稱為沙之惡霸。就連厚厚的鐵板也能被牠 用強力的下顎輕鬆咬爛。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "沙之結夥"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "すなのギャング",
+				'zh-tw': "沙之結夥",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたときと、このポケモンがバトル場で相手のワザのダメージを受けてきぜつしたとき、それぞれ1回使える。相手の手札からオモテを見ないで1枚選び、トラッシュする。",
+				'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，與這隻寶可夢在戰鬥場上受到對手的招式的傷害而【氣絕】時，各可使用1次。在不看正面的情況下，選擇1張對手的手牌，將其丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，與這隻寶可夢在戰鬥場上受到對手的招式的傷害而【氣絕】時，各可使用1次。在不看正面的情況下，選擇1張對手的手牌，將其丟棄。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "捨身衝撞"
+	attacks: [
+		{
+			name: {
+				ja: "すてみタックル",
+				'zh-tw': "捨身衝撞",
+			},
+			damage: 160,
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+				'zh-tw': "這隻寶可夢也受到30點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢也受到30點傷害。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 667945,
+				tcgplayer: 570001,
+			},
 		},
+	],
 
-		damage: 160,
-		cost: ["Darkness", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ワルビル",
+	},
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [553],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/071.ts
+++ b/data-asia/S/S11/071.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "好壞星"
+		ja: "ヒドイデ",
+		'zh-tw': "好壞星",
 	},
 
 	illustrator: "Yuu Nishida",
@@ -14,30 +14,43 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "要是被牠的毒刺給刺中，首先會發麻，接著會奇癢無比， 讓人恨不得把皮都給抓爛。"
+		ja: "棘に 刺されると まず 痺れに 襲われ やがて 掻きむしりたくなる ほどの 痒みに 苦しむのだ。",
+		'zh-tw': "要是被牠的毒刺給刺中，首先會發麻，接著會奇癢無比， 讓人恨不得把皮都給抓爛。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "毒針"
+	attacks: [
+		{
+			name: {
+				ja: "どくばり",
+				'zh-tw': "毒針",
+			},
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667946,
+				tcgplayer: 570002,
+			},
 		},
-
-		cost: ["Darkness"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [747],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/072.ts
+++ b/data-asia/S/S11/072.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "超壞星"
+		ja: "ドヒドイデ",
+		'zh-tw': "超壞星",
 	},
 
 	illustrator: "Ligton",
@@ -14,38 +14,56 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "為了能承受住伽勒爾地區冰涼的水溫，牠用腳搭起圓頂， 藉助體溫保持內部的溫暖。"
+		ja: "ガラル地方の 冷たい 水温に 耐えるため 脚で ドームを つくり 内部を 体温で 温める。",
+		'zh-tw': "為了能承受住伽勒爾地區冰涼的水溫，牠用腳搭起圓頂， 藉助體溫保持內部的溫暖。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "毒液衝擊"
+	attacks: [
+		{
+			name: {
+				ja: "ベノムショック",
+				'zh-tw': "毒液衝擊",
+			},
+			damage: "10+",
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンがどくなら、120ダメージ追加。",
+				'zh-tw': "若對手的戰鬥寶可夢【中毒】，則增加120點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "若對手的戰鬥寶可夢【中毒】，則增加120點傷害。"
+		{
+			name: {
+				ja: "とげショット",
+				'zh-tw': "尖刺射擊",
+			},
+			damage: 90,
+			cost: ["Darkness", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: "10+",
-		cost: ["Darkness"]
-	}, {
-		name: {
-			'zh-tw': "尖刺射擊"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667947,
+				tcgplayer: 570003,
+			},
 		},
+	],
 
-		damage: 90,
-		cost: ["Darkness", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ヒドイデ",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [748],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/073.ts
+++ b/data-asia/S/S11/073.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鐵啞鈴"
+		ja: "ダンバル",
+		'zh-tw': "鐵啞鈴",
 	},
 
 	illustrator: "sowsow",
@@ -14,42 +14,51 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "會從臀部放出磁力將敵人迅猛地吸到身邊， 再以銳利的爪子刺穿對方。"
+		ja: "磁力を お尻から 発生させ 敵を 勢いよく 吸いよせて 鋭い ツメで 串刺しにする。",
+		'zh-tw': "會從臀部放出磁力將敵人迅猛地吸到身邊， 再以銳利的爪子刺穿對方。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "磁力抬升"
+	attacks: [
+		{
+			name: {
+				ja: "マグネリフト",
+				'zh-tw': "磁力抬升",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から好きなカードを1枚選ぶ。残りの山札を切り、選んだカードを山札の上にもどす。",
+				'zh-tw': "從自己的牌庫任意選擇1張卡。重洗剩餘牌庫，將所選的卡放回牌庫上方。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫任意選擇1張卡。重洗剩餘牌庫，將所選的卡放回牌庫上方。"
+		{
+			name: {
+				ja: "たいあたり",
+				'zh-tw': "撞擊",
+			},
+			damage: 20,
+			cost: ["Metal", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "撞擊"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667948,
+				tcgplayer: 570004,
+			},
 		},
-
-		damage: 20,
-		cost: ["Metal", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [374],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/074.ts
+++ b/data-asia/S/S11/074.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "金屬怪"
+		ja: "メタング",
+		'zh-tw': "金屬怪",
 	},
 
 	illustrator: "Shin Nagasawa",
@@ -14,36 +14,48 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "由２隻鐵啞鈴以磁力結合而成。因為有２個大腦， 精神力量也強化成２倍了。"
+		ja: "２匹の ダンバルが 磁力で くっついた。 ２つの 脳みそにより サイコパワーは ２倍に 強化。",
+		'zh-tw': "由２隻鐵啞鈴以磁力結合而成。因為有２個大腦， 精神力量也強化成２倍了。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "子彈拳"
+	attacks: [
+		{
+			name: {
+				ja: "バレットパンチ",
+				'zh-tw': "子彈拳",
+			},
+			damage: "30+",
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×30ダメージ追加。",
+				'zh-tw': "擲2次硬幣，增加正面出現的次數×30點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲2次硬幣，增加正面出現的次數×30點傷害。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667949,
+				tcgplayer: 570005,
+			},
 		},
+	],
 
-		damage: "30+",
-		cost: ["Metal", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ダンバル",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [375],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/075.ts
+++ b/data-asia/S/S11/075.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "巨金怪"
+		ja: "メタグロス",
+		'zh-tw': "巨金怪",
 	},
 
 	illustrator: "Ryuta Fuse",
@@ -14,48 +14,62 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "當氣溫下降到低於冰點時，磁力就會變強。因此棲息在 雪山裡的巨金怪非常有活力。"
+		ja: "気温が 氷点下になると 磁力が 強まるので 雪山に 棲む メタグロスは とても 元気。",
+		'zh-tw': "當氣溫下降到低於冰點時，磁力就會變強。因此棲息在 雪山裡的巨金怪非常有活力。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "緊急進場"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "きんきゅうエントリー",
+				'zh-tw': "緊急進場",
+			},
+			effect: {
+				ja: "自分の番のはじめに、山札からこのカードを引いたとき、自分のベンチに空きがあるなら、手札に加える前に1回使える。このカードを自分のベンチに出す。その後、自分の山札を3枚引く。",
+				'zh-tw': "在自己的回合開始，從牌庫抽出了這張卡時，若自己的備戰區有空位，則在加入手牌前可使用1次。將這張卡放置於自己的備戰區。然後，從自己的牌庫抽出3張卡。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合開始，從牌庫抽出了這張卡時，若自己的備戰區有空位，則在加入手牌前可使用1次。將這張卡放置於自己的備戰區。然後，從自己的牌庫抽出3張卡。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "彗星拳"
+	attacks: [
+		{
+			name: {
+				ja: "コメットパンチ",
+				'zh-tw': "彗星拳",
+			},
+			damage: 100,
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンの「コメットパンチ」のダメージは「+100」される。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢「彗星拳」的傷害「+100」點。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢「彗星拳」的傷害「+100」點。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 667950,
+				tcgplayer: 570006,
+			},
 		},
+	],
 
-		damage: 100,
-		cost: ["Metal", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "メタング",
+	},
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [376],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/076.ts
+++ b/data-asia/S/S11/076.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "種子鐵球"
+		ja: "テッシード",
+		'zh-tw': "種子鐵球",
 	},
 
 	illustrator: "ryoma uratsuka",
@@ -14,39 +14,48 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "會發射尖刺來保護自己。需要反覆訓練才能將 尖刺準確地射中目標。"
+		ja: "棘を 飛ばして 身を 守る。 狙った 方向に 飛ばすには たくさんの 訓練が 必要。",
+		'zh-tw': "會發射尖刺來保護自己。需要反覆訓練才能將 尖刺準確地射中目標。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "撞擊"
+	attacks: [
+		{
+			name: {
+				ja: "たいあたり",
+				'zh-tw': "撞擊",
+			},
+			damage: 10,
+			cost: ["Metal"],
 		},
-
-		damage: 10,
-		cost: ["Metal"]
-	}, {
-		name: {
-			'zh-tw': "滾動衝撞"
+		{
+			name: {
+				ja: "ころがりタックル",
+				'zh-tw': "滾動衝撞",
+			},
+			damage: 20,
+			cost: ["Metal", "Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Metal", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667951,
+				tcgplayer: 570007,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [597],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/077.ts
+++ b/data-asia/S/S11/077.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "堅果啞鈴"
+		ja: "ナットレイ",
+		'zh-tw': "堅果啞鈴",
 	},
 
 	illustrator: "Anesaki Dynamic",
@@ -14,39 +14,52 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "用尖刺刺裂岩壁之後，牠會用觸手的尖端 接觸裂縫吸收營養。"
+		ja: "トゲで 岩盤に キズを つけると 触手の 先端を あてて 栄養を 吸収する。",
+		'zh-tw': "用尖刺刺裂岩壁之後，牠會用觸手的尖端 接觸裂縫吸收營養。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "迴轉攻擊"
+	attacks: [
+		{
+			name: {
+				ja: "かいてんアタック",
+				'zh-tw': "迴轉攻擊",
+			},
+			damage: 50,
+			cost: ["Metal", "Colorless"],
 		},
-
-		damage: 50,
-		cost: ["Metal", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "鞭打粉碎"
+		{
+			name: {
+				ja: "ウィップスマッシュ",
+				'zh-tw': "鞭打粉碎",
+			},
+			damage: 130,
+			cost: ["Metal", "Metal", "Colorless"],
 		},
+	],
 
-		damage: 130,
-		cost: ["Metal", "Metal", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667952,
+				tcgplayer: 570008,
+			},
+		},
+	],
 
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "テッシード",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [598],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/078.ts
+++ b/data-asia/S/S11/078.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伽勒爾 泥巴魚"
+		ja: "ガラル マッギョ",
+		'zh-tw': "伽勒爾 泥巴魚",
 	},
 
 	illustrator: "Shigenori Negishi",
@@ -14,43 +14,52 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "棲息在富含鐵質的泥巴裡，因此獲得了 結實堅固的鋼鐵身軀。"
+		ja: "鉄分 たっぷりの 泥の 中で 生息していたため 頑丈な 鋼の 体に 変化した。",
+		'zh-tw': "棲息在富含鐵質的泥巴裡，因此獲得了 結實堅固的鋼鐵身軀。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "場地陷阱"
+	attacks: [
+		{
+			name: {
+				ja: "フィールドトラップ",
+				'zh-tw': "場地陷阱",
+			},
+			damage: 20,
+			cost: ["Metal"],
+			effect: {
+				ja: "場に出ている相手のスタジアムをトラッシュする。トラッシュした場合、相手のバトルポケモンについているエネルギーを2個選び、トラッシュする。",
+				'zh-tw': "將場上的對手的競技場卡丟棄。有丟棄的情況下，選擇2個對手的戰鬥寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將場上的對手的競技場卡丟棄。有丟棄的情況下，選擇2個對手的戰鬥寶可夢身上附加的能量，將其丟棄。"
+		{
+			name: {
+				ja: "たいあたり",
+				'zh-tw': "撞擊",
+			},
+			damage: 50,
+			cost: ["Metal", "Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Metal"]
-	}, {
-		name: {
-			'zh-tw': "撞擊"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667953,
+				tcgplayer: 570009,
+			},
 		},
-
-		damage: 50,
-		cost: ["Metal", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	],
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [618],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/079.ts
+++ b/data-asia/S/S11/079.ts
@@ -1,55 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伽勒爾 喵頭目V"
+		ja: "ガラル ニャイキングV",
+		'zh-tw': "伽勒爾 喵頭目V",
 	},
 
 	illustrator: "PLANETA Yamashita",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Metal"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "好心情"
+	attacks: [
+		{
+			name: {
+				ja: "じょうきげん",
+				'zh-tw': "好心情",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を3枚引く。",
+				'zh-tw': "從自己的牌庫抽出3張卡。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫抽出3張卡。"
+		{
+			name: {
+				ja: "おたからラッシュ",
+				'zh-tw': "寶物猛攻",
+			},
+			damage: "20×",
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "自分の手札の枚数×20ダメージ。",
+				'zh-tw': "造成自己的手牌的張數×20點傷害。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "寶物猛攻"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 667954,
+				tcgplayer: 570010,
+			},
 		},
-
-		effect: {
-			'zh-tw': "造成自己的手牌的張數×20點傷害。"
-		},
-
-		damage: "20×",
-		cost: ["Metal", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Double rare",
+	dexId: [863],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/080.ts
+++ b/data-asia/S/S11/080.ts
@@ -1,45 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "騎拉帝納V"
+		ja: "ギラティナV",
+		'zh-tw': "騎拉帝納V",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Dragon"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "深淵探求"
+	attacks: [
+		{
+			name: {
+				ja: "アビスシーク",
+				'zh-tw': "深淵探求",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を上から4枚見て、その中からカードを2枚選び、手札に加える。残りのカードはロストゾーンに置く。",
+				'zh-tw': "查看自己的牌庫上方4張卡，從其中選擇2張卡加入手牌。將剩餘卡放置於放逐區。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "查看自己的牌庫上方4張卡，從其中選擇2張卡加入手牌。將剩餘卡放置於放逐區。"
+		{
+			name: {
+				ja: "ひきさく",
+				'zh-tw': "撕裂",
+			},
+			damage: 160,
+			cost: ["Grass", "Psychic", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+				'zh-tw': "這個招式的傷害不計算對手的戰鬥寶可夢身上的附加效果。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "撕裂"
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 667955,
+				tcgplayer: 570011,
+			},
 		},
-
-		effect: {
-			'zh-tw': "這個招式的傷害不計算對手的戰鬥寶可夢身上的附加效果。"
-		},
-
-		damage: 160,
-		cost: ["Grass", "Psychic", "Colorless"]
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Double rare",
+	dexId: [487],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/081.ts
+++ b/data-asia/S/S11/081.ts
@@ -1,44 +1,67 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "騎拉帝納VSTAR"
+		ja: "ギラティナVSTAR",
+		'zh-tw': "騎拉帝納VSTAR",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 280,
 	types: ["Dragon"],
-	stage: "VMAX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "放逐衝擊"
+	stage: "VSTAR",
+
+	attacks: [
+		{
+			name: {
+				ja: "ロストインパクト",
+				'zh-tw': "放逐衝擊",
+			},
+			damage: 280,
+			cost: ["Grass", "Psychic", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについているエネルギーを2個選び、ロストゾーンに置く。",
+				'zh-tw': "選擇2個自己的場上寶可夢身上附加的能量，放置於放逐區。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇2個自己的場上寶可夢身上附加的能量，放置於放逐區。"
+		{
+			name: {
+				ja: "スターレクイエム",
+				'zh-tw': "[VSTAR力量]星星安魂曲",
+			},
+			cost: ["Grass", "Psychic"],
+			effect: {
+				ja: "このワザは、自分のロストゾーンにカードが10枚以上あるときにしか使えない。相手のバトルポケモンをきぜつさせる。［対戦中、自分はVSTARパワーを1回しか使えない。］",
+				'zh-tw': "這個招式只有在自己的放逐區有10張以上的卡時才可使用。將對手的戰鬥寶可夢【氣絕】。[對戰中，己方只可使用1次【VSTAR】力量。]",
+			},
 		},
+	],
 
-		damage: 280,
-		cost: ["Grass", "Psychic", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "[VSTAR力量]星星安魂曲"
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 667956,
+				tcgplayer: 570012,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這個招式只有在自己的放逐區有10張以上的卡時才可使用。將對手的戰鬥寶可夢【氣絕】。[對戰中，己方只可使用1次【VSTAR】力量。]"
-		},
-
-		cost: ["Grass", "Psychic"]
-	}],
+	evolveFrom: {
+		ja: "ギラティナV",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Triple Rare",
+	dexId: [487],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/082.ts
+++ b/data-asia/S/S11/082.ts
@@ -1,57 +1,66 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "大比鳥V"
+		ja: "ピジョットV",
+		'zh-tw': "大比鳥V",
 	},
 
 	illustrator: "Saki Hayashiro",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Colorless"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "消逝之翼"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "きえさるつばさ",
+				'zh-tw': "消逝之翼",
+			},
+			effect: {
+				ja: "このポケモンがベンチにいるなら、自分の番に1回使える。このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。",
+				'zh-tw': "若這隻寶可夢在備戰區，則在自己的回合時可使用1次。將這隻寶可夢與附加的卡，全部放回自己的牌庫並重洗。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢在備戰區，則在自己的回合時可使用1次。將這隻寶可夢與附加的卡，全部放回自己的牌庫並重洗。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "飛行衝浪"
+	attacks: [
+		{
+			name: {
+				ja: "フライトサーフ",
+				'zh-tw': "飛行衝浪",
+			},
+			damage: "80+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "場に自分のスタジアムが出ているなら、80ダメージ追加。",
+				'zh-tw': "若場上有自己的競技場卡，則增加80點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若場上有自己的競技場卡，則增加80點傷害。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 667957,
+				tcgplayer: 570013,
+			},
 		},
-
-		damage: "80+",
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Double rare",
+	dexId: [18],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/083.ts
+++ b/data-asia/S/S11/083.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "多邊獸"
+		ja: "ポリゴン",
+		'zh-tw': "多邊獸",
 	},
 
 	illustrator: "kurumitsu",
@@ -14,37 +14,51 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "牠是以最尖端的科學力量，首度在世上利用程式創造 出來的人工寶可夢。"
+		ja: "最高の 科学力を 使い 世界で はじめて プログラムにより 作られた 人工の ポケモン。",
+		'zh-tw': "牠是以最尖端的科學力量，首度在世上利用程式創造 出來的人工寶可夢。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "分別計算"
+	attacks: [
+		{
+			name: {
+				ja: "ぶんきけいさん",
+				'zh-tw': "分別計算",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分または相手の山札を上から4枚見て、好きな順番に入れ替えて、山札の上にもどす。",
+				'zh-tw': "查看自己或者對手的牌庫上方4張卡，以任意順序排列，放回牌庫上方。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "查看自己或者對手的牌庫上方4張卡，以任意順序排列，放回牌庫上方。"
+		{
+			name: {
+				ja: "ビーム",
+				'zh-tw': "光束",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "光束"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667958,
+				tcgplayer: 570014,
+			},
 		},
-
-		damage: 10,
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [137],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/084.ts
+++ b/data-asia/S/S11/084.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "多邊獸Ⅱ"
+		ja: "ポリゴン2",
+		'zh-tw': "多邊獸Ⅱ",
 	},
 
 	illustrator: "OKACHEKE",
@@ -14,31 +14,48 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "#N/A"
+		ja: "ポリゴンを 特別な データで アップデート。 さまざまな ことを 自分で 学び 成長する。",
+		'zh-tw': "#N/A",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "廢物攻擊"
+	attacks: [
+		{
+			name: {
+				ja: "ガベージアタック",
+				'zh-tw': "廢物攻擊",
+			},
+			damage: "20×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "おたがいのロストゾーンにある「ポケモンのどうぐ」の枚数×20ダメージ。",
+				'zh-tw': "造成雙方的放逐區的「寶可夢道具」卡的張數×20點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "造成雙方的放逐區的「寶可夢道具」卡的張數×20點傷害。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667959,
+				tcgplayer: 570015,
+			},
 		},
+	],
 
-		damage: "20×",
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ポリゴン",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [233],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/085.ts
+++ b/data-asia/S/S11/085.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "多邊獸Ｚ"
+		ja: "ポリゴンZ",
+		'zh-tw': "多邊獸Ｚ",
 	},
 
 	illustrator: "Shibuzoh.",
@@ -14,37 +14,55 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "#N/A"
+		ja: "異次元 空間に 出入りできる プログラムを 追加したところ 挙動が 不安定になった。",
+		'zh-tw': "#N/A",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "降級光束"
+	attacks: [
+		{
+			name: {
+				ja: "デグレードビーム",
+				'zh-tw': "降級光束",
+			},
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手の進化しているポケモンを1匹選び、「進化カード」を好きなだけはがして退化させる。はがしたカードは、相手の山札にもどして切る。",
+				'zh-tw': "選擇對手的1隻進化寶可夢，移除任意數量的「進化卡」使其退化。將移除的卡放回對手的牌庫並重洗。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇對手的1隻進化寶可夢，移除任意數量的「進化卡」使其退化。將移除的卡放回對手的牌庫並重洗。"
+		{
+			name: {
+				ja: "パワービーム",
+				'zh-tw': "强力光束",
+			},
+			damage: 130,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "强力光束"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667960,
+				tcgplayer: 570016,
+			},
 		},
+	],
 
-		damage: 130,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ポリゴン２",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [474],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/086.ts
+++ b/data-asia/S/S11/086.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "晃晃斑"
+		ja: "パッチール",
+		'zh-tw': "晃晃斑",
 	},
 
 	illustrator: "Souichirou Gunjima",
@@ -14,30 +14,43 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "每一隻身上的斑點都不一樣。會用搖搖晃晃的動作 巧妙地避開對手的攻擊。"
+		ja: "１匹ずつ ブチ模様は 異なる。 フラフラした 動きで 相手の 攻撃を 絶妙に かわすぞ。",
+		'zh-tw': "每一隻身上的斑點都不一樣。會用搖搖晃晃的動作 巧妙地避開對手的攻擊。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "搖晃旋轉"
+	attacks: [
+		{
+			name: {
+				ja: "フラフラスピン",
+				'zh-tw': "搖晃旋轉",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ10ダメージ。相手のバトルポケモンをこんらんにする。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的所有寶可夢各受到10點傷害。將對手的戰鬥寶可夢【混亂】。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "對手的所有寶可夢各受到10點傷害。將對手的戰鬥寶可夢【混亂】。[在備戰區不計算弱點・抵抗力。]"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667961,
+				tcgplayer: 570017,
+			},
 		},
-
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [327],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/087.ts
+++ b/data-asia/S/S11/087.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "捲捲耳"
+		ja: "ミミロル",
+		'zh-tw': "捲捲耳",
 	},
 
 	illustrator: "saino misaki",
@@ -14,31 +14,44 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "將左右兩耳都捲起來時，就代表牠的身體或心情 狀況不佳，需要照顧。"
+		ja: "左右の 耳を 丸めているときは 体や 心の 不調が 原因なので ケアが 必要。",
+		'zh-tw': "將左右兩耳都捲起來時，就代表牠的身體或心情 狀況不佳，需要照顧。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "試跳"
+	attacks: [
+		{
+			name: {
+				ja: "はねてみる",
+				'zh-tw': "試跳",
+			},
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+				'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667962,
+				tcgplayer: 570018,
+			},
 		},
-
-		damage: 30,
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [427],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/088.ts
+++ b/data-asia/S/S11/088.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "長耳兔"
+		ja: "ミミロップ",
+		'zh-tw': "長耳兔",
 	},
 
 	illustrator: "Ryuta Fuse",
@@ -14,38 +14,56 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "總是注意著周圍的狀況。危險逼近時，就會給對手 奉上破壞力十足的踢腿。"
+		ja: "まわりの 様子を つねに 気にして 危険が およぶと 破壊力 抜群の キックを おみまいする。",
+		'zh-tw': "總是注意著周圍的狀況。危險逼近時，就會給對手 奉上破壞力十足的踢腿。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "踢飛"
+	attacks: [
+		{
+			name: {
+				ja: "けとばす",
+				'zh-tw': "踢飛",
+			},
+			damage: 30,
+			cost: ["Colorless"],
 		},
-
-		damage: 30,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "二連踢"
+		{
+			name: {
+				ja: "にどげり",
+				'zh-tw': "二連踢",
+			},
+			damage: "100×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×100ダメージ。",
+				'zh-tw': "擲2次硬幣，造成正面出現的次數×100點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲2次硬幣，造成正面出現的次數×100點傷害。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667963,
+				tcgplayer: 570019,
+			},
 		},
+	],
 
-		damage: "100×",
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ミミロル",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [428],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/089.ts
+++ b/data-asia/S/S11/089.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "爆炸頭水牛"
+		ja: "バッフロン",
+		'zh-tw': "爆炸頭水牛",
 	},
 
 	illustrator: "Nisota Niso",
@@ -14,38 +14,52 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "只用頭錘就能壓扁汽車。頭部的那團毛越大一團， 在群體裡的地位就會越高。"
+		ja: "頭突きだけで 車を 潰す。 頭の 毛が 大きいほど 群れでの 地位が 上がるのだ。",
+		'zh-tw': "只用頭錘就能壓扁汽車。頭部的那團毛越大一團， 在群體裡的地位就會越高。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "放逐頭擊"
+	attacks: [
+		{
+			name: {
+				ja: "ロストヘッド",
+				'zh-tw': "放逐頭擊",
+			},
+			damage: 50,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを1個選び、ロストゾーンに置く。",
+				'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的能量，放置於放逐區。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的能量，放置於放逐區。"
+		{
+			name: {
+				ja: "かいりきホーン",
+				'zh-tw': "怪力角擊",
+			},
+			damage: 120,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 50,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "怪力角擊"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667964,
+				tcgplayer: 570020,
+			},
 		},
-
-		damage: 120,
-		cost: ["Colorless", "Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [626],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/090.ts
+++ b/data-asia/S/S11/090.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "小箭雀"
+		ja: "ヤヤコマ",
+		'zh-tw': "小箭雀",
 	},
 
 	illustrator: "Shibuzoh.",
@@ -14,32 +14,40 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "婉轉的叫聲是在威嚇對方。對於闖入自己地盤的傢伙 會毫不留情地啄個不停。"
+		ja: "美しい さえずりは 威嚇。 縄張りに 入った ものは 容赦なく 突きまくる。",
+		'zh-tw': "婉轉的叫聲是在威嚇對方。對於闖入自己地盤的傢伙 會毫不留情地啄個不停。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "啄"
+	attacks: [
+		{
+			name: {
+				ja: "つつく",
+				'zh-tw': "啄",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
+	],
 
-		damage: 10,
-		cost: ["Colorless"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667965,
+				tcgplayer: 570021,
+			},
+		},
+	],
 
 	retreat: 0,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [661],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S11/091.ts
+++ b/data-asia/S/S11/091.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "道具箱"
+		ja: "ツールボックス",
+		'zh-tw': "道具箱",
 	},
 
 	illustrator: "AYUMI ODASHIMA",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "查看自己的牌庫上方7張卡，從其中選擇任意數量的「寶可夢道具」，在給對手看過後加入手牌。將剩餘卡放回牌庫並重洗。"
+		ja: "自分の山札を上から7枚見て、その中から「ポケモンのどうぐ」を好きなだけ選び、相手に見せて、手札に加える。残りのカードは山札にもどして切る。",
+		'zh-tw': "查看自己的牌庫上方7張卡，從其中選擇任意數量的「寶可夢道具」，在給對手看過後加入手牌。將剩餘卡放回牌庫並重洗。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667966,
+				tcgplayer: 570022,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S11/092.ts
+++ b/data-asia/S/S11/092.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "幻想門"
+		ja: "ミラージュゲート",
+		'zh-tw': "幻想門",
 	},
 
 	illustrator: "sadaji",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "這張卡只有在自己的放逐區有7張以上的卡時才可使用。從自己的牌庫選擇最多2張各不同屬性的基本能量卡，以任意方式附於自己的寶可夢身上。並且重洗牌庫。"
+		ja: "このカードは、自分のロストゾーンにカードが7枚以上あるときにしか使えない。 自分の山札から、それぞれちがうタイプの基本エネルギーを2枚まで選び、自分のポケモンに好きなようにつける。そして山札を切る。",
+		'zh-tw': "這張卡只有在自己的放逐區有7張以上的卡時才可使用。從自己的牌庫選擇最多2張各不同屬性的基本能量卡，以任意方式附於自己的寶可夢身上。並且重洗牌庫。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667967,
+				tcgplayer: 570023,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S11/093.ts
+++ b/data-asia/S/S11/093.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "放逐吸塵器"
+		ja: "ロストスイーパー",
+		'zh-tw': "放逐吸塵器",
 	},
 
 	illustrator: "Toyste Beach",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "這張卡必須將自己的1張手牌放置於放逐區才可使用。從雙方的場上寶可夢身上附加的「寶可夢道具」卡與場上的「競技場」卡中選擇1張，放置於放逐區。"
+		ja: "このカードは、自分の手札を1枚、ロストゾーンに置かなければ使えない。おたがいの場のポケモンについている「ポケモンのどうぐ」と場に出ている「スタジアム」の中から1枚選び、ロストゾーンに置く。",
+		'zh-tw': "這張卡必須將自己的1張手牌放置於放逐區才可使用。從雙方的場上寶可夢身上附加的「寶可夢道具」卡與場上的「競技場」卡中選擇1張，放置於放逐區。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667968,
+				tcgplayer: 570024,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S11/094.ts
+++ b/data-asia/S/S11/094.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "恐慌面具"
+		ja: "パニックマスク",
+		'zh-tw': "恐慌面具",
 	},
 
 	illustrator: "Studio Bora Inc.",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。"
+		ja: "このカードをつけているポケモンは、残りHPが「40」以下の相手のポケモンから、ワザのダメージを受けない。",
+		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667969,
+				tcgplayer: 570025,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Tool",
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S11/095.ts
+++ b/data-asia/S/S11/095.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "阿克羅瑪的實驗"
+		ja: "アクロマの実験",
+		'zh-tw': "阿克羅瑪的實驗",
 	},
 
 	illustrator: "Naoki Saito",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "查看自己的牌庫上方5張卡，選擇其中3張卡加入手牌。將剩餘卡放置於放逐區。"
+		ja: "自分の山札を上から5枚見て、その中からカードを3枚選び、手札に加える。残りのカードはロストゾーンに置く。",
+		'zh-tw': "查看自己的牌庫上方5張卡，選擇其中3張卡加入手牌。將剩餘卡放置於放逐區。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667970,
+				tcgplayer: 570026,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S11/096.ts
+++ b/data-asia/S/S11/096.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "千金小姐"
+		ja: "おじょうさま",
+		'zh-tw': "千金小姐",
 	},
 
 	illustrator: "saino misaki",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的牌庫選擇最多4張基本能量卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		ja: "自分の山札にある基本エネルギーを4枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+		'zh-tw': "從自己的牌庫選擇最多4張基本能量卡，在給對手看過後加入手牌。並且重洗牌庫。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667971,
+				tcgplayer: 570027,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S11/097.ts
+++ b/data-asia/S/S11/097.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "捩木"
+		ja: "ネジキ",
+		'zh-tw': "捩木",
 	},
 
 	illustrator: "Hideki Ishikawa",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的棄牌區選擇1張【基礎】寶可夢卡，與自己的場上的1隻【基礎】寶可夢互換（所附加的卡・傷害指示物・特殊狀態・效果等全部保留）。將換下的寶可夢丟棄。"
+		ja: "自分のトラッシュからたねポケモンを1枚選び、自分の場のたねポケモン1匹と入れ替える（ついているカード・ダメカン・特殊状態・効果などは、すべて引きつぐ）。入れ替えたポケモンはトラッシュする。",
+		'zh-tw': "從自己的棄牌區選擇1張【基礎】寶可夢卡，與自己的場上的1隻【基礎】寶可夢互換（所附加的卡・傷害指示物・特殊狀態・效果等全部保留）。將換下的寶可夢丟棄。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667972,
+				tcgplayer: 570028,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S11/098.ts
+++ b/data-asia/S/S11/098.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "梅麗莎"
+		ja: "メリッサ",
+		'zh-tw': "梅麗莎",
 	},
 
 	illustrator: "Ryuta Fuse",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "這張卡只有在自己的放逐區有10張以上的卡時才可使用。在下個對手的回合，自己的所有寶可夢受到對手的「寶可夢【V】」招式的傷害「-120」點。（包含新上場的寶可夢。）"
+		ja: "このカードは、自分のロストゾーンにカードが10枚以上あるときにしか使えない。次の相手の番、自分のポケモン全員が、相手の「ポケモンV」から受けるワザのダメージは「-120」される。（新しく場に出したポケモンもふくむ。）",
+		'zh-tw': "這張卡只有在自己的放逐區有10張以上的卡時才可使用。在下個對手的回合，自己的所有寶可夢受到對手的「寶可夢【V】」招式的傷害「-120」點。（包含新上場的寶可夢。）",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667973,
+				tcgplayer: 570029,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S11/099.ts
+++ b/data-asia/S/S11/099.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "放逐市"
+		ja: "ロストシティ",
+		'zh-tw': "放逐市",
 	},
 
 	illustrator: "AYUMI ODASHIMA",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "每次當雙方的寶可夢【氣絕】時，不丟棄那隻寶可夢，而是放置於放逐區。（寶可夢以外的卡全部丟棄。）"
+		ja: "おたがいのポケモンがきぜつするたび、そのポケモンはトラッシュせずに、ロストゾーンに置く。（ポケモン以外のカードは、すべてトラッシュする。）",
+		'zh-tw': "每次當雙方的寶可夢【氣絕】時，不丟棄那隻寶可夢，而是放置於放逐區。（寶可夢以外的卡全部丟棄。）",
 	},
 
-	trainerType: "Stadium",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667974,
+				tcgplayer: 570030,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Stadium",
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S11/100.ts
+++ b/data-asia/S/S11/100.ts
@@ -1,21 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S11"
+import { Card } from "../../../interfaces";
+import Set from "../S11";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "禮品能量"
+		ja: "ギフトエネルギー",
+		'zh-tw': "禮品能量",
 	},
 
+	illustrator: "",
 	category: "Energy",
+	energyType: "Special",
 
 	effect: {
-		'zh-tw': "只要這張卡附於寶可夢身上，視為提供1個【無】能量。 當附有這張卡的寶可夢受到對手的寶可夢招式的傷害而【氣絕】時，從牌庫抽卡直到自己的手牌滿7張為止。"
+		ja: "このカードは、ポケモンについているかぎり、[C]エネルギー1個ぶんとしてはたらく。このカードをつけているポケモンが、相手のポケモンからワザのダメージを受けてきぜつしたとき、自分の手札が7枚になるように、山札を引く。",
+		'zh-tw': "只要這張卡附於寶可夢身上，視為提供1個【無】能量。 當附有這張卡的寶可夢受到對手的寶可夢招式的傷害而【氣絕】時，從牌庫抽卡直到自己的手牌滿7張為止。",
 	},
 
-	energyType: "Special",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 667975,
+				tcgplayer: 570031,
+			},
+		},
+	],
 
-export default card
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S11/101.ts
+++ b/data-asia/S/S11/101.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マフォクシーV",
+	},
+
+	illustrator: "PLANETA Yamashita",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あやしいともしび" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどとこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "マジカルファイヤー" },
+			damage: 120,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個、ロストゾーンに置き、相手のベンチポケモン1匹にも、120ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 668219,
+				tcgplayer: 570032,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [655],
+};
+
+export default card;

--- a/data-asia/S/S11/102.ts
+++ b/data-asia/S/S11/102.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キュレムV",
+	},
+
+	illustrator: "takuyoa",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きゅうげきれいとう" },
+			cost: ["Water"],
+			effect: {
+				ja: "自分の手札から[W]エネルギーを好きなだけ選び、自分のポケモンに好きなようにつける。",
+			},
+		},
+		{
+			name: { ja: "フロストスマッシュ" },
+			damage: 140,
+			cost: ["Water", "Water", "Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 668220,
+				tcgplayer: 570033,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [646],
+};
+
+export default card;

--- a/data-asia/S/S11/103.ts
+++ b/data-asia/S/S11/103.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロトムV",
+	},
+
+	illustrator: "PLANETA Mochizuki",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "そくせきじゅうでん" },
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、自分の番は終わる。自分の山札を3枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スクラップショート" },
+			damage: "40+",
+			cost: ["Lightning", "Lightning"],
+			effect: {
+				ja: "自分のトラッシュにある「ポケモンのどうぐ」を好きなだけロストゾーンに置き、その枚数×40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 668221,
+				tcgplayer: 570034,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [479],
+};
+
+export default card;

--- a/data-asia/S/S11/104.ts
+++ b/data-asia/S/S11/104.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロトムV",
+	},
+
+	illustrator: "Yuu Nishida",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "そくせきじゅうでん" },
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、自分の番は終わる。自分の山札を3枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スクラップショート" },
+			damage: "40+",
+			cost: ["Lightning", "Lightning"],
+			effect: {
+				ja: "自分のトラッシュにある「ポケモンのどうぐ」を好きなだけロストゾーンに置き、その枚数×40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 668222,
+				tcgplayer: 570035,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [479],
+};
+
+export default card;

--- a/data-asia/S/S11/105.ts
+++ b/data-asia/S/S11/105.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プテラV",
+	},
+
+	illustrator: "N-DESIGN Inc.",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かみつく" },
+			damage: 40,
+			cost: ["Fighting", "Colorless"],
+		},
+		{
+			name: { ja: "ロッククラッシュ" },
+			damage: 120,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 668223,
+				tcgplayer: 570036,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [142],
+};
+
+export default card;

--- a/data-asia/S/S11/106.ts
+++ b/data-asia/S/S11/106.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プテラV",
+	},
+
+	illustrator: "Nurikabe",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かみつく" },
+			damage: 40,
+			cost: ["Fighting", "Colorless"],
+		},
+		{
+			name: { ja: "ロッククラッシュ" },
+			damage: 120,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 668224,
+				tcgplayer: 570037,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [142],
+};
+
+export default card;

--- a/data-asia/S/S11/107.ts
+++ b/data-asia/S/S11/107.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドラピオンV",
+	},
+
+	illustrator: "N-DESIGN Inc.",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ワイルドスタイル" },
+			effect: {
+				ja: "相手の場の「いちげき」「れんげき」「フュージョン」のポケモンの数ぶん、このポケモンがワザを使うための[C]エネルギーは少なくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ダイナミックテール" },
+			damage: 190,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のポケモン1匹にも、60ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 668225,
+				tcgplayer: 570038,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [452],
+};
+
+export default card;

--- a/data-asia/S/S11/108.ts
+++ b/data-asia/S/S11/108.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガラル ニャイキングV",
+	},
+
+	illustrator: "PLANETA Yamashita",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "じょうきげん" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を3枚引く。",
+			},
+		},
+		{
+			name: { ja: "おたからラッシュ" },
+			damage: "20×",
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "自分の手札の枚数×20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 668226,
+				tcgplayer: 570039,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [863],
+};
+
+export default card;

--- a/data-asia/S/S11/109.ts
+++ b/data-asia/S/S11/109.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガラル ニャイキングV",
+	},
+
+	illustrator: "GOSSAN",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "じょうきげん" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を3枚引く。",
+			},
+		},
+		{
+			name: { ja: "おたからラッシュ" },
+			damage: "20×",
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "自分の手札の枚数×20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 668227,
+				tcgplayer: 570040,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [863],
+};
+
+export default card;

--- a/data-asia/S/S11/110.ts
+++ b/data-asia/S/S11/110.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ギラティナV",
+	},
+
+	illustrator: "N-DESIGN Inc.",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アビスシーク" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を上から4枚見て、その中からカードを2枚選び、手札に加える。残りのカードはロストゾーンに置く。",
+			},
+		},
+		{
+			name: { ja: "ひきさく" },
+			damage: 160,
+			cost: ["Grass", "Psychic", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 668228,
+				tcgplayer: 570041,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [487],
+};
+
+export default card;

--- a/data-asia/S/S11/111.ts
+++ b/data-asia/S/S11/111.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ギラティナV",
+	},
+
+	illustrator: "Shinji Kanda",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アビスシーク" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を上から4枚見て、その中からカードを2枚選び、手札に加える。残りのカードはロストゾーンに置く。",
+			},
+		},
+		{
+			name: { ja: "ひきさく" },
+			damage: 160,
+			cost: ["Grass", "Psychic", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 668229,
+				tcgplayer: 570042,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [487],
+};
+
+export default card;

--- a/data-asia/S/S11/112.ts
+++ b/data-asia/S/S11/112.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピジョットV",
+	},
+
+	illustrator: "Saki Hayashiro",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "きえさるつばさ" },
+			effect: {
+				ja: "このポケモンがベンチにいるなら、自分の番に1回使える。このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "フライトサーフ" },
+			damage: "80+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "場に自分のスタジアムが出ているなら、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 668230,
+				tcgplayer: 570043,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [18],
+};
+
+export default card;

--- a/data-asia/S/S11/113.ts
+++ b/data-asia/S/S11/113.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクロマの実験",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から5枚見て、その中からカードを3枚選び、手札に加える。残りのカードはロストゾーンに置く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 668231,
+				tcgplayer: 570044,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S11/114.ts
+++ b/data-asia/S/S11/114.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "おじょうさま",
+	},
+
+	illustrator: "saino misaki",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある基本エネルギーを4枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 668232,
+				tcgplayer: 570045,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S11/115.ts
+++ b/data-asia/S/S11/115.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネジキ",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュからたねポケモンを1枚選び、自分の場のたねポケモン1匹と入れ替える（ついているカード・ダメカン・特殊状態・効果などは、すべて引きつぐ）。入れ替えたポケモンはトラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 668233,
+				tcgplayer: 570046,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S11/116.ts
+++ b/data-asia/S/S11/116.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メリッサ",
+	},
+
+	illustrator: "Ryuta Fuse",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分のロストゾーンにカードが10枚以上あるときにしか使えない。次の相手の番、自分のポケモン全員が、相手の「ポケモンV」から受けるワザのダメージは「-120」される。（新しく場に出したポケモンもふくむ。）",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 668234,
+				tcgplayer: 570047,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S11/117.ts
+++ b/data-asia/S/S11/117.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キュレムVMAX",
+	},
+
+	illustrator: "N-DESIGN Inc.",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Water"],
+
+	stage: "VMAX",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はくぎんせかい" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を上から1枚トラッシュし、そのカードが[W]エネルギーなら、自分のポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ダイフロスト" },
+			damage: "120+",
+			cost: ["Water", "Water", "Water"],
+			effect: {
+				ja: "このポケモンについている[W]エネルギーを好きなだけトラッシュし、その枚数×50ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 668235,
+				tcgplayer: 570049,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キュレムV",
+	},
+
+	retreat: 3,
+	regulationMark: "F",
+	rarity: "Holo Rare",
+	dexId: [646],
+};
+
+export default card;

--- a/data-asia/S/S11/118.ts
+++ b/data-asia/S/S11/118.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プテラVSTAR",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Fighting"],
+
+	stage: "VSTAR",
+
+	attacks: [
+		{
+			name: { ja: "ロストダイブ" },
+			damage: 240,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札を上から3枚、ロストゾーンに置く。",
+			},
+		},
+		{
+			name: { ja: "エンシェントスター" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンは、場をはなれるまで「相手の場の『ポケモンV』（『プテラVSTAR』をのぞく）の特性は、すべてなくなる。」という効果の特性を持つ。［対戦中、自分はVSTARパワーを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 668236,
+				tcgplayer: 570048,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "プテラV",
+	},
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Holo Rare",
+	dexId: [142],
+};
+
+export default card;

--- a/data-asia/S/S11/119.ts
+++ b/data-asia/S/S11/119.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドラピオンVSTAR",
+	},
+
+	illustrator: "PLANETA Mochizuki",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Darkness"],
+
+	stage: "VSTAR",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ハザードスター" },
+			effect: {
+				ja: "自分の番に使える。相手のバトルポケモンをどくとマヒにする。このどくでのせるダメカンの数は3個になる。［対戦中、自分はVSTARパワーを1回しか使えない。］",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ビッグバンアーム 250-" },
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数×10ダメージぶん、このワザのダメージは小さくなる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 668237,
+				tcgplayer: 570050,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ドラピオンV",
+	},
+
+	retreat: 3,
+	regulationMark: "F",
+	rarity: "Holo Rare",
+	dexId: [452],
+};
+
+export default card;

--- a/data-asia/S/S11/120.ts
+++ b/data-asia/S/S11/120.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ギラティナVSTAR",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Dragon"],
+
+	stage: "VSTAR",
+
+	attacks: [
+		{
+			name: { ja: "ロストインパクト" },
+			damage: 280,
+			cost: ["Grass", "Psychic", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについているエネルギーを2個選び、ロストゾーンに置く。",
+			},
+		},
+		{
+			name: { ja: "スターレクイエム" },
+			cost: ["Grass", "Psychic"],
+			effect: {
+				ja: "このワザは、自分のロストゾーンにカードが10枚以上あるときにしか使えない。相手のバトルポケモンをきぜつさせる。［対戦中、自分はVSTARパワーを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 668238,
+				tcgplayer: 570051,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ギラティナV",
+	},
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Holo Rare",
+	dexId: [487],
+};
+
+export default card;

--- a/data-asia/S/S11/121.ts
+++ b/data-asia/S/S11/121.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アクロマの実験",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から5枚見て、その中からカードを3枚選び、手札に加える。残りのカードはロストゾーンに置く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 668239,
+				tcgplayer: 570052,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Holo Rare",
+};
+
+export default card;

--- a/data-asia/S/S11/122.ts
+++ b/data-asia/S/S11/122.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "おじょうさま",
+	},
+
+	illustrator: "saino misaki",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にある基本エネルギーを4枚まで、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 668240,
+				tcgplayer: 570053,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Holo Rare",
+};
+
+export default card;

--- a/data-asia/S/S11/123.ts
+++ b/data-asia/S/S11/123.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネジキ",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュからたねポケモンを1枚選び、自分の場のたねポケモン1匹と入れ替える（ついているカード・ダメカン・特殊状態・効果などは、すべて引きつぐ）。入れ替えたポケモンはトラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 668241,
+				tcgplayer: 570054,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Holo Rare",
+};
+
+export default card;

--- a/data-asia/S/S11/124.ts
+++ b/data-asia/S/S11/124.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メリッサ",
+	},
+
+	illustrator: "Ryuta Fuse",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分のロストゾーンにカードが10枚以上あるときにしか使えない。次の相手の番、自分のポケモン全員が、相手の「ポケモンV」から受けるワザのダメージは「-120」される。（新しく場に出したポケモンもふくむ。）",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 668242,
+				tcgplayer: 570055,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Holo Rare",
+};
+
+export default card;

--- a/data-asia/S/S11/125.ts
+++ b/data-asia/S/S11/125.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ギラティナVSTAR",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Dragon"],
+
+	stage: "VSTAR",
+
+	attacks: [
+		{
+			name: { ja: "ロストインパクト" },
+			damage: 280,
+			cost: ["Grass", "Psychic", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについているエネルギーを2個選び、ロストゾーンに置く。",
+			},
+		},
+		{
+			name: { ja: "スターレクイエム" },
+			cost: ["Grass", "Psychic"],
+			effect: {
+				ja: "このワザは、自分のロストゾーンにカードが10枚以上あるときにしか使えない。相手のバトルポケモンをきぜつさせる。［対戦中、自分はVSTARパワーを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 668243,
+				tcgplayer: 570056,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ギラティナV",
+	},
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Mega Hyper Rare",
+	dexId: [487],
+};
+
+export default card;

--- a/data-asia/S/S11/126.ts
+++ b/data-asia/S/S11/126.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロストスイーパー",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を1枚、ロストゾーンに置かなければ使えない。おたがいの場のポケモンについている「ポケモンのどうぐ」と場に出ている「スタジアム」の中から1枚選び、ロストゾーンに置く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 668244,
+				tcgplayer: 570057,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "F",
+	rarity: "Mega Hyper Rare",
+};
+
+export default card;

--- a/data-asia/S/S11/127.ts
+++ b/data-asia/S/S11/127.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S11";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "崩れたスタジアム",
+	},
+
+	illustrator: "Oswaldo KATO",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーがベンチに出せるポケモンの数は、4匹になる。［ベンチの数を変更する効果は、少ない数が優先される。］（このカードが場に出たとき、ベンチが5匹以上いるプレイヤーは、4匹になるまでトラッシュする。トラッシュするのは、このカードの持ち主から。）",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 668245,
+				tcgplayer: 570058,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "F",
+	rarity: "Mega Hyper Rare",
+};
+
+export default card;

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -236,6 +236,7 @@ export interface Card {
 			// Black White rare
 			| 'Black White Rare'
 			| 'Mega Hyper Rare'
+			| 'Triple Rare'
 			// Japanese Character Rares (since SM11b Dream League)
 			| 'Character Rare' | 'Character Super Rare'
 			// Pokémon TCG Pocket Rarities


### PR DESCRIPTION
## What

Refreshes the existing Japanese set **S11 ロストアビス (Lost Abyss)** from its primary sources. The curated content stays: every card keeps its `zh-tw` texts verbatim.

What changes across the 127 card files:

- `thirdParty.cardmarket` moves onto `variants` objects and 100 missing ids are filled in
- per card where missing: `dexId`, `evolveFrom`, `resistances`, the Japanese flavor text and the Japanese effect/attack texts straight from the official database and limitless

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (667561–668245)
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (569932–570058), keyed by the collection number each product carries in `extendedData`

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- All 127 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
