### PR TITLE
(data) Update Japanese S set S10P Space Juggler

### DIFF
--- a/data-asia/S/S10P/001.ts
+++ b/data-asia/S/S10P/001.ts
@@ -1,50 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "大針蜂V"
+		ja: "スピアーV",
+		'zh-tw': "大針蜂V",
 	},
 
 	illustrator: "Ayaka Yoshida",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Grass"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "雙針"
+	attacks: [
+		{
+			name: {
+				ja: "ダブルニードル",
+				'zh-tw': "雙針",
+			},
+			damage: "40×",
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×40ダメージ。",
+				'zh-tw': "擲2次硬幣，造成正面出現的次數×40點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲2次硬幣，造成正面出現的次數×40點傷害。"
+		{
+			name: {
+				ja: "むれでさす",
+				'zh-tw': "群起刺擊",
+			},
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、自分の場の｢スピアーV｣の数×50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的1隻寶可夢，受到自己的場上「大針蜂【V】」的數量×50點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		damage: "40×",
-		cost: ["Grass"]
-	}, {
-		name: {
-			'zh-tw': "群起刺擊"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651060,
+				tcgplayer: 569844,
+			},
 		},
-
-		effect: {
-			'zh-tw': "對手的1隻寶可夢，受到自己的場上「大針蜂【V】」的數量×50點傷害。[在備戰區不計算弱點・抵抗力。]"
-		},
-
-		cost: ["Grass", "Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Double rare",
+	dexId: [15],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/002.ts
+++ b/data-asia/S/S10P/002.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洗翠 霹靂電球"
+		ja: "ヒスイ ビリリダマ",
+		'zh-tw': "洗翠 霹靂電球",
 	},
 
 	illustrator: "nagimiso",
@@ -14,35 +14,51 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "形狀頗似精靈球的奇異寶可夢。 當情緒高漲時，積蓄在腹部的 電流就會放出，同時發出大笑。"
+		ja: "モンスターボールと 空似せし 謎の ポケモン。 気 昂るほど 腹に 蓄えし電流を 解き放ち 大笑す。",
+		'zh-tw': "形狀頗似精靈球的奇異寶可夢。 當情緒高漲時，積蓄在腹部的 電流就會放出，同時發出大笑。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "精心充能"
+	attacks: [
+		{
+			name: {
+				ja: "ごきげんチャージ",
+				'zh-tw': "精心充能",
+			},
+			cost: [],
+			effect: {
+				ja: "このワザは、後攻プレイヤーの最初の番にだけ使える。自分のベンチポケモンを2匹まで選び、山札から基本エネルギーを1枚ずつつける。そして山札を切る。",
+				'zh-tw': "這個招式只可在後攻玩家的最初回合使用。選擇最多2隻自己的備戰寶可夢，從牌庫附給那些寶可夢各1張基本能量卡。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "這個招式只可在後攻玩家的最初回合使用。選擇最多2隻自己的備戰寶可夢，從牌庫附給那些寶可夢各1張基本能量卡。並且重洗牌庫。"
-		}
-	}, {
-		name: {
-			'zh-tw': "衝撞"
+		{
+			name: {
+				ja: "ぶつかる",
+				'zh-tw': "衝撞",
+			},
+			damage: 10,
+			cost: ["Grass"],
 		},
+	],
 
-		damage: 10,
-		cost: ["Grass"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651061,
+				tcgplayer: 569845,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [100],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/003.ts
+++ b/data-asia/S/S10P/003.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洗翠 頑皮雷彈"
+		ja: "ヒスイ マルマイン",
+		'zh-tw': "洗翠 頑皮雷彈",
 	},
 
 	illustrator: "Akira Komayama",
@@ -14,34 +14,55 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "體表的組織與球果的成分極為接近， 不可思議。當牠情緒焦躁時所放出 的電流，能量足以匹敵２０次的落雷。"
+		ja: "体表の組織 ぼんぐりの成分と 極めて 近く 不思議。 苛立ちしときに 放つ 電流は 落雷 ２０回分に 匹敵す。",
+		'zh-tw': "體表的組織與球果的成分極為接近， 不可思議。當牠情緒焦躁時所放出 的電流，能量足以匹敵２０次的落雷。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "三重抽出"
+	attacks: [
+		{
+			name: {
+				ja: "トリプルドロー",
+				'zh-tw': "三重抽出",
+			},
+			cost: [],
+			effect: {
+				ja: "自分の山札を3枚引く。",
+				'zh-tw': "從自己的牌庫抽出3張卡。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫抽出3張卡。"
-		}
-	}, {
-		name: {
-			'zh-tw': "煩煩炸彈"
+		{
+			name: {
+				ja: "イライラボム",
+				'zh-tw': "煩煩炸彈",
+			},
+			damage: 50,
+			cost: [],
 		},
+	],
 
-		damage: 50
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651062,
+				tcgplayer: 569846,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒスイ ビリリダマ",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [101],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/004.ts
+++ b/data-asia/S/S10P/004.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "圓法師"
+		ja: "コロボーシ",
+		'zh-tw': "圓法師",
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -14,31 +14,44 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "觸角之間互相碰撞時， 會叮叮咚咚地奏出 如同木琴一般的音色。"
+		ja: "触角 同士が ぶつかると コロン コロンと 木琴に 似た 音色を 奏でる。",
+		'zh-tw': "觸角之間互相碰撞時， 會叮叮咚咚地奏出 如同木琴一般的音色。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "打滾"
+	attacks: [
+		{
+			name: {
+				ja: "ころばす",
+				'zh-tw': "打滾",
+			},
+			damage: "10+",
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+				'zh-tw': "擲1次硬幣若為正面，則增加20點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則增加20點傷害。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651063,
+				tcgplayer: 569847,
+			},
 		},
-
-		damage: "10+",
-		cost: ["Grass"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [401],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/005.ts
+++ b/data-asia/S/S10P/005.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "音箱蟀"
+		ja: "コロトック",
+		'zh-tw': "音箱蟀",
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -14,39 +14,58 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "用短刀般的手臂發出聲音。所奏出 的旋律隨個體不同而異，從中尋找 自己喜愛的旋律也是一大樂事。"
+		ja: "短刀の如き 腕で 音を 発す。 メロディは 個体に よりけりゆえ 好みを 探すも 乙なり。",
+		'zh-tw': "用短刀般的手臂發出聲音。所奏出 的旋律隨個體不同而異，從中尋找 自己喜愛的旋律也是一大樂事。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "充溢旋律"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "みなぎるせんりつ",
+				'zh-tw': "充溢旋律",
+			},
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の場の[G]ポケモン（「コロトック」をのぞく）全員の最大HPは、それぞれ「40」大きくなる。この効果は、この特性を持つポケモンが何匹いても、重ならない。",
+				'zh-tw': "只要這隻寶可夢在場上，自己的場上的所有【草】寶可夢（「音箱蟀」除外）的最大HP各增加「40」。無論有多少隻擁有這個特性的寶可夢，這個效果也不會重複。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在場上，自己的場上的所有【草】寶可夢（「音箱蟀」除外）的最大HP各增加「40」。無論有多少隻擁有這個特性的寶可夢，這個效果也不會重複。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "劈開"
+	attacks: [
+		{
+			name: {
+				ja: "きりさく",
+				'zh-tw': "劈開",
+			},
+			damage: 50,
+			cost: ["Grass", "Colorless"],
 		},
+	],
 
-		damage: 50,
-		cost: ["Grass", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651064,
+				tcgplayer: 569848,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コロボーシ",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [402],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/006.ts
+++ b/data-asia/S/S10P/006.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "木木梟"
+		ja: "モクロー",
+		'zh-tw': "木木梟",
 	},
 
 	illustrator: "kawayoo",
@@ -14,31 +14,44 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "靠一對柔韌的翅膀悄然無聲地飛行。 有著用翅膀將鋒利程度不遜於小刀 的羽毛巧妙地發射出去的本領。"
+		ja: "たおやかなる 翼 備え 無音にて 飛翔す。 小刀に比肩す 鋭利なる羽根 翼より 巧みに 飛ばす技 体得す。",
+		'zh-tw': "靠一對柔韌的翅膀悄然無聲地飛行。 有著用翅膀將鋒利程度不遜於小刀 的羽毛巧妙地發射出去的本領。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "飛撲"
+	attacks: [
+		{
+			name: {
+				ja: "とびつく",
+				'zh-tw': "飛撲",
+			},
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、10ダメージ追加。",
+				'zh-tw': "擲1次硬幣若為正面，則增加10點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則增加10點傷害。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651065,
+				tcgplayer: 569849,
+			},
 		},
-
-		damage: "10+",
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [722],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/007.ts
+++ b/data-asia/S/S10P/007.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "投羽梟"
+		ja: "フクスロー",
+		'zh-tw': "投羽梟",
 	},
 
 	illustrator: "0313",
@@ -14,34 +14,52 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "經常為了積蓄力量而沐浴陽光。吾人推測 這是因為當地氣候較為寒冷，然而藏於 雙翅中的刃羽鋒利程度並無不同。"
+		ja: "陽の光 浴び 力 溜めしこと 多し。 寒冷な気候 原因と 察するも 両翼に 仕込みし 刃羽根の切れ味 変化なし。",
+		'zh-tw': "經常為了積蓄力量而沐浴陽光。吾人推測 這是因為當地氣候較為寒冷，然而藏於 雙翅中的刃羽鋒利程度並無不同。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "羽擊"
+	attacks: [
+		{
+			name: {
+				ja: "はばたく",
+				'zh-tw': "羽擊",
+			},
+			damage: 30,
+			cost: ["Colorless"],
 		},
-
-		damage: 30,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "銳利羽"
+		{
+			name: {
+				ja: "するどいはね",
+				'zh-tw': "銳利羽",
+			},
+			damage: 60,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 60,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651066,
+				tcgplayer: 569850,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "モクロー",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [723],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/008.ts
+++ b/data-asia/S/S10P/008.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "索偵蟲"
+		ja: "サッチムシ",
+		'zh-tw': "索偵蟲",
 	},
 
 	illustrator: "Asako Ito",
@@ -14,27 +14,40 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "總是孜孜不倦地收集情報，所以頭腦相當地聰明， 但是力量方面就差了一些。"
+		ja: "いつも せっせと 情報を 集めているので 賢い。 ただし 力は いまいちだ。",
+		'zh-tw': "總是孜孜不倦地收集情報，所以頭腦相當地聰明， 但是力量方面就差了一些。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "咬"
+	attacks: [
+		{
+			name: {
+				ja: "かじる",
+				'zh-tw': "咬",
+			},
+			damage: 30,
+			cost: ["Grass", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Grass", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651067,
+				tcgplayer: 569851,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [824],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/009.ts
+++ b/data-asia/S/S10P/009.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "天罩蟲"
+		ja: "レドームシ",
+		'zh-tw': "天罩蟲",
 	},
 
 	illustrator: "Kyoko Umemoto",
@@ -14,31 +14,48 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "雖然幾乎從來不動但還是活著的。牠的超能力似乎是在縮在殼裡 不吃不喝的過程中覺醒的。"
+		ja: "ほぼ 動かないが 生きている。 飲まず食わずで 殻に こもるうち 超能力に 目覚めたらしい。",
+		'zh-tw': "雖然幾乎從來不動但還是活著的。牠的超能力似乎是在縮在殼裡 不吃不喝的過程中覺醒的。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "屏障攻擊"
+	attacks: [
+		{
+			name: {
+				ja: "バリアアタック",
+				'zh-tw': "屏障攻擊",
+			},
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-30」點。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-30」點。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651068,
+				tcgplayer: 569852,
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "サッチムシ",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [825],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/010.ts
+++ b/data-asia/S/S10P/010.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "以歐路普"
+		ja: "イオルブ",
+		'zh-tw': "以歐路普",
 	},
 
 	illustrator: "yuu",
@@ -14,43 +14,62 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "以頭腦聰慧而聞名。大大的腦子是牠擁有 出眾精神力量的證明。"
+		ja: "賢い ポケモンとして 有名。 大きな 脳みそは 強力な サイコパワーを もつ 証し。",
+		'zh-tw': "以頭腦聰慧而聞名。大大的腦子是牠擁有 出眾精神力量的證明。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "阻礙貼附"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ジャミングアタッチ",
+				'zh-tw': "阻礙貼附",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のトラッシュからエネルギーを3枚まで選び、相手のポケモンに好きなようにつける。",
+				'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。從對手的棄牌區選擇最多3張能量卡，以任意方式附於對手的寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。從對手的棄牌區選擇最多3張能量卡，以任意方式附於對手的寶可夢身上。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "神秘波"
+	attacks: [
+		{
+			name: {
+				ja: "ミステリーウェーブ",
+				'zh-tw': "神秘波",
+			},
+			damage: "30+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数×50ダメージ追加。",
+				'zh-tw': "增加對手的戰鬥寶可夢身上附加的能量的數量×50點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加對手的戰鬥寶可夢身上附加的能量的數量×50點傷害。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651069,
+				tcgplayer: 569853,
+			},
 		},
+	],
 
-		damage: "30+",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "レドームシ",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [826],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/011.ts
+++ b/data-asia/S/S10P/011.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "小火馬"
+		ja: "ポニータ",
+		'zh-tw': "小火馬",
 	},
 
 	illustrator: "Jiro Sasumo",
@@ -14,27 +14,40 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "在草原上群居生活。剛誕生的 幼崽身上沒有火焰鬃毛，而是會 在出生後一小時左右長出來。"
+		ja: "草原にて 群れを成し 暮らす。 産まれたての仔に 炎のたてがみは 無く １時間ほどで 生えそろう。",
+		'zh-tw': "在草原上群居生活。剛誕生的 幼崽身上沒有火焰鬃毛，而是會 在出生後一小時左右長出來。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "火之尾"
+	attacks: [
+		{
+			name: {
+				ja: "ほのおのしっぽ",
+				'zh-tw': "火之尾",
+			},
+			damage: 20,
+			cost: ["Fire"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Fire"]
-	}],
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651070,
+				tcgplayer: 569854,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [77],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/012.ts
+++ b/data-asia/S/S10P/012.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "烈焰馬"
+		ja: "ギャロップ",
+		'zh-tw': "烈焰馬",
 	},
 
 	illustrator: "Ligton",
@@ -14,38 +14,56 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "任由燃燒的鬃毛隨風飄揚，以每小時２４０公里的速度 在大草原上自在奔馳。"
+		ja: "燃える たてがみを はためかせ 時速 ２４０キロの 速度で 大草原を 駆けぬけるのだ。",
+		'zh-tw': "任由燃燒的鬃毛隨風飄揚，以每小時２４０公里的速度 在大草原上自在奔馳。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "烈焰"
+	attacks: [
+		{
+			name: {
+				ja: "かえん",
+				'zh-tw': "烈焰",
+			},
+			damage: 30,
+			cost: ["Fire"],
 		},
-
-		damage: 30,
-		cost: ["Fire"]
-	}, {
-		name: {
-			'zh-tw': "火焰陣"
+		{
+			name: {
+				ja: "フレイムサークル",
+				'zh-tw': "火焰陣",
+			},
+			damage: 50,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。次の相手の番、このワザを受けたポケモンは、にげられない。",
+				'zh-tw': "將對手的戰鬥寶可夢【灼傷】。在下個對手的回合，受到這個招式的寶可夢無法撤退。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【灼傷】。在下個對手的回合，受到這個招式的寶可夢無法撤退。"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651071,
+				tcgplayer: 569855,
+			},
 		},
+	],
 
-		damage: 50,
-		cost: ["Fire", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ポニータ",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [78],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/013.ts
+++ b/data-asia/S/S10P/013.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "煤炭龜"
+		ja: "コータス",
+		'zh-tw': "煤炭龜",
 	},
 
 	illustrator: "Naoyo Kimura",
@@ -14,38 +14,52 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "會在甲殼中燃燒煤炭產生能量。遇到危機時 會噴出黑色的煤煙。"
+		ja: "甲羅の 中で 石炭を 燃やし エネルギーに している。 ピンチの ときは 黒い ススを 噴き出す。",
+		'zh-tw': "會在甲殼中燃燒煤炭產生能量。遇到危機時 會噴出黑色的煤煙。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "踩"
+	attacks: [
+		{
+			name: {
+				ja: "ふむ",
+				'zh-tw': "踩",
+			},
+			damage: 30,
+			cost: ["Fire", "Colorless"],
 		},
-
-		damage: 30,
-		cost: ["Fire", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "噴射火焰"
+		{
+			name: {
+				ja: "かえんほうしゃ",
+				'zh-tw': "噴射火焰",
+			},
+			damage: 130,
+			cost: ["Fire", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651072,
+				tcgplayer: 569856,
+			},
 		},
-
-		damage: 130,
-		cost: ["Fire", "Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [324],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/014.ts
+++ b/data-asia/S/S10P/014.ts
@@ -1,51 +1,64 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "席多藍恩V"
+		ja: "ヒードランV",
+		'zh-tw': "席多藍恩V",
 	},
 
 	illustrator: "Mitsuhiro Arita",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Fire"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "熱灼燒"
+	attacks: [
+		{
+			name: {
+				ja: "ねつでこがす",
+				'zh-tw': "熱灼燒",
+			},
+			damage: 30,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【灼傷】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【灼傷】。"
+		{
+			name: {
+				ja: "マグマフォール",
+				'zh-tw': "熔岩墜落",
+			},
+			damage: "90+",
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "場に自分のスタジアムが出ているなら、90ダメージ追加。",
+				'zh-tw': "若場上有自己的競技場卡，則增加90點傷害。",
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Fire", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "熔岩墜落"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651073,
+				tcgplayer: 569857,
+			},
 		},
-
-		effect: {
-			'zh-tw': "若場上有自己的競技場卡，則增加90點傷害。"
-		},
-
-		damage: "90+",
-		cost: ["Fire", "Fire", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	],
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Double rare",
+	dexId: [485],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/015.ts
+++ b/data-asia/S/S10P/015.ts
@@ -1,51 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "席多藍恩VMAX"
+		ja: "ヒードランVMAX",
+		'zh-tw': "席多藍恩VMAX",
 	},
 
 	illustrator: "N-DESIGN Inc.",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Fire"],
+
 	stage: "VMAX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "熔岩增輝"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "マグマゲイン",
+				'zh-tw': "熔岩增輝",
+			},
+			effect: {
+				ja: "場に自分のスタジアムが出ているなら、自分の番に1回使える。このポケモンのHPを「50」回復する。",
+				'zh-tw': "若場上有自己的競技場卡，則在自己的回合時可使用1次。將這隻寶可夢恢復「50」HP。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若場上有自己的競技場卡，則在自己的回合時可使用1次。將這隻寶可夢恢復「50」HP。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "極巨爆熱"
+	attacks: [
+		{
+			name: {
+				ja: "ダイバクネツ",
+				'zh-tw': "極巨爆熱",
+			},
+			damage: 180,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【灼傷】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【灼傷】。"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651074,
+				tcgplayer: 569858,
+			},
 		},
+	],
 
-		damage: 180,
-		cost: ["Fire", "Fire", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ヒードランV",
+	},
 
 	retreat: 4,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Triple Rare",
+	dexId: [485],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/016.ts
+++ b/data-asia/S/S10P/016.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "可達鴨"
+		ja: "コダック",
+		'zh-tw': "可達鴨",
 	},
 
 	illustrator: "GOSSAN",
@@ -14,37 +14,51 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "常年為頭痛所苦。疼痛增強之時， 蘊藏於體內之力將失控爆發。 故吾人正在摸索舒緩頭痛之法。"
+		ja: "常より 頭痛に 悩む。 強まりしとき 秘めたる力 意に反し 暴発するゆえ 痛み 和らげる術を 模索中なり。",
+		'zh-tw': "常年為頭痛所苦。疼痛增強之時， 蘊藏於體內之力將失控爆發。 故吾人正在摸索舒緩頭痛之法。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "發呆"
+	attacks: [
+		{
+			name: {
+				ja: "ぼーっとする",
+				'zh-tw': "發呆",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、このポケモンのHPを「10」回復する。",
+				'zh-tw': "擲1次硬幣若為正面，則將這隻寶可夢恢復「10」HP。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將這隻寶可夢恢復「10」HP。"
+		{
+			name: {
+				ja: "ぶつかる",
+				'zh-tw': "衝撞",
+			},
+			damage: 20,
+			cost: ["Water", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "衝撞"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651075,
+				tcgplayer: 569859,
+			},
 		},
-
-		damage: 20,
-		cost: ["Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [54],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/017.ts
+++ b/data-asia/S/S10P/017.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "哥達鴨"
+		ja: "ゴルダック",
+		'zh-tw': "哥達鴨",
 	},
 
 	illustrator: "otumami",
@@ -14,37 +14,55 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "生活在水流平穩的河川裡。會用長長的手腳划水， 展現自己優雅的泳姿。"
+		ja: "流れの 穏やかな 川に 棲む。 長い 手足で 水を 掻きわけ 優雅な 泳ぎを みせる。",
+		'zh-tw': "生活在水流平穩的河川裡。會用長長的手腳划水， 展現自己優雅的泳姿。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "水之刀鋒"
+	attacks: [
+		{
+			name: {
+				ja: "アクアエッジ",
+				'zh-tw': "水之刀鋒",
+			},
+			damage: 50,
+			cost: ["Water", "Colorless"],
 		},
-
-		damage: 50,
-		cost: ["Water", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "捲入奇襲"
+		{
+			name: {
+				ja: "まきこみダイブ",
+				'zh-tw': "捲入奇襲",
+			},
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "おたがいのバトルポケモンと、ついているすべてのカードを、トラッシュする。［バトル場に次のポケモンを出すのは自分から。］",
+				'zh-tw': "將雙方的戰鬥寶可夢與附加的卡全部丟棄。[自己先將下一隻寶可夢放置於戰鬥場。]",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將雙方的戰鬥寶可夢與附加的卡全部丟棄。[自己先將下一隻寶可夢放置於戰鬥場。]"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651076,
+				tcgplayer: 569860,
+			},
 		},
+	],
 
-		cost: ["Water", "Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "コダック",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [55],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/018.ts
+++ b/data-asia/S/S10P/018.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "愛心魚"
+		ja: "ラブカス",
+		'zh-tw': "愛心魚",
 	},
 
 	illustrator: "Sekio",
@@ -14,37 +14,51 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "溫暖海域的珊瑚礁是 牠的棲息地。最喜歡在 太陽珊瑚的枝條間睡覺。"
+		ja: "暖かい 海の サンゴ礁が 棲み処。 サニーゴの枝の 間で 眠るのが 特に お気に入り。",
+		'zh-tw': "溫暖海域的珊瑚礁是 牠的棲息地。最喜歡在 太陽珊瑚的枝條間睡覺。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "情侶裝"
+	attacks: [
+		{
+			name: {
+				ja: "ペアルック",
+				'zh-tw': "情侶裝",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "おたがいのプレイヤーは、それぞれの山札からカードを2枚、オモテを見せ合いながら引く。",
+				'zh-tw': "雙方玩家一邊從各自的牌庫抽出2張卡，一邊互看正面。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "雙方玩家一邊從各自的牌庫抽出2張卡，一邊互看正面。"
+		{
+			name: {
+				ja: "たいあたり",
+				'zh-tw': "撞擊",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "撞擊"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651077,
+				tcgplayer: 569861,
+			},
 		},
-
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [370],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/019.ts
+++ b/data-asia/S/S10P/019.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雷吉艾斯"
+		ja: "レジアイス",
+		'zh-tw': "雷吉艾斯",
 	},
 
 	illustrator: "aoki",
@@ -14,41 +14,55 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "能操控降至零下２００度的寒氣，將靠近牠的東西 都在一瞬間就冰封起來。"
+		ja: "マイナス２００度まで 冷えこむ 冷気を 操り 近づいたものを あっという間に 氷漬けにする。",
+		'zh-tw': "能操控降至零下２００度的寒氣，將靠近牠的東西 都在一瞬間就冰封起來。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "雷吉之門"
+	attacks: [
+		{
+			name: {
+				ja: "レジゲート",
+				'zh-tw': "雷吉之門",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からたねポケモンを1枚選び、ベンチに出す。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。"
+		{
+			name: {
+				ja: "ブリザードバインド",
+				'zh-tw': "暴雪制約",
+			},
+			damage: 100,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けた「ポケモンV」は、ワザが使えない。",
+				'zh-tw': "在下個對手的回合，受到這個招式的「寶可夢【V】」，無法使用招式。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "暴雪制約"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651078,
+				tcgplayer: 569862,
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的「寶可夢【V】」，無法使用招式。"
-		},
-
-		damage: 100,
-		cost: ["Water", "Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	],
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [378],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/020.ts
+++ b/data-asia/S/S10P/020.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "無殼海兔"
+		ja: "カラナクシ",
+		'zh-tw': "無殼海兔",
 	},
 
 	illustrator: "Saya Tsuruta",
@@ -14,34 +14,48 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "雖然也有人認為牠的樣子是因吃下的食物而變化的， 不過至今仍未得到證實。"
+		ja: "エサで 姿が 変わるとも いわれるが 正しいことは まだまだ わかっていないのだ。",
+		'zh-tw': "雖然也有人認為牠的樣子是因吃下的食物而變化的， 不過至今仍未得到證實。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "潑水"
+	attacks: [
+		{
+			name: {
+				ja: "みずかけ",
+				'zh-tw': "潑水",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
-
-		damage: 10,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "衝浪"
+		{
+			name: {
+				ja: "なみのり",
+				'zh-tw': "衝浪",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651079,
+				tcgplayer: 569863,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [422],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/021.ts
+++ b/data-asia/S/S10P/021.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "冰伊布"
+		ja: "グレイシア",
+		'zh-tw': "冰伊布",
 	},
 
 	illustrator: "saino misaki",
@@ -14,38 +14,56 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "擁有急速降低體熱的能力。 能凍結大氣，引發細碎冰晶 如同寶石般閃耀飛舞的現象。"
+		ja: "体熱を 急低下させる 能力を 有す。 大気 凍らせ 宝石の如き 煌めく 細氷を 舞い躍らせる 現象 起こす。",
+		'zh-tw': "擁有急速降低體熱的能力。 能凍結大氣，引發細碎冰晶 如同寶石般閃耀飛舞的現象。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "冰霜堡壘"
+	attacks: [
+		{
+			name: {
+				ja: "フロストウォール",
+				'zh-tw': "冰霜堡壘",
+			},
+			damage: 30,
+			cost: ["Water"],
+			effect: {
+				ja: "次の相手の番、このポケモンは進化ポケモンからワザのダメージを受けない。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢不會受到進化寶可夢招式的傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，這隻寶可夢不會受到進化寶可夢招式的傷害。"
+		{
+			name: {
+				ja: "アイスブラスト",
+				'zh-tw': "冰之爆破",
+			},
+			damage: 120,
+			cost: ["Water", "Water", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "冰之爆破"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651080,
+				tcgplayer: 569864,
+			},
 		},
+	],
 
-		damage: 120,
-		cost: ["Water", "Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "イーブイ",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [471],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/022.ts
+++ b/data-asia/S/S10P/022.ts
@@ -1,50 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "起源帕路奇亞V"
+		ja: "オリジンパルキアV",
+		'zh-tw': "起源帕路奇亞V",
 	},
 
 	illustrator: "aky CG Works",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Water"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "領域支配"
+	attacks: [
+		{
+			name: {
+				ja: "りょういきしはい",
+				'zh-tw': "領域支配",
+			},
+			cost: ["Water"],
+			effect: {
+				ja: "自分の山札からスタジアムを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張競技場卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張競技場卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		{
+			name: {
+				ja: "ハイドロブレイク",
+				'zh-tw': "水炮破壞",
+			},
+			damage: 200,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。",
+			},
 		},
+	],
 
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "水炮破壞"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651081,
+				tcgplayer: 569865,
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。"
-		},
-
-		damage: 200,
-		cost: ["Water", "Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Double rare",
+	dexId: [484],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/023.ts
+++ b/data-asia/S/S10P/023.ts
@@ -1,51 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "起源帕路奇亞VSTAR"
+		ja: "オリジンパルキアVSTAR",
+		'zh-tw': "起源帕路奇亞VSTAR",
 	},
 
 	illustrator: "aky CG Works",
 	category: "Pokemon",
 	hp: 280,
 	types: ["Water"],
-	stage: "VMAX",
 
-	abilities: [{
-		type: "Ability",
+	stage: "VSTAR",
 
-		name: {
-			'zh-tw': "星星入口"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "スターポータル",
+				'zh-tw': "星星入口",
+			},
+			effect: {
+				ja: "自分の番に使える。自分のトラッシュから[W]エネルギーを3枚まで選び、自分の[W]ポケモンに好きなようにつける。［対戦中、自分はVSTARパワーを1回しか使えない。］",
+				'zh-tw': "在自己的回合時可使用。從自己的棄牌區選擇最多3張【水】能量卡，以任意方式附於自己的【水】寶可夢身上。[對戰中，己方只可使用1次【VSTAR】力量。]",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時可使用。從自己的棄牌區選擇最多3張【水】能量卡，以任意方式附於自己的【水】寶可夢身上。[對戰中，己方只可使用1次【VSTAR】力量。]"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "亞空潮漩"
+	attacks: [
+		{
+			name: {
+				ja: "あくうのうねり",
+				'zh-tw': "亞空潮漩",
+			},
+			damage: "60+",
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "おたがいのベンチポケモンの数×20ダメージ追加。",
+				'zh-tw': "增加雙方的備戰寶可夢的數量×20點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加雙方的備戰寶可夢的數量×20點傷害。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651082,
+				tcgplayer: 569866,
+			},
 		},
+	],
 
-		damage: "60+",
-		cost: ["Water", "Water"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "nullV",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Triple Rare",
+	dexId: [484],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/024.ts
+++ b/data-asia/S/S10P/024.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "冰寶"
+		ja: "カチコール",
+		'zh-tw': "冰寶",
 	},
 
 	illustrator: "Kouki Saitou",
@@ -14,27 +14,40 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "棲息在萬年積雪覆蓋的山區。 戴著將大氣中的水分冷凍後 形成的冰盔，藉此保護自己。"
+		ja: "万年雪に 覆われた 山岳に 生息す。 大気内の水分を 冷やして 作りし 氷の兜を 被りて 身を護る。",
+		'zh-tw': "棲息在萬年積雪覆蓋的山區。 戴著將大氣中的水分冷凍後 形成的冰盔，藉此保護自己。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "冰柱"
+	attacks: [
+		{
+			name: {
+				ja: "つらら",
+				'zh-tw': "冰柱",
+			},
+			damage: 40,
+			cost: ["Water", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 40,
-		cost: ["Water", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651083,
+				tcgplayer: 569867,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [712],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/025.ts
+++ b/data-asia/S/S10P/025.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洗翠 冰岩怪"
+		ja: "ヒスイ クレベース",
+		'zh-tw': "洗翠 冰岩怪",
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -14,43 +14,62 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "包覆下顎的冰塊裝甲硬度更勝鋼鐵，能輕易地擊碎岩石。冰岩怪藉此剷開 厚重積雪，在險峻的山路上猛衝。"
+		ja: "下顎を 覆う 氷塊の装甲は 鋼に勝り 岩石を 砕くこと 容易なり。 深雪を かき分け 険しい 山道を 猛進す。",
+		'zh-tw': "包覆下顎的冰塊裝甲硬度更勝鋼鐵，能輕易地擊碎岩石。冰岩怪藉此剷開 厚重積雪，在險峻的山路上猛衝。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "渾厚冰"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ぶあついこおり",
+				'zh-tw': "渾厚冰",
+			},
+			effect: {
+				ja: "このポケモンが受けるワザのダメージは「-30」される。",
+				'zh-tw': "這隻寶可夢受到招式的傷害「-30」點。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢受到招式的傷害「-30」點。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "冰山風"
+	attacks: [
+		{
+			name: {
+				ja: "ひょうざんおろし",
+				'zh-tw': "冰山風",
+			},
+			damage: "100+",
+			cost: ["Water", "Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "場にスタジアムが出ているなら、120ダメージ追加。その後、そのスタジアムをトラッシュする。",
+				'zh-tw': "若場上有競技場卡，則增加120點傷害。然後，將那張競技場卡丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若場上有競技場卡，則增加120點傷害。然後，將那張競技場卡丟棄。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651084,
+				tcgplayer: 569868,
+			},
 		},
+	],
 
-		damage: "100+",
-		cost: ["Water", "Water", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "カチコール",
+	},
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [713],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/026.ts
+++ b/data-asia/S/S10P/026.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "波克比"
+		ja: "トゲピー",
+		'zh-tw': "波克比",
 	},
 
 	illustrator: "Mizue",
@@ -14,39 +14,54 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "外觀好似一顆蛋，常讓在野外 遇見牠的人誤會蛋自己會動。 純真的笑容有療癒人心的功效。"
+		ja: "卵に似た姿。 野山にて 遭遇し折 卵が動いたと 早とちりする者 多し。 邪気なき笑顔 人心を癒す 効能あり。",
+		'zh-tw': "外觀好似一顆蛋，常讓在野外 遇見牠的人誤會蛋自己會動。 純真的笑容有療癒人心的功效。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "幸福之觸"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "しあわせタッチ",
+				'zh-tw': "幸福之觸",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分のバトルポケモンのHPを「10」回復する。",
+				'zh-tw': "在自己的回合，當從手牌將這張卡放置於備戰區時，可使用1次。將自己的戰鬥寶可夢恢復「10」HP。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，當從手牌將這張卡放置於備戰區時，可使用1次。將自己的戰鬥寶可夢恢復「10」HP。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "滾動"
+	attacks: [
+		{
+			name: {
+				ja: "ころがる",
+				'zh-tw': "滾動",
+			},
+			damage: 10,
+			cost: ["Psychic"],
 		},
+	],
 
-		damage: 10,
-		cost: ["Psychic"]
-	}],
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651085,
+				tcgplayer: 569869,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [175],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/027.ts
+++ b/data-asia/S/S10P/027.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "波克基古"
+		ja: "トゲチック",
+		'zh-tw': "波克基古",
 	},
 
 	illustrator: "Tika Matsuno",
@@ -14,39 +14,58 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "據說牠會為了將幸福帶給心地善良 的人而現身。"
+		ja: "心優しい 人の 前に 幸せを もたらすため 姿を 現すと 言われている。",
+		'zh-tw': "據說牠會為了將幸福帶給心地善良 的人而現身。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "幸福之聲"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "しあわせボイス",
+				'zh-tw': "幸福之聲",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分のバトルポケモンのHPを「30」回復する。",
+				'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。將自己的戰鬥寶可夢恢復「30」HP。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。將自己的戰鬥寶可夢恢復「30」HP。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "妖精之風"
+	attacks: [
+		{
+			name: {
+				ja: "ようせいのかぜ",
+				'zh-tw': "妖精之風",
+			},
+			damage: 30,
+			cost: ["Psychic", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Psychic", "Colorless"]
-	}],
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651086,
+				tcgplayer: 569870,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "トゲピー",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [176],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/028.ts
+++ b/data-asia/S/S10P/028.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "波克基斯"
+		ja: "トゲキッス",
+		'zh-tw': "波克基斯",
 	},
 
 	illustrator: "sui",
@@ -14,39 +14,58 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "不會出現在發生爭端和紛亂的地方。 近來幾乎見不到牠的身影。"
+		ja: "争い事や もめ事が 起こる 場所には 姿を 見せない。 近ごろは ほとんど 見かけない。",
+		'zh-tw': "不會出現在發生爭端和紛亂的地方。 近來幾乎見不到牠的身影。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "幸福閃耀"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "しあわせシャイン",
+				'zh-tw': "幸福閃耀",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分のバトルポケモンのHPを「90」回復する。",
+				'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。將自己的戰鬥寶可夢恢復「90」HP。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。將自己的戰鬥寶可夢恢復「90」HP。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "魔法射擊"
+	attacks: [
+		{
+			name: {
+				ja: "マジカルショット",
+				'zh-tw': "魔法射擊",
+			},
+			damage: 120,
+			cost: ["Psychic", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 120,
-		cost: ["Psychic", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651087,
+				tcgplayer: 569871,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "トゲチック",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [468],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/029.ts
+++ b/data-asia/S/S10P/029.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "由克希"
+		ja: "ユクシー",
+		'zh-tw': "由克希",
 	},
 
 	illustrator: "sui",
@@ -14,42 +14,51 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "據說因為由克希的誕生， 使人們的生活變得 豐富多彩的智慧才得以出現。"
+		ja: "ユクシーの 誕生により 人々の 生活を 豊かにする 知恵が 生まれたと 言われている。",
+		'zh-tw': "據說因為由克希的誕生， 使人們的生活變得 豐富多彩的智慧才得以出現。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "智慧指引"
+	attacks: [
+		{
+			name: {
+				ja: "ちえのみちびき",
+				'zh-tw': "智慧指引",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から好きなカードを1枚選び、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫任意選擇1張卡加入手牌。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫任意選擇1張卡加入手牌。並且重洗牌庫。"
+		{
+			name: {
+				ja: "サイコショット",
+				'zh-tw': "精神射擊",
+			},
+			damage: 20,
+			cost: ["Psychic"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "精神射擊"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651088,
+				tcgplayer: 569872,
+			},
 		},
-
-		damage: 20,
-		cost: ["Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [480],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/030.ts
+++ b/data-asia/S/S10P/030.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "艾姆利多"
+		ja: "エムリット",
+		'zh-tw': "艾姆利多",
 	},
 
 	illustrator: "zig",
@@ -14,44 +14,54 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "在湖底沉睡。 但據說牠的靈魂會跑出來， 在水面徘徊飛行。"
+		ja: "湖の 底で 眠っているが 魂が 抜け出して 水面を 飛び回ると 言われている。",
+		'zh-tw': "在湖底沉睡。 但據說牠的靈魂會跑出來， 在水面徘徊飛行。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "意識之帳"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "いしきのとばり",
+				'zh-tw': "意識之帳",
+			},
+			effect: {
+				ja: "自分の場に「ユクシー」「アグノム」がいるなら、自分のポケモン全員の弱点は、すべてなくなる。",
+				'zh-tw': "若自己的場上有「由克希」「亞克諾姆」，則自己的所有寶可夢的弱點全部消除。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若自己的場上有「由克希」「亞克諾姆」，則自己的所有寶可夢的弱點全部消除。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "意念頭錘"
+	attacks: [
+		{
+			name: {
+				ja: "しねんのずつき",
+				'zh-tw': "意念頭錘",
+			},
+			damage: 30,
+			cost: ["Psychic", "Psychic"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Psychic", "Psychic"]
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651089,
+				tcgplayer: 569873,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [481],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/031.ts
+++ b/data-asia/S/S10P/031.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "亞克諾姆"
+		ja: "アグノム",
+		'zh-tw': "亞克諾姆",
 	},
 
 	illustrator: "Taira Akitsu",
@@ -14,36 +14,44 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "由克希、艾姆利多和亞克諾姆 被認為是從同一個蛋裡 誕生出的寶可夢。"
+		ja: "ユクシー エムリット アグノムは 同じ タマゴから 生まれた ポケモンと 考えられている。",
+		'zh-tw': "由克希、艾姆利多和亞克諾姆 被認為是從同一個蛋裡 誕生出的寶可夢。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "精神歪曲"
+	attacks: [
+		{
+			name: {
+				ja: "サイコトリップ",
+				'zh-tw': "精神歪曲",
+			},
+			damage: 30,
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【混亂】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【混亂】。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651090,
+				tcgplayer: 569874,
+			},
 		},
-
-		damage: 30,
-		cost: ["Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [482],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/032.ts
+++ b/data-asia/S/S10P/032.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "好啦魷"
+		ja: "マーイーカ",
+		'zh-tw': "好啦魷",
 	},
 
 	illustrator: "miki kudo",
@@ -14,36 +14,44 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "旋轉著閃爍自己的發光體。透過改變閃爍的方式 來和其他夥伴交流。"
+		ja: "回転しながら 発光体を 点滅。 光の パターンで 仲間と コミュニケーションする。",
+		'zh-tw': "旋轉著閃爍自己的發光體。透過改變閃爍的方式 來和其他夥伴交流。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "浮躁攻擊"
+	attacks: [
+		{
+			name: {
+				ja: "きまぐれこうげき",
+				'zh-tw': "浮躁攻擊",
+			},
+			damage: 30,
+			cost: ["Psychic"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+				'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651091,
+				tcgplayer: 569875,
+			},
 		},
-
-		damage: 30,
-		cost: ["Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [686],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/033.ts
+++ b/data-asia/S/S10P/033.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "烏賊王"
+		ja: "カラマネロ",
+		'zh-tw': "烏賊王",
 	},
 
 	illustrator: "Tomokazu Komiya",
@@ -14,43 +14,56 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "要是盯著牠的發光體看，就會馬上陷入催眠狀態， 並且受到牠的控制。"
+		ja: "発光体の 光を 見つめると たちまち 催眠状態になり カラマネロに 操られてしまう。",
+		'zh-tw': "要是盯著牠的發光體看，就會馬上陷入催眠狀態， 並且受到牠的控制。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "同步強念"
+	attacks: [
+		{
+			name: {
+				ja: "シンクロキネシス",
+				'zh-tw': "同步強念",
+			},
+			damage: "30+",
+			cost: ["Psychic"],
+			effect: {
+				ja: "おたがいの手札を見せ合い、その中にそれぞれ同じ名前のカードがあるなら、90ダメージ追加。",
+				'zh-tw': "互看雙方手牌，若其中有名稱相同的卡，則增加90點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "互看雙方手牌，若其中有名稱相同的卡，則增加90點傷害。"
+		{
+			name: {
+				ja: "ねんどうだん",
+				'zh-tw': "念動彈",
+			},
+			damage: 80,
+			cost: ["Psychic", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: "30+",
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "念動彈"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651092,
+				tcgplayer: 569876,
+			},
 		},
+	],
 
-		damage: 80,
-		cost: ["Psychic", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "マーイーカ",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [687],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/034.ts
+++ b/data-asia/S/S10P/034.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "幕下力士"
+		ja: "マクノシタ",
+		'zh-tw': "幕下力士",
 	},
 
 	illustrator: "Shigenori Negishi",
@@ -14,31 +14,44 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "據說為了培育強大的幕下力士， 訓練家們會製作一種 傳統的火鍋料理。"
+		ja: "強い マクノシタを 育てるために トレーナーたちが 伝統的に 作る ナベ料理が あるという。",
+		'zh-tw': "據說為了培育強大的幕下力士， 訓練家們會製作一種 傳統的火鍋料理。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "擊掌奇襲"
+	attacks: [
+		{
+			name: {
+				ja: "ねこだまし",
+				'zh-tw': "擊掌奇襲",
+			},
+			damage: 20,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+				'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651093,
+				tcgplayer: 569877,
+			},
 		},
-
-		damage: 20,
-		cost: ["Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	],
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [296],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/035.ts
+++ b/data-asia/S/S10P/035.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鐵掌力士"
+		ja: "ハリテヤマ",
+		'zh-tw': "鐵掌力士",
 	},
 
 	illustrator: "Scav",
@@ -14,42 +14,60 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "體型壯碩的鐵掌力士未必就很強。 也有體型雖小，但身輕如燕 且技巧高超的鐵掌力士存在。"
+		ja: "太って 大きな ハリテヤマが 強いとは 限らない。 小柄でも 身軽で 技に 長けたものもいる。",
+		'zh-tw': "體型壯碩的鐵掌力士未必就很強。 也有體型雖小，但身輕如燕 且技巧高超的鐵掌力士存在。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "轉倒"
+	attacks: [
+		{
+			name: {
+				ja: "つきおとし",
+				'zh-tw': "轉倒",
+			},
+			damage: 40,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+				'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。"
+		{
+			name: {
+				ja: "マッスルはりて",
+				'zh-tw': "筋肉巴掌",
+			},
+			damage: 100,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+				'zh-tw': "這個招式的傷害不計算抵抗力。",
+			},
 		},
+	],
 
-		damage: 40,
-		cost: ["Fighting", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "筋肉巴掌"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651094,
+				tcgplayer: 569878,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這個招式的傷害不計算抵抗力。"
-		},
-
-		damage: 100,
-		cost: ["Fighting", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "マクノシタ",
+	},
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [297],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/036.ts
+++ b/data-asia/S/S10P/036.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雷吉洛克"
+		ja: "レジロック",
+		'zh-tw': "雷吉洛克",
 	},
 
 	illustrator: "Souichirou Gunjima",
@@ -14,41 +14,55 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "全身所有部分都是由岩石構成。即使身體有磨損， 也能自己補上岩石修復。"
+		ja: "体の あらゆる 部分が 岩で できている。 体が 削れても 自分で 岩を つけて 治す。",
+		'zh-tw': "全身所有部分都是由岩石構成。即使身體有磨損， 也能自己補上岩石修復。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "雷吉之門"
+	attacks: [
+		{
+			name: {
+				ja: "レジゲート",
+				'zh-tw': "雷吉之門",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からたねポケモンを1枚選び、ベンチに出す。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。"
+		{
+			name: {
+				ja: "ギガインパクト",
+				'zh-tw': "終極衝擊",
+			},
+			damage: 140,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "終極衝擊"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651095,
+				tcgplayer: 569879,
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。"
-		},
-
-		damage: 140,
-		cost: ["Fighting", "Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	],
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [377],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/037.ts
+++ b/data-asia/S/S10P/037.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "海兔獸"
+		ja: "トリトドン",
+		'zh-tw': "海兔獸",
 	},
 
 	illustrator: "Sanosuke Sakuma",
@@ -14,41 +14,59 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "為了覓食也會登上陸地。海兔獸經過的地方 會留下黏糊糊的黏液。"
+		ja: "エサを 求めて 陸にも 上がる。 トリトドンが 這った跡には ネバネバの 粘液が 残る。",
+		'zh-tw': "為了覓食也會登上陸地。海兔獸經過的地方 會留下黏糊糊的黏液。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "自我再生"
+	attacks: [
+		{
+			name: {
+				ja: "じこさいせい",
+				'zh-tw': "自我再生",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。このポケモンのHPを、すべて回復する。",
+				'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。將這隻寶可夢的HP全部恢復。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。將這隻寶可夢的HP全部恢復。"
+		{
+			name: {
+				ja: "じしん",
+				'zh-tw': "地震",
+			},
+			damage: 170,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "自分のベンチポケモン全員にも、それぞれ20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "自己的所有備戰寶可夢也各受到20點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "地震"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651096,
+				tcgplayer: 569880,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "自己的所有備戰寶可夢也各受到20點傷害。[在備戰區不計算弱點・抵抗力。]"
-		},
-
-		damage: 170,
-		cost: ["Fighting", "Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "カラナクシ",
+	},
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [423],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/038.ts
+++ b/data-asia/S/S10P/038.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "小碎鑽"
+		ja: "メレシー",
+		'zh-tw': "小碎鑽",
 	},
 
 	illustrator: "Tika Matsuno",
@@ -14,37 +14,51 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "會從嵌在身體的寶石發射出高能量的光線， 將來襲的敵人一掃而盡。"
+		ja: "体に 埋まっている 宝石から 高エネルギーの ビームを 放ち 襲いかかる 敵を 一掃する。",
+		'zh-tw': "會從嵌在身體的寶石發射出高能量的光線， 將來襲的敵人一掃而盡。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "挖到寶"
+	attacks: [
+		{
+			name: {
+				ja: "ほりだしもの",
+				'zh-tw': "挖到寶",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からグッズを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多2張物品卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多2張物品卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		{
+			name: {
+				ja: "パワージェム",
+				'zh-tw': "力量寶石",
+			},
+			damage: 80,
+			cost: ["Fighting", "Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "力量寶石"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651097,
+				tcgplayer: 569881,
+			},
 		},
-
-		damage: 80,
-		cost: ["Fighting", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [703],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/039.ts
+++ b/data-asia/S/S10P/039.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洗翠 狙射樹梟"
+		ja: "ヒスイ ジュナイパー",
+		'zh-tw': "洗翠 狙射樹梟",
 	},
 
 	illustrator: "Kouki Saitou",
@@ -14,40 +14,59 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "為抵抗洗翠的嚴寒氣候，羽毛的芯中含有空氣，因而能夠防寒。 由此可見環境會對進化產生影響。"
+		ja: "ヒスイの 極寒に 耐えるため 羽根の 芯に 空気を含み 防寒機能 有す。 環境が 進化に 影響すると 判明す。",
+		'zh-tw': "為抵抗洗翠的嚴寒氣候，羽毛的芯中含有空氣，因而能夠防寒。 由此可見環境會對進化產生影響。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "深入鉤爪"
+	attacks: [
+		{
+			name: {
+				ja: "くいこむかぎづめ",
+				'zh-tw': "深入鉤爪",
+			},
+			damage: "30×",
+			cost: [],
+			effect: {
+				ja: "相手のバトルポケモンにのっているダメカンの数×30ダメージ。",
+				'zh-tw': "造成對手的戰鬥寶可夢身上放置的傷害指示物的數量×30點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "造成對手的戰鬥寶可夢身上放置的傷害指示物的數量×30點傷害。"
+		{
+			name: {
+				ja: "ダイレクトアロー",
+				'zh-tw': "筆直箭",
+			},
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、80ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的1隻寶可夢受到80點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		damage: "30×"
-	}, {
-		name: {
-			'zh-tw': "筆直箭"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651098,
+				tcgplayer: 569882,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "對手的1隻寶可夢受到80點傷害。[在備戰區不計算弱點・抵抗力。]"
-		},
-
-		cost: ["Fighting", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "フクスロー",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [724],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/040.ts
+++ b/data-asia/S/S10P/040.ts
@@ -1,47 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "劈斧螳螂V"
+		ja: "バサギリV",
+		'zh-tw': "劈斧螳螂V",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Fighting"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "居合斬"
+	attacks: [
+		{
+			name: {
+				ja: "いあいぎり",
+				'zh-tw': "居合斬",
+			},
+			damage: 40,
+			cost: ["Fighting"],
 		},
-
-		damage: 40,
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "鉞斬"
+		{
+			name: {
+				ja: "まさかりスラッシュ",
+				'zh-tw': "鉞斬",
+			},
+			damage: 150,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。その後、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。然後，選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。然後，選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651099,
+				tcgplayer: 569883,
+			},
 		},
-
-		damage: 150,
-		cost: ["Fighting", "Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Double rare",
+	dexId: [900],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/041.ts
+++ b/data-asia/S/S10P/041.ts
@@ -1,50 +1,68 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "劈斧螳螂VSTAR"
+		ja: "バサギリVSTAR",
+		'zh-tw': "劈斧螳螂VSTAR",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 270,
 	types: ["Fighting"],
-	stage: "VMAX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "破壞斧"
+	stage: "VSTAR",
+
+	attacks: [
+		{
+			name: {
+				ja: "ブレイクアックス",
+				'zh-tw': "破壞斧",
+			},
+			damage: 120,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "相手のベンチの「ポケモンV」1匹にも、60ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的備戰區的1隻「寶可夢【V】」也受到60點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
-
-		effect: {
-			'zh-tw': "對手的備戰區的1隻「寶可夢【V】」也受到60點傷害。[在備戰區不計算弱點・抵抗力。]"
+		{
+			name: {
+				ja: "ランページスター",
+				'zh-tw': "[VSTAR力量]亂暴星星",
+			},
+			damage: "30×",
+			cost: ["Fighting"],
+			effect: {
+				ja: "自分のトラッシュにあるポケモンの枚数×30ダメージ。［対戦中、自分はVSTARパワーを1回しか使えない。］",
+				'zh-tw': "造成自己的棄牌區的寶可夢卡的張數×30點傷害。[對戰中，己方只可使用1次【VSTAR】力量。]",
+			},
 		},
+	],
 
-		damage: 120,
-		cost: ["Fighting", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "[VSTAR力量]亂暴星星"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651100,
+				tcgplayer: 569884,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "造成自己的棄牌區的寶可夢卡的張數×30點傷害。[對戰中，己方只可使用1次【VSTAR】力量。]"
-		},
-
-		damage: "30×",
-		cost: ["Fighting"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "バサギリV",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Triple Rare",
+	dexId: [900],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/042.ts
+++ b/data-asia/S/S10P/042.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洗翠 狃拉"
+		ja: "ヒスイ ニューラ",
+		'zh-tw': "洗翠 狃拉",
 	},
 
 	illustrator: "Mizue",
@@ -14,34 +14,48 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "強健的爪子形狀有助於在斷崖絕壁上行動自如。爪子尖端滴出的毒液會在 捉住獵物時侵襲其神經。"
+		ja: "鉤爪 逞しく 断崖絶壁を 踏破するに 有利な 形状。 先端より 毒液 滴り 獲物 捕らえしとき 神経を 侵す。",
+		'zh-tw': "強健的爪子形狀有助於在斷崖絕壁上行動自如。爪子尖端滴出的毒液會在 捉住獵物時侵襲其神經。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "抓"
+	attacks: [
+		{
+			name: {
+				ja: "ひっかく",
+				'zh-tw': "抓",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
-
-		damage: 10,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "利爪劈擊"
+		{
+			name: {
+				ja: "ツメできりさく",
+				'zh-tw': "利爪劈擊",
+			},
+			damage: 30,
+			cost: ["Darkness", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Darkness", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651101,
+				tcgplayer: 569885,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [215],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/043.ts
+++ b/data-asia/S/S10P/043.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洗翠 大狃拉"
+		ja: "ヒスイ オオニューラ",
+		'zh-tw': "洗翠 大狃拉",
 	},
 
 	illustrator: "Kouki Saitou",
@@ -14,39 +14,58 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "擁有凌駕其他物種之上的身體能力以及劇毒。在寒冷的高地上所向無敵。 偏好獨自行動，而不會集結成群。"
+		ja: "他種圧倒する 身体能力と 猛毒 有し 寒冷なる 高地においては 敵なし。 群れ成さず 単独を良しとする 性質。",
+		'zh-tw': "擁有凌駕其他物種之上的身體能力以及劇毒。在寒冷的高地上所向無敵。 偏好獨自行動，而不會集結成群。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "搬運攀爬"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "キャリークライム",
+				'zh-tw': "搬運攀爬",
+			},
+			effect: {
+				ja: "このポケモンがベンチにいるかぎり、自分のバトルポケモンのにげるためのエネルギーは、2個ぶん少なくなる。",
+				'zh-tw': "只要這隻寶可夢在備戰區，自己的戰鬥寶可夢【撤退】所需的能量減少2個。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在備戰區，自己的戰鬥寶可夢【撤退】所需的能量減少2個。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "利爪劈擊"
+	attacks: [
+		{
+			name: {
+				ja: "ツメできりさく",
+				'zh-tw': "利爪劈擊",
+			},
+			damage: 60,
+			cost: ["Darkness", "Colorless"],
 		},
+	],
 
-		damage: 60,
-		cost: ["Darkness", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651102,
+				tcgplayer: 569886,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒスイ ニューラ",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [903],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/044.ts
+++ b/data-asia/S/S10P/044.ts
@@ -1,48 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洗翠 大狃拉V"
+		ja: "ヒスイ オオニューラV",
+		'zh-tw': "洗翠 大狃拉V",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 190,
 	types: ["Darkness"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "毒之爪"
+	attacks: [
+		{
+			name: {
+				ja: "どくのツメ",
+				'zh-tw': "毒之爪",
+			},
+			cost: [],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。"
-		}
-	}, {
-		name: {
-			'zh-tw': "剋命爪"
+		{
+			name: {
+				ja: "フェイタルクロー",
+				'zh-tw': "剋命爪",
+			},
+			damage: "80×",
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが受けている特殊状態の数×80ダメージ。",
+				'zh-tw': "造成對手的戰鬥寶可夢處於特殊狀態的數量×80點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "造成對手的戰鬥寶可夢處於特殊狀態的數量×80點傷害。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651103,
+				tcgplayer: 569887,
+			},
 		},
-
-		damage: "80×",
-		cost: ["Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 0,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Double rare",
+	dexId: [903],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/045.ts
+++ b/data-asia/S/S10P/045.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "達克萊伊"
+		ja: "ダークライ",
+		'zh-tw': "達克萊伊",
 	},
 
 	illustrator: "Shin Nagasawa",
@@ -14,42 +14,56 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "以往曾有過在無月的夜裡，村子裡所有 的人都夢見了惡夢的異事。村人們宣稱 惡夢中出現的寶可夢就是此寶可夢。"
+		ja: "月 消えし夜。 集落の村人 全員が 悪夢 見る 珍事あり。 悪夢の中に 現れしポケモンと 村人ら 証言す。",
+		'zh-tw': "以往曾有過在無月的夜裡，村子裡所有 的人都夢見了惡夢的異事。村人們宣稱 惡夢中出現的寶可夢就是此寶可夢。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "惡夢"
+	attacks: [
+		{
+			name: {
+				ja: "あくむ",
+				'zh-tw': "惡夢",
+			},
+			damage: 30,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【睡眠】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【睡眠】。"
+		{
+			name: {
+				ja: "しっこくのやいば",
+				'zh-tw': "漆黑利刃",
+			},
+			damage: 130,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。",
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Darkness", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "漆黑利刃"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651104,
+				tcgplayer: 569888,
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。"
-		},
-
-		damage: 130,
-		cost: ["Darkness", "Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [491],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/046.ts
+++ b/data-asia/S/S10P/046.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "盾甲龍"
+		ja: "タテトプス",
+		'zh-tw': "盾甲龍",
 	},
 
 	illustrator: "Yuka Morii",
@@ -14,43 +14,52 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "雖然在遠古時代的地層中 發現了牠的化石，但至今未曾 發現臉部以外的部分。"
+		ja: "太古の 地層から 化石が 見つかるが 顔の 部分 以外が 発見 されたことは ない。",
+		'zh-tw': "雖然在遠古時代的地層中 發現了牠的化石，但至今未曾 發現臉部以外的部分。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "堅硬頭錘"
+	attacks: [
+		{
+			name: {
+				ja: "かたいずつき",
+				'zh-tw': "堅硬頭錘",
+			},
+			damage: 30,
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+				'zh-tw': "擲1次硬幣若為正面，則在下個對手的回合，這隻寶可夢不會受到招式的傷害與效果的影響。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則在下個對手的回合，這隻寶可夢不會受到招式的傷害與效果的影響。"
+		{
+			name: {
+				ja: "がちんこ",
+				'zh-tw': "正面對決",
+			},
+			damage: 100,
+			cost: ["Metal", "Metal", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Metal", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "正面對決"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651105,
+				tcgplayer: 569889,
+			},
 		},
-
-		damage: 100,
-		cost: ["Metal", "Metal", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	],
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [410],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/047.ts
+++ b/data-asia/S/S10P/047.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "護城龍"
+		ja: "トリデプス",
+		'zh-tw': "護城龍",
 	},
 
 	illustrator: "Yuya Oka",
@@ -14,48 +14,62 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "大約１億年前的寶可夢。 結實到極點的臉擁有 超越鋼鐵的硬度。"
+		ja: "約１億年前の ポケモン。 恐ろしく 頑丈な 顔は 鋼鉄以上の 硬度を 持つ。",
+		'zh-tw': "大約１億年前的寶可夢。 結實到極點的臉擁有 超越鋼鐵的硬度。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "原始要塞"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "げんしのとりで",
+				'zh-tw': "原始要塞",
+			},
+			effect: {
+				ja: "このポケモンがいるかぎり、自分のポケモン全員が、相手の「ポケモンV」から受けるワザのダメージは「-30」される。",
+				'zh-tw': "只要這隻寶可夢在場上，自己的所有寶可夢受到對手的「寶可夢【V】」招式的傷害「-30」點。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在場上，自己的所有寶可夢受到對手的「寶可夢【V】」招式的傷害「-30」點。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "鐵之衝撞"
+	attacks: [
+		{
+			name: {
+				ja: "アイアンタックル",
+				'zh-tw': "鐵之衝撞",
+			},
+			damage: 180,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+				'zh-tw': "這隻寶可夢也受到30點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢也受到30點傷害。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651106,
+				tcgplayer: 569890,
+			},
 		},
+	],
 
-		damage: 180,
-		cost: ["Metal", "Metal", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "タテトプス",
+	},
 
 	retreat: 4,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Rare",
+	dexId: [411],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/048.ts
+++ b/data-asia/S/S10P/048.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "銅鏡怪"
+		ja: "ドーミラー",
+		'zh-tw': "銅鏡怪",
 	},
 
 	illustrator: "Kouki Saitou",
@@ -14,36 +14,44 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "靠著不可思議的能量飄浮在半空。人們將其背上所刻的紋路視為神聖， 相同紋路有時會被刻在古時的墳墓等地。"
+		ja: "不可思議な エネルギーで 漂う。 背に 刻まれし 文様は 神聖とされ 古き 墓地などに まま 描かれる。",
+		'zh-tw': "靠著不可思議的能量飄浮在半空。人們將其背上所刻的紋路視為神聖， 相同紋路有時會被刻在古時的墳墓等地。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "金屬壓制"
+	attacks: [
+		{
+			name: {
+				ja: "メタルプレス",
+				'zh-tw': "金屬壓制",
+			},
+			damage: 20,
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+				'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651107,
+				tcgplayer: 569891,
+			},
 		},
-
-		damage: 20,
-		cost: ["Metal", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [436],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/049.ts
+++ b/data-asia/S/S10P/049.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "青銅鐘"
+		ja: "ドータクン",
+		'zh-tw': "青銅鐘",
 	},
 
 	illustrator: "Shinji Kanda",
@@ -14,44 +14,58 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "被稱為能召喚雨雲的神明。生氣時會用像鐘聲一般令人 毛骨悚然的聲音來威嚇對手。"
+		ja: "雨雲を呼ぶ 神と いわれる。 怒らせると 鐘の音の ような 不気味な 声で 威嚇する。",
+		'zh-tw': "被稱為能召喚雨雲的神明。生氣時會用像鐘聲一般令人 毛骨悚然的聲音來威嚇對手。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "耐熱"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "たいねつ",
+				'zh-tw': "耐熱",
+			},
+			effect: {
+				ja: "このポケモンは、相手の[R]ポケモンからワザのダメージを受けない。",
+				'zh-tw': "這隻寶可夢不會受到對手的【火】寶可夢招式的傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢不會受到對手的【火】寶可夢招式的傷害。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "頭突"
+	attacks: [
+		{
+			name: {
+				ja: "ぶちかます",
+				'zh-tw': "頭突",
+			},
+			damage: 100,
+			cost: ["Metal", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 100,
-		cost: ["Metal", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651108,
+				tcgplayer: 569892,
+			},
+		},
+	],
 
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ドーミラー",
+	},
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [437],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/050.ts
+++ b/data-asia/S/S10P/050.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "瑪機雅娜"
+		ja: "マギアナ",
+		'zh-tw': "瑪機雅娜",
 	},
 
 	illustrator: "Rianti Hidayat",
@@ -14,43 +14,51 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "由大約５００年前的 科學家所製造。 本體是被稱為魂心的零件。"
+		ja: "およそ ５００年前 科学者に よって 作られた。 ソウルハートと 呼ばれる パーツが 本体なのだ。",
+		'zh-tw': "由大約５００年前的 科學家所製造。 本體是被稱為魂心的零件。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "齒輪刀"
+	attacks: [
+		{
+			name: {
+				ja: "ギアカッター",
+				'zh-tw': "齒輪刀",
+			},
+			damage: 20,
+			cost: ["Metal"],
 		},
-
-		effect: {
-			'zh-tw': "#N/A"
+		{
+			name: {
+				ja: "からくりビーム",
+				'zh-tw': "機關光束",
+			},
+			damage: "60+",
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンに「ポケモンのどうぐ」がついているなら、60ダメージ追加し、相手のバトルポケモンをこんらんにする。",
+			},
 		},
+	],
 
-		damage: 20,
-		cost: ["Metal"]
-	}, {
-		name: {
-			'zh-tw': "機關光束"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651109,
+				tcgplayer: 569893,
+			},
 		},
-
-		damage: "60+",
-		cost: ["Metal", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [801],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/051.ts
+++ b/data-asia/S/S10P/051.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雷吉鐸拉戈"
+		ja: "レジドラゴ",
+		'zh-tw': "雷吉鐸拉戈",
 	},
 
 	illustrator: "DOM",
@@ -14,34 +14,54 @@ const card: Card = {
 	types: ["Dragon"],
 
 	description: {
-		'zh-tw': "有學者認為牠的手臂是古代龍寶可夢頭部的形狀。 但這個學說尚未被證實。"
+		ja: "腕の 形は 古代の ドラゴン ポケモンの 頭という 学説も あるが 証明されていない。",
+		'zh-tw': "有學者認為牠的手臂是古代龍寶可夢頭部的形狀。 但這個學說尚未被證實。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "龍之護庇"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "りゅうのひほう",
+				'zh-tw': "龍之護庇",
+			},
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。自分の手札が4枚になるように、山札を引く。この番、すでに別の「りゅうのひほう」を使っていたなら、この特性は使えない。",
+				'zh-tw': "若這隻寶可夢在戰鬥場上，則在自己的回合時可使用1次。從牌庫抽卡直到自己的手牌滿4張為止。在這個回合，若已經使出了其他的「龍之護庇」，則這個特性無法使用。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢在戰鬥場上，則在自己的回合時可使用1次。從牌庫抽卡直到自己的手牌滿4張為止。在這個回合，若已經使出了其他的「龍之護庇」，則這個特性無法使用。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "巨大之牙"
+	attacks: [
+		{
+			name: {
+				ja: "きょだいなキバ",
+				'zh-tw': "巨大之牙",
+			},
+			damage: 160,
+			cost: ["Grass", "Fire", "Colorless"],
 		},
+	],
 
-		damage: 160,
-		cost: ["Grass", "Fire", "Colorless"]
-	}],
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651110,
+				tcgplayer: 569894,
+			},
+		},
+	],
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [895],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/052.ts
+++ b/data-asia/S/S10P/052.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "大舌頭"
+		ja: "ベロリンガ",
+		'zh-tw': "大舌頭",
 	},
 
 	illustrator: "KIYOTAKA OSHIYAMA",
@@ -14,27 +14,40 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "沾到牠黏糊糊的唾液後如果放著不管，就會變得 奇癢無比，而且癢個不停。"
+		ja: "ネバネバした 唾液に 触れたまま 放っておくと ものすごい 痒みが はじまり とまらなくなるぞ。",
+		'zh-tw': "沾到牠黏糊糊的唾液後如果放著不管，就會變得 奇癢無比，而且癢個不停。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "口水"
+	attacks: [
+		{
+			name: {
+				ja: "よだれ",
+				'zh-tw': "口水",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651111,
+				tcgplayer: 569895,
+			},
+		},
+	],
 
 	retreat: 4,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [108],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/053.ts
+++ b/data-asia/S/S10P/053.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "大舌舔"
+		ja: "ベロベルト",
+		'zh-tw': "大舌舔",
 	},
 
 	illustrator: "Shibuzoh.",
@@ -14,34 +14,52 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "神奇的舌頭能夠伸到身高的好幾倍遠。至今沒人能解開 為什麼它會這麼神奇。"
+		ja: "体の 何倍もの 長さまで 伸びる 不思議な ベロを もつ。 その 不思議は 未解明のまま。",
+		'zh-tw': "神奇的舌頭能夠伸到身高的好幾倍遠。至今沒人能解開 為什麼它會這麼神奇。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "舌擊"
+	attacks: [
+		{
+			name: {
+				ja: "ベロではたく",
+				'zh-tw': "舌擊",
+			},
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
 		},
-
-		damage: 50,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "重磅衝擊"
+		{
+			name: {
+				ja: "ヘビーインパクト",
+				'zh-tw': "重磅衝擊",
+			},
+			damage: 130,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 130,
-		cost: ["Colorless", "Colorless", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651112,
+				tcgplayer: 569896,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ベロリンガ",
+	},
 
 	retreat: 4,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [463],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/054.ts
+++ b/data-asia/S/S10P/054.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伊布"
+		ja: "イーブイ",
+		'zh-tw': "伊布",
 	},
 
 	illustrator: "sowsow",
@@ -14,39 +14,54 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "伊布擁有著能夠為了適應周遭的環境而 改變身體構造的能力。"
+		ja: "まわりの 環境に 合わせて 体の つくりを 変えていく 能力の 持ち主。",
+		'zh-tw': "伊布擁有著能夠為了適應周遭的環境而 改變身體構造的能力。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "共鳴進化"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "きょうめいしんか",
+				'zh-tw': "共鳴進化",
+			},
+			effect: {
+				ja: "自分の番に、自分の別の「イーブイ」が手札から出したポケモンに進化したなら、1回使える。このポケモンから進化するカードを、自分の山札から1枚選び、このポケモンにのせて進化させる。そして山札を切る。",
+				'zh-tw': "在自己的回合，若自己的其他「伊布」進化成從手牌使出的寶可夢，則可使用1次。從自己的牌庫選擇1張從這隻寶可夢進化而來的卡，放置於這隻寶可夢身上完成進化。並且重洗牌庫。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，若自己的其他「伊布」進化成從手牌使出的寶可夢，則可使用1次。從自己的牌庫選擇1張從這隻寶可夢進化而來的卡，放置於這隻寶可夢身上完成進化。並且重洗牌庫。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "撞擊"
+	attacks: [
+		{
+			name: {
+				ja: "たいあたり",
+				'zh-tw': "撞擊",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651113,
+				tcgplayer: 569897,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [133],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/055.ts
+++ b/data-asia/S/S10P/055.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "熊寶寶"
+		ja: "ヒメグマ",
+		'zh-tw': "熊寶寶",
 	},
 
 	illustrator: "Nagomi Nijo",
@@ -14,37 +14,51 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "總是舔舐著滲入掌中的香甜蜜汁。三蜜蜂積蓄在巢中的花蜜時常 被牠毫不客氣地佔為己有。"
+		ja: "掌に 染む 甘き蜜を 舐める 仕草。 ミツハニー 集めし 蜜を 巣より 頂戴し 我がものとする したたかさ。",
+		'zh-tw': "總是舔舐著滲入掌中的香甜蜜汁。三蜜蜂積蓄在巢中的花蜜時常 被牠毫不客氣地佔為己有。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "撿飼料"
+	attacks: [
+		{
+			name: {
+				ja: "エサひろい",
+				'zh-tw': "撿飼料",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、自分のトラッシュからグッズを1枚選び、相手に見せて、手札に加える。",
+				'zh-tw': "擲1次硬幣若為正面，則從自己的棄牌區選擇1張物品卡，在給對手看過後加入手牌。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則從自己的棄牌區選擇1張物品卡，在給對手看過後加入手牌。"
+		{
+			name: {
+				ja: "ツメをたてる",
+				'zh-tw': "豎爪",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "豎爪"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651114,
+				tcgplayer: 569898,
+			},
 		},
-
-		damage: 20,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [216],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/056.ts
+++ b/data-asia/S/S10P/056.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "圈圈熊"
+		ja: "リングマ",
+		'zh-tw': "圈圈熊",
 	},
 
 	illustrator: "Teeziro",
@@ -14,38 +14,56 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "在洗翠大地被嚴寒籠罩的季節裡，徘徊於山野之中尋找愛吃的樹果。 空腹帶來的焦躁使牠變得極為凶暴。"
+		ja: "ヒスイの地を 寒気 覆いたる 季節 好物の木の実 集めに 野山を徘徊す。 空腹ゆえ 気が立ち 極めて凶暴。",
+		'zh-tw': "在洗翠大地被嚴寒籠罩的季節裡，徘徊於山野之中尋找愛吃的樹果。 空腹帶來的焦躁使牠變得極為凶暴。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "連續巴掌"
+	attacks: [
+		{
+			name: {
+				ja: "れんぞくはりて",
+				'zh-tw': "連續巴掌",
+			},
+			damage: "40×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数×40ダメージ。",
+				'zh-tw': "擲硬幣直到出現反面，造成正面出現的次數×40點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲硬幣直到出現反面，造成正面出現的次數×40點傷害。"
+		{
+			name: {
+				ja: "かいりき",
+				'zh-tw': "怪力",
+			},
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: "40×",
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "怪力"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651115,
+				tcgplayer: 569899,
+			},
 		},
+	],
 
-		damage: 100,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ヒメグマ",
+	},
 
 	retreat: 3,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [217],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/057.ts
+++ b/data-asia/S/S10P/057.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "月月熊"
+		ja: "ガチグマ",
+		'zh-tw': "月月熊",
 	},
 
 	illustrator: "nagimiso",
@@ -14,41 +14,59 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "考察結果顯示，正是遍布在洗翠大地上的濕地土壤，造就了牠堅實 的軀體和自在運用泥炭的新能力。"
+		ja: "ヒスイの地に 敷かれし 湿地の土こそ 頑丈なる体躯と 泥炭を 自在に 扱う 新たな 器量 もたらしたと 考察す。",
+		'zh-tw': "考察結果顯示，正是遍布在洗翠大地上的濕地土壤，造就了牠堅實 的軀體和自在運用泥炭的新能力。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "泥炭搜尋"
+	attacks: [
+		{
+			name: {
+				ja: "ピートハント",
+				'zh-tw': "泥炭搜尋",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュから好きなカードを2枚まで選び、相手に見せて、手札に加える。",
+				'zh-tw': "從自己的棄牌區任意選擇最多2張卡，在給對手看過後加入手牌。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的棄牌區任意選擇最多2張卡，在給對手看過後加入手牌。"
+		{
+			name: {
+				ja: "きょたいでつっこむ",
+				'zh-tw': "巨體碰撞",
+			},
+			damage: 200,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+				'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "巨體碰撞"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651116,
+				tcgplayer: 569900,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。"
-		},
-
-		damage: 200,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "リングマ",
+	},
 
 	retreat: 4,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Uncommon",
+	dexId: [901],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/058.ts
+++ b/data-asia/S/S10P/058.ts
@@ -1,52 +1,66 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "智揮猩V"
+		ja: "ヤレユータンV",
+		'zh-tw': "智揮猩V",
 	},
 
 	illustrator: "Uta",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Colorless"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "下訂"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "おとりよせ",
+				'zh-tw': "下訂",
+			},
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。自分の山札から「ポケモンのどうぐ」を2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "若這隻寶可夢在戰鬥場上，則在自己的回合時可使用1次。從自己的牌庫選擇最多2張「寶可夢道具」卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢在戰鬥場上，則在自己的回合時可使用1次。從自己的牌庫選擇最多2張「寶可夢道具」卡，在給對手看過後加入手牌。並且重洗牌庫。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "精神強念"
+	attacks: [
+		{
+			name: {
+				ja: "サイコキネシス",
+				'zh-tw': "精神強念",
+			},
+			damage: "30+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数×50ダメージ追加。",
+				'zh-tw': "增加對手的戰鬥寶可夢身上附加的能量的數量×50點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加對手的戰鬥寶可夢身上附加的能量的數量×50點傷害。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651117,
+				tcgplayer: 569901,
+			},
 		},
-
-		damage: "30+",
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Double rare",
+	dexId: [765],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/059.ts
+++ b/data-asia/S/S10P/059.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "樹枕尾熊"
+		ja: "ネッコアラ",
+		'zh-tw': "樹枕尾熊",
 	},
 
 	illustrator: "HYOGONOSUKE",
@@ -14,43 +14,58 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "終其一生都處於睡著的狀態。 這是因為牠所吃的葉子裡 含有類似麻醉藥的成分。"
+		ja: "死ぬまで ずっと 眠ったままなのは エサの 葉っぱに 麻酔の ような 成分が 含まれているからだ。",
+		'zh-tw': "終其一生都處於睡著的狀態。 這是因為牠所吃的葉子裡 含有類似麻醉藥的成分。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "一場夢"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ゆめおち",
+				'zh-tw': "一場夢",
+			},
+			effect: {
+				ja: "このポケモンがねむりなら、相手のポケモンからワザのダメージを受けてきぜつしても、相手はサイドをとれない。",
+				'zh-tw': "若這隻寶可夢在【睡眠】，則就算受到對手的寶可夢招式的傷害而【氣絕】，對手也無法獲得獎賞卡。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢在【睡眠】，則就算受到對手的寶可夢招式的傷害而【氣絕】，對手也無法獲得獎賞卡。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "倒下"
+	attacks: [
+		{
+			name: {
+				ja: "たおれこむ",
+				'zh-tw': "倒下",
+			},
+			damage: 60,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをねむりにする。",
+				'zh-tw': "將這隻寶可夢【睡眠】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將這隻寶可夢【睡眠】。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651118,
+				tcgplayer: 569902,
+			},
 		},
-
-		damage: 60,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Common",
+	dexId: [775],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S10P/060.ts
+++ b/data-asia/S/S10P/060.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "能量籤"
+		ja: "エネくじ",
+		'zh-tw': "能量籤",
 	},
 
 	illustrator: "ORBITALLINK Inc.",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "查看自己的牌庫上方7張卡。選擇其中1張能量卡，在給對手看過後加入手牌。將剩餘卡放回牌庫並重洗。"
+		ja: "自分の山札を上から7枚見る。その中にあるエネルギーを1枚、相手に見せてから、手札に加えてよい。残りのカードは山札にもどして切る。",
+		'zh-tw': "查看自己的牌庫上方7張卡。選擇其中1張能量卡，在給對手看過後加入手牌。將剩餘卡放回牌庫並重洗。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651119,
+				tcgplayer: 569903,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S10P/061.ts
+++ b/data-asia/S/S10P/061.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "謎之化石"
+		ja: "なぞの化石",
+		'zh-tw': "謎之化石",
 	},
 
 	illustrator: "AYUMI ODASHIMA",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "這張卡可作為HP60的【無】屬性的【基礎】寶可夢放置於場上。若在自己的回合中，則可將場上的這張卡丟棄。這張卡無法撤退。"
+		ja: "このカードは、HP60の[無]タイプのたねポケモンとして、場に出すことができる。自分の番の中でなら、場に出ているこのカードをトラッシュしてよい。このカードは、にげられない。",
+		'zh-tw': "這張卡可作為HP60的【無】屬性的【基礎】寶可夢放置於場上。若在自己的回合中，則可將場上的這張卡丟棄。這張卡無法撤退。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651120,
+				tcgplayer: 569904,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "F",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/S/S10P/062.ts
+++ b/data-asia/S/S10P/062.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洗翠的沉重球"
+		ja: "ヒスイのヘビーボール",
+		'zh-tw': "洗翠的沉重球",
 	},
 
 	illustrator: "Studio Bora Inc.",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "查看自己的所有反面朝上的獎賞卡的正面。從其中選擇1張【基礎】寶可夢卡，在給對手看過後，與這張「洗翠的沉重球」卡互換並加入手牌。將看過的獎賞卡與換入的卡全部翻回反面並重洗，作為獎賞卡放置。"
+		ja: "ウラになっている自分のサイドのオモテをすべて見る。その中からたねポケモンを1枚選び、相手に見せて、この「ヒスイのヘビーボール」と入れ替えて、手札に加える。見たサイドや入れ替えたカードはすべてウラにして切り、サイドとして置く。",
+		'zh-tw': "查看自己的所有反面朝上的獎賞卡的正面。從其中選擇1張【基礎】寶可夢卡，在給對手看過後，與這張「洗翠的沉重球」卡互換並加入手牌。將看過的獎賞卡與換入的卡全部翻回反面並重洗，作為獎賞卡放置。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651121,
+				tcgplayer: 569905,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S10P/063.ts
+++ b/data-asia/S/S10P/063.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "超群眼鏡"
+		ja: "ばつぐんグラス",
+		'zh-tw': "超群眼鏡",
 	},
 
 	illustrator: "Ryo Ueda",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。"
+		ja: "このカードをつけているポケモンが使うワザのダメージで、相手のバトルポケモンの弱点を計算するとき、弱点は「×3」としてダメージ計算をする。",
+		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651122,
+				tcgplayer: 569906,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Tool",
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S10P/064.ts
+++ b/data-asia/S/S10P/064.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "珠貝"
+		ja: "カイ",
+		'zh-tw': "珠貝",
 	},
 
 	illustrator: "kirisAki",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的牌庫選擇【水】寶可夢卡與物品卡各1張，在給對手看過後加入手牌。並且重洗牌庫。"
+		ja: "自分の山札から[W]ポケモンとグッズをそれぞれ1枚ずつ選び、相手に見せて、手札に加える。そして山札を切る。",
+		'zh-tw': "從自己的牌庫選擇【水】寶可夢卡與物品卡各1張，在給對手看過後加入手牌。並且重洗牌庫。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651123,
+				tcgplayer: 569907,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Rare",
+};
+
+export default card;

--- a/data-asia/S/S10P/065.ts
+++ b/data-asia/S/S10P/065.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "查克洛"
+		ja: "ザクロ",
+		'zh-tw': "查克洛",
 	},
 
 	illustrator: "Hideki Ishikawa",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "在這個回合，自己的【鬥】寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+30」點。在自己的回合，若將自己的2張手牌（「查克洛」除外）丟棄，則可從自己的棄牌區將這張「查克洛」給對手看過後加入手牌。（在自己的回合時可使用的支援者卡的張數中，不包含這個效果。）"
+		ja: "この番、自分の[F]ポケモンが使うワザの、相手のバトルポケモンへのダメージは「+30」される。自分の番に、自分の手札（「ザクロ」をのぞく）を2枚トラッシュするなら、この「ザクロ」を自分のトラッシュから、相手に見せて、手札に加える。（この効果は、自分の番に使えるサポートの枚数にふくまない。）",
+		'zh-tw': "在這個回合，自己的【鬥】寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+30」點。在自己的回合，若將自己的2張手牌（「查克洛」除外）丟棄，則可從自己的棄牌區將這張「查克洛」給對手看過後加入手牌。（在自己的回合時可使用的支援者卡的張數中，不包含這個效果。）",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651124,
+				tcgplayer: 569908,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S10P/066.ts
+++ b/data-asia/S/S10P/066.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "曉白"
+		ja: "タイサイ",
+		'zh-tw': "曉白",
 	},
 
 	illustrator: "Hitoshi Ariga",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "雙方玩家各將自己的手牌翻到正面後，雙方互看。從自己的牌庫抽出3張卡。"
+		ja: "おたがいのプレイヤーは、それぞれ、自分の手札をオモテにして、おたがいに見せ合う。自分の山札を3枚引く。",
+		'zh-tw': "雙方玩家各將自己的手牌翻到正面後，雙方互看。從自己的牌庫抽出3張卡。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651125,
+				tcgplayer: 569909,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S10P/067.ts
+++ b/data-asia/S/S10P/067.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S10P"
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "神奧神殿"
+		ja: "シンオウ神殿",
+		'zh-tw': "神奧神殿",
 	},
 
 	illustrator: "Oswaldo KATO",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "雙方的場上寶可夢身上附加的特殊能量的效果全部消除，視為提供1個【無】能量。"
+		ja: "おたがいの場のポケモンについている特殊エネルギーの効果はすべてなくなり、[C]エネルギー1個ぶんとしてはたらく。",
+		'zh-tw': "雙方的場上寶可夢身上附加的特殊能量的效果全部消除，視為提供1個【無】能量。",
 	},
 
-	trainerType: "Stadium",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 651126,
+				tcgplayer: 569910,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Stadium",
+	regulationMark: "F",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S10P/068.ts
+++ b/data-asia/S/S10P/068.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スピアーV",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ダブルニードル" },
+			damage: "40×",
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×40ダメージ。",
+			},
+		},
+		{
+			name: { ja: "むれでさす" },
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、自分の場の｢スピアーV｣の数×50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651331,
+				tcgplayer: 569911,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [15],
+};
+
+export default card;

--- a/data-asia/S/S10P/069.ts
+++ b/data-asia/S/S10P/069.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スピアーV",
+	},
+
+	illustrator: "Narumi Sato",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ダブルニードル" },
+			damage: "40×",
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×40ダメージ。",
+			},
+		},
+		{
+			name: { ja: "むれでさす" },
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、自分の場の｢スピアーV｣の数×50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651332,
+				tcgplayer: 569912,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [15],
+};
+
+export default card;

--- a/data-asia/S/S10P/070.ts
+++ b/data-asia/S/S10P/070.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オリジンパルキアV",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "りょういきしはい" },
+			cost: ["Water"],
+			effect: {
+				ja: "自分の山札からスタジアムを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ハイドロブレイク" },
+			damage: 200,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651333,
+				tcgplayer: 569913,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [484],
+};
+
+export default card;

--- a/data-asia/S/S10P/071.ts
+++ b/data-asia/S/S10P/071.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オリジンパルキアV",
+	},
+
+	illustrator: "Oswaldo KATO",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "りょういきしはい" },
+			cost: ["Water"],
+			effect: {
+				ja: "自分の山札からスタジアムを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ハイドロブレイク" },
+			damage: 200,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651334,
+				tcgplayer: 569914,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [484],
+};
+
+export default card;

--- a/data-asia/S/S10P/072.ts
+++ b/data-asia/S/S10P/072.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒードランV",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ねつでこがす" },
+			damage: 30,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+		{
+			name: { ja: "マグマフォール" },
+			damage: "90+",
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "場に自分のスタジアムが出ているなら、90ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651335,
+				tcgplayer: 569915,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [485],
+};
+
+export default card;

--- a/data-asia/S/S10P/073.ts
+++ b/data-asia/S/S10P/073.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バサギリV",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "いあいぎり" },
+			damage: 40,
+			cost: ["Fighting"],
+		},
+		{
+			name: { ja: "まさかりスラッシュ" },
+			damage: 150,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。その後、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651336,
+				tcgplayer: 569916,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [900],
+};
+
+export default card;

--- a/data-asia/S/S10P/074.ts
+++ b/data-asia/S/S10P/074.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒスイ オオニューラV",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どくのツメ" },
+			cost: [],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+		{
+			name: { ja: "フェイタルクロー" },
+			damage: "80×",
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが受けている特殊状態の数×80ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651337,
+				tcgplayer: 569917,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [903],
+};
+
+export default card;

--- a/data-asia/S/S10P/075.ts
+++ b/data-asia/S/S10P/075.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒスイ オオニューラV",
+	},
+
+	illustrator: "OKACHEKE",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どくのツメ" },
+			cost: [],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+		{
+			name: { ja: "フェイタルクロー" },
+			damage: "80×",
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが受けている特殊状態の数×80ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651338,
+				tcgplayer: 569918,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [903],
+};
+
+export default card;

--- a/data-asia/S/S10P/076.ts
+++ b/data-asia/S/S10P/076.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤレユータンV",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "おとりよせ" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。自分の山札から「ポケモンのどうぐ」を2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "サイコキネシス" },
+			damage: "30+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数×50ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651339,
+				tcgplayer: 569919,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+	dexId: [765],
+};
+
+export default card;

--- a/data-asia/S/S10P/077.ts
+++ b/data-asia/S/S10P/077.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カイ",
+	},
+
+	illustrator: "kirisAki",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から[W]ポケモンとグッズをそれぞれ1枚ずつ選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651340,
+				tcgplayer: 569920,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S10P/078.ts
+++ b/data-asia/S/S10P/078.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ザクロ",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "この番、自分の[F]ポケモンが使うワザの、相手のバトルポケモンへのダメージは「+30」される。自分の番に、自分の手札（「ザクロ」をのぞく）を2枚トラッシュするなら、この「ザクロ」を自分のトラッシュから、相手に見せて、手札に加える。（この効果は、自分の番に使えるサポートの枚数にふくまない。）",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651341,
+				tcgplayer: 569921,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S10P/079.ts
+++ b/data-asia/S/S10P/079.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タイサイ",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、それぞれ、自分の手札をオモテにして、おたがいに見せ合う。自分の山札を3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651342,
+				tcgplayer: 569922,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S10P/080.ts
+++ b/data-asia/S/S10P/080.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒードランVMAX",
+	},
+
+	illustrator: "N-DESIGN Inc.",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Fire"],
+
+	stage: "VMAX",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "マグマゲイン" },
+			effect: {
+				ja: "場に自分のスタジアムが出ているなら、自分の番に1回使える。このポケモンのHPを「50」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ダイバクネツ" },
+			damage: 180,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651343,
+				tcgplayer: 569923,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒードランV",
+	},
+
+	retreat: 4,
+	regulationMark: "F",
+	rarity: "Holo Rare",
+	dexId: [485],
+};
+
+export default card;

--- a/data-asia/S/S10P/081.ts
+++ b/data-asia/S/S10P/081.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オリジンパルキアVSTAR",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Water"],
+
+	stage: "VSTAR",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "スターポータル" },
+			effect: {
+				ja: "自分の番に使える。自分のトラッシュから[W]エネルギーを3枚まで選び、自分の[W]ポケモンに好きなようにつける。［対戦中、自分はVSTARパワーを1回しか使えない。］",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "あくうのうねり" },
+			damage: "60+",
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "おたがいのベンチポケモンの数×20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651344,
+				tcgplayer: 569924,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "nullV",
+	},
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Holo Rare",
+	dexId: [484],
+};
+
+export default card;

--- a/data-asia/S/S10P/082.ts
+++ b/data-asia/S/S10P/082.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バサギリVSTAR",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Fighting"],
+
+	stage: "VSTAR",
+
+	attacks: [
+		{
+			name: { ja: "ブレイクアックス" },
+			damage: 120,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "相手のベンチの「ポケモンV」1匹にも、60ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ランページスター" },
+			damage: "30×",
+			cost: ["Fighting"],
+			effect: {
+				ja: "自分のトラッシュにあるポケモンの枚数×30ダメージ。［対戦中、自分はVSTARパワーを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651345,
+				tcgplayer: 569925,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "バサギリV",
+	},
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Holo Rare",
+	dexId: [900],
+};
+
+export default card;

--- a/data-asia/S/S10P/083.ts
+++ b/data-asia/S/S10P/083.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カイ",
+	},
+
+	illustrator: "kirisAki",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から[W]ポケモンとグッズをそれぞれ1枚ずつ選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651346,
+				tcgplayer: 569926,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Holo Rare",
+};
+
+export default card;

--- a/data-asia/S/S10P/084.ts
+++ b/data-asia/S/S10P/084.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ザクロ",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "この番、自分の[F]ポケモンが使うワザの、相手のバトルポケモンへのダメージは「+30」される。自分の番に、自分の手札（「ザクロ」をのぞく）を2枚トラッシュするなら、この「ザクロ」を自分のトラッシュから、相手に見せて、手札に加える。（この効果は、自分の番に使えるサポートの枚数にふくまない。）",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651347,
+				tcgplayer: 569927,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Holo Rare",
+};
+
+export default card;

--- a/data-asia/S/S10P/085.ts
+++ b/data-asia/S/S10P/085.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タイサイ",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、それぞれ、自分の手札をオモテにして、おたがいに見せ合う。自分の山札を3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651348,
+				tcgplayer: 569928,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Holo Rare",
+};
+
+export default card;

--- a/data-asia/S/S10P/086.ts
+++ b/data-asia/S/S10P/086.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オリジンパルキアVSTAR",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Water"],
+
+	stage: "VSTAR",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "スターポータル" },
+			effect: {
+				ja: "自分の番に使える。自分のトラッシュから[W]エネルギーを3枚まで選び、自分の[W]ポケモンに好きなようにつける。［対戦中、自分はVSTARパワーを1回しか使えない。］",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "あくうのうねり" },
+			damage: "60+",
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "おたがいのベンチポケモンの数×20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651349,
+				tcgplayer: 569929,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "nullV",
+	},
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Mega Hyper Rare",
+	dexId: [484],
+};
+
+export default card;

--- a/data-asia/S/S10P/087.ts
+++ b/data-asia/S/S10P/087.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シンオウ神殿",
+	},
+
+	illustrator: "Oswaldo KATO",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの場のポケモンについている特殊エネルギーの効果はすべてなくなり、[C]エネルギー1個ぶんとしてはたらく。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651350,
+				tcgplayer: 569930,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "F",
+	rarity: "Mega Hyper Rare",
+};
+
+export default card;

--- a/data-asia/S/S10P/088.ts
+++ b/data-asia/S/S10P/088.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S10P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダブルターボエネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、ポケモンについているかぎり、[C]エネルギー2個ぶんとしてはたらく。このカードをつけているポケモンが使うワザの、相手のポケモンへのダメージは「-20」される。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651351,
+				tcgplayer: 569931,
+			},
+		},
+	],
+
+	regulationMark: "F",
+	rarity: "Mega Hyper Rare",
+};
+
+export default card;

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -236,6 +236,7 @@ export interface Card {
 			// Black White rare
 			| 'Black White Rare'
 			| 'Mega Hyper Rare'
+			| 'Triple Rare'
 			// Japanese Character Rares (since SM11b Dream League)
 			| 'Character Rare' | 'Character Super Rare'
 			// Pokémon TCG Pocket Rarities


### PR DESCRIPTION
## What

Refreshes the existing Japanese set **S10P スペースジャグラー (Space Juggler)** from its primary sources. The curated content stays: every card keeps its `zh-tw` texts verbatim.

What changes across the 88 card files:

- `thirdParty.cardmarket` moves onto `variants` objects and 67 missing ids are filled in
- per card where missing: `dexId`, `evolveFrom`, `resistances`, the Japanese flavor text and the Japanese effect/attack texts straight from the official database and limitless

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (651060–651351)
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (569844–569931), keyed by the collection number each product carries in `extendedData`

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- All 88 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
