### PR TITLE
(data) Update Japanese S set S6K Jet-Black Spirit

### DIFF
--- a/data-asia/S/S6K/001.ts
+++ b/data-asia/S/S6K/001.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "芭瓢蟲"
+		ja: "レディバ",
+		'zh-tw': "芭瓢蟲",
 	},
 
 	illustrator: "Naoyo Kimura",
@@ -14,37 +14,51 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "非常膽小的寶可夢。會和夥伴一起張開反射壁，藉此保護巢穴。"
+		ja: "とっても 臆病な ポケモン。 仲間と 一緒に リフレクターを 張って 巣を 守って いるのだ。",
+		'zh-tw': "非常膽小的寶可夢。會和夥伴一起張開反射壁，藉此保護巢穴。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "呼喚"
+	attacks: [
+		{
+			name: {
+				ja: "もってくる",
+				'zh-tw': "呼喚",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+				'zh-tw': "從自己的牌庫抽出1張卡。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫抽出1張卡。"
+		{
+			name: {
+				ja: "パンチ",
+				'zh-tw': "出拳",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "出拳"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560526,
+				tcgplayer: 569229,
+			},
 		},
-
-		damage: 20,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [165],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/002.ts
+++ b/data-asia/S/S6K/002.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "安瓢蟲"
+		ja: "レディアン",
+		'zh-tw': "安瓢蟲",
 	},
 
 	illustrator: "Sekio",
@@ -14,42 +14,60 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "一邊撒落閃閃發亮的粉末，一邊在夜空中飛翔。據說如果身上沾到這種粉末，就會有好事發生。"
+		ja: "きらめく 粉を 振りまきながら 夜空を 飛ぶ。 粉が 身体に つくと いいことが あるといわれる。",
+		'zh-tw': "一邊撒落閃閃發亮的粉末，一邊在夜空中飛翔。據說如果身上沾到這種粉末，就會有好事發生。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "快速抽出"
+	attacks: [
+		{
+			name: {
+				ja: "クイックドロー",
+				'zh-tw': "快速抽出",
+			},
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を2枚引く。",
+				'zh-tw': "從自己的牌庫抽出2張卡。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫抽出2張卡。"
+		{
+			name: {
+				ja: "エアスラッシュ",
+				'zh-tw': "空氣斬",
+			},
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		damage: 20,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "空氣斬"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560529,
+				tcgplayer: 569230,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。"
-		},
-
-		damage: 100,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "レディバ",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [166],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/003.ts
+++ b/data-asia/S/S6K/003.ts
@@ -1,40 +1,59 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "時拉比V"
+		ja: "セレビィV",
+		'zh-tw': "時拉比V",
 	},
 
 	illustrator: "AKIRA EGAWA",
 	category: "Pokemon",
 	hp: 190,
 	types: ["Grass"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "斬返"
+	attacks: [
+		{
+			name: {
+				ja: "わかばのまい",
+				'zh-tw': "斬返",
+			},
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の手札から[草]エネルギーを好きなだけ選び、自分のポケモンに好きなようにつける。",
+				'zh-tw': "將這隻寶可夢與備戰寶可夢互換。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將這隻寶可夢與備戰寶可夢互換。"
+		{
+			name: { ja: "スラッシュバック" },
+			damage: 60,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
 		},
+	],
 
-		damage: 60,
-		cost: ["Grass", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560689,
+				tcgplayer: 569231,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [251],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/004.ts
+++ b/data-asia/S/S6K/004.ts
@@ -1,39 +1,66 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "時拉比VMAX"
+		ja: "セレビィVMAX",
+		'zh-tw': "時拉比VMAX",
 	},
 
 	illustrator: "PLANETA Tsuji",
 	category: "Pokemon",
 	hp: 310,
 	types: ["Grass"],
+
 	stage: "VMAX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "極巨植物"
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "いやしのもり" },
+			effect: {
+				ja: "自分の番に1回使える。自分の[草]ポケモン全員のHPを、それぞれ「20」回復する。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多2張寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。"
+	attacks: [
+		{
+			name: {
+				ja: "ダイプラント",
+				'zh-tw': "極巨植物",
+			},
+			damage: 130,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "自分の山札からポケモンを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多2張寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
+	],
 
-		damage: 130,
-		cost: ["Grass", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560705,
+				tcgplayer: 569232,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "セレビィV",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Triple Rare",
+	dexId: [251],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/005.ts
+++ b/data-asia/S/S6K/005.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "橡實果"
+		ja: "タネボー",
+		'zh-tw': "橡實果",
 	},
 
 	illustrator: "otumami",
@@ -14,31 +14,44 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "會將頭頂黏在樹枝上懸掛著。也有被大風吹落的時候。"
+		ja: "頭の 先を 枝に くっつけて ぶら下がる。 強風に あおられ 落ちてしまう ことも あるのだ。",
+		'zh-tw': "會將頭頂黏在樹枝上懸掛著。也有被大風吹落的時候。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "驚嚇"
+	attacks: [
+		{
+			name: {
+				ja: "おどろかす",
+				'zh-tw': "驚嚇",
+			},
+			damage: 10,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、そのカードのオモテを見てから、相手の山札にもどして切る。",
+				'zh-tw': "在不看正面的情況下，從對手的手牌選擇1張，在看過那張卡正面後放回對手的牌庫並重洗。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在不看正面的情況下，從對手的手牌選擇1張，在看過那張卡正面後放回對手的牌庫並重洗。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560719,
+				tcgplayer: 569233,
+			},
 		},
-
-		damage: 10,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [273],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/006.ts
+++ b/data-asia/S/S6K/006.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "敲音猴"
+		ja: "サルノリ",
+		'zh-tw': "敲音猴",
 	},
 
 	illustrator: "kodama",
@@ -14,31 +14,44 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "會用木棒連續擊打來攻擊。在以飛快的速度擊打的同時，情緒也會變得越來越高漲。"
+		ja: "スティックの 連打で 攻撃。 すごい スピードで 叩くうちに どんどん テンションが 上がるのだ。",
+		'zh-tw': "會用木棒連續擊打來攻擊。在以飛快的速度擊打的同時，情緒也會變得越來越高漲。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "二連敲"
+	attacks: [
+		{
+			name: {
+				ja: "にどたたき",
+				'zh-tw': "二連敲",
+			},
+			damage: "30×",
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×30ダメージ。",
+				'zh-tw': "擲2次硬幣，造成正面出現的次數×30點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲2次硬幣，造成正面出現的次數×30點傷害。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560727,
+				tcgplayer: 569234,
+			},
 		},
-
-		damage: "30×",
-		cost: ["Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [810],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/007.ts
+++ b/data-asia/S/S6K/007.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "啪咚猴"
+		ja: "バチンキー",
+		'zh-tw': "啪咚猴",
 	},
 
 	illustrator: "Kouki Saitou",
@@ -14,31 +14,48 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "打著激烈的節拍戰鬥時，由於過於忘我，甚至不會意識到自己已經把對手打昏了。"
+		ja: "激しい ビートを 刻むことに 夢中になる あまり 戦いで 相手が 気絶しても 気づかない。",
+		'zh-tw': "打著激烈的節拍戰鬥時，由於過於忘我，甚至不會意識到自己已經把對手打昏了。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "拍落"
+	attacks: [
+		{
+			name: {
+				ja: "はたきおとす",
+				'zh-tw': "拍落",
+			},
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、トラッシュする。",
+				'zh-tw': "在不看正面的情況下，選擇1張對手的手牌，將其丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在不看正面的情況下，選擇1張對手的手牌，將其丟棄。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560730,
+				tcgplayer: 569235,
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "サルノリ",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [811],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/008.ts
+++ b/data-asia/S/S6K/008.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "轟擂金剛猩"
+		ja: "ゴリランダー",
+		'zh-tw': "轟擂金剛猩",
 	},
 
 	illustrator: "Hitoshi Ariga",
@@ -14,42 +14,60 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "打鼓技巧最高超的那一隻會成為首領。性情溫和，重視族群的和諧相處。"
+		ja: "ドラムテクニックに 優れた ものが ボスになる。 穏やかな 気性で グループの 調和を 重んじる。",
+		'zh-tw': "打鼓技巧最高超的那一隻會成為首領。性情溫和，重視族群的和諧相處。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "木之吸取"
+	attacks: [
+		{
+			name: {
+				ja: "ウッドドレイン",
+				'zh-tw': "木之吸取",
+			},
+			damage: 60,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+				'zh-tw': "將這隻寶可夢恢復「30」HP。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將這隻寶可夢恢復「30」HP。"
+		{
+			name: {
+				ja: "どとうのれんだ",
+				'zh-tw': "怒濤連打",
+			},
+			damage: "120+",
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについているエネルギーを好きなだけトラッシュし、その枚数×30ダメージ追加。",
+				'zh-tw': "將自己的場上寶可夢身上附加的任意數量的能量丟棄，增加其張數×30點傷害。",
+			},
 		},
+	],
 
-		damage: 60,
-		cost: ["Grass", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "怒濤連打"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560734,
+				tcgplayer: 569236,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將自己的場上寶可夢身上附加的任意數量的能量丟棄，增加其張數×30點傷害。"
-		},
-
-		damage: "120+",
-		cost: ["Grass", "Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "バチンキー",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [812],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/009.ts
+++ b/data-asia/S/S6K/009.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "可達鴨"
+		ja: "コダック",
+		'zh-tw': "可達鴨",
 	},
 
 	illustrator: "OKACHEKE",
@@ -14,27 +14,40 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "據了解，當頭痛發生時，牠的腦細胞活動會比平時活躍１０倍。"
+		ja: "頭痛が 発生している 間 脳細胞が 普段の １０倍 活動 していることが わかった。",
+		'zh-tw': "據了解，當頭痛發生時，牠的腦細胞活動會比平時活躍１０倍。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "潑水"
+	attacks: [
+		{
+			name: {
+				ja: "みずかけ",
+				'zh-tw': "潑水",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
+	],
 
-		damage: 10,
-		cost: ["Colorless"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560738,
+				tcgplayer: 569237,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [54],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/010.ts
+++ b/data-asia/S/S6K/010.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "哥達鴨"
+		ja: "ゴルダック",
+		'zh-tw': "哥達鴨",
 	},
 
 	illustrator: "Kyoko Umemoto",
@@ -14,38 +14,56 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "游泳專家。能靈活地擺動長長的尾巴，連續游上整整２天。"
+		ja: "泳ぎの プロフェッショナル。 長い シッポを 巧みに くねらせ 丸々 ２日 泳いでいられる。",
+		'zh-tw': "游泳專家。能靈活地擺動長長的尾巴，連續游上整整２天。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "幻象光線"
+	attacks: [
+		{
+			name: {
+				ja: "サイケこうせん",
+				'zh-tw': "幻象光線",
+			},
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【混亂】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【混亂】。"
+		{
+			name: {
+				ja: "なみのり",
+				'zh-tw': "衝浪",
+			},
+			damage: 70,
+			cost: ["Water", "Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "衝浪"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560741,
+				tcgplayer: 569238,
+			},
 		},
+	],
 
-		damage: 70,
-		cost: ["Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "コダック",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [55],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/011.ts
+++ b/data-asia/S/S6K/011.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "狃拉"
+		ja: "ニューラ",
+		'zh-tw': "狃拉",
 	},
 
 	illustrator: "NC Empire",
@@ -14,30 +14,43 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "性格狡猾且凶猛。會趁著雙親不在時侵入巢穴把蛋盜走。"
+		ja: "ずる賢く 獰猛な 性質。 親が いない 隙に 巣穴に 侵入。 タマゴを 盗みだす。",
+		'zh-tw': "性格狡猾且凶猛。會趁著雙親不在時侵入巢穴把蛋盜走。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "切落"
+	attacks: [
+		{
+			name: {
+				ja: "きりおとす",
+				'zh-tw': "切落",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "擲1次硬幣若為正面，則選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560745,
+				tcgplayer: 569239,
+			},
 		},
-
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [215],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/012.ts
+++ b/data-asia/S/S6K/012.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "瑪狃拉"
+		ja: "マニューラ",
+		'zh-tw': "瑪狃拉",
 	},
 
 	illustrator: "Taira Akitsu",
@@ -14,40 +14,58 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "透過用爪子留下記號來與夥伴聯絡。據說記號的種類有５００種以上。"
+		ja: "ツメで サインを 描き 仲間と 連絡。 サインの 種類は ５００以上 あると いう。",
+		'zh-tw': "透過用爪子留下記號來與夥伴聯絡。據說記號的種類有５００種以上。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "雙擊必殺"
+	attacks: [
+		{
+			name: {
+				ja: "にげきひっさつ",
+				'zh-tw': "雙擊必殺",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の自分の番、このワザを受けたポケモンは、「れんげき」のポケモンからワザのダメージを受けたらきぜつする。",
+				'zh-tw': "在下個自己的回合，受到這個招式的寶可夢若受到「連擊」寶可夢招式的傷害，會【氣絕】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個自己的回合，受到這個招式的寶可夢若受到「連擊」寶可夢招式的傷害，會【氣絕】。"
+		{
+			name: {
+				ja: "わるだくみ",
+				'zh-tw': "詭計",
+			},
+			cost: ["Water"],
+			effect: {
+				ja: "自分の山札から好きなカードを2枚まで選び、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫任意選擇最多2張卡加入手牌。並且重洗牌庫。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "詭計"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560750,
+				tcgplayer: 569240,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的牌庫任意選擇最多2張卡加入手牌。並且重洗牌庫。"
-		},
-
-		cost: ["Water"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ニューラ",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [461],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/013.ts
+++ b/data-asia/S/S6K/013.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "飄浮泡泡 雨水的樣子"
+		ja: "ポワルン あまみずのすがた",
+		'zh-tw': "飄浮泡泡 雨水的樣子",
 	},
 
 	illustrator: "sowsow",
@@ -14,42 +14,57 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "飄浮泡泡被雨淋到時的樣子。在讓牠淋浴的實驗裡，牠並沒有變成這種形態。"
+		ja: "雨に 打たれる ポワルンの 姿。 シャワーを 浴びせた 実験では この 形に 変化しなかった。",
+		'zh-tw': "飄浮泡泡被雨淋到時的樣子。在讓牠淋浴的實驗裡，牠並沒有變成這種形態。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "看天"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "てんきよみ",
+				'zh-tw': "看天",
+			},
+			effect: {
+				ja: "自分のトラッシュに「スタジアム」が8枚以上あるなら、このポケモンがワザを使うためのエネルギーは、すべてなくなる。",
+				'zh-tw': "若自己的棄牌區有8張以上的「競技場」卡，則這隻寶可夢使用招式所需的能量全部消除。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若自己的棄牌區有8張以上的「競技場」卡，則這隻寶可夢使用招式所需的能量全部消除。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "雨流浴"
+	attacks: [
+		{
+			name: {
+				ja: "レインシャワー",
+				'zh-tw': "雨流浴",
+			},
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的所有寶可夢各受到20點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "對手的所有寶可夢各受到20點傷害。[在備戰區不計算弱點・抵抗力。]"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560754,
+				tcgplayer: 569241,
+			},
 		},
-
-		cost: ["Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	],
 
 	retreat: 0,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [351],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/014.ts
+++ b/data-asia/S/S6K/014.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "愛心魚"
+		ja: "ラブカス",
+		'zh-tw': "愛心魚",
 	},
 
 	illustrator: "Mizue",
@@ -14,37 +14,51 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "溫暖海域的珊瑚礁是牠的棲息地。最喜歡在太陽珊瑚的枝條間睡覺。"
+		ja: "暖かい 海の サンゴ礁が 棲み処。 サニーゴの枝の 間で 眠るのが 特に お気に入り。",
+		'zh-tw': "溫暖海域的珊瑚礁是牠的棲息地。最喜歡在太陽珊瑚的枝條間睡覺。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "同步抽出"
+	attacks: [
+		{
+			name: {
+				ja: "シンクロドロー",
+				'zh-tw': "同步抽出",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札をすべて山札にもどして切る。その後、相手の手札の枚数ぶん、自分の山札を引く。",
+				'zh-tw': "將自己的手牌全部放回牌庫並重洗。然後，從自己的牌庫抽出與對手的手牌張數相同數量的卡。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將自己的手牌全部放回牌庫並重洗。然後，從自己的牌庫抽出與對手的手牌張數相同數量的卡。"
+		{
+			name: {
+				ja: "みずでっぽう",
+				'zh-tw': "水槍",
+			},
+			damage: 20,
+			cost: ["Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "水槍"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560758,
+				tcgplayer: 569242,
+			},
 		},
-
-		damage: 20,
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [370],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/015.ts
+++ b/data-asia/S/S6K/015.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "圓蝌蚪"
+		ja: "オタマロ",
+		'zh-tw': "圓蝌蚪",
 	},
 
 	illustrator: "Mina Nakai",
@@ -14,27 +14,40 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "透過音波來聯繫夥伴。人類和其他寶可夢都聽不見牠發出的警告聲。"
+		ja: "音波で 仲間と 連絡する。 警戒の 鳴き声は 人や ほかの ポケモンには 聞こえない。",
+		'zh-tw': "透過音波來聯繫夥伴。人類和其他寶可夢都聽不見牠發出的警告聲。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "擲泥"
+	attacks: [
+		{
+			name: {
+				ja: "どろかけ",
+				'zh-tw': "擲泥",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
+	],
 
-		damage: 10,
-		cost: ["Colorless"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560764,
+				tcgplayer: 569243,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [535],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/016.ts
+++ b/data-asia/S/S6K/016.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "卡璞・鰭鰭"
+		ja: "カプ・レヒレ",
+		'zh-tw': "卡璞・鰭鰭",
 	},
 
 	illustrator: "Shin Nagasawa",
@@ -14,42 +14,56 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "被稱為守護神，但有時會對隨便靠近自己的對手帶來恐怖的災難。"
+		ja: "守り神と 呼ばれるが 無闇に 近付く 相手には 恐ろしい 災いを もたらすこともある。",
+		'zh-tw': "被稱為守護神，但有時會對隨便靠近自己的對手帶來恐怖的災難。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "粉碎迴轉"
+	attacks: [
+		{
+			name: {
+				ja: "スマッシュターン",
+				'zh-tw': "粉碎迴轉",
+			},
+			damage: 30,
+			cost: ["Water"],
+			effect: {
+				ja: "のぞむなら、このポケモンをベンチポケモンと入れ替える。",
+				'zh-tw': "若希望，將這隻寶可夢與備戰寶可夢互換。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "若希望，將這隻寶可夢與備戰寶可夢互換。"
+		{
+			name: {
+				ja: "オーシャンループ",
+				'zh-tw': "大洋閉環",
+			},
+			damage: 120,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、手札にもどす。",
+				'zh-tw': "選擇1個這隻寶可夢身上附加的能量，放回手牌。",
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "大洋閉環"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560765,
+				tcgplayer: 569244,
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇1個這隻寶可夢身上附加的能量，放回手牌。"
-		},
-
-		damage: 120,
-		cost: ["Water", "Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [788],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/017.ts
+++ b/data-asia/S/S6K/017.ts
@@ -1,40 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鰓魚海獸V"
+		ja: "ウオチルドンV",
+		'zh-tw': "鰓魚海獸V",
 	},
 
 	illustrator: "Eske Yoshinob",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Water"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "終極衝擊"
+	attacks: [
+		{
+			name: {
+				ja: "げんしれいとう",
+				'zh-tw': "終極衝擊",
+			},
+			damage: 80,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けた「ポケモンV・GX」は、ワザが使えない。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。"
+		{
+			name: { ja: "ギガインパクト" },
+			damage: 220,
+			cost: ["Water", "Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
 		},
+	],
 
-		damage: 220,
-		cost: ["Water", "Water", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560766,
+				tcgplayer: 569245,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [881],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/018.ts
+++ b/data-asia/S/S6K/018.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "咩利羊"
+		ja: "メリープ",
+		'zh-tw': "咩利羊",
 	},
 
 	illustrator: "Miki Tanaka",
@@ -14,37 +14,51 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "會累積絨毛摩擦時所產生的電力。如果因為牠可愛而直接用手去摸，就會被電得又麻又痛。"
+		ja: "綿毛が こすれ 電気が たまる。 かわいいからと 素手で 触ると バチッと 痺れて 痛いのだ。",
+		'zh-tw': "會累積絨毛摩擦時所產生的電力。如果因為牠可愛而直接用手去摸，就會被電得又麻又痛。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "叫聲"
+	attacks: [
+		{
+			name: {
+				ja: "なきごえ",
+				'zh-tw': "叫聲",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-20」される。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢使用招式的傷害「-20」點。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢使用招式的傷害「-20」點。"
+		{
+			name: {
+				ja: "バチバチ",
+				'zh-tw': "劈哩啪啦",
+			},
+			damage: 20,
+			cost: ["Lightning", "Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "劈哩啪啦"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560767,
+				tcgplayer: 569246,
+			},
 		},
-
-		damage: 20,
-		cost: ["Lightning", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [179],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/019.ts
+++ b/data-asia/S/S6K/019.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "茸茸羊"
+		ja: "モココ",
+		'zh-tw': "茸茸羊",
 	},
 
 	illustrator: "sui",
@@ -14,27 +14,44 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "會將電力儲存在鬆軟的毛中。因為儲存了太多電力，身上有些地方變得光禿禿的。"
+		ja: "ふかふかの 毛に 電気を ためこむ。 蓄えすぎて ところどころ つるつるに 禿げあがって しまった。",
+		'zh-tw': "會將電力儲存在鬆軟的毛中。因為儲存了太多電力，身上有些地方變得光禿禿的。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "電球"
+	attacks: [
+		{
+			name: {
+				ja: "エレキボール",
+				'zh-tw': "電球",
+			},
+			damage: 50,
+			cost: ["Lightning", "Colorless"],
 		},
+	],
 
-		damage: 50,
-		cost: ["Lightning", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560768,
+				tcgplayer: 569247,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メリープ",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [180],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/020.ts
+++ b/data-asia/S/S6K/020.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "電龍"
+		ja: "デンリュウ",
+		'zh-tw': "電龍",
 	},
 
 	illustrator: "Megumi Mizutani",
@@ -14,42 +14,60 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "尾巴發出的耀眼光芒被船員們當成引路的路標，從過去就一直深受重視。"
+		ja: "シッポは 強く 明るく 輝く。 船乗りたちの 道しるべ として 昔から 大切に されてきた。",
+		'zh-tw': "尾巴發出的耀眼光芒被船員們當成引路的路標，從過去就一直深受重視。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "電擊"
+	attacks: [
+		{
+			name: {
+				ja: "でんきショック",
+				'zh-tw': "電擊",
+			},
+			damage: 50,
+			cost: ["Lightning"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+				'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。"
+		{
+			name: {
+				ja: "サーチライトテール",
+				'zh-tw': "探照燈尾",
+			},
+			damage: "90+",
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "相手の手札を見て、その中にエネルギーがあるなら、90ダメージ追加。",
+				'zh-tw': "查看對手的手牌，若其中有能量卡，則增加90點傷害。",
+			},
 		},
+	],
 
-		damage: 50,
-		cost: ["Lightning"]
-	}, {
-		name: {
-			'zh-tw': "探照燈尾"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560769,
+				tcgplayer: 569248,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "查看對手的手牌，若其中有能量卡，則增加90點傷害。"
-		},
-
-		damage: "90+",
-		cost: ["Lightning", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "モココ",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [181],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/021.ts
+++ b/data-asia/S/S6K/021.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "斑斑馬"
+		ja: "シママ",
+		'zh-tw': "斑斑馬",
 	},
 
 	illustrator: "HYOGONOSUKE",
@@ -14,30 +14,43 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "放電時鬃毛會發光。利用鬃毛閃爍的次數及節奏與夥伴交談。"
+		ja: "放電すると たてがみが 光る。 たてがみが 輝く 回数や リズムで 仲間と 会話している。",
+		'zh-tw': "放電時鬃毛會發光。利用鬃毛閃爍的次數及節奏與夥伴交談。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "雷電箭"
+	attacks: [
+		{
+			name: {
+				ja: "サンダーアロー",
+				'zh-tw': "雷電箭",
+			},
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手のポケモン1匹に、10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的1隻寶可夢受到10點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "對手的1隻寶可夢受到10點傷害。[在備戰區不計算弱點・抵抗力。]"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560770,
+				tcgplayer: 569249,
+			},
 		},
-
-		cost: ["Lightning"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [522],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/022.ts
+++ b/data-asia/S/S6K/022.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雷電斑馬"
+		ja: "ゼブライカ",
+		'zh-tw': "雷電斑馬",
 	},
 
 	illustrator: "Hasuno",
@@ -14,42 +14,60 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "有著閃電般的爆發力。如果雷電斑馬全速奔馳，雷聲就會響徹雲霄。"
+		ja: "稲妻のような 瞬発力。 ゼブライカが 全速力で 走ると 雷鳴が 響きわたる。",
+		'zh-tw': "有著閃電般的爆發力。如果雷電斑馬全速奔馳，雷聲就會響徹雲霄。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "聯合伏特"
+	attacks: [
+		{
+			name: {
+				ja: "れんけいボルト",
+				'zh-tw': "聯合伏特",
+			},
+			damage: "30+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "前の自分の番、このポケモン以外の「れんげき」のポケモンがワザを使っていたなら、90ダメージ追加。",
+				'zh-tw': "在上個自己的回合，若這隻寶可夢以外的「連擊」寶可夢使用了招式，則增加90點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在上個自己的回合，若這隻寶可夢以外的「連擊」寶可夢使用了招式，則增加90點傷害。"
+		{
+			name: {
+				ja: "スパークラッシュ",
+				'zh-tw': "電光衝刺",
+			},
+			damage: "90×",
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数×90ダメージ。",
+				'zh-tw': "擲硬幣直到出現反面，造成正面出現的次數×90點傷害。",
+			},
 		},
+	],
 
-		damage: "30+",
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "電光衝刺"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560771,
+				tcgplayer: 569250,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲硬幣直到出現反面，造成正面出現的次數×90點傷害。"
-		},
-
-		damage: "90×",
-		cost: ["Lightning", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "シママ",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [523],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/023.ts
+++ b/data-asia/S/S6K/023.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "電飛鼠"
+		ja: "エモンガ",
+		'zh-tw': "電飛鼠",
 	},
 
 	illustrator: "Nagomi Nijo",
@@ -14,31 +14,44 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "會一邊到處放電一邊飛行，所以鳥寶可夢們不會靠近牠，這讓牠可以獨佔食物。"
+		ja: "電気を まき散らしながら 飛ぶので とりポケモンたちが 近付かない。 おかげで エサを ひとりじめできる。",
+		'zh-tw': "會一邊到處放電一邊飛行，所以鳥寶可夢們不會靠近牠，這讓牠可以獨佔食物。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "電擊"
+	attacks: [
+		{
+			name: {
+				ja: "でんきショック",
+				'zh-tw': "電擊",
+			},
+			damage: 30,
+			cost: ["Lightning"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+				'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560772,
+				tcgplayer: 569251,
+			},
 		},
-
-		damage: 30,
-		cost: ["Lightning"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 0,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [587],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/024.ts
+++ b/data-asia/S/S6K/024.ts
@@ -1,40 +1,52 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "捷拉奧拉V"
+		ja: "ゼラオラV",
+		'zh-tw': "捷拉奧拉V",
 	},
 
 	illustrator: "chibi",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Lightning"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "十字拳"
+	attacks: [
+		{
+			name: {
+				ja: "クロスフィスト",
+				'zh-tw': "十字拳",
+			},
+			damage: 100,
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "前の自分の番、このポケモン以外の「れんげき」のポケモンがワザを使っていたなら、相手のベンチポケモン1匹にも、160ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "在上個自己的回合，若這隻寶可夢以外的「連擊」寶可夢使用了招式，則對手的1隻備戰寶可夢也受到160點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在上個自己的回合，若這隻寶可夢以外的「連擊」寶可夢使用了招式，則對手的1隻備戰寶可夢也受到160點傷害。[在備戰區不計算弱點・抵抗力。]"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560773,
+				tcgplayer: 569252,
+			},
 		},
-
-		damage: 100,
-		cost: ["Lightning", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [807],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/025.ts
+++ b/data-asia/S/S6K/025.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鬼斯"
+		ja: "ゴース",
+		'zh-tw': "鬼斯",
 	},
 
 	illustrator: "Motofumi Fujiwara",
@@ -14,36 +14,44 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "能用稀薄氣體狀的身體潛入任何地方，但只要起風就會被吹跑。"
+		ja: "薄い ガスのような 体で どこにでも 忍びこむが 風が 吹くと 吹きとばされる。",
+		'zh-tw': "能用稀薄氣體狀的身體潛入任何地方，但只要起風就會被吹跑。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "睡眠波動"
+	attacks: [
+		{
+			name: {
+				ja: "ねむりのはどう",
+				'zh-tw': "睡眠波動",
+			},
+			damage: 10,
+			cost: ["Psychic"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをねむりにする。",
+				'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【睡眠】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【睡眠】。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560774,
+				tcgplayer: 569253,
+			},
 		},
-
-		damage: 10,
-		cost: ["Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [92],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/026.ts
+++ b/data-asia/S/S6K/026.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鬼斯通"
+		ja: "ゴースト",
+		'zh-tw': "鬼斯通",
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -14,32 +14,44 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "如果黑暗中空無一人，但你卻感覺被什麼盯上了，那麼鬼斯通一定就在那裡。"
+		ja: "暗闇で だれもいないのに 見られているような 気がしたら そこに ゴーストが いるのだ。",
+		'zh-tw': "如果黑暗中空無一人，但你卻感覺被什麼盯上了，那麼鬼斯通一定就在那裡。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "鬼火"
+	attacks: [
+		{
+			name: {
+				ja: "おにび",
+				'zh-tw': "鬼火",
+			},
+			damage: 30,
+			cost: ["Psychic"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Psychic"]
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560775,
+				tcgplayer: 569254,
+			},
+		},
+	],
 
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ゴース",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [93],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/027.ts
+++ b/data-asia/S/S6K/027.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "耿鬼"
+		ja: "ゲンガー",
+		'zh-tw': "耿鬼",
 	},
 
 	illustrator: "Aya Kusube",
@@ -14,48 +14,62 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "據說牠會為了奪取山中遇難者的生命而從黑暗中出現。"
+		ja: "山で 遭難したとき 命を 奪いに 暗闇から 現れることが あるという。",
+		'zh-tw': "據說牠會為了奪取山中遇難者的生命而從黑暗中出現。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "臨終之禮"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ダイイングギフト",
+				'zh-tw': "臨終之禮",
+			},
+			effect: {
+				ja: "このポケモンが、相手のポケモンからワザのダメージを受けてきぜつしたとき、自分の山札から好きなカードを2枚まで選び、手札に加える。そして山札を切る。",
+				'zh-tw': "當這隻寶可夢受到對手的寶可夢招式的傷害而【氣絕】時，從自己的牌庫任意選擇最多2張卡加入手牌。並且重洗牌庫。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "當這隻寶可夢受到對手的寶可夢招式的傷害而【氣絕】時，從自己的牌庫任意選擇最多2張卡加入手牌。並且重洗牌庫。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "傷痛暴擊"
+	attacks: [
+		{
+			name: {
+				ja: "ペインバースト",
+				'zh-tw': "傷痛暴擊",
+			},
+			damage: "10+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにのっているダメカンの数×40ダメージ追加。",
+				'zh-tw': "增加對手的戰鬥寶可夢身上放置的傷害指示物的數量×40點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加對手的戰鬥寶可夢身上放置的傷害指示物的數量×40點傷害。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560776,
+				tcgplayer: 569255,
+			},
 		},
+	],
 
-		damage: "10+",
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ゴースト",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [94],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/028.ts
+++ b/data-asia/S/S6K/028.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "勾魂眼"
+		ja: "ヤミラミ",
+		'zh-tw': "勾魂眼",
 	},
 
 	illustrator: "Eri Yamaki",
@@ -14,46 +14,55 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "會去吃寶石的結晶。雙眼在漆黑一片的地方會發出寶石的光芒。"
+		ja: "宝石の 結晶を 食べる。 暗闇の 中では 両目が 宝石の 輝きを 放つ。",
+		'zh-tw': "會去吃寶石的結晶。雙眼在漆黑一片的地方會發出寶石的光芒。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "前往拿取"
+	attacks: [
+		{
+			name: {
+				ja: "とりにいく",
+				'zh-tw': "前往拿取",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からトレーナーズを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張訓練家卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張訓練家卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		{
+			name: {
+				ja: "おいつめる",
+				'zh-tw': "窮追不捨",
+			},
+			damage: 40,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "窮追不捨"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560795,
+				tcgplayer: 569256,
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。"
-		},
-
-		damage: 40,
-		cost: ["Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [302],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/029.ts
+++ b/data-asia/S/S6K/029.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "克雷色利亞"
+		ja: "クレセリア",
+		'zh-tw': "克雷色利亞",
 	},
 
 	illustrator: "Tika Matsuno",
@@ -14,46 +14,55 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "據說只要拿著克雷色利亞的羽毛入睡，就能作個美夢。被稱為新月的化身。"
+		ja: "クレセリアの 羽を 持って 寝ると 楽しい 夢が 見られると いう。 三日月の化身と 呼ばれている。",
+		'zh-tw': "據說只要拿著克雷色利亞的羽毛入睡，就能作個美夢。被稱為新月的化身。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "新月生長"
+	attacks: [
+		{
+			name: {
+				ja: "クレセントグロウ",
+				'zh-tw': "新月生長",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の山札から[超]エネルギーを1枚選び、自分のポケモンにつける。そして山札を切る。後攻プレイヤーの最初の番なら、つけられる枚数は3枚までになり、自分のポケモン1匹につける。",
+				'zh-tw': "從自己的牌庫選擇1張【超】能量卡，附於自己的寶可夢身上。並且重洗牌庫。若在後攻玩家的最初回合使用，則可附上的張數改為最多3張，附於自己的1隻寶可夢身上。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張【超】能量卡，附於自己的寶可夢身上。並且重洗牌庫。若在後攻玩家的最初回合使用，則可附上的張數改為最多3張，附於自己的1隻寶可夢身上。"
+		{
+			name: {
+				ja: "フォトンレーザー",
+				'zh-tw': "光子鐳射",
+			},
+			damage: "30+",
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "自分の場にエネルギーが5個以上あるなら、90ダメージ追加。",
+				'zh-tw': "若自己的場上的能量有5個以上，則增加90點傷害。",
+			},
 		},
+	],
 
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "光子鐳射"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560796,
+				tcgplayer: 569257,
+			},
 		},
-
-		effect: {
-			'zh-tw': "若自己的場上的能量有5個以上，則增加90點傷害。"
-		},
-
-		damage: "30+",
-		cost: ["Psychic", "Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [488],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/030.ts
+++ b/data-asia/S/S6K/030.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "泥偶小人"
+		ja: "ゴビット",
+		'zh-tw': "泥偶小人",
 	},
 
 	illustrator: "0313",
@@ -14,39 +14,48 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "用黏土製成的寶可夢。即使現在也一直遵循著數千年前主人的命令。"
+		ja: "粘土から つくられた ポケモン。 何千年も 前の 主の 命令を 今も 守っている。",
+		'zh-tw': "用黏土製成的寶可夢。即使現在也一直遵循著數千年前主人的命令。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "拍擊"
+	attacks: [
+		{
+			name: {
+				ja: "はたく",
+				'zh-tw': "拍擊",
+			},
+			damage: 10,
+			cost: ["Psychic"],
 		},
-
-		damage: 10,
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "出拳"
+		{
+			name: {
+				ja: "パンチ",
+				'zh-tw': "出拳",
+			},
+			damage: 30,
+			cost: ["Psychic", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Psychic", "Colorless"]
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560797,
+				tcgplayer: 569258,
+			},
+		},
+	],
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [622],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/031.ts
+++ b/data-asia/S/S6K/031.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "泥偶巨人"
+		ja: "ゴルーグ",
+		'zh-tw': "泥偶巨人",
 	},
 
 	illustrator: "Teeziro",
@@ -14,47 +14,60 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "雖然有人認為牠體內有著生成能量的永動機，但至今仍未得到證實。"
+		ja: "体内に エネルギーを 生み出す 永久機関が あると いうが 未だに 解明は されていない。",
+		'zh-tw': "雖然有人認為牠體內有著生成能量的永動機，但至今仍未得到證實。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "強化拳"
+	attacks: [
+		{
+			name: {
+				ja: "きょうかパンチ",
+				'zh-tw': "強化拳",
+			},
+			damage: "60+",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンに「ポケモンのどうぐ」がついているなら、90ダメージ追加。",
+				'zh-tw': "若這隻寶可夢身上附有「寶可夢道具」，則增加90點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "若這隻寶可夢身上附有「寶可夢道具」，則增加90點傷害。"
+		{
+			name: {
+				ja: "メガトンフォール",
+				'zh-tw': "百萬噸墜落",
+			},
+			damage: 190,
+			cost: ["Psychic", "Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+				'zh-tw': "這隻寶可夢也受到30點傷害。",
+			},
 		},
+	],
 
-		damage: "60+",
-		cost: ["Psychic", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "百萬噸墜落"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560798,
+				tcgplayer: 569259,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢也受到30點傷害。"
-		},
-
-		damage: 190,
-		cost: ["Psychic", "Psychic", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ゴビット",
+	},
 
 	retreat: 4,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [623],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/032.ts
+++ b/data-asia/S/S6K/032.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "好啦魷"
+		ja: "マーイーカ",
+		'zh-tw': "好啦魷",
 	},
 
 	illustrator: "Sanosuke Sakuma",
@@ -14,32 +14,40 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "會讓敵人看到自己閃爍的發光體來讓對方喪失戰意，然後趁機逃之夭夭。"
+		ja: "敵に 発光体の 点滅を 浴びせて 戦意を なくしてしまう。 その 隙に 逃げ出すのだ。",
+		'zh-tw': "會讓敵人看到自己閃爍的發光體來讓對方喪失戰意，然後趁機逃之夭夭。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "迴轉攻擊"
+	attacks: [
+		{
+			name: {
+				ja: "かいてんアタック",
+				'zh-tw': "迴轉攻擊",
+			},
+			damage: 20,
+			cost: ["Psychic"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Psychic"]
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560799,
+				tcgplayer: 569260,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [686],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/033.ts
+++ b/data-asia/S/S6K/033.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "烏賊王"
+		ja: "カラマネロ",
+		'zh-tw': "烏賊王",
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -14,36 +14,48 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "據說那些能夠改變歷史的重大事件其實都和烏賊王的催眠能力有關。"
+		ja: "歴史を 変えるほどの 大事件は カラマネロの 催眠能力が かかわっていたと いわれている。",
+		'zh-tw': "據說那些能夠改變歷史的重大事件其實都和烏賊王的催眠能力有關。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "連擊觸手"
+	attacks: [
+		{
+			name: {
+				ja: "れんげきテンタクル",
+				'zh-tw': "連擊觸手",
+			},
+			damage: "40×",
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の手札から「れんげき」のカードを好きなだけ相手に見せて、その枚数×40ダメージ。その後、見せた「れんげき」のカードを山札にもどして切る。",
+				'zh-tw': "從自己的手牌將任意數量的「連擊」卡給對手看過後，造成其張數×40點傷害。然後，將給對手看過的「連擊」卡放回牌庫並重洗。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的手牌將任意數量的「連擊」卡給對手看過後，造成其張數×40點傷害。然後，將給對手看過的「連擊」卡放回牌庫並重洗。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560800,
+				tcgplayer: 569261,
+			},
 		},
+	],
 
-		damage: "40×",
-		cost: ["Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "マーイーカ",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [687],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/034.ts
+++ b/data-asia/S/S6K/034.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "萌虻"
+		ja: "アブリー",
+		'zh-tw': "萌虻",
 	},
 
 	illustrator: "Yukiko Baba",
@@ -14,27 +14,40 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "從敵人散發出的氣場來判斷對方下一步的行動。能輕盈地躲開攻擊並進行反擊。"
+		ja: "敵が 発する オーラから つぎの 行動を 予測する。 攻撃を ひらりと かわして 反撃する。",
+		'zh-tw': "從敵人散發出的氣場來判斷對方下一步的行動。能輕盈地躲開攻擊並進行反擊。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "羽擊"
+	attacks: [
+		{
+			name: {
+				ja: "はばたく",
+				'zh-tw': "羽擊",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
+	],
 
-		damage: 10,
-		cost: ["Colorless"]
-	}],
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560802,
+				tcgplayer: 569262,
+			},
+		},
+	],
 
 	retreat: 0,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [742],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/035.ts
+++ b/data-asia/S/S6K/035.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "蝶結萌虻"
+		ja: "アブリボン",
+		'zh-tw': "蝶結萌虻",
 	},
 
 	illustrator: "Saya Tsuruta",
@@ -14,31 +14,48 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "最討厭雨水弄濕自己。因為伽勒爾地區陰天居多，所以很難見得到牠的身影。"
+		ja: "雨に 濡れることが 大嫌い。 曇りがちな ガラル地方では 姿を めったに 拝めない。",
+		'zh-tw': "最討厭雨水弄濕自己。因為伽勒爾地區陰天居多，所以很難見得到牠的身影。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "戲法舞步"
+	attacks: [
+		{
+			name: {
+				ja: "トリックステップ",
+				'zh-tw': "戲法舞步",
+			},
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "のぞむなら、相手のバトルポケモンについているエネルギーを1個選び、相手のベンチポケモンにつけ替える。",
+				'zh-tw': "若希望，選擇1個對手的戰鬥寶可夢身上附加的能量，改附於對手的備戰寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若希望，選擇1個對手的戰鬥寶可夢身上附加的能量，改附於對手的備戰寶可夢身上。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560803,
+				tcgplayer: 569263,
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "アブリー",
+	},
 
 	retreat: 0,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [743],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/036.ts
+++ b/data-asia/S/S6K/036.ts
@@ -1,44 +1,59 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "黑馬蕾冠王V"
+		ja: "こくばバドレックスV",
+		'zh-tw': "黑馬蕾冠王V",
 	},
 
 	illustrator: "D.A.G Inc.",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Psychic"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "星碎"
+	attacks: [
+		{
+			name: {
+				ja: "シャドーミスト",
+				'zh-tw': "星碎",
+			},
+			damage: 10,
+			cost: ["Psychic"],
+			effect: {
+				ja: "次の相手の番、相手は手札から、「特殊エネルギー」を出してつけられず「スタジアム」も出せない。",
+				'zh-tw': "在對手的2隻寶可夢身上各放置5個傷害指示物。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在對手的2隻寶可夢身上各放置5個傷害指示物。"
+		{
+			name: { ja: "アストラルビット" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン2匹に、それぞれダメカンを5個のせる。",
+			},
 		},
+	],
 
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560806,
+				tcgplayer: 569264,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [898],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/037.ts
+++ b/data-asia/S/S6K/037.ts
@@ -1,44 +1,66 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "黑馬蕾冠王VMAX"
+		ja: "こくばバドレックスVMAX",
+		'zh-tw': "黑馬蕾冠王VMAX",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 320,
 	types: ["Psychic"],
+
 	stage: "VMAX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "極巨之魂"
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "めいかいのとびら" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札から[超]エネルギーを1枚選び、自分のベンチの[超]ポケモンにつける。その後、自分の山札を2枚引く。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加自己的場上寶可夢身上附加的【超】能量的數量×30點傷害。"
+	attacks: [
+		{
+			name: {
+				ja: "ダイガイスト",
+				'zh-tw': "極巨之魂",
+			},
+			damage: "10+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[超]エネルギーの数×30ダメージ追加。",
+				'zh-tw': "增加自己的場上寶可夢身上附加的【超】能量的數量×30點傷害。",
+			},
 		},
+	],
 
-		damage: "10+",
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560808,
+				tcgplayer: 569265,
+			},
+		},
+	],
 
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "こくばバドレックスV",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Triple Rare",
+	dexId: [898],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/038.ts
+++ b/data-asia/S/S6K/038.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "藍蟾蜍"
+		ja: "ガマガル",
+		'zh-tw': "藍蟾蜍",
 	},
 
 	illustrator: "tetsuya koizumi",
@@ -14,34 +14,52 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "有時也會發出悅耳的叫聲。身上突起物越大的藍蟾蜍越能以更廣的音域來鳴叫。"
+		ja: "きれいな 声で 鳴くこともある。 体の 突起が 大きいほど 広い 音域で 鳴けるのだ。",
+		'zh-tw': "有時也會發出悅耳的叫聲。身上突起物越大的藍蟾蜍越能以更廣的音域來鳴叫。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "踩"
+	attacks: [
+		{
+			name: {
+				ja: "ふむ",
+				'zh-tw': "踩",
+			},
+			damage: 20,
+			cost: ["Fighting"],
 		},
-
-		damage: 20,
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "舌擊"
+		{
+			name: {
+				ja: "ベロではたく",
+				'zh-tw': "舌擊",
+			},
+			damage: 50,
+			cost: ["Fighting", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 50,
-		cost: ["Fighting", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560810,
+				tcgplayer: 569266,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "オタマロ",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [536],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/039.ts
+++ b/data-asia/S/S6K/039.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "蟾蜍王"
+		ja: "ガマゲロゲ",
+		'zh-tw': "蟾蜍王",
 	},
 
 	illustrator: "Pani Kobayashi",
@@ -14,38 +14,56 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "在老年人之間廣受歡迎。因為他們覺得牠身上的瘤發出的震動拿來按摩剛剛好。"
+		ja: "コブが 起こす バイブレーションが マッサージに 良いと 老人に 大人気の ポケモンだ。",
+		'zh-tw': "在老年人之間廣受歡迎。因為他們覺得牠身上的瘤發出的震動拿來按摩剛剛好。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "蕩蕩波"
+	attacks: [
+		{
+			name: {
+				ja: "グラグラウェーブ",
+				'zh-tw': "蕩蕩波",
+			},
+			damage: 60,
+			cost: ["Fighting"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、ワザを使うためのエネルギーとにげるためのエネルギーが、それぞれ【無】エネルギー1個ぶん多くなる。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢使用招式所需的能量與【撤退】所需的能量，各增加1個【無】能量。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢使用招式所需的能量與【撤退】所需的能量，各增加1個【無】能量。"
+		{
+			name: {
+				ja: "ハイパーボイス",
+				'zh-tw': "巨聲",
+			},
+			damage: 160,
+			cost: ["Fighting", "Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 60,
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "巨聲"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560812,
+				tcgplayer: 569267,
+			},
 		},
+	],
 
-		damage: 160,
-		cost: ["Fighting", "Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ガマガル",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [537],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/040.ts
+++ b/data-asia/S/S6K/040.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "好勝蟹"
+		ja: "マケンカニ",
+		'zh-tw': "好勝蟹",
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -14,38 +14,52 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "有時會錯把椰蛋樹當成椰子樹而爬上去。惹怒椰蛋樹的牠會被甩下來並遭到踩踏。"
+		ja: "ヤシの木と 間違えて ナッシーに 登ることもある。 怒りを かって 振り落とされて 踏みつけられる。",
+		'zh-tw': "有時會錯把椰蛋樹當成椰子樹而爬上去。惹怒椰蛋樹的牠會被甩下來並遭到踩踏。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "打擊"
+	attacks: [
+		{
+			name: {
+				ja: "なぐる",
+				'zh-tw': "打擊",
+			},
+			damage: 20,
+			cost: ["Fighting"],
 		},
-
-		damage: 20,
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "雙重金勾臂"
+		{
+			name: {
+				ja: "ダブルラリアット",
+				'zh-tw': "雙重金勾臂",
+			},
+			damage: "40×",
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×40ダメージ。",
+				'zh-tw': "擲2次硬幣，造成正面出現的次數×40點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲2次硬幣，造成正面出現的次數×40點傷害。"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560814,
+				tcgplayer: 569268,
+			},
 		},
-
-		damage: "40×",
-		cost: ["Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	],
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [739],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/041.ts
+++ b/data-asia/S/S6K/041.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "好勝毛蟹"
+		ja: "ケケンカニ",
+		'zh-tw': "好勝毛蟹",
 	},
 
 	illustrator: "Shigenori Negishi",
@@ -14,38 +14,56 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "習慣不經過大腦先動手打了再說。以前曾有過用連續不斷的拳擊把雪崩推回去的紀錄。"
+		ja: "考えるより まず 殴ってみる。 ゆきなだれを パンチの ラッシュで 押し返したという 記録も ある。",
+		'zh-tw': "習慣不經過大腦先動手打了再說。以前曾有過用連續不斷的拳擊把雪崩推回去的紀錄。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "雙重金勾臂"
+	attacks: [
+		{
+			name: {
+				ja: "ダブルラリアット",
+				'zh-tw': "雙重金勾臂",
+			},
+			damage: "90×",
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×90ダメージ。",
+				'zh-tw': "擲2次硬幣，造成正面出現的次數×90點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲2次硬幣，造成正面出現的次數×90點傷害。"
+		{
+			name: {
+				ja: "クラブハンマー",
+				'zh-tw': "蟹鉗錘",
+			},
+			damage: 130,
+			cost: ["Fighting", "Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: "90×",
-		cost: ["Fighting", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "蟹鉗錘"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560815,
+				tcgplayer: 569269,
+			},
 		},
+	],
 
-		damage: 130,
-		cost: ["Fighting", "Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "マケンカニ",
+	},
 
 	retreat: 4,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [740],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/042.ts
+++ b/data-asia/S/S6K/042.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "拳拳蛸"
+		ja: "タタッコ",
+		'zh-tw': "拳拳蛸",
 	},
 
 	illustrator: "Yuka Morii",
@@ -14,27 +14,40 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "智商大致相當於３歲的兒童。雖然觸手經常斷掉，但因為能再生，所以牠並不在意。"
+		ja: "３歳児 くらいの 賢さ。 触手は よくちぎれるが 再生するので 気にしない。",
+		'zh-tw': "智商大致相當於３歲的兒童。雖然觸手經常斷掉，但因為能再生，所以牠並不在意。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "敲擊"
+	attacks: [
+		{
+			name: {
+				ja: "たたく",
+				'zh-tw': "敲擊",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560817,
+				tcgplayer: 569270,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [852],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/043.ts
+++ b/data-asia/S/S6K/043.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "八爪武師"
+		ja: "オトスパス",
+		'zh-tw': "八爪武師",
 	},
 
 	illustrator: "Anesaki Dynamic",
@@ -14,43 +14,62 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "會為了試自己的身手而登上陸地尋找對手。戰鬥結束後就會回到海裡。"
+		ja: "おのれの腕を 試すべく 陸に 上がり 対戦相手を 探す。 戦い終えると 海に 帰る。",
+		'zh-tw': "會為了試自己的身手而登上陸地尋找對手。戰鬥結束後就會回到海裡。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "絞技達人"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "しめわざのたつじん",
+				'zh-tw': "絞技達人",
+			},
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手のバトルポケモンのにげるためのエネルギーは、2個ぶん多くなる。",
+				'zh-tw': "只要這隻寶可夢在戰鬥場上，對手的戰鬥寶可夢【撤退】所需的能量增加2個。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在戰鬥場上，對手的戰鬥寶可夢【撤退】所需的能量增加2個。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "同步光炮"
+	attacks: [
+		{
+			name: {
+				ja: "シンクロバスター",
+				'zh-tw': "同步光炮",
+			},
+			damage: "80+",
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の手札と相手の手札が同じ枚数なら、80ダメージ追加。",
+				'zh-tw': "若自己的手牌的張數與對手的手牌的張數相同，則增加80點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若自己的手牌的張數與對手的手牌的張數相同，則增加80點傷害。"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560819,
+				tcgplayer: 569271,
+			},
 		},
+	],
 
-		damage: "80+",
-		cost: ["Fighting", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "タタッコ",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [853],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/044.ts
+++ b/data-asia/S/S6K/044.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "瓦斯彈"
+		ja: "ドガース",
+		'zh-tw': "瓦斯彈",
 	},
 
 	illustrator: "Aya Kusube",
@@ -14,31 +14,44 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "污濁的空氣是牠的美味大餐。據說在昔日的伽勒爾地區曾經存在著更多的瓦斯彈。"
+		ja: "汚い 空気が ごちそう。 むかしの ガラル地方には いまより たくさんの ドガースが いたという。",
+		'zh-tw': "污濁的空氣是牠的美味大餐。據說在昔日的伽勒爾地區曾經存在著更多的瓦斯彈。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "濁霧"
+	attacks: [
+		{
+			name: {
+				ja: "スモッグ",
+				'zh-tw': "濁霧",
+			},
+			damage: 20,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560820,
+				tcgplayer: 569272,
+			},
 		},
-
-		damage: 20,
-		cost: ["Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [109],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/045.ts
+++ b/data-asia/S/S6K/045.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雙彈瓦斯"
+		ja: "マタドガス",
+		'zh-tw': "雙彈瓦斯",
 	},
 
 	illustrator: "Ryuta Fuse",
@@ -14,41 +14,59 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "有時會因為非常罕見的突變，出現２個連在一起的雙胞胎小瓦斯彈。"
+		ja: "ごくまれに 突然変異で 双子の 小さい ドガースが 連結したまま 出ることがある。",
+		'zh-tw': "有時會因為非常罕見的突變，出現２個連在一起的雙胞胎小瓦斯彈。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "混合毒素"
+	attacks: [
+		{
+			name: {
+				ja: "どくそをまぜる",
+				'zh-tw': "混合毒素",
+			},
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。自分のトラッシュから[悪]エネルギーを1枚選び、このポケモンにつける。",
+				'zh-tw': "將對手的戰鬥寶可夢【混亂】。從自己的棄牌區選擇1張【惡】能量卡，附於這隻寶可夢身上。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【混亂】。從自己的棄牌區選擇1張【惡】能量卡，附於這隻寶可夢身上。"
+		{
+			name: {
+				ja: "スモッグバースト",
+				'zh-tw': "煙之暴擊",
+			},
+			damage: "20+",
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[悪]エネルギーの数×20ダメージ追加。",
+				'zh-tw': "增加自己的場上寶可夢身上附加的【惡】能量的數量×20點傷害。",
+			},
 		},
+	],
 
-		cost: ["Darkness"]
-	}, {
-		name: {
-			'zh-tw': "煙之暴擊"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560822,
+				tcgplayer: 569273,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加自己的場上寶可夢身上附加的【惡】能量的數量×20點傷害。"
-		},
-
-		damage: "20+",
-		cost: ["Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ドガース",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [110],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/046.ts
+++ b/data-asia/S/S6K/046.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伽勒爾 雙彈瓦斯"
+		ja: "ガラル マタドガス",
+		'zh-tw': "伽勒爾 雙彈瓦斯",
 	},
 
 	illustrator: "Miki Tanaka",
@@ -14,39 +14,58 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "在往昔工廠林立、空氣嚴重污染的時代，雙彈瓦斯不知道為什麼變成了這個樣子。"
+		ja: "工場が 建ち並び 空気が 汚れていた むかし。 なぜか この姿に 変化した。",
+		'zh-tw': "在往昔工廠林立、空氣嚴重污染的時代，雙彈瓦斯不知道為什麼變成了這個樣子。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "能量工廠"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "エナジーファクトリー",
+				'zh-tw': "能量工廠",
+			},
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の場の、名前に「マタドガス」とつくポケモンについている基本[悪]エネルギーは、それぞれ[悪]エネルギー2個ぶんとしてはたらく。この効果は、この特性を持つポケモンが何匹いても、重ならない。",
+				'zh-tw': "只要這隻寶可夢在場上，自己的場上的，名稱中有「雙彈瓦斯」的寶可夢身上附加的基本【惡】能量，各視為提供2個【惡】能量。無論有多少隻擁有這個特性的寶可夢，這個效果也不會重複。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在場上，自己的場上的，名稱中有「雙彈瓦斯」的寶可夢身上附加的基本【惡】能量，各視為提供2個【惡】能量。無論有多少隻擁有這個特性的寶可夢，這個效果也不會重複。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "瓦斯包圍"
+	attacks: [
+		{
+			name: {
+				ja: "ガスでつつむ",
+				'zh-tw': "瓦斯包圍",
+			},
+			damage: 50,
+			cost: ["Darkness", "Colorless"],
 		},
+	],
 
-		damage: 50,
-		cost: ["Darkness", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560823,
+				tcgplayer: 569274,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ドガース",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [110],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/047.ts
+++ b/data-asia/S/S6K/047.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "長鼻葉"
+		ja: "コノハナ",
+		'zh-tw': "長鼻葉",
 	},
 
 	illustrator: "Atsuko Nishida",
@@ -14,31 +14,48 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "長鼻葉居住在大樹上的洞穴裡，牠吹奏出的草笛聲會讓聽到的人感到不安。"
+		ja: "コノハナの 吹く 草笛の 音は 聞いた ものを 不安に させる。 大木に 開いた 穴で 暮らす。",
+		'zh-tw': "長鼻葉居住在大樹上的洞穴裡，牠吹奏出的草笛聲會讓聽到的人感到不安。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "擊掌奇襲"
+	attacks: [
+		{
+			name: {
+				ja: "ねこだまし",
+				'zh-tw': "擊掌奇襲",
+			},
+			damage: 20,
+			cost: ["Darkness"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+				'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560826,
+				tcgplayer: 569275,
+			},
 		},
+	],
 
-		damage: 20,
-		cost: ["Darkness"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "タネボー",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [274],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/048.ts
+++ b/data-asia/S/S6K/048.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "狡猾天狗"
+		ja: "ダーテング",
+		'zh-tw': "狡猾天狗",
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -14,41 +14,59 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "在森林深處靜靜地生活。據說當牠搧動大大的團扇，就會刮起冬日寒風。"
+		ja: "森の 奥で ひっそりと 暮らす。 大きな 団扇を あおぐと 木枯らしが 吹くと いわれている。",
+		'zh-tw': "在森林深處靜靜地生活。據說當牠搧動大大的團扇，就會刮起冬日寒風。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "天狗再見"
+	attacks: [
+		{
+			name: {
+				ja: "テングッバイ",
+				'zh-tw': "天狗再見",
+			},
+			cost: ["Darkness"],
+			effect: {
+				ja: "ダメカンがのっている相手のバトルポケモンと、ついているすべてのカードを、相手の手札にもどす。",
+				'zh-tw': "將身上放置有傷害指示物的對手的戰鬥寶可夢與附加的卡，全部放回對手的手牌。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將身上放置有傷害指示物的對手的戰鬥寶可夢與附加的卡，全部放回對手的手牌。"
+		{
+			name: {
+				ja: "こがらしせんぷう",
+				'zh-tw': "寒冬旋風",
+			},
+			damage: 130,
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、トラッシュする。",
+				'zh-tw': "在不看正面的情況下，選擇1張對手的手牌，將其丟棄。",
+			},
 		},
+	],
 
-		cost: ["Darkness"]
-	}, {
-		name: {
-			'zh-tw': "寒冬旋風"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560828,
+				tcgplayer: 569276,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在不看正面的情況下，選擇1張對手的手牌，將其丟棄。"
-		},
-
-		damage: 130,
-		cost: ["Darkness", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "コノハナ",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [275],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/049.ts
+++ b/data-asia/S/S6K/049.ts
@@ -1,45 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "巨金怪V"
+		ja: "メタグロスV",
+		'zh-tw': "巨金怪V",
 	},
 
 	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Metal"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "同步之錘"
+	attacks: [
+		{
+			name: {
+				ja: "バレットパンチ",
+				'zh-tw': "同步之錘",
+			},
+			damage: "20+",
+			cost: ["Metal"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×20ダメージ追加。",
+				'zh-tw': "若這隻寶可夢與對手的戰鬥寶可夢，身上附加的能量數量相同，則增加90點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "若這隻寶可夢與對手的戰鬥寶可夢，身上附加的能量數量相同，則增加90點傷害。"
+		{
+			name: { ja: "シンクロハンマー" },
+			damage: "60+",
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "このポケモンと相手のバトルポケモンについているエネルギーの数が同じなら、90ダメージ追加。",
+			},
 		},
+	],
 
-		damage: "60+",
-		cost: ["Metal", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560835,
+				tcgplayer: 569277,
+			},
+		},
+	],
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [376],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/050.ts
+++ b/data-asia/S/S6K/050.ts
@@ -1,44 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "巨金怪VMAX"
+		ja: "メタグロスVMAX",
+		'zh-tw': "巨金怪VMAX",
 	},
 
 	illustrator: "Ryota Murayama",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Metal"],
+
 	stage: "VMAX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "極巨衝刺"
+	attacks: [
+		{
+			name: {
+				ja: "でんじきゅうちゃく",
+				'zh-tw': "極巨衝刺",
+			},
+			cost: ["Metal"],
+			effect: {
+				ja: "自分の山札から好きなカードを2枚まで選び、手札に加える。そして山札を切る。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢「極巨衝刺」的傷害「+150」點。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢「極巨衝刺」的傷害「+150」點。"
+		{
+			name: { ja: "ダイラッシュ" },
+			damage: 100,
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンの「ダイラッシュ」のダメージは「+150」される。",
+			},
 		},
+	],
 
-		damage: 100,
-		cost: ["Metal", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560836,
+				tcgplayer: 569278,
+			},
+		},
+	],
 
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "メタグロスV",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Triple Rare",
+	dexId: [376],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/051.ts
+++ b/data-asia/S/S6K/051.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "勾帕路翁"
+		ja: "コバルオン",
+		'zh-tw': "勾帕路翁",
 	},
 
 	illustrator: "Kazuma Koda",
@@ -14,43 +14,52 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "有著鋼鐵的心靈與身體。當人類傷害寶可夢時，會與夥伴一起制裁人類。"
+		ja: "鋼の 心と 体を 持つ。 人が ポケモンを 傷つけたとき 仲間とともに 人を こらしめた。",
+		'zh-tw': "有著鋼鐵的心靈與身體。當人類傷害寶可夢時，會與夥伴一起制裁人類。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "鐵頭碰"
+	attacks: [
+		{
+			name: {
+				ja: "ヘッドバング",
+				'zh-tw': "鐵頭碰",
+			},
+			damage: 40,
+			cost: ["Metal", "Colorless"],
 		},
-
-		damage: 40,
-		cost: ["Metal", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "金屬斬"
+		{
+			name: {
+				ja: "メタルスラッシュ",
+				'zh-tw': "金屬斬",
+			},
+			damage: 130,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560838,
+				tcgplayer: 569279,
+			},
 		},
-
-		damage: 130,
-		cost: ["Metal", "Metal", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [638],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/052.ts
+++ b/data-asia/S/S6K/052.ts
@@ -1,40 +1,62 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "幸福蛋V"
+		ja: "ハピナスV",
+		'zh-tw': "幸福蛋V",
 	},
 
 	illustrator: "Saki Hayashiro",
 	category: "Pokemon",
 	hp: 250,
 	types: ["Colorless"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "幸福轟炸"
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しぜんかいふく" },
+			effect: {
+				ja: "自分の手札からこのポケモンにエネルギーをつけるたび、このポケモンの特殊状態をすべて回復する。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加這隻寶可夢身上附加的能量的數量×30點傷害。若希望，在造成傷害後，從棄牌區選擇最多3張能量卡，附於這隻寶可夢身上。"
+	attacks: [
+		{
+			name: {
+				ja: "ハッピーボンバー",
+				'zh-tw': "幸福轟炸",
+			},
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーの数×30ダメージ追加。のぞむなら、ダメージを与えたあとに、トラッシュからエネルギーを3枚まで選び、このポケモンにつける。",
+				'zh-tw': "增加這隻寶可夢身上附加的能量的數量×30點傷害。若希望，在造成傷害後，從棄牌區選擇最多3張能量卡，附於這隻寶可夢身上。",
+			},
 		},
+	],
 
-		damage: "10+",
-		cost: ["Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560840,
+				tcgplayer: 569280,
+			},
+		},
+	],
 
 	retreat: 4,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [242],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/053.ts
+++ b/data-asia/S/S6K/053.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "飄浮泡泡"
+		ja: "ポワルン",
+		'zh-tw': "飄浮泡泡",
 	},
 
 	illustrator: "Asako Ito",
@@ -14,43 +14,58 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "樣子會隨著天氣而變化。天氣越是惡劣，性情就會變得越粗暴。"
+		ja: "天気に よって 姿が 変わる。 気象が 荒くなるほど 気性も 荒っぽく なってくる。",
+		'zh-tw': "樣子會隨著天氣而變化。天氣越是惡劣，性情就會變得越粗暴。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "看天"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "てんきよみ",
+				'zh-tw': "看天",
+			},
+			effect: {
+				ja: "自分のトラッシュに「スタジアム」が8枚以上あるなら、このポケモンがワザを使うためのエネルギーは、すべてなくなる。",
+				'zh-tw': "若自己的棄牌區有8張以上的「競技場」卡，則這隻寶可夢使用招式所需的能量全部消除。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若自己的棄牌區有8張以上的「競技場」卡，則這隻寶可夢使用招式所需的能量全部消除。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "氣象之力"
+	attacks: [
+		{
+			name: {
+				ja: "ウェザーフォース",
+				'zh-tw': "氣象之力",
+			},
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の手札が6枚になるように、山札を引く。",
+				'zh-tw': "從牌庫抽卡直到自己的手牌滿6張為止。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從牌庫抽卡直到自己的手牌滿6張為止。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560841,
+				tcgplayer: 569281,
+			},
 		},
-
-		damage: 80,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 0,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [351],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/054.ts
+++ b/data-asia/S/S6K/054.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "變隱龍"
+		ja: "カクレオン",
+		'zh-tw': "變隱龍",
 	},
 
 	illustrator: "KIYOTAKA OSHIYAMA",
@@ -14,39 +14,54 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "就算是在不需要隱身的時候，體色也會隨心情和身體狀態而改變。顏色越濃代表牠越有活力。"
+		ja: "隠れるとき 以外にも 気分や 調子で 身体の色が 変わる。 色が 濃いときほど 元気だぞ。",
+		'zh-tw': "就算是在不需要隱身的時候，體色也會隨心情和身體狀態而改變。顏色越濃代表牠越有活力。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "五顏六色變化"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "いろいろへんげ",
+				'zh-tw': "五顏六色變化",
+			},
+			effect: {
+				ja: "このポケモンは、このポケモンについている基本エネルギーと同じタイプになる。（2種類以上のタイプの基本エネルギーがついているなら、それぞれのタイプになる。）",
+				'zh-tw': "這隻寶可夢的屬性改為與這隻寶可夢身上附加的基本能量相同。（若身上附加的基本能量屬性有2種以上，則改為各自屬性。）",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢的屬性改為與這隻寶可夢身上附加的基本能量相同。（若身上附加的基本能量屬性有2種以上，則改為各自屬性。）"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "迴轉攻擊"
+	attacks: [
+		{
+			name: {
+				ja: "かいてんアタック",
+				'zh-tw': "迴轉攻擊",
+			},
+			damage: 90,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 90,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560842,
+				tcgplayer: 569282,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [352],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/055.ts
+++ b/data-asia/S/S6K/055.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "小箭雀"
+		ja: "ヤヤコマ",
+		'zh-tw': "小箭雀",
 	},
 
 	illustrator: "Sumiyoshi Kizuki",
@@ -14,46 +14,55 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "身體總是很溫暖。寒冷地區的訓練家似乎會和牠一起睡在床上。"
+		ja: "身体は いつでも 暖かい。 寒い 地域の トレーナーは ベッドで 一緒に 寝るらしい。",
+		'zh-tw': "身體總是很溫暖。寒冷地區的訓練家似乎會和牠一起睡在床上。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "順風抽出"
+	attacks: [
+		{
+			name: {
+				ja: "おいかぜドロー",
+				'zh-tw': "順風抽出",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。後攻プレイヤーの最初の番なら、さらに3枚引く。",
+				'zh-tw': "從自己的牌庫抽出1張卡。若在後攻玩家的最初回合使用，則再抽出3張卡。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫抽出1張卡。若在後攻玩家的最初回合使用，則再抽出3張卡。"
+		{
+			name: {
+				ja: "ふいをつく",
+				'zh-tw': "偷襲",
+			},
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+				'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "偷襲"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560843,
+				tcgplayer: 569283,
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。"
-		},
-
-		damage: 20,
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [661],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/056.ts
+++ b/data-asia/S/S6K/056.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "火箭雀"
+		ja: "ヒノヤコマ",
+		'zh-tw': "火箭雀",
 	},
 
 	illustrator: "Yuya Oka",
@@ -14,36 +14,48 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "剛起飛時的速度在所有的鳥寶可夢之中是數一數二的。"
+		ja: "飛びはじめた 直後の スピードは すべての とりポケモンの 中でも トップクラスの 速さ なのだ。",
+		'zh-tw': "剛起飛時的速度在所有的鳥寶可夢之中是數一數二的。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "電光一閃"
+	attacks: [
+		{
+			name: {
+				ja: "でんこうせっか",
+				'zh-tw': "電光一閃",
+			},
+			damage: "20+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+				'zh-tw': "擲1次硬幣若為正面，則增加20點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則增加20點傷害。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560844,
+				tcgplayer: 569284,
+			},
 		},
+	],
 
-		damage: "20+",
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ヤヤコマ",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [662],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/057.ts
+++ b/data-asia/S/S6K/057.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "烈箭鷹"
+		ja: "ファイアロー",
+		'zh-tw': "烈箭鷹",
 	},
 
 	illustrator: "Tika Matsuno",
@@ -14,47 +14,60 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "主要的獵物是鳥寶可夢。會急速接近對手，然後用猛烈的腳踢把對手擊落到地面。"
+		ja: "とりポケモンが 主な 獲物。 急接近からの 力強い キックで 地面に 叩き落す。",
+		'zh-tw': "主要的獵物是鳥寶可夢。會急速接近對手，然後用猛烈的腳踢把對手擊落到地面。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "緊抓"
+	attacks: [
+		{
+			name: {
+				ja: "わしづかみ",
+				'zh-tw': "緊抓",
+			},
+			damage: 40,
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。"
+		{
+			name: {
+				ja: "ニトロダイブ",
+				'zh-tw': "火藥奇襲",
+			},
+			damage: "80+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンに[炎]エネルギーがついているなら、80ダメージ追加。",
+				'zh-tw': "若這隻寶可夢身上附有【火】能量，則增加80點傷害。",
+			},
 		},
+	],
 
-		damage: 40,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "火藥奇襲"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560845,
+				tcgplayer: 569285,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢身上附有【火】能量，則增加80點傷害。"
-		},
-
-		damage: "80+",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ヒノヤコマ",
+	},
 
 	retreat: 0,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [663],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/058.ts
+++ b/data-asia/S/S6K/058.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "貪心栗鼠"
+		ja: "ホシガリス",
+		'zh-tw': "貪心栗鼠",
 	},
 
 	illustrator: "OKACHEKE",
@@ -14,37 +14,51 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "由於牠無論何時都在吃樹果，使得牠比外表看起來還要頑強。會出現在田地裡尋找樹果。"
+		ja: "つねに 木の実を 食っているので 見かけ以上に タフ。 木の実を 狙って 畑に 現れる。",
+		'zh-tw': "由於牠無論何時都在吃樹果，使得牠比外表看起來還要頑強。會出現在田地裡尋找樹果。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "撿起來吃"
+	attacks: [
+		{
+			name: {
+				ja: "ひろいぐい",
+				'zh-tw': "撿起來吃",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュから「ポケモンのどうぐ」を1枚選び、相手に見せて、手札に加える。",
+				'zh-tw': "從自己的棄牌區選擇1張「寶可夢道具」卡，在給對手看過後加入手牌。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的棄牌區選擇1張「寶可夢道具」卡，在給對手看過後加入手牌。"
+		{
+			name: {
+				ja: "かじる",
+				'zh-tw': "咬",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "咬"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560846,
+				tcgplayer: 569286,
+			},
 		},
-
-		damage: 10,
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [819],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/059.ts
+++ b/data-asia/S/S6K/059.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "藏飽栗鼠"
+		ja: "ヨクバリス",
+		'zh-tw': "藏飽栗鼠",
 	},
 
 	illustrator: "HYOGONOSUKE",
@@ -14,39 +14,58 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "無論多麼堅硬的樹果殼都能用引以為傲的大牙咬碎。在伽勒爾是很常見的寶可夢。"
+		ja: "どんなに 硬い 木の実の 殻も 自慢の 歯で ボリボリ 齧る。 ガラルでは よく 見る ポケモン。",
+		'zh-tw': "無論多麼堅硬的樹果殼都能用引以為傲的大牙咬碎。在伽勒爾是很常見的寶可夢。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "不甩人尾"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ふてぶてしっぽ",
+				'zh-tw': "不甩人尾",
+			},
+			effect: {
+				ja: "このポケモンがいるかぎり、自分のポケモンについているエネルギーは、相手のグッズまたはサポートによる、トラッシュする効果と手札や山札にもどす効果を受けない。",
+				'zh-tw': "只要這隻寶可夢在場上，自己的寶可夢身上附加的能量，不會受到對手的物品或者支援者的效果影響而丟棄與放回手牌或牌庫。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在場上，自己的寶可夢身上附加的能量，不會受到對手的物品或者支援者的效果影響而丟棄與放回手牌或牌庫。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "咬"
+	attacks: [
+		{
+			name: {
+				ja: "かじる",
+				'zh-tw': "咬",
+			},
+			damage: 90,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 90,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560847,
+				tcgplayer: 569287,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ホシガリス",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [820],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6K/060.ts
+++ b/data-asia/S/S6K/060.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "霧之水晶"
+		ja: "霧の水晶",
+		'zh-tw': "霧之水晶",
 	},
 
 	illustrator: "sadaji",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的牌庫選擇1張【超】屬性的【基礎】寶可夢卡或者【超】能量卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		ja: "自分の山札から[超]タイプのたねポケモンまたは[超]エネルギーを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+		'zh-tw': "從自己的牌庫選擇1張【超】屬性的【基礎】寶可夢卡或者【超】能量卡，在給對手看過後加入手牌。並且重洗牌庫。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560848,
+				tcgplayer: 569288,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S6K/061.ts
+++ b/data-asia/S/S6K/061.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "除草手套"
+		ja: "草取りグローブ",
+		'zh-tw': "除草手套",
 	},
 
 	illustrator: "Toyste Beach",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "附有這張卡的寶可夢使用的招式，對對手的戰鬥場的【草】寶可夢造成的傷害「+30」點。"
+		ja: "このカードをつけているポケモンが使うワザの、相手のバトル場の[草]ポケモンへのダメージは「+30」される。",
+		'zh-tw': "附有這張卡的寶可夢使用的招式，對對手的戰鬥場的【草】寶可夢造成的傷害「+30」點。",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560849,
+				tcgplayer: 569289,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Tool",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S6K/062.ts
+++ b/data-asia/S/S6K/062.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "正義手套"
+		ja: "正義のグローブ",
+		'zh-tw': "正義手套",
 	},
 
 	illustrator: "Toyste Beach",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "附有這張卡的寶可夢使用的招式，對對手的戰鬥場的【惡】寶可夢造成的傷害「+30」點。"
+		ja: "このカードをつけているポケモンが使うワザの、相手のバトル場の[悪]ポケモンへのダメージは「+30」される。",
+		'zh-tw': "附有這張卡的寶可夢使用的招式，對對手的戰鬥場的【惡】寶可夢造成的傷害「+30」點。",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560850,
+				tcgplayer: 569290,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Tool",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S6K/063.ts
+++ b/data-asia/S/S6K/063.ts
@@ -1,22 +1,45 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "連擊的卷軸 天之卷"
+		ja: "れんげきの巻物 天の巻",
+		'zh-tw': "連擊的卷軸 天之卷",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "附有這張卡的「連擊」寶可夢，可使用這張卡上寫的招式。[需要有足夠使用招式的能量。]雷●　飯綱墜擊　10+增加對手的戰鬥寶可夢身上附加的能量的數量×50點傷害。"
+		ja: "このカードをつけている「れんげき」のポケモンは、このカードに書かれているワザを使える。［ワザを使うためのエネルギーは必要。］",
+		'zh-tw': "附有這張卡的「連擊」寶可夢，可使用這張卡上寫的招式。[需要有足夠使用招式的能量。]雷●　飯綱墜擊　10+增加對手的戰鬥寶可夢身上附加的能量的數量×50點傷害。",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "E"
-}
+	attacks: [
+		{
+			name: { ja: "いづなおとし" },
+			damage: "10+",
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数×50ダメージ追加。",
+			},
+		},
+	],
 
-export default card
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560851,
+				tcgplayer: 569291,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S6K/064.ts
+++ b/data-asia/S/S6K/064.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "嘉德麗雅"
+		ja: "カトレア",
+		'zh-tw': "嘉德麗雅",
 	},
 
 	illustrator: "Sanosuke Sakuma",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "選擇任意數量的自己的手牌，以任意順序排列，放回牌庫下方。然後，從牌庫抽出與放回的張數相同數量的卡。"
+		ja: "自分の手札を好きなだけ選び、好きな順番に入れ替えて、山札の下にもどす。その後、もどした枚数ぶん、自分の山札を引く。",
+		'zh-tw': "選擇任意數量的自己的手牌，以任意順序排列，放回牌庫下方。然後，從牌庫抽出與放回的張數相同數量的卡。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560852,
+				tcgplayer: 569292,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S6K/065.ts
+++ b/data-asia/S/S6K/065.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "菊子"
+		ja: "キクコ",
+		'zh-tw': "菊子",
 	},
 
 	illustrator: "Ken Sugimori",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "選擇最多3個自己的戰鬥寶可夢身上放置的傷害指示物，改放於對手的戰鬥寶可夢身上。"
+		ja: "自分のバトルポケモンにのっているダメカンを3個まで選び、相手のバトルポケモンにのせ替える。",
+		'zh-tw': "選擇最多3個自己的戰鬥寶可夢身上放置的傷害指示物，改放於對手的戰鬥寶可夢身上。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560853,
+				tcgplayer: 569293,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S6K/066.ts
+++ b/data-asia/S/S6K/066.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "夏科婭"
+		ja: "シャクヤ",
+		'zh-tw': "夏科婭",
 	},
 
 	illustrator: "kirisAki",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "選擇最多3張自己的獎賞卡加入手牌。然後，從手牌選擇與加入的張數相同數量的卡，反面朝上作為獎賞卡放置。"
+		ja: "自分のサイドを3枚まで選び、手札に加える。その後、手札から、加えた枚数ぶんのカードを選び、ウラにしてサイドとして置く。",
+		'zh-tw': "選擇最多3張自己的獎賞卡加入手牌。然後，從手牌選擇與加入的張數相同數量的卡，反面朝上作為獎賞卡放置。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560854,
+				tcgplayer: 569294,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S6K/067.ts
+++ b/data-asia/S/S6K/067.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "志米"
+		ja: "ズミ",
+		'zh-tw': "志米",
 	},
 
 	illustrator: "Ken Sugimori",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "選擇最多2隻自己的「連擊」寶可夢，各恢復「60」HP。"
+		ja: "自分の「れんげき」のポケモンを2匹まで選び、HPをそれぞれ「60」回復する。",
+		'zh-tw': "選擇最多2隻自己的「連擊」寶可夢，各恢復「60」HP。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560855,
+				tcgplayer: 569295,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S6K/068.ts
+++ b/data-asia/S/S6K/068.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "遠古墓地"
+		ja: "いにしえの墓地",
+		'zh-tw': "遠古墓地",
 	},
 
 	illustrator: "Oswaldo KATO",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "雙方玩家每次從自己的手牌將能量附於寶可夢（【超】寶可夢除外）身上時，在那隻寶可夢身上放置2個傷害指示物。"
+		ja: "おたがいのプレイヤーは、それぞれ、自分の手札からエネルギーをポケモン（[超]ポケモンをのぞく）につけるたび、そのポケモンにダメカンを2個のせる。",
+		'zh-tw': "雙方玩家每次從自己的手牌將能量附於寶可夢（【超】寶可夢除外）身上時，在那隻寶可夢身上放置2個傷害指示物。",
 	},
 
-	trainerType: "Stadium",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560856,
+				tcgplayer: 569296,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Stadium",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S6K/069.ts
+++ b/data-asia/S/S6K/069.ts
@@ -1,21 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "螺旋能量"
+		ja: "スパイラルエネルギー",
+		'zh-tw': "螺旋能量",
 	},
 
+	illustrator: "",
 	category: "Energy",
+	energyType: "Special",
 
 	effect: {
-		'zh-tw': "這張卡只可附於「連擊」寶可夢身上，若附於「連擊」寶可夢以外的寶可夢身上，則將其丟棄。這張卡只要附於寶可夢身上，視為提供1個所有屬性的能量，附有這張卡的寶可夢不會【麻痺】，受到的【麻痺】會恢復。"
+		ja: "このカードは「れんげき」のポケモンにしかつけられず、「れんげき」のポケモン以外についているなら、トラッシュする。このカードは、ポケモンについているかぎり、すべてのタイプのエネルギー1個ぶんとしてはたらき、このカードをつけているポケモンはマヒにならず、受けているマヒは、すべて回復する。",
+		'zh-tw': "這張卡只可附於「連擊」寶可夢身上，若附於「連擊」寶可夢以外的寶可夢身上，則將其丟棄。這張卡只要附於寶可夢身上，視為提供1個所有屬性的能量，附有這張卡的寶可夢不會【麻痺】，受到的【麻痺】會恢復。",
 	},
 
-	energyType: "Special",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560857,
+				tcgplayer: 569297,
+			},
+		},
+	],
 
-export default card
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S6K/070.ts
+++ b/data-asia/S/S6K/070.ts
@@ -1,21 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6K"
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "幸運能量"
+		ja: "ラッキーエネルギー",
+		'zh-tw': "幸運能量",
 	},
 
+	illustrator: "",
 	category: "Energy",
+	energyType: "Special",
 
 	effect: {
-		'zh-tw': "只要這張卡附於寶可夢身上，視為提供1個【無】能量。當附有這張卡的寶可夢在戰鬥場受到對手的寶可夢招式的傷害時，從自己的牌庫抽出1張卡。"
+		ja: "このカードは、ポケモンについているかぎり、[無]エネルギー1個ぶんとしてはたらく。このカードをつけているポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、自分の山札を1枚引く。",
+		'zh-tw': "只要這張卡附於寶可夢身上，視為提供1個【無】能量。當附有這張卡的寶可夢在戰鬥場受到對手的寶可夢招式的傷害時，從自己的牌庫抽出1張卡。",
 	},
 
-	energyType: "Special",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560858,
+				tcgplayer: 569298,
+			},
+		},
+	],
 
-export default card
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S6K/071.ts
+++ b/data-asia/S/S6K/071.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "セレビィV",
+	},
+
+	illustrator: "PLANETA Tsuji",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "わかばのまい" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の手札から[草]エネルギーを好きなだけ選び、自分のポケモンに好きなようにつける。",
+			},
+		},
+		{
+			name: { ja: "スラッシュバック" },
+			damage: 60,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560972,
+				tcgplayer: 569299,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [251],
+};
+
+export default card;

--- a/data-asia/S/S6K/072.ts
+++ b/data-asia/S/S6K/072.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウオチルドンV",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "げんしれいとう" },
+			damage: 80,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けた「ポケモンV・GX」は、ワザが使えない。",
+			},
+		},
+		{
+			name: { ja: "ギガインパクト" },
+			damage: 220,
+			cost: ["Water", "Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560973,
+				tcgplayer: 569300,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [881],
+};
+
+export default card;

--- a/data-asia/S/S6K/073.ts
+++ b/data-asia/S/S6K/073.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼラオラV",
+	},
+
+	illustrator: "PLANETA Tsuji",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "クロスフィスト" },
+			damage: 100,
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "前の自分の番、このポケモン以外の「れんげき」のポケモンがワザを使っていたなら、相手のベンチポケモン1匹にも、160ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560974,
+				tcgplayer: 569301,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [807],
+};
+
+export default card;

--- a/data-asia/S/S6K/074.ts
+++ b/data-asia/S/S6K/074.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼラオラV",
+	},
+
+	illustrator: "Atsushi Furusawa",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "クロスフィスト" },
+			damage: 100,
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "前の自分の番、このポケモン以外の「れんげき」のポケモンがワザを使っていたなら、相手のベンチポケモン1匹にも、160ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560975,
+				tcgplayer: 569302,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [807],
+};
+
+export default card;

--- a/data-asia/S/S6K/075.ts
+++ b/data-asia/S/S6K/075.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "こくばバドレックスV",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "シャドーミスト" },
+			damage: 10,
+			cost: ["Psychic"],
+			effect: {
+				ja: "次の相手の番、相手は手札から、「特殊エネルギー」を出してつけられず「スタジアム」も出せない。",
+			},
+		},
+		{
+			name: { ja: "アストラルビット" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン2匹に、それぞれダメカンを5個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560976,
+				tcgplayer: 569303,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [898],
+};
+
+export default card;

--- a/data-asia/S/S6K/076.ts
+++ b/data-asia/S/S6K/076.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "こくばバドレックスV",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "シャドーミスト" },
+			damage: 10,
+			cost: ["Psychic"],
+			effect: {
+				ja: "次の相手の番、相手は手札から、「特殊エネルギー」を出してつけられず「スタジアム」も出せない。",
+			},
+		},
+		{
+			name: { ja: "アストラルビット" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン2匹に、それぞれダメカンを5個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560977,
+				tcgplayer: 569304,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [898],
+};
+
+export default card;

--- a/data-asia/S/S6K/077.ts
+++ b/data-asia/S/S6K/077.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メタグロスV",
+	},
+
+	illustrator: "PLANETA Mochizuki",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "バレットパンチ" },
+			damage: "20+",
+			cost: ["Metal"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×20ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "シンクロハンマー" },
+			damage: "60+",
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "このポケモンと相手のバトルポケモンについているエネルギーの数が同じなら、90ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560978,
+				tcgplayer: 569305,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [376],
+};
+
+export default card;

--- a/data-asia/S/S6K/078.ts
+++ b/data-asia/S/S6K/078.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハピナスV",
+	},
+
+	illustrator: "Saki Hayashiro",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しぜんかいふく" },
+			effect: {
+				ja: "自分の手札からこのポケモンにエネルギーをつけるたび、このポケモンの特殊状態をすべて回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ハッピーボンバー" },
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーの数×30ダメージ追加。のぞむなら、ダメージを与えたあとに、トラッシュからエネルギーを3枚まで選び、このポケモンにつける。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560979,
+				tcgplayer: 569306,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [242],
+};
+
+export default card;

--- a/data-asia/S/S6K/079.ts
+++ b/data-asia/S/S6K/079.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハピナスV",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しぜんかいふく" },
+			effect: {
+				ja: "自分の手札からこのポケモンにエネルギーをつけるたび、このポケモンの特殊状態をすべて回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ハッピーボンバー" },
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーの数×30ダメージ追加。のぞむなら、ダメージを与えたあとに、トラッシュからエネルギーを3枚まで選び、このポケモンにつける。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560980,
+				tcgplayer: 569307,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [242],
+};
+
+export default card;

--- a/data-asia/S/S6K/080.ts
+++ b/data-asia/S/S6K/080.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カトレア",
+	},
+
+	illustrator: "En Morikura",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札を好きなだけ選び、好きな順番に入れ替えて、山札の下にもどす。その後、もどした枚数ぶん、自分の山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560981,
+				tcgplayer: 569308,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S6K/081.ts
+++ b/data-asia/S/S6K/081.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キクコ",
+	},
+
+	illustrator: "NC Empire",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンにのっているダメカンを3個まで選び、相手のバトルポケモンにのせ替える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560982,
+				tcgplayer: 569309,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S6K/082.ts
+++ b/data-asia/S/S6K/082.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シャクヤ",
+	},
+
+	illustrator: "kirisAki",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のサイドを3枚まで選び、手札に加える。その後、手札から、加えた枚数ぶんのカードを選び、ウラにしてサイドとして置く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560983,
+				tcgplayer: 569310,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S6K/083.ts
+++ b/data-asia/S/S6K/083.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ズミ",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の「れんげき」のポケモンを2匹まで選び、HPをそれぞれ「60」回復する。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560984,
+				tcgplayer: 569311,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S6K/084.ts
+++ b/data-asia/S/S6K/084.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "セレビィVMAX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Grass"],
+
+	stage: "VMAX",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "いやしのもり" },
+			effect: {
+				ja: "自分の番に1回使える。自分の[草]ポケモン全員のHPを、それぞれ「20」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ダイプラント" },
+			damage: 130,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "自分の山札からポケモンを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560985,
+				tcgplayer: 569312,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "セレビィV",
+	},
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Hyper rare",
+	dexId: [251],
+};
+
+export default card;

--- a/data-asia/S/S6K/085.ts
+++ b/data-asia/S/S6K/085.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "こくばバドレックスVMAX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 320,
+	types: ["Psychic"],
+
+	stage: "VMAX",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "めいかいのとびら" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札から[超]エネルギーを1枚選び、自分のベンチの[超]ポケモンにつける。その後、自分の山札を2枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ダイガイスト" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[超]エネルギーの数×30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560986,
+				tcgplayer: 569313,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "こくばバドレックスV",
+	},
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Hyper rare",
+	dexId: [898],
+};
+
+export default card;

--- a/data-asia/S/S6K/086.ts
+++ b/data-asia/S/S6K/086.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "こくばバドレックスVMAX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 320,
+	types: ["Psychic"],
+
+	stage: "VMAX",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "めいかいのとびら" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札から[超]エネルギーを1枚選び、自分のベンチの[超]ポケモンにつける。その後、自分の山札を2枚引く。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ダイガイスト" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについている[超]エネルギーの数×30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560859,
+				tcgplayer: 569314,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "こくばバドレックスV",
+	},
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Secret Rare",
+	dexId: [898],
+};
+
+export default card;

--- a/data-asia/S/S6K/087.ts
+++ b/data-asia/S/S6K/087.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メタグロスVMAX",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Metal"],
+
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: { ja: "でんじきゅうちゃく" },
+			cost: ["Metal"],
+			effect: {
+				ja: "自分の山札から好きなカードを2枚まで選び、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ダイラッシュ" },
+			damage: 100,
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンの「ダイラッシュ」のダメージは「+150」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560987,
+				tcgplayer: 569315,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メタグロスV",
+	},
+
+	retreat: 3,
+	regulationMark: "E",
+	rarity: "Hyper rare",
+	dexId: [376],
+};
+
+export default card;

--- a/data-asia/S/S6K/088.ts
+++ b/data-asia/S/S6K/088.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カトレア",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札を好きなだけ選び、好きな順番に入れ替えて、山札の下にもどす。その後、もどした枚数ぶん、自分の山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560988,
+				tcgplayer: 569316,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Hyper rare",
+};
+
+export default card;

--- a/data-asia/S/S6K/089.ts
+++ b/data-asia/S/S6K/089.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キクコ",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンにのっているダメカンを3個まで選び、相手のバトルポケモンにのせ替える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560989,
+				tcgplayer: 569317,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Hyper rare",
+};
+
+export default card;

--- a/data-asia/S/S6K/090.ts
+++ b/data-asia/S/S6K/090.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シャクヤ",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のサイドを3枚まで選び、手札に加える。その後、手札から、加えた枚数ぶんのカードを選び、ウラにしてサイドとして置く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560990,
+				tcgplayer: 569318,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Hyper rare",
+};
+
+export default card;

--- a/data-asia/S/S6K/091.ts
+++ b/data-asia/S/S6K/091.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ズミ",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の「れんげき」のポケモンを2匹まで選び、HPをそれぞれ「60」回復する。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560991,
+				tcgplayer: 569319,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Hyper rare",
+};
+
+export default card;

--- a/data-asia/S/S6K/092.ts
+++ b/data-asia/S/S6K/092.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マルマイン",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Lightning"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ボムボムチェイン" },
+			damage: "20+",
+			cost: ["Lightning"],
+			effect: {
+				ja: "ダメージを与える前に、自分の場のポケモンについている「ポケモンのどうぐ」を好きなだけトラッシュし、その枚数×40ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "エレキボール" },
+			damage: 70,
+			cost: ["Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560992,
+				tcgplayer: 569320,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ビリリダマ",
+	},
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Secret Rare",
+	dexId: [101],
+};
+
+export default card;

--- a/data-asia/S/S6K/093.ts
+++ b/data-asia/S/S6K/093.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "霧の水晶",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から[超]タイプのたねポケモンまたは[超]エネルギーを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560993,
+				tcgplayer: 569321,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "E",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/S/S6K/094.ts
+++ b/data-asia/S/S6K/094.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "やまびこホーン",
+	},
+
+	illustrator: "",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のトラッシュからたねポケモンを1枚選び、相手のベンチに出す。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560994,
+				tcgplayer: 569322,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "E",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/S/S6K/095.ts
+++ b/data-asia/S/S6K/095.ts
@@ -1,0 +1,27 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6K";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本超エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560995,
+				tcgplayer: 577290,
+			},
+		},
+	],
+
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -236,6 +236,7 @@ export interface Card {
 			// Black White rare
 			| 'Black White Rare'
 			| 'Mega Hyper Rare'
+			| 'Triple Rare'
 			// Japanese Character Rares (since SM11b Dream League)
 			| 'Character Rare' | 'Character Super Rare'
 			// Pokémon TCG Pocket Rarities


### PR DESCRIPTION
## What

Refreshes the existing Japanese set **S6K 漆黒のガイスト (Jet-Black Spirit)** from its primary sources. The curated content stays: every card keeps its `zh-tw` texts verbatim.

What changes across the 95 card files:

- `thirdParty.cardmarket` moves onto `variants` objects and 70 missing ids are filled in
- per card where missing: `dexId`, `evolveFrom`, `resistances`, the Japanese flavor text and the Japanese effect/attack texts straight from the official database and limitless

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (560526–560995)
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (569229–577290), keyed by the collection number each product carries in `extendedData`

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- 063 is a Pokémon Tool that grant an attack — modeled as `effect` + `attacks`, like their English prints
- All 95 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
