### PR TITLE
(data) Update Japanese S set S8b VMAX Climax

### DIFF
--- a/data-asia/S/S8b/001.ts
+++ b/data-asia/S/S8b/001.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "獨角蟲"
+		ja: "ビードル",
+		'zh-tw': "獨角蟲",
 	},
 
 	illustrator: "Sanosuke Sakuma",
@@ -14,27 +14,46 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "毒針非常厲害。鮮豔的體色是用來 警告對手的。"
+		ja: "毒針は とても 強力。 目立つ 体の 色は 相手に 警戒を させるためだ。",
+		'zh-tw': "毒針非常厲害。鮮豔的體色是用來 警告對手的。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "突刺"
+	attacks: [
+		{
+			name: {
+				ja: "つきさす",
+				'zh-tw': "突刺",
+			},
+			damage: 20,
+			cost: ["Grass"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Grass"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586516,
+				tcgplayer: 571254,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578354,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [13],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/002.ts
+++ b/data-asia/S/S8b/002.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鐵殼蛹"
+		ja: "コクーン",
+		'zh-tw': "鐵殼蛹",
 	},
 
 	illustrator: "nagimiso",
@@ -14,30 +14,53 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "為了不被天敵發現，會躲在葉子背面或樹枝的間隙中， 等待進化的時刻到來。"
+		ja: "天敵に 見つからないように 葉っぱの 裏や 枝の すきまに 隠れて 進化の ときを 待つ。",
+		'zh-tw': "為了不被天敵發現，會躲在葉子背面或樹枝的間隙中， 等待進化的時刻到來。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "凝固"
+	attacks: [
+		{
+			name: {
+				ja: "かたまる",
+				'zh-tw': "凝固",
+			},
+			cost: ["Grass"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-40」される。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-40」點。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-40」點。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586517,
+				tcgplayer: 571255,
+			},
 		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578355,
+			},
+		},
+	],
 
-		cost: ["Grass"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ビードル",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [14],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/003.ts
+++ b/data-asia/S/S8b/003.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "大針蜂"
+		ja: "スピアー",
+		'zh-tw': "大針蜂",
 	},
 
 	illustrator: "Misa Tsutsui",
@@ -14,41 +14,59 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "有時會成群結隊地出現。能以極快的速度飛來飛去， 並用尾部的毒針不斷刺擊對手。"
+		ja: "集団で 現れることもある。 猛スピードで 飛び回り お尻の 毒針で 刺しまくる。",
+		'zh-tw': "有時會成群結隊地出現。能以極快的速度飛來飛去， 並用尾部的毒針不斷刺擊對手。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "對點針刺"
+	attacks: [
+		{
+			name: {
+				ja: "いってんばり",
+				'zh-tw': "對點針刺",
+			},
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンに特殊エネルギーがついているなら、そのポケモンをきぜつさせる。",
+				'zh-tw': "若對手的戰鬥寶可夢身上附有特殊能量，則將那隻寶可夢【氣絕】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "若對手的戰鬥寶可夢身上附有特殊能量，則將那隻寶可夢【氣絕】。"
+		{
+			name: {
+				ja: "ジェットスピア",
+				'zh-tw': "噴射尖槍",
+			},
+			damage: 110,
+			cost: ["Grass"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		cost: ["Grass"]
-	}, {
-		name: {
-			'zh-tw': "噴射尖槍"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586518,
+				tcgplayer: 571256,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。"
-		},
-
-		damage: 110,
-		cost: ["Grass"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "コクーン",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [15],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/004.ts
+++ b/data-asia/S/S8b/004.ts
@@ -1,52 +1,66 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "音箱蟀V"
+		ja: "コロトックV",
+		'zh-tw': "音箱蟀V",
 	},
 
 	illustrator: "Satoshi Shirai",
 	category: "Pokemon",
 	hp: 180,
 	types: ["Grass"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "激動舞台"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "エキサイトステージ",
+				'zh-tw': "激動舞台",
+			},
+			effect: {
+				ja: "自分の番に1回使える。自分の手札が3枚になるように、山札を引く。このポケモンがバトル場にいるなら、4枚になるように引く。この番、すでに別の「エキサイトステージ」を使っていたなら、この特性は使えない。",
+				'zh-tw': "在自己的回合時，可使用1次。從牌庫抽卡直到自己的手牌滿3張為止。若這隻寶可夢在戰鬥場上，則抽卡直到滿4張為止。在這個回合，若已經使出了其他的「激動舞台」，則這個特性無法使用。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，可使用1次。從牌庫抽卡直到自己的手牌滿3張為止。若這隻寶可夢在戰鬥場上，則抽卡直到滿4張為止。在這個回合，若已經使出了其他的「激動舞台」，則這個特性無法使用。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "十字剪"
+	attacks: [
+		{
+			name: {
+				ja: "シザークロス",
+				'zh-tw': "十字剪",
+			},
+			damage: "80+",
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、80ダメージ追加。",
+				'zh-tw': "擲1次硬幣若為正面，則增加80點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則增加80點傷害。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586519,
+				tcgplayer: 571257,
+			},
 		},
-
-		damage: "80+",
-		cost: ["Grass", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [402],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/005.ts
+++ b/data-asia/S/S8b/005.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "櫻花寶"
+		ja: "チェリンボ",
+		'zh-tw': "櫻花寶",
 	},
 
 	illustrator: "Naoyo Kimura",
@@ -14,39 +14,60 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "身體越紅的櫻花寶含有的營養越豐富，味道也很甜很好吃。"
+		ja: "体が 赤い チェリンボほど 栄養が 多く 玉の 味も 甘くて おいしいよ。",
+		'zh-tw': "身體越紅的櫻花寶含有的營養越豐富，味道也很甜很好吃。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "活潑果實"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "はつらつかじつ",
+				'zh-tw': "活潑果實",
+			},
+			effect: {
+				ja: "このポケモンは、相手のポケモンが使うワザの効果を受けない。",
+				'zh-tw': "這隻寶可夢不會受到對手的寶可夢使用招式的效果的影響。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢不會受到對手的寶可夢使用招式的效果的影響。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "樹葉"
+	attacks: [
+		{
+			name: {
+				ja: "このは",
+				'zh-tw': "樹葉",
+			},
+			damage: 20,
+			cost: ["Grass", "Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Grass", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586520,
+				tcgplayer: 571258,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578356,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [420],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/006.ts
+++ b/data-asia/S/S8b/006.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "櫻花兒"
+		ja: "チェリム",
+		'zh-tw': "櫻花兒",
 	},
 
 	illustrator: "Tika Matsuno",
@@ -14,39 +14,58 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "盛開的花瓣中散發出的微微香氣會吸引蟲寶可夢聚集而來。"
+		ja: "満開の 花びら から ただよう かすかな 香りが 虫ポケモンを 集める。",
+		'zh-tw': "盛開的花瓣中散發出的微微香氣會吸引蟲寶可夢聚集而來。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "春爛漫"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "はるらんまん",
+				'zh-tw': "春爛漫",
+			},
+			effect: {
+				ja: "自分の番に何回でも使える。自分の手札から[草]エネルギーを1枚選び、自分のポケモン（「ルールを持つポケモン」をのぞく）につける。",
+				'zh-tw': "在自己的回合時，可不限次數使用。從自己的手牌選擇1張【草】能量卡，附於自己的寶可夢（「擁有規則的寶可夢」除外）身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，可不限次數使用。從自己的手牌選擇1張【草】能量卡，附於自己的寶可夢（「擁有規則的寶可夢」除外）身上。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "種子炸彈"
+	attacks: [
+		{
+			name: {
+				ja: "タネばくだん",
+				'zh-tw': "種子炸彈",
+			},
+			damage: 70,
+			cost: ["Grass", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 70,
-		cost: ["Grass", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586521,
+				tcgplayer: 571259,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チェリンボ",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [421],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/007.ts
+++ b/data-asia/S/S8b/007.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雪笠怪"
+		ja: "ユキカブリ",
+		'zh-tw': "雪笠怪",
 	},
 
 	illustrator: "Naoki Saito",
@@ -14,27 +14,46 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "雪笠怪肚子上結出來的樹果口感彷如冰棒， 是伽勒爾的火紅不倒翁們的最愛。"
+		ja: "お腹に 実る アイス みたいな 木の実は ガラルに 暮らす ダルマッカたちの 大好物。",
+		'zh-tw': "雪笠怪肚子上結出來的樹果口感彷如冰棒， 是伽勒爾的火紅不倒翁們的最愛。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "擊倒"
+	attacks: [
+		{
+			name: {
+				ja: "はりたおす",
+				'zh-tw': "擊倒",
+			},
+			damage: 60,
+			cost: ["Grass", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 60,
-		cost: ["Grass", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586522,
+				tcgplayer: 571260,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578357,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [459],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/008.ts
+++ b/data-asia/S/S8b/008.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "暴雪王"
+		ja: "ユキノオー",
+		'zh-tw': "暴雪王",
 	},
 
 	illustrator: "Akira Komayama",
@@ -14,39 +14,64 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "會引發暴風雪的寶可夢。只要牠搖動巨大的身體， 周圍立刻會變得一片雪白。"
+		ja: "ブリザードを 巻き起こす ポケモン。 大きな 体を 揺すれば あたり一面 すぐに 真っ白だ。",
+		'zh-tw': "會引發暴風雪的寶可夢。只要牠搖動巨大的身體， 周圍立刻會變得一片雪白。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "堅韌提升"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "タフネスアップ",
+				'zh-tw': "堅韌提升",
+			},
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の場の「いちげき」のポケモン（「ユキノオー」をのぞく）全員の最大HPは、それぞれ「50」大きくなる。この効果は、この特性を持つポケモンが何匹いても、重ならない。",
+				'zh-tw': "只要這隻寶可夢在場上，自己的場上的所有「一擊」寶可夢（「暴雪王」除外）的最大HP各增加「50」。無論有多少隻擁有這個特性的寶可夢，這個效果也不會重複。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在場上，自己的場上的所有「一擊」寶可夢（「暴雪王」除外）的最大HP各增加「50」。無論有多少隻擁有這個特性的寶可夢，這個效果也不會重複。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "百萬噸重拳"
+	attacks: [
+		{
+			name: {
+				ja: "メガトンパンチ",
+				'zh-tw': "百萬噸重拳",
+			},
+			damage: 90,
+			cost: ["Grass", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 90,
-		cost: ["Grass", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586523,
+				tcgplayer: 571261,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578358,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ユキカブリ",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [460],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/009.ts
+++ b/data-asia/S/S8b/009.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "索偵蟲"
+		ja: "サッチムシ",
+		'zh-tw': "索偵蟲",
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -14,27 +14,46 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "經常出現在田地裡的寶可夢。會透過長在身體上的毛來感應周圍發生的事。"
+		ja: "畑で よく見かける ポケモン。 体に 生えた 毛で まわりで 起きていることを 感じとる。",
+		'zh-tw': "經常出現在田地裡的寶可夢。會透過長在身體上的毛來感應周圍發生的事。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "踩"
+	attacks: [
+		{
+			name: {
+				ja: "ふむ",
+				'zh-tw': "踩",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
+	],
 
-		damage: 10,
-		cost: ["Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586524,
+				tcgplayer: 571262,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578359,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [824],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/010.ts
+++ b/data-asia/S/S8b/010.ts
@@ -1,51 +1,64 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "以歐路普V"
+		ja: "イオルブV",
+		'zh-tw': "以歐路普V",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 180,
 	types: ["Grass"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "狡兔三窟"
+	attacks: [
+		{
+			name: {
+				ja: "ひるがえす",
+				'zh-tw': "狡兔三窟",
+			},
+			damage: 20,
+			cost: ["Grass"],
+			effect: {
+				ja: "のぞむなら、このポケモンをベンチポケモンと入れ替える。",
+				'zh-tw': "若希望，將這隻寶可夢與備戰寶可夢互換。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "若希望，將這隻寶可夢與備戰寶可夢互換。"
+		{
+			name: {
+				ja: "ミステリーウェーブ",
+				'zh-tw': "神秘波",
+			},
+			damage: "50+",
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数×30ダメージ追加。",
+				'zh-tw': "增加對手的戰鬥寶可夢身上附加的能量的數量×30點傷害。",
+			},
 		},
+	],
 
-		damage: 20,
-		cost: ["Grass"]
-	}, {
-		name: {
-			'zh-tw': "神秘波"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586525,
+				tcgplayer: 571263,
+			},
 		},
-
-		effect: {
-			'zh-tw': "增加對手的戰鬥寶可夢身上附加的能量的數量×30點傷害。"
-		},
-
-		damage: "50+",
-		cost: ["Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "Double rare",
+	dexId: [826],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/011.ts
+++ b/data-asia/S/S8b/011.ts
@@ -1,51 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "以歐路普VMAX"
+		ja: "イオルブVMAX",
+		'zh-tw': "以歐路普VMAX",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 310,
 	types: ["Grass"],
+
 	stage: "VMAX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "怪光線"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "かいこうせん",
+				'zh-tw': "怪光線",
+			},
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。相手のポケモン全員に、それぞれダメカンを1個のせる。",
+				'zh-tw': "若這隻寶可夢在戰鬥場上，則在自己的回合時可使用1次。在對手的所有寶可夢身上各放置1個傷害指示物。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢在戰鬥場上，則在自己的回合時可使用1次。在對手的所有寶可夢身上各放置1個傷害指示物。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "超極巨波瀾壯闊"
+	attacks: [
+		{
+			name: {
+				ja: "キョダイウェーブ",
+				'zh-tw': "超極巨波瀾壯闊",
+			},
+			damage: "50+",
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数×50ダメージ追加。",
+				'zh-tw': "增加對手的戰鬥寶可夢身上附加的能量的數量×50點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加對手的戰鬥寶可夢身上附加的能量的數量×50點傷害。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586526,
+				tcgplayer: 571264,
+			},
 		},
+	],
 
-		damage: "50+",
-		cost: ["Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "イオルブV",
+	},
 
 	retreat: 1,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "Triple Rare",
+	dexId: [826],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/012.ts
+++ b/data-asia/S/S8b/012.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "啃果蟲"
+		ja: "カジッチュ",
+		'zh-tw': "啃果蟲",
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -14,30 +14,49 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "終其一生都在蘋果裡度過。遇到天敵鳥寶可夢時，會裝成蘋果保護自己。"
+		ja: "一生 りんごの 中で 暮らし 天敵の 鳥ポケモンに 出会うと りんごの 振りをして 身を守る。",
+		'zh-tw': "終其一生都在蘋果裡度過。遇到天敵鳥寶可夢時，會裝成蘋果保護自己。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "縮入殼中"
+	attacks: [
+		{
+			name: {
+				ja: "からにこもる",
+				'zh-tw': "縮入殼中",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージを受けない。",
+				'zh-tw': "擲1次硬幣若為正面，則在下個對手的回合，這隻寶可夢不會受到招式的傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則在下個對手的回合，這隻寶可夢不會受到招式的傷害。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586527,
+				tcgplayer: 571265,
+			},
 		},
-
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578360,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "None",
+	dexId: [840],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/013.ts
+++ b/data-asia/S/S8b/013.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "蘋裹龍"
+		ja: "アップリュー",
+		'zh-tw': "蘋裹龍",
 	},
 
 	illustrator: "Shin Nagasawa",
@@ -14,43 +14,62 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "啃果蟲吃了酸蘋果後進化而成。頰囊裡儲存著足以造成灼傷的強酸性液體。"
+		ja: "すっぱい りんごを 食べて 進化。 火傷する ほど 強酸性の 液体を 頬袋に 溜める。",
+		'zh-tw': "啃果蟲吃了酸蘋果後進化而成。頰囊裡儲存著足以造成灼傷的強酸性液體。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "蘋果墜擊"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "アップルドロップ",
+				'zh-tw': "蘋果墜擊",
+			},
+			effect: {
+				ja: "自分の番に1回使える。相手のポケモン1匹に、ダメカンを2個のせる。その後、このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。",
+				'zh-tw': "在自己的回合時，可使用1次。在對手的1隻寶可夢身上放置2個傷害指示物。然後，將這隻寶可夢與附加的卡，全部放回自己的牌庫並重洗。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，可使用1次。在對手的1隻寶可夢身上放置2個傷害指示物。然後，將這隻寶可夢與附加的卡，全部放回自己的牌庫並重洗。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "酸液炸彈"
+	attacks: [
+		{
+			name: {
+				ja: "アシッドボム",
+				'zh-tw': "酸液炸彈",
+			},
+			damage: 60,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "擲1次硬幣若為正面，則選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586528,
+				tcgplayer: 571266,
+			},
 		},
+	],
 
-		damage: 60,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "カジッチュ",
+	},
 
 	retreat: 1,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "None",
+	dexId: [841],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/014.ts
+++ b/data-asia/S/S8b/014.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "薩戮德"
+		ja: "ザルード",
+		'zh-tw': "薩戮德",
 	},
 
 	illustrator: "Shin Nagasawa",
@@ -14,41 +14,55 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "生長在身上的藤蔓斷落後會化為土壤的養分，孕育森林裡的各種植物。"
+		ja: "体に 生える ツルは ちぎれると 土の 栄養分となって 森の 植物たちを 育てるのだ。",
+		'zh-tw': "生長在身上的藤蔓斷落後會化為土壤的養分，孕育森林裡的各種植物。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "群喚之歌"
+	attacks: [
+		{
+			name: {
+				ja: "むれよびのうた",
+				'zh-tw': "群喚之歌",
+			},
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の山札から[草]ポケモンを1枚選び、相手に見せて、手札に加える。そして山札を切る。後攻プレイヤーの最初の番なら、手札に加えられる[草]ポケモンの枚数は3枚までになる。",
+				'zh-tw': "從自己的牌庫選擇1張【草】寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。若在後攻玩家的最初回合使用，則可加入手牌的【草】寶可夢卡張數改為最多3張。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張【草】寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。若在後攻玩家的最初回合使用，則可加入手牌的【草】寶可夢卡張數改為最多3張。"
+		{
+			name: {
+				ja: "さみだれのムチ",
+				'zh-tw': "反覆之鞭",
+			},
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[草]エネルギーの数×20ダメージ追加。",
+				'zh-tw': "增加這隻寶可夢身上附加的【草】能量的數量×20點傷害。",
+			},
 		},
+	],
 
-		cost: ["Grass"]
-	}, {
-		name: {
-			'zh-tw': "反覆之鞭"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586529,
+				tcgplayer: 571267,
+			},
 		},
-
-		effect: {
-			'zh-tw': "增加這隻寶可夢身上附加的【草】能量的數量×20點傷害。"
-		},
-
-		damage: "60+",
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [893],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/015.ts
+++ b/data-asia/S/S8b/015.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "小火龍"
+		ja: "ヒトカゲ",
+		'zh-tw': "小火龍",
 	},
 
 	illustrator: "MAHOU",
@@ -14,37 +14,57 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "天生喜歡熱熱的東西。據說當牠被雨淋濕的時候，尾巴的末端會冒出煙來。"
+		ja: "熱いものを 好む 性格。 雨に濡れると しっぽの 先から 煙が 出るという。",
+		'zh-tw': "天生喜歡熱熱的東西。據說當牠被雨淋濕的時候，尾巴的末端會冒出煙來。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "呼喚"
+	attacks: [
+		{
+			name: {
+				ja: "もってくる",
+				'zh-tw': "呼喚",
+			},
+			cost: ["Fire"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+				'zh-tw': "從自己的牌庫抽出1張卡。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫抽出1張卡。"
+		{
+			name: {
+				ja: "ほのお",
+				'zh-tw': "火焰",
+			},
+			damage: 30,
+			cost: ["Fire", "Fire"],
 		},
+	],
 
-		cost: ["Fire"]
-	}, {
-		name: {
-			'zh-tw': "火焰"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586530,
+				tcgplayer: 571268,
+			},
 		},
-
-		damage: 30,
-		cost: ["Fire", "Fire"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578361,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "None",
+	dexId: [4],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/016.ts
+++ b/data-asia/S/S8b/016.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "火恐龍"
+		ja: "リザード",
+		'zh-tw': "火恐龍",
 	},
 
 	illustrator: "SATOSHI NAKAI",
@@ -14,38 +14,62 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "揮動燃燒著火焰的尾巴，用鋒利的爪子撕裂對手。性情十分粗暴。"
+		ja: "燃える しっぽを 振りまわし するどい ツメで 相手を 切り裂く 荒々しい 性格。",
+		'zh-tw': "揮動燃燒著火焰的尾巴，用鋒利的爪子撕裂對手。性情十分粗暴。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "劈開"
+	attacks: [
+		{
+			name: {
+				ja: "きりさく",
+				'zh-tw': "劈開",
+			},
+			damage: 20,
+			cost: ["Fire"],
 		},
-
-		damage: 20,
-		cost: ["Fire"]
-	}, {
-		name: {
-			'zh-tw': "森林火災"
+		{
+			name: {
+				ja: "やまかじ",
+				'zh-tw': "森林火災",
+			},
+			damage: 60,
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "自分の山札を上から3枚トラッシュする。",
+				'zh-tw': "將自己的牌庫上方3張卡丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將自己的牌庫上方3張卡丟棄。"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586531,
+				tcgplayer: 571269,
+			},
 		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578362,
+			},
+		},
+	],
 
-		damage: 60,
-		cost: ["Fire", "Fire"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ヒトカゲ",
+	},
 
 	retreat: 2,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "None",
+	dexId: [5],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/017.ts
+++ b/data-asia/S/S8b/017.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "噴火龍"
+		ja: "リザードン",
+		'zh-tw': "噴火龍",
 	},
 
 	illustrator: "NC Empire",
@@ -14,43 +14,62 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "會噴出彷彿連岩石都能燒焦的灼熱火焰。有時會引發森林火災。"
+		ja: "岩石も 焼けるような 灼熱の 炎を 吐いて 山火事を 起こすことが ある。",
+		'zh-tw': "會噴出彷彿連岩石都能燒焦的灼熱火焰。有時會引發森林火災。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "戰鬥意識"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "バトルセンス",
+				'zh-tw': "戰鬥意識",
+			},
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を上から3枚見て、その中からカードを1枚選び、手札に加える。残りのカードはトラッシュする。",
+				'zh-tw': "在自己的回合時，可使用1次。查看自己的牌庫上方3張卡，選擇其中1張卡加入手牌。將剩餘卡丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，可使用1次。查看自己的牌庫上方3張卡，選擇其中1張卡加入手牌。將剩餘卡丟棄。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "王者火焰"
+	attacks: [
+		{
+			name: {
+				ja: "キングブレイズ",
+				'zh-tw': "王者火焰",
+			},
+			damage: "100+",
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "自分のトラッシュにある「ダンデ」の枚数×50ダメージ追加。",
+				'zh-tw': "增加自己的棄牌區的「丹帝」的張數×50點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加自己的棄牌區的「丹帝」的張數×50點傷害。"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586532,
+				tcgplayer: 571270,
+			},
 		},
+	],
 
-		damage: "100+",
-		cost: ["Fire", "Fire"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "リザード",
+	},
 
 	retreat: 3,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "None",
+	dexId: [6],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/018.ts
+++ b/data-asia/S/S8b/018.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "火伊布"
+		ja: "ブースター",
+		'zh-tw': "火伊布",
 	},
 
 	illustrator: "Eri Yamaki",
@@ -14,39 +14,64 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "當火焰在體內積蓄時，火伊布的體溫也會隨之上升到最高９００度。"
+		ja: "体内に 炎が 溜まると ブースターの 体温も 最高 ９００度 まで 上がっていく。",
+		'zh-tw': "當火焰在體內積蓄時，火伊布的體溫也會隨之上升到最高９００度。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "灼熱覺醒"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "しゃくねつのめざめ",
+				'zh-tw': "灼熱覺醒",
+			},
+			effect: {
+				ja: "このポケモンに「メモリーカプセル」がついているなら、おたがいの場の[草]ポケモンの特性は、すべてなくなる。",
+				'zh-tw': "若這隻寶可夢身上附有「回憶膠囊」，則雙方的場上【草】寶可夢的特性全部消除。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢身上附有「回憶膠囊」，則雙方的場上【草】寶可夢的特性全部消除。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "火之鬃"
+	attacks: [
+		{
+			name: {
+				ja: "ほのおのたてがみ",
+				'zh-tw': "火之鬃",
+			},
+			damage: 100,
+			cost: ["Fire", "Fire", "Colorless"],
 		},
+	],
 
-		damage: 100,
-		cost: ["Fire", "Fire", "Colorless"]
-	}],
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586533,
+				tcgplayer: 571271,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578363,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
 
 	retreat: 2,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "None",
+	dexId: [136],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/019.ts
+++ b/data-asia/S/S8b/019.ts
@@ -1,47 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "火焰雞V"
+		ja: "バシャーモV",
+		'zh-tw': "火焰雞V",
 	},
 
 	illustrator: "Ayaka Yoshida",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Fire"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "飛膝踢"
+	attacks: [
+		{
+			name: {
+				ja: "とびひざげり",
+				'zh-tw': "飛膝踢",
+			},
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
 		},
-
-		damage: 50,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "火焰旋渦"
+		{
+			name: {
+				ja: "ほのおのうず",
+				'zh-tw': "火焰旋渦",
+			},
+			damage: 210,
+			cost: ["Fire", "Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+				'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586534,
+				tcgplayer: 571272,
+			},
 		},
-
-		damage: 210,
-		cost: ["Fire", "Fire", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [257],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/020.ts
+++ b/data-asia/S/S8b/020.ts
@@ -1,50 +1,68 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "火焰雞VMAX"
+		ja: "バシャーモVMAX",
+		'zh-tw': "火焰雞VMAX",
 	},
 
 	illustrator: "AKIRA EGAWA",
 	category: "Pokemon",
 	hp: 320,
 	types: ["Fire"],
+
 	stage: "VMAX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "緊抓"
+	attacks: [
+		{
+			name: {
+				ja: "わしづかみ",
+				'zh-tw': "緊抓",
+			},
+			damage: 60,
+			cost: ["Fire"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。"
+		{
+			name: {
+				ja: "ダイブレイズ",
+				'zh-tw': "極巨火焰",
+			},
+			damage: 130,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチの「れんげき」のポケモンを2匹まで選び、自分のトラッシュからエネルギーを1枚ずつつける。",
+				'zh-tw': "選擇最多2隻自己的備戰區的「連擊」寶可夢，從自己的棄牌區附給那些寶可夢各1張能量卡。",
+			},
 		},
+	],
 
-		damage: 60,
-		cost: ["Fire"]
-	}, {
-		name: {
-			'zh-tw': "極巨火焰"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586535,
+				tcgplayer: 571273,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇最多2隻自己的備戰區的「連擊」寶可夢，從自己的棄牌區附給那些寶可夢各1張能量卡。"
-		},
-
-		damage: 130,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "バシャーモV",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Triple Rare",
+	dexId: [257],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/021.ts
+++ b/data-asia/S/S8b/021.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "飄浮泡泡 太陽的樣子"
+		ja: "ポワルン たいようのすがた",
+		'zh-tw': "飄浮泡泡 太陽的樣子",
 	},
 
 	illustrator: "Yuka Morii",
@@ -14,43 +14,64 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "暴露在烈日下就會變成這個樣子。如果去摸牠熱烘烘的身體，會感覺到乾巴巴的。"
+		ja: "暑い 日差しを 浴びていると この姿に 変わる。 火照った 身体を 触ると パサパサするぞ。",
+		'zh-tw': "暴露在烈日下就會變成這個樣子。如果去摸牠熱烘烘的身體，會感覺到乾巴巴的。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "看天"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "てんきよみ",
+				'zh-tw': "看天",
+			},
+			effect: {
+				ja: "自分のトラッシュに「スタジアム」が8枚以上あるなら、このポケモンがワザを使うためのエネルギーは、すべてなくなる。",
+				'zh-tw': "若自己的棄牌區有8張以上的「競技場」卡，則這隻寶可夢使用招式所需的能量全部消除。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若自己的棄牌區有8張以上的「競技場」卡，則這隻寶可夢使用招式所需的能量全部消除。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "高氣壓爆破"
+	attacks: [
+		{
+			name: {
+				ja: "こうきあつブラスト",
+				'zh-tw': "高氣壓爆破",
+			},
+			damage: 150,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "場に出ている「スタジアム」をトラッシュする。トラッシュできないなら、このワザは失敗。",
+				'zh-tw': "將場上的「競技場」丟棄。若無法丟棄，則這個招式失敗。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將場上的「競技場」丟棄。若無法丟棄，則這個招式失敗。"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586536,
+				tcgplayer: 571274,
+			},
 		},
-
-		damage: 150,
-		cost: ["Fire", "Fire", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578364,
+			},
+		},
+	],
 
 	retreat: 0,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [351],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/022.ts
+++ b/data-asia/S/S8b/022.ts
@@ -1,47 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "焚焰蚣V"
+		ja: "マルヤクデV",
+		'zh-tw': "焚焰蚣V",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Fire"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "熱放射"
+	attacks: [
+		{
+			name: {
+				ja: "ねつほうしゃ",
+				'zh-tw': "熱放射",
+			},
+			damage: 20,
+			cost: ["Fire"],
+			effect: {
+				ja: "のぞむなら、このポケモンについているエネルギーを1個選び、トラッシュする。その場合、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "若希望，選擇1個這隻寶可夢身上附加的能量，將其丟棄。這個情況下，選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "若希望，選擇1個這隻寶可夢身上附加的能量，將其丟棄。這個情況下，選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。"
+		{
+			name: {
+				ja: "バーニングトレイン",
+				'zh-tw': "燃燒列車",
+			},
+			damage: 180,
+			cost: ["Fire", "Fire", "Fire", "Fire"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Fire"]
-	}, {
-		name: {
-			'zh-tw': "燃燒列車"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586537,
+				tcgplayer: 571275,
+			},
 		},
-
-		damage: 180,
-		cost: ["Fire", "Fire", "Fire", "Fire"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	],
 
 	retreat: 3,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "Double rare",
+	dexId: [851],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/023.ts
+++ b/data-asia/S/S8b/023.ts
@@ -1,39 +1,56 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "焚焰蚣VMAX"
+		ja: "マルヤクデVMAX",
+		'zh-tw': "焚焰蚣VMAX",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 320,
 	types: ["Fire"],
+
 	stage: "VMAX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "超極巨百火焚野"
+	attacks: [
+		{
+			name: {
+				ja: "キョダイヒャッカ",
+				'zh-tw': "超極巨百火焚野",
+			},
+			damage: "40+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[炎]エネルギーの数×40ダメージ追加。のぞむなら、ダメージを与えたあとに、自分のトラッシュから[炎]エネルギーを1枚選び、このポケモンにつける。",
+				'zh-tw': "增加這隻寶可夢身上附加的【火】能量的數量×40點傷害。若希望，在造成傷害後，從自己的棄牌區選擇1張【火】能量卡，附於這隻寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加這隻寶可夢身上附加的【火】能量的數量×40點傷害。若希望，在造成傷害後，從自己的棄牌區選擇1張【火】能量卡，附於這隻寶可夢身上。"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586538,
+				tcgplayer: 571276,
+			},
 		},
+	],
 
-		damage: "40+",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "マルヤクデV",
+	},
 
 	retreat: 3,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "Triple Rare",
+	dexId: [851],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/024.ts
+++ b/data-asia/S/S8b/024.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "墨海馬"
+		ja: "タッツー",
+		'zh-tw': "墨海馬",
 	},
 
 	illustrator: "Anesaki Dynamic",
@@ -14,31 +14,50 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "會在珊瑚的陰影處安家。如果感到危險，就會從口中吐出漆黑的墨汁逃跑。"
+		ja: "サンゴの 陰に 住処を 作る。 危険を 感じると 口から 真っ黒い 墨を 吐いて 逃げる。",
+		'zh-tw': "會在珊瑚的陰影處安家。如果感到危險，就會從口中吐出漆黑的墨汁逃跑。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "煙幕"
+	attacks: [
+		{
+			name: {
+				ja: "えんまく",
+				'zh-tw': "煙幕",
+			},
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンがワザを使うとき、相手はコインを1回投げる。ウラならそのワザは失敗。",
+				'zh-tw': "在下個對手的回合，當受到這個招式的寶可夢使用招式時，對手擲1次硬幣。若為反面，則那個招式失敗。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，當受到這個招式的寶可夢使用招式時，對手擲1次硬幣。若為反面，則那個招式失敗。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586539,
+				tcgplayer: 571277,
+			},
 		},
-
-		damage: 10,
-		cost: ["Water"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578365,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [116],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/025.ts
+++ b/data-asia/S/S8b/025.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "海刺龍"
+		ja: "シードラ",
+		'zh-tw': "海刺龍",
 	},
 
 	illustrator: "0313",
@@ -14,27 +14,50 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "這種寶可夢可以藉著快速擺動翅膀和尾巴，在面向前方的情況下向後游動。"
+		ja: "羽と 尻尾を 素早く 動かし 前を 向いたまま 後ろへ 泳ぐこともできる ポケモン。",
+		'zh-tw': "這種寶可夢可以藉著快速擺動翅膀和尾巴，在面向前方的情況下向後游動。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "水槍"
+	attacks: [
+		{
+			name: {
+				ja: "みずでっぽう",
+				'zh-tw': "水槍",
+			},
+			damage: 40,
+			cost: ["Water"],
 		},
+	],
 
-		damage: 40,
-		cost: ["Water"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586540,
+				tcgplayer: 571278,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578366,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タッツー",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [117],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/026.ts
+++ b/data-asia/S/S8b/026.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "刺龍王"
+		ja: "キングドラ",
+		'zh-tw': "刺龍王",
 	},
 
 	illustrator: "kawayoo",
@@ -14,43 +14,62 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "據說牠會沉睡在任何生物都無法潛到的深海底部積蓄力量。"
+		ja: "どんな 生き物も 降りられない 深い 海の底で 眠りながら 力を 蓄えている という。",
+		'zh-tw': "據說牠會沉睡在任何生物都無法潛到的深海底部積蓄力量。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "海底霸主"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "かいていのぬし",
+				'zh-tw': "海底霸主",
+			},
+			effect: {
+				ja: "自分のバトルポケモンが、相手のポケモンからワザのダメージを受けてきぜつするたび、1回使える。きぜつしたポケモンについている[水]エネルギーを好きなだけ選び、このポケモンにつけ替える。",
+				'zh-tw': "每次當自己的戰鬥寶可夢受到對手的寶可夢招式的傷害而【氣絕】時，可使用1次。選擇【氣絕】的寶可夢身上附加的任意數量的【水】能量，改附於這隻寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "每次當自己的戰鬥寶可夢受到對手的寶可夢招式的傷害而【氣絕】時，可使用1次。選擇【氣絕】的寶可夢身上附加的任意數量的【水】能量，改附於這隻寶可夢身上。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "水暴流"
+	attacks: [
+		{
+			name: {
+				ja: "アクアバースト",
+				'zh-tw': "水暴流",
+			},
+			damage: "40×",
+			cost: ["Water"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーの数×40ダメージ。",
+				'zh-tw': "造成這隻寶可夢身上附加的【水】能量的數量×40點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "造成這隻寶可夢身上附加的【水】能量的數量×40點傷害。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586541,
+				tcgplayer: 571279,
+			},
 		},
+	],
 
-		damage: "40×",
-		cost: ["Water"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "シードラ",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [230],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/027.ts
+++ b/data-asia/S/S8b/027.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伽勒爾 魔牆人偶"
+		ja: "ガラル バリヤード",
+		'zh-tw': "伽勒爾 魔牆人偶",
 	},
 
 	illustrator: "kodama",
@@ -14,37 +14,57 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "會從腳底釋放出冷氣。一整天都會在自己凍住的地板上努力練習踢踏舞。"
+		ja: "足の 裏から 冷気を 出す。 凍らせた 床の 上で １日 タップダンスに 励んでいる。",
+		'zh-tw': "會從腳底釋放出冷氣。一整天都會在自己凍住的地板上努力練習踢踏舞。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "拍擊"
+	attacks: [
+		{
+			name: {
+				ja: "はたく",
+				'zh-tw': "拍擊",
+			},
+			damage: 10,
+			cost: ["Water"],
 		},
-
-		damage: 10,
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "找到"
+		{
+			name: {
+				ja: "さぐりあてる",
+				'zh-tw': "找到",
+			},
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札からグッズを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張物品卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張物品卡，在給對手看過後加入手牌。並且重洗牌庫。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586542,
+				tcgplayer: 571280,
+			},
 		},
-
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578367,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [122],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/028.ts
+++ b/data-asia/S/S8b/028.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伽勒爾 踏冰人偶"
+		ja: "ガラル バリコオル",
+		'zh-tw': "伽勒爾 踏冰人偶",
 	},
 
 	illustrator: "HYOGONOSUKE",
@@ -14,38 +14,62 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "幽默的動作使牠獲得了眾人的喜愛。能從腹部的圖案釋放出精神力量。"
+		ja: "ユーモラスな 動きで みんなの 人気者。 お腹の 模様から サイコパワーを 放出する。",
+		'zh-tw': "幽默的動作使牠獲得了眾人的喜愛。能從腹部的圖案釋放出精神力量。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "球戲法"
+	attacks: [
+		{
+			name: {
+				ja: "ボールジャグリング",
+				'zh-tw': "球戲法",
+			},
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の手札から名前に「ボール」とつくグッズを好きなだけトラッシュし、その枚数×40ダメージ追加。",
+				'zh-tw': "從自己的手牌將任意數量的名稱中有「球」的物品卡丟棄，增加其張數×40點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的手牌將任意數量的名稱中有「球」的物品卡丟棄，增加其張數×40點傷害。"
+		{
+			name: {
+				ja: "フロストスマッシュ",
+				'zh-tw': "冰霜粉碎",
+			},
+			damage: 80,
+			cost: ["Water", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: "10+",
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "冰霜粉碎"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586543,
+				tcgplayer: 571281,
+			},
 		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578368,
+			},
+		},
+	],
 
-		damage: 80,
-		cost: ["Water", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ガラル バリヤード",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [866],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/029.ts
+++ b/data-asia/S/S8b/029.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "水伊布"
+		ja: "シャワーズ",
+		'zh-tw': "水伊布",
 	},
 
 	illustrator: "kodama",
@@ -14,39 +14,64 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "當水伊布開始微微顫動牠全身上下的鰭，就表示幾個小時之後要下雨了。"
+		ja: "シャワーズの 全身の ひれが 小刻みに 震えはじめるのは 数時間後に 雨が降る しるし。",
+		'zh-tw': "當水伊布開始微微顫動牠全身上下的鰭，就表示幾個小時之後要下雨了。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "激流覺醒"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "げきりゅうのめざめ",
+				'zh-tw': "激流覺醒",
+			},
+			effect: {
+				ja: "このポケモンに「メモリーカプセル」がついているなら、おたがいの場の[炎]ポケモンの特性は、すべてなくなる。",
+				'zh-tw': "若這隻寶可夢身上附有「回憶膠囊」，則雙方的場上【火】寶可夢的特性全部消除。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢身上附有「回憶膠囊」，則雙方的場上【火】寶可夢的特性全部消除。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "極光束"
+	attacks: [
+		{
+			name: {
+				ja: "オーロラビーム",
+				'zh-tw': "極光束",
+			},
+			damage: 70,
+			cost: ["Water", "Colorless"],
 		},
+	],
 
-		damage: 70,
-		cost: ["Water", "Colorless"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586544,
+				tcgplayer: 571282,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578369,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
 
 	retreat: 2,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "None",
+	dexId: [134],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/030.ts
+++ b/data-asia/S/S8b/030.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鐵炮魚"
+		ja: "テッポウオ",
+		'zh-tw': "鐵炮魚",
 	},
 
 	illustrator: "HYOGONOSUKE",
@@ -14,34 +14,54 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "會用變成吸盤狀的背鰭吸附在巨翅飛魚身上， 吃牠平常吃剩下的東西。"
+		ja: "吸盤の ように 変化した 背びれで マンタインに くっつき 食べ残しを わけてもらっている。",
+		'zh-tw': "會用變成吸盤狀的背鰭吸附在巨翅飛魚身上， 吃牠平常吃剩下的東西。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "水槍"
+	attacks: [
+		{
+			name: {
+				ja: "みずでっぽう",
+				'zh-tw': "水槍",
+			},
+			damage: 10,
+			cost: ["Water"],
 		},
-
-		damage: 10,
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "銳利鰭"
+		{
+			name: {
+				ja: "するどいひれ",
+				'zh-tw': "銳利鰭",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586545,
+				tcgplayer: 571283,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578370,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [223],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/031.ts
+++ b/data-asia/S/S8b/031.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "章魚桶"
+		ja: "オクタン",
+		'zh-tw': "章魚桶",
 	},
 
 	illustrator: "Souichirou Gunjima",
@@ -14,39 +14,58 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "有著堅硬結實的腦袋。會用帶有吸盤的腳纏住對手， 然後不停地用頭猛撞。"
+		ja: "頑丈な 石頭。 吸盤つきの 脚を 絡ませ ひたすら 頭で 打ちすえる。",
+		'zh-tw': "有著堅硬結實的腦袋。會用帶有吸盤的腳纏住對手， 然後不停地用頭猛撞。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "連擊搜索"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "れんげきサーチ",
+				'zh-tw': "連擊搜索",
+			},
+			effect: {
+				ja: "自分の番に1回使える。自分の山札から「れんげき」のカードを1枚選び、相手に見せて、手札に加える。そして山札を切る。この番、すでに別の「れんげきサーチ」を使っていたなら、この特性は使えない。",
+				'zh-tw': "在自己的回合時，可使用1次。從自己的牌庫選擇1張「連擊」卡，在給對手看過後加入手牌。並且重洗牌庫。在這個回合，若已經使出了其他的「連擊搜索」，則這個特性無法使用。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，可使用1次。從自己的牌庫選擇1張「連擊」卡，在給對手看過後加入手牌。並且重洗牌庫。在這個回合，若已經使出了其他的「連擊搜索」，則這個特性無法使用。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "攀瀑"
+	attacks: [
+		{
+			name: {
+				ja: "たきのぼり",
+				'zh-tw': "攀瀑",
+			},
+			damage: 50,
+			cost: ["Water", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 50,
-		cost: ["Water", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586546,
+				tcgplayer: 571284,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "テッポウオ",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [224],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/032.ts
+++ b/data-asia/S/S8b/032.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "飄浮泡泡 雨水的樣子"
+		ja: "ポワルン あまみずのすがた",
+		'zh-tw': "飄浮泡泡 雨水的樣子",
 	},
 
 	illustrator: "sowsow",
@@ -14,42 +14,63 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "飄浮泡泡被雨淋到時的樣子。在讓牠淋浴的實驗裡，牠並沒有變成這種形態。"
+		ja: "雨に 打たれる ポワルンの 姿。 シャワーを 浴びせた 実験では この 形に 変化しなかった。",
+		'zh-tw': "飄浮泡泡被雨淋到時的樣子。在讓牠淋浴的實驗裡，牠並沒有變成這種形態。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "看天"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "てんきよみ",
+				'zh-tw': "看天",
+			},
+			effect: {
+				ja: "自分のトラッシュに「スタジアム」が8枚以上あるなら、このポケモンがワザを使うためのエネルギーは、すべてなくなる。",
+				'zh-tw': "若自己的棄牌區有8張以上的「競技場」卡，則這隻寶可夢使用招式所需的能量全部消除。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若自己的棄牌區有8張以上的「競技場」卡，則這隻寶可夢使用招式所需的能量全部消除。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "雨流浴"
+	attacks: [
+		{
+			name: {
+				ja: "レインシャワー",
+				'zh-tw': "雨流浴",
+			},
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的所有寶可夢各受到20點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "對手的所有寶可夢各受到20點傷害。[在備戰區不計算弱點・抵抗力。]"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586547,
+				tcgplayer: 571285,
+			},
 		},
-
-		cost: ["Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578371,
+			},
+		},
+	],
 
 	retreat: 0,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [351],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/033.ts
+++ b/data-asia/S/S8b/033.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "飄浮泡泡 雪雲的樣子"
+		ja: "ポワルン ゆきぐものすがた",
+		'zh-tw': "飄浮泡泡 雪雲的樣子",
 	},
 
 	illustrator: "miki kudo",
@@ -14,43 +14,64 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "被冰雹打到時就會變成這個樣子。全身上下冷冰冰的，皮膚有一點結冰。"
+		ja: "霰に 打たれると この 姿に 変化する。 全身 冷たく 皮膚は 少し 凍っているぞ。",
+		'zh-tw': "被冰雹打到時就會變成這個樣子。全身上下冷冰冰的，皮膚有一點結冰。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "看天"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "てんきよみ",
+				'zh-tw': "看天",
+			},
+			effect: {
+				ja: "自分のトラッシュに「スタジアム」が8枚以上あるなら、このポケモンがワザを使うためのエネルギーは、すべてなくなる。",
+				'zh-tw': "若自己的棄牌區有8張以上的「競技場」卡，則這隻寶可夢使用招式所需的能量全部消除。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若自己的棄牌區有8張以上的「競技場」卡，則這隻寶可夢使用招式所需的能量全部消除。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "冰霜颱風"
+	attacks: [
+		{
+			name: {
+				ja: "フロストタイフーン",
+				'zh-tw': "冰霜颱風",
+			},
+			damage: 120,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「フロストタイフーン」が使えない。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「冰霜颱風」。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「冰霜颱風」。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586548,
+				tcgplayer: 571286,
+			},
 		},
-
-		damage: 120,
-		cost: ["Water", "Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578372,
+			},
+		},
+	],
 
 	retreat: 0,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [351],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/034.ts
+++ b/data-asia/S/S8b/034.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雪童子"
+		ja: "ユキワラシ",
+		'zh-tw': "雪童子",
 	},
 
 	illustrator: "HYOGONOSUKE",
@@ -14,37 +14,57 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "只能在寒冷的土地上生存。即使在零下１００度的環境下也能充滿活力地到處蹦蹦跳跳。"
+		ja: "寒い 土地でしか 生きられない。 マイナス １００度の 環境でも 元気に 跳ねまわっているよ。",
+		'zh-tw': "只能在寒冷的土地上生存。即使在零下１００度的環境下也能充滿活力地到處蹦蹦跳跳。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "冰之氣息"
+	attacks: [
+		{
+			name: {
+				ja: "こおりのいき",
+				'zh-tw': "冰之氣息",
+			},
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+				'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。"
+		{
+			name: {
+				ja: "スノーアイス",
+				'zh-tw': "雪花冰",
+			},
+			damage: 20,
+			cost: ["Water", "Colorless"],
 		},
+	],
 
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "雪花冰"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586550,
+				tcgplayer: 571287,
+			},
 		},
-
-		damage: 20,
-		cost: ["Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578373,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [361],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/035.ts
+++ b/data-asia/S/S8b/035.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雪妖女"
+		ja: "ユキメノコ",
+		'zh-tw': "雪妖女",
 	},
 
 	illustrator: "Souichirou Gunjima",
@@ -14,43 +14,62 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "會吐出零下５０度的冷氣凍住獵物，並把牠們帶回自己的巢穴，整齊地擺成一排。"
+		ja: "マイナス５０度の 冷気を 吐き 凍らせた 獲物を すみかに 持ち帰り きれいに 並べる。",
+		'zh-tw': "會吐出零下５０度的冷氣凍住獵物，並把牠們帶回自己的巢穴，整齊地擺成一排。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "降霜"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "しもふらし",
+				'zh-tw': "降霜",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分のトラッシュから[水]エネルギーを1枚選び、自分のポケモンにつける。",
+				'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。從自己的棄牌區選擇1張【水】能量卡，附於自己的寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。從自己的棄牌區選擇1張【水】能量卡，附於自己的寶可夢身上。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "水晶吐息"
+	attacks: [
+		{
+			name: {
+				ja: "クリスタルブレス",
+				'zh-tw': "水晶吐息",
+			},
+			damage: 90,
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586551,
+				tcgplayer: 571288,
+			},
 		},
+	],
 
-		damage: 90,
-		cost: ["Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ユキワラシ",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [478],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/036.ts
+++ b/data-asia/S/S8b/036.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "淚眼蜥"
+		ja: "メッソン",
+		'zh-tw': "淚眼蜥",
 	},
 
 	illustrator: "Yuu Nishida",
@@ -14,41 +14,61 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "皮膚在濕掉時會變色，彷彿像是隱身了一樣， 誰都看不見牠的身影。"
+		ja: "皮膚の 色は 濡れると 変わる。 カモフラージュ されたかの ように 姿が 見えなく なるのだ。",
+		'zh-tw': "皮膚在濕掉時會變色，彷彿像是隱身了一樣， 誰都看不見牠的身影。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "連連召喚"
+	attacks: [
+		{
+			name: {
+				ja: "どんどんよぶ",
+				'zh-tw': "連連召喚",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から「れんげき」のたねポケモンを3枚まで選び、ベンチに出す。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多3張「連擊」【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多3張「連擊」【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。"
+		{
+			name: {
+				ja: "ダブルスピン",
+				'zh-tw': "雙重旋轉",
+			},
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×20ダメージ。",
+				'zh-tw': "擲2次硬幣，造成正面出現的次數×20點傷害。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "雙重旋轉"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586552,
+				tcgplayer: 571289,
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲2次硬幣，造成正面出現的次數×20點傷害。"
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578374,
+			},
 		},
-
-		damage: "20×",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [816],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/037.ts
+++ b/data-asia/S/S8b/037.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "變澀蜥"
+		ja: "ジメレオン",
+		'zh-tw': "變澀蜥",
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -14,31 +14,54 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "頭腦聰明但是很怕麻煩。為了不讓敵人接近自己的地盤， 在各個地方都設下了陷阱。"
+		ja: "頭が よく 面倒くさがり。 縄張りに 敵が 近づかないよう そこかしこに 罠を 仕掛けている。",
+		'zh-tw': "頭腦聰明但是很怕麻煩。為了不讓敵人接近自己的地盤， 在各個地方都設下了陷阱。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "彈跳"
+	attacks: [
+		{
+			name: {
+				ja: "とびはねる",
+				'zh-tw': "彈跳",
+			},
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+				'zh-tw': "將這隻寶可夢與備戰寶可夢互換。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將這隻寶可夢與備戰寶可夢互換。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586553,
+				tcgplayer: 571290,
+			},
 		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578375,
+			},
+		},
+	],
 
-		damage: 40,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "メッソン",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [817],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/038.ts
+++ b/data-asia/S/S8b/038.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "千面避役"
+		ja: "インテレオン",
+		'zh-tw': "千面避役",
 	},
 
 	illustrator: "AKIRA EGAWA",
@@ -14,39 +14,58 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "能從指尖射出速度高達３馬赫的水槍。牠的瞬膜能幫助牠看穿 敵人的弱點，準確地擊中要害。"
+		ja: "指先から 放つ 水鉄砲は マッハ３の 速さ。 瞬膜で 急所を 見抜いて 撃ちぬくぞ。",
+		'zh-tw': "能從指尖射出速度高達３馬赫的水槍。牠的瞬膜能幫助牠看穿 敵人的弱點，準確地擊中要害。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "快速射擊手"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "クイックシューター",
+				'zh-tw': "快速射擊手",
+			},
+			effect: {
+				ja: "自分の番に1回使える。相手のポケモン1匹に、ダメカンを2個のせる。",
+				'zh-tw': "在自己的回合時，可使用1次。在對手的1隻寶可夢身上放置2個傷害指示物。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，可使用1次。在對手的1隻寶可夢身上放置2個傷害指示物。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "攀瀑"
+	attacks: [
+		{
+			name: {
+				ja: "たきのぼり",
+				'zh-tw': "攀瀑",
+			},
+			damage: 70,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 70,
-		cost: ["Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586554,
+				tcgplayer: 571291,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジメレオン",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [818],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/039.ts
+++ b/data-asia/S/S8b/039.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雪吞蟲"
+		ja: "ユキハミ",
+		'zh-tw': "雪吞蟲",
 	},
 
 	illustrator: "Mina Nakai",
@@ -14,27 +14,46 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "會吃地面上的積雪。吃得越多，背上的刺就會長得越挺拔。"
+		ja: "地面に 積もった 雪を 食べる。 たくさん 食べれば 食べるほど 背中の 棘は 立派に 育つ。",
+		'zh-tw': "會吃地面上的積雪。吃得越多，背上的刺就會長得越挺拔。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "衝撞"
+	attacks: [
+		{
+			name: {
+				ja: "ぶつかる",
+				'zh-tw': "衝撞",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
+	],
 
-		damage: 10,
-		cost: ["Colorless"]
-	}],
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586555,
+				tcgplayer: 571292,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578376,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "None",
+	dexId: [872],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/040.ts
+++ b/data-asia/S/S8b/040.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雪絨蛾"
+		ja: "モスノウ",
+		'zh-tw': "雪絨蛾",
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -14,39 +14,58 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "絕不放過破壞山野環境的人。會用冰冷的翅膀四處飛翔，製造出暴風雪來懲罰他們。"
+		ja: "野山を 荒らすものには 容赦 しない。 冷たいはねで 飛びまわり 吹雪を 起こして 懲らしめる。",
+		'zh-tw': "絕不放過破壞山野環境的人。會用冰冷的翅膀四處飛翔，製造出暴風雪來懲罰他們。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "冰雪之舞"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ひょうせつのまい",
+				'zh-tw': "冰雪之舞",
+			},
+			effect: {
+				ja: "自分の番に何回でも使える。自分の手札から[水]エネルギーを1枚選び、ベンチの[水]ポケモンにつける。",
+				'zh-tw': "在自己的回合時，可不限次數使用。從自己的手牌選擇1張【水】能量卡，附於備戰區的【水】寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，可不限次數使用。從自己的手牌選擇1張【水】能量卡，附於備戰區的【水】寶可夢身上。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "極光束"
+	attacks: [
+		{
+			name: {
+				ja: "オーロラビーム",
+				'zh-tw': "極光束",
+			},
+			damage: 30,
+			cost: ["Water", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Water", "Colorless"]
-	}],
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586556,
+				tcgplayer: 571293,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ユキハミ",
+	},
 
 	retreat: 2,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "None",
+	dexId: [873],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/041.ts
+++ b/data-asia/S/S8b/041.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "冰砌鵝"
+		ja: "コオリッポ",
+		'zh-tw': "冰砌鵝",
 	},
 
 	illustrator: "nagimiso",
@@ -14,37 +14,57 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "頭上的毛連接著大腦的表層，一旦開始動腦思考就會產生冷氣。"
+		ja: "頭の 毛は 脳の 表面に つながっている。 考えごとを すると 冷気が 発生する。",
+		'zh-tw': "頭上的毛連接著大腦的表層，一旦開始動腦思考就會產生冷氣。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "冰塊滑梯"
+	attacks: [
+		{
+			name: {
+				ja: "ブロックスライダー",
+				'zh-tw': "冰塊滑梯",
+			},
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、自分の場のポケモンについている「フュージョンエネルギー」の数×40ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的1隻寶可夢受到自己的場上寶可夢身上附加的「匯流能量」的數量×40點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
-
-		effect: {
-			'zh-tw': "對手的1隻寶可夢受到自己的場上寶可夢身上附加的「匯流能量」的數量×40點傷害。[在備戰區不計算弱點・抵抗力。]"
+		{
+			name: {
+				ja: "つららミサイル",
+				'zh-tw': "冰柱飛彈",
+			},
+			damage: 100,
+			cost: ["Water", "Water", "Colorless"],
 		},
+	],
 
-		cost: ["Water", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "冰柱飛彈"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586557,
+				tcgplayer: 571294,
+			},
 		},
-
-		damage: 100,
-		cost: ["Water", "Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578377,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [875],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/042.ts
+++ b/data-asia/S/S8b/042.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "連擊武道熊師"
+		ja: "れんげきウーラオス",
+		'zh-tw': "連擊武道熊師",
 	},
 
 	illustrator: "Naoki Saito",
@@ -14,38 +14,56 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "以多擊必勝作為信念。會如流水般連續不斷地 用打擊招式轟打對手。"
+		ja: "多撃必倒を 信条とする。 水の 流れのように 途切れなく 打撃技を 相手に 叩きこむ。",
+		'zh-tw': "以多擊必勝作為信念。會如流水般連續不斷地 用打擊招式轟打對手。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "利爪揮砍"
+	attacks: [
+		{
+			name: {
+				ja: "スラッシュクロー",
+				'zh-tw': "利爪揮砍",
+			},
+			damage: 40,
+			cost: ["Colorless"],
 		},
-
-		damage: 40,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "連彈衝刺"
+		{
+			name: {
+				ja: "れんだんラッシュ",
+				'zh-tw': "連彈衝刺",
+			},
+			damage: "30×",
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "自分の場の「れんげき」のポケモンの数×30ダメージ。",
+				'zh-tw': "造成自己的場上「連擊」寶可夢的數量×30點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "造成自己的場上「連擊」寶可夢的數量×30點傷害。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586558,
+				tcgplayer: 571295,
+			},
 		},
+	],
 
-		damage: "30×",
-		cost: ["Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ダクマ",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [892],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/043.ts
+++ b/data-asia/S/S8b/043.ts
@@ -1,47 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "白馬蕾冠王V"
+		ja: "はくばバドレックスV",
+		'zh-tw': "白馬蕾冠王V",
 	},
 
 	illustrator: "D.A.G Inc.",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Water"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "突刺"
+	attacks: [
+		{
+			name: {
+				ja: "つきさす",
+				'zh-tw': "突刺",
+			},
+			damage: 40,
+			cost: ["Water"],
 		},
-
-		damage: 40,
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "雪矛"
+		{
+			name: {
+				ja: "ブリザードランス",
+				'zh-tw': "雪矛",
+			},
+			damage: 200,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+				'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586559,
+				tcgplayer: 571296,
+			},
 		},
-
-		damage: 200,
-		cost: ["Water", "Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [898],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/044.ts
+++ b/data-asia/S/S8b/044.ts
@@ -1,50 +1,68 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "白馬蕾冠王VMAX"
+		ja: "はくばバドレックスVMAX",
+		'zh-tw': "白馬蕾冠王VMAX",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 320,
 	types: ["Water"],
+
 	stage: "VMAX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "君王騎行"
+	attacks: [
+		{
+			name: {
+				ja: "エンペラーライド",
+				'zh-tw': "君王騎行",
+			},
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数×30ダメージ追加。",
+				'zh-tw': "增加對手的備戰寶可夢的數量×30點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "增加對手的備戰寶可夢的數量×30點傷害。"
+		{
+			name: {
+				ja: "ダイランス",
+				'zh-tw': "極巨之矛",
+			},
+			damage: "10+",
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "のぞむなら、このポケモンについているエネルギーを2枚まで選び、トラッシュする。その場合、トラッシュした枚数×120ダメージ追加。",
+				'zh-tw': "若希望，選擇最多2張這隻寶可夢身上附加的能量卡，將其丟棄。這個情況下，增加丟棄的張數×120點傷害。",
+			},
 		},
+	],
 
-		damage: "10+",
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "極巨之矛"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586560,
+				tcgplayer: 571297,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若希望，選擇最多2張這隻寶可夢身上附加的能量卡，將其丟棄。這個情況下，增加丟棄的張數×120點傷害。"
-		},
-
-		damage: "10+",
-		cost: ["Water", "Water"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "はくばバドレックスV",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Triple Rare",
+	dexId: [898],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/045.ts
+++ b/data-asia/S/S8b/045.ts
@@ -1,50 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "皮卡丘V"
+		ja: "ピカチュウV",
+		'zh-tw': "皮卡丘V",
 	},
 
 	illustrator: "Saki Hayashiro",
 	category: "Pokemon",
 	hp: 190,
 	types: ["Lightning"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "充電"
+	attacks: [
+		{
+			name: {
+				ja: "じゅうでん",
+				'zh-tw': "充電",
+			},
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分の山札から[雷]エネルギーを2枚まで選び、このポケモンにつける。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多2張【雷】能量卡，附於這隻寶可夢身上。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多2張【雷】能量卡，附於這隻寶可夢身上。並且重洗牌庫。"
+		{
+			name: {
+				ja: "10まんボルト",
+				'zh-tw': "十萬伏特",
+			},
+			damage: 200,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、すべてトラッシュする。",
+				'zh-tw': "將這隻寶可夢身上附加的能量全部丟棄。",
+			},
 		},
+	],
 
-		cost: ["Lightning"]
-	}, {
-		name: {
-			'zh-tw': "十萬伏特"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586561,
+				tcgplayer: 571298,
+			},
 		},
-
-		effect: {
-			'zh-tw': "將這隻寶可夢身上附加的能量全部丟棄。"
-		},
-
-		damage: 200,
-		cost: ["Lightning", "Lightning", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "Double rare",
+	dexId: [25],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/046.ts
+++ b/data-asia/S/S8b/046.ts
@@ -1,39 +1,56 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "皮卡丘VMAX"
+		ja: "ピカチュウVMAX",
+		'zh-tw': "皮卡丘VMAX",
 	},
 
 	illustrator: "aky CG Works",
 	category: "Pokemon",
 	hp: 310,
 	types: ["Lightning"],
+
 	stage: "VMAX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "超極巨伏特攻擊"
+	attacks: [
+		{
+			name: {
+				ja: "キョダイボルテッカー",
+				'zh-tw': "超極巨伏特攻擊",
+			},
+			damage: "120+",
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "のぞむなら、このポケモンについているエネルギーを、すべてトラッシュする。その場合、150ダメージ追加。",
+				'zh-tw': "若希望，將這隻寶可夢身上附加的能量全部丟棄。這個情況下，增加150點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若希望，將這隻寶可夢身上附加的能量全部丟棄。這個情況下，增加150點傷害。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586562,
+				tcgplayer: 571299,
+			},
 		},
+	],
 
-		damage: "120+",
-		cost: ["Lightning", "Lightning", "Lightning"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ピカチュウV",
+	},
 
 	retreat: 2,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "Triple Rare",
+	dexId: [25],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/047.ts
+++ b/data-asia/S/S8b/047.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "霹靂電球"
+		ja: "ビリリダマ",
+		'zh-tw': "霹靂電球",
 	},
 
 	illustrator: "Sekio",
@@ -14,27 +14,46 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "會出現在發電廠等地方。很多人會把牠錯當成精靈球去觸碰而被電麻。"
+		ja: "発電所などに 現れる。 モンスターボールと 間違えて 触って しびれる 人が 多い。",
+		'zh-tw': "會出現在發電廠等地方。很多人會把牠錯當成精靈球去觸碰而被電麻。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "電球"
+	attacks: [
+		{
+			name: {
+				ja: "エレキボール",
+				'zh-tw': "電球",
+			},
+			damage: 40,
+			cost: ["Lightning", "Lightning"],
 		},
+	],
 
-		damage: 40,
-		cost: ["Lightning", "Lightning"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586563,
+				tcgplayer: 571300,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578378,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "None",
+	dexId: [100],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/048.ts
+++ b/data-asia/S/S8b/048.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "頑皮雷彈"
+		ja: "マルマイン",
+		'zh-tw': "頑皮雷彈",
 	},
 
 	illustrator: "sui",
@@ -14,39 +14,58 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "因為體內儲存著多到快要滿出來的電能，所以稍微受點刺激就會爆炸。"
+		ja: "あふれるほどの 電気エネルギーを 体内に ためこんでいるので 少しの 刺激で 爆発する。",
+		'zh-tw': "因為體內儲存著多到快要滿出來的電能，所以稍微受點刺激就會爆炸。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "能量發電"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "エネエネはつでん",
+				'zh-tw': "能量發電",
+			},
+			effect: {
+				ja: "このポケモンがベンチにいるなら、自分の番に1回使えて、使ったなら、このポケモンをきぜつさせる。自分の山札から[雷]エネルギーを2枚まで選び、自分の[雷]ポケモンに好きなようにつける。そして山札を切る。",
+				'zh-tw': "若這隻寶可夢在備戰區，則在自己的回合時可使用1次，若使用，則將這隻寶可夢【氣絕】。從自己的牌庫選擇最多2張【雷】能量卡，以任意方式附於自己的【雷】寶可夢身上。並且重洗牌庫。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢在備戰區，則在自己的回合時可使用1次，若使用，則將這隻寶可夢【氣絕】。從自己的牌庫選擇最多2張【雷】能量卡，以任意方式附於自己的【雷】寶可夢身上。並且重洗牌庫。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "雷電球"
+	attacks: [
+		{
+			name: {
+				ja: "ライトニングボール",
+				'zh-tw': "雷電球",
+			},
+			damage: 100,
+			cost: ["Lightning", "Lightning", "Colorless"],
 		},
+	],
 
-		damage: 100,
-		cost: ["Lightning", "Lightning", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586564,
+				tcgplayer: 571301,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ビリリダマ",
+	},
 
 	retreat: 1,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "None",
+	dexId: [101],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/049.ts
+++ b/data-asia/S/S8b/049.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雷伊布"
+		ja: "サンダース",
+		'zh-tw': "雷伊布",
 	},
 
 	illustrator: "Mizue",
@@ -14,39 +14,64 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "當雷伊布生氣或是吃驚時，牠全身的體毛會像針一樣豎起來刺穿對手。"
+		ja: "怒ったり 驚いたりすると 全身の 毛が 針の ように 逆立って 相手を つらぬく。",
+		'zh-tw': "當雷伊布生氣或是吃驚時，牠全身的體毛會像針一樣豎起來刺穿對手。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "迅雷覺醒"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "じんらいのめざめ",
+				'zh-tw': "迅雷覺醒",
+			},
+			effect: {
+				ja: "このポケモンに「メモリーカプセル」がついているなら、おたがいの場の[水]ポケモンの特性は、すべてなくなる。",
+				'zh-tw': "若這隻寶可夢身上附有「回憶膠囊」，則雙方的場上【水】寶可夢的特性全部消除。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢身上附有「回憶膠囊」，則雙方的場上【水】寶可夢的特性全部消除。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "雷電球"
+	attacks: [
+		{
+			name: {
+				ja: "ライトニングボール",
+				'zh-tw': "雷電球",
+			},
+			damage: 90,
+			cost: ["Lightning", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 90,
-		cost: ["Lightning", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586565,
+				tcgplayer: 571302,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578379,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
 
 	retreat: 1,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "None",
+	dexId: [135],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/050.ts
+++ b/data-asia/S/S8b/050.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "閃電鳥"
+		ja: "サンダー",
+		'zh-tw': "閃電鳥",
 	},
 
 	illustrator: "AKIRA EGAWA",
@@ -14,42 +14,51 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "據說藏身在雷雲中的傳說的寶可夢。能夠隨心所欲地操縱雷電。"
+		ja: "雷雲の 中に いると 言われる 伝説の ポケモン。 雷を 自在に 操る。",
+		'zh-tw': "據說藏身在雷雲中的傳說的寶可夢。能夠隨心所欲地操縱雷電。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "啄鑽"
+	attacks: [
+		{
+			name: {
+				ja: "ドリルくちばし",
+				'zh-tw': "啄鑽",
+			},
+			damage: 20,
+			cost: ["Colorless"],
 		},
-
-		damage: 20,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "狙擊雷電"
+		{
+			name: {
+				ja: "スナイプサンダー",
+				'zh-tw': "狙擊雷電",
+			},
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーをすべてトラッシュし、相手の「ポケモンV・GX」1匹に、160ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "將這隻寶可夢身上附加的能量全部丟棄，對手的1隻「寶可夢【V】・【GX】」受到160點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將這隻寶可夢身上附加的能量全部丟棄，對手的1隻「寶可夢【V】・【GX】」受到160點傷害。[在備戰區不計算弱點・抵抗力。]"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586566,
+				tcgplayer: 571303,
+			},
 		},
-
-		cost: ["Lightning", "Lightning", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "None",
+	dexId: [145],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/051.ts
+++ b/data-asia/S/S8b/051.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "咩利羊"
+		ja: "メリープ",
+		'zh-tw': "咩利羊",
 	},
 
 	illustrator: "Miki Tanaka",
@@ -14,37 +14,57 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "會累積絨毛摩擦時所產生的電力。如果因為牠可愛而直接用手去摸，就會被電得又麻又痛。"
+		ja: "綿毛が こすれ 電気が たまる。 かわいいからと 素手で 触ると バチッと 痺れて 痛いのだ。",
+		'zh-tw': "會累積絨毛摩擦時所產生的電力。如果因為牠可愛而直接用手去摸，就會被電得又麻又痛。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "叫聲"
+	attacks: [
+		{
+			name: {
+				ja: "なきごえ",
+				'zh-tw': "叫聲",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-20」される。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢使用招式的傷害「-20」點。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢使用招式的傷害「-20」點。"
+		{
+			name: {
+				ja: "バチバチ",
+				'zh-tw': "劈哩啪啦",
+			},
+			damage: 20,
+			cost: ["Lightning", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "劈哩啪啦"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586567,
+				tcgplayer: 571304,
+			},
 		},
-
-		damage: 20,
-		cost: ["Lightning", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578380,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [179],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/052.ts
+++ b/data-asia/S/S8b/052.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "茸茸羊"
+		ja: "モココ",
+		'zh-tw': "茸茸羊",
 	},
 
 	illustrator: "Pani Kobayashi",
@@ -14,39 +14,64 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "會將電力儲存在鬆軟的毛中。因為儲存了太多電力，身上有些地方變得光禿禿的。"
+		ja: "ふかふかの 毛に 電気を ためこむ。 蓄えすぎて ところどころ つるつるに 禿げあがって しまった。",
+		'zh-tw': "會將電力儲存在鬆軟的毛中。因為儲存了太多電力，身上有些地方變得光禿禿的。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "電氣發電機"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "エレキダイナモ",
+				'zh-tw': "電氣發電機",
+			},
+			effect: {
+				ja: "自分の番に1回使える。自分のトラッシュから[雷]エネルギーを1枚選び、ベンチポケモンにつける。",
+				'zh-tw': "在自己的回合時，可使用1次。從自己的棄牌區選擇1張【雷】能量卡，附於備戰寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，可使用1次。從自己的棄牌區選擇1張【雷】能量卡，附於備戰寶可夢身上。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "電球"
+	attacks: [
+		{
+			name: {
+				ja: "エレキボール",
+				'zh-tw': "電球",
+			},
+			damage: 50,
+			cost: ["Lightning", "Lightning", "Colorless"],
 		},
+	],
 
-		damage: 50,
-		cost: ["Lightning", "Lightning", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586568,
+				tcgplayer: 571305,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578381,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メリープ",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [180],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/053.ts
+++ b/data-asia/S/S8b/053.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "捷克羅姆"
+		ja: "ゼクロム",
+		'zh-tw': "捷克羅姆",
 	},
 
 	illustrator: "hatachu",
@@ -14,38 +14,52 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "當尾巴的內部像馬達那樣旋轉起來，就能製造出好幾道閃電，穿透周圍的一切。"
+		ja: "しっぽの 内部が モーターのように 回ると 何本もの 稲妻が 発生して 周囲を つらぬく。",
+		'zh-tw': "當尾巴的內部像馬達那樣旋轉起來，就能製造出好幾道閃電，穿透周圍的一切。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "劈開"
+	attacks: [
+		{
+			name: {
+				ja: "きりさく",
+				'zh-tw': "劈開",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
 		},
-
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "狂野衝擊"
+		{
+			name: {
+				ja: "ワイルドショック",
+				'zh-tw': "狂野衝擊",
+			},
+			damage: 130,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンにも60ダメージ。相手のバトルポケモンをマヒにする。",
+				'zh-tw': "這隻寶可夢也受到60點傷害。將對手的戰鬥寶可夢【麻痺】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢也受到60點傷害。將對手的戰鬥寶可夢【麻痺】。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586569,
+				tcgplayer: 571306,
+			},
 		},
-
-		damage: 130,
-		cost: ["Lightning", "Lightning", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 3,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "None",
+	dexId: [644],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/054.ts
+++ b/data-asia/S/S8b/054.ts
@@ -1,40 +1,52 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "捷拉奧拉V"
+		ja: "ゼラオラV",
+		'zh-tw': "捷拉奧拉V",
 	},
 
 	illustrator: "chibi",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Lightning"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "十字拳"
+	attacks: [
+		{
+			name: {
+				ja: "クロスフィスト",
+				'zh-tw': "十字拳",
+			},
+			damage: 100,
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "前の自分の番、このポケモン以外の「れんげき」のポケモンがワザを使っていたなら、相手のベンチポケモン1匹にも、160ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "在上個自己的回合，若這隻寶可夢以外的「連擊」寶可夢使用了招式，則對手的1隻備戰寶可夢也受到160點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在上個自己的回合，若這隻寶可夢以外的「連擊」寶可夢使用了招式，則對手的1隻備戰寶可夢也受到160點傷害。[在備戰區不計算弱點・抵抗力。]"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586570,
+				tcgplayer: 571307,
+			},
 		},
-
-		damage: 100,
-		cost: ["Lightning", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [807],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/055.ts
+++ b/data-asia/S/S8b/055.ts
@@ -1,50 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "逐電犬V"
+		ja: "パルスワンV",
+		'zh-tw': "逐電犬V",
 	},
 
 	illustrator: "aky CG Works",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Lightning"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "輸電"
+	attacks: [
+		{
+			name: {
+				ja: "そうでん",
+				'zh-tw': "輸電",
+			},
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分の山札から[雷]エネルギーを2枚まで選び、ベンチポケモンに好きなようにつける。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多2張【雷】能量卡，以任意方式附於備戰寶可夢身上。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多2張【雷】能量卡，以任意方式附於備戰寶可夢身上。並且重洗牌庫。"
+		{
+			name: {
+				ja: "ライトニングストーム",
+				'zh-tw': "雷電風暴",
+			},
+			damage: "10+",
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[雷]エネルギーの数×30ダメージ追加。",
+				'zh-tw': "增加自己的場上寶可夢身上附加的【雷】能量的數量×30點傷害。",
+			},
 		},
+	],
 
-		cost: ["Lightning"]
-	}, {
-		name: {
-			'zh-tw': "雷電風暴"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586571,
+				tcgplayer: 571308,
+			},
 		},
-
-		effect: {
-			'zh-tw': "增加自己的場上寶可夢身上附加的【雷】能量的數量×30點傷害。"
-		},
-
-		damage: "10+",
-		cost: ["Lightning", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "Double rare",
+	dexId: [836],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/056.ts
+++ b/data-asia/S/S8b/056.ts
@@ -1,82 +1,50 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "莫魯貝可V-UNION"
+		ja: "モルペコV-UNION",
+		'zh-tw': "莫魯貝可V-UNION",
 	},
 
 	illustrator: "Mitsuhiro Arita",
 	category: "Pokemon",
 	hp: 310,
 	types: ["Lightning"],
+
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "寶可夢V-UNION放置方法"
+	attacks: [
+		{
+			name: {
+				ja: "ユニオンゲイン",
+				'zh-tw': "寶可夢V-UNION放置方法",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュから[L]エネルギーを2枚まで選び、このポケモンにつける。",
+				'zh-tw': "對戰中可放置1次，在自己的回合將自己的棄牌區中4種莫魯貝可【V-UNION】加以組合，放置於備戰區。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "對戰中可放置1次，在自己的回合將自己的棄牌區中4種莫魯貝可【V-UNION】加以組合，放置於備戰區。"
-		}
-	}, {
-		name: {
-			'zh-tw': "聯盟增輝"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586572,
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的棄牌區選擇最多2張【雷】能量卡，附於這隻寶可夢身上。"
-		},
-
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "吃到飽"
-		},
-
-		effect: {
-			'zh-tw': "從牌庫抽卡直到自己的手牌滿10張為止。"
-		},
-
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "爆炸輪"
-		},
-
-		effect: {
-			'zh-tw': "將這隻寶可夢身上附加的能量全部丟棄，造成其張數×100點傷害。"
-		},
-
-		damage: "100×",
-		cost: ["Lightning", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "雷電球"
-		},
-
-		damage: 160,
-		cost: ["Lightning", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "V-UNION規則"
-		},
-
-		effect: {
-			'zh-tw': "寶可夢【V-UNION】【氣絕】時，對手獲得3張獎賞卡。"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Triple Rare",
+	dexId: [877],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/057.ts
+++ b/data-asia/S/S8b/057.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モルペコV-UNION",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たべほうだい" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の手札が10枚になるように、山札を引く。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586573,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Triple Rare",
+	dexId: [877],
+};
+
+export default card;

--- a/data-asia/S/S8b/058.ts
+++ b/data-asia/S/S8b/058.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モルペコV-UNION",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "バーストホイール" },
+			damage: "100×",
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーをすべてトラッシュし、その枚数×100ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586574,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Triple Rare",
+	dexId: [877],
+};
+
+export default card;

--- a/data-asia/S/S8b/059.ts
+++ b/data-asia/S/S8b/059.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モルペコV-UNION",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ライトニングボール" },
+			damage: 160,
+			cost: ["Lightning", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586575,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Triple Rare",
+	dexId: [877],
+};
+
+export default card;

--- a/data-asia/S/S8b/060.ts
+++ b/data-asia/S/S8b/060.ts
@@ -1,57 +1,66 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伽勒爾 急凍鳥V"
+		ja: "ガラル フリーザーV",
+		'zh-tw': "伽勒爾 急凍鳥V",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Psychic"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "再構築"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "さいこうちく",
+				'zh-tw': "再構築",
+			},
+			effect: {
+				ja: "自分の番に、自分の手札を2枚トラッシュするなら、1回使える。自分の山札を1枚引く。",
+				'zh-tw': "在自己的回合時，若將自己的2張手牌丟棄，則可使用1次。從自己的牌庫抽出1張卡。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，若將自己的2張手牌丟棄，則可使用1次。從自己的牌庫抽出1張卡。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "精神光束"
+	attacks: [
+		{
+			name: {
+				ja: "サイコビーム",
+				'zh-tw': "精神光束",
+			},
+			damage: 110,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【混亂】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【混亂】。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586576,
+				tcgplayer: 571313,
+			},
 		},
-
-		damage: 110,
-		cost: ["Psychic", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [144],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/061.ts
+++ b/data-asia/S/S8b/061.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "拉魯拉絲"
+		ja: "ラルトス",
+		'zh-tw': "拉魯拉絲",
 	},
 
 	illustrator: "Narumi Sato",
@@ -14,30 +14,49 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "用紅色的角感知到人和寶可夢的溫情後，全身也會變得有點暖暖的。"
+		ja: "赤いツノで 人や ポケモンの 温かな 気持ちを キャッチすると 全身が ほのかに 熱くなる。",
+		'zh-tw': "用紅色的角感知到人和寶可夢的溫情後，全身也會變得有點暖暖的。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "奇異之光"
+	attacks: [
+		{
+			name: {
+				ja: "あやしいひかり",
+				'zh-tw': "奇異之光",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【混亂】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【混亂】。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586577,
+				tcgplayer: 571314,
+			},
 		},
-
-		cost: ["Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578382,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [280],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/062.ts
+++ b/data-asia/S/S8b/062.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "奇魯莉安"
+		ja: "キルリア",
+		'zh-tw': "奇魯莉安",
 	},
 
 	illustrator: "0313",
@@ -14,30 +14,53 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "能夠操縱精神力量來扭曲周圍的空間，讓自己看見未來。"
+		ja: "サイコパワーを 操り まわりの 空間を ねじ曲げる ことで 未来を 見通す ことが できる。",
+		'zh-tw': "能夠操縱精神力量來扭曲周圍的空間，讓自己看見未來。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "幻想舞步"
+	attacks: [
+		{
+			name: {
+				ja: "ミラージュステップ",
+				'zh-tw': "幻想舞步",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の山札から「キルリア」を3枚まで選び、ベンチに出す。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多3張「奇魯莉安」卡，放置於備戰區。並且重洗牌庫。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多3張「奇魯莉安」卡，放置於備戰區。並且重洗牌庫。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586578,
+				tcgplayer: 571315,
+			},
 		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578383,
+			},
+		},
+	],
 
-		cost: ["Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ラルトス",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [281],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/063.ts
+++ b/data-asia/S/S8b/063.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "沙奈朵"
+		ja: "サーナイト",
+		'zh-tw': "沙奈朵",
 	},
 
 	illustrator: "kodama",
@@ -14,43 +14,62 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "如果是為了保護訓練家，牠會不惜用盡自己的精神力量製造出小型黑洞。"
+		ja: "トレーナーを 守るためなら サイコパワーを 使いきり 小さな ブラックホールを つくりだす。",
+		'zh-tw': "如果是為了保護訓練家，牠會不惜用盡自己的精神力量製造出小型黑洞。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "奧祕閃耀"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "アルカナシャイン",
+				'zh-tw': "奧祕閃耀",
+			},
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を上から2枚見て、その中から基本エネルギーを好きなだけ選び、自分のポケモンに好きなようにつける。残りのカードは手札に加える。",
+				'zh-tw': "在自己的回合時，可使用1次。查看自己的牌庫上方2張卡，選擇其中任意數量的基本能量卡，以任意方式附於自己的寶可夢身上。將剩餘卡加入手牌。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，可使用1次。查看自己的牌庫上方2張卡，選擇其中任意數量的基本能量卡，以任意方式附於自己的寶可夢身上。將剩餘卡加入手牌。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "腦力波"
+	attacks: [
+		{
+			name: {
+				ja: "ブレインウェーブ",
+				'zh-tw': "腦力波",
+			},
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[超]エネルギーの数×30ダメージ追加。",
+				'zh-tw': "增加這隻寶可夢身上附加的【超】能量的數量×30點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加這隻寶可夢身上附加的【超】能量的數量×30點傷害。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586579,
+				tcgplayer: 571316,
+			},
 		},
+	],
 
-		damage: "60+",
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "キルリア",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [282],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/064.ts
+++ b/data-asia/S/S8b/064.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "怨影娃娃"
+		ja: "カゲボウズ",
+		'zh-tw': "怨影娃娃",
 	},
 
 	illustrator: "OKACHEKE",
@@ -14,32 +14,46 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "不要去跟那些在黃昏時有怨影娃娃在排隊的人家來往。 這是自古流傳下來的諺語。"
+		ja: "日暮れに カゲボウズが 並ぶような 家とは 付き合うな と いう 古い ことわざが 残っている。",
+		'zh-tw': "不要去跟那些在黃昏時有怨影娃娃在排隊的人家來往。 這是自古流傳下來的諺語。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "鬼火"
+	attacks: [
+		{
+			name: {
+				ja: "おにび",
+				'zh-tw': "鬼火",
+			},
+			damage: 20,
+			cost: ["Psychic"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Psychic"]
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586580,
+				tcgplayer: 571317,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578384,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [353],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/065.ts
+++ b/data-asia/S/S8b/065.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "詛咒娃娃"
+		ja: "ジュペッタ",
+		'zh-tw': "詛咒娃娃",
 	},
 
 	illustrator: "Megumi Higuchi",
@@ -14,47 +14,66 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "誕生自遭到捨棄時的怨念。據說只要讓牠感覺自己受到重視， 牠就會滿意地變回原本的玩偶。"
+		ja: "捨てられた 怨念で 生まれる。 大切に されると 満足して 元の ヌイグルミに 戻るという。",
+		'zh-tw': "誕生自遭到捨棄時的怨念。據說只要讓牠感覺自己受到重視， 牠就會滿意地變回原本的玩偶。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "覺悟怨恨"
+	attacks: [
+		{
+			name: {
+				ja: "かくごのうらみ",
+				'zh-tw': "覺悟怨恨",
+			},
+			damage: "20×",
+			cost: ["Psychic"],
+			effect: {
+				ja: "このポケモンにダメカンを7個までのせ、のせた数×20ダメージ。",
+				'zh-tw': "在這隻寶可夢身上放置最多7個傷害指示物，造成放置的數量×20點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在這隻寶可夢身上放置最多7個傷害指示物，造成放置的數量×20點傷害。"
+		{
+			name: {
+				ja: "ぶきみなひかり",
+				'zh-tw': "不祥之光",
+			},
+			damage: 50,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【混亂】。",
+			},
 		},
+	],
 
-		damage: "20×",
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "不祥之光"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586581,
+				tcgplayer: 571318,
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【混亂】。"
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578385,
+			},
 		},
+	],
 
-		damage: 50,
-		cost: ["Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "カゲボウズ",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [354],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/066.ts
+++ b/data-asia/S/S8b/066.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "夜巡靈"
+		ja: "ヨマワル",
+		'zh-tw': "夜巡靈",
 	},
 
 	illustrator: "nagimiso",
@@ -14,35 +14,49 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "據說一旦發現不聽話的孩子，牠就會在深夜裡把那個孩子帶去某個不知名的地方。"
+		ja: "いいつけを 守らない 子供を 見つけると 夜中に どこかへ 連れていくと いわれている。",
+		'zh-tw': "據說一旦發現不聽話的孩子，牠就會在深夜裡把那個孩子帶去某個不知名的地方。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "預知未來"
+	attacks: [
+		{
+			name: {
+				ja: "みらいよち",
+				'zh-tw': "預知未來",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分または相手の山札を上から4枚見て、好きな順番に入れ替えて、山札の上にもどす。",
+				'zh-tw': "查看自己或者對手的牌庫上方4張卡，以任意順序排列，放回牌庫上方。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "查看自己或者對手的牌庫上方4張卡，以任意順序排列，放回牌庫上方。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586582,
+				tcgplayer: 571319,
+			},
 		},
-
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578386,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "None",
+	dexId: [355],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/067.ts
+++ b/data-asia/S/S8b/067.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "彷徨夜靈"
+		ja: "サマヨール",
+		'zh-tw': "彷徨夜靈",
 	},
 
 	illustrator: "Kazuma Koda",
@@ -14,42 +14,61 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "身體內部是空的。只要一張開嘴就會像黑洞一樣吸入所有東西。"
+		ja: "体の 中は 空っぽ。 口を 開けると ブラックホールの ように なんでも 吸いこんでしまう。",
+		'zh-tw': "身體內部是空的。只要一張開嘴就會像黑洞一樣吸入所有東西。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "奇異之光"
+	attacks: [
+		{
+			name: {
+				ja: "あやしいひかり",
+				'zh-tw': "奇異之光",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【混亂】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【混亂】。"
+		{
+			name: {
+				ja: "サイコパンチ",
+				'zh-tw': "精神拳",
+			},
+			damage: 60,
+			cost: ["Psychic", "Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "精神拳"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586583,
+				tcgplayer: 571320,
+			},
 		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578387,
+			},
+		},
+	],
 
-		damage: 60,
-		cost: ["Psychic", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ヨマワル",
+	},
 
 	retreat: 2,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "None",
+	dexId: [356],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/068.ts
+++ b/data-asia/S/S8b/068.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "黑夜魔靈"
+		ja: "ヨノワール",
+		'zh-tw': "黑夜魔靈",
 	},
 
 	illustrator: "Shigenori Negishi",
@@ -14,44 +14,58 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "沒人知道牠是否擁有意識。會從來自靈界的電波中接受指示，將人和寶可夢帶走。"
+		ja: "意思が あるのか わかっていない。 霊界からの 電波に 従い 人や ポケモンを 連れ去るのだ。",
+		'zh-tw': "沒人知道牠是否擁有意識。會從來自靈界的電波中接受指示，將人和寶可夢帶走。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "幽靈漂白"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ゴーストブリーチ",
+				'zh-tw': "幽靈漂白",
+			},
+			effect: {
+				ja: "このポケモンがいるかぎり、おたがいの場のポケモンについている特殊エネルギーの効果はすべてなくなり、【無】エネルギー1個ぶんとしてはたらく。",
+				'zh-tw': "只要這隻寶可夢在場上，雙方的場上寶可夢身上附加的特殊能量的效果全部消除，視為提供1個【無】能量。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在場上，雙方的場上寶可夢身上附加的特殊能量的效果全部消除，視為提供1個【無】能量。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "陰森射擊"
+	attacks: [
+		{
+			name: {
+				ja: "ホロウショット",
+				'zh-tw': "陰森射擊",
+			},
+			damage: 120,
+			cost: ["Psychic", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 120,
-		cost: ["Psychic", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586584,
+				tcgplayer: 571321,
+			},
+		},
+	],
 
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "サマヨール",
+	},
 
 	retreat: 2,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "None",
+	dexId: [477],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/069.ts
+++ b/data-asia/S/S8b/069.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "克雷色利亞"
+		ja: "クレセリア",
+		'zh-tw': "克雷色利亞",
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -14,46 +14,55 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "據說只要拿著克雷色利亞的羽毛入睡，就能作個美夢。被稱為新月的化身。"
+		ja: "クレセリアの 羽を 持って 寝ると 楽しい 夢が 見られると いう。 三日月の化身と 呼ばれている。",
+		'zh-tw': "據說只要拿著克雷色利亞的羽毛入睡，就能作個美夢。被稱為新月的化身。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "新月生長"
+	attacks: [
+		{
+			name: {
+				ja: "クレセントグロウ",
+				'zh-tw': "新月生長",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の山札から[超]エネルギーを1枚選び、自分のポケモンにつける。そして山札を切る。後攻プレイヤーの最初の番なら、つけられる枚数は3枚までになり、自分のポケモン1匹につける。",
+				'zh-tw': "從自己的牌庫選擇1張【超】能量卡，附於自己的寶可夢身上。並且重洗牌庫。若在後攻玩家的最初回合使用，則可附上的張數改為最多3張，附於自己的1隻寶可夢身上。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張【超】能量卡，附於自己的寶可夢身上。並且重洗牌庫。若在後攻玩家的最初回合使用，則可附上的張數改為最多3張，附於自己的1隻寶可夢身上。"
+		{
+			name: {
+				ja: "フォトンレーザー",
+				'zh-tw': "光子鐳射",
+			},
+			damage: "30+",
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "自分の場にエネルギーが5個以上あるなら、90ダメージ追加。",
+				'zh-tw': "若自己的場上的能量有5個以上，則增加90點傷害。",
+			},
 		},
+	],
 
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "光子鐳射"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586585,
+				tcgplayer: 571322,
+			},
 		},
-
-		effect: {
-			'zh-tw': "若自己的場上的能量有5個以上，則增加90點傷害。"
-		},
-
-		damage: "30+",
-		cost: ["Psychic", "Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [488],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/070.ts
+++ b/data-asia/S/S8b/070.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "象徵鳥"
+		ja: "シンボラー",
+		'zh-tw': "象徵鳥",
 	},
 
 	illustrator: "Naoyo Kimura",
@@ -14,48 +14,64 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "利用精神力量在空中飛翔，被稱為古代都市的守護神。也有人認為牠是守護神的使者。"
+		ja: "サイコパワーで 空を 飛ぶ。 古代都市の 守り神 とも その遣いとも いわれている。",
+		'zh-tw': "利用精神力量在空中飛翔，被稱為古代都市的守護神。也有人認為牠是守護神的使者。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "反擊"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "はんげき",
+				'zh-tw': "反擊",
+			},
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、ワザを使ったポケモンにダメカンを3個のせる。",
+				'zh-tw': "這隻寶可夢在戰鬥場受到對手的寶可夢招式的傷害時，在使用招式的寶可夢身上放置3個傷害指示物。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢在戰鬥場受到對手的寶可夢招式的傷害時，在使用招式的寶可夢身上放置3個傷害指示物。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "精神傷害"
+	attacks: [
+		{
+			name: {
+				ja: "サイコダメージ",
+				'zh-tw': "精神傷害",
+			},
+			damage: "30+",
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにのっているダメカンの数×10ダメージ追加。",
+				'zh-tw': "增加對手的戰鬥寶可夢身上放置的傷害指示物的數量×10點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加對手的戰鬥寶可夢身上放置的傷害指示物的數量×10點傷害。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586586,
+				tcgplayer: 571323,
+			},
 		},
-
-		damage: "30+",
-		cost: ["Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578388,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "None",
+	dexId: [561],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/071.ts
+++ b/data-asia/S/S8b/071.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "好啦魷"
+		ja: "マーイーカ",
+		'zh-tw': "好啦魷",
 	},
 
 	illustrator: "Sanosuke Sakuma",
@@ -14,32 +14,46 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "會讓敵人看到自己閃爍的發光體來讓對方喪失戰意， 然後趁機逃之夭夭。"
+		ja: "敵に 発光体の 点滅を 浴びせて 戦意を なくしてしまう。 その 隙に 逃げ出すのだ。",
+		'zh-tw': "會讓敵人看到自己閃爍的發光體來讓對方喪失戰意， 然後趁機逃之夭夭。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "迴轉攻擊"
+	attacks: [
+		{
+			name: {
+				ja: "かいてんアタック",
+				'zh-tw': "迴轉攻擊",
+			},
+			damage: 20,
+			cost: ["Psychic"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Psychic"]
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586587,
+				tcgplayer: 571324,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578389,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [686],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/072.ts
+++ b/data-asia/S/S8b/072.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "烏賊王"
+		ja: "カラマネロ",
+		'zh-tw': "烏賊王",
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -14,36 +14,54 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "據說那些能夠改變歷史的重大事件其實都和 烏賊王的催眠能力有關。"
+		ja: "歴史を 変えるほどの 大事件は カラマネロの 催眠能力が かかわっていたと いわれている。",
+		'zh-tw': "據說那些能夠改變歷史的重大事件其實都和 烏賊王的催眠能力有關。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "連擊觸手"
+	attacks: [
+		{
+			name: {
+				ja: "れんげきテンタクル",
+				'zh-tw': "連擊觸手",
+			},
+			damage: "40×",
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の手札から「れんげき」のカードを好きなだけ相手に見せて、その枚数×40ダメージ。その後、見せた「れんげき」のカードを山札にもどして切る。",
+				'zh-tw': "從自己的手牌將任意數量的「連擊」卡給對手看過後，造成其張數×40點傷害。然後，將給對手看過的「連擊」卡放回牌庫並重洗。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的手牌將任意數量的「連擊」卡給對手看過後，造成其張數×40點傷害。然後，將給對手看過的「連擊」卡放回牌庫並重洗。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586588,
+				tcgplayer: 571325,
+			},
 		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578390,
+			},
+		},
+	],
 
-		damage: "40×",
-		cost: ["Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "マーイーカ",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [687],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/073.ts
+++ b/data-asia/S/S8b/073.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "咚咚鼠"
+		ja: "デデンネ",
+		'zh-tw': "咚咚鼠",
 	},
 
 	illustrator: "Nagomi Nijo",
@@ -14,31 +14,50 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "由於發電的能力不強，因此會從插座或其他的電氣寶可夢那裡偷電。"
+		ja: "電気を 生みだす 力が 弱いので コンセントや ほかの 電気ポケモンから 盗むのだ。",
+		'zh-tw': "由於發電的能力不強，因此會從插座或其他的電氣寶可夢那裡偷電。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "咚咚閃光"
+	attacks: [
+		{
+			name: {
+				ja: "デデフラッシュ",
+				'zh-tw': "咚咚閃光",
+			},
+			damage: "20+",
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のサイドの残り枚数が1枚なら、60ダメージ追加し、相手のバトルポケモンをこんらんにする。",
+				'zh-tw': "若對手剩餘獎賞卡的張數為1張，則增加60點傷害，並將對手的戰鬥寶可夢【混亂】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若對手剩餘獎賞卡的張數為1張，則增加60點傷害，並將對手的戰鬥寶可夢【混亂】。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586589,
+				tcgplayer: 571326,
+			},
 		},
-
-		damage: "20+",
-		cost: ["Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578391,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [702],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/074.ts
+++ b/data-asia/S/S8b/074.ts
@@ -1,48 +1,62 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "仙子伊布V"
+		ja: "ニンフィアV",
+		'zh-tw': "仙子伊布V",
 	},
 
 	illustrator: "aky CG Works",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Psychic"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "夢境之禮"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ドリームギフト",
+				'zh-tw': "夢境之禮",
+			},
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、自分の番は終わる。自分の山札からグッズを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "在自己的回合時可使用1次，若使用，則自己的回合結束。從自己的牌庫選擇1張物品卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時可使用1次，若使用，則自己的回合結束。從自己的牌庫選擇1張物品卡，在給對手看過後加入手牌。並且重洗牌庫。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "魔法射擊"
+	attacks: [
+		{
+			name: {
+				ja: "マジカルショット",
+				'zh-tw': "魔法射擊",
+			},
+			damage: 60,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 60,
-		cost: ["Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586590,
+				tcgplayer: 571327,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [700],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/075.ts
+++ b/data-asia/S/S8b/075.ts
@@ -1,49 +1,67 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "仙子伊布VMAX"
+		ja: "ニンフィアVMAX",
+		'zh-tw': "仙子伊布VMAX",
 	},
 
 	illustrator: "Ryota Murayama",
 	category: "Pokemon",
 	hp: 310,
 	types: ["Psychic"],
+
 	stage: "VMAX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "貴重之觸"
+	attacks: [
+		{
+			name: {
+				ja: "プレシャスタッチ",
+				'zh-tw': "貴重之觸",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の手札からエネルギーを1枚選び、自分のベンチポケモンにつける。その後、そのポケモンのHPを「120」回復する。",
+				'zh-tw': "從自己的手牌選擇1張能量卡，附於自己的備戰寶可夢身上。然後，將那隻寶可夢恢復「120」HP。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的手牌選擇1張能量卡，附於自己的備戰寶可夢身上。然後，將那隻寶可夢恢復「120」HP。"
+		{
+			name: {
+				ja: "ダイハーモニー",
+				'zh-tw': "極巨和諧",
+			},
+			damage: "70+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチポケモンのタイプの数×30ダメージ追加。",
+				'zh-tw': "增加自己的備戰寶可夢的屬性種類的數量×30點傷害。",
+			},
 		},
+	],
 
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "極巨和諧"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586591,
+				tcgplayer: 571328,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加自己的備戰寶可夢的屬性種類的數量×30點傷害。"
-		},
-
-		damage: "70+",
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ニンフィアV",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Triple Rare",
+	dexId: [700],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/076.ts
+++ b/data-asia/S/S8b/076.ts
@@ -1,56 +1,65 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "謎擬ＱV"
+		ja: "ミミッキュV",
+		'zh-tw': "謎擬ＱV",
 	},
 
 	illustrator: "Eske Yoshinob",
 	category: "Pokemon",
 	hp: 160,
 	types: ["Psychic"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "虛構娃娃"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ダミードール",
+				'zh-tw': "虛構娃娃",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。次の相手の番の終わりまで、この「ミミッキュV」は、相手のポケモンからワザのダメージを受けない。",
+				'zh-tw': "在自己的回合，當從手牌將這張卡放置於備戰區時，可使用1次。在下個對手的回合結束前，這隻「謎擬Ｑ【V】」不會受到對手的寶可夢招式的傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，當從手牌將這張卡放置於備戰區時，可使用1次。在下個對手的回合結束前，這隻「謎擬Ｑ【V】」不會受到對手的寶可夢招式的傷害。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "羨慕之瞳"
+	attacks: [
+		{
+			name: {
+				ja: "うらやむひとみ",
+				'zh-tw': "羨慕之瞳",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手がすでにとったサイドの枚数×3個ぶんのダメカンを、相手のバトルポケモンにのせる。",
+				'zh-tw': "將與對手已經獲得的獎賞卡的張數×3個的相同數量的傷害指示物，放置於對手的戰鬥寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將與對手已經獲得的獎賞卡的張數×3個的相同數量的傷害指示物，放置於對手的戰鬥寶可夢身上。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586592,
+				tcgplayer: 571329,
+			},
 		},
-
-		cost: ["Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [778],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/077.ts
+++ b/data-asia/S/S8b/077.ts
@@ -1,54 +1,67 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "謎擬ＱVMAX"
+		ja: "ミミッキュVMAX",
+		'zh-tw': "謎擬ＱVMAX",
 	},
 
 	illustrator: "Studio Bora Inc.",
 	category: "Pokemon",
 	hp: 300,
 	types: ["Psychic"],
+
 	stage: "VMAX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "靈異數字"
+	attacks: [
+		{
+			name: {
+				ja: "オカルトナンバー",
+				'zh-tw': "靈異數字",
+			},
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "ダメカン4個を、相手のポケモンに好きなようにのせる。この番、自分の手札から「アセロラの予感」を出して使っていたなら、のせるダメカンの数は13個になる。",
+				'zh-tw': "將4個傷害指示物以任意方式放置於對手的寶可夢身上。在這個回合，若從自己的手牌使出了「阿塞蘿拉的預感」，則放置的傷害指示物的數量改為13個。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將4個傷害指示物以任意方式放置於對手的寶可夢身上。在這個回合，若從自己的手牌使出了「阿塞蘿拉的預感」，則放置的傷害指示物的數量改為13個。"
+		{
+			name: {
+				ja: "ダイシャドー",
+				'zh-tw': "極巨暗影",
+			},
+			damage: 120,
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、トラッシュする。",
+				'zh-tw': "在不看正面的情況下，選擇1張對手的手牌，將其丟棄。",
+			},
 		},
+	],
 
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "極巨暗影"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586593,
+				tcgplayer: 571330,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在不看正面的情況下，選擇1張對手的手牌，將其丟棄。"
-		},
-
-		damage: 120,
-		cost: ["Psychic", "Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ミミッキュV",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Triple Rare",
+	dexId: [778],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/078.ts
+++ b/data-asia/S/S8b/078.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "天罩蟲"
+		ja: "レドームシ",
+		'zh-tw': "天罩蟲",
 	},
 
 	illustrator: "Midori Harada",
@@ -14,42 +14,61 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "正在殼裡成長著。用精神力量掌握外界的狀況，做好進化的準備。"
+		ja: "殻の 中で 成長中。 サイコパワーで 外の 様子を うかがい 進化に 備えている。",
+		'zh-tw': "正在殼裡成長著。用精神力量掌握外界的狀況，做好進化的準備。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "雷達"
+	attacks: [
+		{
+			name: {
+				ja: "レーダー",
+				'zh-tw': "雷達",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の山札を上から4枚見て、好きな順番に入れ替えて、山札の上にもどす。",
+				'zh-tw': "查看自己的牌庫上方4張卡，以任意順序排列，放回牌庫上方。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "查看自己的牌庫上方4張卡，以任意順序排列，放回牌庫上方。"
+		{
+			name: {
+				ja: "ぶつかる",
+				'zh-tw': "衝撞",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "衝撞"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586594,
+				tcgplayer: 571331,
+			},
 		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578392,
+			},
+		},
+	],
 
-		damage: 20,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "サッチムシ",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [825],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/079.ts
+++ b/data-asia/S/S8b/079.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "以歐路普"
+		ja: "イオルブ",
+		'zh-tw': "以歐路普",
 	},
 
 	illustrator: "Mizue",
@@ -14,42 +14,55 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "釋放出精神力量來調查周圍的情況。牠的偵測範圍甚至可以達到方圓１０公里。"
+		ja: "サイコパワーを 放ち 周囲を 調べている。 観測範囲は 周囲 １０キロにも 達するぞ。",
+		'zh-tw': "釋放出精神力量來調查周圍的情況。牠的偵測範圍甚至可以達到方圓１０公里。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "進化掌控"
+	attacks: [
+		{
+			name: {
+				ja: "エボルコントロール",
+				'zh-tw': "進化掌控",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーの数ぶんまで、自分の山札から2進化ポケモン（「イオルブ」をのぞく）を選び、ベンチに出す。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多與這隻寶可夢身上附加的能量相同數量的【2階進化】寶可夢卡（「以歐路普」除外），放置於備戰區。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多與這隻寶可夢身上附加的能量相同數量的【2階進化】寶可夢卡（「以歐路普」除外），放置於備戰區。並且重洗牌庫。"
+		{
+			name: {
+				ja: "しねんのずつき",
+				'zh-tw': "意念頭錘",
+			},
+			damage: 120,
+			cost: ["Psychic", "Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "意念頭錘"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586595,
+				tcgplayer: 571332,
+			},
 		},
+	],
 
-		damage: 120,
-		cost: ["Psychic", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "レドームシ",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [826],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/080.ts
+++ b/data-asia/S/S8b/080.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "小仙奶"
+		ja: "マホミル",
+		'zh-tw': "小仙奶",
 	},
 
 	illustrator: "Misa Tsutsui",
@@ -14,37 +14,57 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "據說有小仙奶現身的蛋糕店保證能生意興隆。"
+		ja: "マホミルが 姿を みせた パティスリーは 大繁盛が 約束されると いわれている。",
+		'zh-tw': "據說有小仙奶現身的蛋糕店保證能生意興隆。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "引路"
+	attacks: [
+		{
+			name: {
+				ja: "みちびく",
+				'zh-tw': "引路",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の山札からサポートを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張支援者卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張支援者卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		{
+			name: {
+				ja: "ぶつかる",
+				'zh-tw': "衝撞",
+			},
+			damage: 10,
+			cost: ["Psychic"],
 		},
+	],
 
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "衝撞"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586596,
+				tcgplayer: 571333,
+			},
 		},
-
-		damage: 10,
-		cost: ["Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578393,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [868],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/081.ts
+++ b/data-asia/S/S8b/081.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "霜奶仙"
+		ja: "マホイップ",
+		'zh-tw': "霜奶仙",
 	},
 
 	illustrator: "sowsow",
@@ -14,43 +14,68 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "當牠感到幸福的時候，手中產生出的鮮奶油會變得更加香濃甜美。"
+		ja: "手から 生みだす クリームは マホイップが 幸せなとき 甘味と コクが 深まる。",
+		'zh-tw': "當牠感到幸福的時候，手中產生出的鮮奶油會變得更加香濃甜美。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "追加點餐"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ついかオーダー",
+				'zh-tw': "追加點餐",
+			},
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、自分の「マスター」を使っても、自分の番は終わらない。",
+				'zh-tw': "只要這隻寶可夢在戰鬥場上，就算使用了自己的「老闆」，自己的回合也不會結束。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在戰鬥場上，就算使用了自己的「老闆」，自己的回合也不會結束。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "彩虹口味"
+	attacks: [
+		{
+			name: {
+				ja: "レインボーフレーバー",
+				'zh-tw': "彩虹口味",
+			},
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている基本エネルギーのタイプの数×40ダメージ追加。",
+				'zh-tw': "增加自己的場上寶可夢身上附加的基本能量的屬性種類的數量×40點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加自己的場上寶可夢身上附加的基本能量的屬性種類的數量×40點傷害。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586597,
+				tcgplayer: 571334,
+			},
 		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578394,
+			},
+		},
+	],
 
-		damage: "10+",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "マホミル",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [869],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/082.ts
+++ b/data-asia/S/S8b/082.ts
@@ -1,55 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "黑馬蕾冠王V"
+		ja: "こくばバドレックスV",
+		'zh-tw': "黑馬蕾冠王V",
 	},
 
 	illustrator: "D.A.G Inc.",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Psychic"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "暗影薄霧"
+	attacks: [
+		{
+			name: {
+				ja: "シャドーミスト",
+				'zh-tw': "暗影薄霧",
+			},
+			damage: 10,
+			cost: ["Psychic"],
+			effect: {
+				ja: "次の相手の番、相手は手札から、「特殊エネルギー」を出してつけられず「スタジアム」も出せない。",
+				'zh-tw': "在下個對手的回合，對手無法從手牌附上「特殊能量」，也無法使出「競技場」。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，對手無法從手牌附上「特殊能量」，也無法使出「競技場」。"
+		{
+			name: {
+				ja: "アストラルビット",
+				'zh-tw': "星碎",
+			},
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン2匹に、それぞれダメカンを5個のせる。",
+				'zh-tw': "在對手的2隻寶可夢身上各放置5個傷害指示物。",
+			},
 		},
+	],
 
-		damage: 10,
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "星碎"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586598,
+				tcgplayer: 571335,
+			},
 		},
-
-		effect: {
-			'zh-tw': "在對手的2隻寶可夢身上各放置5個傷害指示物。"
-		},
-
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [898],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/083.ts
+++ b/data-asia/S/S8b/083.ts
@@ -1,56 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "黑馬蕾冠王VMAX"
+		ja: "こくばバドレックスVMAX",
+		'zh-tw': "黑馬蕾冠王VMAX",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 320,
 	types: ["Psychic"],
+
 	stage: "VMAX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "冥界之扉"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "めいかいのとびら",
+				'zh-tw': "冥界之扉",
+			},
+			effect: {
+				ja: "自分の番に1回使える。自分の手札から[超]エネルギーを1枚選び、自分のベンチの[超]ポケモンにつける。その後、自分の山札を2枚引く。",
+				'zh-tw': "在自己的回合時，可使用1次。從自己的手牌選擇1張【超】能量卡，附於自己的備戰區的【超】寶可夢身上。然後，從自己的牌庫抽出2張卡。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，可使用1次。從自己的手牌選擇1張【超】能量卡，附於自己的備戰區的【超】寶可夢身上。然後，從自己的牌庫抽出2張卡。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "極巨之魂"
+	attacks: [
+		{
+			name: {
+				ja: "ダイガイスト",
+				'zh-tw': "極巨之魂",
+			},
+			damage: "10+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[超]エネルギーの数×30ダメージ追加。",
+				'zh-tw': "增加自己的場上寶可夢身上附加的【超】能量的數量×30點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加自己的場上寶可夢身上附加的【超】能量的數量×30點傷害。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586599,
+				tcgplayer: 571336,
+			},
 		},
+	],
 
-		damage: "10+",
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "こくばバドレックスV",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Triple Rare",
+	dexId: [898],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/084.ts
+++ b/data-asia/S/S8b/084.ts
@@ -1,52 +1,66 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伽勒爾 閃電鳥V"
+		ja: "ガラル サンダーV",
+		'zh-tw': "伽勒爾 閃電鳥V",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Fighting"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "鬥爭本能"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "とうそうほんのう",
+				'zh-tw': "鬥爭本能",
+			},
+			effect: {
+				ja: "相手の場の「ポケモンV」の数ぶん、このポケモンがワザを使うための【無】エネルギーは少なくなる。",
+				'zh-tw': "這隻寶可夢使用招式所需的【無】能量，減少對手的場上的「寶可夢【V】」的數量。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢使用招式所需的【無】能量，減少對手的場上的「寶可夢【V】」的數量。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "雷鳴蹴擊"
+	attacks: [
+		{
+			name: {
+				ja: "らいめいげり",
+				'zh-tw': "雷鳴蹴擊",
+			},
+			damage: 170,
+			cost: ["Fighting", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "ダメージを与える前に、相手のバトルポケモンについている特殊エネルギーを1個選び、トラッシュする。",
+				'zh-tw': "在造成傷害前，選擇1個對手的戰鬥寶可夢身上附加的特殊能量，將其丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在造成傷害前，選擇1個對手的戰鬥寶可夢身上附加的特殊能量，將其丟棄。"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586600,
+				tcgplayer: 571337,
+			},
 		},
-
-		damage: 170,
-		cost: ["Fighting", "Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [145],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/085.ts
+++ b/data-asia/S/S8b/085.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "艾路雷朵"
+		ja: "エルレイド",
+		'zh-tw': "艾路雷朵",
 	},
 
 	illustrator: "NC Empire",
@@ -14,42 +14,66 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "能夠敏銳地感知到尋求幫助的感情，並且火速趕去援助對方。"
+		ja: "助けを 求める 感情を 敏感に キャッチ。 相手の もとへ 馳せ参じ 加勢するぞ。",
+		'zh-tw': "能夠敏銳地感知到尋求幫助的感情，並且火速趕去援助對方。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "佯攻"
+	attacks: [
+		{
+			name: {
+				ja: "フェイント",
+				'zh-tw': "佯攻",
+			},
+			damage: 60,
+			cost: ["Psychic"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+				'zh-tw': "這個招式的傷害不計算抵抗力。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "這個招式的傷害不計算抵抗力。"
+		{
+			name: {
+				ja: "ダイナブレード",
+				'zh-tw': "力之利刃",
+			},
+			damage: "60×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手の場の「ポケモンV」の数×60ダメージ。",
+				'zh-tw': "造成對手的場上的「寶可夢【V】」的數量×60點傷害。",
+			},
 		},
+	],
 
-		damage: 60,
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "力之利刃"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586601,
+				tcgplayer: 571338,
+			},
 		},
-
-		effect: {
-			'zh-tw': "造成對手的場上的「寶可夢【V】」的數量×60點傷害。"
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578395,
+			},
 		},
+	],
 
-		damage: "60×",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "キルリア",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [475],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/086.ts
+++ b/data-asia/S/S8b/086.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "岩狗狗"
+		ja: "イワンコ",
+		'zh-tw': "岩狗狗",
 	},
 
 	illustrator: "Yuu Nishida",
@@ -14,31 +14,50 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "會用脖子上的岩石來摩蹭，代表彼此感情深厚。但因為 岩石很銳利，所以會很痛。"
+		ja: "首の 岩を こすりつけてくるのは 親愛の 証。 ただし 岩は 鋭いので かなり 痛いぞ。",
+		'zh-tw': "會用脖子上的岩石來摩蹭，代表彼此感情深厚。但因為 岩石很銳利，所以會很痛。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "咬碎"
+	attacks: [
+		{
+			name: {
+				ja: "かみくだく",
+				'zh-tw': "咬碎",
+			},
+			damage: 30,
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "擲1次硬幣若為正面，則選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586602,
+				tcgplayer: 571339,
+			},
 		},
-
-		damage: 30,
-		cost: ["Fighting", "Fighting"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578396,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [744],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/087.ts
+++ b/data-asia/S/S8b/087.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鬃岩狼人"
+		ja: "ルガルガン",
+		'zh-tw': "鬃岩狼人",
 	},
 
 	illustrator: "Teeziro",
@@ -14,31 +14,48 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "不集結成群，而是單獨生活。只會聽命於能夠引出 自己力量的訓練家。"
+		ja: "群れを 作らず １匹で 暮らす。 自分の 力を 引き出してくれる トレーナーの いうことしか 聞かない。",
+		'zh-tw': "不集結成群，而是單獨生活。只會聽命於能夠引出 自己力量的訓練家。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "惡棍獠牙"
+	attacks: [
+		{
+			name: {
+				ja: "ローグファング",
+				'zh-tw': "惡棍獠牙",
+			},
+			damage: "80+",
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "自分のトラッシュにある「いちげき」のポケモンの枚数×10ダメージ追加。",
+				'zh-tw': "增加自己的棄牌區的「一擊」寶可夢的張數×10點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加自己的棄牌區的「一擊」寶可夢的張數×10點傷害。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586603,
+				tcgplayer: 571340,
+			},
 		},
+	],
 
-		damage: "80+",
-		cost: ["Fighting", "Fighting"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "イワンコ",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [745],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/088.ts
+++ b/data-asia/S/S8b/088.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "投擲猴"
+		ja: "ナゲツケサル",
+		'zh-tw': "投擲猴",
 	},
 
 	illustrator: "Teeziro",
@@ -14,42 +14,63 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "２０幾隻形成團隊來生活。靠著每個成員明確的分工， 在嚴苛的大自然中生存下來。"
+		ja: "２０匹ほどの グループで 暮らす。 決まった 役割を こなすことで 厳しい 自然を 生き抜いてきた。",
+		'zh-tw': "２０幾隻形成團隊來生活。靠著每個成員明確的分工， 在嚴苛的大自然中生存下來。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "拋投特訓"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "スローイングコーチ",
+				'zh-tw': "拋投特訓",
+			},
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の「れんげき」のポケモンが使うワザの、相手のベンチの「ポケモンV・GX」へのダメージは「+30」される。この効果は、この特性を持つポケモンが何匹いても、重ならない。",
+				'zh-tw': "只要這隻寶可夢在場上，自己的「連擊」寶可夢使用的招式，對對手的備戰區的「寶可夢【V】・【GX】」造成的傷害「+30」點。無論有多少隻擁有這個特性的寶可夢，這個效果也不會重複。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在場上，自己的「連擊」寶可夢使用的招式，對對手的備戰區的「寶可夢【V】・【GX】」造成的傷害「+30」點。無論有多少隻擁有這個特性的寶可夢，這個效果也不會重複。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "投擲"
+	attacks: [
+		{
+			name: {
+				ja: "なげつける",
+				'zh-tw': "投擲",
+			},
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のポケモン1匹に、20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的1隻寶可夢受到20點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "對手的1隻寶可夢受到20點傷害。[在備戰區不計算弱點・抵抗力。]"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586604,
+				tcgplayer: 571341,
+			},
 		},
-
-		cost: ["Fighting"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578397,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [766],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/089.ts
+++ b/data-asia/S/S8b/089.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "列陣兵"
+		ja: "タイレーツ",
+		'zh-tw': "列陣兵",
 	},
 
 	illustrator: "Hasuno",
@@ -14,31 +14,50 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "６隻為一體的寶可夢。慣於團隊行動，會一邊 變換陣形一邊戰鬥。"
+		ja: "６匹で １匹の ポケモン。 隊列を 組み替えながら チームワークで 戦うのだ。",
+		'zh-tw': "６隻為一體的寶可夢。慣於團隊行動，會一邊 變換陣形一邊戰鬥。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "連擊之陣"
+	attacks: [
+		{
+			name: {
+				ja: "れんげきのじん",
+				'zh-tw': "連擊之陣",
+			},
+			damage: "20×",
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "自分の場の「れんげき」のポケモンの数×20ダメージ。",
+				'zh-tw': "造成自己的場上「連擊」寶可夢的數量×20點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "造成自己的場上「連擊」寶可夢的數量×20點傷害。"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586605,
+				tcgplayer: 571342,
+			},
 		},
-
-		damage: "20×",
-		cost: ["Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578398,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [870],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/090.ts
+++ b/data-asia/S/S8b/090.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "巨石丁"
+		ja: "イシヘンジン",
+		'zh-tw': "巨石丁",
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -14,42 +14,62 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "每年會有一天，牠們會在特定的時間突然出現， 聚集在一起排成一個圈。"
+		ja: "１年に 一度 きまった 日時に どこから ともなく 集まり 輪に なって 並ぶ 習性が ある。",
+		'zh-tw': "每年會有一天，牠們會在特定的時間突然出現， 聚集在一起排成一個圈。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "大地鼓動"
+	attacks: [
+		{
+			name: {
+				ja: "だいちのこどう",
+				'zh-tw': "大地鼓動",
+			},
+			damage: "30+",
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "場にスタジアムが出ているなら、30ダメージ追加。",
+				'zh-tw': "若場上有競技場卡，則增加30點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "若場上有競技場卡，則增加30點傷害。"
+		{
+			name: {
+				ja: "ギガハンマー",
+				'zh-tw': "兆幅鐵錘",
+			},
+			damage: 120,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「ギガハンマー」が使えない。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「兆幅鐵錘」。",
+			},
 		},
+	],
 
-		damage: "30+",
-		cost: ["Fighting", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "兆幅鐵錘"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586606,
+				tcgplayer: 577551,
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「兆幅鐵錘」。"
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578471,
+			},
 		},
-
-		damage: 120,
-		cost: ["Fighting", "Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	],
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [874],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/091.ts
+++ b/data-asia/S/S8b/091.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "熊徒弟"
+		ja: "ダクマ",
+		'zh-tw': "熊徒弟",
 	},
 
 	illustrator: "Kouki Saitou",
@@ -14,37 +14,57 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "拉緊頭上又白又長的體毛就會變得氣勢高昂，並且由丹田湧出力量。"
+		ja: "頭の 白く 長い 体毛を 引っぱると 気合が 高まり 丹田から パワーが 湧きあがる。",
+		'zh-tw': "拉緊頭上又白又長的體毛就會變得氣勢高昂，並且由丹田湧出力量。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "鍛鍊"
+	attacks: [
+		{
+			name: {
+				ja: "たんれん",
+				'zh-tw': "鍛鍊",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から基本エネルギーを1枚選び、このポケモンにつける。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張基本能量卡，附於這隻寶可夢身上。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張基本能量卡，附於這隻寶可夢身上。並且重洗牌庫。"
+		{
+			name: {
+				ja: "ひじうち",
+				'zh-tw': "肘擊",
+			},
+			damage: 60,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "肘擊"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586607,
+				tcgplayer: 571344,
+			},
 		},
-
-		damage: 60,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578399,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [891],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/092.ts
+++ b/data-asia/S/S8b/092.ts
@@ -1,50 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "一擊武道熊師V"
+		ja: "いちげきウーラオスV",
+		'zh-tw': "一擊武道熊師V",
 	},
 
 	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Fighting"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "磨礪"
+	attacks: [
+		{
+			name: {
+				ja: "とぎすます",
+				'zh-tw': "磨礪",
+			},
+			cost: ["Fighting"],
+			effect: {
+				ja: "自分の山札から[闘]エネルギーを2枚まで選び、このポケモンにつける。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多2張【鬥】能量卡，附於這隻寶可夢身上。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多2張【鬥】能量卡，附於這隻寶可夢身上。並且重洗牌庫。"
+		{
+			name: {
+				ja: "インパクトブロー",
+				'zh-tw': "衝擊打擊",
+			},
+			damage: 180,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「インパクトブロー」が使えない。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「衝擊打擊」。",
+			},
 		},
+	],
 
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "衝擊打擊"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586608,
+				tcgplayer: 571345,
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「衝擊打擊」。"
-		},
-
-		damage: 180,
-		cost: ["Fighting", "Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [892],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/093.ts
+++ b/data-asia/S/S8b/093.ts
@@ -1,46 +1,64 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "一擊武道熊師VMAX"
+		ja: "いちげきウーラオスVMAX",
+		'zh-tw': "一擊武道熊師VMAX",
 	},
 
 	illustrator: "PLANETA Tsuji",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Fighting"],
+
 	stage: "VMAX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "正拳突"
+	attacks: [
+		{
+			name: {
+				ja: "せいけんづき",
+				'zh-tw': "正拳突",
+			},
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
-
-		damage: 100,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "超極巨奪命一擊"
+		{
+			name: {
+				ja: "キョダイイチゲキ",
+				'zh-tw': "超極巨奪命一擊",
+			},
+			damage: 270,
+			cost: ["Fighting", "Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、すべてトラッシュする。このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+				'zh-tw': "將這隻寶可夢身上附加的能量全部丟棄。這個招式的傷害不計算對手的戰鬥寶可夢身上的附加效果。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將這隻寶可夢身上附加的能量全部丟棄。這個招式的傷害不計算對手的戰鬥寶可夢身上的附加效果。"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586609,
+				tcgplayer: 571346,
+			},
 		},
+	],
 
-		damage: 270,
-		cost: ["Fighting", "Fighting", "Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "いちげきウーラオスV",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Triple Rare",
+	dexId: [892],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/094.ts
+++ b/data-asia/S/S8b/094.ts
@@ -1,47 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "連擊武道熊師V"
+		ja: "れんげきウーラオスV",
+		'zh-tw': "連擊武道熊師V",
 	},
 
 	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Fighting"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "狡兔三窟"
+	attacks: [
+		{
+			name: {
+				ja: "ひるがえす",
+				'zh-tw': "狡兔三窟",
+			},
+			damage: 30,
+			cost: ["Fighting"],
+			effect: {
+				ja: "のぞむなら、このポケモンをベンチポケモンと入れ替える。",
+				'zh-tw': "若希望，將這隻寶可夢與備戰寶可夢互換。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "若希望，將這隻寶可夢與備戰寶可夢互換。"
+		{
+			name: {
+				ja: "ひゃくれつラッシュ",
+				'zh-tw': "百裂猛攻",
+			},
+			damage: 150,
+			cost: ["Fighting", "Fighting", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "百裂猛攻"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586610,
+				tcgplayer: 571347,
+			},
 		},
-
-		damage: 150,
-		cost: ["Fighting", "Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [892],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/095.ts
+++ b/data-asia/S/S8b/095.ts
@@ -1,49 +1,67 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "連擊武道熊師VMAX"
+		ja: "れんげきウーラオスVMAX",
+		'zh-tw': "連擊武道熊師VMAX",
 	},
 
 	illustrator: "PLANETA Tsuji",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Fighting"],
+
 	stage: "VMAX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "疾風直撞"
+	attacks: [
+		{
+			name: {
+				ja: "しっぷうづき",
+				'zh-tw': "疾風直撞",
+			},
+			damage: "30+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "この番、このポケモンがベンチからバトル場に出ていたなら、120ダメージ追加。",
+				'zh-tw': "在這個回合，若從備戰區將這隻寶可夢放置於戰鬥場，則增加120點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在這個回合，若從備戰區將這隻寶可夢放置於戰鬥場，則增加120點傷害。"
+		{
+			name: {
+				ja: "キョダイレンゲキ",
+				'zh-tw': "超極巨流水連擊",
+			},
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーをすべてトラッシュし、相手のポケモン2匹に、それぞれ120ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "將這隻寶可夢身上附加的能量全部丟棄，對手的2隻寶可夢各受到120點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		damage: "30+",
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "超極巨流水連擊"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586611,
+				tcgplayer: 571348,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將這隻寶可夢身上附加的能量全部丟棄，對手的2隻寶可夢各受到120點傷害。[在備戰區不計算弱點・抵抗力。]"
-		},
-
-		cost: ["Fighting", "Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "れんげきウーラオスV",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Triple Rare",
+	dexId: [892],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/096.ts
+++ b/data-asia/S/S8b/096.ts
@@ -1,52 +1,66 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伽勒爾 火焰鳥V"
+		ja: "ガラル ファイヤーV",
+		'zh-tw': "伽勒爾 火焰鳥V",
 	},
 
 	illustrator: "aky CG Works",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Darkness"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "邪焰之翼"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "じゃえんのつばさ",
+				'zh-tw': "邪焰之翼",
+			},
+			effect: {
+				ja: "自分の番に1回使える。自分のトラッシュから[悪]エネルギーを1枚選び、このポケモンにつける。この番、すでに別の「じゃえんのつばさ」を使っていたなら、この特性は使えない。",
+				'zh-tw': "在自己的回合時，可使用1次。從自己的棄牌區選擇1張【惡】能量卡，附於這隻寶可夢身上。在這個回合，若已經使出了其他的「邪焰之翼」，則這個特性無法使用。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，可使用1次。從自己的棄牌區選擇1張【惡】能量卡，附於這隻寶可夢身上。在這個回合，若已經使出了其他的「邪焰之翼」，則這個特性無法使用。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "氣場烈焰"
+	attacks: [
+		{
+			name: {
+				ja: "オーラバーン",
+				'zh-tw': "氣場烈焰",
+			},
+			damage: 190,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+				'zh-tw': "這隻寶可夢也受到30點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢也受到30點傷害。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586612,
+				tcgplayer: 571349,
+			},
 		},
-
-		damage: 190,
-		cost: ["Darkness", "Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [146],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/097.ts
+++ b/data-asia/S/S8b/097.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "圓絲蛛"
+		ja: "イトマル",
+		'zh-tw': "圓絲蛛",
 	},
 
 	illustrator: "Kyoko Umemoto",
@@ -14,34 +14,54 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "牙齒的毒性並不強烈，但用來削弱那些掛在蛛網上無法動彈的獵物是綽綽有餘。"
+		ja: "キバの 毒は さほど 強くないが 巣に かかって 動けない 獲物を 弱らせるには 充分。",
+		'zh-tw': "牙齒的毒性並不強烈，但用來削弱那些掛在蛛網上無法動彈的獵物是綽綽有餘。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "垂吊"
+	attacks: [
+		{
+			name: {
+				ja: "ぶらさがる",
+				'zh-tw': "垂吊",
+			},
+			damage: 10,
+			cost: ["Darkness"],
 		},
-
-		damage: 10,
-		cost: ["Darkness"]
-	}, {
-		name: {
-			'zh-tw': "刺刺痛痛"
+		{
+			name: {
+				ja: "チクチクさす",
+				'zh-tw': "刺刺痛痛",
+			},
+			damage: 20,
+			cost: ["Darkness", "Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Darkness", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586613,
+				tcgplayer: 571350,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578400,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "None",
+	dexId: [167],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/098.ts
+++ b/data-asia/S/S8b/098.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "阿利多斯"
+		ja: "アリアドス",
+		'zh-tw': "阿利多斯",
 	},
 
 	illustrator: "Shin Nagasawa",
@@ -14,43 +14,68 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "會吐絲來捕捉獵物。每到夜晚就會離開巢穴，積極地展開狩獵。"
+		ja: "糸を はいて 獲物を 捕らえる。 夜に なると 巣から 離れて 積極的に 狩りを するぞ。",
+		'zh-tw': "會吐絲來捕捉獵物。每到夜晚就會離開巢穴，積極地展開狩獵。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "蜘蛛網"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "スパイダーネット",
+				'zh-tw': "蜘蛛網",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のベンチの進化ポケモンを1匹選び、バトルポケモンと入れ替える。",
+				'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。選擇對手的備戰區的1隻進化寶可夢，與戰鬥寶可夢互換。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。選擇對手的備戰區的1隻進化寶可夢，與戰鬥寶可夢互換。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "毒針"
+	attacks: [
+		{
+			name: {
+				ja: "どくばり",
+				'zh-tw': "毒針",
+			},
+			damage: 30,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586614,
+				tcgplayer: 571351,
+			},
 		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578401,
+			},
+		},
+	],
 
-		damage: 30,
-		cost: ["Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "イトマル",
+	},
 
 	retreat: 2,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "None",
+	dexId: [168],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/099.ts
+++ b/data-asia/S/S8b/099.ts
@@ -1,52 +1,66 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "叉字蝠V"
+		ja: "クロバットV",
+		'zh-tw': "叉字蝠V",
 	},
 
 	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
 	hp: 180,
 	types: ["Darkness"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "暗夜能源"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ナイトアセット",
+				'zh-tw': "暗夜能源",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の手札が6枚になるように、山札を引く。この番、すでに別の「ナイトアセット」を使っていたなら、この特性は使えない。",
+				'zh-tw': "在自己的回合，當從手牌將這張卡放置於備戰區時，可使用1次。從牌庫抽卡直到自己的手牌滿6張為止。在這個回合，若已經使出了其他的「暗夜能源」，則這個特性無法使用。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，當從手牌將這張卡放置於備戰區時，可使用1次。從牌庫抽卡直到自己的手牌滿6張為止。在這個回合，若已經使出了其他的「暗夜能源」，則這個特性無法使用。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "毒牙"
+	attacks: [
+		{
+			name: {
+				ja: "どくのキバ",
+				'zh-tw': "毒牙",
+			},
+			damage: 70,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586615,
+				tcgplayer: 571352,
+			},
 		},
-
-		damage: 70,
-		cost: ["Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "Double rare",
+	dexId: [169],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/100.ts
+++ b/data-asia/S/S8b/100.ts
@@ -1,51 +1,64 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "月亮伊布V"
+		ja: "ブラッキーV",
+		'zh-tw': "月亮伊布V",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Darkness"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "黑色目光"
+	attacks: [
+		{
+			name: {
+				ja: "くろいまなざし",
+				'zh-tw': "黑色目光",
+			},
+			damage: 30,
+			cost: ["Darkness"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。"
+		{
+			name: {
+				ja: "げっこうのやいば",
+				'zh-tw': "月光利刃",
+			},
+			damage: "80+",
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにダメカンがのっているなら、80ダメージ追加。",
+				'zh-tw': "若這隻寶可夢身上放置有傷害指示物，則增加80點傷害。",
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Darkness"]
-	}, {
-		name: {
-			'zh-tw': "月光利刃"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586616,
+				tcgplayer: 571353,
+			},
 		},
-
-		effect: {
-			'zh-tw': "若這隻寶可夢身上放置有傷害指示物，則增加80點傷害。"
-		},
-
-		damage: "80+",
-		cost: ["Darkness", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [197],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/101.ts
+++ b/data-asia/S/S8b/101.ts
@@ -1,47 +1,66 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "月亮伊布VMAX"
+		ja: "ブラッキーVMAX",
+		'zh-tw': "月亮伊布VMAX",
 	},
 
 	illustrator: "AKIRA EGAWA",
 	category: "Pokemon",
 	hp: 310,
 	types: ["Darkness"],
+
 	stage: "VMAX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "黑暗信號"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ダークシグナル",
+				'zh-tw': "黑暗信號",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+				'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。選擇1隻對手的備戰寶可夢，與戰鬥寶可夢互換。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。選擇1隻對手的備戰寶可夢，與戰鬥寶可夢互換。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "極巨惡霸"
+	attacks: [
+		{
+			name: {
+				ja: "ダイアーク",
+				'zh-tw': "極巨惡霸",
+			},
+			damage: 160,
+			cost: ["Darkness", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 160,
-		cost: ["Darkness", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586617,
+				tcgplayer: 571354,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ブラッキーV",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Triple Rare",
+	dexId: [197],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/102.ts
+++ b/data-asia/S/S8b/102.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "戴魯比"
+		ja: "デルビル",
+		'zh-tw': "戴魯比",
 	},
 
 	illustrator: "Sanosuke Sakuma",
@@ -14,27 +14,46 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "會在天亮前反覆發出令人不寒而慄的長嚎，藉此強調 自己群體的存在。"
+		ja: "夜明け前に 不気味な 遠吠えを 繰り返し 自分たちの 群れの 存在を アピール している。",
+		'zh-tw': "會在天亮前反覆發出令人不寒而慄的長嚎，藉此強調 自己群體的存在。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "咬住"
+	attacks: [
+		{
+			name: {
+				ja: "かみつく",
+				'zh-tw': "咬住",
+			},
+			damage: 20,
+			cost: ["Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Colorless"]
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586618,
+				tcgplayer: 571355,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578402,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [228],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/103.ts
+++ b/data-asia/S/S8b/103.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "黑魯加"
+		ja: "ヘルガー",
+		'zh-tw': "黑魯加",
 	},
 
 	illustrator: "Ryota Murayama",
@@ -14,39 +14,58 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "特徵是令人不寒而慄的長嚎。過去人們認為牠是來自 地獄的使者，對牠十分畏懼。"
+		ja: "不気味な 遠吠えが 特徴。 昔の 人は 地獄 からの 使いと 考え 恐れていた。",
+		'zh-tw': "特徵是令人不寒而慄的長嚎。過去人們認為牠是來自 地獄的使者，對牠十分畏懼。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "一擊咆哮"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "いちげきのほうこう",
+				'zh-tw': "一擊咆哮",
+			},
+			effect: {
+				ja: "自分の番に1回使える。自分の山札から「いちげきエネルギー」を1枚選び、自分の「いちげき」のポケモンにつける。そして山札を切る。その後、つけたポケモンにダメカンを2個のせる。",
+				'zh-tw': "在自己的回合時，可使用1次。從自己的牌庫選擇1張「一擊能量」卡，附於自己的「一擊」寶可夢身上。並且重洗牌庫。然後，在附上那張卡的寶可夢身上放置2個傷害指示物。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，可使用1次。從自己的牌庫選擇1張「一擊能量」卡，附於自己的「一擊」寶可夢身上。並且重洗牌庫。然後，在附上那張卡的寶可夢身上放置2個傷害指示物。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "暗之牙"
+	attacks: [
+		{
+			name: {
+				ja: "やみのキバ",
+				'zh-tw': "暗之牙",
+			},
+			damage: 50,
+			cost: ["Darkness", "Colorless"],
 		},
+	],
 
-		damage: 50,
-		cost: ["Darkness", "Colorless"]
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586619,
+				tcgplayer: 571356,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "デルビル",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [229],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/104.ts
+++ b/data-asia/S/S8b/104.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伽勒爾 蛇紋熊"
+		ja: "ガラル ジグザグマ",
+		'zh-tw': "伽勒爾 蛇紋熊",
 	},
 
 	illustrator: "kirisAki",
@@ -14,43 +14,64 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "這似乎是蛇紋熊最古老的樣子。會之字形亂走，把周圍弄得一團糟。"
+		ja: "この姿が いちばん 古い ジグザグマの 姿 らしい。 ジグザグ動いて あたりを 荒らす。",
+		'zh-tw': "這似乎是蛇紋熊最古老的樣子。會之字形亂走，把周圍弄得一團糟。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "煩躁頭擊"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "かんしゃくヘッド",
+				'zh-tw': "煩躁頭擊",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。相手のポケモン1匹に、ダメカンを1個のせる。",
+				'zh-tw': "在自己的回合，當從手牌將這張卡放置於備戰區時，可使用1次。在對手的1隻寶可夢身上放置1個傷害指示物。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，當從手牌將這張卡放置於備戰區時，可使用1次。在對手的1隻寶可夢身上放置1個傷害指示物。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "偷襲"
+	attacks: [
+		{
+			name: {
+				ja: "ふいをつく",
+				'zh-tw': "偷襲",
+			},
+			damage: 30,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+				'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586620,
+				tcgplayer: 571357,
+			},
 		},
-
-		damage: 30,
-		cost: ["Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578403,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "None",
+	dexId: [263],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/105.ts
+++ b/data-asia/S/S8b/105.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伽勒爾 直衝熊"
+		ja: "ガラル マッスグマ",
+		'zh-tw': "伽勒爾 直衝熊",
 	},
 
 	illustrator: "nagimiso",
@@ -14,38 +14,62 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "有著十分好戰的性情。即使是比自己強的對手也會魯莽地發起挑戰。"
+		ja: "とても 好戦的な 性質。 自分より 格上の 相手にも 平気で 挑む むこうみず。",
+		'zh-tw': "有著十分好戰的性情。即使是比自己強的對手也會魯莽地發起挑戰。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "暗襲要害"
+	attacks: [
+		{
+			name: {
+				ja: "つじぎり",
+				'zh-tw': "暗襲要害",
+			},
+			damage: 20,
+			cost: ["Darkness"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+				'zh-tw': "將這隻寶可夢與備戰寶可夢互換。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將這隻寶可夢與備戰寶可夢互換。"
+		{
+			name: {
+				ja: "ぶちかます",
+				'zh-tw': "頭突",
+			},
+			damage: 70,
+			cost: ["Darkness", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Darkness"]
-	}, {
-		name: {
-			'zh-tw': "頭突"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586621,
+				tcgplayer: 571358,
+			},
 		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578404,
+			},
+		},
+	],
 
-		damage: 70,
-		cost: ["Darkness", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ガラル ジグザグマ",
+	},
 
 	retreat: 2,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "None",
+	dexId: [264],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/106.ts
+++ b/data-asia/S/S8b/106.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伽勒爾 堵攔熊"
+		ja: "ガラル タチフサグマ",
+		'zh-tw': "伽勒爾 堵攔熊",
 	},
 
 	illustrator: "Kouki Saitou",
@@ -14,43 +14,62 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "在不斷的鬥爭中得到了進化。牠交叉著雙臂發出的怒吼能讓一切對手都為之膽怯。"
+		ja: "ケンカを 繰り返し 進化。 腕をクロスし 叫ぶ 雄叫びは どんな 相手も 怯ませるぞ。",
+		'zh-tw': "在不斷的鬥爭中得到了進化。牠交叉著雙臂發出的怒吼能讓一切對手都為之膽怯。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "暴躁嚎叫"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "あらくれシャウト",
+				'zh-tw': "暴躁嚎叫",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のポケモン1匹に、ダメカンを3個のせる。",
+				'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。在對手的1隻寶可夢身上放置3個傷害指示物。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。在對手的1隻寶可夢身上放置3個傷害指示物。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "攔堵"
+	attacks: [
+		{
+			name: {
+				ja: "ブロッキング",
+				'zh-tw': "攔堵",
+			},
+			damage: 90,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンはたねポケモンからワザのダメージを受けない。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢不會受到【基礎】寶可夢招式的傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，這隻寶可夢不會受到【基礎】寶可夢招式的傷害。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586622,
+				tcgplayer: 571359,
+			},
 		},
+	],
 
-		damage: 90,
-		cost: ["Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ガラル マッスグマ",
+	},
 
 	retreat: 2,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "None",
+	dexId: [862],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/107.ts
+++ b/data-asia/S/S8b/107.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "花岩怪"
+		ja: "ミカルゲ",
+		'zh-tw': "花岩怪",
 	},
 
 	illustrator: "Shibuzoh.",
@@ -14,37 +14,57 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "因為５００年前作惡多端，導致身體被綁縛在楔石的裂縫裡。"
+		ja: "５００年前に 悪さをしたため 要石の ひび割れに 体を つなぎとめられてしまった。",
+		'zh-tw': "因為５００年前作惡多端，導致身體被綁縛在楔石的裂縫裡。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "亡者呐喊"
+	attacks: [
+		{
+			name: {
+				ja: "もうじゃのさけび",
+				'zh-tw': "亡者呐喊",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のトラッシュにあるポケモンの枚数ぶんのダメカンを、相手のポケモンに好きなようにのせる。その後、相手のトラッシュにあるポケモンをすべて、相手の山札にもどして切る。",
+				'zh-tw': "將與對手棄牌區的寶可夢卡張數相同數量的傷害指示物，以任意方式放置在對手的寶可夢身上。然後，將對手棄牌區的寶可夢卡全部放回對手的牌庫並重洗。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將與對手棄牌區的寶可夢卡張數相同數量的傷害指示物，以任意方式放置在對手的寶可夢身上。然後，將對手棄牌區的寶可夢卡全部放回對手的牌庫並重洗。"
+		{
+			name: {
+				ja: "おにび",
+				'zh-tw': "鬼火",
+			},
+			damage: 20,
+			cost: ["Darkness"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "鬼火"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586623,
+				tcgplayer: 571360,
+			},
 		},
-
-		damage: 20,
-		cost: ["Darkness"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578405,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [442],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/108.ts
+++ b/data-asia/S/S8b/108.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "胡帕"
+		ja: "フーパ",
+		'zh-tw': "胡帕",
 	},
 
 	illustrator: "Souichirou Gunjima",
@@ -14,31 +14,44 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "用圓環將喜歡的東西傳送到秘密的住處。會鑽進圓環瞬間移動。"
+		ja: "気に入った ものを リングを 使い 秘密の 住処へ 集めている。 リングを 潜って テレポートする。",
+		'zh-tw': "用圓環將喜歡的東西傳送到秘密的住處。會鑽進圓環瞬間移動。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "進擊之門"
+	attacks: [
+		{
+			name: {
+				ja: "アサルトゲート",
+				'zh-tw': "進擊之門",
+			},
+			damage: 90,
+			cost: ["Darkness"],
+			effect: {
+				ja: "この番、このポケモンがベンチからバトル場に出ていないなら、このワザは失敗。このワザのダメージは弱点を計算しない。",
+				'zh-tw': "在這個回合，若沒有從備戰區將這隻寶可夢放置於戰鬥場，則這個招式失敗。這個招式的傷害不計算弱點。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在這個回合，若沒有從備戰區將這隻寶可夢放置於戰鬥場，則這個招式失敗。這個招式的傷害不計算弱點。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586624,
+				tcgplayer: 571361,
+			},
 		},
-
-		damage: 90,
-		cost: ["Darkness"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "None",
+	dexId: [720],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/109.ts
+++ b/data-asia/S/S8b/109.ts
@@ -1,51 +1,64 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "無極汰那V"
+		ja: "ムゲンダイナV",
+		'zh-tw': "無極汰那V",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Darkness"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "衝力"
+	attacks: [
+		{
+			name: {
+				ja: "パワーアクセル",
+				'zh-tw': "衝力",
+			},
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "のぞむなら、自分の手札から[悪]エネルギーを1枚選び、ベンチポケモンにつける。",
+				'zh-tw': "若希望，從自己的手牌選擇1張【惡】能量卡，附於備戰寶可夢身上。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "若希望，從自己的手牌選擇1張【惡】能量卡，附於備戰寶可夢身上。"
+		{
+			name: {
+				ja: "ダイマックスほう",
+				'zh-tw': "極巨炮",
+			},
+			damage: "120+",
+			cost: ["Darkness", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが「ポケモンVMAX」なら、120ダメージ追加。",
+				'zh-tw': "若對手的戰鬥寶可夢為「寶可夢【VMAX】」，則增加120點傷害。",
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "極巨炮"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586625,
+				tcgplayer: 571362,
+			},
 		},
-
-		effect: {
-			'zh-tw': "若對手的戰鬥寶可夢為「寶可夢【VMAX】」，則增加120點傷害。"
-		},
-
-		damage: "120+",
-		cost: ["Darkness", "Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "Double rare",
+	dexId: [890],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/110.ts
+++ b/data-asia/S/S8b/110.ts
@@ -1,51 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "無極汰那VMAX"
+		ja: "ムゲンダイナVMAX",
+		'zh-tw': "無極汰那VMAX",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 340,
 	types: ["Darkness"],
+
 	stage: "VMAX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "無極領域"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ムゲンゾーン",
+				'zh-tw': "無極領域",
+			},
+			effect: {
+				ja: "自分の場のポケモン全員が[悪]タイプならはたらく。自分のベンチに出せる[悪]ポケモンの数は8匹になり、別のタイプは場に出せない。（この特性がはたらかなくなったとき、ベンチが5匹になるまでトラッシュする。）",
+				'zh-tw': "若自己的所有場上寶可夢皆為【惡】屬性則生效。可放置於自己的備戰區的【惡】寶可夢數量改為8隻，其他屬性無法放置於場上。（當這個特性不生效後，將備戰區的寶可夢丟棄直到變為5隻為止。）",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若自己的所有場上寶可夢皆為【惡】屬性則生效。可放置於自己的備戰區的【惡】寶可夢數量改為8隻，其他屬性無法放置於場上。（當這個特性不生效後，將備戰區的寶可夢丟棄直到變為5隻為止。）"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "忌憚之末"
+	attacks: [
+		{
+			name: {
+				ja: "ドレッドエンド",
+				'zh-tw': "忌憚之末",
+			},
+			damage: "30×",
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "自分の場の[悪]ポケモンの数×30ダメージ。",
+				'zh-tw': "造成自己的場上【惡】寶可夢的數量×30點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "造成自己的場上【惡】寶可夢的數量×30點傷害。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586626,
+				tcgplayer: 571363,
+			},
 		},
+	],
 
-		damage: "30×",
-		cost: ["Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ムゲンダイナV",
+	},
 
 	retreat: 3,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "Triple Rare",
+	dexId: [890],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/111.ts
+++ b/data-asia/S/S8b/111.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "一擊武道熊師"
+		ja: "いちげきウーラオス",
+		'zh-tw': "一擊武道熊師",
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -14,42 +14,60 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "棲息在遙遠地區的山岳地帶。會在斷崖絕壁上來回奔跑 鍛鍊下盤，磨練招式。"
+		ja: "遠い 地方の 山岳地帯で 暮らす。 断崖絶壁を 走り 足腰を 鍛え 技を 磨く。",
+		'zh-tw': "棲息在遙遠地區的山岳地帶。會在斷崖絕壁上來回奔跑 鍛鍊下盤，磨練招式。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "場地粉碎"
+	attacks: [
+		{
+			name: {
+				ja: "フィールドクラッシュ",
+				'zh-tw': "場地粉碎",
+			},
+			damage: 50,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "場に出ている相手のスタジアムをトラッシュする。",
+				'zh-tw': "將場上的對手的競技場卡丟棄。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將場上的對手的競技場卡丟棄。"
+		{
+			name: {
+				ja: "しゅらのこぶし",
+				'zh-tw': "修羅拳",
+			},
+			damage: "100+",
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "このポケモンにダメカンがのっているなら、100ダメージ追加。",
+				'zh-tw': "若這隻寶可夢身上放置有傷害指示物，則增加100點傷害。",
+			},
 		},
+	],
 
-		damage: 50,
-		cost: ["Darkness", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "修羅拳"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586627,
+				tcgplayer: 571364,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢身上放置有傷害指示物，則增加100點傷害。"
-		},
-
-		damage: "100+",
-		cost: ["Darkness", "Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ダクマ",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [892],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/112.ts
+++ b/data-asia/S/S8b/112.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "銅鏡怪"
+		ja: "ドーミラー",
+		'zh-tw': "銅鏡怪",
 	},
 
 	illustrator: "Mizue",
@@ -14,32 +14,46 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "雖然人們說把銅鏡怪打磨到發光，牠就能映照出真相，但其實牠非常討厭被打磨。"
+		ja: "磨けば 光り 真実を 映しだすとも いわれるが ドーミラーは とても 嫌がる。",
+		'zh-tw': "雖然人們說把銅鏡怪打磨到發光，牠就能映照出真相，但其實牠非常討厭被打磨。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "衝撞"
+	attacks: [
+		{
+			name: {
+				ja: "ぶつかる",
+				'zh-tw': "衝撞",
+			},
+			damage: 30,
+			cost: ["Metal", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Metal", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586628,
+				tcgplayer: 571365,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578406,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [436],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/113.ts
+++ b/data-asia/S/S8b/113.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "青銅鐘"
+		ja: "ドータクン",
+		'zh-tw': "青銅鐘",
 	},
 
 	illustrator: "Atsushi Furusawa",
@@ -14,44 +14,58 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "牠身上的紋路讓許多學者認為牠原本並不存在於伽勒爾。"
+		ja: "体の模様 から 本来 ガラルには いない ポケモンと 考える 学者も 多い。",
+		'zh-tw': "牠身上的紋路讓許多學者認為牠原本並不存在於伽勒爾。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "金屬轉移"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "メタルトランス",
+				'zh-tw': "金屬轉移",
+			},
+			effect: {
+				ja: "自分の番に何回でも使える。自分の場のポケモンについている[鋼]エネルギーを1個選び、自分の別のポケモンにつけ替える。",
+				'zh-tw': "在自己的回合時，可不限次數使用。選擇1個自己的場上寶可夢身上附加的【鋼】能量，改附於自己的其他寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，可不限次數使用。選擇1個自己的場上寶可夢身上附加的【鋼】能量，改附於自己的其他寶可夢身上。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "意念頭錘"
+	attacks: [
+		{
+			name: {
+				ja: "しねんのずつき",
+				'zh-tw': "意念頭錘",
+			},
+			damage: 70,
+			cost: ["Metal", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 70,
-		cost: ["Metal", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586629,
+				tcgplayer: 571366,
+			},
+		},
+	],
 
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ドーミラー",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [437],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/114.ts
+++ b/data-asia/S/S8b/114.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "勾帕路翁"
+		ja: "コバルオン",
+		'zh-tw': "勾帕路翁",
 	},
 
 	illustrator: "Kazuma Koda",
@@ -14,43 +14,52 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "有著鋼鐵的心靈與身體。當人類傷害寶可夢時，會與夥伴一起制裁人類。"
+		ja: "鋼の 心と 体を 持つ。 人が ポケモンを 傷つけたとき 仲間とともに 人を こらしめた。",
+		'zh-tw': "有著鋼鐵的心靈與身體。當人類傷害寶可夢時，會與夥伴一起制裁人類。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "鐵頭碰"
+	attacks: [
+		{
+			name: {
+				ja: "ヘッドバング",
+				'zh-tw': "鐵頭碰",
+			},
+			damage: 40,
+			cost: ["Metal", "Colorless"],
 		},
-
-		damage: 40,
-		cost: ["Metal", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "金屬斬"
+		{
+			name: {
+				ja: "メタルスラッシュ",
+				'zh-tw': "金屬斬",
+			},
+			damage: 130,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586630,
+				tcgplayer: 571367,
+			},
 		},
-
-		damage: 130,
-		cost: ["Metal", "Metal", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [638],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/115.ts
+++ b/data-asia/S/S8b/115.ts
@@ -1,56 +1,64 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鋼鎧鴉V"
+		ja: "アーマーガアV",
+		'zh-tw': "鋼鎧鴉V",
 	},
 
 	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Metal"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "緊抓"
+	attacks: [
+		{
+			name: {
+				ja: "わしづかみ",
+				'zh-tw': "緊抓",
+			},
+			damage: 30,
+			cost: ["Metal"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。"
+		{
+			name: {
+				ja: "スカイハリケーン",
+				'zh-tw': "天空颶風",
+			},
+			damage: 190,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「スカイハリケーン」が使えない。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「天空颶風」。",
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Metal"]
-	}, {
-		name: {
-			'zh-tw': "天空颶風"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586631,
+				tcgplayer: 571368,
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「天空颶風」。"
-		},
-
-		damage: 190,
-		cost: ["Metal", "Metal", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [823],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/116.ts
+++ b/data-asia/S/S8b/116.ts
@@ -1,56 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鋼鎧鴉VMAX"
+		ja: "アーマーガアVMAX",
+		'zh-tw': "鋼鎧鴉VMAX",
 	},
 
 	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
 	hp: 320,
 	types: ["Metal"],
+
 	stage: "VMAX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "潔淨之軀"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ラスターボディ",
+				'zh-tw': "潔淨之軀",
+			},
+			effect: {
+				ja: "このポケモンは、相手のポケモンから特性の効果を受けない。",
+				'zh-tw': "這隻寶可夢不會受到對手的寶可夢的特性的效果的影響。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢不會受到對手的寶可夢的特性的效果的影響。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "超極巨風狂暴雨"
+	attacks: [
+		{
+			name: {
+				ja: "キョダイハリケーン",
+				'zh-tw': "超極巨風狂暴雨",
+			},
+			damage: 240,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「キョダイハリケーン」が使えない。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「超極巨風狂暴雨」。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「超極巨風狂暴雨」。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586632,
+				tcgplayer: 571369,
+			},
 		},
+	],
 
-		damage: 240,
-		cost: ["Metal", "Metal", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "アーマーガアV",
+	},
 
 	retreat: 0,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Triple Rare",
+	dexId: [823],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/117.ts
+++ b/data-asia/S/S8b/117.ts
@@ -1,57 +1,66 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "蒼響V"
+		ja: "ザシアンV",
+		'zh-tw': "蒼響V",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Metal"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "不撓之劍"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ふとうのつるぎ",
+				'zh-tw': "不撓之劍",
+			},
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、自分の番は終わる。自分の山札を上から3枚見て、その中から[鋼]エネルギーを好きなだけ選び、このポケモンにつける。残りのカードは手札に加える。",
+				'zh-tw': "在自己的回合時可使用1次，若使用，則自己的回合結束。查看自己的牌庫上方3張卡，選擇其中任意數量的【鋼】能量卡，附於這隻寶可夢身上。將剩餘卡加入手牌。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時可使用1次，若使用，則自己的回合結束。查看自己的牌庫上方3張卡，選擇其中任意數量的【鋼】能量卡，附於這隻寶可夢身上。將剩餘卡加入手牌。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "無畏聖劍"
+	attacks: [
+		{
+			name: {
+				ja: "ブレイブキャリバー",
+				'zh-tw': "無畏聖劍",
+			},
+			damage: 230,
+			cost: ["Metal", "Metal", "Metal"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586633,
+				tcgplayer: 571370,
+			},
 		},
-
-		damage: 230,
-		cost: ["Metal", "Metal", "Metal"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "Double rare",
+	dexId: [888],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/118.ts
+++ b/data-asia/S/S8b/118.ts
@@ -1,57 +1,66 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "藏瑪然特V"
+		ja: "ザマゼンタV",
+		'zh-tw': "藏瑪然特V",
 	},
 
 	illustrator: "aky CG Works",
 	category: "Pokemon",
 	hp: 230,
 	types: ["Metal"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "不屈之盾"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ふくつのたて",
+				'zh-tw': "不屈之盾",
+			},
+			effect: {
+				ja: "このポケモンは、相手の「ポケモンVMAX」からワザのダメージを受けない。",
+				'zh-tw': "這隻寶可夢不會受到對手的「寶可夢【VMAX】」招式的傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢不會受到對手的「寶可夢【VMAX】」招式的傷害。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "進擊衝撞"
+	attacks: [
+		{
+			name: {
+				ja: "アサルトタックル",
+				'zh-tw': "進擊衝撞",
+			},
+			damage: 130,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについている特殊エネルギーを1個選び、トラッシュする。",
+				'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的特殊能量，將其丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的特殊能量，將其丟棄。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586634,
+				tcgplayer: 571371,
+			},
 		},
-
-		damage: 130,
-		cost: ["Metal", "Metal", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "Double rare",
+	dexId: [889],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/119.ts
+++ b/data-asia/S/S8b/119.ts
@@ -1,46 +1,64 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "烈空坐V"
+		ja: "レックウザV",
+		'zh-tw': "烈空坐V",
 	},
 
 	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Dragon"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "龍之波動"
+	attacks: [
+		{
+			name: {
+				ja: "りゅうのはどう",
+				'zh-tw': "龍之波動",
+			},
+			damage: 40,
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分の山札を上から2枚トラッシュする。",
+				'zh-tw': "將自己的牌庫上方2張卡丟棄。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將自己的牌庫上方2張卡丟棄。"
+		{
+			name: {
+				ja: "スパイラルバースト",
+				'zh-tw': "螺旋爆破",
+			},
+			damage: "20+",
+			cost: ["Fire", "Lightning"],
+			effect: {
+				ja: "のぞむなら、このポケモンについている[炎]または[雷]タイプのどちらかの基本エネルギーを2枚までトラッシュし、その枚数×80ダメージ追加。",
+				'zh-tw': "若希望，將這隻寶可夢身上附加的【火】或者【雷】任一屬性的最多2張基本能量卡丟棄，增加其張數×80點傷害。",
+			},
 		},
+	],
 
-		damage: 40,
-		cost: ["Lightning"]
-	}, {
-		name: {
-			'zh-tw': "螺旋爆破"
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586635,
+				tcgplayer: 571372,
+			},
 		},
-
-		effect: {
-			'zh-tw': "若希望，將這隻寶可夢身上附加的【火】或者【雷】任一屬性的最多2張基本能量卡丟棄，增加其張數×80點傷害。"
-		},
-
-		damage: "20+",
-		cost: ["Fire", "Lightning"]
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [384],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/120.ts
+++ b/data-asia/S/S8b/120.ts
@@ -1,46 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "烈空坐VMAX"
+		ja: "レックウザVMAX",
+		'zh-tw': "烈空坐VMAX",
 	},
 
 	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
 	hp: 320,
 	types: ["Dragon"],
+
 	stage: "VMAX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "蒼空波動"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "そうくうのはどう",
+				'zh-tw': "蒼空波動",
+			},
+			effect: {
+				ja: "自分の番に1回使える。自分の手札をすべてトラッシュし、山札を3枚引く。",
+				'zh-tw': "在自己的回合時，可使用1次。將自己的手牌全部丟棄，從牌庫抽出3張卡。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，可使用1次。將自己的手牌全部丟棄，從牌庫抽出3張卡。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "極巨爆破"
+	attacks: [
+		{
+			name: {
+				ja: "ダイバースト",
+				'zh-tw': "極巨爆破",
+			},
+			damage: "20+",
+			cost: ["Fire", "Lightning"],
+			effect: {
+				ja: "このポケモンについている[炎]または[雷]タイプのどちらかの基本エネルギーを好きなだけトラッシュし、その枚数×80ダメージ追加。",
+				'zh-tw': "將這隻寶可夢身上附加的【火】或者【雷】任一屬性的任意數量的基本能量卡丟棄，增加其張數×80點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將這隻寶可夢身上附加的【火】或者【雷】任一屬性的任意數量的基本能量卡丟棄，增加其張數×80點傷害。"
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586636,
+				tcgplayer: 571373,
+			},
 		},
+	],
 
-		damage: "20+",
-		cost: ["Fire", "Lightning"]
-	}],
+	evolveFrom: {
+		ja: "レックウザV",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Triple Rare",
+	dexId: [384],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/121.ts
+++ b/data-asia/S/S8b/121.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "赤面龍"
+		ja: "クリムガン",
+		'zh-tw': "赤面龍",
 	},
 
 	illustrator: "Ryo Ueda",
@@ -14,33 +14,58 @@ const card: Card = {
 	types: ["Dragon"],
 
 	description: {
-		'zh-tw': "性情凶暴且狡猾。會搶奪其他寶可夢挖好的巢穴，來當作是自己的窩。"
+		ja: "凶暴で ずる賢い。 ほかの ポケモンが 掘った 巣穴を 奪って すみかにする。",
+		'zh-tw': "性情凶暴且狡猾。會搶奪其他寶可夢挖好的巢穴，來當作是自己的窩。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "報復"
+	attacks: [
+		{
+			name: {
+				ja: "リベンジ",
+				'zh-tw': "報復",
+			},
+			damage: "40+",
+			cost: ["Fire", "Water"],
+			effect: {
+				ja: "前の相手の番に、ワザのダメージで、自分のポケモンがきぜつしていたなら、120ダメージ追加。",
+				'zh-tw': "若在上個對手的回合，自己的寶可夢因招式的傷害而【氣絕】了，則增加120點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "若在上個對手的回合，自己的寶可夢因招式的傷害而【氣絕】了，則增加120點傷害。"
+		{
+			name: {
+				ja: "ドラゴンクロー",
+				'zh-tw': "龍爪",
+			},
+			damage: 120,
+			cost: ["Fire", "Water", "Colorless"],
 		},
+	],
 
-		damage: "40+",
-		cost: ["Fire", "Water"]
-	}, {
-		name: {
-			'zh-tw': "龍爪"
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586637,
+				tcgplayer: 571374,
+			},
 		},
-
-		damage: 120,
-		cost: ["Fire", "Water", "Colorless"]
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578407,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [621],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/122.ts
+++ b/data-asia/S/S8b/122.ts
@@ -1,42 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鋁鋼龍V"
+		ja: "ジュラルドンV",
+		'zh-tw': "鋁鋼龍V",
 	},
 
 	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Dragon"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "金屬爪"
+	attacks: [
+		{
+			name: {
+				ja: "メタルクロー",
+				'zh-tw': "金屬爪",
+			},
+			damage: 70,
+			cost: ["Fighting", "Metal"],
 		},
-
-		damage: 70,
-		cost: ["Fighting", "Metal"]
-	}, {
-		name: {
-			'zh-tw': "廣域破壞"
+		{
+			name: {
+				ja: "ワイドブレイカー",
+				'zh-tw': "廣域破壞",
+			},
+			damage: 140,
+			cost: ["Fighting", "Metal", "Metal"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-30」される。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢使用招式的傷害「-30」點。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢使用招式的傷害「-30」點。"
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586638,
+				tcgplayer: 571375,
+			},
 		},
-
-		damage: 140,
-		cost: ["Fighting", "Metal", "Metal"]
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [884],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/123.ts
+++ b/data-asia/S/S8b/123.ts
@@ -1,46 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鋁鋼龍VMAX"
+		ja: "ジュラルドンVMAX",
+		'zh-tw': "鋁鋼龍VMAX",
 	},
 
 	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Dragon"],
+
 	stage: "VMAX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "摩天樓"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "まてんろう",
+				'zh-tw': "摩天樓",
+			},
+			effect: {
+				ja: "このポケモンは、特殊エネルギーがついている相手のポケモンから、ワザのダメージを受けない。",
+				'zh-tw': "這隻寶可夢不會受到對手的身上附有特殊能量的寶可夢招式的傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢不會受到對手的身上附有特殊能量的寶可夢招式的傷害。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "超極巨碎骨粉身"
+	attacks: [
+		{
+			name: {
+				ja: "キョダイフンサイ",
+				'zh-tw': "超極巨碎骨粉身",
+			},
+			damage: 220,
+			cost: ["Fighting", "Metal", "Metal"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+				'zh-tw': "這個招式的傷害不計算對手的戰鬥寶可夢身上的附加效果。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這個招式的傷害不計算對手的戰鬥寶可夢身上的附加效果。"
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586639,
+				tcgplayer: 571376,
+			},
 		},
+	],
 
-		damage: 220,
-		cost: ["Fighting", "Metal", "Metal"]
-	}],
+	evolveFrom: {
+		ja: "ジュラルドンV",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Triple Rare",
+	dexId: [884],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/124.ts
+++ b/data-asia/S/S8b/124.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "肯泰羅"
+		ja: "ケンタロス",
+		'zh-tw': "肯泰羅",
 	},
 
 	illustrator: "nagimiso",
@@ -14,42 +14,56 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "會組成群體來生活。群體中角最粗、最長， 且傷痕最多的就是老大。"
+		ja: "集団で 生活する。 群れの 中で １番 太く 長く キズだらけの ツノを持つのが ボス。",
+		'zh-tw': "會組成群體來生活。群體中角最粗、最長， 且傷痕最多的就是老大。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "蠻牛"
+	attacks: [
+		{
+			name: {
+				ja: "レイジングブル",
+				'zh-tw': "蠻牛",
+			},
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数×20ダメージ追加。このポケモンをこんらんにする。",
+				'zh-tw': "增加這隻寶可夢身上放置的傷害指示物的數量×20點傷害。將這隻寶可夢【混亂】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "增加這隻寶可夢身上放置的傷害指示物的數量×20點傷害。將這隻寶可夢【混亂】。"
+		{
+			name: {
+				ja: "とっしん",
+				'zh-tw': "猛撞",
+			},
+			damage: 80,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+				'zh-tw': "這隻寶可夢也受到30點傷害。",
+			},
 		},
+	],
 
-		damage: "20+",
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "猛撞"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586640,
+				tcgplayer: 571377,
+			},
 		},
-
-		effect: {
-			'zh-tw': "這隻寶可夢也受到30點傷害。"
-		},
-
-		damage: 80,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [128],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/125.ts
+++ b/data-asia/S/S8b/125.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伊布"
+		ja: "イーブイ",
+		'zh-tw': "伊布",
 	},
 
 	illustrator: "Atsushi Furusawa",
@@ -14,37 +14,57 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "由於不穩定的基因，蘊含著各式各樣進化可能性的特殊寶可夢。"
+		ja: "不安定な 遺伝子の おかげで さまざまな 進化の 可能性を 秘めている 特殊な ポケモン。",
+		'zh-tw': "由於不穩定的基因，蘊含著各式各樣進化可能性的特殊寶可夢。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "布搜索"
+	attacks: [
+		{
+			name: {
+				ja: "ブイサーチ",
+				'zh-tw': "布搜索",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から「ポケモンV」を3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多3張「寶可夢【V】」卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多3張「寶可夢【V】」卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		{
+			name: {
+				ja: "ふむ",
+				'zh-tw': "踩",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "踩"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586641,
+				tcgplayer: 571378,
+			},
 		},
-
-		damage: 20,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578409,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [133],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/126.ts
+++ b/data-asia/S/S8b/126.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "卡比獸"
+		ja: "カビゴン",
+		'zh-tw': "卡比獸",
 	},
 
 	illustrator: "Narumi Sato",
@@ -14,43 +14,58 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "每天不吃下４００公斤的食物絕不會善罷甘休。吃飽了就會開始睡覺。"
+		ja: "１日に 食べ物を ４００キロ 食べないと 気がすまない。 食べ終わると 眠ってしまう。",
+		'zh-tw': "每天不吃下４００公斤的食物絕不會善罷甘休。吃飽了就會開始睡覺。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "積食"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "くいだめ",
+				'zh-tw': "積食",
+			},
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使えて、使ったなら、自分の番は終わる。自分の手札が7枚になるように、山札を引く。",
+				'zh-tw': "若這隻寶可夢在戰鬥場上，則在自己的回合時可使用1次，若使用，則自己的回合結束。從牌庫抽卡直到自己的手牌滿7張為止。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢在戰鬥場上，則在自己的回合時可使用1次，若使用，則自己的回合結束。從牌庫抽卡直到自己的手牌滿7張為止。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "泰山壓頂"
+	attacks: [
+		{
+			name: {
+				ja: "のしかかり",
+				'zh-tw': "泰山壓頂",
+			},
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+				'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586642,
+				tcgplayer: 571379,
+			},
 		},
-
-		damage: 100,
-		cost: ["Colorless", "Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 3,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "None",
+	dexId: [143],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/127.ts
+++ b/data-asia/S/S8b/127.ts
@@ -1,48 +1,62 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "幸福蛋V"
+		ja: "ハピナスV",
+		'zh-tw': "幸福蛋V",
 	},
 
 	illustrator: "Saki Hayashiro",
 	category: "Pokemon",
 	hp: 250,
 	types: ["Colorless"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "自然回復"
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しぜんかいふく" },
+			effect: {
+				ja: "自分の手札からこのポケモンにエネルギーをつけるたび、このポケモンの特殊状態をすべて回復する。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "每次從自己的手牌將能量附於這隻寶可夢身上時，都將這隻寶可夢的特殊狀態全部恢復。"
-		}
-	}, {
-		name: {
-			'zh-tw': "幸福轟炸"
+	attacks: [
+		{
+			name: {
+				ja: "ハッピーボンバー",
+				'zh-tw': "自然回復",
+			},
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーの数×30ダメージ追加。のぞむなら、ダメージを与えたあとに、トラッシュからエネルギーを3枚まで選び、このポケモンにつける。",
+				'zh-tw': "每次從自己的手牌將能量附於這隻寶可夢身上時，都將這隻寶可夢的特殊狀態全部恢復。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加這隻寶可夢身上附加的能量的數量×30點傷害。若希望，在造成傷害後，從棄牌區選擇最多3張能量卡，附於這隻寶可夢身上。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586643,
+				tcgplayer: 571380,
+			},
 		},
-
-		damage: "10+",
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 4,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [242],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/128.ts
+++ b/data-asia/S/S8b/128.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "飄浮泡泡"
+		ja: "ポワルン",
+		'zh-tw': "飄浮泡泡",
 	},
 
 	illustrator: "Asako Ito",
@@ -14,43 +14,64 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "樣子會隨著天氣而變化。天氣越是惡劣，性情就會變得越粗暴。"
+		ja: "天気に よって 姿が 変わる。 気象が 荒くなるほど 気性も 荒っぽく なってくる。",
+		'zh-tw': "樣子會隨著天氣而變化。天氣越是惡劣，性情就會變得越粗暴。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "看天"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "てんきよみ",
+				'zh-tw': "看天",
+			},
+			effect: {
+				ja: "自分のトラッシュに「スタジアム」が8枚以上あるなら、このポケモンがワザを使うためのエネルギーは、すべてなくなる。",
+				'zh-tw': "若自己的棄牌區有8張以上的「競技場」卡，則這隻寶可夢使用招式所需的能量全部消除。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若自己的棄牌區有8張以上的「競技場」卡，則這隻寶可夢使用招式所需的能量全部消除。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "氣象之力"
+	attacks: [
+		{
+			name: {
+				ja: "ウェザーフォース",
+				'zh-tw': "氣象之力",
+			},
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の手札が6枚になるように、山札を引く。",
+				'zh-tw': "從牌庫抽卡直到自己的手牌滿6張為止。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從牌庫抽卡直到自己的手牌滿6張為止。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586644,
+				tcgplayer: 571381,
+			},
 		},
-
-		damage: 80,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578410,
+			},
+		},
+	],
 
 	retreat: 0,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "None",
+	dexId: [351],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/129.ts
+++ b/data-asia/S/S8b/129.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "智揮猩"
+		ja: "ヤレユータン",
+		'zh-tw': "智揮猩",
 	},
 
 	illustrator: "Shigenori Negishi",
@@ -14,39 +14,54 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "對森林的各個角落都瞭若指掌。如果有寶可夢受傷了，就會去尋找藥草為牠們治療。"
+		ja: "森の 隅々まで 知り尽くし 傷ついた ポケモンが いると 薬草を 探して 治療する。",
+		'zh-tw': "對森林的各個角落都瞭若指掌。如果有寶可夢受傷了，就會去尋找藥草為牠們治療。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "小聰明"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "さるぢえ",
+				'zh-tw': "小聰明",
+			},
+			effect: {
+				ja: "自分の番に1回使える。自分の手札を1枚選び、山札の上のカードと入れ替える。",
+				'zh-tw': "在自己的回合時，可使用1次。選擇1張自己的手牌，與牌庫上方的卡互換。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，可使用1次。選擇1張自己的手牌，與牌庫上方的卡互換。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "擊倒"
+	attacks: [
+		{
+			name: {
+				ja: "はりたおす",
+				'zh-tw': "擊倒",
+			},
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 70,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586645,
+				tcgplayer: 571382,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "None",
+	dexId: [765],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8b/130.ts
+++ b/data-asia/S/S8b/130.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "離洞繩"
+		ja: "あなぬけのヒモ",
+		'zh-tw': "離洞繩",
 	},
 
 	illustrator: "sadaji",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "雙方玩家將自己的戰鬥寶可夢與備戰寶可夢互換。（由對手先進行互換。沒有備戰寶可夢的玩家不用進行互換。）"
+		ja: "おたがいのプレイヤーは、それぞれ、自分のバトルポケモンをベンチポケモンと入れ替える。（入れ替えは相手からおこない、ベンチがいないプレイヤーは、入れ替えをしない。）",
+		'zh-tw': "雙方玩家將自己的戰鬥寶可夢與備戰寶可夢互換。（由對手先進行互換。沒有備戰寶可夢的玩家不用進行互換。）",
 	},
 
-	trainerType: "Item",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586646,
+				tcgplayer: 571383,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578411,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "E",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/131.ts
+++ b/data-asia/S/S8b/131.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "潮漩之扇"
+		ja: "うねりの扇",
+		'zh-tw': "潮漩之扇",
 	},
 
 	illustrator: "sadaji",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "選擇1個對手的場上寶可夢身上附加的特殊能量，放回對手的牌庫下方。"
+		ja: "相手の場のポケモンについている特殊エネルギーを1個選び、相手の山札の下にもどす。",
+		'zh-tw': "選擇1個對手的場上寶可夢身上附加的特殊能量，放回對手的牌庫下方。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586647,
+				tcgplayer: 571384,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578412,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "E",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/132.ts
+++ b/data-asia/S/S8b/132.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "渡魂燈籠"
+		ja: "おむかえちょうちん",
+		'zh-tw': "渡魂燈籠",
 	},
 
 	illustrator: "Studio Bora Inc.",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的棄牌區選擇1張「一擊」支援者卡，在給對手看過後加入手牌。"
+		ja: "自分のトラッシュから「いちげき」のサポートを1枚選び、相手に見せて、手札に加える。",
+		'zh-tw': "從自己的棄牌區選擇1張「一擊」支援者卡，在給對手看過後加入手牌。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586648,
+				tcgplayer: 571385,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578413,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "E",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/133.ts
+++ b/data-asia/S/S8b/133.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "回收網"
+		ja: "回収ネット",
+		'zh-tw': "回收網",
 	},
 
 	illustrator: "Ryo Ueda",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "選擇自己的1隻寶可夢（「寶可夢【V】・【GX】」除外），放回手牌。（寶可夢以外的卡全部丟棄。）"
+		ja: "自分のポケモン（「ポケモンV・GX」をのぞく）を1匹選び、手札にもどす。（ポケモン以外のカードは、すべてトラッシュする。）",
+		'zh-tw': "選擇自己的1隻寶可夢（「寶可夢【V】・【GX】」除外），放回手牌。（寶可夢以外的卡全部丟棄。）",
 	},
 
-	trainerType: "Item",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586649,
+				tcgplayer: 571386,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578414,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "D",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/134.ts
+++ b/data-asia/S/S8b/134.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "活力之壺"
+		ja: "活力の壺",
+		'zh-tw': "活力之壺",
 	},
 
 	illustrator: "Toyste Beach",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的棄牌區選擇最多2張「一擊能量」卡，在給對手看過後放回牌庫並重洗。"
+		ja: "自分のトラッシュから「いちげきエネルギー」を2枚まで選び、相手に見せて、山札にもどして切る。",
+		'zh-tw': "從自己的棄牌區選擇最多2張「一擊能量」卡，在給對手看過後放回牌庫並重洗。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586650,
+				tcgplayer: 571387,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578415,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "E",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/135.ts
+++ b/data-asia/S/S8b/135.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "霧之水晶"
+		ja: "霧の水晶",
+		'zh-tw': "霧之水晶",
 	},
 
 	illustrator: "sadaji",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的牌庫選擇1張【超】屬性的【基礎】寶可夢卡或者【超】能量卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		ja: "自分の山札から[超]タイプのたねポケモンまたは[超]エネルギーを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+		'zh-tw': "從自己的牌庫選擇1張【超】屬性的【基礎】寶可夢卡或者【超】能量卡，在給對手看過後加入手牌。並且重洗牌庫。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586651,
+				tcgplayer: 571388,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578416,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "E",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/136.ts
+++ b/data-asia/S/S8b/136.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "渦輪修正檔"
+		ja: "ターボパッチ",
+		'zh-tw': "渦輪修正檔",
 	},
 
 	illustrator: "Toyste Beach",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "擲1次硬幣若為正面，則從自己的棄牌區選擇1張基本能量卡，附於自己的【基礎】寶可夢（「寶可夢【GX】」 除外）身上。"
+		ja: "コインを1回投げオモテなら、自分のトラッシュから基本エネルギーを1枚選び、自分のたねポケモン（「ポケモンGX」をのぞく）につける。",
+		'zh-tw': "擲1次硬幣若為正面，則從自己的棄牌區選擇1張基本能量卡，附於自己的【基礎】寶可夢（「寶可夢【GX】」 除外）身上。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586652,
+				tcgplayer: 571389,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578417,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "D",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/137.ts
+++ b/data-asia/S/S8b/137.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "足量水桶"
+		ja: "たっぷりバケツ",
+		'zh-tw': "足量水桶",
 	},
 
 	illustrator: "sadaji",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的牌庫選擇最多2張【水】能量卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		ja: "自分の山札から[水]エネルギーを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+		'zh-tw': "從自己的牌庫選擇最多2張【水】能量卡，在給對手看過後加入手牌。並且重洗牌庫。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586653,
+				tcgplayer: 571390,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578418,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "D",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/138.ts
+++ b/data-asia/S/S8b/138.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "道具拆除器"
+		ja: "ツールスクラッパー",
+		'zh-tw': "道具拆除器",
 	},
 
 	illustrator: "Studio Bora Inc.",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "選擇最多2張雙方的場上寶可夢身上附加的「寶可夢道具」卡，將其丟棄。"
+		ja: "おたがいの場のポケモンについている「ポケモンのどうぐ」を2枚まで選び、トラッシュする。",
+		'zh-tw': "選擇最多2張雙方的場上寶可夢身上附加的「寶可夢道具」卡，將其丟棄。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586654,
+				tcgplayer: 571391,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578419,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "D",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/139.ts
+++ b/data-asia/S/S8b/139.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "普通釣竿"
+		ja: "ふつうのつりざお",
+		'zh-tw': "普通釣竿",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的棄牌區選擇最多2張寶可夢卡與最多2張基本能量卡，在給對手看過後放回牌庫並重洗。（可只選擇寶可夢卡或者只選擇基本能量卡。）"
+		ja: "自分のトラッシュからポケモンを2枚までと、基本エネルギーを2枚まで選び、相手に見せて、山札にもどして切る。（ポケモンまたは基本エネルギーのどちらかだけでもよい。）",
+		'zh-tw': "從自己的棄牌區選擇最多2張寶可夢卡與最多2張基本能量卡，在給對手看過後放回牌庫並重洗。（可只選擇寶可夢卡或者只選擇基本能量卡。）",
 	},
 
-	trainerType: "Item",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586655,
+				tcgplayer: 571392,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578420,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "D",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/140.ts
+++ b/data-asia/S/S8b/140.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "山谷回音喇叭"
+		ja: "やまびこホーン",
+		'zh-tw': "山谷回音喇叭",
 	},
 
 	illustrator: "Studio Bora Inc.",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從對手的棄牌區選擇1張【基礎】寶可夢卡，放置於對手的備戰區。"
+		ja: "相手のトラッシュからたねポケモンを1枚選び、相手のベンチに出す。",
+		'zh-tw': "從對手的棄牌區選擇1張【基礎】寶可夢卡，放置於對手的備戰區。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586656,
+				tcgplayer: 571393,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578421,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "E",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/141.ts
+++ b/data-asia/S/S8b/141.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "等級球"
+		ja: "レベルボール",
+		'zh-tw': "等級球",
 	},
 
 	illustrator: "Ryo Ueda",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的牌庫選擇1張HP為「90」以下的寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		ja: "自分の山札から、HPが「90」以下のポケモンを1枚選び、相手に見せてから、手札に加える。そして山札を切る。",
+		'zh-tw': "從自己的牌庫選擇1張HP為「90」以下的寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586657,
+				tcgplayer: 571394,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578422,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "E",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/142.ts
+++ b/data-asia/S/S8b/142.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "消災手套"
+		ja: "おはらいグローブ",
+		'zh-tw': "消災手套",
 	},
 
 	illustrator: "Toyste Beach",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。"
+		ja: "このカードをつけているポケモンが使うワザの、相手のバトル場の[P]ポケモンへのダメージは「+30」される。",
+		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586658,
+				tcgplayer: 571395,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578423,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Tool",
+	regulationMark: "E",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/143.ts
+++ b/data-asia/S/S8b/143.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "堅韌斗篷"
+		ja: "タフネスマント",
+		'zh-tw': "堅韌斗篷",
 	},
 
 	illustrator: "inose yukie",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。"
+		ja: "このカードをつけているたねポケモン（「ポケモンGX」をのぞく）の最大HPは「50」大きくなる。",
+		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586659,
+				tcgplayer: 571396,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578424,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Tool",
+	regulationMark: "D",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/144.ts
+++ b/data-asia/S/S8b/144.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "獵人手套"
+		ja: "ハンターグローブ",
+		'zh-tw': "獵人手套",
 	},
 
 	illustrator: "Toyste Beach",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。"
+		ja: "このカードをつけているポケモンが使うワザの、相手のバトル場の[N]ポケモンへのダメージは「+30」される。",
+		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586660,
+				tcgplayer: 571397,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578425,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Tool",
+	regulationMark: "E",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/145.ts
+++ b/data-asia/S/S8b/145.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "氣球"
+		ja: "ふうせん",
+		'zh-tw': "氣球",
 	},
 
 	illustrator: "Yoshinobu Saito",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。"
+		ja: "このカードをつけているポケモンは、にげるためのエネルギーが2個ぶん少なくなる。",
+		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586661,
+				tcgplayer: 571398,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578426,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Tool",
+	regulationMark: "D",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/146.ts
+++ b/data-asia/S/S8b/146.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "望遠鏡"
+		ja: "望遠スコープ",
+		'zh-tw': "望遠鏡",
 	},
 
 	illustrator: "Toyste Beach",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。"
+		ja: "このカードをつけているポケモンが使うワザの、相手のベンチの「ポケモンV・GX」へのダメージは「+30」される",
+		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586662,
+				tcgplayer: 571399,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578427,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Tool",
+	regulationMark: "D",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/147.ts
+++ b/data-asia/S/S8b/147.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "回憶膠囊"
+		ja: "メモリーカプセル",
+		'zh-tw': "回憶膠囊",
 	},
 
 	illustrator: "sadaji",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。"
+		ja: "このカードをつけているポケモンは、進化前に持っていたワザを、すべて使える。［ワザを使うためのエネルギーは必要。］",
+		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586663,
+				tcgplayer: 571400,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578428,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Tool",
+	regulationMark: "D",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/148.ts
+++ b/data-asia/S/S8b/148.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "阿塞蘿拉的預感"
+		ja: "アセロラの予感",
+		'zh-tw': "阿塞蘿拉的預感",
 	},
 
 	illustrator: "Shiburingaru",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "查看對手的手牌，從自己的牌庫抽出與其中訓練家卡的張數相同數量的卡。"
+		ja: "相手の手札を見て、その中にあるトレーナーズの枚数ぶん、自分の山札を引く。",
+		'zh-tw': "查看對手的手牌，從自己的牌庫抽出與其中訓練家卡的張數相同數量的卡。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586664,
+				tcgplayer: 571401,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578429,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/149.ts
+++ b/data-asia/S/S8b/149.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伽勒爾的夥伴"
+		ja: "ガラルの仲間たち",
+		'zh-tw': "伽勒爾的夥伴",
 	},
 
 	illustrator: "Yuu Nishida",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的牌庫抽出3張卡。"
+		ja: "自分の山札を3枚引く。",
+		'zh-tw': "從自己的牌庫抽出3張卡。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586665,
+				tcgplayer: 571402,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578430,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/150.ts
+++ b/data-asia/S/S8b/150.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "奇巴納"
+		ja: "キバナ",
+		'zh-tw': "奇巴納",
 	},
 
 	illustrator: "take",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "這張卡必須在上個對手的回合自己的寶可夢【氣絕】了才可使用。 從自己的棄牌區選擇1張基本能量卡，附於自己的寶可夢身上。然後，從自己的牌庫任意選擇1張卡加入手牌。並且重洗牌庫。"
+		ja: "このカードは、前の相手の番に、自分のポケモンがきぜつしていなければ使えない。自分のトラッシュから基本エネルギーを1枚選び、自分のポケモンにつける。その後、自分の山札から好きなカードを1枚選び、手札に加える。そして山札を切る。",
+		'zh-tw': "這張卡必須在上個對手的回合自己的寶可夢【氣絕】了才可使用。 從自己的棄牌區選擇1張基本能量卡，附於自己的寶可夢身上。然後，從自己的牌庫任意選擇1張卡加入手牌。並且重洗牌庫。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586666,
+				tcgplayer: 571403,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578431,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/151.ts
+++ b/data-asia/S/S8b/151.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "克拉拉"
+		ja: "クララ",
+		'zh-tw': "克拉拉",
 	},
 
 	illustrator: "Ken Sugimori",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的棄牌區選擇最多2張寶可夢卡與最多2張基本能量卡，在給對手看過後加入手牌。（可只選擇寶可夢卡或者只選擇基本能量卡。）"
+		ja: "自分のトラッシュからポケモンを2枚までと、基本エネルギーを2枚まで選び、相手に見せて、手札に加える。（ポケモンまたは基本エネルギーのどちらかだけでもよい。）",
+		'zh-tw': "從自己的棄牌區選擇最多2張寶可夢卡與最多2張基本能量卡，在給對手看過後加入手牌。（可只選擇寶可夢卡或者只選擇基本能量卡。）",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586667,
+				tcgplayer: 571404,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578432,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/152.ts
+++ b/data-asia/S/S8b/152.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "可爾妮的氣勢"
+		ja: "コルニの気合い",
+		'zh-tw': "可爾妮的氣勢",
 	},
 
 	illustrator: "kirisAki",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從牌庫抽卡直到自己的手牌滿6張為止。"
+		ja: "自分の手札が6枚になるように、山札を引く。",
+		'zh-tw': "從牌庫抽卡直到自己的手牌滿6張為止。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586668,
+				tcgplayer: 571405,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578433,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/153.ts
+++ b/data-asia/S/S8b/153.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "希巴"
+		ja: "シバ",
+		'zh-tw': "希巴",
 	},
 
 	illustrator: "Ken Sugimori",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "將自己的手牌全部放回牌庫並重洗。然後，從牌庫抽出4張卡。在上個對手的回合，若自己的寶可夢【氣絕】了，則改爲抽出7張卡。"
+		ja: "自分の手札をすべて山札にもどして切る。その後、山札を4枚引く。前の相手の番に、自分のポケモンがきぜつしていたなら、引く枚数は7枚になる。",
+		'zh-tw': "將自己的手牌全部放回牌庫並重洗。然後，從牌庫抽出4張卡。在上個對手的回合，若自己的寶可夢【氣絕】了，則改爲抽出7張卡。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586669,
+				tcgplayer: 571406,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578434,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/154.ts
+++ b/data-asia/S/S8b/154.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "丹帝"
+		ja: "ダンデ",
+		'zh-tw': "丹帝",
 	},
 
 	illustrator: "Ken Sugimori",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "在這個回合，自己的寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+30」點。"
+		ja: "この番、自分のポケモンが使うワザの、相手のバトルポケモンへのダメージは「+30」される。",
+		'zh-tw': "在這個回合，自己的寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+30」點。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586670,
+				tcgplayer: 571407,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/155.ts
+++ b/data-asia/S/S8b/155.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "養鳥人"
+		ja: "とりつかい",
+		'zh-tw': "養鳥人",
 	},
 
 	illustrator: "Hideki Ishikawa",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "將自己的戰鬥寶可夢與備戰寶可夢互換。然後，從自己的牌庫抽出3張卡。"
+		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。その後、自分の山札を3枚引く。",
+		'zh-tw': "將自己的戰鬥寶可夢與備戰寶可夢互換。然後，從自己的牌庫抽出3張卡。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586671,
+				tcgplayer: 571408,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578435,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/156.ts
+++ b/data-asia/S/S8b/156.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "皮歐尼"
+		ja: "ピオニー",
+		'zh-tw': "皮歐尼",
 	},
 
 	illustrator: "Ken Sugimori",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "將自己的手牌全部丟棄，從自己的牌庫選擇最多2張訓練家卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		ja: "自分の手札をすべてトラッシュし、自分の山札からトレーナーズを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+		'zh-tw': "將自己的手牌全部丟棄，從自己的牌庫選擇最多2張訓練家卡，在給對手看過後加入手牌。並且重洗牌庫。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586672,
+				tcgplayer: 571409,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578436,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/157.ts
+++ b/data-asia/S/S8b/157.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "冒險家的發現"
+		ja: "冒険家の発見",
+		'zh-tw': "冒險家的發現",
 	},
 
 	illustrator: "Taira Akitsu",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的牌庫選擇最多3張「寶可夢【V】」卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		ja: "自分の山札から「ポケモンV」を3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+		'zh-tw': "從自己的牌庫選擇最多3張「寶可夢【V】」卡，在給對手看過後加入手牌。並且重洗牌庫。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586673,
+				tcgplayer: 577552,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578472,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/158.ts
+++ b/data-asia/S/S8b/158.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "老大的指令（弗拉達利）"
+		ja: "ボスの指令",
+		'zh-tw': "老大的指令（弗拉達利）",
 	},
 
 	illustrator: "Ryuta Fuse",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "選擇1隻對手的備戰寶可夢，與戰鬥寶可夢互換。"
+		ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+		'zh-tw': "選擇1隻對手的備戰寶可夢，與戰鬥寶可夢互換。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586674,
+				tcgplayer: 571410,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/159.ts
+++ b/data-asia/S/S8b/159.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "老闆"
+		ja: "マスター",
+		'zh-tw': "老闆",
 	},
 
 	illustrator: "Hasegawa Saki",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "若使用了這張卡，則自己的回合結束。選擇最多3隻自己的備戰寶可夢，從牌庫附給那些寶可夢各1張各不同屬性的基本能量卡。並且重洗牌庫。"
+		ja: "このカードを使ったら、自分の番は終わる。自分のベンチポケモンを3匹まで選び、山札から、それぞれちがうタイプの基本エネルギーを1枚ずつつける。そして山札を切る。",
+		'zh-tw': "若使用了這張卡，則自己的回合結束。選擇最多3隻自己的備戰寶可夢，從牌庫附給那些寶可夢各1張各不同屬性的基本能量卡。並且重洗牌庫。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586675,
+				tcgplayer: 571411,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578437,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/160.ts
+++ b/data-asia/S/S8b/160.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "瑪俐"
+		ja: "マリィ",
+		'zh-tw': "瑪俐",
 	},
 
 	illustrator: "kirisAki",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "雙方玩家各將自己的手牌全部翻回反面並重洗，放回牌庫下方。然後，從牌庫抽卡，自己抽出5張，對手抽出4張。"
+		ja: "おたがいのプレイヤーは、それぞれ自分の手札をすべてウラにして切り、山札の下にもどす。その後、自分は5枚、相手は4枚、山札を引く。",
+		'zh-tw': "雙方玩家各將自己的手牌全部翻回反面並重洗，放回牌庫下方。然後，從牌庫抽卡，自己抽出5張，對手抽出4張。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586676,
+				tcgplayer: 571412,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578438,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/161.ts
+++ b/data-asia/S/S8b/161.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "美蓉"
+		ja: "メロン",
+		'zh-tw': "美蓉",
 	},
 
 	illustrator: "take",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的棄牌區選擇1張【水】能量卡，附於自己的「寶可夢【V】」身上。然後，從自己的牌庫抽出3張卡。"
+		ja: "自分のトラッシュから[水]エネルギーを1枚選び、自分の「ポケモンV」につける。その後、自分の山札を3枚引く。",
+		'zh-tw': "從自己的棄牌區選擇1張【水】能量卡，附於自己的「寶可夢【V】」身上。然後，從自己的牌庫抽出3張卡。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586677,
+				tcgplayer: 571413,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578439,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/162.ts
+++ b/data-asia/S/S8b/162.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "芽米"
+		ja: "モミ",
+		'zh-tw': "芽米",
 	},
 
 	illustrator: "Ken Sugimori",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "將自己的所有進化寶可夢的HP全部恢復。然後，將恢復的寶可夢身上附加的能量全部丟棄。"
+		ja: "自分の進化ポケモン全員のHPを、すべて回復する。その後、回復したポケモンについているエネルギーを、すべてトラッシュする。",
+		'zh-tw': "將自己的所有進化寶可夢的HP全部恢復。然後，將恢復的寶可夢身上附加的能量全部丟棄。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586678,
+				tcgplayer: 571414,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578440,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/163.ts
+++ b/data-asia/S/S8b/163.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "小優"
+		ja: "ユウリ",
+		'zh-tw': "小優",
 	},
 
 	illustrator: "Ken Sugimori",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的牌庫選擇最多3張【基礎】寶可夢卡（「擁有規則的寶可夢」除外），放置於備戰區。並且重洗牌庫。"
+		ja: "自分の山札からたねポケモン（「ルールを持つポケモン」をのぞく）を3枚まで選び、ベンチに出す。そして山札を切る。",
+		'zh-tw': "從自己的牌庫選擇最多3張【基礎】寶可夢卡（「擁有規則的寶可夢」除外），放置於備戰區。並且重洗牌庫。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586679,
+				tcgplayer: 571415,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578441,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/164.ts
+++ b/data-asia/S/S8b/164.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "露璃娜"
+		ja: "ルリナ",
+		'zh-tw': "露璃娜",
 	},
 
 	illustrator: "take",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的棄牌區選擇【水】寶可夢卡與【水】能量卡合計最多4張，在給對手看過後加入手牌。"
+		ja: "自分のトラッシュから[水]ポケモンと[水]エネルギーを合計4枚まで選び、相手に見せて、手札に加える。",
+		'zh-tw': "從自己的棄牌區選擇【水】寶可夢卡與【水】能量卡合計最多4張，在給對手看過後加入手牌。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586680,
+				tcgplayer: 571416,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578442,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/165.ts
+++ b/data-asia/S/S8b/165.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洛茲"
+		ja: "ローズ",
+		'zh-tw': "洛茲",
 	},
 
 	illustrator: "Yusuke Ohmura",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的棄牌區選擇最多2張基本能量卡，附於自己的1隻「寶可夢【VMAX】」身上。然後，將自己的手牌全部丟棄。"
+		ja: "自分のトラッシュから基本エネルギーを2枚まで選び、自分の「ポケモンVMAX」1匹につける。その後、自分の手札をすべてトラッシュする。",
+		'zh-tw': "從自己的棄牌區選擇最多2張基本能量卡，附於自己的1隻「寶可夢【VMAX】」身上。然後，將自己的手牌全部丟棄。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586681,
+				tcgplayer: 571417,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578443,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/166.ts
+++ b/data-asia/S/S8b/166.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "惡之塔"
+		ja: "あくの塔",
+		'zh-tw': "惡之塔",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "雙方玩家在每個自己的回合時，可使用1次，若從自己的手牌將1張「一擊」卡丟棄，則可從自己的牌庫抽出2張卡。"
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の手札から「いちげき」のカードを1枚トラッシュするなら、自分の山札を2枚引いてよい。",
+		'zh-tw': "雙方玩家在每個自己的回合時，可使用1次，若從自己的手牌將1張「一擊」卡丟棄，則可從自己的牌庫抽出2張卡。",
 	},
 
-	trainerType: "Stadium",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586682,
+				tcgplayer: 571418,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578444,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Stadium",
+	regulationMark: "E",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/167.ts
+++ b/data-asia/S/S8b/167.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "通頂雪道"
+		ja: "頂への雪道",
+		'zh-tw': "通頂雪道",
 	},
 
 	illustrator: "Oswaldo KATO",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "雙方場上的「擁有規則的寶可夢」的特性全部消除。"
+		ja: "おたがいの場の「ルールを持つポケモン」の特性は、すべてなくなる。",
+		'zh-tw': "雙方場上的「擁有規則的寶可夢」的特性全部消除。",
 	},
 
-	trainerType: "Stadium",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586683,
+				tcgplayer: 571419,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578445,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Stadium",
+	regulationMark: "E",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/168.ts
+++ b/data-asia/S/S8b/168.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "遠古墓地"
+		ja: "いにしえの墓地",
+		'zh-tw': "遠古墓地",
 	},
 
 	illustrator: "Oswaldo KATO",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "雙方玩家每次從自己的手牌將能量附於寶可夢（【超】寶可夢除外）身上時，在那隻寶可夢身上放置2個傷害指示物。"
+		ja: "おたがいのプレイヤーは、それぞれ、自分の手札からエネルギーをポケモン（[超]ポケモンをのぞく）につけるたび、そのポケモンにダメカンを2個のせる。",
+		'zh-tw': "雙方玩家每次從自己的手牌將能量附於寶可夢（【超】寶可夢除外）身上時，在那隻寶可夢身上放置2個傷害指示物。",
 	},
 
-	trainerType: "Stadium",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586684,
+				tcgplayer: 571420,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578446,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Stadium",
+	regulationMark: "E",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/169.ts
+++ b/data-asia/S/S8b/169.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "草路競技場"
+		ja: "ターフスタジアム",
+		'zh-tw': "草路競技場",
 	},
 
 	illustrator: "aky CG Works",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "雙方玩家在每個自己的回合時，可使用1次，可從自己的牌庫選擇1張【草】屬性的進化寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の山札から[草]タイプの進化ポケモンを1枚選び、相手に見せて、手札に加えてよい。そして山札を切る。",
+		'zh-tw': "雙方玩家在每個自己的回合時，可使用1次，可從自己的牌庫選擇1張【草】屬性的進化寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。",
 	},
 
-	trainerType: "Stadium",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586685,
+				tcgplayer: 571421,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578447,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Stadium",
+	regulationMark: "D",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/170.ts
+++ b/data-asia/S/S8b/170.ts
@@ -1,22 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "水之塔"
+		ja: "みずの塔",
+		'zh-tw': "水之塔",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "雙方的所有「連擊」寶可夢【撤退】所需的能量各減少2個。"
+		ja: "おたがいの「れんげき」のポケモン全員のにげるためのエネルギーは、それぞれ2個ぶん少なくなる。",
+		'zh-tw': "雙方的所有「連擊」寶可夢【撤退】所需的能量各減少2個。",
 	},
 
-	trainerType: "Stadium",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586686,
+				tcgplayer: 571422,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578448,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Stadium",
+	regulationMark: "E",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/171.ts
+++ b/data-asia/S/S8b/171.ts
@@ -1,21 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "芳香草能量"
+		ja: "アロマ草エネルギー",
+		'zh-tw': "芳香草能量",
 	},
 
+	illustrator: "",
 	category: "Energy",
+	energyType: "Special",
 
 	effect: {
-		'zh-tw': "只要這張卡附於寶可夢身上，視為提供1個【草】能量。附有這張卡的【草】寶可夢不會陷入特殊狀態，並將受到的特殊狀態全部恢復。"
+		ja: "このカードは、ポケモンについているかぎり、[草]エネルギー1個ぶんとしてはたらく。このカードをつけている[草]ポケモンは、特殊状態にならず、受けている特殊状態は、すべて回復する。",
+		'zh-tw': "只要這張卡附於寶可夢身上，視為提供1個【草】能量。附有這張卡的【草】寶可夢不會陷入特殊狀態，並將受到的特殊狀態全部恢復。",
 	},
 
-	energyType: "Special",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586687,
+				tcgplayer: 571423,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578449,
+			},
+		},
+	],
 
-export default card
+	regulationMark: "D",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/172.ts
+++ b/data-asia/S/S8b/172.ts
@@ -1,21 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "高溫火能量"
+		ja: "ヒート炎エネルギー",
+		'zh-tw': "高溫火能量",
 	},
 
+	illustrator: "",
 	category: "Energy",
+	energyType: "Special",
 
 	effect: {
-		'zh-tw': "只要這張卡附於寶可夢身上，視為提供1個【火】能量。附有這張卡的【火】寶可夢的最大HP增加「20」。"
+		ja: "このカードは、ポケモンについているかぎり、[炎]エネルギー1個ぶんとしてはたらく。このカードをつけている[炎]ポケモンの最大HPは「20」大きくなる。",
+		'zh-tw': "只要這張卡附於寶可夢身上，視為提供1個【火】能量。附有這張卡的【火】寶可夢的最大HP增加「20」。",
 	},
 
-	energyType: "Special",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586688,
+				tcgplayer: 571424,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578450,
+			},
+		},
+	],
 
-export default card
+	regulationMark: "D",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/173.ts
+++ b/data-asia/S/S8b/173.ts
@@ -1,21 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "清洗水能量"
+		ja: "ウォッシュ水エネルギー",
+		'zh-tw': "清洗水能量",
 	},
 
+	illustrator: "",
 	category: "Energy",
+	energyType: "Special",
 
 	effect: {
-		'zh-tw': "只要這張卡附於寶可夢身上，視為提供1個【水】能量。 附有這張卡的【水】寶可夢，不會受到對手的寶可夢使用招式的效果的影響。（已經受到的效果無法消除。）"
+		ja: "このカードは、ポケモンについているかぎり、[水]エネルギー1個ぶんとしてはたらく。このカードをつけている[水]ポケモンは、相手のポケモンが使うワザの効果を受けない。（すでに受けている効果は、なくならない。）",
+		'zh-tw': "只要這張卡附於寶可夢身上，視為提供1個【水】能量。 附有這張卡的【水】寶可夢，不會受到對手的寶可夢使用招式的效果的影響。（已經受到的效果無法消除。）",
 	},
 
-	energyType: "Special",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586689,
+				tcgplayer: 571425,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578451,
+			},
+		},
+	],
 
-export default card
+	regulationMark: "D",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/174.ts
+++ b/data-asia/S/S8b/174.ts
@@ -1,21 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "高速雷能量"
+		ja: "スピード雷エネルギー",
+		'zh-tw': "高速雷能量",
 	},
 
+	illustrator: "",
 	category: "Energy",
+	energyType: "Special",
 
 	effect: {
-		'zh-tw': "只要這張卡附於寶可夢身上，視為提供1個【雷】能量。 當從手牌將這張卡附於【雷】寶可夢身上時，從自己的牌庫抽出2張卡。"
+		ja: "このカードは、ポケモンについているかぎり、[雷]エネルギー1個ぶんとしてはたらく。このカードを手札から[雷]ポケモンにつけたとき、自分の山札を2枚引く。",
+		'zh-tw': "只要這張卡附於寶可夢身上，視為提供1個【雷】能量。 當從手牌將這張卡附於【雷】寶可夢身上時，從自己的牌庫抽出2張卡。",
 	},
 
-	energyType: "Special",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586690,
+				tcgplayer: 571426,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578452,
+			},
+		},
+	],
 
-export default card
+	regulationMark: "D",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/175.ts
+++ b/data-asia/S/S8b/175.ts
@@ -1,21 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "恐怖超能量"
+		ja: "ホラー超エネルギー",
+		'zh-tw': "恐怖超能量",
 	},
 
+	illustrator: "",
 	category: "Energy",
+	energyType: "Special",
 
 	effect: {
-		'zh-tw': "只要這張卡附於寶可夢身上，視為提供1個【超】能量。 當附有這張卡的【超】寶可夢在戰鬥場上受到對手的寶可夢招式的傷害時，在使用招式的寶可夢身上放置2個傷害指示物。"
+		ja: "このカードは、ポケモンについているかぎり、[超]エネルギー1個ぶんとしてはたらく。このカードをつけている[超]ポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、ワザを使ったポケモンにダメカンを2個のせる。",
+		'zh-tw': "只要這張卡附於寶可夢身上，視為提供1個【超】能量。 當附有這張卡的【超】寶可夢在戰鬥場上受到對手的寶可夢招式的傷害時，在使用招式的寶可夢身上放置2個傷害指示物。",
 	},
 
-	energyType: "Special",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586691,
+				tcgplayer: 571427,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578453,
+			},
+		},
+	],
 
-export default card
+	regulationMark: "D",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/176.ts
+++ b/data-asia/S/S8b/176.ts
@@ -1,21 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "岩石鬥能量"
+		ja: "ストーン闘エネルギー",
+		'zh-tw': "岩石鬥能量",
 	},
 
+	illustrator: "",
 	category: "Energy",
+	energyType: "Special",
 
 	effect: {
-		'zh-tw': "只要這張卡附於寶可夢身上，視為提供1個【鬥】能量。附有這張卡的【鬥】寶可夢，受到對手的寶可夢招式的傷害「-20」點。"
+		ja: "このカードは、ポケモンについているかぎり、[闘]エネルギー1個ぶんとしてはたらく。このカードをつけている[闘]ポケモンが、相手のポケモンから受けるワザのダメージは「-20」される。",
+		'zh-tw': "只要這張卡附於寶可夢身上，視為提供1個【鬥】能量。附有這張卡的【鬥】寶可夢，受到對手的寶可夢招式的傷害「-20」點。",
 	},
 
-	energyType: "Special",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586692,
+				tcgplayer: 571428,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578454,
+			},
+		},
+	],
 
-export default card
+	regulationMark: "D",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/177.ts
+++ b/data-asia/S/S8b/177.ts
@@ -1,21 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "潛行惡能量"
+		ja: "ハイド悪エネルギー",
+		'zh-tw': "潛行惡能量",
 	},
 
+	illustrator: "",
 	category: "Energy",
+	energyType: "Special",
 
 	effect: {
-		'zh-tw': "只要這張卡附於寶可夢身上，視為提供1個【惡】能量。附有這張卡的【惡】寶可夢【撤退】所需的能量全部消除。"
+		ja: "このカードは、ポケモンについているかぎり、[悪]エネルギー1個ぶんとしてはたらく。このカードをつけている[悪]ポケモンのにげるためのエネルギーは、すべてなくなる。",
+		'zh-tw': "只要這張卡附於寶可夢身上，視為提供1個【惡】能量。附有這張卡的【惡】寶可夢【撤退】所需的能量全部消除。",
 	},
 
-	energyType: "Special",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586693,
+				tcgplayer: 571429,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578455,
+			},
+		},
+	],
 
-export default card
+	regulationMark: "D",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/178.ts
+++ b/data-asia/S/S8b/178.ts
@@ -1,21 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "塗層鋼能量"
+		ja: "コーティング鋼エネルギー",
+		'zh-tw': "塗層鋼能量",
 	},
 
+	illustrator: "",
 	category: "Energy",
+	energyType: "Special",
 
 	effect: {
-		'zh-tw': "只要這張卡附於寶可夢身上，視為提供1個【鋼】能量。 附有這張卡的【鋼】寶可夢的弱點全部消除。"
+		ja: "このカードは、ポケモンについているかぎり、[鋼]エネルギー1個ぶんとしてはたらく。このカードをつけている[鋼]ポケモンの弱点は、すべてなくなる。",
+		'zh-tw': "只要這張卡附於寶可夢身上，視為提供1個【鋼】能量。 附有這張卡的【鋼】寶可夢的弱點全部消除。",
 	},
 
-	energyType: "Special",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586694,
+				tcgplayer: 571430,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578456,
+			},
+		},
+	],
 
-export default card
+	regulationMark: "D",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/179.ts
+++ b/data-asia/S/S8b/179.ts
@@ -1,21 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "強力無能量"
+		ja: "パワフル無色エネルギー",
+		'zh-tw': "強力無能量",
 	},
 
+	illustrator: "",
 	category: "Energy",
+	energyType: "Special",
 
 	effect: {
-		'zh-tw': "只要這張卡附於寶可夢身上，視為提供1個【無】能量。 附有這張卡的【無】寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+20」點。"
+		ja: "このカードは、ポケモンについているかぎり、[無]エネルギー1個ぶんとしてはたらく。このカードをつけている[無]ポケモンが使うワザの、相手のバトルポケモンへのダメージは「＋20」される。",
+		'zh-tw': "只要這張卡附於寶可夢身上，視為提供1個【無】能量。 附有這張卡的【無】寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+20」點。",
 	},
 
-	energyType: "Special",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586695,
+				tcgplayer: 571431,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578457,
+			},
+		},
+	],
 
-export default card
+	regulationMark: "D",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/180.ts
+++ b/data-asia/S/S8b/180.ts
@@ -1,21 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "一擊能量"
+		ja: "いちげきエネルギー",
+		'zh-tw': "一擊能量",
 	},
 
+	illustrator: "",
 	category: "Energy",
+	energyType: "Special",
 
 	effect: {
-		'zh-tw': "這張卡只可附於「一擊」寶可夢身上，若附於「一擊」寶可夢以外的寶可夢身上，則將其丟棄。 只要這張卡附於寶可夢身上，視為提供1個【鬥】【惡】2種屬性的能量，附有這張卡的寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+20」點。"
+		ja: "このカードは「いちげき」のポケモンにしかつけられず、「いちげき」のポケモン以外についているなら、トラッシュする。このカードは、ポケモンについているかぎり、[闘][悪]の2つのタイプのエネルギー1個ぶんとしてはたらき、このカードをつけているポケモンが使うワザの、相手のバトルポケモンへのダメージは「＋20」される。",
+		'zh-tw': "這張卡只可附於「一擊」寶可夢身上，若附於「一擊」寶可夢以外的寶可夢身上，則將其丟棄。 只要這張卡附於寶可夢身上，視為提供1個【鬥】【惡】2種屬性的能量，附有這張卡的寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+20」點。",
 	},
 
-	energyType: "Special",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586696,
+				tcgplayer: 571432,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578458,
+			},
+		},
+	],
 
-export default card
+	regulationMark: "E",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/181.ts
+++ b/data-asia/S/S8b/181.ts
@@ -1,21 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "極光能量"
+		ja: "オーロラエネルギー",
+		'zh-tw': "極光能量",
 	},
 
+	illustrator: "",
 	category: "Energy",
+	energyType: "Special",
 
 	effect: {
-		'zh-tw': "必須將自己的1張手牌丟棄才可從手牌將這張卡附於寶可夢身上。 只要這張卡附於寶可夢身上，視為提供1個所有屬性的能量。"
+		ja: "このカードは、手札からポケモンにつけるとき、自分の手札を1枚トラッシュしなければつけられない。このカードは、ポケモンについているかぎり、すべてのタイプのエネルギー1個ぶんとしてはたらく。",
+		'zh-tw': "必須將自己的1張手牌丟棄才可從手牌將這張卡附於寶可夢身上。 只要這張卡附於寶可夢身上，視為提供1個所有屬性的能量。",
 	},
 
-	energyType: "Special",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586697,
+				tcgplayer: 571433,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578459,
+			},
+		},
+	],
 
-export default card
+	regulationMark: "D",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/182.ts
+++ b/data-asia/S/S8b/182.ts
@@ -1,21 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "捕獲能量"
+		ja: "キャプチャーエネルギー",
+		'zh-tw': "捕獲能量",
 	},
 
+	illustrator: "",
 	category: "Energy",
+	energyType: "Special",
 
 	effect: {
-		'zh-tw': "只要這張卡附於寶可夢身上，視為提供1個【無】能量。 當從手牌將這張卡附於寶可夢身上時，從自己的牌庫選擇1張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。"
+		ja: "このカードは、ポケモンについているかぎり、[無]エネルギー1個ぶんとしてはたらく。このカードを手札からポケモンにつけたとき、自分の山札からたねポケモンを1枚選び、ベンチに出す。そして山札を切る。",
+		'zh-tw': "只要這張卡附於寶可夢身上，視為提供1個【無】能量。 當從手牌將這張卡附於寶可夢身上時，從自己的牌庫選擇1張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。",
 	},
 
-	energyType: "Special",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586698,
+				tcgplayer: 571434,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578460,
+			},
+		},
+	],
 
-export default card
+	regulationMark: "D",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/183.ts
+++ b/data-asia/S/S8b/183.ts
@@ -1,21 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雙子能量"
+		ja: "ツインエネルギー",
+		'zh-tw': "雙子能量",
 	},
 
+	illustrator: "",
 	category: "Energy",
+	energyType: "Special",
 
 	effect: {
-		'zh-tw': "只要這張卡附於寶可夢身上，視為提供2個【無】能量。 若附於「寶可夢【V】・【GX】」身上，則視為提供1個【無】能量。"
+		ja: "このカードは、ポケモンについているかぎり、[無]エネルギー2個ぶんとしてはたらく。「ポケモンV・GX」についているなら、[無]エネルギー1個ぶんとしてはたらく。",
+		'zh-tw': "只要這張卡附於寶可夢身上，視為提供2個【無】能量。 若附於「寶可夢【V】・【GX】」身上，則視為提供1個【無】能量。",
 	},
 
-	energyType: "Special",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586699,
+				tcgplayer: 571435,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578461,
+			},
+		},
+	],
 
-export default card
+	regulationMark: "D",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/184.ts
+++ b/data-asia/S/S8b/184.ts
@@ -1,21 +1,40 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8b"
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "連擊能量"
+		ja: "れんげきエネルギー",
+		'zh-tw': "連擊能量",
 	},
 
+	illustrator: "",
 	category: "Energy",
+	energyType: "Special",
 
 	effect: {
-		'zh-tw': "這張卡只可附於「連擊」寶可夢身上，若附於「連擊」寶可夢以外的寶可夢身上，則將其丟棄。 只要這張卡附於寶可夢身上，視為提供2個【水】【鬥】2種屬性的能量。"
+		ja: "このカードは「れんげき」のポケモンにしかつけられず、「れんげき」のポケモン以外についているなら、トラッシュする。このカードは、ポケモンについているかぎり、[水][闘]の2つのタイプのエネルギー2個ぶんとしてはたらく。",
+		'zh-tw': "這張卡只可附於「連擊」寶可夢身上，若附於「連擊」寶可夢以外的寶可夢身上，則將其丟棄。 只要這張卡附於寶可夢身上，視為提供2個【水】【鬥】2種屬性的能量。",
 	},
 
-	energyType: "Special",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 586700,
+				tcgplayer: 571436,
+			},
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 578462,
+			},
+		},
+	],
 
-export default card
+	regulationMark: "E",
+	rarity: "None",
+};
+
+export default card;

--- a/data-asia/S/S8b/185.ts
+++ b/data-asia/S/S8b/185.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユキノオー",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Grass"],
+
+	description: {
+		ja: "ブリザードを 巻き起こす ポケモン。 大きな 体を 揺すれば あたり一面 すぐに 真っ白だ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "タフネスアップ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の場の「いちげき」のポケモン（「ユキノオー」をのぞく）全員の最大HPは、それぞれ「50」大きくなる。この効果は、この特性を持つポケモンが何匹いても、重ならない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "メガトンパンチ" },
+			damage: 90,
+			cost: ["Grass", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586924,
+				tcgplayer: 571437,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ユキカブリ",
+	},
+
+	retreat: 3,
+	regulationMark: "E",
+	rarity: "Character Rare",
+	dexId: [460],
+};
+
+export default card;

--- a/data-asia/S/S8b/186.ts
+++ b/data-asia/S/S8b/186.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アップリュー",
+	},
+
+	illustrator: "Misaki Hashimoto",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Grass"],
+
+	description: {
+		ja: "すっぱい りんごを 食べて 進化。 火傷する ほど 強酸性の 液体を 頬袋に 溜める。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "アップルドロップ" },
+			effect: {
+				ja: "自分の番に1回使える。相手のポケモン1匹に、ダメカンを2個のせる。その後、このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アシッドボム" },
+			damage: 60,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586925,
+				tcgplayer: 571438,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カジッチュ",
+	},
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Character Rare",
+	dexId: [841],
+};
+
+export default card;

--- a/data-asia/S/S8b/187.ts
+++ b/data-asia/S/S8b/187.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リザードン",
+	},
+
+	illustrator: "GIDORA",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Fire"],
+
+	description: {
+		ja: "岩石も 焼けるような 灼熱の 炎を 吐いて 山火事を 起こすことが ある。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "バトルセンス" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を上から3枚見て、その中からカードを1枚選び、手札に加える。残りのカードはトラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "キングブレイズ" },
+			damage: "100+",
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "自分のトラッシュにある「ダンデ」の枚数×50ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586926,
+				tcgplayer: 571439,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "リザード",
+	},
+
+	retreat: 3,
+	regulationMark: "D",
+	rarity: "Character Rare",
+	dexId: [6],
+};
+
+export default card;

--- a/data-asia/S/S8b/188.ts
+++ b/data-asia/S/S8b/188.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブースター",
+	},
+
+	illustrator: "You Iribi",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fire"],
+
+	description: {
+		ja: "体内に 炎が 溜まると ブースターの 体温も 最高 ９００度 まで 上がっていく。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しゃくねつのめざめ" },
+			effect: {
+				ja: "このポケモンに「メモリーカプセル」がついているなら、おたがいの場の[草]ポケモンの特性は、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ほのおのたてがみ" },
+			damage: 100,
+			cost: ["Fire", "Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586927,
+				tcgplayer: 571440,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Character Rare",
+	dexId: [136],
+};
+
+export default card;

--- a/data-asia/S/S8b/189.ts
+++ b/data-asia/S/S8b/189.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シャワーズ",
+	},
+
+	illustrator: "Jiro Sasumo",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Water"],
+
+	description: {
+		ja: "シャワーズの 全身の ひれが 小刻みに 震えはじめるのは 数時間後に 雨が降る しるし。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "げきりゅうのめざめ" },
+			effect: {
+				ja: "このポケモンに「メモリーカプセル」がついているなら、おたがいの場の[炎]ポケモンの特性は、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "オーロラビーム" },
+			damage: 70,
+			cost: ["Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586928,
+				tcgplayer: 571441,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Character Rare",
+	dexId: [134],
+};
+
+export default card;

--- a/data-asia/S/S8b/190.ts
+++ b/data-asia/S/S8b/190.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キングドラ",
+	},
+
+	illustrator: "Taira Akitsu",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Water"],
+
+	description: {
+		ja: "どんな 生き物も 降りられない 深い 海の底で 眠りながら 力を 蓄えている という。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かいていのぬし" },
+			effect: {
+				ja: "自分のバトルポケモンが、相手のポケモンからワザのダメージを受けてきぜつするたび、1回使える。きぜつしたポケモンについている[水]エネルギーを好きなだけ選び、このポケモンにつけ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アクアバースト" },
+			damage: "40×",
+			cost: ["Water"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーの数×40ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586929,
+				tcgplayer: 571442,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シードラ",
+	},
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Character Rare",
+	dexId: [230],
+};
+
+export default card;

--- a/data-asia/S/S8b/191.ts
+++ b/data-asia/S/S8b/191.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オクタン",
+	},
+
+	illustrator: "Shinya Komatsu",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Water"],
+
+	description: {
+		ja: "頑丈な 石頭。 吸盤つきの 脚を 絡ませ ひたすら 頭で 打ちすえる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "れんげきサーチ" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札から「れんげき」のカードを1枚選び、相手に見せて、手札に加える。そして山札を切る。この番、すでに別の「れんげきサーチ」を使っていたなら、この特性は使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "たきのぼり" },
+			damage: 50,
+			cost: ["Water", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586930,
+				tcgplayer: 571443,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "テッポウオ",
+	},
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Character Rare",
+	dexId: [224],
+};
+
+export default card;

--- a/data-asia/S/S8b/192.ts
+++ b/data-asia/S/S8b/192.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モスノウ",
+	},
+
+	illustrator: "aoki",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Water"],
+
+	description: {
+		ja: "野山を 荒らすものには 容赦 しない。 冷たいはねで 飛びまわり 吹雪を 起こして 懲らしめる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひょうせつのまい" },
+			effect: {
+				ja: "自分の番に何回でも使える。自分の手札から[水]エネルギーを1枚選び、ベンチの[水]ポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "オーロラビーム" },
+			damage: 30,
+			cost: ["Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586931,
+				tcgplayer: 571444,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ユキハミ",
+	},
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Character Rare",
+	dexId: [873],
+};
+
+export default card;

--- a/data-asia/S/S8b/193.ts
+++ b/data-asia/S/S8b/193.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サンダース",
+	},
+
+	illustrator: "DOM",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Lightning"],
+
+	description: {
+		ja: "怒ったり 驚いたりすると 全身の 毛が 針の ように 逆立って 相手を つらぬく。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "じんらいのめざめ" },
+			effect: {
+				ja: "このポケモンに「メモリーカプセル」がついているなら、おたがいの場の[水]ポケモンの特性は、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ライトニングボール" },
+			damage: 90,
+			cost: ["Lightning", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586932,
+				tcgplayer: 571445,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Character Rare",
+	dexId: [135],
+};
+
+export default card;

--- a/data-asia/S/S8b/194.ts
+++ b/data-asia/S/S8b/194.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モココ",
+	},
+
+	illustrator: "saino misaki",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Lightning"],
+
+	description: {
+		ja: "ふかふかの 毛に 電気を ためこむ。 蓄えすぎて ところどころ つるつるに 禿げあがって しまった。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エレキダイナモ" },
+			effect: {
+				ja: "自分の番に1回使える。自分のトラッシュから[雷]エネルギーを1枚選び、ベンチポケモンにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エレキボール" },
+			damage: 50,
+			cost: ["Lightning", "Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586933,
+				tcgplayer: 571446,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メリープ",
+	},
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Character Rare",
+	dexId: [180],
+};
+
+export default card;

--- a/data-asia/S/S8b/195.ts
+++ b/data-asia/S/S8b/195.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼクロム",
+	},
+
+	illustrator: "AKIRA EGAWA",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Lightning"],
+
+	description: {
+		ja: "しっぽの 内部が モーターのように 回ると 何本もの 稲妻が 発生して 周囲を つらぬく。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きりさく" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ワイルドショック" },
+			damage: 130,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンにも60ダメージ。相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586934,
+				tcgplayer: 571447,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "D",
+	rarity: "Character Rare",
+	dexId: [644],
+};
+
+export default card;

--- a/data-asia/S/S8b/196.ts
+++ b/data-asia/S/S8b/196.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サーナイト",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Psychic"],
+
+	description: {
+		ja: "トレーナーを 守るためなら サイコパワーを 使いきり 小さな ブラックホールを つくりだす。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "アルカナシャイン" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を上から2枚見て、その中から基本エネルギーを好きなだけ選び、自分のポケモンに好きなようにつける。残りのカードは手札に加える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ブレインウェーブ" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[超]エネルギーの数×30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586935,
+				tcgplayer: 571448,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キルリア",
+	},
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Character Rare",
+	dexId: [282],
+};
+
+export default card;

--- a/data-asia/S/S8b/197.ts
+++ b/data-asia/S/S8b/197.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュペッタ",
+	},
+
+	illustrator: "Tomomi Kaneko",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Psychic"],
+
+	description: {
+		ja: "捨てられた 怨念で 生まれる。 大切に されると 満足して 元の ヌイグルミに 戻るという。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かくごのうらみ" },
+			damage: "20×",
+			cost: ["Psychic"],
+			effect: {
+				ja: "このポケモンにダメカンを7個までのせ、のせた数×20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ぶきみなひかり" },
+			damage: 50,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586936,
+				tcgplayer: 571449,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カゲボウズ",
+	},
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Character Rare",
+	dexId: [354],
+};
+
+export default card;

--- a/data-asia/S/S8b/198.ts
+++ b/data-asia/S/S8b/198.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨノワール",
+	},
+
+	illustrator: "Megumi Higuchi",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Psychic"],
+
+	description: {
+		ja: "意思が あるのか わかっていない。 霊界からの 電波に 従い 人や ポケモンを 連れ去るのだ。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ゴーストブリーチ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、おたがいの場のポケモンについている特殊エネルギーの効果はすべてなくなり、【無】エネルギー1個ぶんとしてはたらく。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ホロウショット" },
+			damage: 120,
+			cost: ["Psychic", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586937,
+				tcgplayer: 571450,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "サマヨール",
+	},
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Character Rare",
+	dexId: [477],
+};
+
+export default card;

--- a/data-asia/S/S8b/199.ts
+++ b/data-asia/S/S8b/199.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カラマネロ",
+	},
+
+	illustrator: "Fumie Kittaka",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "歴史を 変えるほどの 大事件は カラマネロの 催眠能力が かかわっていたと いわれている。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "れんげきテンタクル" },
+			damage: "40×",
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の手札から「れんげき」のカードを好きなだけ相手に見せて、その枚数×40ダメージ。その後、見せた「れんげき」のカードを山札にもどして切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586938,
+				tcgplayer: 571451,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マーイーカ",
+	},
+
+	retreat: 3,
+	regulationMark: "E",
+	rarity: "Character Rare",
+	dexId: [687],
+};
+
+export default card;

--- a/data-asia/S/S8b/200.ts
+++ b/data-asia/S/S8b/200.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デデンネ",
+	},
+
+	illustrator: "kurumitsu",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "電気を 生みだす 力が 弱いので コンセントや ほかの 電気ポケモンから 盗むのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "デデフラッシュ" },
+			damage: "20+",
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のサイドの残り枚数が1枚なら、60ダメージ追加し、相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586939,
+				tcgplayer: 571452,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Character Rare",
+	dexId: [702],
+};
+
+export default card;

--- a/data-asia/S/S8b/201.ts
+++ b/data-asia/S/S8b/201.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マホイップ",
+	},
+
+	illustrator: "OKACHEKE",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "手から 生みだす クリームは マホイップが 幸せなとき 甘味と コクが 深まる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ついかオーダー" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、自分の「マスター」を使っても、自分の番は終わらない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "レインボーフレーバー" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている基本エネルギーのタイプの数×40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586940,
+				tcgplayer: 571453,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マホミル",
+	},
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Character Rare",
+	dexId: [869],
+};
+
+export default card;

--- a/data-asia/S/S8b/202.ts
+++ b/data-asia/S/S8b/202.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イワンコ",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "首の 岩を こすりつけてくるのは 親愛の 証。 ただし 岩は 鋭いので かなり 痛いぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かみくだく" },
+			damage: 30,
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587084,
+				tcgplayer: 571454,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Character Rare",
+	dexId: [744],
+};
+
+export default card;

--- a/data-asia/S/S8b/203.ts
+++ b/data-asia/S/S8b/203.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナゲツケサル",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "２０匹ほどの グループで 暮らす。 決まった 役割を こなすことで 厳しい 自然を 生き抜いてきた。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "スローイングコーチ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の「れんげき」のポケモンが使うワザの、相手のベンチの「ポケモンV・GX」へのダメージは「+30」される。この効果は、この特性を持つポケモンが何匹いても、重ならない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "なげつける" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のポケモン1匹に、20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586941,
+				tcgplayer: 571455,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Character Rare",
+	dexId: [766],
+};
+
+export default card;

--- a/data-asia/S/S8b/204.ts
+++ b/data-asia/S/S8b/204.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タイレーツ",
+	},
+
+	illustrator: "Kinu Nishimura",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "６匹で １匹の ポケモン。 隊列を 組み替えながら チームワークで 戦うのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "れんげきのじん" },
+			damage: "20×",
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "自分の場の「れんげき」のポケモンの数×20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586942,
+				tcgplayer: 571456,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Character Rare",
+	dexId: [870],
+};
+
+export default card;

--- a/data-asia/S/S8b/205.ts
+++ b/data-asia/S/S8b/205.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アリアドス",
+	},
+
+	illustrator: "Shiburingaru",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Darkness"],
+
+	description: {
+		ja: "糸を はいて 獲物を 捕らえる。 夜に なると 巣から 離れて 積極的に 狩りを するぞ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "スパイダーネット" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のベンチの進化ポケモンを1匹選び、バトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "どくばり" },
+			damage: 30,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586943,
+				tcgplayer: 571457,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イトマル",
+	},
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Character Rare",
+	dexId: [168],
+};
+
+export default card;

--- a/data-asia/S/S8b/206.ts
+++ b/data-asia/S/S8b/206.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヘルガー",
+	},
+
+	illustrator: "NC Empire",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Darkness"],
+
+	description: {
+		ja: "不気味な 遠吠えが 特徴。 昔の 人は 地獄 からの 使いと 考え 恐れていた。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "いちげきのほうこう" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札から「いちげきエネルギー」を1枚選び、自分の「いちげき」のポケモンにつける。そして山札を切る。その後、つけたポケモンにダメカンを2個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "やみのキバ" },
+			damage: 50,
+			cost: ["Darkness", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586944,
+				tcgplayer: 571458,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "デルビル",
+	},
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Character Rare",
+	dexId: [229],
+};
+
+export default card;

--- a/data-asia/S/S8b/207.ts
+++ b/data-asia/S/S8b/207.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガラル タチフサグマ",
+	},
+
+	illustrator: "GOSSAN",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Darkness"],
+
+	description: {
+		ja: "ケンカを 繰り返し 進化。 腕をクロスし 叫ぶ 雄叫びは どんな 相手も 怯ませるぞ。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "あらくれシャウト" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のポケモン1匹に、ダメカンを3個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ブロッキング" },
+			damage: 90,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンはたねポケモンからワザのダメージを受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586945,
+				tcgplayer: 571459,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ガラル マッスグマ",
+	},
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Character Rare",
+	dexId: [862],
+};
+
+export default card;

--- a/data-asia/S/S8b/208.ts
+++ b/data-asia/S/S8b/208.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドータクン",
+	},
+
+	illustrator: "Hataya",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Metal"],
+
+	description: {
+		ja: "体の模様 から 本来 ガラルには いない ポケモンと 考える 学者も 多い。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "メタルトランス" },
+			effect: {
+				ja: "自分の番に何回でも使える。自分の場のポケモンについている[鋼]エネルギーを1個選び、自分の別のポケモンにつけ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "しねんのずつき" },
+			damage: 70,
+			cost: ["Metal", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586946,
+				tcgplayer: 571460,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ドーミラー",
+	},
+
+	retreat: 3,
+	regulationMark: "E",
+	rarity: "Character Rare",
+	dexId: [437],
+};
+
+export default card;

--- a/data-asia/S/S8b/209.ts
+++ b/data-asia/S/S8b/209.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クリムガン",
+	},
+
+	illustrator: "Teeziro",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Dragon"],
+
+	description: {
+		ja: "凶暴で ずる賢い。 ほかの ポケモンが 掘った 巣穴を 奪って すみかにする。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "リベンジ" },
+			damage: "40+",
+			cost: ["Fire", "Water"],
+			effect: {
+				ja: "前の相手の番に、ワザのダメージで、自分のポケモンがきぜつしていたなら、120ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ドラゴンクロー" },
+			damage: 120,
+			cost: ["Fire", "Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586947,
+				tcgplayer: 571461,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Character Rare",
+	dexId: [621],
+};
+
+export default card;

--- a/data-asia/S/S8b/210.ts
+++ b/data-asia/S/S8b/210.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イーブイ",
+	},
+
+	illustrator: "Souichirou Gunjima",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "不安定な 遺伝子の おかげで さまざまな 進化の 可能性を 秘めている 特殊な ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ブイサーチ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から「ポケモンV」を3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ふむ" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 586948,
+				tcgplayer: 571462,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Character Rare",
+	dexId: [133],
+};
+
+export default card;

--- a/data-asia/S/S8b/211.ts
+++ b/data-asia/S/S8b/211.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポワルン",
+	},
+
+	illustrator: "Atsushi Furusawa",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "天気に よって 姿が 変わる。 気象が 荒くなるほど 気性も 荒っぽく なってくる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "てんきよみ" },
+			effect: {
+				ja: "自分のトラッシュに「スタジアム」が8枚以上あるなら、このポケモンがワザを使うためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ウェザーフォース" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の手札が6枚になるように、山札を引く。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587009,
+				tcgplayer: 571463,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "E",
+	rarity: "Character Rare",
+	dexId: [351],
+};
+
+export default card;

--- a/data-asia/S/S8b/212.ts
+++ b/data-asia/S/S8b/212.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤレユータン",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Colorless"],
+
+	description: {
+		ja: "森の 隅々まで 知り尽くし 傷ついた ポケモンが いると 薬草を 探して 治療する。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "さるぢえ" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札を1枚選び、山札の上のカードと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "はりたおす" },
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587010,
+				tcgplayer: 571464,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Character Rare",
+	dexId: [765],
+};
+
+export default card;

--- a/data-asia/S/S8b/213.ts
+++ b/data-asia/S/S8b/213.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コロトックV",
+	},
+
+	illustrator: "HYOGONOSUKE",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エキサイトステージ" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札が3枚になるように、山札を引く。このポケモンがバトル場にいるなら、4枚になるように引く。この番、すでに別の「エキサイトステージ」を使っていたなら、この特性は使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "シザークロス" },
+			damage: "80+",
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587011,
+				tcgplayer: 571465,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [402],
+};
+
+export default card;

--- a/data-asia/S/S8b/214.ts
+++ b/data-asia/S/S8b/214.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イオルブV",
+	},
+
+	illustrator: "Nisota Niso",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひるがえす" },
+			damage: 20,
+			cost: ["Grass"],
+			effect: {
+				ja: "のぞむなら、このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "ミステリーウェーブ" },
+			damage: "50+",
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数×30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587012,
+				tcgplayer: 571466,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Character Super Rare",
+	dexId: [826],
+};
+
+export default card;

--- a/data-asia/S/S8b/215.ts
+++ b/data-asia/S/S8b/215.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イオルブVMAX",
+	},
+
+	illustrator: "Teeziro",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Grass"],
+
+	stage: "VMAX",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かいこうせん" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。相手のポケモン全員に、それぞれダメカンを1個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "キョダイウェーブ" },
+			damage: "50+",
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数×50ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587013,
+				tcgplayer: 571467,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イオルブV",
+	},
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Character Super Rare",
+	dexId: [826],
+};
+
+export default card;

--- a/data-asia/S/S8b/216.ts
+++ b/data-asia/S/S8b/216.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バシャーモV",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とびひざげり" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ほのおのうず" },
+			damage: 210,
+			cost: ["Fire", "Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587014,
+				tcgplayer: 571468,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [257],
+};
+
+export default card;

--- a/data-asia/S/S8b/217.ts
+++ b/data-asia/S/S8b/217.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バシャーモVMAX",
+	},
+
+	illustrator: "KIYOTAKA OSHIYAMA",
+	category: "Pokemon",
+	hp: 320,
+	types: ["Fire"],
+
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: { ja: "わしづかみ" },
+			damage: 60,
+			cost: ["Fire"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "ダイブレイズ" },
+			damage: 130,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチの「れんげき」のポケモンを2匹まで選び、自分のトラッシュからエネルギーを1枚ずつつける。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587015,
+				tcgplayer: 571469,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "バシャーモV",
+	},
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [257],
+};
+
+export default card;

--- a/data-asia/S/S8b/218.ts
+++ b/data-asia/S/S8b/218.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マルヤクデV",
+	},
+
+	illustrator: "Yuya Oka",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ねつほうしゃ" },
+			damage: 20,
+			cost: ["Fire"],
+			effect: {
+				ja: "のぞむなら、このポケモンについているエネルギーを1個選び、トラッシュする。その場合、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "バーニングトレイン" },
+			damage: 180,
+			cost: ["Fire", "Fire", "Fire", "Fire"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587016,
+				tcgplayer: 571470,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "D",
+	rarity: "Character Super Rare",
+	dexId: [851],
+};
+
+export default card;

--- a/data-asia/S/S8b/219.ts
+++ b/data-asia/S/S8b/219.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マルヤクデVMAX",
+	},
+
+	illustrator: "Oswaldo KATO",
+	category: "Pokemon",
+	hp: 320,
+	types: ["Fire"],
+
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: { ja: "キョダイヒャッカ" },
+			damage: "40+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[炎]エネルギーの数×40ダメージ追加。のぞむなら、ダメージを与えたあとに、自分のトラッシュから[炎]エネルギーを1枚選び、このポケモンにつける。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587017,
+				tcgplayer: 571471,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マルヤクデV",
+	},
+
+	retreat: 3,
+	regulationMark: "D",
+	rarity: "Character Super Rare",
+	dexId: [851],
+};
+
+export default card;

--- a/data-asia/S/S8b/220.ts
+++ b/data-asia/S/S8b/220.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "はくばバドレックスV",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つきさす" },
+			damage: 40,
+			cost: ["Water"],
+		},
+		{
+			name: { ja: "ブリザードランス" },
+			damage: 200,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587018,
+				tcgplayer: 571472,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [898],
+};
+
+export default card;

--- a/data-asia/S/S8b/221.ts
+++ b/data-asia/S/S8b/221.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "はくばバドレックスVMAX",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 320,
+	types: ["Water"],
+
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: { ja: "エンペラーライド" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数×30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ダイランス" },
+			damage: "10+",
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "のぞむなら、このポケモンについているエネルギーを2枚まで選び、トラッシュする。その場合、トラッシュした枚数×120ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587019,
+				tcgplayer: 571473,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "はくばバドレックスV",
+	},
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [898],
+};
+
+export default card;

--- a/data-asia/S/S8b/222.ts
+++ b/data-asia/S/S8b/222.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウV",
+	},
+
+	illustrator: "Ryota Murayama",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "じゅうでん" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分の山札から[雷]エネルギーを2枚まで選び、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "10まんボルト" },
+			damage: 200,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、すべてトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587020,
+				tcgplayer: 571474,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Character Super Rare",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/S/S8b/223.ts
+++ b/data-asia/S/S8b/223.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウVMAX",
+	},
+
+	illustrator: "Souichirou Gunjima",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Lightning"],
+
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: { ja: "キョダイボルテッカー" },
+			damage: "120+",
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "のぞむなら、このポケモンについているエネルギーを、すべてトラッシュする。その場合、150ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587021,
+				tcgplayer: 571475,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ピカチュウV",
+	},
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Character Super Rare",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/S/S8b/224.ts
+++ b/data-asia/S/S8b/224.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼラオラV",
+	},
+
+	illustrator: "yuu",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "クロスフィスト" },
+			damage: 100,
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "前の自分の番、このポケモン以外の「れんげき」のポケモンがワザを使っていたなら、相手のベンチポケモン1匹にも、160ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587022,
+				tcgplayer: 571476,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [807],
+};
+
+export default card;

--- a/data-asia/S/S8b/225.ts
+++ b/data-asia/S/S8b/225.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パルスワンV",
+	},
+
+	illustrator: "GIDORA",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "そうでん" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分の山札から[雷]エネルギーを2枚まで選び、ベンチポケモンに好きなようにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ライトニングストーム" },
+			damage: "10+",
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[雷]エネルギーの数×30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587023,
+				tcgplayer: 571477,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Character Super Rare",
+	dexId: [836],
+};
+
+export default card;

--- a/data-asia/S/S8b/226.ts
+++ b/data-asia/S/S8b/226.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モルペコV-UNION",
+	},
+
+	illustrator: "Yuu Nishida",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ユニオンゲイン" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュから[L]エネルギーを2枚まで選び、このポケモンにつける。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587024,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [877],
+};
+
+export default card;

--- a/data-asia/S/S8b/227.ts
+++ b/data-asia/S/S8b/227.ts
@@ -1,0 +1,45 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モルペコV-UNION",
+	},
+
+	illustrator: "Yuu Nishida",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たべほうだい" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の手札が10枚になるように、山札を引く。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587025,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [877],
+};
+
+export default card;

--- a/data-asia/S/S8b/228.ts
+++ b/data-asia/S/S8b/228.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モルペコV-UNION",
+	},
+
+	illustrator: "Yuu Nishida",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "バーストホイール" },
+			damage: "100×",
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーをすべてトラッシュし、その枚数×100ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587026,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [877],
+};
+
+export default card;

--- a/data-asia/S/S8b/229.ts
+++ b/data-asia/S/S8b/229.ts
@@ -1,0 +1,43 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モルペコV-UNION",
+	},
+
+	illustrator: "Yuu Nishida",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ライトニングボール" },
+			damage: 160,
+			cost: ["Lightning", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587027,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [877],
+};
+
+export default card;

--- a/data-asia/S/S8b/230.ts
+++ b/data-asia/S/S8b/230.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガラル フリーザーV",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "さいこうちく" },
+			effect: {
+				ja: "自分の番に、自分の手札を2枚トラッシュするなら、1回使える。自分の山札を1枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "サイコビーム" },
+			damage: 110,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587028,
+				tcgplayer: 571482,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [144],
+};
+
+export default card;

--- a/data-asia/S/S8b/231.ts
+++ b/data-asia/S/S8b/231.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニンフィアV",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ドリームギフト" },
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、自分の番は終わる。自分の山札からグッズを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "マジカルショット" },
+			damage: 60,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587029,
+				tcgplayer: 571483,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [700],
+};
+
+export default card;

--- a/data-asia/S/S8b/232.ts
+++ b/data-asia/S/S8b/232.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニンフィアVMAX",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Psychic"],
+
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: { ja: "プレシャスタッチ" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の手札からエネルギーを1枚選び、自分のベンチポケモンにつける。その後、そのポケモンのHPを「120」回復する。",
+			},
+		},
+		{
+			name: { ja: "ダイハーモニー" },
+			damage: "70+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチポケモンのタイプの数×30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587030,
+				tcgplayer: 571484,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニンフィアV",
+	},
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [700],
+};
+
+export default card;

--- a/data-asia/S/S8b/233.ts
+++ b/data-asia/S/S8b/233.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミミッキュV",
+	},
+
+	illustrator: "saino misaki",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ダミードール" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。次の相手の番の終わりまで、この「ミミッキュV」は、相手のポケモンからワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "うらやむひとみ" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手がすでにとったサイドの枚数×3個ぶんのダメカンを、相手のバトルポケモンにのせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587031,
+				tcgplayer: 571485,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [778],
+};
+
+export default card;

--- a/data-asia/S/S8b/234.ts
+++ b/data-asia/S/S8b/234.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミミッキュVMAX",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 300,
+	types: ["Psychic"],
+
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: { ja: "オカルトナンバー" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "ダメカン4個を、相手のポケモンに好きなようにのせる。この番、自分の手札から「アセロラの予感」を出して使っていたなら、のせるダメカンの数は13個になる。",
+			},
+		},
+		{
+			name: { ja: "ダイシャドー" },
+			damage: 120,
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587032,
+				tcgplayer: 571486,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ミミッキュV",
+	},
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [778],
+};
+
+export default card;

--- a/data-asia/S/S8b/235.ts
+++ b/data-asia/S/S8b/235.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "こくばバドレックスV",
+	},
+
+	illustrator: "Oswaldo KATO",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "シャドーミスト" },
+			damage: 10,
+			cost: ["Psychic"],
+			effect: {
+				ja: "次の相手の番、相手は手札から、「特殊エネルギー」を出してつけられず「スタジアム」も出せない。",
+			},
+		},
+		{
+			name: { ja: "アストラルビット" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン2匹に、それぞれダメカンを5個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587033,
+				tcgplayer: 571487,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [898],
+};
+
+export default card;

--- a/data-asia/S/S8b/236.ts
+++ b/data-asia/S/S8b/236.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "こくばバドレックスVMAX",
+	},
+
+	illustrator: "chibi",
+	category: "Pokemon",
+	hp: 320,
+	types: ["Psychic"],
+
+	stage: "VMAX",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "めいかいのとびら" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札から[超]エネルギーを1枚選び、自分のベンチの[超]ポケモンにつける。その後、自分の山札を2枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ダイガイスト" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[超]エネルギーの数×30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587034,
+				tcgplayer: 571488,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "こくばバドレックスV",
+	},
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [898],
+};
+
+export default card;

--- a/data-asia/S/S8b/237.ts
+++ b/data-asia/S/S8b/237.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガラル サンダーV",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "とうそうほんのう" },
+			effect: {
+				ja: "相手の場の「ポケモンV」の数ぶん、このポケモンがワザを使うための【無】エネルギーは少なくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "らいめいげり" },
+			damage: 170,
+			cost: ["Fighting", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "ダメージを与える前に、相手のバトルポケモンについている特殊エネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587035,
+				tcgplayer: 571489,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [145],
+};
+
+export default card;

--- a/data-asia/S/S8b/238.ts
+++ b/data-asia/S/S8b/238.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "いちげきウーラオスV",
+	},
+
+	illustrator: "Yuu Nishida",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とぎすます" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "自分の山札から[闘]エネルギーを2枚まで選び、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "インパクトブロー" },
+			damage: 180,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「インパクトブロー」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587036,
+				tcgplayer: 571490,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [892],
+};
+
+export default card;

--- a/data-asia/S/S8b/239.ts
+++ b/data-asia/S/S8b/239.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "いちげきウーラオスVMAX",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Fighting"],
+
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: { ja: "せいけんづき" },
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "キョダイイチゲキ" },
+			damage: 270,
+			cost: ["Fighting", "Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、すべてトラッシュする。このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587037,
+				tcgplayer: 571491,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "いちげきウーラオスV",
+	},
+
+	retreat: 3,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [892],
+};
+
+export default card;

--- a/data-asia/S/S8b/240.ts
+++ b/data-asia/S/S8b/240.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "れんげきウーラオスV",
+	},
+
+	illustrator: "takuyoa",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひるがえす" },
+			damage: 30,
+			cost: ["Fighting"],
+			effect: {
+				ja: "のぞむなら、このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "ひゃくれつラッシュ" },
+			damage: 150,
+			cost: ["Fighting", "Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587038,
+				tcgplayer: 571492,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [892],
+};
+
+export default card;

--- a/data-asia/S/S8b/241.ts
+++ b/data-asia/S/S8b/241.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "れんげきウーラオスVMAX",
+	},
+
+	illustrator: "Scav",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Fighting"],
+
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: { ja: "しっぷうづき" },
+			damage: "30+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "この番、このポケモンがベンチからバトル場に出ていたなら、120ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "キョダイレンゲキ" },
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーをすべてトラッシュし、相手のポケモン2匹に、それぞれ120ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587039,
+				tcgplayer: 571493,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "れんげきウーラオスV",
+	},
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [892],
+};
+
+export default card;

--- a/data-asia/S/S8b/242.ts
+++ b/data-asia/S/S8b/242.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガラル ファイヤーV",
+	},
+
+	illustrator: "Jiro Sasumo",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "じゃえんのつばさ" },
+			effect: {
+				ja: "自分の番に1回使える。自分のトラッシュから[悪]エネルギーを1枚選び、このポケモンにつける。この番、すでに別の「じゃえんのつばさ」を使っていたなら、この特性は使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "オーラバーン" },
+			damage: 190,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587040,
+				tcgplayer: 571494,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [146],
+};
+
+export default card;

--- a/data-asia/S/S8b/243.ts
+++ b/data-asia/S/S8b/243.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クロバットV",
+	},
+
+	illustrator: "GOSSAN",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ナイトアセット" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の手札が6枚になるように、山札を引く。この番、すでに別の「ナイトアセット」を使っていたなら、この特性は使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "どくのキバ" },
+			damage: 70,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587041,
+				tcgplayer: 571495,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Character Super Rare",
+	dexId: [169],
+};
+
+export default card;

--- a/data-asia/S/S8b/244.ts
+++ b/data-asia/S/S8b/244.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブラッキーV",
+	},
+
+	illustrator: "Ligton",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "くろいまなざし" },
+			damage: 30,
+			cost: ["Darkness"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "げっこうのやいば" },
+			damage: "80+",
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにダメカンがのっているなら、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587042,
+				tcgplayer: 571496,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [197],
+};
+
+export default card;

--- a/data-asia/S/S8b/245.ts
+++ b/data-asia/S/S8b/245.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブラッキーVMAX",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Darkness"],
+
+	stage: "VMAX",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ダークシグナル" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ダイアーク" },
+			damage: 160,
+			cost: ["Darkness", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587043,
+				tcgplayer: 571497,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ブラッキーV",
+	},
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [197],
+};
+
+export default card;

--- a/data-asia/S/S8b/246.ts
+++ b/data-asia/S/S8b/246.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ムゲンダイナV",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "パワーアクセル" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "のぞむなら、自分の手札から[悪]エネルギーを1枚選び、ベンチポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "ダイマックスほう" },
+			damage: "120+",
+			cost: ["Darkness", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが「ポケモンVMAX」なら、120ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587044,
+				tcgplayer: 571498,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Character Super Rare",
+	dexId: [890],
+};
+
+export default card;

--- a/data-asia/S/S8b/247.ts
+++ b/data-asia/S/S8b/247.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ムゲンダイナVMAX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 340,
+	types: ["Darkness"],
+
+	stage: "VMAX",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ムゲンゾーン" },
+			effect: {
+				ja: "自分の場のポケモン全員が[悪]タイプならはたらく。自分のベンチに出せる[悪]ポケモンの数は8匹になり、別のタイプは場に出せない。（この特性がはたらかなくなったとき、ベンチが5匹になるまでトラッシュする。）",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ドレッドエンド" },
+			damage: "30×",
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "自分の場の[悪]ポケモンの数×30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587045,
+				tcgplayer: 571499,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ムゲンダイナV",
+	},
+
+	retreat: 3,
+	regulationMark: "D",
+	rarity: "Character Super Rare",
+	dexId: [890],
+};
+
+export default card;

--- a/data-asia/S/S8b/248.ts
+++ b/data-asia/S/S8b/248.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アーマーガアV",
+	},
+
+	illustrator: "KIYOTAKA OSHIYAMA",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "わしづかみ" },
+			damage: 30,
+			cost: ["Metal"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "スカイハリケーン" },
+			damage: 190,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「スカイハリケーン」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587046,
+				tcgplayer: 571500,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [823],
+};
+
+export default card;

--- a/data-asia/S/S8b/249.ts
+++ b/data-asia/S/S8b/249.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アーマーガアVMAX",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 320,
+	types: ["Metal"],
+
+	stage: "VMAX",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ラスターボディ" },
+			effect: {
+				ja: "このポケモンは、相手のポケモンから特性の効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "キョダイハリケーン" },
+			damage: 240,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「キョダイハリケーン」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587047,
+				tcgplayer: 571501,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アーマーガアV",
+	},
+
+	retreat: 0,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [823],
+};
+
+export default card;

--- a/data-asia/S/S8b/250.ts
+++ b/data-asia/S/S8b/250.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ザシアンV",
+	},
+
+	illustrator: "aoki",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ふとうのつるぎ" },
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、自分の番は終わる。自分の山札を上から3枚見て、その中から[鋼]エネルギーを好きなだけ選び、このポケモンにつける。残りのカードは手札に加える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ブレイブキャリバー" },
+			damage: 230,
+			cost: ["Metal", "Metal", "Metal"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587048,
+				tcgplayer: 571502,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Character Super Rare",
+	dexId: [888],
+};
+
+export default card;

--- a/data-asia/S/S8b/251.ts
+++ b/data-asia/S/S8b/251.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ザマゼンタV",
+	},
+
+	illustrator: "Ryuta Fuse",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ふくつのたて" },
+			effect: {
+				ja: "このポケモンは、相手の「ポケモンVMAX」からワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "アサルトタックル" },
+			damage: 130,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについている特殊エネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587049,
+				tcgplayer: 571503,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Character Super Rare",
+	dexId: [889],
+};
+
+export default card;

--- a/data-asia/S/S8b/252.ts
+++ b/data-asia/S/S8b/252.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レックウザVMAX",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Pokemon",
+	hp: 320,
+	types: ["Dragon"],
+
+	stage: "VMAX",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "そうくうのはどう" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札をすべてトラッシュし、山札を3枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ダイバースト" },
+			damage: "20+",
+			cost: ["Fire", "Lightning"],
+			effect: {
+				ja: "このポケモンについている[炎]または[雷]タイプのどちらかの基本エネルギーを好きなだけトラッシュし、その枚数×80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587050,
+				tcgplayer: 571504,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "レックウザV",
+	},
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [384],
+};
+
+export default card;

--- a/data-asia/S/S8b/253.ts
+++ b/data-asia/S/S8b/253.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュラルドンVMAX",
+	},
+
+	illustrator: "AKIRA EGAWA",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Dragon"],
+
+	stage: "VMAX",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "まてんろう" },
+			effect: {
+				ja: "このポケモンは、特殊エネルギーがついている相手のポケモンから、ワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "キョダイフンサイ" },
+			damage: 220,
+			cost: ["Fighting", "Metal", "Metal"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587051,
+				tcgplayer: 571505,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジュラルドンV",
+	},
+
+	retreat: 3,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [884],
+};
+
+export default card;

--- a/data-asia/S/S8b/254.ts
+++ b/data-asia/S/S8b/254.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハピナスV",
+	},
+
+	illustrator: "You Iribi",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しぜんかいふく" },
+			effect: {
+				ja: "自分の手札からこのポケモンにエネルギーをつけるたび、このポケモンの特殊状態をすべて回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ハッピーボンバー" },
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーの数×30ダメージ追加。のぞむなら、ダメージを与えたあとに、トラッシュからエネルギーを3枚まで選び、このポケモンにつける。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587052,
+				tcgplayer: 571506,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "E",
+	rarity: "Character Super Rare",
+	dexId: [242],
+};
+
+export default card;

--- a/data-asia/S/S8b/255.ts
+++ b/data-asia/S/S8b/255.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アセロラの予感",
+	},
+
+	illustrator: "yuu",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手の手札を見て、その中にあるトレーナーズの枚数ぶん、自分の山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587053,
+				tcgplayer: 571507,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S8b/256.ts
+++ b/data-asia/S/S8b/256.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オニオン",
+	},
+
+	illustrator: "Jiro Sasumo",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を3枚引く。その後、自分の手札を3枚まで選び、トラッシュする。（必ず1枚はトラッシュする。）",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587054,
+				tcgplayer: 571508,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S8b/257.ts
+++ b/data-asia/S/S8b/257.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カブ",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札をすべて山札にもどして切る。その後、山札を4枚引く。自分の場のポケモンがバトルポケモンだけなら、引く枚数は8枚になる。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587055,
+				tcgplayer: 571509,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S8b/258.ts
+++ b/data-asia/S/S8b/258.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガラルの仲間たち",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587056,
+				tcgplayer: 571510,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S8b/259.ts
+++ b/data-asia/S/S8b/259.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キバナ",
+	},
+
+	illustrator: "take",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、前の相手の番に、自分のポケモンがきぜつしていなければ使えない。自分のトラッシュから基本エネルギーを1枚選び、自分のポケモンにつける。その後、自分の山札から好きなカードを1枚選び、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587057,
+				tcgplayer: 571511,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S8b/260.ts
+++ b/data-asia/S/S8b/260.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コック",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンのHPを「70」回復する。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587058,
+				tcgplayer: 571512,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S8b/261.ts
+++ b/data-asia/S/S8b/261.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サイトウ",
+	},
+
+	illustrator: "Souichirou Gunjima",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から5枚トラッシュし、その中にあるエネルギーをすべて、ベンチの[闘]ポケモンに好きなようにつける。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587059,
+				tcgplayer: 571513,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S8b/262.ts
+++ b/data-asia/S/S8b/262.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャッジマン",
+	},
+
+	illustrator: "Ryuta Fuse",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、それぞれ、手札をすべて山札にもどし、山札を切る。その後、それぞれの山札を4枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587060,
+				tcgplayer: 571514,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S8b/263.ts
+++ b/data-asia/S/S8b/263.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソッドとシルディ",
+	},
+
+	illustrator: "nagimiso",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュからトレーナーズを1枚選び、相手に見せて、手札に加えて良いかを相手にたずねる。相手が良いなら、選んだカードを手札に加える。良くないなら、選んだカードをトラッシュにもどし、自分の山札を3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587061,
+				tcgplayer: 571515,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S8b/264.ts
+++ b/data-asia/S/S8b/264.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネズ",
+	},
+
+	illustrator: "GOSSAN",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から[悪]ポケモンとエネルギーを1枚ずつ選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587062,
+				tcgplayer: 571516,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S8b/265.ts
+++ b/data-asia/S/S8b/265.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バーネット博士",
+	},
+
+	illustrator: "kirisAki",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から好きなカードを2枚まで選び、トラッシュする。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587063,
+				tcgplayer: 571517,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S8b/266.ts
+++ b/data-asia/S/S8b/266.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "博士の研究",
+	},
+
+	illustrator: "Yuu Nishida",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札をすべてトラッシュし、山札を7枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587064,
+				tcgplayer: 577554,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S8b/267.ts
+++ b/data-asia/S/S8b/267.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "冒険家の発見",
+	},
+
+	illustrator: "Taira Akitsu",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から「ポケモンV」を3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587065,
+				tcgplayer: 571518,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S8b/268.ts
+++ b/data-asia/S/S8b/268.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ボスの指令",
+	},
+
+	illustrator: "NC Empire",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587066,
+				tcgplayer: 571519,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S8b/269.ts
+++ b/data-asia/S/S8b/269.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポプラ",
+	},
+
+	illustrator: "Taira Akitsu",
+	category: "Trainer",
+
+	effect: {
+		ja: "コインを2回投げ、オモテの数ぶんまで、自分の山札から好きなカードを選び、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587067,
+				tcgplayer: 571520,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S8b/270.ts
+++ b/data-asia/S/S8b/270.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マクワ",
+	},
+
+	illustrator: "Ryuta Fuse",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から7枚見る。その中からエネルギーを好きなだけ選び、相手に見せて、手札に加える。残りのカードは山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587068,
+				tcgplayer: 571521,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S8b/271.ts
+++ b/data-asia/S/S8b/271.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マスター",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードを使ったら、自分の番は終わる。自分のベンチポケモンを3匹まで選び、山札から、それぞれちがうタイプの基本エネルギーを1枚ずつつける。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587069,
+				tcgplayer: 571522,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S8b/272.ts
+++ b/data-asia/S/S8b/272.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マスタード いちげきのかた",
+	},
+
+	illustrator: "Souichirou Gunjima",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札がこのカード1枚だけのときにしか使えない。自分の山札から「いちげき」のポケモンを1枚選び、ベンチに出す。そして山札を切る。その後、自分の山札を5枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587070,
+				tcgplayer: 571523,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S8b/273.ts
+++ b/data-asia/S/S8b/273.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マスタード れんげきのかた",
+	},
+
+	illustrator: "KIYOTAKA OSHIYAMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札がこのカード1枚だけのときにしか使えない。自分のトラッシュから「れんげき」のポケモンを1枚選び、ベンチに出す。その後、自分の山札を5枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587071,
+				tcgplayer: 571524,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S8b/274.ts
+++ b/data-asia/S/S8b/274.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メロン",
+	},
+
+	illustrator: "nagimiso",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュから[水]エネルギーを1枚選び、自分の「ポケモンV」につける。その後、自分の山札を3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587072,
+				tcgplayer: 571525,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S8b/275.ts
+++ b/data-asia/S/S8b/275.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤロー",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札を2枚までトラッシュし、その枚数×2枚、自分の山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587073,
+				tcgplayer: 571526,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S8b/276.ts
+++ b/data-asia/S/S8b/276.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ユウリ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札からたねポケモン（「ルールを持つポケモン」をのぞく）を3枚まで選び、ベンチに出す。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587074,
+				tcgplayer: 571527,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S8b/277.ts
+++ b/data-asia/S/S8b/277.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルリナ",
+	},
+
+	illustrator: "saino misaki",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュから[水]ポケモンと[水]エネルギーを合計4枚まで選び、相手に見せて、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587075,
+				tcgplayer: 571528,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S8b/278.ts
+++ b/data-asia/S/S8b/278.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "はくばバドレックスVMAX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 320,
+	types: ["Water"],
+
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: { ja: "エンペラーライド" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数×30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ダイランス" },
+			damage: "10+",
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "のぞむなら、このポケモンについているエネルギーを2枚まで選び、トラッシュする。その場合、トラッシュした枚数×120ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587076,
+				tcgplayer: 571529,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "はくばバドレックスV",
+	},
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Secret Rare",
+	dexId: [898],
+};
+
+export default card;

--- a/data-asia/S/S8b/279.ts
+++ b/data-asia/S/S8b/279.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウVMAX",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Lightning"],
+
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: { ja: "キョダイボルテッカー" },
+			damage: "120+",
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "のぞむなら、このポケモンについているエネルギーを、すべてトラッシュする。その場合、150ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587077,
+				tcgplayer: 571530,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ピカチュウV",
+	},
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Secret Rare",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/S/S8b/280.ts
+++ b/data-asia/S/S8b/280.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミュウVMAX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Psychic"],
+
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: { ja: "クロスフュージョン" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチの「フュージョン」のポケモンが持っているワザを1つ選び、このワザとして使う。",
+			},
+		},
+		{
+			name: { ja: "ダイミラクル" },
+			damage: 130,
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587078,
+				tcgplayer: 571531,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ミュウV",
+	},
+
+	retreat: 0,
+	regulationMark: "E",
+	rarity: "Secret Rare",
+	dexId: [151],
+};
+
+export default card;

--- a/data-asia/S/S8b/281.ts
+++ b/data-asia/S/S8b/281.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "こくばバドレックスVMAX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 320,
+	types: ["Psychic"],
+
+	stage: "VMAX",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "めいかいのとびら" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札から[超]エネルギーを1枚選び、自分のベンチの[超]ポケモンにつける。その後、自分の山札を2枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ダイガイスト" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[超]エネルギーの数×30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587079,
+				tcgplayer: 571532,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "こくばバドレックスV",
+	},
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Secret Rare",
+	dexId: [898],
+};
+
+export default card;

--- a/data-asia/S/S8b/282.ts
+++ b/data-asia/S/S8b/282.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "いちげきウーラオスVMAX",
+	},
+
+	illustrator: "PLANETA Tsuji",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Fighting"],
+
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: { ja: "せいけんづき" },
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "キョダイイチゲキ" },
+			damage: 270,
+			cost: ["Fighting", "Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、すべてトラッシュする。このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587081,
+				tcgplayer: 571533,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "いちげきウーラオスV",
+	},
+
+	retreat: 3,
+	regulationMark: "E",
+	rarity: "Secret Rare",
+	dexId: [892],
+};
+
+export default card;

--- a/data-asia/S/S8b/283.ts
+++ b/data-asia/S/S8b/283.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "れんげきウーラオスVMAX",
+	},
+
+	illustrator: "PLANETA Tsuji",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Fighting"],
+
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: { ja: "しっぷうづき" },
+			damage: "30+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "この番、このポケモンがベンチからバトル場に出ていたなら、120ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "キョダイレンゲキ" },
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーをすべてトラッシュし、相手のポケモン2匹に、それぞれ120ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587080,
+				tcgplayer: 571534,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "れんげきウーラオスV",
+	},
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Secret Rare",
+	dexId: [892],
+};
+
+export default card;

--- a/data-asia/S/S8b/284.ts
+++ b/data-asia/S/S8b/284.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レックウザVMAX",
+	},
+
+	illustrator: "PLANETA Mochizuki",
+	category: "Pokemon",
+	hp: 320,
+	types: ["Dragon"],
+
+	stage: "VMAX",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "そうくうのはどう" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札をすべてトラッシュし、山札を3枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ダイバースト" },
+			damage: "20+",
+			cost: ["Fire", "Lightning"],
+			effect: {
+				ja: "このポケモンについている[炎]または[雷]タイプのどちらかの基本エネルギーを好きなだけトラッシュし、その枚数×80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587082,
+				tcgplayer: 571535,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "レックウザV",
+	},
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Secret Rare",
+	dexId: [384],
+};
+
+export default card;

--- a/data-asia/S/S8b/285.ts
+++ b/data-asia/S/S8b/285.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8b";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュラルドンVMAX",
+	},
+
+	illustrator: "PLANETA Mochizuki",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Dragon"],
+
+	stage: "VMAX",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "まてんろう" },
+			effect: {
+				ja: "このポケモンは、特殊エネルギーがついている相手のポケモンから、ワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "キョダイフンサイ" },
+			damage: 220,
+			cost: ["Fighting", "Metal", "Metal"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 587083,
+				tcgplayer: 571536,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジュラルドンV",
+	},
+
+	retreat: 3,
+	regulationMark: "E",
+	rarity: "Secret Rare",
+	dexId: [884],
+};
+
+export default card;

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -236,6 +236,7 @@ export interface Card {
 			// Black White rare
 			| 'Black White Rare'
 			| 'Mega Hyper Rare'
+			| 'Triple Rare'
 			// Japanese Character Rares (since SM11b Dream League)
 			| 'Character Rare' | 'Character Super Rare'
 			// Pokémon TCG Pocket Rarities


### PR DESCRIPTION
## What

Refreshes the existing Japanese set **S8b VMAXクライマックス (VMAX Climax)** from its primary sources. The curated content stays: every card keeps its `zh-tw` texts verbatim.

What changes across the 285 card files:

- `thirdParty.cardmarket` moves onto `variants` objects and 181 missing ids are filled in
- per card where missing: `dexId`, `evolveFrom`, `resistances`, the Japanese flavor text and the Japanese effect/attack texts straight from the official database and limitless

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (586516–587084)
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (571254–577554), keyed by the collection number each product carries in `extendedData`

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- All 285 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
