### PR TITLE
(data) Update Japanese S set S8 Fusion Arts

### DIFF
--- a/data-asia/S/S8/001.ts
+++ b/data-asia/S/S8/001.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "綠毛蟲"
+		ja: "キャタピー",
+		'zh-tw': "綠毛蟲",
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -14,37 +14,51 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "別看牠的腳很短，因為是吸盤，所以無論是斜坡還是牆壁都能輕鬆前進。"
+		ja: "脚は 短いが 吸盤に なっているので 坂でも 壁でも くたびれることなく 進んでいく。",
+		'zh-tw': "別看牠的腳很短，因為是吸盤，所以無論是斜坡還是牆壁都能輕鬆前進。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "群聚"
+	attacks: [
+		{
+			name: {
+				ja: "むれる",
+				'zh-tw': "群聚",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から「キャタピー」を1枚選び、ベンチに出す。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張「綠毛蟲」卡，放置於備戰區。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張「綠毛蟲」卡，放置於備戰區。並且重洗牌庫。"
+		{
+			name: {
+				ja: "むしくい",
+				'zh-tw': "蟲咬",
+			},
+			damage: 10,
+			cost: ["Grass"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "蟲咬"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575551,
+				tcgplayer: 569502,
+			},
 		},
-
-		damage: 10,
-		cost: ["Grass"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [10],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/002.ts
+++ b/data-asia/S/S8/002.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鐵甲蛹"
+		ja: "トランセル",
+		'zh-tw': "鐵甲蛹",
 	},
 
 	illustrator: "Saya Tsuruta",
@@ -14,39 +14,58 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "雖然有堅硬的外殼，但因為殼裡的身體很軟，所以無法抵抗強力的攻擊。"
+		ja: "硬い 殻に 包まれているが 中身は 軟らかいので 強い 攻撃には 耐えられない。",
+		'zh-tw': "雖然有堅硬的外殼，但因為殼裡的身體很軟，所以無法抵抗強力的攻擊。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "堅硬身軀"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "かたいからだ",
+				'zh-tw': "堅硬身軀",
+			},
+			effect: {
+				ja: "このポケモンが受けるワザのダメージは「-20」される。",
+				'zh-tw': "這隻寶可夢受到招式的傷害「-20」點。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢受到招式的傷害「-20」點。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "衝撞"
+	attacks: [
+		{
+			name: {
+				ja: "ぶつかる",
+				'zh-tw': "衝撞",
+			},
+			damage: 10,
+			cost: ["Grass"],
 		},
+	],
 
-		damage: 10,
-		cost: ["Grass"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575552,
+				tcgplayer: 569503,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キャタピー",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [11],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/003.ts
+++ b/data-asia/S/S8/003.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "巴大蝶"
+		ja: "バタフリー",
+		'zh-tw': "巴大蝶",
 	},
 
 	illustrator: "ryoma uratsuka",
@@ -14,39 +14,58 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "每天都忙著採集花蜜。習慣在腿部的細毛上塗滿花蜜，然後帶回巢穴裡。"
+		ja: "毎日 ミツを 集めまわる。 脚の 産毛に ミツを 塗りこんで 巣に 持ち帰る 習性をもつ。",
+		'zh-tw': "每天都忙著採集花蜜。習慣在腿部的細毛上塗滿花蜜，然後帶回巢穴裡。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "三色鱗粉"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "さんしょくりんぷん",
+				'zh-tw': "三色鱗粉",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。相手のバトルポケモンをどくとやけどとこんらんにする。",
+				'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。將對手的戰鬥寶可夢【中毒】、【灼傷】與【混亂】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。將對手的戰鬥寶可夢【中毒】、【灼傷】與【混亂】。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "起風"
+	attacks: [
+		{
+			name: {
+				ja: "かぜおこし",
+				'zh-tw': "起風",
+			},
+			damage: 90,
+			cost: ["Grass", "Colorless"],
 		},
+	],
 
-		damage: 90,
-		cost: ["Grass", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 575553,
+				tcgplayer: 569504,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "トランセル",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [12],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/004.ts
+++ b/data-asia/S/S8/004.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "蘑蘑菇"
+		ja: "キノココ",
+		'zh-tw': "蘑蘑菇",
 	},
 
 	illustrator: "Naoyo Kimura",
@@ -14,34 +14,48 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "會從頭頂上噴出毒孢子。如果不小心吸入了孢子，身上的每處關節都會開始疼痛。"
+		ja: "頭の てっぺんから 毒胞子を 噴き出す。 胞子を 吸いこむと 体の 節々が 痛くなる。",
+		'zh-tw': "會從頭頂上噴出毒孢子。如果不小心吸入了孢子，身上的每處關節都會開始疼痛。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "撞擊"
+	attacks: [
+		{
+			name: {
+				ja: "たいあたり",
+				'zh-tw': "撞擊",
+			},
+			damage: 10,
+			cost: ["Grass"],
 		},
-
-		damage: 10,
-		cost: ["Grass"]
-	}, {
-		name: {
-			'zh-tw': "種子炸彈"
+		{
+			name: {
+				ja: "タネばくだん",
+				'zh-tw': "種子炸彈",
+			},
+			damage: 20,
+			cost: ["Grass", "Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Grass", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575554,
+				tcgplayer: 569505,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [285],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/005.ts
+++ b/data-asia/S/S8/005.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "斗笠菇"
+		ja: "キノガッサ",
+		'zh-tw': "斗笠菇",
 	},
 
 	illustrator: "Yukiko Baba",
@@ -14,38 +14,56 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "會撒出毒孢子，然後再讓因吸入孢子而痛苦不堪的對手吃上一記重拳。"
+		ja: "毒の 胞子を ばらまき 吸いこんで 苦しむ 相手に 強烈な パンチを くらわせる。",
+		'zh-tw': "會撒出毒孢子，然後再讓因吸入孢子而痛苦不堪的對手吃上一記重拳。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "頭錘"
+	attacks: [
+		{
+			name: {
+				ja: "ずつき",
+				'zh-tw': "頭錘",
+			},
+			damage: 30,
+			cost: ["Grass"],
 		},
-
-		damage: 30,
-		cost: ["Grass"]
-	}, {
-		name: {
-			'zh-tw': "衝擊打擊"
+		{
+			name: {
+				ja: "インパクトブロー",
+				'zh-tw': "衝擊打擊",
+			},
+			damage: 150,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「インパクトブロー」が使えない。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「衝擊打擊」。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「衝擊打擊」。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575555,
+				tcgplayer: 569506,
+			},
 		},
+	],
 
-		damage: 150,
-		cost: ["Grass", "Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "キノココ",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [286],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/006.ts
+++ b/data-asia/S/S8/006.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "沙鈴仙人掌"
+		ja: "マラカッチ",
+		'zh-tw': "沙鈴仙人掌",
 	},
 
 	illustrator: "0313",
@@ -14,38 +14,52 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "一年散播一次種子。花的種子營養十足，是沙漠中貴重的食糧。"
+		ja: "１年に 一度 種を まく。 花の 種は 栄養満点で 砂漠の 貴重な 食料。",
+		'zh-tw': "一年散播一次種子。花的種子營養十足，是沙漠中貴重的食糧。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "啄"
+	attacks: [
+		{
+			name: {
+				ja: "つつく",
+				'zh-tw': "啄",
+			},
+			damage: 20,
+			cost: ["Grass"],
 		},
-
-		damage: 20,
-		cost: ["Grass"]
-	}, {
-		name: {
-			'zh-tw': "丟丟搖擺"
+		{
+			name: {
+				ja: "ぽいぽいシェイク",
+				'zh-tw': "丟丟搖擺",
+			},
+			damage: "50×",
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "自分の手札から「ポケモンのどうぐ」を好きなだけトラッシュし、その枚数×50ダメージ。",
+				'zh-tw': "從自己的手牌將任意數量的「寶可夢道具」卡丟棄，造成其張數×50點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的手牌將任意數量的「寶可夢道具」卡丟棄，造成其張數×50點傷害。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575556,
+				tcgplayer: 569507,
+			},
 		},
-
-		damage: "50×",
-		cost: ["Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [556],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/007.ts
+++ b/data-asia/S/S8/007.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "小嘴蝸"
+		ja: "チョボマキ",
+		'zh-tw': "小嘴蝸",
 	},
 
 	illustrator: "Shibuzoh.",
@@ -14,27 +14,40 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "有著會對電能產生反應的奇異體質。不知為何，和蓋蓋蟲待在一起就會進化。"
+		ja: "電気 エネルギーに 反応する 不思議な 体質。 カブルモと ともに いると なぜか 進化する。",
+		'zh-tw': "有著會對電能產生反應的奇異體質。不知為何，和蓋蓋蟲待在一起就會進化。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "噴吐光束"
+	attacks: [
+		{
+			name: {
+				ja: "スピットビーム",
+				'zh-tw': "噴吐光束",
+			},
+			damage: 20,
+			cost: ["Grass"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Grass"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575557,
+				tcgplayer: 569508,
+			},
+		},
+	],
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [616],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/008.ts
+++ b/data-asia/S/S8/008.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "敏捷蟲"
+		ja: "アギルダー",
+		'zh-tw': "敏捷蟲",
 	},
 
 	illustrator: "nagimiso",
@@ -14,31 +14,48 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "脫殼後變得更輕巧了。為了防止乾燥，會將帶狀的黏膜裹在身上。"
+		ja: "殻を 脱ぎ捨て 身軽に なった。 帯状の 粘膜を 体に 巻きつけ 乾燥を 防ぐ。",
+		'zh-tw': "脫殼後變得更輕巧了。為了防止乾燥，會將帶狀的黏膜裹在身上。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "忍者龍捲風"
+	attacks: [
+		{
+			name: {
+				ja: "ニンジャトルネード",
+				'zh-tw': "忍者龍捲風",
+			},
+			damage: 120,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "この番、このポケモンがベンチからバトル場に出ていたなら、このワザは【草】エネルギー1個で使える。",
+				'zh-tw': "在這個回合，若從備戰區將這隻寶可夢放置於戰鬥場，則這個招式只需要1個【草】能量即可使用。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在這個回合，若從備戰區將這隻寶可夢放置於戰鬥場，則這個招式只需要1個【草】能量即可使用。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575558,
+				tcgplayer: 569509,
+			},
 		},
+	],
 
-		damage: 120,
-		cost: ["Grass", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "チョボマキ",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [617],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/009.ts
+++ b/data-asia/S/S8/009.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "畢力吉翁"
+		ja: "ビリジオン",
+		'zh-tw': "畢力吉翁",
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -14,37 +14,51 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "傳說中，牠會以輕快的動作戲弄對手，並保護寶可夢。"
+		ja: "素早い 身のこなしで 相手を 翻弄して ポケモンを 守ると 伝説で 伝えられている。",
+		'zh-tw': "傳說中，牠會以輕快的動作戲弄對手，並保護寶可夢。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "救出"
+	attacks: [
+		{
+			name: {
+				ja: "すくいだす",
+				'zh-tw': "救出",
+			},
+			cost: ["Grass"],
+			effect: {
+				ja: "自分のトラッシュからポケモンを2枚まで選び、相手に見せて、手札に加える。",
+				'zh-tw': "從自己的棄牌區選擇最多2張寶可夢卡，在給對手看過後加入手牌。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的棄牌區選擇最多2張寶可夢卡，在給對手看過後加入手牌。"
+		{
+			name: {
+				ja: "ソーラービーム",
+				'zh-tw': "日光束",
+			},
+			damage: 90,
+			cost: ["Grass", "Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Grass"]
-	}, {
-		name: {
-			'zh-tw': "日光束"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575559,
+				tcgplayer: 569510,
+			},
 		},
-
-		damage: 90,
-		cost: ["Grass", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [640],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/010.ts
+++ b/data-asia/S/S8/010.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "強顎雞母蟲"
+		ja: "アゴジムシ",
+		'zh-tw': "強顎雞母蟲",
 	},
 
 	illustrator: "Asako Ito",
@@ -14,41 +14,55 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "會用巨大的顎部在森林中挖地製造巢穴。最喜歡甜甜的樹汁。"
+		ja: "大きな 顎で 森の 地面を 掘って 巣穴を つくる。 甘い 樹液が 大好物。",
+		'zh-tw': "會用巨大的顎部在森林中挖地製造巢穴。最喜歡甜甜的樹汁。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "帶電"
+	attacks: [
+		{
+			name: {
+				ja: "たいでん",
+				'zh-tw': "帶電",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュから[雷]エネルギーを1枚選び、このポケモンにつける。",
+				'zh-tw': "從自己的棄牌區選擇1張【雷】能量卡，附於這隻寶可夢身上。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的棄牌區選擇1張【雷】能量卡，附於這隻寶可夢身上。"
+		{
+			name: {
+				ja: "ふいをつく",
+				'zh-tw': "偷襲",
+			},
+			damage: 50,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+				'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "偷襲"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575560,
+				tcgplayer: 569511,
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。"
-		},
-
-		damage: 50,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [736],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/011.ts
+++ b/data-asia/S/S8/011.ts
@@ -1,40 +1,52 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "甜冷美后V"
+		ja: "アマージョV",
+		'zh-tw': "甜冷美后V",
 	},
 
 	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Grass"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "皇后命令"
+	attacks: [
+		{
+			name: {
+				ja: "クイーンオーダー",
+				'zh-tw': "皇后命令",
+			},
+			damage: "20+",
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "自分のベンチポケモンを好きなだけトラッシュし、トラッシュしたベンチポケモンの数×40ダメージ追加。",
+				'zh-tw': "將自己的任意數量的備戰寶可夢丟棄，增加丟棄的備戰寶可夢的數量×40點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將自己的任意數量的備戰寶可夢丟棄，增加丟棄的備戰寶可夢的數量×40點傷害。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 575561,
+				tcgplayer: 569512,
+			},
 		},
-
-		damage: "20+",
-		cost: ["Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [763],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/012.ts
+++ b/data-asia/S/S8/012.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "卡蒂狗"
+		ja: "ガーディ",
+		'zh-tw': "卡蒂狗",
 	},
 
 	illustrator: "Narumi Sato",
@@ -14,37 +14,51 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "性格忠誠。為了保護自己的訓練家，會拼命地朝對手狂吠。"
+		ja: "忠実な 性格で 親の トレーナーを 守るため 必死に 相手に 吠えかかる。",
+		'zh-tw': "性格忠誠。為了保護自己的訓練家，會拼命地朝對手狂吠。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "升溫"
+	attacks: [
+		{
+			name: {
+				ja: "あたためる",
+				'zh-tw': "升溫",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から[炎]エネルギーを1枚選び、自分のポケモンにつける。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張【火】能量卡，附於自己的寶可夢身上。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張【火】能量卡，附於自己的寶可夢身上。並且重洗牌庫。"
+		{
+			name: {
+				ja: "かえん",
+				'zh-tw': "烈焰",
+			},
+			damage: 30,
+			cost: ["Fire", "Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "烈焰"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575567,
+				tcgplayer: 569513,
+			},
 		},
-
-		damage: 30,
-		cost: ["Fire", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [58],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/013.ts
+++ b/data-asia/S/S8/013.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "風速狗"
+		ja: "ウインディ",
+		'zh-tw': "風速狗",
 	},
 
 	illustrator: "Yuu Nishida",
@@ -14,38 +14,56 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "從古時候起就是擄獲眾多人心的美麗寶可夢。能像飛一樣輕盈地奔跑。"
+		ja: "昔から 多くの 人を 虜にした 美しい ポケモン。 飛ぶように 軽やかに 走る。",
+		'zh-tw': "從古時候起就是擄獲眾多人心的美麗寶可夢。能像飛一樣輕盈地奔跑。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "火之爪"
+	attacks: [
+		{
+			name: {
+				ja: "ほのおのツメ",
+				'zh-tw': "火之爪",
+			},
+			damage: 40,
+			cost: ["Fire"],
 		},
-
-		damage: 40,
-		cost: ["Fire"]
-	}, {
-		name: {
-			'zh-tw': "熱力衝撞"
+		{
+			name: {
+				ja: "ヒートタックル",
+				'zh-tw': "熱力衝撞",
+			},
+			damage: 160,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+				'zh-tw': "這隻寶可夢也受到30點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢也受到30點傷害。"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575568,
+				tcgplayer: 569514,
+			},
 		},
+	],
 
-		damage: 160,
-		cost: ["Fire", "Fire", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ガーディ",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [59],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/014.ts
+++ b/data-asia/S/S8/014.ts
@@ -1,50 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "水晶燈火靈V"
+		ja: "シャンデラV",
+		'zh-tw': "水晶燈火靈V",
 	},
 
 	illustrator: "Saki Hayashiro",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Fire"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "奇異之光"
+	attacks: [
+		{
+			name: {
+				ja: "あやしいひかり",
+				'zh-tw': "奇異之光",
+			},
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【混亂】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【混亂】。"
+		{
+			name: {
+				ja: "ポルターガイスト",
+				'zh-tw': "靈騷",
+			},
+			damage: "40×",
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "相手の手札を見て、その中にあるトレーナーズの枚数×40ダメージ。",
+				'zh-tw': "查看對手的手牌，造成其中訓練家卡的張數×40點傷害。",
+			},
 		},
+	],
 
-		cost: ["Fire"]
-	}, {
-		name: {
-			'zh-tw': "靈騷"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 575569,
+				tcgplayer: 569515,
+			},
 		},
-
-		effect: {
-			'zh-tw': "查看對手的手牌，造成其中訓練家卡的張數×40點傷害。"
-		},
-
-		damage: "40×",
-		cost: ["Fire", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [609],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/015.ts
+++ b/data-asia/S/S8/015.ts
@@ -1,51 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "水晶燈火靈VMAX"
+		ja: "シャンデラVMAX",
+		'zh-tw': "水晶燈火靈VMAX",
 	},
 
 	illustrator: "AKIRA EGAWA",
 	category: "Pokemon",
 	hp: 320,
 	types: ["Fire"],
+
 	stage: "VMAX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "咒縛陽炎"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "じゅばくのかげろう",
+				'zh-tw': "咒縛陽炎",
+			},
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手は手札から「ポケモンのどうぐ」を出してつけられない。",
+				'zh-tw': "只要這隻寶可夢在戰鬥場上，對手無法從手牌使出並附上「寶可夢道具」。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在戰鬥場上，對手無法從手牌使出並附上「寶可夢道具」。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "極巨靈騷"
+	attacks: [
+		{
+			name: {
+				ja: "ダイポルターガイスト",
+				'zh-tw': "極巨靈騷",
+			},
+			damage: "70×",
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "相手の手札を見て、その中にあるトレーナーズの枚数×70ダメージ。",
+				'zh-tw': "查看對手的手牌，造成其中訓練家卡的張數×70點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "查看對手的手牌，造成其中訓練家卡的張數×70點傷害。"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 575570,
+				tcgplayer: 569516,
+			},
 		},
+	],
 
-		damage: "70×",
-		cost: ["Fire", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "シャンデラV",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Triple Rare",
+	dexId: [609],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/016.ts
+++ b/data-asia/S/S8/016.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "熔蟻獸"
+		ja: "クイタラン",
+		'zh-tw': "熔蟻獸",
 	},
 
 	illustrator: "Oswaldo KATO",
@@ -14,42 +14,56 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "將火焰當成舌頭來使用。會一點一點地熔化鐵蟻堅硬的外骨骼，然後把牠吃掉。"
+		ja: "炎を ベロの ように 使う。 アイアントの 硬い 外骨格を じわじわと 溶かし いただくのだ。",
+		'zh-tw': "將火焰當成舌頭來使用。會一點一點地熔化鐵蟻堅硬的外骨骼，然後把牠吃掉。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "火焰纏身"
+	attacks: [
+		{
+			name: {
+				ja: "ほのおをまとう",
+				'zh-tw': "火焰纏身",
+			},
+			damage: 20,
+			cost: ["Fire"],
+			effect: {
+				ja: "自分のトラッシュから[炎]エネルギーを1枚選び、このポケモンにつける。",
+				'zh-tw': "從自己的棄牌區選擇1張【火】能量卡，附於這隻寶可夢身上。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的棄牌區選擇1張【火】能量卡，附於這隻寶可夢身上。"
+		{
+			name: {
+				ja: "エキサイトフレイム",
+				'zh-tw': "激動火焰",
+			},
+			damage: 90,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このワザを使うためのエネルギーより、3個多くエネルギーがついているなら、相手のベンチポケモン1匹にも、180ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "若身上附有的能量比使用這個招式所需的能量多3個，則對手的1隻備戰寶可夢也受到180點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		damage: 20,
-		cost: ["Fire"]
-	}, {
-		name: {
-			'zh-tw': "激動火焰"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575571,
+				tcgplayer: 569517,
+			},
 		},
-
-		effect: {
-			'zh-tw': "若身上附有的能量比使用這個招式所需的能量多3個，則對手的1隻備戰寶可夢也受到180點傷害。[在備戰區不計算弱點・抵抗力。]"
-		},
-
-		damage: 90,
-		cost: ["Fire", "Fire", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [631],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/017.ts
+++ b/data-asia/S/S8/017.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "花舞鳥"
+		ja: "オドリドリ",
+		'zh-tw': "花舞鳥",
 	},
 
 	illustrator: "Oswaldo KATO",
@@ -14,42 +14,57 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "吸食了朱紅色花蜜的花舞鳥。訓練家如果做出了錯誤的指示，感情起伏激烈的牠就會非常生氣。"
+		ja: "くれないのミツを 吸った オドリドリ。 トレーナーが 指示を 間違えると 激しく 怒る 激情家 だ。",
+		'zh-tw': "吸食了朱紅色花蜜的花舞鳥。訓練家如果做出了錯誤的指示，感情起伏激烈的牠就會非常生氣。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "熱血練習"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ねっけつレッスン",
+				'zh-tw': "熱血練習",
+			},
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の「フュージョン」のポケモン全員が、相手のポケモンから受けるワザのダメージは「-20」される。この効果は、この特性を持つポケモンが何匹いても、重ならない。",
+				'zh-tw': "只要這隻寶可夢在場上，自己的所有「匯流」寶可夢，受到對手的寶可夢招式的傷害「-20」點。無論有多少隻擁有這個特性的寶可夢，這個效果也不會重複。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在場上，自己的所有「匯流」寶可夢，受到對手的寶可夢招式的傷害「-20」點。無論有多少隻擁有這個特性的寶可夢，這個效果也不會重複。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "熱情水滴"
+	attacks: [
+		{
+			name: {
+				ja: "じょうねつのしずく",
+				'zh-tw': "熱情水滴",
+			},
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "ダメカン5個を、相手のポケモンに好きなようにのせる。",
+				'zh-tw': "將5個傷害指示物以任意方式放置於對手的寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將5個傷害指示物以任意方式放置於對手的寶可夢身上。"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575572,
+				tcgplayer: 569518,
+			},
 		},
-
-		cost: ["Fire", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [741],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/018.ts
+++ b/data-asia/S/S8/018.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "海星星"
+		ja: "ヒトデマン",
+		'zh-tw': "海星星",
 	},
 
 	illustrator: "tetsuya koizumi",
@@ -14,37 +14,51 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "不管受多少傷都不怕。由於再生能力很強，只要半天左右就會復原。"
+		ja: "いくら 傷ついても 平気。 再生能力が 高いので 半日ぐらいで 元に 戻るぞ。",
+		'zh-tw': "不管受多少傷都不怕。由於再生能力很強，只要半天左右就會復原。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "泡水"
+	attacks: [
+		{
+			name: {
+				ja: "みずにひたる",
+				'zh-tw': "泡水",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札から[水]エネルギーを1枚選び、このポケモンにつける。",
+				'zh-tw': "從自己的手牌選擇1張【水】能量卡，附於這隻寶可夢身上。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的手牌選擇1張【水】能量卡，附於這隻寶可夢身上。"
+		{
+			name: {
+				ja: "かいてんアタック",
+				'zh-tw': "迴轉攻擊",
+			},
+			damage: 10,
+			cost: ["Water"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "迴轉攻擊"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575573,
+				tcgplayer: 569519,
+			},
 		},
-
-		damage: 10,
-		cost: ["Water"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [120],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/019.ts
+++ b/data-asia/S/S8/019.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "寶石海星"
+		ja: "スターミー",
+		'zh-tw': "寶石海星",
 	},
 
 	illustrator: "Uta",
@@ -14,30 +14,47 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "會轉動像幾何圖形般的身體在水中游動。似乎一直在發射神秘的電波。"
+		ja: "幾何学的な ボディを 回転し 水中を 泳ぐ。 常に 謎の 電波を 発信して いるらしい。",
+		'zh-tw': "會轉動像幾何圖形般的身體在水中游動。似乎一直在發射神秘的電波。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "連彈星星"
+	attacks: [
+		{
+			name: {
+				ja: "れんだんスター",
+				'zh-tw': "連彈星星",
+			},
+			cost: ["Water"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーを好きなだけトラッシュし、その枚数ぶん、相手のポケモンを選ぶ（1匹を2回以上選べる）。その後、選んだポケモン全員に、弱点・抵抗力を計算せず、選んだ回数×30ダメージ。",
+				'zh-tw': "將這隻寶可夢身上附加的任意數量的【水】能量卡丟棄，以其張數選擇對手的寶可夢（1隻可選擇2次以上）。然後，對所選的所有寶可夢不計算弱點・抵抗力，造成其選擇次數×30點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將這隻寶可夢身上附加的任意數量的【水】能量卡丟棄，以其張數選擇對手的寶可夢（1隻可選擇2次以上）。然後，對所選的所有寶可夢不計算弱點・抵抗力，造成其選擇次數×30點傷害。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 575574,
+				tcgplayer: 569520,
+			},
 		},
+	],
 
-		cost: ["Water"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ヒトデマン",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [121],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/020.ts
+++ b/data-asia/S/S8/020.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "小鋸鱷"
+		ja: "ワニノコ",
+		'zh-tw': "小鋸鱷",
 	},
 
 	illustrator: "Mizue",
@@ -14,27 +14,40 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "發達的雙顎充滿了力量，不管什麼東西都能咬碎，所以就算是牠的訓練家也要當心。"
+		ja: "発達した アゴは パワフルで なんでも かみくだいて しまうので 親のトレーナーでも 要注意。",
+		'zh-tw': "發達的雙顎充滿了力量，不管什麼東西都能咬碎，所以就算是牠的訓練家也要當心。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "潑水"
+	attacks: [
+		{
+			name: {
+				ja: "みずかけ",
+				'zh-tw': "潑水",
+			},
+			damage: 20,
+			cost: ["Water"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Water"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575575,
+				tcgplayer: 569521,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [158],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/021.ts
+++ b/data-asia/S/S8/021.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "藍鱷"
+		ja: "アリゲイツ",
+		'zh-tw': "藍鱷",
 	},
 
 	illustrator: "Tomokazu Komiya",
@@ -14,34 +14,52 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "一旦咬住，除非牙齒脫落，否則絕不會鬆口。脫落的牙齒馬上就能再長出來。"
+		ja: "一度 かみつくと キバが 抜けるまで 絶対に 離さない。 抜けた キバは すぐに 生えてくる。",
+		'zh-tw': "一旦咬住，除非牙齒脫落，否則絕不會鬆口。脫落的牙齒馬上就能再長出來。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "飛濺"
+	attacks: [
+		{
+			name: {
+				ja: "スプラッシュ",
+				'zh-tw': "飛濺",
+			},
+			damage: 30,
+			cost: ["Water"],
 		},
-
-		damage: 30,
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "衝浪"
+		{
+			name: {
+				ja: "なみのり",
+				'zh-tw': "衝浪",
+			},
+			damage: 60,
+			cost: ["Water", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 60,
-		cost: ["Water", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575576,
+				tcgplayer: 569522,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ワニノコ",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [159],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/022.ts
+++ b/data-asia/S/S8/022.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "大力鱷"
+		ja: "オーダイル",
+		'zh-tw': "大力鱷",
 	},
 
 	illustrator: "Anesaki Dynamic",
@@ -14,43 +14,62 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "會用大而有力的雙顎咬住對手然後甩動脖子，將對手撕成碎片。"
+		ja: "大きく 力強い アゴで かみつくと そのまま 首を振って 相手を ずたずたに 引きちぎる。",
+		'zh-tw': "會用大而有力的雙顎咬住對手然後甩動脖子，將對手撕成碎片。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "暴徒"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "あばれんぼう",
+				'zh-tw': "暴徒",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、必ず1回使う。コインを1回投げオモテなら、相手の山札を上から5枚トラッシュする。ウラなら、自分の山札を上から5枚トラッシュする。",
+				'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，一定要使用1次。擲1次硬幣若為正面，則將對手的牌庫上方5張卡丟棄。若為反面，則將自己的牌庫上方5張卡丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，一定要使用1次。擲1次硬幣若為正面，則將對手的牌庫上方5張卡丟棄。若為反面，則將自己的牌庫上方5張卡丟棄。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "咬碎"
+	attacks: [
+		{
+			name: {
+				ja: "かみくだく",
+				'zh-tw': "咬碎",
+			},
+			damage: 140,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 575577,
+				tcgplayer: 569523,
+			},
 		},
+	],
 
-		damage: 140,
-		cost: ["Water", "Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "アリゲイツ",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [160],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/023.ts
+++ b/data-asia/S/S8/023.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "珍珠貝"
+		ja: "パールル",
+		'zh-tw': "珍珠貝",
 	},
 
 	illustrator: "Anesaki Dynamic",
@@ -14,27 +14,40 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "珍珠貝的珍珠非常貴重，據說價值是大舌貝所產珍珠的１０倍以上。"
+		ja: "パールルの 真珠は とても 貴重。 シェルダーの 真珠の １０倍以上 価値が あるとも。",
+		'zh-tw': "珍珠貝的珍珠非常貴重，據說價值是大舌貝所產珍珠的１０倍以上。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "泡沫濺射"
+	attacks: [
+		{
+			name: {
+				ja: "はじけるあわ",
+				'zh-tw': "泡沫濺射",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
+	],
 
-		damage: 10,
-		cost: ["Colorless"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575578,
+				tcgplayer: 569524,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [366],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/024.ts
+++ b/data-asia/S/S8/024.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "獵斑魚"
+		ja: "ハンテール",
+		'zh-tw': "獵斑魚",
 	},
 
 	illustrator: "otumami",
@@ -14,39 +14,58 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "棲息在深海中。傳說如果有獵斑魚被沖上沙灘，就會有不好的事發生。"
+		ja: "深海に 生息。 ハンテールが 浜に 打ちあがると 不吉なことが 起こるという 言い伝えが ある。",
+		'zh-tw': "棲息在深海中。傳說如果有獵斑魚被沖上沙灘，就會有不好的事發生。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "妨礙一擊者"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "いちげきジャマー",
+				'zh-tw': "妨礙一擊者",
+			},
+			effect: {
+				ja: "このポケモンがいるかぎり、相手の「いちげき」のポケモンは、ワザを使うためのエネルギーが、【無】エネルギー1個ぶん多くなる。",
+				'zh-tw': "只要這隻寶可夢在場上，對手的「一擊」寶可夢使用招式所需的能量增加1個【無】能量。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在場上，對手的「一擊」寶可夢使用招式所需的能量增加1個【無】能量。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "深咬"
+	attacks: [
+		{
+			name: {
+				ja: "ばっくりバイト",
+				'zh-tw': "深咬",
+			},
+			damage: 80,
+			cost: ["Water", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 80,
-		cost: ["Water", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575579,
+				tcgplayer: 569525,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "パールル",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [367],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/025.ts
+++ b/data-asia/S/S8/025.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "櫻花魚"
+		ja: "サクラビス",
+		'zh-tw': "櫻花魚",
 	},
 
 	illustrator: "Misa Tsutsui",
@@ -14,43 +14,62 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "會吸取獵物的體液。剩下的肉會沉入海底，成為其他寶可夢的食物。"
+		ja: "獲物の 体液を 吸う。 肉は 海底に 沈み 他の ポケモンの エサに なるのだ。",
+		'zh-tw': "會吸取獵物的體液。剩下的肉會沉入海底，成為其他寶可夢的食物。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "連擊消弭"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "れんげきキャンセラー",
+				'zh-tw': "連擊消弭",
+			},
+			effect: {
+				ja: "このポケモンがいるかぎり、相手の場の「れんげき」のポケモンの特性は、すべてなくなる。",
+				'zh-tw': "只要這隻寶可夢在場上，對手的場上「連擊」寶可夢的特性全部消除。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在場上，對手的場上「連擊」寶可夢的特性全部消除。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "吸取之吻"
+	attacks: [
+		{
+			name: {
+				ja: "ドレインキッス",
+				'zh-tw': "吸取之吻",
+			},
+			damage: 50,
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+				'zh-tw': "將這隻寶可夢恢復「30」HP。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將這隻寶可夢恢復「30」HP。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575580,
+				tcgplayer: 569526,
+			},
 		},
+	],
 
-		damage: 50,
-		cost: ["Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "パールル",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [368],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/026.ts
+++ b/data-asia/S/S8/026.ts
@@ -1,50 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "好勝毛蟹V"
+		ja: "ケケンカニV",
+		'zh-tw': "好勝毛蟹V",
 	},
 
 	illustrator: "MUGENUP",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Water"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "起崩"
+	attacks: [
+		{
+			name: {
+				ja: "なだれおこし",
+				'zh-tw': "起崩",
+			},
+			cost: ["Water"],
+			effect: {
+				ja: "相手の山札を上から2枚トラッシュする。",
+				'zh-tw': "將對手的牌庫上方2張卡丟棄。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的牌庫上方2張卡丟棄。"
+		{
+			name: {
+				ja: "デストロイヤーパンチ",
+				'zh-tw': "破壞者之拳",
+			},
+			damage: "90+",
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにのっているダメカンの数×60ダメージ追加。",
+				'zh-tw': "增加對手的戰鬥寶可夢身上放置的傷害指示物的數量×60點傷害。",
+			},
 		},
+	],
 
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "破壞者之拳"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 575581,
+				tcgplayer: 569527,
+			},
 		},
-
-		effect: {
-			'zh-tw': "增加對手的戰鬥寶可夢身上放置的傷害指示物的數量×60點傷害。"
-		},
-
-		damage: "90+",
-		cost: ["Water", "Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	],
 
 	retreat: 4,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [740],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/027.ts
+++ b/data-asia/S/S8/027.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "拳海參"
+		ja: "ナマコブシ",
+		'zh-tw': "拳海參",
 	},
 
 	illustrator: "Tomokazu Komiya",
@@ -14,39 +14,54 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "覆蓋著皮膚的黏液具有出眾的保濕效果，即使在陸地上待好幾天也不會乾掉。"
+		ja: "保湿効果に 優れた 粘液が 皮膚を 被っているので 何日も 陸地に いても 干からびない。",
+		'zh-tw': "覆蓋著皮膚的黏液具有出眾的保濕效果，即使在陸地上待好幾天也不會乾掉。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "拳海參上投"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ナマコブシなげ",
+				'zh-tw': "拳海參上投",
+			},
+			effect: {
+				ja: "このカードが手札にあるなら、自分の番に1回使える。このカードを山札の下にもどす。その後、自分の山札を1枚引く。この番、すでに別の「ナマコブシなげ」を使っていたなら、この特性は使えない。",
+				'zh-tw': "若手牌有這張卡，則在自己的回合時可使用1次。將這張卡放回牌庫下方。然後，從自己的牌庫抽出1張卡。在這個回合，若已經使出了其他的「拳海參上投」，則這個特性無法使用。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若手牌有這張卡，則在自己的回合時可使用1次。將這張卡放回牌庫下方。然後，從自己的牌庫抽出1張卡。在這個回合，若已經使出了其他的「拳海參上投」，則這個特性無法使用。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "拳骨"
+	attacks: [
+		{
+			name: {
+				ja: "げんこつ",
+				'zh-tw': "拳骨",
+			},
+			damage: 50,
+			cost: ["Water", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 50,
-		cost: ["Water", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575582,
+				tcgplayer: 569528,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [771],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/028.ts
+++ b/data-asia/S/S8/028.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雪吞蟲"
+		ja: "ユキハミ",
+		'zh-tw': "雪吞蟲",
 	},
 
 	illustrator: "Yuka Morii",
@@ -14,30 +14,43 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "會吃地面上的積雪。吃得越多，背上的刺就會長得越挺拔。"
+		ja: "地面に 積もった 雪を 食べる。 たくさん 食べれば 食べるほど 背中の 棘は 立派に 育つ。",
+		'zh-tw': "會吃地面上的積雪。吃得越多，背上的刺就會長得越挺拔。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "冰之呼喚"
+	attacks: [
+		{
+			name: {
+				ja: "アイスコール",
+				'zh-tw': "冰之呼喚",
+			},
+			cost: ["Water"],
+			effect: {
+				ja: "自分の山札から[水]エネルギーを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多2張【水】能量卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多2張【水】能量卡，在給對手看過後加入手牌。並且重洗牌庫。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575583,
+				tcgplayer: 569529,
+			},
 		},
-
-		cost: ["Water"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [872],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/029.ts
+++ b/data-asia/S/S8/029.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雪絨蛾"
+		ja: "モスノウ",
+		'zh-tw': "雪絨蛾",
 	},
 
 	illustrator: "chibi",
@@ -14,41 +14,59 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "絕不放過破壞山野環境的人。會用冰冷的翅膀四處飛翔，製造出暴風雪來懲罰他們。"
+		ja: "野山を 荒らすものには 容赦 しない。 冷たいはねで 飛びまわり 吹雪を 起こして 懲らしめる。",
+		'zh-tw': "絕不放過破壞山野環境的人。會用冰冷的翅膀四處飛翔，製造出暴風雪來懲罰他們。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "冰凍之風"
+	attacks: [
+		{
+			name: {
+				ja: "こごえるかぜ",
+				'zh-tw': "冰凍之風",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【睡眠】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【睡眠】。"
+		{
+			name: {
+				ja: "ブリザードループ",
+				'zh-tw': "暴雪閉環",
+			},
+			damage: 160,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、すべて手札にもどす。",
+				'zh-tw': "將這隻寶可夢身上附加的能量全部放回手牌。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "暴雪閉環"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575584,
+				tcgplayer: 569530,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將這隻寶可夢身上附加的能量全部放回手牌。"
-		},
-
-		damage: 160,
-		cost: ["Water", "Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ユキハミ",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [873],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/030.ts
+++ b/data-asia/S/S8/030.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "傘電蜥"
+		ja: "エリキテル",
+		'zh-tw': "傘電蜥",
 	},
 
 	illustrator: "Mina Nakai",
@@ -14,34 +14,48 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "擁有太陽能發電的結構。如果有人打擾牠發電，牠就會因心理壓力而衰弱。"
+		ja: "太陽発電の 仕組みを もつ。 発電を じゃま されると ストレスで 弱ってしまう。",
+		'zh-tw': "擁有太陽能發電的結構。如果有人打擾牠發電，牠就會因心理壓力而衰弱。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "咬"
+	attacks: [
+		{
+			name: {
+				ja: "かじる",
+				'zh-tw': "咬",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
-
-		damage: 10,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "電球"
+		{
+			name: {
+				ja: "エレキボール",
+				'zh-tw': "電球",
+			},
+			damage: 20,
+			cost: ["Lightning", "Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Lightning", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575585,
+				tcgplayer: 569531,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [694],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/031.ts
+++ b/data-asia/S/S8/031.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "光電傘蜥"
+		ja: "エレザード",
+		'zh-tw': "光電傘蜥",
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -14,38 +14,56 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "如果展開頸傘沐浴陽光，單憑１隻光電傘蜥就能製造出大城市所需的電力。"
+		ja: "襟巻を 広げて 太陽光を 浴びると 大都会で 使われる 電気を １匹で 発電する。",
+		'zh-tw': "如果展開頸傘沐浴陽光，單憑１隻光電傘蜥就能製造出大城市所需的電力。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "咬"
+	attacks: [
+		{
+			name: {
+				ja: "かじる",
+				'zh-tw': "咬",
+			},
+			damage: 20,
+			cost: ["Colorless"],
 		},
-
-		damage: 20,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "電氣子彈"
+		{
+			name: {
+				ja: "エレキバレット",
+				'zh-tw': "電氣子彈",
+			},
+			damage: 60,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的1隻備戰寶可夢也受到20點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "對手的1隻備戰寶可夢也受到20點傷害。[在備戰區不計算弱點・抵抗力。]"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575586,
+				tcgplayer: 569532,
+			},
 		},
+	],
 
-		damage: 60,
-		cost: ["Lightning", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "エリキテル",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [695],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/032.ts
+++ b/data-asia/S/S8/032.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "蟲電寶"
+		ja: "デンヂムシ",
+		'zh-tw': "蟲電寶",
 	},
 
 	illustrator: "sowsow",
@@ -14,34 +14,52 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "蟲電寶消化吃掉的落葉時會產生電能。牠會把這些電能儲存在自己肚子上的電囊中。"
+		ja: "食べた 落ち葉を 消化するとき 発電する 仕組み。 お腹の 電気袋に 充電される。",
+		'zh-tw': "蟲電寶消化吃掉的落葉時會產生電能。牠會把這些電能儲存在自己肚子上的電囊中。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "夾住"
+	attacks: [
+		{
+			name: {
+				ja: "はさむ",
+				'zh-tw': "夾住",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
 		},
-
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "伏特頭擊"
+		{
+			name: {
+				ja: "ヘッドボルト",
+				'zh-tw': "伏特頭擊",
+			},
+			damage: 60,
+			cost: ["Lightning", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 60,
-		cost: ["Lightning", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575587,
+				tcgplayer: 569533,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アゴジムシ",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [737],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/033.ts
+++ b/data-asia/S/S8/033.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鍬農炮蟲"
+		ja: "クワガノン",
+		'zh-tw': "鍬農炮蟲",
 	},
 
 	illustrator: "nagimiso",
@@ -14,37 +14,55 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "如果牠在飛行時把蟲電寶抱住當作備用電池，就能連續發射電力超高的電磁光束。"
+		ja: "予備バッテリーとして デンヂムシを 抱えて 飛べば 大電力の 電磁ビームを 連射できる。",
+		'zh-tw': "如果牠在飛行時把蟲電寶抱住當作備用電池，就能連續發射電力超高的電磁光束。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "咬住"
+	attacks: [
+		{
+			name: {
+				ja: "かみつく",
+				'zh-tw': "咬住",
+			},
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
-
-		damage: 70,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "電氣引爆"
+		{
+			name: {
+				ja: "エレキブラスター",
+				'zh-tw': "電氣引爆",
+			},
+			cost: ["Lightning", "Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[雷]エネルギーを2個トラッシュし、相手のポケモン1匹に、200ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "將這隻寶可夢身上附加的2個【雷】能量丟棄，對手的1隻寶可夢受到200點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將這隻寶可夢身上附加的2個【雷】能量丟棄，對手的1隻寶可夢受到200點傷害。[在備戰區不計算弱點・抵抗力。]"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575588,
+				tcgplayer: 569534,
+			},
 		},
+	],
 
-		cost: ["Lightning", "Lightning", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "デンヂムシ",
+	},
 
 	retreat: 0,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [738],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/034.ts
+++ b/data-asia/S/S8/034.ts
@@ -1,51 +1,64 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "逐電犬V"
+		ja: "パルスワンV",
+		'zh-tw': "逐電犬V",
 	},
 
 	illustrator: "Shin Nagasawa",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Lightning"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "粉碎迴轉"
+	attacks: [
+		{
+			name: {
+				ja: "スマッシュターン",
+				'zh-tw': "粉碎迴轉",
+			},
+			damage: 30,
+			cost: ["Lightning"],
+			effect: {
+				ja: "のぞむなら、このポケモンをベンチポケモンと入れ替える。",
+				'zh-tw': "若希望，將這隻寶可夢與備戰寶可夢互換。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "若希望，將這隻寶可夢與備戰寶可夢互換。"
+		{
+			name: {
+				ja: "エレキバレット",
+				'zh-tw': "電氣子彈",
+			},
+			damage: 120,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的1隻備戰寶可夢也受到30點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Lightning"]
-	}, {
-		name: {
-			'zh-tw': "電氣子彈"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 575589,
+				tcgplayer: 569535,
+			},
 		},
-
-		effect: {
-			'zh-tw': "對手的1隻備戰寶可夢也受到30點傷害。[在備戰區不計算弱點・抵抗力。]"
-		},
-
-		damage: 120,
-		cost: ["Lightning", "Lightning", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [836],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/035.ts
+++ b/data-asia/S/S8/035.ts
@@ -1,50 +1,68 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "逐電犬VMAX"
+		ja: "パルスワンVMAX",
+		'zh-tw': "逐電犬VMAX",
 	},
 
 	illustrator: "PLANETA Tsuji",
 	category: "Pokemon",
 	hp: 320,
 	types: ["Lightning"],
+
 	stage: "VMAX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "雷電風暴"
+	attacks: [
+		{
+			name: {
+				ja: "ライトニングストーム",
+				'zh-tw': "雷電風暴",
+			},
+			damage: "30+",
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[雷]エネルギーの数×30ダメージ追加。",
+				'zh-tw': "增加自己的場上寶可夢身上附加的【雷】能量的數量×30點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "增加自己的場上寶可夢身上附加的【雷】能量的數量×30點傷害。"
+		{
+			name: {
+				ja: "ダイボルト",
+				'zh-tw': "極巨伏特",
+			},
+			damage: 230,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「ダイボルト」が使えない。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「極巨伏特」。",
+			},
 		},
+	],
 
-		damage: "30+",
-		cost: ["Lightning", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "極巨伏特"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 575590,
+				tcgplayer: 569536,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「極巨伏特」。"
-		},
-
-		damage: 230,
-		cost: ["Lightning", "Lightning", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "パルスワンV",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Triple Rare",
+	dexId: [836],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/036.ts
+++ b/data-asia/S/S8/036.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "毒電嬰"
+		ja: "エレズン",
+		'zh-tw': "毒電嬰",
 	},
 
 	illustrator: "kodama",
@@ -14,37 +14,51 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "透過讓自身的毒素產生化學反應來發電。電力雖然弱，卻能造成麻痺。"
+		ja: "毒素を 化学変化 させて 電気を 出す。 電力は 弱いが ビリビリと 痺れる。",
+		'zh-tw': "透過讓自身的毒素產生化學反應來發電。電力雖然弱，卻能造成麻痺。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "叫聲"
+	attacks: [
+		{
+			name: {
+				ja: "なきごえ",
+				'zh-tw': "叫聲",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-30」される。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢使用招式的傷害「-30」點。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢使用招式的傷害「-30」點。"
+		{
+			name: {
+				ja: "プチボルト",
+				'zh-tw': "小伏特",
+			},
+			damage: 10,
+			cost: ["Lightning"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "小伏特"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575591,
+				tcgplayer: 569537,
+			},
 		},
-
-		damage: 10,
-		cost: ["Lightning"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [848],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/037.ts
+++ b/data-asia/S/S8/037.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "顫弦蠑螈"
+		ja: "ストリンダー",
+		'zh-tw': "顫弦蠑螈",
 	},
 
 	illustrator: "nagimiso",
@@ -14,39 +14,58 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "發電器官長在胸部。當牠製造出電力的時候，會發出貝斯般的聲音。"
+		ja: "発電器官が 胸に ある。 電気が つくられるとき ベースのような 音が 響く。",
+		'zh-tw': "發電器官長在胸部。當牠製造出電力的時候，會發出貝斯般的聲音。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "極度洩氣"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "マックスダウナー",
+				'zh-tw': "極度洩氣",
+			},
+			effect: {
+				ja: "自分の場のポケモン全員が「フュージョン」のポケモンなら、はたらく。このポケモンがいるかぎり、相手の場の「ポケモンVMAX」全員の最大HPは、それぞれ「30」小さくなる。",
+				'zh-tw': "若自己的所有場上寶可夢皆為「匯流」寶可夢則生效。只要這隻寶可夢在場上，對手的場上的所有「寶可夢【VMAX】」的最大HP各減少「30」。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若自己的所有場上寶可夢皆為「匯流」寶可夢則生效。只要這隻寶可夢在場上，對手的場上的所有「寶可夢【VMAX】」的最大HP各減少「30」。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "伏特頭擊"
+	attacks: [
+		{
+			name: {
+				ja: "ヘッドボルト",
+				'zh-tw': "伏特頭擊",
+			},
+			damage: 90,
+			cost: ["Lightning", "Lightning", "Colorless"],
 		},
+	],
 
-		damage: 90,
-		cost: ["Lightning", "Lightning", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 575592,
+				tcgplayer: 569538,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "エレズン",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [849],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/038.ts
+++ b/data-asia/S/S8/038.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "迷唇姐"
+		ja: "ルージュラ",
+		'zh-tw': "迷唇姐",
 	},
 
 	illustrator: "Shigenori Negishi",
@@ -14,46 +14,55 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "奇異的叫聲聽起來就像是人類的語言。也有些音樂家會創作讓迷唇姐唱的曲子。"
+		ja: "人間の 言葉のような 不思議な 鳴き声。 ルージュラに 歌わせる 曲を 作る 音楽家もいる。",
+		'zh-tw': "奇異的叫聲聽起來就像是人類的語言。也有些音樂家會創作讓迷唇姐唱的曲子。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "雙重抽出"
+	attacks: [
+		{
+			name: {
+				ja: "ダブルドロー",
+				'zh-tw': "雙重抽出",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を2枚引く。",
+				'zh-tw': "從自己的牌庫抽出2張卡。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫抽出2張卡。"
+		{
+			name: {
+				ja: "げんわくダンス",
+				'zh-tw': "眩目舞",
+			},
+			damage: 30,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【混亂】。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "眩目舞"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575593,
+				tcgplayer: 569539,
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【混亂】。"
-		},
-
-		damage: 30,
-		cost: ["Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [124],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/039.ts
+++ b/data-asia/S/S8/039.ts
@@ -1,55 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "夢幻V"
+		ja: "ミュウV",
+		'zh-tw': "夢幻V",
 	},
 
 	illustrator: "Mitsuhiro Arita",
 	category: "Pokemon",
 	hp: 180,
 	types: ["Psychic"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "能量混和"
+	attacks: [
+		{
+			name: {
+				ja: "エナジーミックス",
+				'zh-tw': "能量混和",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の山札からエネルギーを1枚選び、自分の「フュージョン」のポケモンにつける。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張能量卡，附於自己的「匯流」寶可夢身上。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張能量卡，附於自己的「匯流」寶可夢身上。並且重洗牌庫。"
+		{
+			name: {
+				ja: "サイコジャンプ",
+				'zh-tw': "精神之跳",
+			},
+			damage: 70,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。",
+				'zh-tw': "若希望，將這隻寶可夢與附加的卡，全部放回自己的牌庫並重洗。",
+			},
 		},
+	],
 
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "精神之跳"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 575594,
+				tcgplayer: 569540,
+			},
 		},
-
-		effect: {
-			'zh-tw': "若希望，將這隻寶可夢與附加的卡，全部放回自己的牌庫並重洗。"
-		},
-
-		damage: 70,
-		cost: ["Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 0,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [151],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/040.ts
+++ b/data-asia/S/S8/040.ts
@@ -1,54 +1,67 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "夢幻VMAX"
+		ja: "ミュウVMAX",
+		'zh-tw': "夢幻VMAX",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 310,
 	types: ["Psychic"],
+
 	stage: "VMAX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "交錯匯流"
+	attacks: [
+		{
+			name: {
+				ja: "クロスフュージョン",
+				'zh-tw': "交錯匯流",
+			},
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチの「フュージョン」のポケモンが持っているワザを1つ選び、このワザとして使う。",
+				'zh-tw': "選擇自己的備戰區的「匯流」寶可夢持有的1個招式，作為這個招式使用。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇自己的備戰區的「匯流」寶可夢持有的1個招式，作為這個招式使用。"
+		{
+			name: {
+				ja: "ダイミラクル",
+				'zh-tw': "極巨奇跡",
+			},
+			damage: 130,
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+				'zh-tw': "這個招式的傷害不計算對手的戰鬥寶可夢身上的附加效果。",
+			},
 		},
+	],
 
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "極巨奇跡"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 575595,
+				tcgplayer: 569541,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這個招式的傷害不計算對手的戰鬥寶可夢身上的附加效果。"
-		},
-
-		damage: 130,
-		cost: ["Psychic", "Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ミュウV",
+	},
 
 	retreat: 0,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Triple Rare",
+	dexId: [151],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/041.ts
+++ b/data-asia/S/S8/041.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "布魯"
+		ja: "ブルー",
+		'zh-tw': "布魯",
 	},
 
 	illustrator: "Kyoko Umemoto",
@@ -14,34 +14,48 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "個性與外表相反，其實很膽小。要是把牠和其他小狗寶可夢放在一起，牠有可能會被欺負。"
+		ja: "見た目と 違って 臆病なので 他の こいぬポケモンと 一緒に すると いじめられることも ある。",
+		'zh-tw': "個性與外表相反，其實很膽小。要是把牠和其他小狗寶可夢放在一起，牠有可能會被欺負。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "頭錘"
+	attacks: [
+		{
+			name: {
+				ja: "ずつき",
+				'zh-tw': "頭錘",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
-
-		damage: 10,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "咬住"
+		{
+			name: {
+				ja: "かみつく",
+				'zh-tw': "咬住",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575596,
+				tcgplayer: 569542,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [209],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/042.ts
+++ b/data-asia/S/S8/042.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "布魯皇"
+		ja: "グランブル",
+		'zh-tw': "布魯皇",
 	},
 
 	illustrator: "Akira Komayama",
@@ -14,39 +14,58 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "雖然很受年輕女性歡迎，但牠不但膽小而且個性纖細，以看門狗來說一點用都沒有。"
+		ja: "若い 女性に 大人気だが 臆病な上に 繊細なので 番犬 としては 無能だ。",
+		'zh-tw': "雖然很受年輕女性歡迎，但牠不但膽小而且個性纖細，以看門狗來說一點用都沒有。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "抓取"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "つかみとる",
+				'zh-tw': "抓取",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分のトラッシュから「ポケモンのどうぐ」を2枚まで選び、相手に見せて、手札に加える。",
+				'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。從自己的棄牌區選擇最多2張「寶可夢道具」卡，在給對手看過後加入手牌。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。從自己的棄牌區選擇最多2張「寶可夢道具」卡，在給對手看過後加入手牌。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "咬住"
+	attacks: [
+		{
+			name: {
+				ja: "かみつく",
+				'zh-tw': "咬住",
+			},
+			damage: 90,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 90,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575597,
+				tcgplayer: 569543,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ブルー",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [210],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/043.ts
+++ b/data-asia/S/S8/043.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伽勒爾 太陽珊瑚"
+		ja: "ガラル サニーゴ",
+		'zh-tw': "伽勒爾 太陽珊瑚",
 	},
 
 	illustrator: "Kouki Saitou",
@@ -14,32 +14,40 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "牠是因急遽環境變化而死去的遠古太陽珊瑚。會用珊瑚枝吸取人的精氣。"
+		ja: "急な 環境の 変化で 死んだ 太古の サニーゴ。 枝で 人の 生気を 吸う。",
+		'zh-tw': "牠是因急遽環境變化而死去的遠古太陽珊瑚。會用珊瑚枝吸取人的精氣。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "撞擊"
+	attacks: [
+		{
+			name: {
+				ja: "たいあたり",
+				'zh-tw': "撞擊",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575598,
+				tcgplayer: 569544,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [222],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/044.ts
+++ b/data-asia/S/S8/044.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伽勒爾 魔靈珊瑚"
+		ja: "ガラル サニゴーン",
+		'zh-tw': "伽勒爾 魔靈珊瑚",
 	},
 
 	illustrator: "sui",
@@ -14,42 +14,55 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "一定要小心牠那包覆著靈魂的靈體。如果觸摸到，就會像石頭一樣動彈不得。"
+		ja: "魂を 被う 霊体の 体には 注意。 触れると 石のように 動けなく なるぞ。",
+		'zh-tw': "一定要小心牠那包覆著靈魂的靈體。如果觸摸到，就會像石頭一樣動彈不得。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "強迫再生"
+	attacks: [
+		{
+			name: {
+				ja: "おしつけさいせい",
+				'zh-tw': "強迫再生",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のトラッシュからたねポケモンの「ポケモンV」を1枚選び、相手のベンチに出す。その後、そのポケモンの残りHPが「30」になるように、ダメカンをのせる。",
+				'zh-tw': "從對手的棄牌區選擇1張【基礎】寶可夢的「寶可夢【V】」卡，放置於對手的備戰區。然後，在身上放置傷害指示物直到那隻寶可夢的剩餘HP變為「30」為止。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從對手的棄牌區選擇1張【基礎】寶可夢的「寶可夢【V】」卡，放置於對手的備戰區。然後，在身上放置傷害指示物直到那隻寶可夢的剩餘HP變為「30」為止。"
+		{
+			name: {
+				ja: "ホロウショット",
+				'zh-tw': "陰森射擊",
+			},
+			damage: 80,
+			cost: ["Psychic", "Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "陰森射擊"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575599,
+				tcgplayer: 569545,
+			},
 		},
+	],
 
-		damage: 80,
-		cost: ["Psychic", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ガラル サニーゴ",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [864],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/045.ts
+++ b/data-asia/S/S8/045.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "代歐奇希斯"
+		ja: "デオキシス",
+		'zh-tw': "代歐奇希斯",
 	},
 
 	illustrator: "Kouki Saitou",
@@ -14,36 +14,44 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "宇宙病毒發生突變後變成了寶可夢。出現在極光的附近。"
+		ja: "宇宙ウイルスが 突然変異を 起こして ポケモンに なった。 オーロラの 近くに 現れる。",
+		'zh-tw': "宇宙病毒發生突變後變成了寶可夢。出現在極光的附近。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "光子提昇"
+	attacks: [
+		{
+			name: {
+				ja: "フォトンブースト",
+				'zh-tw': "光子提昇",
+			},
+			damage: "80+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンに「フュージョンエネルギー」がついているなら、80ダメージ追加。",
+				'zh-tw': "若這隻寶可夢身上附有「匯流能量」，則增加80點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢身上附有「匯流能量」，則增加80點傷害。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 575600,
+				tcgplayer: 569546,
+			},
 		},
-
-		damage: "80+",
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [386],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/046.ts
+++ b/data-asia/S/S8/046.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "食夢夢"
+		ja: "ムンナ",
+		'zh-tw': "食夢夢",
 	},
 
 	illustrator: "miki kudo",
@@ -14,32 +14,40 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "在吃掉夢之後會吐出煙霧。吃了快樂的夢時，煙霧是粉紅色的；如果是惡夢，煙霧則是黑灰色的。"
+		ja: "夢を 食べて 煙を 吐く。 楽しい 夢なら ピンク色で 悪夢の ときは 黒っぽいぞ。",
+		'zh-tw': "在吃掉夢之後會吐出煙霧。吃了快樂的夢時，煙霧是粉紅色的；如果是惡夢，煙霧則是黑灰色的。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "衝撞"
+	attacks: [
+		{
+			name: {
+				ja: "ぶつかる",
+				'zh-tw': "衝撞",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
+	],
 
-		damage: 10,
-		cost: ["Colorless"]
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575601,
+				tcgplayer: 569547,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [517],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/047.ts
+++ b/data-asia/S/S8/047.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "夢夢蝕"
+		ja: "ムシャーナ",
+		'zh-tw': "夢夢蝕",
 	},
 
 	illustrator: "Tika Matsuno",
@@ -14,46 +14,59 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "總是在打瞌睡作夢。剛睡醒的時候會鬧脾氣，所以最好別去招惹牠。"
+		ja: "いつも まどろみ 夢を 見ている。 寝起きは とっても 不機嫌に なるので そっとして おこう。",
+		'zh-tw': "總是在打瞌睡作夢。剛睡醒的時候會鬧脾氣，所以最好別去招惹牠。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "誘導睡眠"
+	attacks: [
+		{
+			name: {
+				ja: "ねむりにさそう",
+				'zh-tw': "誘導睡眠",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、新しく出てきたポケモンをねむりにする。",
+				'zh-tw': "選擇對手的1隻備戰寶可夢，與戰鬥寶可夢互換。然後，將新上場的寶可夢【睡眠】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇對手的1隻備戰寶可夢，與戰鬥寶可夢互換。然後，將新上場的寶可夢【睡眠】。"
+		{
+			name: {
+				ja: "サイコキネシス",
+				'zh-tw': "精神強念",
+			},
+			damage: "30+",
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数×30ダメージ追加。",
+				'zh-tw': "增加對手的戰鬥寶可夢身上附加的能量的數量×30點傷害。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "精神強念"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575602,
+				tcgplayer: 569548,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加對手的戰鬥寶可夢身上附加的能量的數量×30點傷害。"
-		},
-
-		damage: "30+",
-		cost: ["Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ムンナ",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [518],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/048.ts
+++ b/data-asia/S/S8/048.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "美洛耶塔"
+		ja: "メロエッタ",
+		'zh-tw': "美洛耶塔",
 	},
 
 	illustrator: "kirisAki",
@@ -14,36 +14,44 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "以特殊的發聲法唱出的旋律，能自在地操控聽者的情緒。"
+		ja: "特殊な 発声法で 歌う メロディは 聞いた者の 感情を 自在に 操る。",
+		'zh-tw': "以特殊的發聲法唱出的旋律，能自在地操控聽者的情緒。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "旋律迴響"
+	attacks: [
+		{
+			name: {
+				ja: "メロディアスエコー",
+				'zh-tw': "旋律迴響",
+			},
+			damage: "70×",
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている「フュージョンエネルギー」の数×70ダメージ。",
+				'zh-tw': "造成自己的場上寶可夢身上附加的「匯流能量」的數量×70點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "造成自己的場上寶可夢身上附加的「匯流能量」的數量×70點傷害。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575603,
+				tcgplayer: 569549,
+			},
 		},
-
-		damage: "70×",
-		cost: ["Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [648],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/049.ts
+++ b/data-asia/S/S8/049.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "多龍梅西亞"
+		ja: "ドラメシヤ",
+		'zh-tw': "多龍梅西亞",
 	},
 
 	illustrator: "Teeziro",
@@ -14,36 +14,44 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "雖然單獨１隻弱得甚至敵不過小孩，但會和夥伴合作一起鍛鍊，透過進化而變得更強。"
+		ja: "１匹では 子どもにも 負けるくらい 非力だが 仲間の 協力で 鍛えられ 進化して 強くなる。",
+		'zh-tw': "雖然單獨１隻弱得甚至敵不過小孩，但會和夥伴合作一起鍛鍊，透過進化而變得更強。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "死纏爛打"
+	attacks: [
+		{
+			name: {
+				ja: "まとわりつく",
+				'zh-tw': "死纏爛打",
+			},
+			damage: 10,
+			cost: ["Psychic"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575604,
+				tcgplayer: 569550,
+			},
 		},
-
-		damage: 10,
-		cost: ["Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [885],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/050.ts
+++ b/data-asia/S/S8/050.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "多龍奇"
+		ja: "ドロンチ",
+		'zh-tw': "多龍奇",
 	},
 
 	illustrator: "HYOGONOSUKE",
@@ -14,43 +14,56 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "要是沒讓自己在照顧的多龍梅西亞乘在頭上就靜不下心來，甚至會因此試圖把別的寶可夢放到頭上。"
+		ja: "世話をする ドラメシヤを 頭に 乗せていないと 落ち着かないので ほかの ポケモンを 乗せようとする。",
+		'zh-tw': "要是沒讓自己在照顧的多龍梅西亞乘在頭上就靜不下心來，甚至會因此試圖把別的寶可夢放到頭上。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "陰森射擊"
+	attacks: [
+		{
+			name: {
+				ja: "ホロウショット",
+				'zh-tw': "陰森射擊",
+			},
+			damage: 20,
+			cost: ["Psychic"],
 		},
-
-		damage: 20,
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "急速折返"
+		{
+			name: {
+				ja: "とんぼがえり",
+				'zh-tw': "急速折返",
+			},
+			damage: 30,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+				'zh-tw': "將這隻寶可夢與備戰寶可夢互換。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將這隻寶可夢與備戰寶可夢互換。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575605,
+				tcgplayer: 569551,
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ドラメシヤ",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [886],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/051.ts
+++ b/data-asia/S/S8/051.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "多龍巴魯托"
+		ja: "ドラパルト",
+		'zh-tw': "多龍巴魯托",
 	},
 
 	illustrator: "Souichirou Gunjima",
@@ -14,43 +14,56 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "牠角裡的多龍梅西亞似乎滿心期待著能被以音速發射出去。"
+		ja: "ツノに 入った ドラメシヤは マッハの スピードで 飛ばされるのを 心待ちに しているらしい。",
+		'zh-tw': "牠角裡的多龍梅西亞似乎滿心期待著能被以音速發射出去。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "匯流進擊"
+	attacks: [
+		{
+			name: {
+				ja: "フュージョンアサルト",
+				'zh-tw': "匯流進擊",
+			},
+			damage: "30×",
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の場の「フュージョン」のポケモンの数×30ダメージ。",
+				'zh-tw': "造成自己的場上「匯流」寶可夢的數量×30點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "造成自己的場上「匯流」寶可夢的數量×30點傷害。"
+		{
+			name: {
+				ja: "スピードアタック",
+				'zh-tw': "高速攻擊",
+			},
+			damage: 120,
+			cost: ["Psychic", "Colorless"],
 		},
+	],
 
-		damage: "30×",
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "高速攻擊"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 575606,
+				tcgplayer: 569552,
+			},
 		},
+	],
 
-		damage: 120,
-		cost: ["Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ドロンチ",
+	},
 
 	retreat: 0,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [887],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/052.ts
+++ b/data-asia/S/S8/052.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "小拳石"
+		ja: "イシツブテ",
+		'zh-tw': "小拳石",
 	},
 
 	illustrator: "OKACHEKE",
@@ -14,34 +14,48 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "會用雙手攀登險峻的山崖。人們似乎是在目睹牠那姿態之後才開始了抱石攀岩運動。"
+		ja: "両手を 使い 険しい 崖を 登る。 その姿を 見た 人が ボルダリングを 始めたらしい。",
+		'zh-tw': "會用雙手攀登險峻的山崖。人們似乎是在目睹牠那姿態之後才開始了抱石攀岩運動。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "滾動"
+	attacks: [
+		{
+			name: {
+				ja: "ころがる",
+				'zh-tw': "滾動",
+			},
+			damage: 10,
+			cost: ["Fighting"],
 		},
-
-		damage: 10,
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "打擊"
+		{
+			name: {
+				ja: "なぐる",
+				'zh-tw': "打擊",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575607,
+				tcgplayer: 569553,
+			},
+		},
+	],
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [74],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/053.ts
+++ b/data-asia/S/S8/053.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "隆隆石"
+		ja: "ゴローン",
+		'zh-tw': "隆隆石",
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -14,34 +14,52 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "藉著從山崖上滾落來移動。如果不小心掉進河裡，就會在最後掙扎時來個大爆炸。"
+		ja: "崖を 転がり 移動する。 間違えて 川に 落ちると 最期の あがきで 大爆発。",
+		'zh-tw': "藉著從山崖上滾落來移動。如果不小心掉進河裡，就會在最後掙扎時來個大爆炸。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "撞擊"
+	attacks: [
+		{
+			name: {
+				ja: "たいあたり",
+				'zh-tw': "撞擊",
+			},
+			damage: 30,
+			cost: ["Fighting"],
 		},
-
-		damage: 30,
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "岩石粉碎"
+		{
+			name: {
+				ja: "ロックスマッシュ",
+				'zh-tw': "岩石粉碎",
+			},
+			damage: 70,
+			cost: ["Fighting", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 70,
-		cost: ["Fighting", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575608,
+				tcgplayer: 569554,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イシツブテ",
+	},
 
 	retreat: 4,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [75],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/054.ts
+++ b/data-asia/S/S8/054.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "隆隆岩"
+		ja: "ゴローニャ",
+		'zh-tw': "隆隆岩",
 	},
 
 	illustrator: "KEIICHIRO ITO",
@@ -14,43 +14,62 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "會讓自己的身體爆炸，然後利用爆炸的力量快速登上陡峭的山路。"
+		ja: "自分で 身体を 爆発させる。 そのパワーで 急な 山道も すごい スピードで 登っていく。",
+		'zh-tw': "會讓自己的身體爆炸，然後利用爆炸的力量快速登上陡峭的山路。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "自棄轟炸"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "やけくそボンバー",
+				'zh-tw': "自棄轟炸",
+			},
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けてきぜつしたとき、ワザを使ったポケモンにダメカンを10個のせる。",
+				'zh-tw': "當這隻寶可夢在戰鬥場上受到對手的寶可夢招式的傷害而【氣絕】時，在使用招式的寶可夢身上放置10個傷害指示物。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "當這隻寶可夢在戰鬥場上受到對手的寶可夢招式的傷害而【氣絕】時，在使用招式的寶可夢身上放置10個傷害指示物。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "捨身衝撞"
+	attacks: [
+		{
+			name: {
+				ja: "すてみタックル",
+				'zh-tw': "捨身衝撞",
+			},
+			damage: 160,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+				'zh-tw': "這隻寶可夢也受到30點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢也受到30點傷害。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575609,
+				tcgplayer: 569555,
+			},
 		},
+	],
 
-		damage: 160,
-		cost: ["Fighting", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ゴローン",
+	},
 
 	retreat: 4,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [76],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/055.ts
+++ b/data-asia/S/S8/055.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "大岩蛇"
+		ja: "イワーク",
+		'zh-tw': "大岩蛇",
 	},
 
 	illustrator: "KEIICHIRO ITO",
@@ -14,38 +14,52 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "彎曲扭動巨大結實的身體，以時速８０公里的猛烈勢頭挖掘前進。"
+		ja: "大きく 丈夫な 体を くねらせ よじらせ 時速８０キロで 地面を 勢いよく 掘り進む。",
+		'zh-tw': "彎曲扭動巨大結實的身體，以時速８０公里的猛烈勢頭挖掘前進。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "防守壓制"
+	attacks: [
+		{
+			name: {
+				ja: "ガードプレス",
+				'zh-tw': "防守壓制",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-30」點。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-30」點。"
+		{
+			name: {
+				ja: "いわおとし",
+				'zh-tw': "落石",
+			},
+			damage: 90,
+			cost: ["Fighting", "Fighting", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "落石"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575610,
+				tcgplayer: 569556,
+			},
 		},
-
-		damage: 90,
-		cost: ["Fighting", "Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	],
 
 	retreat: 4,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [95],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/056.ts
+++ b/data-asia/S/S8/056.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "大鋼蛇"
+		ja: "ハガネール",
+		'zh-tw': "大鋼蛇",
 	},
 
 	illustrator: "Ryuta Fuse",
@@ -14,42 +14,60 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "人們認為牠的身體是因為堆積了和泥土一起吞下的鐵質，才會發生變化的。"
+		ja: "土と 一緒に 飲みこんだ 鉄分が 溜まっていって 体が 変化したとも 考えられる。",
+		'zh-tw': "人們認為牠的身體是因為堆積了和泥土一起吞下的鐵質，才會發生變化的。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "强力激怒"
+	attacks: [
+		{
+			name: {
+				ja: "パワーレイジ",
+				'zh-tw': "强力激怒",
+			},
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数×20ダメージ。",
+				'zh-tw': "造成這隻寶可夢身上放置的傷害指示物的數量×20點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "造成這隻寶可夢身上放置的傷害指示物的數量×20點傷害。"
+		{
+			name: {
+				ja: "じしん",
+				'zh-tw': "地震",
+			},
+			damage: 180,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "自分のベンチポケモン全員にも、それぞれ30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "自己的所有備戰寶可夢也各受到30點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		damage: "20×",
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "地震"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 575611,
+				tcgplayer: 569557,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "自己的所有備戰寶可夢也各受到30點傷害。[在備戰區不計算弱點・抵抗力。]"
-		},
-
-		damage: 180,
-		cost: ["Fighting", "Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "イワーク",
+	},
 
 	retreat: 4,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [208],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/057.ts
+++ b/data-asia/S/S8/057.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "螺釘地鼠"
+		ja: "モグリュー",
+		'zh-tw': "螺釘地鼠",
 	},
 
 	illustrator: "tetsuya koizumi",
@@ -14,27 +14,40 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "會用爪子在地底挖掘前進。一些農民因為擔心牠會因此糟蹋蔬菜而討厭牠。"
+		ja: "ツメで 地中を 掘り進むので 育てた 野菜が 傷むと 農業関係者は 嫌う。",
+		'zh-tw': "會用爪子在地底挖掘前進。一些農民因為擔心牠會因此糟蹋蔬菜而討厭牠。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "抓"
+	attacks: [
+		{
+			name: {
+				ja: "ひっかく",
+				'zh-tw': "抓",
+			},
+			damage: 20,
+			cost: ["Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Colorless"]
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575612,
+				tcgplayer: 569558,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [529],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/058.ts
+++ b/data-asia/S/S8/058.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "列陣兵"
+		ja: "タイレーツ",
+		'zh-tw': "列陣兵",
 	},
 
 	illustrator: "Akira Komayama",
@@ -14,38 +14,52 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "６隻為一體的寶可夢。慣於團隊行動，會一邊變換陣形一邊戰鬥。"
+		ja: "６匹で １匹の ポケモン。 隊列を 組み替えながら チームワークで 戦うのだ。",
+		'zh-tw': "６隻為一體的寶可夢。慣於團隊行動，會一邊變換陣形一邊戰鬥。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "頭錘"
+	attacks: [
+		{
+			name: {
+				ja: "ずつき",
+				'zh-tw': "頭錘",
+			},
+			damage: 30,
+			cost: ["Fighting"],
 		},
-
-		damage: 30,
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "背水列陣"
+		{
+			name: {
+				ja: "がけっぷちのじん",
+				'zh-tw': "背水列陣",
+			},
+			damage: "60+",
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のサイドの残り枚数が1枚なら、160ダメージ追加。",
+				'zh-tw': "若對手剩餘獎賞卡的張數為1張，則增加160點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若對手剩餘獎賞卡的張數為1張，則增加160點傷害。"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575613,
+				tcgplayer: 569559,
+			},
 		},
-
-		damage: "60+",
-		cost: ["Fighting", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [870],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/059.ts
+++ b/data-asia/S/S8/059.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伽勒爾 蛇紋熊"
+		ja: "ガラル ジグザグマ",
+		'zh-tw': "伽勒爾 蛇紋熊",
 	},
 
 	illustrator: "Eri Yamaki",
@@ -14,31 +14,44 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "這似乎是蛇紋熊最古老的樣子。會之字形亂走，把周圍弄得一團糟。"
+		ja: "この姿が いちばん 古い ジグザグマの 姿 らしい。 ジグザグ動いて あたりを 荒らす。",
+		'zh-tw': "這似乎是蛇紋熊最古老的樣子。會之字形亂走，把周圍弄得一團糟。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "舌舔"
+	attacks: [
+		{
+			name: {
+				ja: "したでなめる",
+				'zh-tw': "舌舔",
+			},
+			damage: 10,
+			cost: ["Darkness"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+				'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575614,
+				tcgplayer: 569560,
+			},
 		},
-
-		damage: 10,
-		cost: ["Darkness"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [263],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/060.ts
+++ b/data-asia/S/S8/060.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伽勒爾 直衝熊"
+		ja: "ガラル マッスグマ",
+		'zh-tw': "伽勒爾 直衝熊",
 	},
 
 	illustrator: "sowsow",
@@ -14,27 +14,44 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "有著十分好戰的性情。即使是比自己強的對手也會魯莽地發起挑戰。"
+		ja: "とても 好戦的な 性質。 自分より 格上の 相手にも 平気で 挑む むこうみず。",
+		'zh-tw': "有著十分好戰的性情。即使是比自己強的對手也會魯莽地發起挑戰。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "後踢"
+	attacks: [
+		{
+			name: {
+				ja: "うしろげり",
+				'zh-tw': "後踢",
+			},
+			damage: 30,
+			cost: ["Darkness"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Darkness"]
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575615,
+				tcgplayer: 569561,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ガラル ジグザグマ",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [264],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/061.ts
+++ b/data-asia/S/S8/061.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伽勒爾 堵攔熊"
+		ja: "ガラル タチフサグマ",
+		'zh-tw': "伽勒爾 堵攔熊",
 	},
 
 	illustrator: "kodama",
@@ -14,42 +14,60 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "在不斷的鬥爭中得到了進化。牠交叉著雙臂發出的怒吼能讓一切對手都為之膽怯。"
+		ja: "ケンカを 繰り返し 進化。 腕をクロスし 叫ぶ 雄叫びは どんな 相手も 怯ませるぞ。",
+		'zh-tw': "在不斷的鬥爭中得到了進化。牠交叉著雙臂發出的怒吼能讓一切對手都為之膽怯。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "封口"
+	attacks: [
+		{
+			name: {
+				ja: "だまらせる",
+				'zh-tw': "封口",
+			},
+			damage: 30,
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンが持っているワザを1つ選ぶ。次の相手の番、このワザを受けたポケモンは、選ばれたワザが使えない。",
+				'zh-tw': "選擇對手的戰鬥寶可夢持有的1個招式。在下個對手的回合，受到這個招式的寶可夢無法使用被選擇的招式。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇對手的戰鬥寶可夢持有的1個招式。在下個對手的回合，受到這個招式的寶可夢無法使用被選擇的招式。"
+		{
+			name: {
+				ja: "むじひないちげき",
+				'zh-tw': "狠心一擊",
+			},
+			damage: "60+",
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンにダメカンがのっているなら、90ダメージ追加。",
+				'zh-tw': "若對手的戰鬥寶可夢身上放置有傷害指示物，則增加90點傷害。",
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Darkness"]
-	}, {
-		name: {
-			'zh-tw': "狠心一擊"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 575616,
+				tcgplayer: 569562,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若對手的戰鬥寶可夢身上放置有傷害指示物，則增加90點傷害。"
-		},
-
-		damage: "60+",
-		cost: ["Darkness"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ガラル マッスグマ",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [862],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/062.ts
+++ b/data-asia/S/S8/062.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "破破袋"
+		ja: "ヤブクロン",
+		'zh-tw': "破破袋",
 	},
 
 	illustrator: "Shibuzoh.",
@@ -14,41 +14,55 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "誕生自塞滿垃圾的垃圾袋裡。牠嘴裡噴出的毒氣是伽勒爾雙彈瓦斯的最愛。"
+		ja: "ゴミの 詰まった ゴミ袋から 生まれた。 吐き出す 毒ガスは ガラルの マタドガスの 好物。",
+		'zh-tw': "誕生自塞滿垃圾的垃圾袋裡。牠嘴裡噴出的毒氣是伽勒爾雙彈瓦斯的最愛。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "呼朋引伴"
+	attacks: [
+		{
+			name: {
+				ja: "なかまをよぶ",
+				'zh-tw': "呼朋引伴",
+			},
+			cost: ["Darkness"],
+			effect: {
+				ja: "自分の山札からたねポケモンを1枚選び、ベンチに出す。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。"
+		{
+			name: {
+				ja: "どくのいき",
+				'zh-tw': "毒之氣息",
+			},
+			damage: 20,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】。",
+			},
 		},
+	],
 
-		cost: ["Darkness"]
-	}, {
-		name: {
-			'zh-tw': "毒之氣息"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575617,
+				tcgplayer: 569563,
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。"
-		},
-
-		damage: 20,
-		cost: ["Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [568],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/063.ts
+++ b/data-asia/S/S8/063.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "灰塵山"
+		ja: "ダストダス",
+		'zh-tw': "灰塵山",
 	},
 
 	illustrator: "sui",
@@ -14,38 +14,56 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "從右臂噴出的毒液十分危險，虛弱的生物只要一沾到，立刻就會丟掉性命。"
+		ja: "右腕から 出す 毒液は 弱った 生物が 浴びれば 即死するほど 危険な シロモノ。",
+		'zh-tw': "從右臂噴出的毒液十分危險，虛弱的生物只要一沾到，立刻就會丟掉性命。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "毒瓦斯"
+	attacks: [
+		{
+			name: {
+				ja: "どくガス",
+				'zh-tw': "毒瓦斯",
+			},
+			damage: 30,
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。"
+		{
+			name: {
+				ja: "ヘドロのうず",
+				'zh-tw': "污泥旋渦",
+			},
+			damage: 130,
+			cost: ["Darkness", "Darkness", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Darkness"]
-	}, {
-		name: {
-			'zh-tw': "污泥旋渦"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575618,
+				tcgplayer: 569564,
+			},
 		},
+	],
 
-		damage: 130,
-		cost: ["Darkness", "Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ヤブクロン",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [569],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/064.ts
+++ b/data-asia/S/S8/064.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "禿鷹丫頭"
+		ja: "バルチャイ",
+		'zh-tw': "禿鷹丫頭",
 	},
 
 	illustrator: "Shigenori Negishi",
@@ -14,43 +14,52 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "由於很快就會長大，屁股上的骸骨會接著傳給巢裡更小的禿鷹丫頭用。"
+		ja: "すぐに 大きく 育つので お尻の 骸骨は 巣の 中で お下がりとして 使いまわされる。",
+		'zh-tw': "由於很快就會長大，屁股上的骸骨會接著傳給巢裡更小的禿鷹丫頭用。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "銳利羽"
+	attacks: [
+		{
+			name: {
+				ja: "するどいはね",
+				'zh-tw': "銳利羽",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
-
-		damage: 10,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "空氣斬"
+		{
+			name: {
+				ja: "エアスラッシュ",
+				'zh-tw': "空氣斬",
+			},
+			damage: 30,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575619,
+				tcgplayer: 569565,
+			},
 		},
-
-		damage: 30,
-		cost: ["Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [629],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/065.ts
+++ b/data-asia/S/S8/065.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "禿鷹娜"
+		ja: "バルジーナ",
+		'zh-tw': "禿鷹娜",
 	},
 
 	illustrator: "Narumi Sato",
@@ -14,43 +14,56 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "把撿來的骨頭裝飾在身上。在骨頭形狀這方面似乎也是有流行趨勢的。"
+		ja: "拾った 骨で 身を 飾る。 まとう 骨の 形には 流行が あるらしい。",
+		'zh-tw': "把撿來的骨頭裝飾在身上。在骨頭形狀這方面似乎也是有流行趨勢的。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "骨之封鎖"
+	attacks: [
+		{
+			name: {
+				ja: "ほねふうじ",
+				'zh-tw': "骨之封鎖",
+			},
+			damage: 20,
+			cost: ["Darkness"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、手札からポケモンを出して進化できない。",
+				'zh-tw': "在下個對手的回合，無法從手牌使出寶可夢將受到這個招式的寶可夢進化。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，無法從手牌使出寶可夢將受到這個招式的寶可夢進化。"
+		{
+			name: {
+				ja: "ダークカッター",
+				'zh-tw': "暗黑利刃",
+			},
+			damage: 70,
+			cost: ["Darkness", "Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Darkness"]
-	}, {
-		name: {
-			'zh-tw': "暗黑利刃"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575620,
+				tcgplayer: 569566,
+			},
 		},
+	],
 
-		damage: 70,
-		cost: ["Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "バルチャイ",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [630],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/066.ts
+++ b/data-asia/S/S8/066.ts
@@ -1,52 +1,66 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "胡帕V"
+		ja: "フーパV",
+		'zh-tw': "胡帕V",
 	},
 
 	illustrator: "takuyoa",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Darkness"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "雙面"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ダブルフェイス",
+				'zh-tw': "雙面",
+			},
+			effect: {
+				ja: "このポケモンは、場にいるかぎり[超]と[悪]の2つのタイプになる。",
+				'zh-tw': "只要這隻寶可夢在場上，改為【超】與【惡】2種屬性。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在場上，改為【超】與【惡】2種屬性。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "暗影衝擊"
+	attacks: [
+		{
+			name: {
+				ja: "シャドーインパクト",
+				'zh-tw': "暗影衝擊",
+			},
+			damage: 170,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "自分のポケモン1匹に、ダメカンを3個のせる。",
+				'zh-tw': "在自己的1隻寶可夢身上放置3個傷害指示物。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的1隻寶可夢身上放置3個傷害指示物。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 575621,
+				tcgplayer: 569567,
+			},
 		},
-
-		damage: 170,
-		cost: ["Darkness", "Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [720],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/067.ts
+++ b/data-asia/S/S8/067.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "龍頭地鼠"
+		ja: "ドリュウズ",
+		'zh-tw': "龍頭地鼠",
 	},
 
 	illustrator: "Lee HyunJung",
@@ -14,43 +14,56 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "別名鑽頭王。在地底下挖掘前進的速度高達每小時１５０公里。"
+		ja: "別名 ドリルキング。 地中を 掘り進む 速度は 時速１５０キロに 達する。",
+		'zh-tw': "別名鑽頭王。在地底下挖掘前進的速度高達每小時１５０公里。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "金屬爪"
+	attacks: [
+		{
+			name: {
+				ja: "メタルクロー",
+				'zh-tw': "金屬爪",
+			},
+			damage: 50,
+			cost: ["Metal", "Colorless"],
 		},
-
-		damage: 50,
-		cost: ["Metal", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "岩石封鎖"
+		{
+			name: {
+				ja: "がんせきふうじ",
+				'zh-tw': "岩石封鎖",
+			},
+			damage: 120,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575622,
+				tcgplayer: 569568,
+			},
 		},
+	],
 
-		damage: 120,
-		cost: ["Metal", "Metal", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "モグリュー",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [530],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/068.ts
+++ b/data-asia/S/S8/068.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鐵蟻"
+		ja: "アイアント",
+		'zh-tw': "鐵蟻",
 	},
 
 	illustrator: "Shin Nagasawa",
@@ -14,36 +14,44 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "巨大的顎部能咬碎岩石。為了不讓沙螺蟒把蛋搶走，會和其他同類一起並肩戰鬥。"
+		ja: "大きな顎は 岩石をも かみ砕く。 サダイジャから タマゴを 守るため 群れで 戦う。",
+		'zh-tw': "巨大的顎部能咬碎岩石。為了不讓沙螺蟒把蛋搶走，會和其他同類一起並肩戰鬥。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "逆境顎"
+	attacks: [
+		{
+			name: {
+				ja: "ぎゃっきょうのアゴ",
+				'zh-tw': "逆境顎",
+			},
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが[炎]ポケモンなら、そのポケモンをマヒにする。",
+				'zh-tw': "若對手的戰鬥寶可夢為【火】寶可夢，則將那隻寶可夢【麻痺】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若對手的戰鬥寶可夢為【火】寶可夢，則將那隻寶可夢【麻痺】。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575623,
+				tcgplayer: 569569,
+			},
 		},
-
-		damage: 70,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [632],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/069.ts
+++ b/data-asia/S/S8/069.ts
@@ -1,57 +1,66 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "蓋諾賽克特V"
+		ja: "ゲノセクトV",
+		'zh-tw': "蓋諾賽克特V",
 	},
 
 	illustrator: "PLANETA Tsuji",
 	category: "Pokemon",
 	hp: 190,
 	types: ["Metal"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "匯流系統"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "フュージョンシステム",
+				'zh-tw': "匯流系統",
+			},
+			effect: {
+				ja: "自分の番に1回使える。自分の手札の枚数が、自分の場の「フュージョン」のポケモンの数と同じ枚数になるように、山札を引く。",
+				'zh-tw': "在自己的回合時，可使用1次。從牌庫抽卡直到自己的手牌的張數與自己的場上「匯流」寶可夢的數量相同為止。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，可使用1次。從牌庫抽卡直到自己的手牌的張數與自己的場上「匯流」寶可夢的數量相同為止。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "高科技光炮"
+	attacks: [
+		{
+			name: {
+				ja: "テクノバスター",
+				'zh-tw': "高科技光炮",
+			},
+			damage: 210,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 575624,
+				tcgplayer: 569570,
+			},
 		},
-
-		damage: 210,
-		cost: ["Metal", "Metal", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [649],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/070.ts
+++ b/data-asia/S/S8/070.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "托戈德瑪爾"
+		ja: "トゲデマル",
+		'zh-tw': "托戈德瑪爾",
 	},
 
 	illustrator: "Oswaldo KATO",
@@ -14,43 +14,52 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "在危急時刻會把身體捲成一團、倒豎起背上的尖刺，不分青紅皂白地發出電擊。"
+		ja: "ピンチになると 体を 丸めて 背中の とげとげを 逆立てると でたらめに 電撃を 撃ちまくる。",
+		'zh-tw': "在危急時刻會把身體捲成一團、倒豎起背上的尖刺，不分青紅皂白地發出電擊。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "一同滾動"
+	attacks: [
+		{
+			name: {
+				ja: "みんなでころがる",
+				'zh-tw': "一同滾動",
+			},
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチの、ワザ「みんなでころがる」を持つポケモンの数×20ダメージ。",
+				'zh-tw': "造成自己的備戰區的，持有「一同滾動」招式的寶可夢的數量×20點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "造成自己的備戰區的，持有「一同滾動」招式的寶可夢的數量×20點傷害。"
+		{
+			name: {
+				ja: "ボールアタック",
+				'zh-tw': "滾球攻擊",
+			},
+			damage: 50,
+			cost: ["Metal", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: "20×",
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "滾球攻擊"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575625,
+				tcgplayer: 569571,
+			},
 		},
-
-		damage: 50,
-		cost: ["Metal", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [777],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/071.ts
+++ b/data-asia/S/S8/071.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "美錄坦"
+		ja: "メルタン",
+		'zh-tw': "美錄坦",
 	},
 
 	illustrator: "Teeziro",
@@ -14,42 +14,51 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "身體是融化成液狀的鋼鐵。能夠將地底的鐵或其他金屬溶解後吸收進體內。"
+		ja: "とろりと 溶けた 鋼の 体。 地中の 鉄分や 金属を 溶かして 吸収する。",
+		'zh-tw': "身體是融化成液狀的鋼鐵。能夠將地底的鐵或其他金屬溶解後吸收進體內。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "鐵質攝取"
+	attacks: [
+		{
+			name: {
+				ja: "てつぶんせっしゅ",
+				'zh-tw': "鐵質攝取",
+			},
+			cost: ["Metal"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+				'zh-tw': "將這隻寶可夢恢復「30」HP。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將這隻寶可夢恢復「30」HP。"
+		{
+			name: {
+				ja: "ずつき",
+				'zh-tw': "頭錘",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Metal"]
-	}, {
-		name: {
-			'zh-tw': "頭錘"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575626,
+				tcgplayer: 569572,
+			},
 		},
-
-		damage: 20,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [808],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/072.ts
+++ b/data-asia/S/S8/072.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "美錄梅塔"
+		ja: "メルメタル",
+		'zh-tw': "美錄梅塔",
 	},
 
 	illustrator: "Hasuno",
@@ -14,47 +14,60 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "擁有產出鐵的力量，因而受到人們的崇拜。不知為何，在經過3000年的時間後甦醒過來。"
+		ja: "鉄を 産み出す 力を 持つと 崇められていた。 ３０００年の 時を 経て なぜか 蘇った。",
+		'zh-tw': "擁有產出鐵的力量，因而受到人們的崇拜。不知為何，在經過3000年的時間後甦醒過來。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "鐵塊橫掃"
+	attacks: [
+		{
+			name: {
+				ja: "インゴットスイング",
+				'zh-tw': "鐵塊橫掃",
+			},
+			damage: 80,
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンは特性を持つポケモンからワザのダメージを受けない。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢不會受到擁有特性的寶可夢招式的傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，這隻寶可夢不會受到擁有特性的寶可夢招式的傷害。"
+		{
+			name: {
+				ja: "ブラストハンマー",
+				'zh-tw': "爆破之錘",
+			},
+			damage: 150,
+			cost: ["Metal", "Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		damage: 80,
-		cost: ["Metal", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "爆破之錘"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 575627,
+				tcgplayer: 569573,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。"
-		},
-
-		damage: 150,
-		cost: ["Metal", "Metal", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "メルタン",
+	},
 
 	retreat: 4,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [809],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/073.ts
+++ b/data-asia/S/S8/073.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鋼鎧鴉"
+		ja: "アーマーガア",
+		'zh-tw': "鋼鎧鴉",
 	},
 
 	illustrator: "Ryuta Fuse",
@@ -14,47 +14,60 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "擁有優秀飛行能力和極度聰明頭腦的牠在伽勒爾地區從事飛翔計程車的工作。"
+		ja: "飛行能力に 優れていて とても 賢いため ガラル地方で 空の タクシーとして 活躍。",
+		'zh-tw': "擁有優秀飛行能力和極度聰明頭腦的牠在伽勒爾地區從事飛翔計程車的工作。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "鋼翼"
+	attacks: [
+		{
+			name: {
+				ja: "はがねのつばさ",
+				'zh-tw': "鋼翼",
+			},
+			damage: 50,
+			cost: ["Metal"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-30」點。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-30」點。"
+		{
+			name: {
+				ja: "パワーサイクロン",
+				'zh-tw': "能量旋風",
+			},
+			damage: 160,
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、ベンチポケモンにつけ替える。",
+				'zh-tw': "選擇1個這隻寶可夢身上附加的能量，改附於備戰寶可夢身上。",
+			},
 		},
+	],
 
-		damage: 50,
-		cost: ["Metal"]
-	}, {
-		name: {
-			'zh-tw': "能量旋風"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575628,
+				tcgplayer: 569574,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇1個這隻寶可夢身上附加的能量，改附於備戰寶可夢身上。"
-		},
-
-		damage: 160,
-		cost: ["Metal", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "アオガラス",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [823],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/074.ts
+++ b/data-asia/S/S8/074.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "拉帝亞斯"
+		ja: "ラティアス",
+		'zh-tw': "拉帝亞斯",
 	},
 
 	illustrator: "Yuu Nishida",
@@ -14,38 +14,58 @@ const card: Card = {
 	types: ["Dragon"],
 
 	description: {
-		'zh-tw': "透過心靈感應和人類交流情感。會用能令光線折射的羽毛變化成其他的樣子。"
+		ja: "テレパシーで 人間と 気持ちを 通わせる。 光を 屈折させる 羽毛で 別の 姿に 変わる。",
+		'zh-tw': "透過心靈感應和人類交流情感。會用能令光線折射的羽毛變化成其他的樣子。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "紅色支援"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "レッドアシスト",
+				'zh-tw': "紅色支援",
+			},
+			effect: {
+				ja: "自分の番に1回使える。自分の手札から[超]エネルギーを1枚選び、自分の「ラティオス」につける。",
+				'zh-tw': "在自己的回合時，可使用1次。從自己的手牌選擇1張【超】能量卡，附於自己的「拉帝歐斯」身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，可使用1次。從自己的手牌選擇1張【超】能量卡，附於自己的「拉帝歐斯」身上。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "力之屏障"
+	attacks: [
+		{
+			name: {
+				ja: "ダイナバリア",
+				'zh-tw': "力之屏障",
+			},
+			damage: 70,
+			cost: ["Fire", "Psychic", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンは「ポケモンVMAX」からワザのダメージを受けない。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢不會受到「寶可夢【VMAX】」招式的傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，這隻寶可夢不會受到「寶可夢【VMAX】」招式的傷害。"
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575629,
+				tcgplayer: 569575,
+			},
 		},
-
-		damage: 70,
-		cost: ["Fire", "Psychic", "Colorless"]
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [380],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/075.ts
+++ b/data-asia/S/S8/075.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "拉帝歐斯"
+		ja: "ラティオス",
+		'zh-tw': "拉帝歐斯",
 	},
 
 	illustrator: "hatachu",
@@ -14,38 +14,58 @@ const card: Card = {
 	types: ["Dragon"],
 
 	description: {
-		'zh-tw': "擁有很高的智慧，能理解人類的語言。是厭惡爭鬥的溫柔寶可夢。"
+		ja: "高い 知能を 持ち 人間の 言葉を 理解する。 争いを 嫌う 優しい ポケモンだ。",
+		'zh-tw': "擁有很高的智慧，能理解人類的語言。是厭惡爭鬥的溫柔寶可夢。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "藍色支援"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ブルーアシスト",
+				'zh-tw': "藍色支援",
+			},
+			effect: {
+				ja: "自分の番に1回使える。自分の手札から[超]エネルギーを1枚選び、自分の「ラティアス」につける。",
+				'zh-tw': "在自己的回合時，可使用1次。從自己的手牌選擇1張【超】能量卡，附於自己的「拉帝亞斯」身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，可使用1次。從自己的手牌選擇1張【超】能量卡，附於自己的「拉帝亞斯」身上。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "潔淨光芒"
+	attacks: [
+		{
+			name: {
+				ja: "ラスターパージ",
+				'zh-tw': "潔淨光芒",
+			},
+			damage: 210,
+			cost: ["Water", "Water", "Psychic", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+				'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。"
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 575630,
+				tcgplayer: 569576,
+			},
 		},
-
-		damage: 210,
-		cost: ["Water", "Water", "Psychic", "Colorless"]
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [381],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/076.ts
+++ b/data-asia/S/S8/076.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "黏黏寶"
+		ja: "ヌメラ",
+		'zh-tw': "黏黏寶",
 	},
 
 	illustrator: "Miki Tanaka",
@@ -14,29 +14,48 @@ const card: Card = {
 	types: ["Dragon"],
 
 	description: {
-		'zh-tw': "牠的觸角是優秀的感覺器官。只要感覺到有敵人就會立刻躲起來，以此存活到了現在。"
+		ja: "ツノは 優れた 感覚器官。 敵の 気配を 感じ取り すぐに 隠れる ことで 生き残ってきた。",
+		'zh-tw': "牠的觸角是優秀的感覺器官。只要感覺到有敵人就會立刻躲起來，以此存活到了現在。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "撞擊"
+	attacks: [
+		{
+			name: {
+				ja: "たいあたり",
+				'zh-tw': "撞擊",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
-
-		damage: 10,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "溶解"
+		{
+			name: {
+				ja: "とかす",
+				'zh-tw': "溶解",
+			},
+			damage: 20,
+			cost: ["Water", "Psychic"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Water", "Psychic"]
-	}],
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575631,
+				tcgplayer: 569577,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [704],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/077.ts
+++ b/data-asia/S/S8/077.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "黏美兒"
+		ja: "ヌメイル",
+		'zh-tw': "黏美兒",
 	},
 
 	illustrator: "Saya Tsuruta",
@@ -14,33 +14,56 @@ const card: Card = {
 	types: ["Dragon"],
 
 	description: {
-		'zh-tw': "背上的突起物裡裝著牠小小的腦子，裡面只想著吃飯和逃離敵人這兩件事。"
+		ja: "背中の 突起の 中に 小さな 脳みそが ある。 エサと 敵から 逃げることしか 考えていない。",
+		'zh-tw': "背上的突起物裡裝著牠小小的腦子，裡面只想著吃飯和逃離敵人這兩件事。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "溶解"
+	attacks: [
+		{
+			name: {
+				ja: "とかす",
+				'zh-tw': "溶解",
+			},
+			damage: 20,
+			cost: ["Colorless"],
 		},
-
-		damage: 20,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "泰山壓頂"
+		{
+			name: {
+				ja: "のしかかり",
+				'zh-tw': "泰山壓頂",
+			},
+			damage: 50,
+			cost: ["Water", "Psychic"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+				'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。"
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575632,
+				tcgplayer: 569578,
+			},
 		},
+	],
 
-		damage: 50,
-		cost: ["Water", "Psychic"]
-	}],
+	evolveFrom: {
+		ja: "ヌメラ",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [705],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/078.ts
+++ b/data-asia/S/S8/078.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "黏美龍"
+		ja: "ヌメルゴン",
+		'zh-tw': "黏美龍",
 	},
 
 	illustrator: "Nagomi Nijo",
@@ -14,34 +14,58 @@ const card: Card = {
 	types: ["Dragon"],
 
 	description: {
-		'zh-tw': "用伸長角產生的力道來攻擊對手，產生的威力比重量級拳擊手的拳擊還強１００倍。"
+		ja: "長い ツノを 伸ばす 勢いで 攻撃。 威力は ヘビー級 ボクサーの パンチの １００倍だ。",
+		'zh-tw': "用伸長角產生的力道來攻擊對手，產生的威力比重量級拳擊手的拳擊還強１００倍。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "黏黏滑滑空間"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ぬるぬるルーム",
+				'zh-tw': "黏黏滑滑空間",
+			},
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手は手札からエネルギーをポケモンにつけるとき、つける前にコインを1回投げる。ウラなら、そのエネルギーはつけたことにならず、トラッシュする。",
+				'zh-tw': "只要這隻寶可夢在戰鬥場上，對手從手牌將能量附於寶可夢身上時，附上前擲1次硬幣。若為反面，則那個能量不附上，將其丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在戰鬥場上，對手從手牌將能量附於寶可夢身上時，附上前擲1次硬幣。若為反面，則那個能量不附上，將其丟棄。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "光炮尾"
+	attacks: [
+		{
+			name: {
+				ja: "バスターテール",
+				'zh-tw': "光炮尾",
+			},
+			damage: 120,
+			cost: ["Water", "Psychic"],
 		},
+	],
 
-		damage: 120,
-		cost: ["Water", "Psychic"]
-	}],
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575633,
+				tcgplayer: 569579,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヌメイル",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [706],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/079.ts
+++ b/data-asia/S/S8/079.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "土龍弟弟"
+		ja: "ノコッチ",
+		'zh-tw': "土龍弟弟",
 	},
 
 	illustrator: "ryoma uratsuka",
@@ -14,39 +14,54 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "一看到人就會用尾巴挖洞逃走。如果能夠遇見牠，代表你很幸運。"
+		ja: "人の 姿を 見ると シッポで 穴を 掘って 逃げてしまう。 もし 出会えたなら ラッキーだよ。",
+		'zh-tw': "一看到人就會用尾巴挖洞逃走。如果能夠遇見牠，代表你很幸運。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "神秘巢穴"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ふしぎなすあな",
+				'zh-tw': "神秘巢穴",
+			},
+			effect: {
+				ja: "このポケモンがいるかぎり、おたがいの場の【無】ポケモン全員の弱点は、すべてなくなる。",
+				'zh-tw': "只要這隻寶可夢在場上，雙方的場上的所有【無】寶可夢的弱點全部消除。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在場上，雙方的場上的所有【無】寶可夢的弱點全部消除。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "滾動"
+	attacks: [
+		{
+			name: {
+				ja: "ころがる",
+				'zh-tw': "滾動",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575634,
+				tcgplayer: 569580,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [206],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/080.ts
+++ b/data-asia/S/S8/080.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "圖圖犬"
+		ja: "ドーブル",
+		'zh-tw': "圖圖犬",
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -14,37 +14,51 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "會用尾巴前端分泌出的液體畫下標記。其中有些標記會吸引愛好者以高價買賣。"
+		ja: "シッポの 先から でる 体液で マークを えがく。 マークに よっては マニアに 高値で 取引される。",
+		'zh-tw': "會用尾巴前端分泌出的液體畫下標記。其中有些標記會吸引愛好者以高價買賣。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "棄牌寫生"
+	attacks: [
+		{
+			name: {
+				ja: "トラッシュスケッチ",
+				'zh-tw': "棄牌寫生",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュから「フュージョン」のトレーナーズを2枚まで選び、相手に見せて、手札に加える。",
+				'zh-tw': "從自己的棄牌區選擇最多2張「匯流」訓練家卡，在給對手看過後加入手牌。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的棄牌區選擇最多2張「匯流」訓練家卡，在給對手看過後加入手牌。"
+		{
+			name: {
+				ja: "しっぽではたく",
+				'zh-tw': "擺尾拍擊",
+			},
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "擺尾拍擊"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575635,
+				tcgplayer: 569581,
+			},
 		},
-
-		damage: 80,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [235],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/081.ts
+++ b/data-asia/S/S8/081.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "向尾喵"
+		ja: "エネコ",
+		'zh-tw': "向尾喵",
 	},
 
 	illustrator: "Yukiko Baba",
@@ -14,31 +14,44 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "有時會展現出追著自己的尾巴玩，但玩著玩著就會頭昏眼花的可愛一面。"
+		ja: "自分の 尻尾を 追いかけて 遊んでいると 目を 回すといった 可愛らしい 一面を みせる。",
+		'zh-tw': "有時會展現出追著自己的尾巴玩，但玩著玩著就會頭昏眼花的可愛一面。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "胡思亂撞"
+	attacks: [
+		{
+			name: {
+				ja: "きまぐれタックル",
+				'zh-tw': "胡思亂撞",
+			},
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+				'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575636,
+				tcgplayer: 569582,
+			},
 		},
-
-		damage: 30,
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [300],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/082.ts
+++ b/data-asia/S/S8/082.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "優雅貓"
+		ja: "エネコロロ",
+		'zh-tw': "優雅貓",
 	},
 
 	illustrator: "kirisAki",
@@ -14,41 +14,59 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "有著美麗的毛髮，非常受女性訓練家的歡迎。沒有固定的住所。"
+		ja: "美しい 毛並みを 持ち 女性トレーナーに 大人気。 決まった 住処を 持たない。",
+		'zh-tw': "有著美麗的毛髮，非常受女性訓練家的歡迎。沒有固定的住所。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "愛管閒事"
+	attacks: [
+		{
+			name: {
+				ja: "きままなせわやき",
+				'zh-tw': "愛管閒事",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手の手札を見て、その中からカードを1枚選び、相手の山札の下にもどす。",
+				'zh-tw': "查看對手的手牌，選擇其中1張卡，放回對手的牌庫下方。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "查看對手的手牌，選擇其中1張卡，放回對手的牌庫下方。"
+		{
+			name: {
+				ja: "おうふくビンタ",
+				'zh-tw': "連環巴掌",
+			},
+			damage: "50×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×50ダメージ。",
+				'zh-tw': "擲2次硬幣，造成正面出現的次數×50點傷害。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "連環巴掌"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575637,
+				tcgplayer: 569583,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲2次硬幣，造成正面出現的次數×50點傷害。"
-		},
-
-		damage: "50×",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "エネコ",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [301],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/083.ts
+++ b/data-asia/S/S8/083.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "掘掘兔"
+		ja: "ホルビー",
+		'zh-tw': "掘掘兔",
 	},
 
 	illustrator: "sui",
@@ -14,41 +14,55 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "對危險很敏感。只要聽到鋼鎧鴉拍打翅膀的聲音，就會馬上挖洞鑽進地下藏身。"
+		ja: "危険に 敏感。 アーマーガアの 羽音を 聴きとると あっという間に 穴を 掘って 地面に 潜る。",
+		'zh-tw': "對危險很敏感。只要聽到鋼鎧鴉拍打翅膀的聲音，就會馬上挖洞鑽進地下藏身。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "尋找朋友"
+	attacks: [
+		{
+			name: {
+				ja: "ともだちをさがす",
+				'zh-tw': "尋找朋友",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からポケモンを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		{
+			name: {
+				ja: "とっしん",
+				'zh-tw': "猛撞",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも10ダメージ。",
+				'zh-tw': "這隻寶可夢也受到10點傷害。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "猛撞"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575638,
+				tcgplayer: 569584,
+			},
 		},
-
-		effect: {
-			'zh-tw': "這隻寶可夢也受到10點傷害。"
-		},
-
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [659],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/084.ts
+++ b/data-asia/S/S8/084.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "掘地兔"
+		ja: "ホルード",
+		'zh-tw': "掘地兔",
 	},
 
 	illustrator: "MAHOU",
@@ -14,38 +14,56 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "肚子上的體毛保溫性能優秀。在過去，人們會用牠掉落的毛來製作保暖服裝。"
+		ja: "お腹の 体毛は 保温性に 優れる。 昔の 人は 抜けた 体毛で 防寒着を つくった。",
+		'zh-tw': "肚子上的體毛保溫性能優秀。在過去，人們會用牠掉落的毛來製作保暖服裝。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "頭突"
+	attacks: [
+		{
+			name: {
+				ja: "ぶちかます",
+				'zh-tw': "頭突",
+			},
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
-
-		damage: 80,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "猛撞"
+		{
+			name: {
+				ja: "とっしん",
+				'zh-tw': "猛撞",
+			},
+			damage: 150,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+				'zh-tw': "這隻寶可夢也受到30點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢也受到30點傷害。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575639,
+				tcgplayer: 569585,
+			},
 		},
+	],
 
-		damage: 150,
-		cost: ["Colorless", "Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ホルビー",
+	},
 
 	retreat: 4,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [660],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/085.ts
+++ b/data-asia/S/S8/085.ts
@@ -1,51 +1,64 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "藏飽栗鼠V"
+		ja: "ヨクバリスV",
+		'zh-tw': "藏飽栗鼠V",
 	},
 
 	illustrator: "PLANETA Yamashita",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Colorless"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "泰山壓頂"
+	attacks: [
+		{
+			name: {
+				ja: "のしかかり",
+				'zh-tw': "泰山壓頂",
+			},
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+				'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。"
+		{
+			name: {
+				ja: "がっつくまえば",
+				'zh-tw': "貪心門牙",
+			},
+			damage: 120,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札を3枚引く。",
+				'zh-tw': "從自己的牌庫抽出3張卡。",
+			},
 		},
+	],
 
-		damage: 40,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "貪心門牙"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 575640,
+				tcgplayer: 569586,
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫抽出3張卡。"
-		},
-
-		damage: 120,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [820],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/086.ts
+++ b/data-asia/S/S8/086.ts
@@ -1,50 +1,68 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "藏飽栗鼠VMAX"
+		ja: "ヨクバリスVMAX",
+		'zh-tw': "藏飽栗鼠VMAX",
 	},
 
 	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
 	hp: 320,
 	types: ["Colorless"],
+
 	stage: "VMAX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "零成本"
+	attacks: [
+		{
+			name: {
+				ja: "まるもうけ",
+				'zh-tw': "零成本",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージで、相手のたねポケモンがきぜつしたなら、サイドを2枚多くとる。",
+				'zh-tw': "若這個招式的傷害將對手的【基礎】寶可夢【氣絕】，則多獲得2張獎賞卡。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "若這個招式的傷害將對手的【基礎】寶可夢【氣絕】，則多獲得2張獎賞卡。"
+		{
+			name: {
+				ja: "ダイゴウヨク",
+				'zh-tw': "極巨強慾",
+			},
+			damage: 160,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札を3枚引く。",
+				'zh-tw': "從自己的牌庫抽出3張卡。",
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "極巨強慾"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 575641,
+				tcgplayer: 569587,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的牌庫抽出3張卡。"
-		},
-
-		damage: 160,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ヨクバリスV",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Triple Rare",
+	dexId: [820],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/087.ts
+++ b/data-asia/S/S8/087.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "稚山雀"
+		ja: "ココガラ",
+		'zh-tw': "稚山雀",
 	},
 
 	illustrator: "OKACHEKE",
@@ -14,36 +14,44 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "嬌小的體型讓牠能敏捷地飛翔。攻其不備的戰法將體型巨大的對手玩弄於股掌之間。"
+		ja: "小さい 体で 機敏に 飛んで 隙を 突く 戦法で 体の 大きな 相手を 手玉に取る。",
+		'zh-tw': "嬌小的體型讓牠能敏捷地飛翔。攻其不備的戰法將體型巨大的對手玩弄於股掌之間。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "亂擊"
+	attacks: [
+		{
+			name: {
+				ja: "みだれづき",
+				'zh-tw': "亂擊",
+			},
+			damage: "10×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数×10ダメージ。",
+				'zh-tw': "擲3次硬幣，造成正面出現的次數×10點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲3次硬幣，造成正面出現的次數×10點傷害。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575642,
+				tcgplayer: 569588,
+			},
 		},
-
-		damage: "10×",
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [821],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/088.ts
+++ b/data-asia/S/S8/088.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "藍鴉"
+		ja: "アオガラス",
+		'zh-tw': "藍鴉",
 	},
 
 	illustrator: "Naoyo Kimura",
@@ -14,36 +14,48 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "歷經無數次艱難的戰鬥後，牠學會了該如何正確地判斷敵人的力量。"
+		ja: "厳しい 戦いを くぐり抜けて 相手の 力量を 正確に 判断する 力が 身についた。",
+		'zh-tw': "歷經無數次艱難的戰鬥後，牠學會了該如何正確地判斷敵人的力量。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "亂擊"
+	attacks: [
+		{
+			name: {
+				ja: "みだれづき",
+				'zh-tw': "亂擊",
+			},
+			damage: "30×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数×30ダメージ。",
+				'zh-tw': "擲3次硬幣，造成正面出現的次數×30點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲3次硬幣，造成正面出現的次數×30點傷害。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575643,
+				tcgplayer: 569589,
+			},
 		},
+	],
 
-		damage: "30×",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ココガラ",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [822],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S8/089.ts
+++ b/data-asia/S/S8/089.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "交錯收發機"
+		ja: "クロスシーバー",
+		'zh-tw': "交錯收發機",
 	},
 
 	illustrator: "Studio Bora Inc.",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "「交錯收發機」只可2張同時使用。（效果是2張生效1次。） 從自己的棄牌區選擇1張寶可夢卡或者支援者卡，在給對手看過後加入手牌。"
+		ja: "「クロスシーバー」は、2枚同時にしか使えない。（効果は、2枚で1回はたらく。）自分のトラッシュからポケモンまたはサポートを1枚選び、相手に見せて、手札に加える。",
+		'zh-tw': "「交錯收發機」只可2張同時使用。（效果是2張生效1次。） 從自己的棄牌區選擇1張寶可夢卡或者支援者卡，在給對手看過後加入手牌。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575644,
+				tcgplayer: 569590,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S8/090.ts
+++ b/data-asia/S/S8/090.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "交錯切換機"
+		ja: "クロススイッチャー",
+		'zh-tw': "交錯切換機",
 	},
 
 	illustrator: "inose yukie",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "「交錯切換機」只可2張同時使用。（效果是2張生效1次。）選擇1隻對手的備戰寶可夢，與戰鬥寶可夢互換。然後，將自己的戰鬥寶可夢與備戰寶可夢互換。"
+		ja: "「クロススイッチャー」は、2枚同時にしか使えない。（効果は、2枚で1回はたらく。）相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、自分のバトルポケモンをベンチポケモンと入れ替える。",
+		'zh-tw': "「交錯切換機」只可2張同時使用。（效果是2張生效1次。）選擇1隻對手的備戰寶可夢，與戰鬥寶可夢互換。然後，將自己的戰鬥寶可夢與備戰寶可夢互換。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575645,
+				tcgplayer: 569591,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S8/091.ts
+++ b/data-asia/S/S8/091.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "對戰VIP參加證"
+		ja: "バトルVIPパス",
+		'zh-tw': "對戰VIP參加證",
 	},
 
 	illustrator: "Ryo Ueda",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "這張卡只能在自己的最初回合使用。 從自己的牌庫選擇最多2張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。"
+		ja: "このカードは、最初の自分の番にしか使えない。自分の山札からたねポケモンを2枚まで選び、ベンチに出す。そして山札を切る。",
+		'zh-tw': "這張卡只能在自己的最初回合使用。 從自己的牌庫選擇最多2張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575646,
+				tcgplayer: 569592,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S8/092.ts
+++ b/data-asia/S/S8/092.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "強力糖錠"
+		ja: "パワータブレット",
+		'zh-tw': "強力糖錠",
 	},
 
 	illustrator: "Toyste Beach",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "在這個回合，自己的「匯流」寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+30」點。"
+		ja: "この番、自分の「フュージョン」のポケモンが使うワザの、相手のバトルポケモンへのダメージは「+30」される。",
+		'zh-tw': "在這個回合，自己的「匯流」寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+30」點。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575647,
+				tcgplayer: 569593,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S8/093.ts
+++ b/data-asia/S/S8/093.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "海綿手套"
+		ja: "スポンジグローブ",
+		'zh-tw': "海綿手套",
 	},
 
 	illustrator: "Toyste Beach",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。"
+		ja: "このカードをつけているポケモンが使うワザの、相手のバトル場の【水】ポケモンへのダメージは「+30」される。",
+		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575648,
+				tcgplayer: 569594,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Tool",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S8/094.ts
+++ b/data-asia/S/S8/094.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "餘音大鈴鐺"
+		ja: "なごりの大鈴",
+		'zh-tw': "餘音大鈴鐺",
 	},
 
 	illustrator: "AYUMI ODASHIMA",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。"
+		ja: "このカードをつけている「ポケモンVMAX」が、相手のポケモンからワザのダメージを受けてきぜつしたとき、自分の山札から好きなカードを1枚選び、手札に加える、そして山札を切る。",
+		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575649,
+				tcgplayer: 569595,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Tool",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S8/095.ts
+++ b/data-asia/S/S8/095.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "花月"
+		ja: "カゲツ",
+		'zh-tw': "花月",
 	},
 
 	illustrator: "Hideki Ishikawa",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "查看對手的手牌，從其中選擇最多2張「寶可夢道具」「競技場」「特殊能量」卡，將其丟棄。"
+		ja: "相手の手札を見て、その中から「ポケモンのどうぐ」「スタジアム」「特殊エネルギー」を2枚まで選び、トラッシュする。",
+		'zh-tw': "查看對手的手牌，從其中選擇最多2張「寶可夢道具」「競技場」「特殊能量」卡，將其丟棄。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575650,
+				tcgplayer: 569596,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S8/096.ts
+++ b/data-asia/S/S8/096.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "小菊兒的璀璨"
+		ja: "カミツレのきらめき",
+		'zh-tw': "小菊兒的璀璨",
 	},
 
 	illustrator: "Yusuke Ohmura",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "選擇最多2隻自己的「匯流」寶可夢，從牌庫附給那些寶可夢各1張「匯流能量」卡。並且重洗牌庫。"
+		ja: "自分の「フュージョン」のポケモンを2匹まで選び、山札から「フュージョンエネルギー」を1枚ずつつける。そして山札を切る。",
+		'zh-tw': "選擇最多2隻自己的「匯流」寶可夢，從牌庫附給那些寶可夢各1張「匯流能量」卡。並且重洗牌庫。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575651,
+				tcgplayer: 569597,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S8/097.ts
+++ b/data-asia/S/S8/097.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "舞者"
+		ja: "ダンサー",
+		'zh-tw': "舞者",
 	},
 
 	illustrator: "Sanosuke Sakuma",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的牌庫抽出2張卡。若在後攻玩家的最初回合使用，則再抽出3張卡。"
+		ja: "自分の山札を2枚引く。後攻プレイヤーの最初の番に使ったなら、さらに3枚引く。",
+		'zh-tw': "從自己的牌庫抽出2張卡。若在後攻玩家的最初回合使用，則再抽出3張卡。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575652,
+				tcgplayer: 569598,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S8/098.ts
+++ b/data-asia/S/S8/098.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伯特與天桐與寇恩"
+		ja: "ポッドとデントとコーン",
+		'zh-tw': "伯特與天桐與寇恩",
 	},
 
 	illustrator: "Yusuke Ohmura",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的牌庫選擇最多3張「匯流」寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		ja: "自分の山札から「フュージョン」のポケモンを3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+		'zh-tw': "從自己的牌庫選擇最多3張「匯流」寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575653,
+				tcgplayer: 569599,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S8/099.ts
+++ b/data-asia/S/S8/099.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "滑板選手的公園"
+		ja: "スケーターズパーク",
+		'zh-tw': "滑板選手的公園",
 	},
 
 	illustrator: "Oswaldo KATO",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "雙方的戰鬥寶可夢【撤退】時，若丟棄的能量為基本能量，則不丟棄那些能量，而是放回自己的手牌。"
+		ja: "おたがいのバトルポケモンがにげるとき、トラッシュするエネルギーが基本エネルギーなら、そのエネルギーはトラッシュせず、自分の手札にもどす。",
+		'zh-tw': "雙方的戰鬥寶可夢【撤退】時，若丟棄的能量為基本能量，則不丟棄那些能量，而是放回自己的手牌。",
 	},
 
-	trainerType: "Stadium",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575654,
+				tcgplayer: 569600,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Stadium",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S8/100.ts
+++ b/data-asia/S/S8/100.ts
@@ -1,21 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S8"
+import { Card } from "../../../interfaces";
+import Set from "../S8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "匯流能量"
+		ja: "フュージョンエネルギー",
+		'zh-tw': "匯流能量",
 	},
 
+	illustrator: "",
 	category: "Energy",
+	energyType: "Special",
 
 	effect: {
-		'zh-tw': "這張卡只可附於「匯流」寶可夢身上，若附於「匯流」寶可夢以外的寶可夢身上，則將其丟棄。 只要這張卡附於寶可夢身上，視為提供1個所有屬性的能量，附有這張卡的寶可夢，不會受到對手的寶可夢的特性效果影響。"
+		ja: "このカードは「フュージョン」のポケモンにしかつけられず、「フュージョン」のポケモン以外についているなら、トラッシュする。このカードは、ポケモンについているかぎり、すべてのタイプのエネルギー1個ぶんとしてはたらき、このカードをつけているポケモンは、相手のポケモンから特性の効果を受けない。",
+		'zh-tw': "這張卡只可附於「匯流」寶可夢身上，若附於「匯流」寶可夢以外的寶可夢身上，則將其丟棄。 只要這張卡附於寶可夢身上，視為提供1個所有屬性的能量，附有這張卡的寶可夢，不會受到對手的寶可夢的特性效果影響。",
 	},
 
-	energyType: "Special",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575655,
+				tcgplayer: 569601,
+			},
+		},
+	],
 
-export default card
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S8/101.ts
+++ b/data-asia/S/S8/101.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アマージョV",
+	},
+
+	illustrator: "PLANETA Mochizuki",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "クイーンオーダー" },
+			damage: "20+",
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "自分のベンチポケモンを好きなだけトラッシュし、トラッシュしたベンチポケモンの数×40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576179,
+				tcgplayer: 569602,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [763],
+};
+
+export default card;

--- a/data-asia/S/S8/102.ts
+++ b/data-asia/S/S8/102.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シャンデラV",
+	},
+
+	illustrator: "Saki Hayashiro",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あやしいひかり" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "ポルターガイスト" },
+			damage: "40×",
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "相手の手札を見て、その中にあるトレーナーズの枚数×40ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576180,
+				tcgplayer: 569603,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [609],
+};
+
+export default card;

--- a/data-asia/S/S8/103.ts
+++ b/data-asia/S/S8/103.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケケンカニV",
+	},
+
+	illustrator: "MUGENUP",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なだれおこし" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手の山札を上から2枚トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "デストロイヤーパンチ" },
+			damage: "90+",
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにのっているダメカンの数×60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576181,
+				tcgplayer: 569604,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [740],
+};
+
+export default card;

--- a/data-asia/S/S8/104.ts
+++ b/data-asia/S/S8/104.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パルスワンV",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "スマッシュターン" },
+			damage: 30,
+			cost: ["Lightning"],
+			effect: {
+				ja: "のぞむなら、このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "エレキバレット" },
+			damage: 120,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576182,
+				tcgplayer: 569605,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [836],
+};
+
+export default card;

--- a/data-asia/S/S8/105.ts
+++ b/data-asia/S/S8/105.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミュウV",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "エナジーミックス" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の山札からエネルギーを1枚選び、自分の「フュージョン」のポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "サイコジャンプ" },
+			damage: 70,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576183,
+				tcgplayer: 569606,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [151],
+};
+
+export default card;

--- a/data-asia/S/S8/106.ts
+++ b/data-asia/S/S8/106.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミュウV",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "エナジーミックス" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の山札からエネルギーを1枚選び、自分の「フュージョン」のポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "サイコジャンプ" },
+			damage: 70,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンと、ついているすべてのカードを、自分の山札にもどして切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576184,
+				tcgplayer: 569607,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [151],
+};
+
+export default card;

--- a/data-asia/S/S8/107.ts
+++ b/data-asia/S/S8/107.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フーパV",
+	},
+
+	illustrator: "takuyoa",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ダブルフェイス" },
+			effect: {
+				ja: "このポケモンは、場にいるかぎり[超]と[悪]の2つのタイプになる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "シャドーインパクト" },
+			damage: 170,
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "自分のポケモン1匹に、ダメカンを3個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576185,
+				tcgplayer: 569608,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [720],
+};
+
+export default card;

--- a/data-asia/S/S8/108.ts
+++ b/data-asia/S/S8/108.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲノセクトV",
+	},
+
+	illustrator: "PLANETA Tsuji",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "フュージョンシステム" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札の枚数が、自分の場の「フュージョン」のポケモンの数と同じ枚数になるように、山札を引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "テクノバスター" },
+			damage: 210,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576186,
+				tcgplayer: 569609,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [649],
+};
+
+export default card;

--- a/data-asia/S/S8/109.ts
+++ b/data-asia/S/S8/109.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲノセクトV",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "フュージョンシステム" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札の枚数が、自分の場の「フュージョン」のポケモンの数と同じ枚数になるように、山札を引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "テクノバスター" },
+			damage: 210,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576187,
+				tcgplayer: 569610,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [649],
+};
+
+export default card;

--- a/data-asia/S/S8/110.ts
+++ b/data-asia/S/S8/110.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨクバリスV",
+	},
+
+	illustrator: "PLANETA Mochizuki",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "のしかかり" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "がっつくまえば" },
+			damage: 120,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札を3枚引く。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576188,
+				tcgplayer: 569611,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [820],
+};
+
+export default card;

--- a/data-asia/S/S8/111.ts
+++ b/data-asia/S/S8/111.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨクバリスV",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "のしかかり" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "がっつくまえば" },
+			damage: 120,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札を3枚引く。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576189,
+				tcgplayer: 569612,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [820],
+};
+
+export default card;

--- a/data-asia/S/S8/112.ts
+++ b/data-asia/S/S8/112.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カゲツ",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手の手札を見て、その中から「ポケモンのどうぐ」「スタジアム」「特殊エネルギー」を2枚まで選び、トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576190,
+				tcgplayer: 569613,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S8/113.ts
+++ b/data-asia/S/S8/113.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カミツレのきらめき",
+	},
+
+	illustrator: "Ryuta Fuse",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の「フュージョン」のポケモンを2匹まで選び、山札から「フュージョンエネルギー」を1枚ずつつける。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576191,
+				tcgplayer: 569614,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S8/114.ts
+++ b/data-asia/S/S8/114.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダンサー",
+	},
+
+	illustrator: "Yuu Nishida",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を2枚引く。後攻プレイヤーの最初の番に使ったなら、さらに3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576192,
+				tcgplayer: 569615,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S8/115.ts
+++ b/data-asia/S/S8/115.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポッドとデントとコーン",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から「フュージョン」のポケモンを3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576193,
+				tcgplayer: 569616,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S8/116.ts
+++ b/data-asia/S/S8/116.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シャンデラVMAX",
+	},
+
+	illustrator: "AKIRA EGAWA",
+	category: "Pokemon",
+	hp: 320,
+	types: ["Fire"],
+
+	stage: "VMAX",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "じゅばくのかげろう" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手は手札から「ポケモンのどうぐ」を出してつけられない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ダイポルターガイスト" },
+			damage: "70×",
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "相手の手札を見て、その中にあるトレーナーズの枚数×70ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576194,
+				tcgplayer: 569617,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シャンデラV",
+	},
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Hyper rare",
+	dexId: [609],
+};
+
+export default card;

--- a/data-asia/S/S8/117.ts
+++ b/data-asia/S/S8/117.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パルスワンVMAX",
+	},
+
+	illustrator: "PLANETA Tsuji",
+	category: "Pokemon",
+	hp: 320,
+	types: ["Lightning"],
+
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: { ja: "ライトニングストーム" },
+			damage: "30+",
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[雷]エネルギーの数×30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ダイボルト" },
+			damage: 230,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「ダイボルト」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576195,
+				tcgplayer: 569618,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "パルスワンV",
+	},
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Hyper rare",
+	dexId: [836],
+};
+
+export default card;

--- a/data-asia/S/S8/118.ts
+++ b/data-asia/S/S8/118.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミュウVMAX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Psychic"],
+
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: { ja: "クロスフュージョン" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチの「フュージョン」のポケモンが持っているワザを1つ選び、このワザとして使う。",
+			},
+		},
+		{
+			name: { ja: "ダイミラクル" },
+			damage: 130,
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576196,
+				tcgplayer: 569619,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ミュウV",
+	},
+
+	retreat: 0,
+	regulationMark: "E",
+	rarity: "Hyper rare",
+	dexId: [151],
+};
+
+export default card;

--- a/data-asia/S/S8/119.ts
+++ b/data-asia/S/S8/119.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミュウVMAX",
+	},
+
+	illustrator: "AKIRA EGAWA",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Psychic"],
+
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: { ja: "クロスフュージョン" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチの「フュージョン」のポケモンが持っているワザを1つ選び、このワザとして使う。",
+			},
+		},
+		{
+			name: { ja: "ダイミラクル" },
+			damage: 130,
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576197,
+				tcgplayer: 569620,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ミュウV",
+	},
+
+	retreat: 0,
+	regulationMark: "E",
+	rarity: "Secret Rare",
+	dexId: [151],
+};
+
+export default card;

--- a/data-asia/S/S8/120.ts
+++ b/data-asia/S/S8/120.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨクバリスVMAX",
+	},
+
+	illustrator: "PLANETA Mochizuki",
+	category: "Pokemon",
+	hp: 320,
+	types: ["Colorless"],
+
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: { ja: "まるもうけ" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージで、相手のたねポケモンがきぜつしたなら、サイドを2枚多くとる。",
+			},
+		},
+		{
+			name: { ja: "ダイゴウヨク" },
+			damage: 160,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札を3枚引く。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576198,
+				tcgplayer: 569621,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヨクバリスV",
+	},
+
+	retreat: 3,
+	regulationMark: "E",
+	rarity: "Hyper rare",
+	dexId: [820],
+};
+
+export default card;

--- a/data-asia/S/S8/121.ts
+++ b/data-asia/S/S8/121.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カゲツ",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手の手札を見て、その中から「ポケモンのどうぐ」「スタジアム」「特殊エネルギー」を2枚まで選び、トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576199,
+				tcgplayer: 569622,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Hyper rare",
+};
+
+export default card;

--- a/data-asia/S/S8/122.ts
+++ b/data-asia/S/S8/122.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カミツレのきらめき",
+	},
+
+	illustrator: "Ryuta Fuse",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の「フュージョン」のポケモンを2匹まで選び、山札から「フュージョンエネルギー」を1枚ずつつける。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576200,
+				tcgplayer: 569623,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Hyper rare",
+};
+
+export default card;

--- a/data-asia/S/S8/123.ts
+++ b/data-asia/S/S8/123.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダンサー",
+	},
+
+	illustrator: "Yuu Nishida",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を2枚引く。後攻プレイヤーの最初の番に使ったなら、さらに3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576201,
+				tcgplayer: 569624,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Hyper rare",
+};
+
+export default card;

--- a/data-asia/S/S8/124.ts
+++ b/data-asia/S/S8/124.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポッドとデントとコーン",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から「フュージョン」のポケモンを3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576202,
+				tcgplayer: 569625,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Hyper rare",
+};
+
+export default card;

--- a/data-asia/S/S8/125.ts
+++ b/data-asia/S/S8/125.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モココ",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Lightning"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "でんじしょうがい" },
+			damage: 40,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "次の相手の番、相手は手札からグッズを出して使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576203,
+				tcgplayer: 569626,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メリープ",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Secret Rare",
+	dexId: [180],
+};
+
+export default card;

--- a/data-asia/S/S8/126.ts
+++ b/data-asia/S/S8/126.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トレーニングコート",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分のトラッシュから基本エネルギーを1枚選び、相手に見せて、手札に加えてよい。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576204,
+				tcgplayer: 569627,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "D",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/S/S8/127.ts
+++ b/data-asia/S/S8/127.ts
@@ -1,0 +1,27 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本草エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576205,
+				tcgplayer: 569628,
+			},
+		},
+	],
+
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/S/S8/128.ts
+++ b/data-asia/S/S8/128.ts
@@ -1,0 +1,27 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本炎エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576206,
+				tcgplayer: 577430,
+			},
+		},
+	],
+
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/S/S8/129.ts
+++ b/data-asia/S/S8/129.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パワータブレット",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "この番、自分の「フュージョン」のポケモンが使うワザの、相手のバトルポケモンへのダメージは「+30」される。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576207,
+				tcgplayer: 577431,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "E",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -236,6 +236,7 @@ export interface Card {
 			// Black White rare
 			| 'Black White Rare'
 			| 'Mega Hyper Rare'
+			| 'Triple Rare'
 			// Japanese Character Rares (since SM11b Dream League)
 			| 'Character Rare' | 'Character Super Rare'
 			// Pokémon TCG Pocket Rarities


### PR DESCRIPTION
## What

Refreshes the existing Japanese set **S8 フュージョンアーツ (Fusion Arts)** from its primary sources. The curated content stays: every card keeps its `zh-tw` texts verbatim.

What changes across the 129 card files:

- `thirdParty.cardmarket` moves onto `variants` objects and 100 missing ids are filled in
- per card where missing: `dexId`, `evolveFrom`, `resistances`, the Japanese flavor text and the Japanese effect/attack texts straight from the official database and limitless

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (575551–576207)
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (569502–577431), keyed by the collection number each product carries in `extendedData`

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- All 129 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
