### PR TITLE
(data) Update Japanese S set S7D Skyscraping Perfection

### DIFF
--- a/data-asia/S/S7D/001.ts
+++ b/data-asia/S/S7D/001.ts
@@ -1,52 +1,66 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "水君V"
+		ja: "スイクンV",
+		'zh-tw': "水君V",
 	},
 
 	illustrator: "Ayaka Yoshida",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Water"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "瞬步"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "しゅんそく",
+				'zh-tw': "瞬步",
+			},
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。自分の山札を1枚引く。",
+				'zh-tw': "若這隻寶可夢在戰鬥場上，則在自己的回合時可使用1次。從自己的牌庫抽出1張卡。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢在戰鬥場上，則在自己的回合時可使用1次。從自己的牌庫抽出1張卡。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "暴雪迴旋曲"
+	attacks: [
+		{
+			name: {
+				ja: "ブリザードロンド",
+				'zh-tw': "暴雪迴旋曲",
+			},
+			damage: "20+",
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "おたがいのベンチポケモンの数×20ダメージ追加。",
+				'zh-tw': "增加雙方的備戰寶可夢的數量×20點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加雙方的備戰寶可夢的數量×20點傷害。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 571583,
+				tcgplayer: 569324,
+			},
 		},
-
-		damage: "20+",
-		cost: ["Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [245],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/002.ts
+++ b/data-asia/S/S7D/002.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "蓮葉童子"
+		ja: "ハスボー",
+		'zh-tw': "蓮葉童子",
 	},
 
 	illustrator: "Teeziro",
@@ -14,37 +14,51 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "因為葉子長得太大太重，所以才會改變習性，漂浮在水面上生活。"
+		ja: "葉っぱが 大きく なりすぎて 重くなって しまったため 水に 浮かんで 暮らすように なった。",
+		'zh-tw': "因為葉子長得太大太重，所以才會改變習性，漂浮在水面上生活。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "呼朋引伴"
+	attacks: [
+		{
+			name: {
+				ja: "なかまをよぶ",
+				'zh-tw': "呼朋引伴",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からたねポケモンを2枚まで選び、ベンチに出す。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多2張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多2張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。"
+		{
+			name: {
+				ja: "みずかけ",
+				'zh-tw': "潑水",
+			},
+			damage: 20,
+			cost: ["Water", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "潑水"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571584,
+				tcgplayer: 569325,
+			},
 		},
-
-		damage: 20,
-		cost: ["Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [270],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/003.ts
+++ b/data-asia/S/S7D/003.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "蓮帽小童"
+		ja: "ハスブレロ",
+		'zh-tw': "蓮帽小童",
 	},
 
 	illustrator: "miki kudo",
@@ -14,27 +14,44 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "住在日照充足的水邊。白天在水草做的床上睡覺，太陽下山後就會出來活動。"
+		ja: "日当たりの 良い 水辺に 棲む。 昼間は 水草の ベッドで 眠り 日が 暮れると 動き出す。",
+		'zh-tw': "住在日照充足的水邊。白天在水草做的床上睡覺，太陽下山後就會出來活動。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "飛濺"
+	attacks: [
+		{
+			name: {
+				ja: "スプラッシュ",
+				'zh-tw': "飛濺",
+			},
+			damage: 50,
+			cost: ["Water", "Colorless"],
 		},
+	],
 
-		damage: 50,
-		cost: ["Water", "Colorless"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571585,
+				tcgplayer: 569326,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ハスボー",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [271],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/004.ts
+++ b/data-asia/S/S7D/004.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "樂天河童"
+		ja: "ルンパッパ",
+		'zh-tw': "樂天河童",
 	},
 
 	illustrator: "sowsow",
@@ -14,39 +14,58 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "樂天河童會跟著歡快的音樂搖擺身體，藉而增強自己的力量。"
+		ja: "陽気な リズムに あわせて 体を 動かす ことで パワーを 増幅させて いるのだ。",
+		'zh-tw': "樂天河童會跟著歡快的音樂搖擺身體，藉而增強自己的力量。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "嗨翻舞"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ハイテンションダンス",
+				'zh-tw': "嗨翻舞",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。この番、自分のたねポケモンが使うワザの、相手のバトルポケモンへのダメージは「+100」される。",
+				'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。在這個回合，自己的【基礎】寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+100」點。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。在這個回合，自己的【基礎】寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+100」點。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "飛濺"
+	attacks: [
+		{
+			name: {
+				ja: "スプラッシュ",
+				'zh-tw': "飛濺",
+			},
+			damage: 120,
+			cost: ["Water", "Colorless"],
 		},
+	],
 
-		damage: 120,
-		cost: ["Water", "Colorless"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 571586,
+				tcgplayer: 569327,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ハスブレロ",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [272],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/005.ts
+++ b/data-asia/S/S7D/005.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "冷水猴"
+		ja: "ヒヤップ",
+		'zh-tw': "冷水猴",
 	},
 
 	illustrator: "Sekio",
@@ -14,31 +14,44 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "頭上的毛髮叢裡儲藏的水充滿營養。如果拿來灌溉，植物就會茁壯成長。"
+		ja: "頭の ふさに ためた 水は 栄養 たっぷり。 植物に かけると 大きく 育つのだ。",
+		'zh-tw': "頭上的毛髮叢裡儲藏的水充滿營養。如果拿來灌溉，植物就會茁壯成長。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "猛地一動"
+	attacks: [
+		{
+			name: {
+				ja: "ぐいっとする",
+				'zh-tw': "猛地一動",
+			},
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "相手の手札を見る。",
+				'zh-tw': "查看對手的手牌。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "查看對手的手牌。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571587,
+				tcgplayer: 569328,
+			},
 		},
-
-		damage: 10,
-		cost: ["Water"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [515],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/006.ts
+++ b/data-asia/S/S7D/006.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "冷水猿"
+		ja: "ヒヤッキー",
+		'zh-tw': "冷水猿",
 	},
 
 	illustrator: "Shin Nagasawa",
@@ -14,42 +14,60 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "喜歡水質乾淨的地方。頭上儲存的水如果減少，就會從尾巴吸取水來補給。"
+		ja: "水が きれいな 場所を 好む。 頭に ためこんだ 水が減ると 尻尾から 吸いあげて 補給。",
+		'zh-tw': "喜歡水質乾淨的地方。頭上儲存的水如果減少，就會從尾巴吸取水來補給。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "水之波動"
+	attacks: [
+		{
+			name: {
+				ja: "みずのはどう",
+				'zh-tw': "水之波動",
+			},
+			damage: 20,
+			cost: ["Water"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【睡眠】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【睡眠】。"
+		{
+			name: {
+				ja: "ずぶぬれサーカス",
+				'zh-tw': "濕透雜耍",
+			},
+			damage: "60×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手の手札を見て、その中にあるサポートの枚数×60ダメージ。",
+				'zh-tw': "查看對手的手牌，造成其中支援者卡的張數×60點傷害。",
+			},
 		},
+	],
 
-		damage: 20,
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "濕透雜耍"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571588,
+				tcgplayer: 569329,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "查看對手的手牌，造成其中支援者卡的張數×60點傷害。"
-		},
-
-		damage: "60×",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ヒヤップ",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [516],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/007.ts
+++ b/data-asia/S/S7D/007.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鐵臂槍蝦"
+		ja: "ウデッポウ",
+		'zh-tw': "鐵臂槍蝦",
 	},
 
 	illustrator: "Pani Kobayashi",
@@ -14,34 +14,48 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "從右邊的鉗子噴出水來移動。因為無法取得平衡，所以不擅長直線游動。"
+		ja: "右の ハサミから 水を 噴き出し 移動。 バランスが 悪いので まっすぐ 泳ぐのは 下手くそ。",
+		'zh-tw': "從右邊的鉗子噴出水來移動。因為無法取得平衡，所以不擅長直線游動。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "水槍"
+	attacks: [
+		{
+			name: {
+				ja: "みずでっぽう",
+				'zh-tw': "水槍",
+			},
+			damage: 10,
+			cost: ["Water"],
 		},
-
-		damage: 10,
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "夾住"
+		{
+			name: {
+				ja: "はさむ",
+				'zh-tw': "夾住",
+			},
+			damage: 20,
+			cost: ["Water", "Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Water", "Colorless"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571589,
+				tcgplayer: 569330,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [692],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/008.ts
+++ b/data-asia/S/S7D/008.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鋼炮臂蝦"
+		ja: "ブロスター",
+		'zh-tw': "鋼炮臂蝦",
 	},
 
 	illustrator: "tetsuya koizumi",
@@ -14,37 +14,55 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "右臂的肉非常緊實飽滿。脫落下來的鉗子會被當成食材外銷到海外。"
+		ja: "右腕の 身は よく締まっている。 もげた ハサミは 食材 として 海外に 輸出 される。",
+		'zh-tw': "右臂的肉非常緊實飽滿。脫落下來的鉗子會被當成食材外銷到海外。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "狙擊"
+	attacks: [
+		{
+			name: {
+				ja: "ねらいうち",
+				'zh-tw': "狙擊",
+			},
+			cost: ["Water"],
+			effect: {
+				ja: "相手のベンチポケモン1匹に、50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的1隻備戰寶可夢受到50點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
-
-		effect: {
-			'zh-tw': "對手的1隻備戰寶可夢受到50點傷害。[在備戰區不計算弱點・抵抗力。]"
+		{
+			name: {
+				ja: "クラブハンマー",
+				'zh-tw': "蟹鉗錘",
+			},
+			damage: 110,
+			cost: ["Water", "Water", "Colorless"],
 		},
+	],
 
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "蟹鉗錘"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571590,
+				tcgplayer: 569331,
+			},
 		},
+	],
 
-		damage: 110,
-		cost: ["Water", "Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ウデッポウ",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [693],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/009.ts
+++ b/data-asia/S/S7D/009.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "冰砌鵝"
+		ja: "コオリッポ",
+		'zh-tw': "冰砌鵝",
 	},
 
 	illustrator: "Mizue",
@@ -14,38 +14,52 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "無論何時都用冰塊冰鎮著自己怕熱的臉。會把頭頂上的毛垂到海裡釣食物吃。"
+		ja: "暑さに 弱い 顔を いつも 氷で 冷やしている。 頭の 毛を 海に たらして 餌を釣る。",
+		'zh-tw': "無論何時都用冰塊冰鎮著自己怕熱的臉。會把頭頂上的毛垂到海裡釣食物吃。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "雪花冰"
+	attacks: [
+		{
+			name: {
+				ja: "スノーアイス",
+				'zh-tw': "雪花冰",
+			},
+			damage: 20,
+			cost: ["Water"],
 		},
-
-		damage: 20,
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "冰塊頭"
+		{
+			name: {
+				ja: "ブロックフェイス",
+				'zh-tw': "冰塊頭",
+			},
+			damage: 70,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンはたねポケモンからワザのダメージを受けない。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢不會受到【基礎】寶可夢招式的傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，這隻寶可夢不會受到【基礎】寶可夢招式的傷害。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571591,
+				tcgplayer: 569332,
+			},
 		},
-
-		damage: 70,
-		cost: ["Water", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [875],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/010.ts
+++ b/data-asia/S/S7D/010.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "胖丁"
+		ja: "プリン",
+		'zh-tw': "胖丁",
 	},
 
 	illustrator: "Saya Tsuruta",
@@ -14,38 +14,52 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "隨著棲息的地方不同，所唱的歌也完全不一樣。甚至有一部分胖丁唱的歌聽起來就像是在大吼大叫。"
+		ja: "歌う 歌は 棲む 地方によって 全然 違っている。 中には シャウトするような ものまで あるぞ。",
+		'zh-tw': "隨著棲息的地方不同，所唱的歌也完全不一樣。甚至有一部分胖丁唱的歌聽起來就像是在大吼大叫。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "拍擊"
+	attacks: [
+		{
+			name: {
+				ja: "はたく",
+				'zh-tw': "拍擊",
+			},
+			damage: 20,
+			cost: ["Psychic"],
 		},
-
-		damage: 20,
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "一同滾動"
+		{
+			name: {
+				ja: "みんなでころがる",
+				'zh-tw': "一同滾動",
+			},
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチの、ワザ「みんなでころがる」を持つポケモンの数×20ダメージ。",
+				'zh-tw': "造成自己的備戰區的，持有「一同滾動」招式的寶可夢的數量×20點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "造成自己的備戰區的，持有「一同滾動」招式的寶可夢的數量×20點傷害。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571592,
+				tcgplayer: 569333,
+			},
 		},
-
-		damage: "20×",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [39],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/011.ts
+++ b/data-asia/S/S7D/011.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "胖可丁"
+		ja: "プクリン",
+		'zh-tw': "胖可丁",
 	},
 
 	illustrator: "Asako Ito",
@@ -14,37 +14,55 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "生氣時會拼命吸氣，讓自己的身體不斷膨脹。有時甚至能脹大到原來的２０倍。"
+		ja: "怒ると 思いっきり 息を 吸い込み どんどん 膨らんでいく。 なんと ２０倍に なることもある。",
+		'zh-tw': "生氣時會拼命吸氣，讓自己的身體不斷膨脹。有時甚至能脹大到原來的２０倍。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "發現寶物"
+	attacks: [
+		{
+			name: {
+				ja: "たからをみつける",
+				'zh-tw': "發現寶物",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の山札から好きなカードを2枚まで選び、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫任意選擇最多2張卡加入手牌。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫任意選擇最多2張卡加入手牌。並且重洗牌庫。"
+		{
+			name: {
+				ja: "ハイパーボイス",
+				'zh-tw': "巨聲",
+			},
+			damage: 90,
+			cost: ["Psychic", "Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "巨聲"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571593,
+				tcgplayer: 569334,
+			},
 		},
+	],
 
-		damage: 90,
-		cost: ["Psychic", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "プリン",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [40],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/012.ts
+++ b/data-asia/S/S7D/012.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伽勒爾 急凍鳥"
+		ja: "ガラル フリーザー",
+		'zh-tw': "伽勒爾 急凍鳥",
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -14,47 +14,57 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "擁有急凍鳥之名的寶可夢。射出的光束會讓對方的身體像結凍似地失去自由。"
+		ja: "凍りついたかのように 体の 自由を 奪う ビームを 撃ちだす フリーザーの 名を もつ ポケモン。",
+		'zh-tw': "擁有急凍鳥之名的寶可夢。射出的光束會讓對方的身體像結凍似地失去自由。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "冷酷充能"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "れいこくチャージ",
+				'zh-tw': "冷酷充能",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の手札から[超]エネルギーを2枚まで選び、このポケモンにつける。",
+				'zh-tw': "在自己的回合，當從手牌將這張卡放置於備戰區時，可使用1次。從自己的手牌選擇最多2張【超】能量卡，附於這隻寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，當從手牌將這張卡放置於備戰區時，可使用1次。從自己的手牌選擇最多2張【超】能量卡，附於這隻寶可夢身上。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "精神鐳射"
+	attacks: [
+		{
+			name: {
+				ja: "サイコレーザー",
+				'zh-tw': "精神鐳射",
+			},
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[超]エネルギーをすべてトラッシュし、相手のポケモン1匹に、120ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "將這隻寶可夢身上附加的【超】能量全部丟棄，對手的1隻寶可夢受到120點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將這隻寶可夢身上附加的【超】能量全部丟棄，對手的1隻寶可夢受到120點傷害。[在備戰區不計算弱點・抵抗力。]"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 571594,
+				tcgplayer: 569335,
+			},
 		},
-
-		cost: ["Psychic", "Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [144],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/013.ts
+++ b/data-asia/S/S7D/013.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "果然翁"
+		ja: "ソーナンス",
+		'zh-tw': "果然翁",
 	},
 
 	illustrator: "Anesaki Dynamic",
@@ -14,42 +14,51 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "為了隱藏漆黑的尾巴而悄悄地生活在黑暗之中。不會主動發動攻擊。"
+		ja: "真っ黒な 尻尾を 隠すため 暗闇で ひっそりと 生きている。 自分からは 攻撃しない。",
+		'zh-tw': "為了隱藏漆黑的尾巴而悄悄地生活在黑暗之中。不會主動發動攻擊。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "鏡面傷痛"
+	attacks: [
+		{
+			name: {
+				ja: "ミラーペイン",
+				'zh-tw': "鏡面傷痛",
+			},
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチポケモンを1匹選び、選んだポケモンにのっているダメカンと同じ数のダメカンを、相手のバトルポケモンにのせる。",
+				'zh-tw': "選擇自己的1隻備戰寶可夢，將與所選的寶可夢身上放置的傷害指示物數量相同的傷害指示物，放置於對手的戰鬥寶可夢身上。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇自己的1隻備戰寶可夢，將與所選的寶可夢身上放置的傷害指示物數量相同的傷害指示物，放置於對手的戰鬥寶可夢身上。"
+		{
+			name: {
+				ja: "とびだしヘッド",
+				'zh-tw': "魯莽頭擊",
+			},
+			damage: 70,
+			cost: ["Psychic", "Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "魯莽頭擊"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571595,
+				tcgplayer: 569336,
+			},
 		},
-
-		damage: 70,
-		cost: ["Psychic", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [202],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/014.ts
+++ b/data-asia/S/S7D/014.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "象徵鳥"
+		ja: "シンボラー",
+		'zh-tw': "象徵鳥",
 	},
 
 	illustrator: "Yukiko Baba",
@@ -14,47 +14,56 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "人們在象徵鳥飛過的沙漠地下進行調查，結果在那裡發現了疑似古代都市的遺跡。"
+		ja: "シンボラーが 飛ぶ 砂漠の下を 調査すると 古代の 都市と 思われる 名残りが 見つかった。",
+		'zh-tw': "人們在象徵鳥飛過的沙漠地下進行調查，結果在那裡發現了疑似古代都市的遺跡。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "狙落"
+	attacks: [
+		{
+			name: {
+				ja: "ねらいおとす",
+				'zh-tw': "狙落",
+			},
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "ダメージを与える前に、相手のバトルポケモンについている「ポケモンのどうぐ」をトラッシュする。",
+				'zh-tw': "在造成傷害前，將對手的戰鬥寶可夢身上附加的「寶可夢道具」丟棄。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在造成傷害前，將對手的戰鬥寶可夢身上附加的「寶可夢道具」丟棄。"
+		{
+			name: {
+				ja: "エネリフレクト",
+				'zh-tw': "能量反射",
+			},
+			damage: 60,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、ベンチポケモンにつけ替える。",
+				'zh-tw': "選擇1個這隻寶可夢身上附加的能量，改附於備戰寶可夢身上。",
+			},
 		},
+	],
 
-		damage: 20,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "能量反射"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571596,
+				tcgplayer: 569337,
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇1個這隻寶可夢身上附加的能量，改附於備戰寶可夢身上。"
-		},
-
-		damage: 60,
-		cost: ["Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [561],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/015.ts
+++ b/data-asia/S/S7D/015.ts
@@ -1,52 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "泥偶巨人V"
+		ja: "ゴルーグV",
+		'zh-tw': "泥偶巨人V",
 	},
 
 	illustrator: "Eske Yoshinob",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Psychic"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "百萬噸重拳"
+	attacks: [
+		{
+			name: {
+				ja: "メガトンパンチ",
+				'zh-tw': "百萬噸重拳",
+			},
+			damage: 80,
+			cost: ["Psychic", "Colorless", "Colorless"],
 		},
-
-		damage: 80,
-		cost: ["Psychic", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "倒轉光束"
+		{
+			name: {
+				ja: "リワインドビーム",
+				'zh-tw': "倒轉光束",
+			},
+			damage: 180,
+			cost: ["Psychic", "Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の進化しているバトルポケモンから、「進化カード」を1枚はがして退化させる。はがしたカードは、相手の手札にもどす。",
+				'zh-tw': "從對手的進化的戰鬥寶可夢身上，移除1張「進化卡」使其退化。將移除的卡放回對手的手牌。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從對手的進化的戰鬥寶可夢身上，移除1張「進化卡」使其退化。將移除的卡放回對手的手牌。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 571597,
+				tcgplayer: 569338,
+			},
 		},
-
-		damage: 180,
-		cost: ["Psychic", "Psychic", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [623],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/016.ts
+++ b/data-asia/S/S7D/016.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "南瓜精"
+		ja: "バケッチャ",
+		'zh-tw': "南瓜精",
 	},
 
 	illustrator: "Yuka Morii",
@@ -14,44 +14,54 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "南瓜的洞裡發出的光會催眠並控制看到牠的人和寶可夢。"
+		ja: "かぼちゃの 穴から 照らしている 光は 見た 人や ポケモンを 催眠状態にして 操る。",
+		'zh-tw': "南瓜的洞裡發出的光會催眠並控制看到牠的人和寶可夢。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "南瓜洞穴"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "かぼちゃのあな",
+				'zh-tw': "南瓜洞穴",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。場に出ているスタジアムをトラッシュする。",
+				'zh-tw': "在自己的回合，當從手牌將這張卡放置於備戰區時，可使用1次。將場上的競技場卡丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，當從手牌將這張卡放置於備戰區時，可使用1次。將場上的競技場卡丟棄。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "踩"
+	attacks: [
+		{
+			name: {
+				ja: "ふむ",
+				'zh-tw': "踩",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571598,
+				tcgplayer: 569339,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [710],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/017.ts
+++ b/data-asia/S/S7D/017.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "南瓜怪人"
+		ja: "パンプジン",
+		'zh-tw': "南瓜怪人",
 	},
 
 	illustrator: "Megumi Higuchi",
@@ -14,36 +14,48 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "南瓜怪人會在朔月的夜裡去別人家門口敲門。開了門的人會被牠帶往另一個世界。"
+		ja: "新月の 夜 玄関の ドアを パンプジンが ノックする。 開けた 人を あの世へ 連れて行くのだ。",
+		'zh-tw': "南瓜怪人會在朔月的夜裡去別人家門口敲門。開了門的人會被牠帶往另一個世界。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "百鬼夜行"
+	attacks: [
+		{
+			name: {
+				ja: "ひゃっきやこう",
+				'zh-tw': "百鬼夜行",
+			},
+			damage: "60×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札を上から6枚オモテにする。その中にある[超]ポケモンの数×60ダメージ。オモテにした[超]ポケモンは山札にもどして切る。残りのカードはトラッシュする。",
+				'zh-tw': "將自己的牌庫上方6張卡翻到正面。造成其中的【超】寶可夢的數量×60點傷害。將翻到正面的【超】寶可夢放回牌庫並重洗。將剩餘卡丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將自己的牌庫上方6張卡翻到正面。造成其中的【超】寶可夢的數量×60點傷害。將翻到正面的【超】寶可夢放回牌庫並重洗。將剩餘卡丟棄。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571599,
+				tcgplayer: 569340,
+			},
 		},
+	],
 
-		damage: "60×",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "バケッチャ",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [711],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/018.ts
+++ b/data-asia/S/S7D/018.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "快拳郎"
+		ja: "エビワラー",
+		'zh-tw': "快拳郎",
 	},
 
 	illustrator: "Uta",
@@ -14,42 +14,56 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "打出的拳擊甚至能劈開空氣。但連續攻擊３分鐘後，牠似乎就會想休息一下。"
+		ja: "空気をも 切り裂く パンチ。 だが ３分間 攻撃すると ひと休み したくなるらしい。",
+		'zh-tw': "打出的拳擊甚至能劈開空氣。但連續攻擊３分鐘後，牠似乎就會想休息一下。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "俐落一擊"
+	attacks: [
+		{
+			name: {
+				ja: "クリーンヒット",
+				'zh-tw': "俐落一擊",
+			},
+			damage: "20+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のバトルポケモンが進化ポケモンなら、50ダメージ追加。",
+				'zh-tw': "若對手的戰鬥寶可夢為進化寶可夢，則增加50點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "若對手的戰鬥寶可夢為進化寶可夢，則增加50點傷害。"
+		{
+			name: {
+				ja: "だんがんストレート",
+				'zh-tw': "槍彈直擊",
+			},
+			damage: 40,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+				'zh-tw': "這個招式的傷害不計算抵抗力。",
+			},
 		},
+	],
 
-		damage: "20+",
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "槍彈直擊"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571600,
+				tcgplayer: 569341,
+			},
 		},
-
-		effect: {
-			'zh-tw': "這個招式的傷害不計算抵抗力。"
-		},
-
-		damage: 40,
-		cost: ["Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [107],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/019.ts
+++ b/data-asia/S/S7D/019.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伽勒爾 閃電鳥"
+		ja: "ガラル サンダー",
+		'zh-tw': "伽勒爾 閃電鳥",
 	},
 
 	illustrator: "kodama",
@@ -14,43 +14,58 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "擁有能夠一腳踢毀砂石車的強勁腳力。據說能以時速３００公里在山中奔跑。"
+		ja: "ひと蹴りで ダンプカーを 粉々に する 脚力を もつ。 時速 ３００キロで 山を 駆けるという。",
+		'zh-tw': "擁有能夠一腳踢毀砂石車的強勁腳力。據說能以時速３００公里在山中奔跑。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "健腳充能"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "けんきゃくチャージ",
+				'zh-tw': "健腳充能",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の手札から[闘]エネルギーを2枚まで選び、このポケモンにつける。",
+				'zh-tw': "在自己的回合，當從手牌將這張卡放置於備戰區時，可使用1次。從自己的手牌選擇最多2張【鬥】能量卡，附於這隻寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，當從手牌將這張卡放置於備戰區時，可使用1次。從自己的手牌選擇最多2張【鬥】能量卡，附於這隻寶可夢身上。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "閃踢"
+	attacks: [
+		{
+			name: {
+				ja: "ザッパーキック",
+				'zh-tw': "閃踢",
+			},
+			damage: 70,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンについているエネルギーを、すべてトラッシュする。その場合、相手のバトルポケモンをマヒにする。",
+				'zh-tw': "若希望，將這隻寶可夢身上附加的能量全部丟棄。這個情況下，將對手的戰鬥寶可夢【麻痺】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若希望，將這隻寶可夢身上附加的能量全部丟棄。這個情況下，將對手的戰鬥寶可夢【麻痺】。"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 571601,
+				tcgplayer: 569342,
+			},
 		},
-
-		damage: 70,
-		cost: ["Fighting", "Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	],
 
 	retreat: 0,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [145],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/020.ts
+++ b/data-asia/S/S7D/020.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "天蠍"
+		ja: "グライガー",
+		'zh-tw': "天蠍",
 	},
 
 	illustrator: "Misa Tsutsui",
@@ -14,37 +14,51 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "會朝著獵物迎面飛來，然後趁著被纏上的獵物驚慌失措時刺入毒針。"
+		ja: "顔面 めがけて 飛んでくる。 張りつかれた 獲物が 驚く あいだに 毒針を 刺しこむ。",
+		'zh-tw': "會朝著獵物迎面飛來，然後趁著被纏上的獵物驚慌失措時刺入毒針。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "毒針"
+	attacks: [
+		{
+			name: {
+				ja: "どくばり",
+				'zh-tw': "毒針",
+			},
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。"
+		{
+			name: {
+				ja: "つきさす",
+				'zh-tw': "突刺",
+			},
+			damage: 30,
+			cost: ["Fighting", "Colorless"],
 		},
+	],
 
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "突刺"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571602,
+				tcgplayer: 569343,
+			},
 		},
-
-		damage: 30,
-		cost: ["Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [207],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/021.ts
+++ b/data-asia/S/S7D/021.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "天蠍王"
+		ja: "グライオン",
+		'zh-tw': "天蠍王",
 	},
 
 	illustrator: "SATOSHI NAKAI",
@@ -14,42 +14,60 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "可不發出振翅聲而在空中飛行。先用長長的尾巴攫住獵物，再用牙齒朝弱點給予一刺。"
+		ja: "羽音を 立てずに 空を 飛ぶ。 長い 尻尾で 獲物を 捕まえ キバで 急所を 一突き。",
+		'zh-tw': "可不發出振翅聲而在空中飛行。先用長長的尾巴攫住獵物，再用牙齒朝弱點給予一刺。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "切落"
+	attacks: [
+		{
+			name: {
+				ja: "きりおとす",
+				'zh-tw': "切落",
+			},
+			damage: 30,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。"
+		{
+			name: {
+				ja: "ベノムヒット",
+				'zh-tw': "毒液一擊",
+			},
+			damage: 100,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】。",
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Fighting", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "毒液一擊"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571603,
+				tcgplayer: 569344,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。"
-		},
-
-		damage: 100,
-		cost: ["Fighting", "Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "グライガー",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [472],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/022.ts
+++ b/data-asia/S/S7D/022.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "幕下力士"
+		ja: "マクノシタ",
+		'zh-tw': "幕下力士",
 	},
 
 	illustrator: "Oswaldo KATO",
@@ -14,34 +14,48 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "據說為了培育強大的幕下力士，訓練家們會製作一種傳統的火鍋料理。"
+		ja: "強い マクノシタを 育てるために トレーナーたちが 伝統的に 作る ナベ料理が あるという。",
+		'zh-tw': "據說為了培育強大的幕下力士，訓練家們會製作一種傳統的火鍋料理。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "撞倒"
+	attacks: [
+		{
+			name: {
+				ja: "つきたおし",
+				'zh-tw': "撞倒",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
-
-		damage: 10,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "頭突"
+		{
+			name: {
+				ja: "ぶちかます",
+				'zh-tw': "頭突",
+			},
+			damage: 60,
+			cost: ["Fighting", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 60,
-		cost: ["Fighting", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571604,
+				tcgplayer: 569345,
+			},
+		},
+	],
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [296],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/023.ts
+++ b/data-asia/S/S7D/023.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鐵掌力士"
+		ja: "ハリテヤマ",
+		'zh-tw': "鐵掌力士",
 	},
 
 	illustrator: "Hitoshi Ariga",
@@ -14,39 +14,58 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "體型壯碩的鐵掌力士未必就很強。也有體型雖小，但身輕如燕且技巧高超的鐵掌力士存在。"
+		ja: "太って 大きな ハリテヤマが 強いとは 限らない。 小柄でも 身軽で 技に 長けたものもいる。",
+		'zh-tw': "體型壯碩的鐵掌力士未必就很強。也有體型雖小，但身輕如燕且技巧高超的鐵掌力士存在。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "毅力"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "こんじょう",
+				'zh-tw': "毅力",
+			},
+			effect: {
+				ja: "このポケモンが、ワザのダメージを受けてきぜつするとき、自分はコインを1回投げる。オモテなら、このポケモンはきぜつせず、残りHPが「10」の状態で場に残る。",
+				'zh-tw': "這隻寶可夢受到招式的傷害而【氣絕】時，擲1次硬幣。若為正面，則這隻寶可夢不會【氣絕】，而是以剩餘HP為「10」的狀態留在場上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢受到招式的傷害而【氣絕】時，擲1次硬幣。若為正面，則這隻寶可夢不會【氣絕】，而是以剩餘HP為「10」的狀態留在場上。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "頭突"
+	attacks: [
+		{
+			name: {
+				ja: "ぶちかます",
+				'zh-tw': "頭突",
+			},
+			damage: 100,
+			cost: ["Fighting", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 100,
-		cost: ["Fighting", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571605,
+				tcgplayer: 569346,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マクノシタ",
+	},
 
 	retreat: 4,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [297],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/024.ts
+++ b/data-asia/S/S7D/024.ts
@@ -1,47 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鬃岩狼人V"
+		ja: "ルガルガンV",
+		'zh-tw': "鬃岩狼人V",
 	},
 
 	illustrator: "PLANETA Tsuji",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Fighting"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "落石"
+	attacks: [
+		{
+			name: {
+				ja: "いわおとし",
+				'zh-tw': "落石",
+			},
+			damage: 40,
+			cost: ["Fighting"],
 		},
-
-		damage: 40,
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "粉碎獠牙"
+		{
+			name: {
+				ja: "クラッシュファング",
+				'zh-tw': "粉碎獠牙",
+			},
+			damage: 200,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 571606,
+				tcgplayer: 569347,
+			},
 		},
-
-		damage: 200,
-		cost: ["Fighting", "Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [745],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/025.ts
+++ b/data-asia/S/S7D/025.ts
@@ -1,49 +1,67 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鬃岩狼人VMAX"
+		ja: "ルガルガンVMAX",
+		'zh-tw': "鬃岩狼人VMAX",
 	},
 
 	illustrator: "Mitsuhiro Arita",
 	category: "Pokemon",
 	hp: 320,
 	types: ["Fighting"],
+
 	stage: "VMAX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "狩獵爪"
+	attacks: [
+		{
+			name: {
+				ja: "ハンティングクロー",
+				'zh-tw': "狩獵爪",
+			},
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手の場の残りHPが「60」以下のポケモンを1匹選び、きぜつさせる。",
+				'zh-tw': "選擇1隻對手場上的剩餘HP為「60」以下的寶可夢，將其【氣絕】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇1隻對手場上的剩餘HP為「60」以下的寶可夢，將其【氣絕】。"
+		{
+			name: {
+				ja: "ダイエッジ",
+				'zh-tw': "極巨刀鋒",
+			},
+			damage: 190,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的1隻備戰寶可夢也受到30點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "極巨刀鋒"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 571607,
+				tcgplayer: 569348,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "對手的1隻備戰寶可夢也受到30點傷害。[在備戰區不計算弱點・抵抗力。]"
-		},
-
-		damage: 190,
-		cost: ["Fighting", "Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ルガルガンV",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Triple Rare",
+	dexId: [745],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/026.ts
+++ b/data-asia/S/S7D/026.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伽勒爾 火焰鳥"
+		ja: "ガラル ファイヤー",
+		'zh-tw': "伽勒爾 火焰鳥",
 	},
 
 	illustrator: "Kazuma Koda",
@@ -14,43 +14,58 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "釋放著像火焰般燃起的邪惡氣場。這樣的外觀讓牠得到了火焰鳥之名。"
+		ja: "邪悪な オーラを 炎のように 燃え上がらせる その 姿から ファイヤーと 名づけられた。",
+		'zh-tw': "釋放著像火焰般燃起的邪惡氣場。這樣的外觀讓牠得到了火焰鳥之名。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "邪惡充能"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "じゃあくチャージ",
+				'zh-tw': "邪惡充能",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の手札から[悪]エネルギーを2枚まで選び、このポケモンにつける。",
+				'zh-tw': "在自己的回合，當從手牌將這張卡放置於備戰區時，可使用1次。從自己的手牌選擇最多2張【惡】能量卡，附於這隻寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，當從手牌將這張卡放置於備戰區時，可使用1次。從自己的手牌選擇最多2張【惡】能量卡，附於這隻寶可夢身上。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "怒火中燒"
+	attacks: [
+		{
+			name: {
+				ja: "もえあがるいかり",
+				'zh-tw': "怒火中燒",
+			},
+			damage: "20+",
+			cost: ["Darkness", "Darkness", "Colorless"],
+			effect: {
+				ja: "相手がすでにとったサイドの枚数×50ダメージ追加。",
+				'zh-tw': "增加對手已經獲得的獎賞卡的張數×50點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加對手已經獲得的獎賞卡的張數×50點傷害。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 571608,
+				tcgplayer: 569349,
+			},
 		},
-
-		damage: "20+",
-		cost: ["Darkness", "Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [146],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/027.ts
+++ b/data-asia/S/S7D/027.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "阿勃梭魯"
+		ja: "アブソル",
+		'zh-tw': "阿勃梭魯",
 	},
 
 	illustrator: "Eri Yamaki",
@@ -14,37 +14,51 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "老人們稱呼牠為災禍寶可夢，對牠十分忌諱。但目前牠預知災害的能力正越來越受到重視。"
+		ja: "老人は わざわいポケモンと 呼び 忌み嫌うが 災害を 予知 する 力に 関心が 高まっている。",
+		'zh-tw': "老人們稱呼牠為災禍寶可夢，對牠十分忌諱。但目前牠預知災害的能力正越來越受到重視。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "拖出"
+	attacks: [
+		{
+			name: {
+				ja: "ひきずりだす",
+				'zh-tw': "拖出",
+			},
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、新しく出てきたポケモンに30ダメージ。",
+				'zh-tw': "選擇對手的1隻備戰寶可夢，與戰鬥寶可夢互換。然後，新上場的寶可夢受到30點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇對手的1隻備戰寶可夢，與戰鬥寶可夢互換。然後，新上場的寶可夢受到30點傷害。"
+		{
+			name: {
+				ja: "きりさく",
+				'zh-tw': "劈開",
+			},
+			damage: 80,
+			cost: ["Darkness", "Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "劈開"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571610,
+				tcgplayer: 569350,
+			},
 		},
-
-		damage: 80,
-		cost: ["Darkness", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [359],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/028.ts
+++ b/data-asia/S/S7D/028.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "不良蛙"
+		ja: "グレッグル",
+		'zh-tw': "不良蛙",
 	},
 
 	illustrator: "Nagomi Nijo",
@@ -14,27 +14,40 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "毒素在稀釋後能製成藥品。牠是製藥公司的吉祥物，廣受眾人的歡迎。"
+		ja: "毒を 薄めると 薬に なる。 薬品会社の マスコットに なって 人気者に なった。",
+		'zh-tw': "毒素在稀釋後能製成藥品。牠是製藥公司的吉祥物，廣受眾人的歡迎。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "推擊"
+	attacks: [
+		{
+			name: {
+				ja: "どつく",
+				'zh-tw': "推擊",
+			},
+			damage: 20,
+			cost: ["Darkness"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Darkness"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571611,
+				tcgplayer: 569351,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [453],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/029.ts
+++ b/data-asia/S/S7D/029.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "毒骷蛙"
+		ja: "ドクロッグ",
+		'zh-tw': "毒骷蛙",
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -14,37 +14,55 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "制服了獵物之後，便會呱呱地發出勝利的歡呼。與蟾蜍王是相近的物種。"
+		ja: "獲物を しとめると ゲロゲロと 勝利の 雄叫びを あげる。 ガマゲロゲと 種として 近い。",
+		'zh-tw': "制服了獵物之後，便會呱呱地發出勝利的歡呼。與蟾蜍王是相近的物種。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "惡棍猛毒"
+	attacks: [
+		{
+			name: {
+				ja: "バッドポイズン",
+				'zh-tw': "惡棍猛毒",
+			},
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。このどくでのせるダメカンの数は4個になる。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】。因這個【中毒】而放置的傷害指示物的數量改為4個。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。因這個【中毒】而放置的傷害指示物的數量改為4個。"
+		{
+			name: {
+				ja: "マグナムパンチ",
+				'zh-tw': "增量拳",
+			},
+			damage: 90,
+			cost: ["Darkness", "Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Darkness"]
-	}, {
-		name: {
-			'zh-tw': "增量拳"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571612,
+				tcgplayer: 569352,
+			},
 		},
+	],
 
-		damage: 90,
-		cost: ["Darkness", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "グレッグル",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [454],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/030.ts
+++ b/data-asia/S/S7D/030.ts
@@ -1,47 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "灰塵山V"
+		ja: "ダストダスV",
+		'zh-tw': "灰塵山V",
 	},
 
 	illustrator: "Uta",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Darkness"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "垃圾臭氣"
+	attacks: [
+		{
+			name: {
+				ja: "ゴミしゅうき",
+				'zh-tw': "垃圾臭氣",
+			},
+			damage: 40,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。次の相手の番、このワザを受けたポケモンは、にげられない。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】。在下個對手的回合，受到這個招式的寶可夢無法撤退。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。在下個對手的回合，受到這個招式的寶可夢無法撤退。"
+		{
+			name: {
+				ja: "ヘドロばくだん",
+				'zh-tw': "污泥炸彈",
+			},
+			damage: 130,
+			cost: ["Darkness", "Darkness", "Colorless"],
 		},
+	],
 
-		damage: 40,
-		cost: ["Darkness", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "污泥炸彈"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 571613,
+				tcgplayer: 569353,
+			},
 		},
-
-		damage: 130,
-		cost: ["Darkness", "Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [569],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/031.ts
+++ b/data-asia/S/S7D/031.ts
@@ -1,51 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "灰塵山VMAX"
+		ja: "ダストダスVMAX",
+		'zh-tw': "灰塵山VMAX",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Darkness"],
+
 	stage: "VMAX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "集破爛"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ガラクタあつめ",
+				'zh-tw': "集破爛",
+			},
+			effect: {
+				ja: "このポケモンは、「ポケモンのどうぐ」を2枚までつけられる。（この特性がなくなったとき、自分は「ポケモンのどうぐ」を1枚になるようにトラッシュする。）",
+				'zh-tw': "這隻寶可夢身上最多可附有2張「寶可夢道具」卡。（這個特性消除時，自己將「寶可夢道具」卡丟棄直到變為1張為止。）",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢身上最多可附有2張「寶可夢道具」卡。（這個特性消除時，自己將「寶可夢道具」卡丟棄直到變為1張為止。）"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "超極巨臭氣沖天"
+	attacks: [
+		{
+			name: {
+				ja: "キョダイシュウキ",
+				'zh-tw': "超極巨臭氣沖天",
+			},
+			damage: 120,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。次の相手の番、このワザを受けたポケモンは、にげられない。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】。在下個對手的回合，受到這個招式的寶可夢無法撤退。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。在下個對手的回合，受到這個招式的寶可夢無法撤退。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 571614,
+				tcgplayer: 569354,
+			},
 		},
+	],
 
-		damage: 120,
-		cost: ["Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ダストダスV",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Triple Rare",
+	dexId: [569],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/032.ts
+++ b/data-asia/S/S7D/032.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "偷兒狐"
+		ja: "クスネ",
+		'zh-tw': "偷兒狐",
 	},
 
 	illustrator: "Hasegawa Saki",
@@ -14,27 +14,40 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "性情謹慎且狡猾。在偷盜食物逃走的時候會用尾巴擦掉自己的足跡。"
+		ja: "用心深く ずる賢い。 エサを 盗むと しっぽで 足跡を 消しながら 逃げるのだ。",
+		'zh-tw': "性情謹慎且狡猾。在偷盜食物逃走的時候會用尾巴擦掉自己的足跡。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "擺尾拍擊"
+	attacks: [
+		{
+			name: {
+				ja: "しっぽではたく",
+				'zh-tw': "擺尾拍擊",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571615,
+				tcgplayer: 569355,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [827],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/033.ts
+++ b/data-asia/S/S7D/033.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "狐大盜"
+		ja: "フォクスライ",
+		'zh-tw': "狐大盜",
 	},
 
 	illustrator: "Kyoko Umemoto",
@@ -14,39 +14,58 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "靠著輕盈的身體和銳利的爪子到處去偷食物和蛋。逐電犬是牠的天敵。"
+		ja: "身軽な 体と 鋭い ツメで エサや タマゴを 盗んで まわる。 パルスワンが 天敵。",
+		'zh-tw': "靠著輕盈的身體和銳利的爪子到處去偷食物和蛋。逐電犬是牠的天敵。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "漏接之手"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ファンブルハンド",
+				'zh-tw': "漏接之手",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。おたがいのプレイヤーは、それぞれ自分の手札をすべてウラにして切り、山札の下にもどす。その後、それぞれ山札を4枚引く。",
+				'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。雙方玩家各將自己的手牌全部翻回反面並重洗，放回牌庫下方。然後，各從牌庫抽出4張卡。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。雙方玩家各將自己的手牌全部翻回反面並重洗，放回牌庫下方。然後，各從牌庫抽出4張卡。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "尾擊"
+	attacks: [
+		{
+			name: {
+				ja: "しっぽでたたく",
+				'zh-tw': "尾擊",
+			},
+			damage: 60,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 60,
-		cost: ["Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571616,
+				tcgplayer: 569356,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "クスネ",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [828],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/034.ts
+++ b/data-asia/S/S7D/034.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伽勒爾 喵喵"
+		ja: "ガラル ニャース",
+		'zh-tw': "伽勒爾 喵喵",
 	},
 
 	illustrator: "0313",
@@ -14,42 +14,51 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "額頭上的金幣越黑就越硬，也越能受到夥伴的尊敬。性情勇猛，什麼都不怕。"
+		ja: "額の 小判は より 黒いほど 硬く 仲間から 尊敬される。 勇猛で 恐れを 知らない。",
+		'zh-tw': "額頭上的金幣越黑就越硬，也越能受到夥伴的尊敬。性情勇猛，什麼都不怕。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "叫聲"
+	attacks: [
+		{
+			name: {
+				ja: "なきごえ",
+				'zh-tw': "叫聲",
+			},
+			cost: ["Metal"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-20」される。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢使用招式的傷害「-20」點。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢使用招式的傷害「-20」點。"
+		{
+			name: {
+				ja: "きりさく",
+				'zh-tw': "劈開",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Metal"]
-	}, {
-		name: {
-			'zh-tw': "劈開"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571617,
+				tcgplayer: 569357,
+			},
 		},
-
-		damage: 20,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [52],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/035.ts
+++ b/data-asia/S/S7D/035.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伽勒爾 喵頭目"
+		ja: "ガラル ニャイキング",
+		'zh-tw': "伽勒爾 喵頭目",
 	},
 
 	illustrator: "Shigenori Negishi",
@@ -14,42 +14,55 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "在日復一日的戰鬥中得以進化。進化的結果是那危險的指甲，留長後能當作短劍來用。"
+		ja: "戦いに 明け暮れて 進化した 結果 伸ばすと 短剣に 変わる 物騒な ツメを 手に入れた。",
+		'zh-tw': "在日復一日的戰鬥中得以進化。進化的結果是那危險的指甲，留長後能當作短劍來用。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "鼓勵"
+	attacks: [
+		{
+			name: {
+				ja: "げきをとばす",
+				'zh-tw': "鼓勵",
+			},
+			cost: ["Metal"],
+			effect: {
+				ja: "自分の山札から基本エネルギーを2枚まで選び、自分のポケモンに好きなようにつける。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多2張基本能量卡，以任意方式附於自己的寶可夢身上。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多2張基本能量卡，以任意方式附於自己的寶可夢身上。並且重洗牌庫。"
+		{
+			name: {
+				ja: "ヘッドバング",
+				'zh-tw': "鐵頭碰",
+			},
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Metal"]
-	}, {
-		name: {
-			'zh-tw': "鐵頭碰"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571618,
+				tcgplayer: 569358,
+			},
 		},
+	],
 
-		damage: 80,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ガラル ニャース",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [863],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/036.ts
+++ b/data-asia/S/S7D/036.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "盔甲鳥"
+		ja: "エアームド",
+		'zh-tw': "盔甲鳥",
 	},
 
 	illustrator: "Megumi Higuchi",
@@ -14,43 +14,52 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "全身披著鋼鐵鎧甲。看起來很重，但牠能以最高３００公里的時速飛行。"
+		ja: "鋼の 鎧を 身に まとう。 重そうに 見えるが 最大 ３００キロの 速度で 飛べるぞ。",
+		'zh-tw': "全身披著鋼鐵鎧甲。看起來很重，但牠能以最高３００公里的時速飛行。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "鋼翼"
+	attacks: [
+		{
+			name: {
+				ja: "はがねのつばさ",
+				'zh-tw': "鋼翼",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-30」點。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-30」點。"
+		{
+			name: {
+				ja: "スライスブレード",
+				'zh-tw': "利刃切割",
+			},
+			damage: 110,
+			cost: ["Metal", "Metal", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "利刃切割"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571619,
+				tcgplayer: 569359,
+			},
 		},
-
-		damage: 110,
-		cost: ["Metal", "Metal", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [227],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/037.ts
+++ b/data-asia/S/S7D/037.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鑰圈兒"
+		ja: "クレッフィ",
+		'zh-tw': "鑰圈兒",
 	},
 
 	illustrator: "MAHOU",
@@ -14,36 +14,44 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "過去棲息在礦山裡，因為作為食物的礦物逐漸減少，於是開始出現在人類的聚落中。"
+		ja: "昔は 鉱山に 棲んでいたが エサの 鉱物が 減ってきたので 人里に 現れるようになった。",
+		'zh-tw': "過去棲息在礦山裡，因為作為食物的礦物逐漸減少，於是開始出現在人類的聚落中。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "解鎖"
+	attacks: [
+		{
+			name: {
+				ja: "アンロック",
+				'zh-tw': "解鎖",
+			},
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を2枚引く。",
+				'zh-tw': "從自己的牌庫抽出2張卡。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的牌庫抽出2張卡。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571620,
+				tcgplayer: 569360,
+			},
 		},
-
-		damage: 10,
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [707],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/038.ts
+++ b/data-asia/S/S7D/038.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "銅象"
+		ja: "ゾウドウ",
+		'zh-tw': "銅象",
 	},
 
 	illustrator: "Oswaldo KATO",
@@ -14,43 +14,52 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "擅長需要力氣的工作。銅質的身體會因雨水而生鏽，轉變成鮮豔的綠色。"
+		ja: "力仕事なら お任せ。 銅の 体は 雨で 錆び 鮮やかな 緑に 変わる。",
+		'zh-tw': "擅長需要力氣的工作。銅質的身體會因雨水而生鏽，轉變成鮮豔的綠色。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "滾動"
+	attacks: [
+		{
+			name: {
+				ja: "ころがる",
+				'zh-tw': "滾動",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
-
-		damage: 10,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "十萬馬力"
+		{
+			name: {
+				ja: "10まんばりき",
+				'zh-tw': "十萬馬力",
+			},
+			damage: 80,
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも20ダメージ。",
+				'zh-tw': "這隻寶可夢也受到20點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢也受到20點傷害。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571621,
+				tcgplayer: 569361,
+			},
 		},
-
-		damage: 80,
-		cost: ["Metal", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	],
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [878],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/039.ts
+++ b/data-asia/S/S7D/039.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "大王銅象"
+		ja: "ダイオウドウ",
+		'zh-tw': "大王銅象",
 	},
 
 	illustrator: "KEIICHIRO ITO",
@@ -14,43 +14,56 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "群居的寶可夢。鼻子的握力十分強勁，甚至能把大石頭弄得粉碎。"
+		ja: "群れを つくって 暮らしている。 鼻の 握力は 大岩も 粉々に 砕くほど 強い。",
+		'zh-tw': "群居的寶可夢。鼻子的握力十分強勁，甚至能把大石頭弄得粉碎。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "怪力"
+	attacks: [
+		{
+			name: {
+				ja: "かいりき",
+				'zh-tw': "怪力",
+			},
+			damage: 90,
+			cost: ["Metal", "Colorless", "Colorless"],
 		},
-
-		damage: 90,
-		cost: ["Metal", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "十萬馬力"
+		{
+			name: {
+				ja: "10まんばりき",
+				'zh-tw': "十萬馬力",
+			},
+			damage: 160,
+			cost: ["Metal", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+				'zh-tw': "這隻寶可夢也受到30點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢也受到30點傷害。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571622,
+				tcgplayer: 569362,
+			},
 		},
+	],
 
-		damage: 160,
-		cost: ["Metal", "Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ゾウドウ",
+	},
 
 	retreat: 4,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [879],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/040.ts
+++ b/data-asia/S/S7D/040.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "七夕青鳥"
+		ja: "チルタリス",
+		'zh-tw': "七夕青鳥",
 	},
 
 	illustrator: "sui",
@@ -14,34 +14,58 @@ const card: Card = {
 	types: ["Dragon"],
 
 	description: {
-		'zh-tw': "在晴朗的日子會混在雲朵中，自在地在空中來回飛行。會用美妙的高音歌唱。"
+		ja: "晴れた日 綿雲に まぎれながら 大空を 自由に 飛び回り 美しい ソプラノで 歌う。",
+		'zh-tw': "在晴朗的日子會混在雲朵中，自在地在空中來回飛行。會用美妙的高音歌唱。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "勸誘曲調"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "いざなうしらべ",
+				'zh-tw': "勸誘曲調",
+			},
+			effect: {
+				ja: "自分の番に1回使える。自分の山札からサポートを1枚選び、相手に見せる。残りの山札を切り、選んだカードを山札の上にもどす。",
+				'zh-tw': "在自己的回合時，可使用1次。從自己的牌庫選擇1張支援者卡，給對手看過。重洗剩餘牌庫，將所選的卡放回牌庫上方。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，可使用1次。從自己的牌庫選擇1張支援者卡，給對手看過。重洗剩餘牌庫，將所選的卡放回牌庫上方。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "滑翔"
+	attacks: [
+		{
+			name: {
+				ja: "かっくう",
+				'zh-tw': "滑翔",
+			},
+			damage: 60,
+			cost: ["Water", "Metal"],
 		},
+	],
 
-		damage: 60,
-		cost: ["Water", "Metal"]
-	}],
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571624,
+				tcgplayer: 569363,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チルット",
+	},
 
 	retreat: 0,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [334],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/041.ts
+++ b/data-asia/S/S7D/041.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "帝牙盧卡"
+		ja: "ディアルガ",
+		'zh-tw': "帝牙盧卡",
 	},
 
 	illustrator: "Ryuta Fuse",
@@ -14,33 +14,52 @@ const card: Card = {
 	types: ["Dragon"],
 
 	description: {
-		'zh-tw': "擁有操縱時間的力量。在神奧地區被稱為神，並在神話中登場。"
+		ja: "時間を 操る 力を 持つ。 シンオウ地方では 神様と 呼ばれ 神話に 登場する。",
+		'zh-tw': "擁有操縱時間的力量。在神奧地區被稱為神，並在神話中登場。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "時間扭轉"
+	attacks: [
+		{
+			name: {
+				ja: "クロノワインド",
+				'zh-tw': "時間扭轉",
+			},
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けた「ポケモンV」は、ワザが使えない。",
+				'zh-tw': "在下個對手的回合，受到這個招式的「寶可夢【V】」無法使用招式。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的「寶可夢【V】」無法使用招式。"
+		{
+			name: {
+				ja: "ヘビーインパクト",
+				'zh-tw': "重磅衝擊",
+			},
+			damage: 210,
+			cost: ["Psychic", "Metal", "Metal", "Colorless"],
 		},
+	],
 
-		damage: 80,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "重磅衝擊"
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 571625,
+				tcgplayer: 569364,
+			},
 		},
-
-		damage: 210,
-		cost: ["Psychic", "Metal", "Metal", "Colorless"]
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [483],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/042.ts
+++ b/data-asia/S/S7D/042.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "單首龍"
+		ja: "モノズ",
+		'zh-tw': "單首龍",
 	},
 
 	illustrator: "HYOGONOSUKE",
@@ -14,32 +14,51 @@ const card: Card = {
 	types: ["Dragon"],
 
 	description: {
-		'zh-tw': "因為眼睛看不見，所以會又撞又咬，來判斷四周的狀況。"
+		ja: "目が 見えないので 手あたりしだい 噛みついて 自分の まわりの 状況を 把握 している。",
+		'zh-tw': "因為眼睛看不見，所以會又撞又咬，來判斷四周的狀況。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "呼朋引伴"
+	attacks: [
+		{
+			name: {
+				ja: "なかまをよぶ",
+				'zh-tw': "呼朋引伴",
+			},
+			cost: ["Darkness"],
+			effect: {
+				ja: "自分の山札からたねポケモンを1枚選び、ベンチに出す。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。"
+		{
+			name: {
+				ja: "かみつく",
+				'zh-tw': "咬住",
+			},
+			damage: 30,
+			cost: ["Psychic", "Darkness"],
 		},
+	],
 
-		cost: ["Darkness"]
-	}, {
-		name: {
-			'zh-tw': "咬住"
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571627,
+				tcgplayer: 569365,
+			},
 		},
-
-		damage: 30,
-		cost: ["Psychic", "Darkness"]
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [633],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/043.ts
+++ b/data-asia/S/S7D/043.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雙首暴龍"
+		ja: "ジヘッド",
+		'zh-tw': "雙首暴龍",
 	},
 
 	illustrator: "Akira Komayama",
@@ -14,29 +14,52 @@ const card: Card = {
 	types: ["Dragon"],
 
 	description: {
-		'zh-tw': "２個頭會爭搶同一個食物。明明沒有去和別人戰鬥，卻總是遍體鱗傷。"
+		ja: "１つの エサを ２つの 頭で 奪い合う。 誰とも 戦って いないのに いつも 傷だらけ。",
+		'zh-tw': "２個頭會爭搶同一個食物。明明沒有去和別人戰鬥，卻總是遍體鱗傷。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "咬住"
+	attacks: [
+		{
+			name: {
+				ja: "かみつく",
+				'zh-tw': "咬住",
+			},
+			damage: 40,
+			cost: ["Psychic", "Darkness"],
 		},
-
-		damage: 40,
-		cost: ["Psychic", "Darkness"]
-	}, {
-		name: {
-			'zh-tw': "龍之頭擊"
+		{
+			name: {
+				ja: "リューズヘッド",
+				'zh-tw': "龍之頭擊",
+			},
+			damage: 100,
+			cost: ["Psychic", "Darkness", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 100,
-		cost: ["Psychic", "Darkness", "Colorless", "Colorless"]
-	}],
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571628,
+				tcgplayer: 569366,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "モノズ",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [634],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/044.ts
+++ b/data-asia/S/S7D/044.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "三首惡龍"
+		ja: "サザンドラ",
+		'zh-tw': "三首惡龍",
 	},
 
 	illustrator: "hatachu",
@@ -14,33 +14,56 @@ const card: Card = {
 	types: ["Dragon"],
 
 	description: {
-		'zh-tw': "３個頭會輪流去咬敵人。在對方倒下之前，絕對不會停止攻擊。"
+		ja: "３つの 頭で 代わるがわる 噛みつく。 相手が 倒れるまで 攻撃の 手を 休めない。",
+		'zh-tw': "３個頭會輪流去咬敵人。在對方倒下之前，絕對不會停止攻擊。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "龍之反擊"
+	attacks: [
+		{
+			name: {
+				ja: "ドラゴンカウンター",
+				'zh-tw': "龍之反擊",
+			},
+			damage: "20+",
+			cost: ["Psychic", "Darkness"],
+			effect: {
+				ja: "前の相手の番に、相手がとったサイドの枚数×100ダメージ追加。",
+				'zh-tw': "增加上個對手的回合對手獲得的獎賞卡的張數×100點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "增加上個對手的回合對手獲得的獎賞卡的張數×100點傷害。"
+		{
+			name: {
+				ja: "しっこくのキバ",
+				'zh-tw': "漆黑之牙",
+			},
+			damage: 210,
+			cost: ["Psychic", "Darkness", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: "20+",
-		cost: ["Psychic", "Darkness"]
-	}, {
-		name: {
-			'zh-tw': "漆黑之牙"
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 571630,
+				tcgplayer: 569367,
+			},
 		},
+	],
 
-		damage: 210,
-		cost: ["Psychic", "Darkness", "Colorless", "Colorless"]
-	}],
+	evolveFrom: {
+		ja: "ジヘッド",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [635],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/045.ts
+++ b/data-asia/S/S7D/045.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "酋雷姆"
+		ja: "キュレム",
+		'zh-tw': "酋雷姆",
 	},
 
 	illustrator: "Souichirou Gunjima",
@@ -14,26 +14,44 @@ const card: Card = {
 	types: ["Dragon"],
 
 	description: {
-		'zh-tw': "在體內製造出強大的冷凍能量，但漏出的寒氣使身體結凍了。"
+		ja: "強力な 冷凍エネルギーを 体内で 作り出すが 漏れ出した 冷気で 体が 凍っている。",
+		'zh-tw': "在體內製造出強大的冷凍能量，但漏出的寒氣使身體結凍了。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "極限冰凍"
+	attacks: [
+		{
+			name: {
+				ja: "きょくげんれいとう",
+				'zh-tw': "極限冰凍",
+			},
+			damage: "60×",
+			cost: ["Water", "Water", "Metal"],
+			effect: {
+				ja: "自分の場のポケモンについている[水]エネルギーを好きなだけトラッシュし、その枚数×60ダメージ。",
+				'zh-tw': "將自己的場上寶可夢身上附加的任意數量的【水】能量卡丟棄，造成其張數×60點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將自己的場上寶可夢身上附加的任意數量的【水】能量卡丟棄，造成其張數×60點傷害。"
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 571631,
+				tcgplayer: 569368,
+			},
 		},
-
-		damage: "60×",
-		cost: ["Water", "Water", "Metal"]
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [646],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/046.ts
+++ b/data-asia/S/S7D/046.ts
@@ -1,45 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "音波龍V"
+		ja: "オンバーンV",
+		'zh-tw': "音波龍V",
 	},
 
 	illustrator: "Ayaka Yoshida",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Dragon"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "爆音波"
+	attacks: [
+		{
+			name: {
+				ja: "ばくおんぱ",
+				'zh-tw': "爆音波",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的所有寶可夢各受到20點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
-
-		effect: {
-			'zh-tw': "對手的所有寶可夢各受到20點傷害。[在備戰區不計算弱點・抵抗力。]"
+		{
+			name: {
+				ja: "シンクロラウド",
+				'zh-tw': "同步高聲",
+			},
+			damage: "60+",
+			cost: ["Psychic", "Darkness"],
+			effect: {
+				ja: "自分の手札と相手の手札が同じ枚数なら、120ダメージ追加。",
+				'zh-tw': "若自己的手牌的張數與對手的手牌的張數相同，則增加120點傷害。",
+			},
 		},
+	],
 
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "同步高聲"
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 571632,
+				tcgplayer: 569369,
+			},
 		},
-
-		effect: {
-			'zh-tw': "若自己的手牌的張數與對手的手牌的張數相同，則增加120點傷害。"
-		},
-
-		damage: "60+",
-		cost: ["Psychic", "Darkness"]
-	}],
+	],
 
 	retreat: 0,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [715],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/047.ts
+++ b/data-asia/S/S7D/047.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "老翁龍"
+		ja: "ジジーロン",
+		'zh-tw': "老翁龍",
 	},
 
 	illustrator: "Tomokazu Komiya",
@@ -14,33 +14,52 @@ const card: Card = {
 	types: ["Dragon"],
 
 	description: {
-		'zh-tw': "心地善良愛親近人，但只要生氣就會颳起強風吹倒一切。"
+		ja: "人懐っこく 心優しいが ひとたび 怒ると 強風を 巻き起こし すべてを なぎ倒す。",
+		'zh-tw': "心地善良愛親近人，但只要生氣就會颳起強風吹倒一切。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "推擊"
+	attacks: [
+		{
+			name: {
+				ja: "どつく",
+				'zh-tw': "推擊",
+			},
+			damage: 30,
+			cost: ["Colorless"],
 		},
-
-		damage: 30,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "怒火沖天"
+		{
+			name: {
+				ja: "ぎゃくじょう",
+				'zh-tw': "怒火沖天",
+			},
+			damage: "70+",
+			cost: ["Water", "Fighting"],
+			effect: {
+				ja: "自分のベンチポケモンにダメカンがのっているなら、90ダメージ追加。",
+				'zh-tw': "若自己的備戰寶可夢身上放置有傷害指示物，則增加90點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若自己的備戰寶可夢身上放置有傷害指示物，則增加90點傷害。"
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571633,
+				tcgplayer: 569370,
+			},
 		},
-
-		damage: "70+",
-		cost: ["Water", "Fighting"]
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [780],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/048.ts
+++ b/data-asia/S/S7D/048.ts
@@ -1,42 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鋁鋼龍V"
+		ja: "ジュラルドンV",
+		'zh-tw': "鋁鋼龍V",
 	},
 
 	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Dragon"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "金屬爪"
+	attacks: [
+		{
+			name: {
+				ja: "メタルクロー",
+				'zh-tw': "金屬爪",
+			},
+			damage: 70,
+			cost: ["Fighting", "Metal"],
 		},
-
-		damage: 70,
-		cost: ["Fighting", "Metal"]
-	}, {
-		name: {
-			'zh-tw': "廣域破壞"
+		{
+			name: {
+				ja: "ワイドブレイカー",
+				'zh-tw': "廣域破壞",
+			},
+			damage: 140,
+			cost: ["Fighting", "Metal", "Metal"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-30」される。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢使用招式的傷害「-30」點。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢使用招式的傷害「-30」點。"
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 571635,
+				tcgplayer: 569371,
+			},
 		},
-
-		damage: 140,
-		cost: ["Fighting", "Metal", "Metal"]
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [884],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/049.ts
+++ b/data-asia/S/S7D/049.ts
@@ -1,46 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鋁鋼龍VMAX"
+		ja: "ジュラルドンVMAX",
+		'zh-tw': "鋁鋼龍VMAX",
 	},
 
 	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Dragon"],
+
 	stage: "VMAX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "摩天樓"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "まてんろう",
+				'zh-tw': "摩天樓",
+			},
+			effect: {
+				ja: "このポケモンは、特殊エネルギーがついている相手のポケモンから、ワザのダメージを受けない。",
+				'zh-tw': "這隻寶可夢不會受到對手的身上附有特殊能量的寶可夢招式的傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢不會受到對手的身上附有特殊能量的寶可夢招式的傷害。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "超極巨碎骨粉身"
+	attacks: [
+		{
+			name: {
+				ja: "キョダイフンサイ",
+				'zh-tw': "超極巨碎骨粉身",
+			},
+			damage: 220,
+			cost: ["Fighting", "Metal", "Metal"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+				'zh-tw': "這個招式的傷害不計算對手的戰鬥寶可夢身上的附加效果。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這個招式的傷害不計算對手的戰鬥寶可夢身上的附加效果。"
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 571636,
+				tcgplayer: 569372,
+			},
 		},
+	],
 
-		damage: 220,
-		cost: ["Fighting", "Metal", "Metal"]
-	}],
+	evolveFrom: {
+		ja: "ジュラルドンV",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Triple Rare",
+	dexId: [884],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/050.ts
+++ b/data-asia/S/S7D/050.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "懶人獺"
+		ja: "ナマケロ",
+		'zh-tw': "懶人獺",
 	},
 
 	illustrator: "OKACHEKE",
@@ -14,31 +14,44 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "每天只要能吃上３片葉子就滿足了。除此之外，牠還能睡上２０個小時。"
+		ja: "１日に 葉っぱを ３枚も 食べれば 満足で それ以外は ２０時間も 眠っている。",
+		'zh-tw': "每天只要能吃上３片葉子就滿足了。除此之外，牠還能睡上２０個小時。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "揍人後睡覺"
+	attacks: [
+		{
+			name: {
+				ja: "ぶったらねる",
+				'zh-tw': "揍人後睡覺",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンをねむりにする。",
+				'zh-tw': "將這隻寶可夢【睡眠】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將這隻寶可夢【睡眠】。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571638,
+				tcgplayer: 569373,
+			},
 		},
-
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [287],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/051.ts
+++ b/data-asia/S/S7D/051.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "過動猿"
+		ja: "ヤルキモノ",
+		'zh-tw': "過動猿",
 	},
 
 	illustrator: "nagimiso",
@@ -14,38 +14,56 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "如果不活動身體，就會累積過多的壓力，使身體狀況變糟。"
+		ja: "体を 動かしていないと ストレスが たまりすぎて 具合が 悪くなって しまうのだ。",
+		'zh-tw': "如果不活動身體，就會累積過多的壓力，使身體狀況變糟。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "敲壞"
+	attacks: [
+		{
+			name: {
+				ja: "たたきこわす",
+				'zh-tw': "敲壞",
+			},
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "場に出ているスタジアムをトラッシュする。",
+				'zh-tw': "將場上的競技場卡丟棄。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將場上的競技場卡丟棄。"
+		{
+			name: {
+				ja: "きりさく",
+				'zh-tw': "劈開",
+			},
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "劈開"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571639,
+				tcgplayer: 569374,
+			},
 		},
+	],
 
-		damage: 50,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ナマケロ",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [288],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/052.ts
+++ b/data-asia/S/S7D/052.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "請假王"
+		ja: "ケッキング",
+		'zh-tw': "請假王",
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -14,43 +14,62 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "雖然是世界上最懶散的寶可夢，但能藉由把積蓄的能量一次釋放，發揮出驚人的力量。"
+		ja: "世界一の ぐうたらだが たまった エネルギーを 一気に 出す ことで 恐ろしい パワーを 発揮する。",
+		'zh-tw': "雖然是世界上最懶散的寶可夢，但能藉由把積蓄的能量一次釋放，發揮出驚人的力量。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "橫行"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "のさばる",
+				'zh-tw': "橫行",
+			},
+			effect: {
+				ja: "場にスタジアムが出ているなら、このポケモンはワザが使えない。",
+				'zh-tw': "若場上有競技場卡，則這隻寶可夢無法使用招式。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若場上有競技場卡，則這隻寶可夢無法使用招式。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "踢散"
+	attacks: [
+		{
+			name: {
+				ja: "けちらす",
+				'zh-tw': "踢散",
+			},
+			damage: "120+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数×30ダメージ追加。",
+				'zh-tw': "增加對手的備戰寶可夢的數量×30點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加對手的備戰寶可夢的數量×30點傷害。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 571640,
+				tcgplayer: 569375,
+			},
 		},
+	],
 
-		damage: "120+",
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ヤルキモノ",
+	},
 
 	retreat: 4,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [289],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/053.ts
+++ b/data-asia/S/S7D/053.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "青綿鳥"
+		ja: "チルット",
+		'zh-tw': "青綿鳥",
 	},
 
 	illustrator: "Lee HyunJung",
@@ -14,36 +14,44 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "從不疏於打理絲綿般的翅膀。一弄髒就會到水裡洗乾淨。"
+		ja: "真綿の ような 翼の 手入れは 絶対に 欠かさない。汚れると 水浴びをして きれいに 洗う。",
+		'zh-tw': "從不疏於打理絲綿般的翅膀。一弄髒就會到水裡洗乾淨。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "偷襲"
+	attacks: [
+		{
+			name: {
+				ja: "ふいをつく",
+				'zh-tw': "偷襲",
+			},
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+				'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571641,
+				tcgplayer: 569376,
+			},
 		},
-
-		damage: 30,
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [333],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/054.ts
+++ b/data-asia/S/S7D/054.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "毛辮羊"
+		ja: "ウールー",
+		'zh-tw': "毛辮羊",
 	},
 
 	illustrator: "Miki Tanaka",
@@ -14,42 +14,56 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "要是身上的毛長得太長就會不能動彈。用毛辮羊的體毛織成的布結實得讓人吃驚。"
+		ja: "毛が 伸びすぎると 動けない。 ウールーの 体毛で 織られた 布は 驚くほど 丈夫。",
+		'zh-tw': "要是身上的毛長得太長就會不能動彈。用毛辮羊的體毛織成的布結實得讓人吃驚。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "阻撓"
+	attacks: [
+		{
+			name: {
+				ja: "くつがえす",
+				'zh-tw': "阻撓",
+			},
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについている特殊エネルギーを1個選び、トラッシュする。",
+				'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的特殊能量，將其丟棄。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的特殊能量，將其丟棄。"
+		{
+			name: {
+				ja: "みんなでころがる",
+				'zh-tw': "一同滾動",
+			},
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチの、ワザ「みんなでころがる」を持つポケモンの数×20ダメージ。",
+				'zh-tw': "造成自己的備戰區的，持有「一同滾動」招式的寶可夢的數量×20點傷害。",
+			},
 		},
+	],
 
-		damage: 10,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "一同滾動"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571642,
+				tcgplayer: 569377,
+			},
 		},
-
-		effect: {
-			'zh-tw': "造成自己的備戰區的，持有「一同滾動」招式的寶可夢的數量×20點傷害。"
-		},
-
-		damage: "20×",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [831],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/055.ts
+++ b/data-asia/S/S7D/055.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "毛毛角羊"
+		ja: "バイウールー",
+		'zh-tw': "毛毛角羊",
 	},
 
 	illustrator: "Shibuzoh.",
@@ -14,38 +14,56 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "長得長長的角是為了向異性求愛而存在的。牠從不會把角當作武器。"
+		ja: "立派に 伸びた ツノは 異性に アピールするために 生えている。 武器として 使うことはない。",
+		'zh-tw': "長得長長的角是為了向異性求愛而存在的。牠從不會把角當作武器。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "彈跳"
+	attacks: [
+		{
+			name: {
+				ja: "とびはねる",
+				'zh-tw': "彈跳",
+			},
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンをベンチポケモンと入れ替える。",
+				'zh-tw': "若希望，將這隻寶可夢與備戰寶可夢互換。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "若希望，將這隻寶可夢與備戰寶可夢互換。"
+		{
+			name: {
+				ja: "ころがりタックル",
+				'zh-tw': "滾動衝撞",
+			},
+			damage: 70,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "滾動衝撞"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571644,
+				tcgplayer: 569378,
+			},
 		},
+	],
 
-		damage: 70,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ウールー",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [832],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S7D/056.ts
+++ b/data-asia/S/S7D/056.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "離洞繩"
+		ja: "あなぬけのヒモ",
+		'zh-tw': "離洞繩",
 	},
 
 	illustrator: "sadaji",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "雙方玩家將自己的戰鬥寶可夢與備戰寶可夢互換。（由對手先進行互換。沒有備戰寶可夢的玩家不用進行互換。）"
+		ja: "おたがいのプレイヤーは、それぞれ、自分のバトルポケモンをベンチポケモンと入れ替える。（入れ替えは相手からおこない、ベンチがいないプレイヤーは、入れ替えをしない。）",
+		'zh-tw': "雙方玩家將自己的戰鬥寶可夢與備戰寶可夢互換。（由對手先進行互換。沒有備戰寶可夢的玩家不用進行互換。）",
 	},
 
-	trainerType: "Item",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571645,
+				tcgplayer: 569379,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S7D/057.ts
+++ b/data-asia/S/S7D/057.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "進化薰香"
+		ja: "しんかのおこう",
+		'zh-tw': "進化薰香",
 	},
 
 	illustrator: "Ryo Ueda",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的牌庫選擇1張進化寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		ja: "自分の山札から進化ポケモンを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+		'zh-tw': "從自己的牌庫選擇1張進化寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571646,
+				tcgplayer: 569380,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "D",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S7D/058.ts
+++ b/data-asia/S/S7D/058.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "掉包杯"
+		ja: "すりかえカップ",
+		'zh-tw': "掉包杯",
 	},
 
 	illustrator: "Ryo Ueda",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "選擇1張自己的手牌，與牌庫上方的卡互換。"
+		ja: "自分の手札を1枚選び、山札の上のカードと入れ替える。",
+		'zh-tw': "選擇1張自己的手牌，與牌庫上方的卡互換。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571647,
+				tcgplayer: 569381,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S7D/059.ts
+++ b/data-asia/S/S7D/059.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "救援行李箱"
+		ja: "レスキューキャリー",
+		'zh-tw': "救援行李箱",
 	},
 
 	illustrator: "Ryo Ueda",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的棄牌區選擇最多2張HP為「90」以下的寶可夢卡，在給對手看過後加入手牌。"
+		ja: "自分のトラッシュからHPが「90」以下のポケモンを2枚まで選び、相手に見せて、手札に加える。",
+		'zh-tw': "從自己的棄牌區選擇最多2張HP為「90」以下的寶可夢卡，在給對手看過後加入手牌。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571648,
+				tcgplayer: 569382,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S7D/060.ts
+++ b/data-asia/S/S7D/060.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "挖洞手套"
+		ja: "穴掘りグローブ",
+		'zh-tw': "挖洞手套",
 	},
 
 	illustrator: "Toyste Beach",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。"
+		ja: "このカードをつけているポケモンが使うワザの、相手のバトル場の[闘]ポケモンへのダメージは「+30」される。",
+		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571650,
+				tcgplayer: 569383,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Tool",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S7D/061.ts
+++ b/data-asia/S/S7D/061.ts
@@ -1,22 +1,44 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "一擊的卷軸 牙龍之卷"
+		ja: "いちげきの巻物 牙竜の巻",
+		'zh-tw': "一擊的卷軸 牙龍之卷",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。"
+		ja: "このカードをつけている「いちげき」のポケモンは、このカードに書かれているワザを使える。［ワザを使うためのエネルギーは必要。］",
+		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "E"
-}
+	attacks: [
+		{
+			name: { ja: "ごうりきざん" },
+			cost: [],
+			effect: {
+				ja: "このポケモンについているエネルギーを、すべてトラッシュする。",
+			},
+		},
+	],
 
-export default card
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571651,
+				tcgplayer: 569384,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S7D/062.ts
+++ b/data-asia/S/S7D/062.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "全罩防守"
+		ja: "フルフェイスガード",
+		'zh-tw': "全罩防守",
 	},
 
 	illustrator: "AYUMI ODASHIMA",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。"
+		ja: "このカードをつけているポケモン（特性を持つポケモンをのぞく）が、相手のポケモンから受けるワザのダメージは「-20」される。",
+		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571652,
+				tcgplayer: 569385,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Tool",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S7D/063.ts
+++ b/data-asia/S/S7D/063.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "奇巴納"
+		ja: "キバナ",
+		'zh-tw': "奇巴納",
 	},
 
 	illustrator: "take",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "這張卡必須在上個對手的回合自己的寶可夢【氣絕】了才可使用。 從自己的棄牌區選擇1張基本能量卡，附於自己的寶可夢身上。然後，從自己的牌庫任意選擇1張卡加入手牌。並且重洗牌庫。"
+		ja: "このカードは、前の相手の番に、自分のポケモンがきぜつしていなければ使えない。自分のトラッシュから基本エネルギーを1枚選び、自分のポケモンにつける。その後、自分の山札から好きなカードを1枚選び、手札に加える。そして山札を切る。",
+		'zh-tw': "這張卡必須在上個對手的回合自己的寶可夢【氣絕】了才可使用。 從自己的棄牌區選擇1張基本能量卡，附於自己的寶可夢身上。然後，從自己的牌庫任意選擇1張卡加入手牌。並且重洗牌庫。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571653,
+				tcgplayer: 569386,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S7D/064.ts
+++ b/data-asia/S/S7D/064.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "女學生"
+		ja: "スクールガール",
+		'zh-tw': "女學生",
 	},
 
 	illustrator: "kirisAki",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的牌庫抽出2張卡。若對手剩餘獎賞卡的張數為6張・4張・2張，則再抽出2張卡。"
+		ja: "自分の山札を2枚引く。相手のサイドの残り枚数が6枚・4枚・2枚なら、さらに2枚引く。",
+		'zh-tw': "從自己的牌庫抽出2張卡。若對手剩餘獎賞卡的張數為6張・4張・2張，則再抽出2張卡。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571654,
+				tcgplayer: 569387,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/S/S7D/065.ts
+++ b/data-asia/S/S7D/065.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "模仿少女"
+		ja: "モノマネむすめ",
+		'zh-tw': "模仿少女",
 	},
 
 	illustrator: "Sanosuke Sakuma",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "將自己的手牌全部放回牌庫並重洗。然後，從自己的牌庫抽出與對手的手牌張數相同數量的卡。"
+		ja: "自分の手札をすべて山札にもどして切る。その後、相手の手札の枚数ぶん、自分の山札を引く。",
+		'zh-tw': "將自己的手牌全部放回牌庫並重洗。然後，從自己的牌庫抽出與對手的手牌張數相同數量的卡。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571655,
+				tcgplayer: 569388,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/S/S7D/066.ts
+++ b/data-asia/S/S7D/066.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "結晶洞窟"
+		ja: "結晶の洞窟",
+		'zh-tw': "結晶洞窟",
 	},
 
 	illustrator: "Toyste Beach",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "雙方玩家在每個自己的回合時，可使用1次，可將自己的所有【鋼】寶可夢與【龍】寶可夢各恢復「30」HP。"
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の[鋼]ポケモンと[竜]ポケモン全員のHPを、それぞれ「30」回復してよい。",
+		'zh-tw': "雙方玩家在每個自己的回合時，可使用1次，可將自己的所有【鋼】寶可夢與【龍】寶可夢各恢復「30」HP。",
 	},
 
-	trainerType: "Stadium",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571657,
+				tcgplayer: 569389,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Stadium",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S7D/067.ts
+++ b/data-asia/S/S7D/067.ts
@@ -1,21 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S7D"
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雙子能量"
+		ja: "ツインエネルギー",
+		'zh-tw': "雙子能量",
 	},
 
+	illustrator: "",
 	category: "Energy",
+	energyType: "Special",
 
 	effect: {
-		'zh-tw': "只要這張卡附於寶可夢身上，視為提供2個【無】能量。 若附於「寶可夢【V】・【GX】」身上，則視為提供1個【無】能量。"
+		ja: "このカードは、ポケモンについているかぎり、[無]エネルギー2個ぶんとしてはたらく。「ポケモンV・GX」についているなら、[無]エネルギー1個ぶんとしてはたらく。",
+		'zh-tw': "只要這張卡附於寶可夢身上，視為提供2個【無】能量。 若附於「寶可夢【V】・【GX】」身上，則視為提供1個【無】能量。",
 	},
 
-	energyType: "Special",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571658,
+				tcgplayer: 569390,
+			},
+		},
+	],
 
-export default card
+	regulationMark: "D",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S7D/068.ts
+++ b/data-asia/S/S7D/068.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スイクンV",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しゅんそく" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。自分の山札を1枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ブリザードロンド" },
+			damage: "20+",
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "おたがいのベンチポケモンの数×20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572050,
+				tcgplayer: 569391,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [245],
+};
+
+export default card;

--- a/data-asia/S/S7D/069.ts
+++ b/data-asia/S/S7D/069.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴルーグV",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "メガトンパンチ" },
+			damage: 80,
+			cost: ["Psychic", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "リワインドビーム" },
+			damage: 180,
+			cost: ["Psychic", "Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の進化しているバトルポケモンから、「進化カード」を1枚はがして退化させる。はがしたカードは、相手の手札にもどす。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572051,
+				tcgplayer: 569392,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [623],
+};
+
+export default card;

--- a/data-asia/S/S7D/070.ts
+++ b/data-asia/S/S7D/070.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴルーグV",
+	},
+
+	illustrator: "Oswaldo KATO",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "メガトンパンチ" },
+			damage: 80,
+			cost: ["Psychic", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "リワインドビーム" },
+			damage: 180,
+			cost: ["Psychic", "Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の進化しているバトルポケモンから、「進化カード」を1枚はがして退化させる。はがしたカードは、相手の手札にもどす。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572052,
+				tcgplayer: 569393,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [623],
+};
+
+export default card;

--- a/data-asia/S/S7D/071.ts
+++ b/data-asia/S/S7D/071.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルガルガンV",
+	},
+
+	illustrator: "PLANETA Tsuji",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "いわおとし" },
+			damage: 40,
+			cost: ["Fighting"],
+		},
+		{
+			name: { ja: "クラッシュファング" },
+			damage: 200,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572053,
+				tcgplayer: 569394,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [745],
+};
+
+export default card;

--- a/data-asia/S/S7D/072.ts
+++ b/data-asia/S/S7D/072.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダストダスV",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ゴミしゅうき" },
+			damage: 40,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "ヘドロばくだん" },
+			damage: 130,
+			cost: ["Darkness", "Darkness", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572054,
+				tcgplayer: 569395,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [569],
+};
+
+export default card;

--- a/data-asia/S/S7D/073.ts
+++ b/data-asia/S/S7D/073.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オンバーンV",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ばくおんぱ" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "シンクロラウド" },
+			damage: "60+",
+			cost: ["Psychic", "Darkness"],
+			effect: {
+				ja: "自分の手札と相手の手札が同じ枚数なら、120ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572055,
+				tcgplayer: 569396,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [715],
+};
+
+export default card;

--- a/data-asia/S/S7D/074.ts
+++ b/data-asia/S/S7D/074.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オンバーンV",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ばくおんぱ" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "シンクロラウド" },
+			damage: "60+",
+			cost: ["Psychic", "Darkness"],
+			effect: {
+				ja: "自分の手札と相手の手札が同じ枚数なら、120ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572056,
+				tcgplayer: 569397,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [715],
+};
+
+export default card;

--- a/data-asia/S/S7D/075.ts
+++ b/data-asia/S/S7D/075.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュラルドンV",
+	},
+
+	illustrator: "PLANETA Mochizuki",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "メタルクロー" },
+			damage: 70,
+			cost: ["Fighting", "Metal"],
+		},
+		{
+			name: { ja: "ワイドブレイカー" },
+			damage: 140,
+			cost: ["Fighting", "Metal", "Metal"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572057,
+				tcgplayer: 569398,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [884],
+};
+
+export default card;

--- a/data-asia/S/S7D/076.ts
+++ b/data-asia/S/S7D/076.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュラルドンV",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "メタルクロー" },
+			damage: 70,
+			cost: ["Fighting", "Metal"],
+		},
+		{
+			name: { ja: "ワイドブレイカー" },
+			damage: 140,
+			cost: ["Fighting", "Metal", "Metal"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572058,
+				tcgplayer: 569399,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [884],
+};
+
+export default card;

--- a/data-asia/S/S7D/077.ts
+++ b/data-asia/S/S7D/077.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キバナ",
+	},
+
+	illustrator: "kirisAki",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、前の相手の番に、自分のポケモンがきぜつしていなければ使えない。自分のトラッシュから基本エネルギーを1枚選び、自分のポケモンにつける。その後、自分の山札から好きなカードを1枚選び、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572059,
+				tcgplayer: 569400,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S7D/078.ts
+++ b/data-asia/S/S7D/078.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スクールガール",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を2枚引く。相手のサイドの残り枚数が6枚・4枚・2枚なら、さらに2枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572060,
+				tcgplayer: 569401,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S7D/079.ts
+++ b/data-asia/S/S7D/079.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モノマネむすめ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札をすべて山札にもどして切る。その後、相手の手札の枚数ぶん、自分の山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572061,
+				tcgplayer: 569402,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S7D/080.ts
+++ b/data-asia/S/S7D/080.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルガルガンVMAX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 320,
+	types: ["Fighting"],
+
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: { ja: "ハンティングクロー" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手の場の残りHPが「60」以下のポケモンを1匹選び、きぜつさせる。",
+			},
+		},
+		{
+			name: { ja: "ダイエッジ" },
+			damage: 190,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572062,
+				tcgplayer: 569403,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ルガルガンV",
+	},
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Hyper rare",
+	dexId: [745],
+};
+
+export default card;

--- a/data-asia/S/S7D/081.ts
+++ b/data-asia/S/S7D/081.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダストダスVMAX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Darkness"],
+
+	stage: "VMAX",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ガラクタあつめ" },
+			effect: {
+				ja: "このポケモンは、「ポケモンのどうぐ」を2枚までつけられる。（この特性がなくなったとき、自分は「ポケモンのどうぐ」を1枚になるようにトラッシュする。）",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "キョダイシュウキ" },
+			damage: 120,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572063,
+				tcgplayer: 569404,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ダストダスV",
+	},
+
+	retreat: 3,
+	regulationMark: "E",
+	rarity: "Hyper rare",
+	dexId: [569],
+};
+
+export default card;

--- a/data-asia/S/S7D/082.ts
+++ b/data-asia/S/S7D/082.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュラルドンVMAX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Dragon"],
+
+	stage: "VMAX",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "まてんろう" },
+			effect: {
+				ja: "このポケモンは、特殊エネルギーがついている相手のポケモンから、ワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "キョダイフンサイ" },
+			damage: 220,
+			cost: ["Fighting", "Metal", "Metal"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572064,
+				tcgplayer: 569405,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジュラルドンV",
+	},
+
+	retreat: 3,
+	regulationMark: "E",
+	rarity: "Hyper rare",
+	dexId: [884],
+};
+
+export default card;

--- a/data-asia/S/S7D/083.ts
+++ b/data-asia/S/S7D/083.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュラルドンVMAX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Dragon"],
+
+	stage: "VMAX",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "まてんろう" },
+			effect: {
+				ja: "このポケモンは、特殊エネルギーがついている相手のポケモンから、ワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "キョダイフンサイ" },
+			damage: 220,
+			cost: ["Fighting", "Metal", "Metal"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572065,
+				tcgplayer: 569406,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジュラルドンV",
+	},
+
+	retreat: 3,
+	regulationMark: "E",
+	rarity: "Secret Rare",
+	dexId: [884],
+};
+
+export default card;

--- a/data-asia/S/S7D/084.ts
+++ b/data-asia/S/S7D/084.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キバナ",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、前の相手の番に、自分のポケモンがきぜつしていなければ使えない。自分のトラッシュから基本エネルギーを1枚選び、自分のポケモンにつける。その後、自分の山札から好きなカードを1枚選び、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572066,
+				tcgplayer: 569407,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Hyper rare",
+};
+
+export default card;

--- a/data-asia/S/S7D/085.ts
+++ b/data-asia/S/S7D/085.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スクールガール",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を2枚引く。相手のサイドの残り枚数が6枚・4枚・2枚なら、さらに2枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572067,
+				tcgplayer: 569408,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Hyper rare",
+};
+
+export default card;

--- a/data-asia/S/S7D/086.ts
+++ b/data-asia/S/S7D/086.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モノマネむすめ",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札をすべて山札にもどして切る。その後、相手の手札の枚数ぶん、自分の山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572068,
+				tcgplayer: 569409,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Hyper rare",
+};
+
+export default card;

--- a/data-asia/S/S7D/087.ts
+++ b/data-asia/S/S7D/087.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クレセリア",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みなぎるひかり" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の山札から「基本[P]エネルギー」を2枚まで選び、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "オーロラビーム" },
+			damage: 90,
+			cost: ["Psychic", "Psychic", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572069,
+				tcgplayer: 569410,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Secret Rare",
+	dexId: [488],
+};
+
+export default card;

--- a/data-asia/S/S7D/088.ts
+++ b/data-asia/S/S7D/088.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フルフェイスガード",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモン（特性を持つポケモンをのぞく）が、相手のポケモンから受けるワザのダメージは「-20」される。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572070,
+				tcgplayer: 569411,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "E",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/S/S7D/089.ts
+++ b/data-asia/S/S7D/089.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "結晶の洞窟",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の[鋼]ポケモンと[竜]ポケモン全員のHPを、それぞれ「30」回復してよい。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572071,
+				tcgplayer: 569412,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "E",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/S/S7D/090.ts
+++ b/data-asia/S/S7D/090.ts
@@ -1,0 +1,27 @@
+import { Card } from "../../../interfaces";
+import Set from "../S7D";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本鋼エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572072,
+				tcgplayer: 577426,
+			},
+		},
+	],
+
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -236,6 +236,7 @@ export interface Card {
 			// Black White rare
 			| 'Black White Rare'
 			| 'Mega Hyper Rare'
+			| 'Triple Rare'
 			// Japanese Character Rares (since SM11b Dream League)
 			| 'Character Rare' | 'Character Super Rare'
 			// Pokémon TCG Pocket Rarities


### PR DESCRIPTION
## What

Refreshes the existing Japanese set **S7D 摩天パーフェクト (Skyscraping Perfection)** from its primary sources. The curated content stays: every card keeps its `zh-tw` texts verbatim.

What changes across the 90 card files:

- `thirdParty.cardmarket` moves onto `variants` objects and 67 missing ids are filled in
- per card where missing: `dexId`, `evolveFrom`, `resistances`, the Japanese flavor text and the Japanese effect/attack texts straight from the official database and limitless

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (571583–572072)
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (569324–577426), keyed by the collection number each product carries in `extendedData`

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- 061 is a Pokémon Tool that grant an attack — modeled as `effect` + `attacks`, like their English prints
- All 90 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
