### PR TITLE
(data) Update Japanese S set S6H Silver Lance

### DIFF
--- a/data-asia/S/S6H/001.ts
+++ b/data-asia/S/S6H/001.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雪笠怪"
+		ja: "ユキカブリ",
+		'zh-tw': "雪笠怪",
 	},
 
 	illustrator: "Naoki Saito",
@@ -14,41 +14,40 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "雪笠怪肚子上結出來的樹果口感彷如冰棒，是伽勒爾的火紅不倒翁們的最愛。"
+		ja: "お腹に 実る アイス みたいな 木の実は ガラルに 暮らす ダルマッカたちの 大好物。",
+		'zh-tw': "雪笠怪肚子上結出來的樹果口感彷如冰棒，是伽勒爾的火紅不倒翁們的最愛。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "前往拿取"
+	attacks: [
+		{
+			name: {
+				ja: "はりたおす",
+				'zh-tw': "前往拿取",
+			},
+			damage: 60,
+			cost: ["Grass", "Colorless", "Colorless"],
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張訓練家卡，在給對手看過後加入手牌。並且重洗牌庫。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560417,
+				tcgplayer: 569133,
+			},
 		},
-
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "窮追不捨"
-		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。"
-		},
-
-		damage: 40,
-		cost: ["Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [459],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/002.ts
+++ b/data-asia/S/S6H/002.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "暴雪王"
+		ja: "ユキノオー",
+		'zh-tw': "暴雪王",
 	},
 
 	illustrator: "Akira Komayama",
@@ -14,41 +14,54 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "會引發暴風雪的寶可夢。只要牠搖動巨大的身體，周圍立刻會變得一片雪白。"
+		ja: "ブリザードを 巻き起こす ポケモン。 大きな 体を 揺すれば あたり一面 すぐに 真っ白だ。",
+		'zh-tw': "會引發暴風雪的寶可夢。只要牠搖動巨大的身體，周圍立刻會變得一片雪白。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "新月生長"
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "タフネスアップ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の場の「いちげき」のポケモン（「ユキノオー」をのぞく）全員の最大HPは、それぞれ「50」大きくなる。この効果は、この特性を持つポケモンが何匹いても、重ならない。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張【超】能量卡，附於自己的寶可夢身上。並且重洗牌庫。若在後攻玩家的最初回合使用，則可附上的張數改為最多3張，附於自己的1隻寶可夢身上。"
+	attacks: [
+		{
+			name: {
+				ja: "メガトンパンチ",
+				'zh-tw': "新月生長",
+			},
+			damage: 90,
+			cost: ["Grass", "Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "光子鐳射"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560418,
+				tcgplayer: 569134,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若自己的場上的能量有5個以上，則增加90點傷害。"
-		},
-
-		damage: "30+",
-		cost: ["Psychic", "Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ユキカブリ",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [460],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/003.ts
+++ b/data-asia/S/S6H/003.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "石居蟹"
+		ja: "イシズマイ",
+		'zh-tw': "石居蟹",
 	},
 
 	illustrator: "Shigenori Negishi",
@@ -14,34 +14,51 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "如果找不到大小合適的石頭來當成自己的家，牠也會住到河馬獸的洞裡。"
+		ja: "家に ちょうどいい 小石が 見つからないと カバルドンの 穴に 棲んでしまうことも。",
+		'zh-tw': "如果找不到大小合適的石頭來當成自己的家，牠也會住到河馬獸的洞裡。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "拍擊"
+	attacks: [
+		{
+			name: {
+				ja: "ぶつかる",
+				'zh-tw': "拍擊",
+			},
+			damage: 10,
+			cost: ["Grass"],
 		},
-
-		damage: 10,
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "出拳"
+		{
+			name: {
+				ja: "するどいツメ",
+				'zh-tw': "出拳",
+			},
+			damage: "10+",
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、30ダメージ追加。",
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Psychic", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560419,
+				tcgplayer: 569135,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [557],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/004.ts
+++ b/data-asia/S/S6H/004.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "岩殿居蟹"
+		ja: "イワパレス",
+		'zh-tw': "岩殿居蟹",
 	},
 
 	illustrator: "sowsow",
@@ -14,42 +14,56 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "厚實的鉗子是牠最大的武器。硬度高到甚至能讓超甲狂犀的護具裂開。"
+		ja: "太い ツメが 最大の 武器。 ドサイドンの プロテクターにさえ ひびを 入れるほど 硬いぞ。",
+		'zh-tw': "厚實的鉗子是牠最大的武器。硬度高到甚至能讓超甲狂犀的護具裂開。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "強化拳"
+	attacks: [
+		{
+			name: {
+				ja: "シザークロス",
+				'zh-tw': "強化拳",
+			},
+			damage: "30+",
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、60ダメージ追加。",
+				'zh-tw': "若這隻寶可夢身上附有「寶可夢道具」，則增加90點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "若這隻寶可夢身上附有「寶可夢道具」，則增加90點傷害。"
+		{
+			name: {
+				ja: "ぶちかます",
+				'zh-tw': "百萬噸墜落",
+			},
+			damage: 130,
+			cost: ["Grass", "Grass", "Colorless"],
 		},
+	],
 
-		damage: "60+",
-		cost: ["Psychic", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "百萬噸墜落"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560420,
+				tcgplayer: 569136,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢也受到30點傷害。"
-		},
-
-		damage: 190,
-		cost: ["Psychic", "Psychic", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "イシズマイ",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [558],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/005.ts
+++ b/data-asia/S/S6H/005.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "四季鹿"
+		ja: "シキジカ",
+		'zh-tw': "四季鹿",
 	},
 
 	illustrator: "Lee HyunJung",
@@ -14,27 +14,47 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "到了季節交替之際，體毛與氣味就會產生變化。是通知季節來臨的寶可夢。"
+		ja: "季節の 変わり目に なると 体毛と においが 変化する。 季節を 告げる ポケモン。",
+		'zh-tw': "到了季節交替之際，體毛與氣味就會產生變化。是通知季節來臨的寶可夢。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "迴轉攻擊"
+	attacks: [
+		{
+			name: {
+				ja: "なきごえ",
+				'zh-tw': "迴轉攻擊",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-20」される。",
+			},
 		},
+		{
+			name: { ja: "うしろげり" },
+			damage: 20,
+			cost: ["Grass", "Colorless"],
+		},
+	],
 
-		damage: 20,
-		cost: ["Psychic"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560421,
+				tcgplayer: 569137,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [585],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/006.ts
+++ b/data-asia/S/S6H/006.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "萌芽鹿"
+		ja: "メブキジカ",
+		'zh-tw': "萌芽鹿",
 	},
 
 	illustrator: "Sekio",
@@ -14,31 +14,52 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "會隨著季節的推移改變居所。所以也有人說萌芽鹿會運來春天。"
+		ja: "季節の 移り変わりと ともに 住処を 変えるので メブキジカが 春を運ぶと いう 人もいる。",
+		'zh-tw': "會隨著季節的推移改變居所。所以也有人說萌芽鹿會運來春天。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "連擊觸手"
+	attacks: [
+		{
+			name: {
+				ja: "たいあたり",
+				'zh-tw': "連擊觸手",
+			},
+			damage: 30,
+			cost: ["Colorless"],
 		},
-
-		effect: {
-			'zh-tw': "從自己的手牌將任意數量的「連擊」卡給對手看過後，造成其張數×40點傷害。然後，將給對手看過的「連擊」卡放回牌庫並重洗。"
+		{
+			name: { ja: "ウインターホーン" },
+			damage: "80+",
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "場に自分のスタジアムが出ているなら、80ダメージ追加。",
+			},
 		},
+	],
 
-		damage: "40×",
-		cost: ["Psychic"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560422,
+				tcgplayer: 569138,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シキジカ",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [586],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/007.ts
+++ b/data-asia/S/S6H/007.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "甜竹竹"
+		ja: "アマカジ",
+		'zh-tw': "甜竹竹",
 	},
 
 	illustrator: "MAHOU",
@@ -14,27 +14,40 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "受到襲擊時流下的汗水非常甜美可口。那種香氣會吸引更多敵人的注意。"
+		ja: "襲われた ときに 流す 汗は 甘くて 美味しい。 その 香りが さらに 敵を 増やしてしまうのだ。",
+		'zh-tw': "受到襲擊時流下的汗水非常甜美可口。那種香氣會吸引更多敵人的注意。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "羽擊"
+	attacks: [
+		{
+			name: {
+				ja: "はねる",
+				'zh-tw': "羽擊",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 10,
-		cost: ["Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560423,
+				tcgplayer: 569139,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [761],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/008.ts
+++ b/data-asia/S/S6H/008.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "甜舞妮"
+		ja: "アママイコ",
+		'zh-tw': "甜舞妮",
 	},
 
 	illustrator: "Tomokazu Komiya",
@@ -14,31 +14,52 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "會用頭部的果蒂擊打飛來啄食自己的藍鴉，並且對牠使出猛烈的踢擊。"
+		ja: "突いてくる アオガラスには 頭の ヘタで 殴りつけてから 鋭い 蹴り技を おみまいする。",
+		'zh-tw': "會用頭部的果蒂擊打飛來啄食自己的藍鴉，並且對牠使出猛烈的踢擊。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "戲法舞步"
+	attacks: [
+		{
+			name: {
+				ja: "はねる",
+				'zh-tw': "戲法舞步",
+			},
+			damage: 20,
+			cost: ["Colorless"],
 		},
-
-		effect: {
-			'zh-tw': "若希望，選擇1個對手的戰鬥寶可夢身上附加的能量，改附於對手的備戰寶可夢身上。"
+		{
+			name: { ja: "ふみつけ" },
+			damage: "50+",
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、30ダメージ追加。",
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560424,
+				tcgplayer: 569140,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アマカジ",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [762],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/009.ts
+++ b/data-asia/S/S6H/009.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "甜冷美后"
+		ja: "アマージョ",
+		'zh-tw': "甜冷美后",
 	},
 
 	illustrator: "Yuu Nishida",
@@ -14,41 +14,56 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "用又尖又硬的腳尖施展踢擊，朝對手的身體和心靈留下無法磨滅的創傷。"
+		ja: "硬く 尖った つま先で 蹴りを おみまいして 相手の 体と 心に 消えない 傷を 残す。",
+		'zh-tw': "用又尖又硬的腳尖施展踢擊，朝對手的身體和心靈留下無法磨滅的創傷。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "暗影薄霧"
+	attacks: [
+		{
+			name: {
+				ja: "ふみにじる",
+				'zh-tw': "暗影薄霧",
+			},
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンのにげるためのエネルギーの数×50ダメージ追加。",
+				'zh-tw': "在下個對手的回合，對手無法從手牌附上「特殊能量」，也無法使出「競技場」。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，對手無法從手牌附上「特殊能量」，也無法使出「競技場」。"
+		{
+			name: {
+				ja: "ソーラービーム",
+				'zh-tw': "星碎",
+			},
+			damage: 120,
+			cost: ["Grass", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 10,
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "星碎"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560425,
+				tcgplayer: 569141,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在對手的2隻寶可夢身上各放置5個傷害指示物。"
-		},
-
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "アママイコ",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [763],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/010.ts
+++ b/data-asia/S/S6H/010.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "薩戮德"
+		ja: "ザルード",
+		'zh-tw': "薩戮德",
 	},
 
 	illustrator: "Shin Nagasawa",
@@ -14,43 +14,51 @@ const card: Card = {
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "生長在身上的藤蔓斷落後會化為土壤的養分，孕育森林裡的各種植物。"
+		ja: "体に 生える ツルは ちぎれると 土の 栄養分となって 森の 植物たちを 育てるのだ。",
+		'zh-tw': "生長在身上的藤蔓斷落後會化為土壤的養分，孕育森林裡的各種植物。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "冥界之扉"
+	attacks: [
+		{
+			name: {
+				ja: "むれよびのうた",
+				'zh-tw': "極巨之魂",
+			},
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の山札から[草]ポケモンを1枚選び、相手に見せて、手札に加える。そして山札を切る。後攻プレイヤーの最初の番なら、手札に加えられる[草]ポケモンの枚数は3枚までになる。",
+				'zh-tw': "增加自己的場上寶可夢身上附加的【超】能量的數量×30點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在自己的回合時，可使用1次。從自己的手牌選擇1張【超】能量卡，附於自己的備戰區的【超】寶可夢身上。然後，從自己的牌庫抽出2張卡。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "極巨之魂"
+		{
+			name: { ja: "さみだれのムチ" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[草]エネルギーの数×20ダメージ追加。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加自己的場上寶可夢身上附加的【超】能量的數量×30點傷害。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560426,
+				tcgplayer: 569142,
+			},
 		},
-
-		damage: "10+",
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [893],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/011.ts
+++ b/data-asia/S/S6H/011.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "飄浮泡泡 太陽的樣子"
+		ja: "ポワルン たいようのすがた",
+		'zh-tw': "飄浮泡泡 太陽的樣子",
 	},
 
 	illustrator: "Yuka Morii",
@@ -14,34 +14,53 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "暴露在烈日下就會變成這個樣子。如果去摸牠熱烘烘的身體，會感覺到乾巴巴的。"
+		ja: "暑い 日差しを 浴びていると この姿に 変わる。 火照った 身体を 触ると パサパサするぞ。",
+		'zh-tw': "暴露在烈日下就會變成這個樣子。如果去摸牠熱烘烘的身體，會感覺到乾巴巴的。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "踩"
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "てんきよみ" },
+			effect: {
+				ja: "自分のトラッシュに「スタジアム」が8枚以上あるなら、このポケモンがワザを使うためのエネルギーは、すべてなくなる。",
+			},
 		},
+	],
 
-		damage: 20,
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "舌擊"
+	attacks: [
+		{
+			name: {
+				ja: "こうきあつブラスト",
+				'zh-tw': "踩",
+			},
+			damage: 150,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "場に出ている「スタジアム」をトラッシュする。トラッシュできないなら、このワザは失敗。",
+			},
 		},
+	],
 
-		damage: 50,
-		cost: ["Fighting", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560427,
+				tcgplayer: 569143,
+			},
+		},
+	],
 
 	retreat: 0,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [351],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/012.ts
+++ b/data-asia/S/S6H/012.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "小獅獅"
+		ja: "シシコ",
+		'zh-tw': "小獅獅",
 	},
 
 	illustrator: "Misa Tsutsui",
@@ -14,38 +14,40 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "血氣方剛且好奇心旺盛。當牠生氣或是開始戰鬥時，短短的鬃毛就會變熱。"
+		ja: "血気盛んで 好奇心旺盛。 怒ったり 戦いが 始まると 短い たてがみは 熱くなる。",
+		'zh-tw': "血氣方剛且好奇心旺盛。當牠生氣或是開始戰鬥時，短短的鬃毛就會變熱。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "蕩蕩波"
+	attacks: [
+		{
+			name: {
+				ja: "ひだね",
+				'zh-tw': "蕩蕩波",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢使用招式所需的能量與【撤退】所需的能量，各增加1個【無】能量。"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560428,
+				tcgplayer: 569144,
+			},
 		},
-
-		damage: 60,
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "巨聲"
-		},
-
-		damage: 160,
-		cost: ["Fighting", "Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [667],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/013.ts
+++ b/data-asia/S/S6H/013.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "火炎獅"
+		ja: "カエンジシ",
+		'zh-tw': "火炎獅",
 	},
 
 	illustrator: "Hitoshi Ariga",
@@ -14,38 +14,56 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "能吐出攝氏６０００度的氣息，但不會用在獵物身上，因為牠比較喜歡吃生肉。"
+		ja: "摂氏 ６０００度の 息を 吐くが 獲物には 使わない。 肉は 生のほうが 好み だから。",
+		'zh-tw': "能吐出攝氏６０００度的氣息，但不會用在獵物身上，因為牠比較喜歡吃生肉。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "打擊"
+	attacks: [
+		{
+			name: {
+				ja: "かえん",
+				'zh-tw': "打擊",
+			},
+			damage: 30,
+			cost: ["Colorless"],
 		},
-
-		damage: 20,
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "雙重金勾臂"
+		{
+			name: {
+				ja: "はかいのツメ",
+				'zh-tw': "雙重金勾臂",
+			},
+			damage: 70,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "擲2次硬幣，造成正面出現的次數×40點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲2次硬幣，造成正面出現的次數×40點傷害。"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560429,
+				tcgplayer: 569145,
+			},
 		},
+	],
 
-		damage: "40×",
-		cost: ["Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "シシコ",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [668],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/014.ts
+++ b/data-asia/S/S6H/014.ts
@@ -1,47 +1,59 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "波爾凱尼恩V"
+		ja: "ボルケニオンV",
+		'zh-tw': "波爾凱尼恩V",
 	},
 
 	illustrator: "Ryota Murayama",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Fire"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "雙重金勾臂"
+	attacks: [
+		{
+			name: {
+				ja: "ヒートブラスト",
+				'zh-tw': "雙重金勾臂",
+			},
+			damage: 50,
+			cost: ["Fire", "Colorless"],
 		},
-
-		effect: {
-			'zh-tw': "擲2次硬幣，造成正面出現的次數×90點傷害。"
+		{
+			name: {
+				ja: "ダイナマイトタックル",
+				'zh-tw': "蟹鉗錘",
+			},
+			damage: "100+",
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンにダメカンが10個以上のっているなら、150ダメージ追加。",
+			},
 		},
+	],
 
-		damage: "90×",
-		cost: ["Fighting", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "蟹鉗錘"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560430,
+				tcgplayer: 569146,
+			},
 		},
-
-		damage: 130,
-		cost: ["Fighting", "Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	],
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [721],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/015.ts
+++ b/data-asia/S/S6H/015.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "炎兔兒"
+		ja: "ヒバニー",
+		'zh-tw': "炎兔兒",
 	},
 
 	illustrator: "tetsuya koizumi",
@@ -14,27 +14,40 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "一旦做好了戰鬥的準備，牠鼻頭上和腳底的肉球就會散發出極度的高溫。"
+		ja: "戦う 準備が 整うと 鼻の 頭と 足の 裏の 肉球が 高熱を 発する。",
+		'zh-tw': "一旦做好了戰鬥的準備，牠鼻頭上和腳底的肉球就會散發出極度的高溫。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "敲擊"
+	attacks: [
+		{
+			name: {
+				ja: "ずつき",
+				'zh-tw': "敲擊",
+			},
+			damage: 20,
+			cost: ["Fire"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560431,
+				tcgplayer: 569147,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [813],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/016.ts
+++ b/data-asia/S/S6H/016.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "騰蹴小將"
+		ja: "ラビフット",
+		'zh-tw': "騰蹴小將",
 	},
 
 	illustrator: "Souichirou Gunjima",
@@ -14,43 +14,48 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "會用腳把樹果從樹木上踢落，用來練習挑球，藉此鍛鍊自己的腳法。"
+		ja: "手を 使わずに 木の 枝から 木の実を 摘み取り リフティング。 足技を 磨く 練習。",
+		'zh-tw': "會用腳把樹果從樹木上踢落，用來練習挑球，藉此鍛鍊自己的腳法。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "絞技達人"
+	attacks: [
+		{
+			name: {
+				ja: "ボレーキック",
+				'zh-tw': "同步光炮",
+			},
+			damage: 60,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+				'zh-tw': "若自己的手牌的張數與對手的手牌的張數相同，則增加80點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在戰鬥場上，對手的戰鬥寶可夢【撤退】所需的能量增加2個。"
-		}
-	}],
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-	attacks: [{
-		name: {
-			'zh-tw': "同步光炮"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560432,
+				tcgplayer: 569148,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若自己的手牌的張數與對手的手牌的張數相同，則增加80點傷害。"
-		},
-
-		damage: "80+",
-		cost: ["Fighting", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ヒバニー",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [814],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/017.ts
+++ b/data-asia/S/S6H/017.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "閃焰王牌"
+		ja: "エースバーン",
+		'zh-tw': "閃焰王牌",
 	},
 
 	illustrator: "Ryuta Fuse",
@@ -14,31 +14,58 @@ const card: Card = {
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "擁有熟練的進攻和防守技巧。只要得到聲援就會更有衝勁，但有時會為了出風頭而弄巧成拙。"
+		ja: "攻守に 優れ 応援されると さらに 燃えるが スタンドプレイに 走り ピンチを 招くこともある。",
+		'zh-tw': "擁有熟練的進攻和防守技巧。只要得到聲援就會更有衝勁，但有時會為了出風頭而弄巧成拙。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "濁霧"
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かじばのパワー" },
+			effect: {
+				ja: "このポケモンが使うワザの、相手のバトルポケモンへのダメージは、相手がすでにとったサイド1枚につき「+30」される。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。"
+	attacks: [
+		{
+			name: {
+				ja: "ひのたまシュート",
+				'zh-tw': "濁霧",
+			},
+			damage: 150,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】。",
+			},
 		},
+	],
 
-		damage: 20,
-		cost: ["Darkness", "Colorless"]
-	}],
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560433,
+				tcgplayer: 569149,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ラビフット",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [815],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/018.ts
+++ b/data-asia/S/S6H/018.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "拉普拉斯"
+		ja: "ラプラス",
+		'zh-tw': "拉普拉斯",
 	},
 
 	illustrator: "Atsushi Furusawa",
@@ -14,41 +14,55 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "十分耐寒，不畏冰海。皮膚滑滑的，摸起來會有點涼。"
+		ja: "寒さに 強く 氷の 海も 平気。 皮膚は スベスベで 少しだけ ひんやり しているよ。",
+		'zh-tw': "十分耐寒，不畏冰海。皮膚滑滑的，摸起來會有點涼。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "混合毒素"
+	attacks: [
+		{
+			name: {
+				ja: "ホワイトコール",
+				'zh-tw': "混合毒素",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から「メロン」を2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "將對手的戰鬥寶可夢【混亂】。從自己的棄牌區選擇1張【惡】能量卡，附於這隻寶可夢身上。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【混亂】。從自己的棄牌區選擇1張【惡】能量卡，附於這隻寶可夢身上。"
+		{
+			name: {
+				ja: "こごえるかぜ",
+				'zh-tw': "煙之暴擊",
+			},
+			damage: 50,
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+				'zh-tw': "增加自己的場上寶可夢身上附加的【惡】能量的數量×20點傷害。",
+			},
 		},
+	],
 
-		cost: ["Darkness"]
-	}, {
-		name: {
-			'zh-tw': "煙之暴擊"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560434,
+				tcgplayer: 569150,
+			},
 		},
-
-		effect: {
-			'zh-tw': "增加自己的場上寶可夢身上附加的【惡】能量的數量×20點傷害。"
-		},
-
-		damage: "20+",
-		cost: ["Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [131],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/019.ts
+++ b/data-asia/S/S6H/019.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "飄浮泡泡 雪雲的樣子"
+		ja: "ポワルン ゆきぐものすがた",
+		'zh-tw': "飄浮泡泡 雪雲的樣子",
 	},
 
 	illustrator: "miki kudo",
@@ -14,39 +14,57 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "被冰雹打到時就會變成這個樣子。全身上下冷冰冰的，皮膚有一點結冰。"
+		ja: "霰に 打たれると この 姿に 変化する。 全身 冷たく 皮膚は 少し 凍っているぞ。",
+		'zh-tw': "被冰雹打到時就會變成這個樣子。全身上下冷冰冰的，皮膚有一點結冰。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "能量工廠"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "てんきよみ",
+				'zh-tw': "能量工廠",
+			},
+			effect: {
+				ja: "自分のトラッシュに「スタジアム」が8枚以上あるなら、このポケモンがワザを使うためのエネルギーは、すべてなくなる。",
+				'zh-tw': "只要這隻寶可夢在場上，自己的場上的，名稱中有「雙彈瓦斯」的寶可夢身上附加的基本【惡】能量，各視為提供2個【惡】能量。無論有多少隻擁有這個特性的寶可夢，這個效果也不會重複。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在場上，自己的場上的，名稱中有「雙彈瓦斯」的寶可夢身上附加的基本【惡】能量，各視為提供2個【惡】能量。無論有多少隻擁有這個特性的寶可夢，這個效果也不會重複。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "瓦斯包圍"
+	attacks: [
+		{
+			name: {
+				ja: "フロストタイフーン",
+				'zh-tw': "瓦斯包圍",
+			},
+			damage: 120,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「フロストタイフーン」が使えない。",
+			},
 		},
+	],
 
-		damage: 50,
-		cost: ["Darkness", "Colorless"]
-	}],
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560435,
+				tcgplayer: 569151,
+			},
+		},
+	],
 
 	retreat: 0,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [351],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/020.ts
+++ b/data-asia/S/S6H/020.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雪童子"
+		ja: "ユキワラシ",
+		'zh-tw': "雪童子",
 	},
 
 	illustrator: "Kouki Saitou",
@@ -14,31 +14,40 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "只能在寒冷的土地上生存。即使在零下１００度的環境下也能充滿活力地到處蹦蹦跳跳。"
+		ja: "寒い 土地でしか 生きられない。 マイナス １００度の 環境でも 元気に 跳ねまわっているよ。",
+		'zh-tw': "只能在寒冷的土地上生存。即使在零下１００度的環境下也能充滿活力地到處蹦蹦跳跳。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "擊掌奇襲"
+	attacks: [
+		{
+			name: {
+				ja: "ずつき",
+				'zh-tw': "擊掌奇襲",
+			},
+			damage: 30,
+			cost: ["Water", "Colorless"],
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560436,
+				tcgplayer: 569152,
+			},
 		},
-
-		damage: 20,
-		cost: ["Darkness"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [361],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/021.ts
+++ b/data-asia/S/S6H/021.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雪妖女"
+		ja: "ユキメノコ",
+		'zh-tw': "雪妖女",
 	},
 
 	illustrator: "Souichirou Gunjima",
@@ -14,41 +14,58 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "會吐出零下５０度的冷氣凍住獵物，並把牠們帶回自己的巢穴，整齊地擺成一排。"
+		ja: "マイナス５０度の 冷気を 吐き 凍らせた 獲物を すみかに 持ち帰り きれいに 並べる。",
+		'zh-tw': "會吐出零下５０度的冷氣凍住獵物，並把牠們帶回自己的巢穴，整齊地擺成一排。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "天狗再見"
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しもふらし" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分のトラッシュから[水]エネルギーを1枚選び、自分のポケモンにつける。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將身上放置有傷害指示物的對手的戰鬥寶可夢與附加的卡，全部放回對手的手牌。"
+	attacks: [
+		{
+			name: {
+				ja: "クリスタルブレス",
+				'zh-tw': "天狗再見",
+			},
+			damage: 90,
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+				'zh-tw': "將身上放置有傷害指示物的對手的戰鬥寶可夢與附加的卡，全部放回對手的手牌。",
+			},
 		},
+	],
 
-		cost: ["Darkness"]
-	}, {
-		name: {
-			'zh-tw': "寒冬旋風"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560437,
+				tcgplayer: 569153,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在不看正面的情況下，選擇1張對手的手牌，將其丟棄。"
-		},
-
-		damage: 130,
-		cost: ["Darkness", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ユキワラシ",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [478],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/022.ts
+++ b/data-asia/S/S6H/022.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "海豹球"
+		ja: "タマザラシ",
+		'zh-tw': "海豹球",
 	},
 
 	illustrator: "kirisAki",
@@ -14,42 +14,40 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "身體被蓬鬆的體毛覆蓋著，因此即使在冰上翻滾也不會覺得冷。"
+		ja: "フサフサの 体毛で 体が 覆われて いるので 氷の 上を 転がっても 冷たくない。",
+		'zh-tw': "身體被蓬鬆的體毛覆蓋著，因此即使在冰上翻滾也不會覺得冷。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "子彈拳"
+	attacks: [
+		{
+			name: {
+				ja: "ぶつかる",
+				'zh-tw': "子彈拳",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲2次硬幣，增加正面出現的次數×20點傷害。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560438,
+				tcgplayer: 569154,
+			},
 		},
-
-		damage: "20+",
-		cost: ["Metal"]
-	}, {
-		name: {
-			'zh-tw': "同步之錘"
-		},
-
-		effect: {
-			'zh-tw': "若這隻寶可夢與對手的戰鬥寶可夢，身上附加的能量數量相同，則增加90點傷害。"
-		},
-
-		damage: "60+",
-		cost: ["Metal", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [363],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/023.ts
+++ b/data-asia/S/S6H/023.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "海魔獅"
+		ja: "トドグラー",
+		'zh-tw': "海魔獅",
 	},
 
 	illustrator: "tetsuya koizumi",
@@ -14,41 +14,52 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "只要是圓形的東西，無論是精靈球還是海豹球，都能頂在鼻子上隨心所欲地轉動。"
+		ja: "まるければ モンスターボールでも タマザラシでも 鼻の上に 乗せて 自由自在に くるくる 回すぞ。",
+		'zh-tw': "只要是圓形的東西，無論是精靈球還是海豹球，都能頂在鼻子上隨心所欲地轉動。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "電磁吸附"
+	attacks: [
+		{
+			name: {
+				ja: "ぶつかる",
+				'zh-tw': "電磁吸附",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫任意選擇最多2張卡加入手牌。並且重洗牌庫。"
+		{
+			name: {
+				ja: "オーロラビーム",
+				'zh-tw': "極巨衝刺",
+			},
+			damage: 70,
+			cost: ["Water", "Water", "Colorless"],
 		},
+	],
 
-		cost: ["Metal"]
-	}, {
-		name: {
-			'zh-tw': "極巨衝刺"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560439,
+				tcgplayer: 569155,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢「極巨衝刺」的傷害「+150」點。"
-		},
-
-		damage: 100,
-		cost: ["Metal", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "タマザラシ",
+	},
 
 	retreat: 4,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [364],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/024.ts
+++ b/data-asia/S/S6H/024.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "帝牙海獅"
+		ja: "トドゼルガ",
+		'zh-tw': "帝牙海獅",
 	},
 
 	illustrator: "KEIICHIRO ITO",
@@ -14,38 +14,56 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "用強壯的獠牙粉碎浮冰。厚厚的脂肪可以反彈敵人的攻擊。"
+		ja: "たくましい キバで 流氷を 粉砕する。 分厚い 脂肪が 敵の 攻撃を 跳ね返す。",
+		'zh-tw': "用強壯的獠牙粉碎浮冰。厚厚的脂肪可以反彈敵人的攻擊。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "鐵頭碰"
+	attacks: [
+		{
+			name: {
+				ja: "オーロラビーム",
+				'zh-tw': "鐵頭碰",
+			},
+			damage: 70,
+			cost: ["Colorless", "Colorless"],
 		},
-
-		damage: 40,
-		cost: ["Metal", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "金屬斬"
+		{
+			name: {
+				ja: "ヘイルプリズン",
+				'zh-tw': "金屬斬",
+			},
+			damage: 160,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個トラッシュし、相手のバトルポケモンをマヒにする。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560440,
+				tcgplayer: 569156,
+			},
 		},
+	],
 
-		damage: 130,
-		cost: ["Metal", "Metal", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "トドグラー",
+	},
 
 	retreat: 4,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [365],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/025.ts
+++ b/data-asia/S/S6H/025.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "冰寶"
+		ja: "カチコール",
+		'zh-tw': "冰寶",
 	},
 
 	illustrator: "kirisAki",
@@ -14,39 +14,48 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "棲息在極其寒冷的地域。會把自己的腳凍在冰岩怪的背上固定起來。"
+		ja: "極寒の 地域に 生息する。 クレベースの 背中と 自分の 足を 凍りつかせて 固定する。",
+		'zh-tw': "棲息在極其寒冷的地域。會把自己的腳凍在冰岩怪的背上固定起來。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "自然回復"
+	attacks: [
+		{
+			name: {
+				ja: "たいあたり",
+				'zh-tw': "自然回復",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
-
-		effect: {
-			'zh-tw': "每次從自己的手牌將能量附於這隻寶可夢身上時，都將這隻寶可夢的特殊狀態全部恢復。"
-		}
-	}, {
-		name: {
-			'zh-tw': "幸福轟炸"
+		{
+			name: {
+				ja: "かいてんアタック",
+				'zh-tw': "幸福轟炸",
+			},
+			damage: 20,
+			cost: ["Water", "Colorless"],
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加這隻寶可夢身上附加的能量的數量×30點傷害。若希望，在造成傷害後，從棄牌區選擇最多3張能量卡，附於這隻寶可夢身上。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560441,
+				tcgplayer: 569157,
+			},
 		},
-
-		damage: "10+",
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [712],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/026.ts
+++ b/data-asia/S/S6H/026.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "冰岩怪"
+		ja: "クレベース",
+		'zh-tw': "冰岩怪",
 	},
 
 	illustrator: "Kouki Saitou",
@@ -14,43 +14,53 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "雖然身體的裂縫會因白天的活動而變大，但只要一晚就能全部長好。"
+		ja: "日中の 活動で 体の 亀裂は 深くなるが 一晩で 亀裂の ない 体に もどる。",
+		'zh-tw': "雖然身體的裂縫會因白天的活動而變大，但只要一晚就能全部長好。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "看天"
+	attacks: [
+		{
+			name: {
+				ja: "フロストバリア",
+				'zh-tw': "氣象之力",
+			},
+			damage: 80,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+				'zh-tw': "從牌庫抽卡直到自己的手牌滿6張為止。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "若自己的棄牌區有8張以上的「競技場」卡，則這隻寶可夢使用招式所需的能量全部消除。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "氣象之力"
+		{
+			name: { ja: "ぶちかます" },
+			damage: 140,
+			cost: ["Water", "Water", "Colorless", "Colorless"],
 		},
+	],
 
-		effect: {
-			'zh-tw': "從牌庫抽卡直到自己的手牌滿6張為止。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560442,
+				tcgplayer: 569158,
+			},
 		},
+	],
 
-		damage: 80,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "カチコール",
+	},
 
 	retreat: 4,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [713],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/027.ts
+++ b/data-asia/S/S6H/027.ts
@@ -1,48 +1,56 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "白馬蕾冠王V"
+		ja: "はくばバドレックスV",
+		'zh-tw': "白馬蕾冠王V",
 	},
 
 	illustrator: "D.A.G Inc.",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Water"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "五顏六色變化"
+	attacks: [
+		{
+			name: {
+				ja: "つきさす",
+				'zh-tw': "迴轉攻擊",
+			},
+			damage: 40,
+			cost: ["Water"],
 		},
-
-		effect: {
-			'zh-tw': "這隻寶可夢的屬性改為與這隻寶可夢身上附加的基本能量相同。（若身上附加的基本能量屬性有2種以上，則改為各自屬性。）"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "迴轉攻擊"
+		{
+			name: { ja: "ブリザードランス" },
+			damage: 200,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+			},
 		},
+	],
 
-		damage: 90,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560443,
+				tcgplayer: 569159,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [898],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/028.ts
+++ b/data-asia/S/S6H/028.ts
@@ -1,49 +1,68 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "白馬蕾冠王VMAX"
+		ja: "はくばバドレックスVMAX",
+		'zh-tw': "白馬蕾冠王VMAX",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
 	hp: 320,
 	types: ["Water"],
+
 	stage: "VMAX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "順風抽出"
+	attacks: [
+		{
+			name: {
+				ja: "エンペラーライド",
+				'zh-tw': "順風抽出",
+			},
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数×30ダメージ追加。",
+				'zh-tw': "從自己的牌庫抽出1張卡。若在後攻玩家的最初回合使用，則再抽出3張卡。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫抽出1張卡。若在後攻玩家的最初回合使用，則再抽出3張卡。"
+		{
+			name: {
+				ja: "ダイランス",
+				'zh-tw': "偷襲",
+			},
+			damage: "10+",
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "のぞむなら、このポケモンについているエネルギーを2枚まで選び、トラッシュする。その場合、トラッシュした枚数×120ダメージ追加。",
+				'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "偷襲"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560444,
+				tcgplayer: 569160,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。"
-		},
-
-		damage: 20,
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "はくばバドレックスV",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Triple Rare",
+	dexId: [898],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/029.ts
+++ b/data-asia/S/S6H/029.ts
@@ -1,45 +1,59 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伽勒爾 烈焰馬V"
+		ja: "ガラル ギャロップV",
+		'zh-tw': "伽勒爾 烈焰馬V",
 	},
 
 	illustrator: "Saki Hayashiro",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Psychic"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "電光一閃"
+	attacks: [
+		{
+			name: {
+				ja: "リブラホーン",
+				'zh-tw': "電光一閃",
+			},
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、そのポケモンの残りHPが「100」になるように、ダメカンをのせる。",
+				'zh-tw': "擲1次硬幣若為正面，則增加20點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則增加20點傷害。"
+		{
+			name: { ja: "サイコキネシス" },
+			damage: "60+",
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数×30ダメージ追加。",
+			},
 		},
+	],
 
-		damage: "20+",
-		cost: ["Colorless"]
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560445,
+				tcgplayer: 569161,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [78],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/030.ts
+++ b/data-asia/S/S6H/030.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伽勒爾 呆呆獸"
+		ja: "ガラル ヤドン",
+		'zh-tw': "伽勒爾 呆呆獸",
 	},
 
 	illustrator: "Naoyo Kimura",
@@ -14,47 +14,48 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "牠以只生長在伽勒爾地區的植物的種子為食，因此尾巴是辣味的。"
+		ja: "ガラル地方にだけ 生息する 植物の タネを 食べているため しっぽは スパイシーな 味わいだ。",
+		'zh-tw': "牠以只生長在伽勒爾地區的植物的種子為食，因此尾巴是辣味的。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "緊抓"
+	attacks: [
+		{
+			name: {
+				ja: "ぴりっ",
+				'zh-tw': "緊抓",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。"
+		{
+			name: {
+				ja: "ずつき",
+				'zh-tw': "火藥奇襲",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 40,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "火藥奇襲"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560446,
+				tcgplayer: 569162,
+			},
 		},
-
-		effect: {
-			'zh-tw': "若這隻寶可夢身上附有【火】能量，則增加80點傷害。"
-		},
-
-		damage: "80+",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [79],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/031.ts
+++ b/data-asia/S/S6H/031.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "催眠貘"
+		ja: "スリープ",
+		'zh-tw': "催眠貘",
 	},
 
 	illustrator: "nagimiso",
@@ -14,42 +14,40 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "會讓獵物睡著，吃掉對方所做的夢。惡夢的味道是酸的，所以牠似乎不怎麼愛吃。"
+		ja: "獲物を 眠らせ 見ている ユメを 喰らう。 悪いユメは すっぱくて あまり 好んで 食べないらしい。",
+		'zh-tw': "會讓獵物睡著，吃掉對方所做的夢。惡夢的味道是酸的，所以牠似乎不怎麼愛吃。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "撿起來吃"
+	attacks: [
+		{
+			name: {
+				ja: "はたく",
+				'zh-tw': "撿起來吃",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的棄牌區選擇1張「寶可夢道具」卡，在給對手看過後加入手牌。"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560447,
+				tcgplayer: 569163,
+			},
 		},
-
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "咬"
-		},
-
-		damage: 10,
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [96],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/032.ts
+++ b/data-asia/S/S6H/032.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "引夢貘人"
+		ja: "スリーパー",
+		'zh-tw': "引夢貘人",
 	},
 
 	illustrator: "Miki Tanaka",
@@ -14,44 +14,54 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "為了幫助那些晚上失眠的人，也有些引夢貘人會到醫院去協助醫生。"
+		ja: "夜に 眠れない 人の ために 病院で お医者さんの 手伝いをする スリーパーも いる。",
+		'zh-tw': "為了幫助那些晚上失眠的人，也有些引夢貘人會到醫院去協助醫生。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "不甩人尾"
+	attacks: [
+		{
+			name: {
+				ja: "さいみんじゅつ",
+				'zh-tw': "咬",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "只要這隻寶可夢在場上，自己的寶可夢身上附加的能量，不會受到對手的物品或者支援者的效果影響而丟棄與放回手牌或牌庫。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "咬"
+		{
+			name: { ja: "めざましビンタ" },
+			damage: "30+",
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンが特殊状態なら、90ダメージ追加。その後、相手のバトルポケモンの特殊状態をすべて回復する。",
+			},
 		},
+	],
 
-		damage: 90,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560448,
+				tcgplayer: 569164,
+			},
+		},
+	],
 
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "スリープ",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [97],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/033.ts
+++ b/data-asia/S/S6H/033.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "拉魯拉絲"
+		ja: "ラルトス",
+		'zh-tw': "拉魯拉絲",
 	},
 
 	illustrator: "Narumi Sato",
@@ -14,18 +14,39 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "用紅色的角感知到人和寶可夢的溫情後，全身也會變得有點暖暖的。"
+		ja: "赤いツノで 人や ポケモンの 温かな 気持ちを キャッチすると 全身が ほのかに 熱くなる。",
+		'zh-tw': "用紅色的角感知到人和寶可夢的溫情後，全身也會變得有點暖暖的。",
 	},
 
 	stage: "Basic",
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	attacks: [
+		{
+			name: { ja: "あやしいひかり" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560449,
+				tcgplayer: 569165,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [280],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/034.ts
+++ b/data-asia/S/S6H/034.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "奇魯莉安"
+		ja: "キルリア",
+		'zh-tw': "奇魯莉安",
 	},
 
 	illustrator: "0313",
@@ -14,18 +14,43 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "能夠操縱精神力量來扭曲周圍的空間，讓自己看見未來。"
+		ja: "サイコパワーを 操り まわりの 空間を ねじ曲げる ことで 未来を 見通す ことが できる。",
+		'zh-tw': "能夠操縱精神力量來扭曲周圍的空間，讓自己看見未來。",
 	},
 
 	stage: "Stage1",
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	attacks: [
+		{
+			name: { ja: "ミラージュステップ" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の山札から「キルリア」を3枚まで選び、ベンチに出す。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560450,
+				tcgplayer: 569166,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ラルトス",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [281],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/035.ts
+++ b/data-asia/S/S6H/035.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "沙奈朵"
+		ja: "サーナイト",
+		'zh-tw': "沙奈朵",
 	},
 
 	illustrator: "kodama",
@@ -14,18 +14,54 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "如果是為了保護訓練家，牠會不惜用盡自己的精神力量製造出小型黑洞。"
+		ja: "トレーナーを 守るためなら サイコパワーを 使いきり 小さな ブラックホールを つくりだす。",
+		'zh-tw': "如果是為了保護訓練家，牠會不惜用盡自己的精神力量製造出小型黑洞。",
 	},
 
 	stage: "Stage2",
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "アルカナシャイン" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を上から2枚見て、その中から基本エネルギーを好きなだけ選び、自分のポケモンに好きなようにつける。残りのカードは手札に加える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ブレインウェーブ" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[超]エネルギーの数×30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560451,
+				tcgplayer: 569167,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キルリア",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [282],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/036.ts
+++ b/data-asia/S/S6H/036.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "怨影娃娃"
+		ja: "カゲボウズ",
+		'zh-tw': "怨影娃娃",
 	},
 
 	illustrator: "OKACHEKE",
@@ -14,23 +14,37 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "不要去跟那些在黃昏時有怨影娃娃在排隊的人家來往。這是自古流傳下來的諺語。"
+		ja: "日暮れに カゲボウズが 並ぶような 家とは 付き合うな と いう 古い ことわざが 残っている。",
+		'zh-tw': "不要去跟那些在黃昏時有怨影娃娃在排隊的人家來往。這是自古流傳下來的諺語。",
 	},
 
 	stage: "Basic",
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
+	attacks: [
+		{
+			name: { ja: "おにび" },
+			damage: 20,
+			cost: ["Psychic"],
+		},
+	],
 
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560452,
+				tcgplayer: 569168,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [353],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/037.ts
+++ b/data-asia/S/S6H/037.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "詛咒娃娃"
+		ja: "ジュペッタ",
+		'zh-tw': "詛咒娃娃",
 	},
 
 	illustrator: "Megumi Higuchi",
@@ -14,23 +14,52 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "誕生自遭到捨棄時的怨念。據說只要讓牠感覺自己受到重視，牠就會滿意地變回原本的玩偶。"
+		ja: "捨てられた 怨念で 生まれる。 大切に されると 満足して 元の ヌイグルミに 戻るという。",
+		'zh-tw': "誕生自遭到捨棄時的怨念。據說只要讓牠感覺自己受到重視，牠就會滿意地變回原本的玩偶。",
 	},
 
 	stage: "Stage1",
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
+	attacks: [
+		{
+			name: { ja: "かくごのうらみ" },
+			damage: "20×",
+			cost: ["Psychic"],
+			effect: {
+				ja: "このポケモンにダメカンを7個までのせ、のせた数×20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ぶきみなひかり" },
+			damage: 50,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
 
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560453,
+				tcgplayer: 569169,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カゲボウズ",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [354],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/038.ts
+++ b/data-asia/S/S6H/038.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "沙河馬"
+		ja: "ヒポポタス",
+		'zh-tw': "沙河馬",
 	},
 
 	illustrator: "Yuya Oka",
@@ -14,18 +14,42 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "主要在白天活動。因為沙漠的夜晚會降溫，所以會鑽進沙子的深處睡覺。"
+		ja: "おもに 昼間に 活動する。 砂漠の夜は 冷えるので 砂の 奥深くに 潜って 眠る。",
+		'zh-tw': "主要在白天活動。因為沙漠的夜晚會降溫，所以會鑽進沙子的深處睡覺。",
 	},
 
 	stage: "Basic",
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 30,
+			cost: ["Fighting", "Colorless"],
+		},
+		{
+			name: { ja: "マッドショット" },
+			damage: 50,
+			cost: ["Fighting", "Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560454,
+				tcgplayer: 569170,
+			},
+		},
+	],
 
 	retreat: 4,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [449],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/039.ts
+++ b/data-asia/S/S6H/039.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "河馬獸"
+		ja: "カバルドン",
+		'zh-tw': "河馬獸",
 	},
 
 	illustrator: "Eri Yamaki",
@@ -14,18 +14,49 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "生氣的時候非常凶暴。會噴出儲存在體內的沙子來引發沙塵暴。"
+		ja: "怒らせると かなり 狂暴。 取りこんだ 砂を 噴き出して 砂嵐を 巻き起こす。",
+		'zh-tw': "生氣的時候非常凶暴。會噴出儲存在體內的沙子來引發沙塵暴。",
 	},
 
 	stage: "Stage1",
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	attacks: [
+		{
+			name: { ja: "ぶちかます" },
+			damage: 120,
+			cost: ["Fighting", "Fighting", "Colorless"],
+		},
+		{
+			name: { ja: "サンドプレス" },
+			damage: 220,
+			cost: ["Fighting", "Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560455,
+				tcgplayer: 569171,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒポポタス",
+	},
 
 	retreat: 4,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [450],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/040.ts
+++ b/data-asia/S/S6H/040.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "艾路雷朵"
+		ja: "エルレイド",
+		'zh-tw': "艾路雷朵",
 	},
 
 	illustrator: "NC Empire",
@@ -14,18 +14,52 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "能夠敏銳地感知到尋求幫助的感情，並且火速趕去援助對方。"
+		ja: "助けを 求める 感情を 敏感に キャッチ。 相手の もとへ 馳せ参じ 加勢するぞ。",
+		'zh-tw': "能夠敏銳地感知到尋求幫助的感情，並且火速趕去援助對方。",
 	},
 
 	stage: "Stage2",
 
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	attacks: [
+		{
+			name: { ja: "フェイント" },
+			damage: 60,
+			cost: ["Psychic"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "ダイナブレード" },
+			damage: "60×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手の場の「ポケモンV」の数×60ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560456,
+				tcgplayer: 569172,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キルリア",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [475],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/041.ts
+++ b/data-asia/S/S6H/041.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "岩狗狗"
+		ja: "イワンコ",
+		'zh-tw': "岩狗狗",
 	},
 
 	illustrator: "Yuu Nishida",
@@ -14,18 +14,40 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "會用脖子上的岩石來摩蹭，代表彼此感情深厚。但因為岩石很銳利，所以會很痛。"
+		ja: "首の 岩を こすりつけてくるのは 親愛の 証。 ただし 岩は 鋭いので かなり 痛いぞ。",
+		'zh-tw': "會用脖子上的岩石來摩蹭，代表彼此感情深厚。但因為岩石很銳利，所以會很痛。",
 	},
 
 	stage: "Basic",
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	attacks: [
+		{
+			name: { ja: "かみくだく" },
+			damage: 30,
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560457,
+				tcgplayer: 569173,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [744],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/042.ts
+++ b/data-asia/S/S6H/042.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鬃岩狼人"
+		ja: "ルガルガン",
+		'zh-tw': "鬃岩狼人",
 	},
 
 	illustrator: "Teeziro",
@@ -14,18 +14,44 @@ const card: Card = {
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "不集結成群，而是單獨生活。只會聽命於能夠引出自己力量的訓練家。"
+		ja: "群れを 作らず １匹で 暮らす。 自分の 力を 引き出してくれる トレーナーの いうことしか 聞かない。",
+		'zh-tw': "不集結成群，而是單獨生活。只會聽命於能夠引出自己力量的訓練家。",
 	},
 
 	stage: "Stage1",
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	attacks: [
+		{
+			name: { ja: "ローグファング" },
+			damage: "80+",
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "自分のトラッシュにある「いちげき」のポケモンの枚数×10ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560458,
+				tcgplayer: 569174,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イワンコ",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [745],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/043.ts
+++ b/data-asia/S/S6H/043.ts
@@ -1,27 +1,55 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "沙螺蟒V"
+		ja: "サダイジャV",
+		'zh-tw': "沙螺蟒V",
 	},
 
 	illustrator: "Shin Nagasawa",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Fighting"],
-	stage: "Basic",
-	suffix: "V",
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "すなのぼうへき" },
+			effect: {
+				ja: "このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ランドクラッシュ" },
+			damage: 140,
+			cost: ["Fighting", "Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560459,
+				tcgplayer: 569175,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [844],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/044.ts
+++ b/data-asia/S/S6H/044.ts
@@ -1,39 +1,64 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "沙螺蟒VMAX"
+		ja: "サダイジャVMAX",
+		'zh-tw': "沙螺蟒VMAX",
 	},
 
 	illustrator: "aky CG Works",
 	category: "Pokemon",
 	hp: 320,
 	types: ["Fighting"],
+
 	stage: "VMAX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "超極巨旋風氣旋"
+	attacks: [
+		{
+			name: {
+				ja: "サンドインパルス",
+				'zh-tw': "超極巨旋風氣旋",
+			},
+			damage: 60,
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のベンチポケモン全員にも、それぞれ20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "選擇自己的場上寶可夢身上附加的任意數量的能量，以任意方式改附於自己的寶可夢身上。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇自己的場上寶可夢身上附加的任意數量的能量，以任意方式改附於自己的寶可夢身上。"
+		{
+			name: { ja: "キョダイサイクロン" },
+			damage: 180,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについているエネルギーを好きなだけ選び、自分のポケモンに好きなようにつけ替える。",
+			},
 		},
+	],
 
-		damage: 180,
-		cost: ["Fighting", "Fighting", "Colorless"]
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560460,
+				tcgplayer: 569176,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "サダイジャV",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Triple Rare",
+	dexId: [844],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/045.ts
+++ b/data-asia/S/S6H/045.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伽勒爾 呆呆王"
+		ja: "ガラル ヤドキング",
+		'zh-tw': "伽勒爾 呆呆王",
 	},
 
 	illustrator: "Naoki Saito",
@@ -14,39 +14,58 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "會一邊吟唱詭怪的咒語，一邊混合吃進的東西和體內的毒素來製造可疑的藥。"
+		ja: "妖しげな 呪文を 唱えながら 食べた ものと 体内の 毒素を 混ぜて 怪しい 薬を 作る。",
+		'zh-tw': "會一邊吟唱詭怪的咒語，一邊混合吃進的東西和體內的毒素來製造可疑的藥。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "秘密藥"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ひみつのくすり",
+				'zh-tw': "秘密藥",
+			},
+			effect: {
+				ja: "自分の番に1回使える。自分のポケモンを1匹選び、コインを1回投げる。オモテなら、そのポケモンのHPを「90」回復する。ウラなら、そのポケモンにダメカンを3個のせる。",
+				'zh-tw': "在自己的回合時，可使用1次。選擇自己的1隻寶可夢，擲1次硬幣。若為正面，則將那隻寶可夢恢復「90」HP。若為反面，則在那隻寶可夢身上放置3個傷害指示物。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，可使用1次。選擇自己的1隻寶可夢，擲1次硬幣。若為正面，則將那隻寶可夢恢復「90」HP。若為反面，則在那隻寶可夢身上放置3個傷害指示物。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "噴汁"
+	attacks: [
+		{
+			name: {
+				ja: "しるをとばす",
+				'zh-tw': "噴汁",
+			},
+			damage: 90,
+			cost: ["Darkness", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 90,
-		cost: ["Darkness", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560461,
+				tcgplayer: 569177,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ガラル ヤドラン",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [199],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/046.ts
+++ b/data-asia/S/S6H/046.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "千針魚"
+		ja: "ハリーセン",
+		'zh-tw': "千針魚",
 	},
 
 	illustrator: "Anesaki Dynamic",
@@ -14,43 +14,58 @@ const card: Card = {
 	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "全身上下的小針是由鱗片變化而來的。如果被刺中的話，就會中毒並陷入昏迷。"
+		ja: "全身の 小さな 針は ウロコが 変化したもの。 刺さると 毒で 気を失う。",
+		'zh-tw': "全身上下的小針是由鱗片變化而來的。如果被刺中的話，就會中毒並陷入昏迷。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "破裂針"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "はれつばり",
+				'zh-tw': "破裂針",
+			},
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けてきぜつしたとき、ワザを使ったポケモンにダメカンを6個のせる。",
+				'zh-tw': "當這隻寶可夢在戰鬥場上受到對手的寶可夢招式的傷害而【氣絕】時，在使用招式的寶可夢身上放置6個傷害指示物。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "當這隻寶可夢在戰鬥場上受到對手的寶可夢招式的傷害而【氣絕】時，在使用招式的寶可夢身上放置6個傷害指示物。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "毒擊"
+	attacks: [
+		{
+			name: {
+				ja: "どくづき",
+				'zh-tw': "毒擊",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560462,
+				tcgplayer: 569178,
+			},
 		},
-
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [211],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/047.ts
+++ b/data-asia/S/S6H/047.ts
@@ -1,40 +1,62 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "酷豹V"
+		ja: "レパルダスV",
+		'zh-tw': "酷豹V",
 	},
 
 	illustrator: "Ayaka Yoshida",
 	category: "Pokemon",
 	hp: 190,
 	types: ["Darkness"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "暗影拆裂"
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かくしヅメ" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。おたがいの場のポケモンについている「ポケモンのどうぐ」を1枚選び、トラッシュする。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若希望，將這隻寶可夢與附加的卡，全部放回手牌。"
+	attacks: [
+		{
+			name: {
+				ja: "シャドーリッパー",
+				'zh-tw': "暗影拆裂",
+			},
+			damage: 110,
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンと、ついているすべてのカードを、手札にもどす。",
+				'zh-tw': "若希望，將這隻寶可夢與附加的卡，全部放回手牌。",
+			},
 		},
+	],
 
-		damage: 110,
-		cost: ["Darkness", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560463,
+				tcgplayer: 569179,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [510],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/048.ts
+++ b/data-asia/S/S6H/048.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "可可多拉"
+		ja: "ココドラ",
+		'zh-tw': "可可多拉",
 	},
 
 	illustrator: "Kyoko Umemoto",
@@ -14,39 +14,48 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "覆蓋全身的鋼鐵盔甲會在進化時全部脫落，然後長出新的盔甲。"
+		ja: "体を 覆う 鋼の よろいは 進化するとき ポロリと はがれ落ち 新しい よろいが 作られる。",
+		'zh-tw': "覆蓋全身的鋼鐵盔甲會在進化時全部脫落，然後長出新的盔甲。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "咬"
+	attacks: [
+		{
+			name: {
+				ja: "かじる",
+				'zh-tw': "咬",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
-
-		damage: 20,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "滾動衝撞"
+		{
+			name: {
+				ja: "ころがりタックル",
+				'zh-tw': "滾動衝撞",
+			},
+			damage: 50,
+			cost: ["Metal", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 50,
-		cost: ["Metal", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560464,
+				tcgplayer: 569180,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [304],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/049.ts
+++ b/data-asia/S/S6H/049.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "可多拉"
+		ja: "コドラ",
+		'zh-tw': "可多拉",
 	},
 
 	illustrator: "HYOGONOSUKE",
@@ -14,39 +14,52 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "有著用鋼甲撞擊岩石時產生的火花大小來顯示自己有多強大的習性。"
+		ja: "鋼の よろいを 岩に ぶつけた ときに 出る 火花の 大きさで 強さを アピールする 習性。",
+		'zh-tw': "有著用鋼甲撞擊岩石時產生的火花大小來顯示自己有多強大的習性。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "撞擊"
+	attacks: [
+		{
+			name: {
+				ja: "たいあたり",
+				'zh-tw': "撞擊",
+			},
+			damage: 50,
+			cost: ["Metal", "Colorless", "Colorless"],
 		},
-
-		damage: 50,
-		cost: ["Metal", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "金屬爪"
+		{
+			name: {
+				ja: "メタルクロー",
+				'zh-tw': "金屬爪",
+			},
+			damage: 90,
+			cost: ["Metal", "Metal", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 90,
-		cost: ["Metal", "Metal", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560465,
+				tcgplayer: 569181,
+			},
+		},
+	],
 
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ココドラ",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [305],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/050.ts
+++ b/data-asia/S/S6H/050.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "波士可多拉"
+		ja: "ボスゴドラ",
+		'zh-tw': "波士可多拉",
 	},
 
 	illustrator: "Teeziro",
@@ -14,47 +14,60 @@ const card: Card = {
 	types: ["Metal"],
 
 	description: {
-		'zh-tw': "會一邊用鋼角撞塌堅硬的岩盤，一邊挖掘隧道尋找鐵礦，用來作為自己的食物。"
+		ja: "鋼の ツノで 硬い 岩盤を 突き崩しながら 食料の 鉄を 探して トンネルを 掘る。",
+		'zh-tw': "會一邊用鋼角撞塌堅硬的岩盤，一邊挖掘隧道尋找鐵礦，用來作為自己的食物。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "防守壓制"
+	attacks: [
+		{
+			name: {
+				ja: "ガードプレス",
+				'zh-tw': "防守壓制",
+			},
+			damage: 100,
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-30」點。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-30」點。"
+		{
+			name: {
+				ja: "ちきゅうわり",
+				'zh-tw': "劈地球",
+			},
+			damage: 240,
+			cost: ["Metal", "Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のポケモン全員にも、それぞれ30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "自己的所有寶可夢也各受到30點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		damage: 100,
-		cost: ["Metal", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "劈地球"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560466,
+				tcgplayer: 569182,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "自己的所有寶可夢也各受到30點傷害。[在備戰區不計算弱點・抵抗力。]"
-		},
-
-		damage: 240,
-		cost: ["Metal", "Metal", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "コドラ",
+	},
 
 	retreat: 4,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [306],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/051.ts
+++ b/data-asia/S/S6H/051.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "肯泰羅"
+		ja: "ケンタロス",
+		'zh-tw': "肯泰羅",
 	},
 
 	illustrator: "nagimiso",
@@ -14,42 +14,56 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "會組成群體來生活。群體中角最粗、最長，且傷痕最多的就是老大。"
+		ja: "集団で 生活する。 群れの 中で １番 太く 長く キズだらけの ツノを持つのが ボス。",
+		'zh-tw': "會組成群體來生活。群體中角最粗、最長，且傷痕最多的就是老大。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "蠻牛"
+	attacks: [
+		{
+			name: {
+				ja: "レイジングブル",
+				'zh-tw': "蠻牛",
+			},
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数×20ダメージ追加。このポケモンをこんらんにする。",
+				'zh-tw': "增加這隻寶可夢身上放置的傷害指示物的數量×20點傷害。將這隻寶可夢【混亂】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "增加這隻寶可夢身上放置的傷害指示物的數量×20點傷害。將這隻寶可夢【混亂】。"
+		{
+			name: {
+				ja: "とっしん",
+				'zh-tw': "猛撞",
+			},
+			damage: 80,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+				'zh-tw': "這隻寶可夢也受到30點傷害。",
+			},
 		},
+	],
 
-		damage: "20+",
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "猛撞"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560467,
+				tcgplayer: 569183,
+			},
 		},
-
-		effect: {
-			'zh-tw': "這隻寶可夢也受到30點傷害。"
-		},
-
-		damage: 80,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [128],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/052.ts
+++ b/data-asia/S/S6H/052.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "多邊獸"
+		ja: "ポリゴン",
+		'zh-tw': "多邊獸",
 	},
 
 	illustrator: "ryoma uratsuka",
@@ -14,27 +14,40 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "在２０年前被夢想著能探索宇宙的科學家們創造出來。這個夢想至今仍未實現。"
+		ja: "２０年前 宇宙を 夢見た 科学者たちに よって 作られた。 未だ その夢は 叶っていない。",
+		'zh-tw': "在２０年前被夢想著能探索宇宙的科學家們創造出來。這個夢想至今仍未實現。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "稜角化"
+	attacks: [
+		{
+			name: {
+				ja: "かくばる",
+				'zh-tw': "稜角化",
+			},
+			damage: 20,
+			cost: ["Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560468,
+				tcgplayer: 569184,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [137],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/053.ts
+++ b/data-asia/S/S6H/053.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "多邊獸Ⅱ"
+		ja: "ポリゴン２",
+		'zh-tw': "多邊獸Ⅱ",
 	},
 
 	illustrator: "Nagomi Nijo",
@@ -14,31 +14,48 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "雖然在宇宙空間裡也不會死亡，但在無重力的環境下，牠根本無法順利活動身體。"
+		ja: "宇宙空間 でも 死なないが 無重力 では うまく 身動きを とることが できない。",
+		'zh-tw': "雖然在宇宙空間裡也不會死亡，但在無重力的環境下，牠根本無法順利活動身體。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "三重攻擊"
+	attacks: [
+		{
+			name: {
+				ja: "トライアタック",
+				'zh-tw': "三重攻擊",
+			},
+			damage: "30×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数×30ダメージ。",
+				'zh-tw': "擲3次硬幣，造成正面出現的次數×30點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲3次硬幣，造成正面出現的次數×30點傷害。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560469,
+				tcgplayer: 569185,
+			},
 		},
+	],
 
-		damage: "30×",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ポリゴン",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [233],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/054.ts
+++ b/data-asia/S/S6H/054.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "多邊獸Ｚ"
+		ja: "ポリゴンＺ",
+		'zh-tw': "多邊獸Ｚ",
 	},
 
 	illustrator: "Tomokazu Komiya",
@@ -14,43 +14,62 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "新追加的程式大有問題，做出的動作明顯地有些怪異。實驗或許可說是失敗了。"
+		ja: "追加した プログラムが まずかった。 おかしな 挙動が 目立つので 実験失敗 なのかも しれない。",
+		'zh-tw': "新追加的程式大有問題，做出的動作明顯地有些怪異。實驗或許可說是失敗了。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "漏洞傳輸"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "バグそうしん",
+				'zh-tw': "漏洞傳輸",
+			},
+			effect: {
+				ja: "自分の番に、自分の手札からエネルギーをこのポケモンにつけるたび、1回使える。相手のバトルポケモンをこんらんにする。",
+				'zh-tw': "在自己的回合，每次從自己的手牌將能量附於這隻寶可夢身上時，都可使用1次。將對手的戰鬥寶可夢【混亂】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，每次從自己的手牌將能量附於這隻寶可夢身上時，都可使用1次。將對手的戰鬥寶可夢【混亂】。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "超級光束"
+	attacks: [
+		{
+			name: {
+				ja: "スーパービーム",
+				'zh-tw': "超級光束",
+			},
+			damage: 170,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+				'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560698,
+				tcgplayer: 569186,
+			},
 		},
+	],
 
-		damage: 170,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ポリゴン２",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Rare",
+	dexId: [474],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/055.ts
+++ b/data-asia/S/S6H/055.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "熊寶寶"
+		ja: "ヒメグマ",
+		'zh-tw': "熊寶寶",
 	},
 
 	illustrator: "Mizue",
@@ -14,27 +14,40 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "有著在食物短缺的冬季來臨之前，將食物藏在各處的習性。"
+		ja: "食べ物が 減る 冬の前に あちこちに 食べ物を 隠す 習性を 持っている。",
+		'zh-tw': "有著在食物短缺的冬季來臨之前，將食物藏在各處的習性。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "抓"
+	attacks: [
+		{
+			name: {
+				ja: "ひっかく",
+				'zh-tw': "抓",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
+	],
 
-		damage: 10,
-		cost: ["Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560471,
+				tcgplayer: 569187,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [216],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/056.ts
+++ b/data-asia/S/S6H/056.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "圈圈熊"
+		ja: "リングマ",
+		'zh-tw': "圈圈熊",
 	},
 
 	illustrator: "Hasegawa Saki",
@@ -14,34 +14,52 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "雖然體型很大，但很擅長爬樹，會在樹上進食和睡覺。"
+		ja: "大きな 体の 持ち主だが 木登りが 上手で 木の 上で エサを 食べたり 寝たりする。",
+		'zh-tw': "雖然體型很大，但很擅長爬樹，會在樹上進食和睡覺。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "劈開"
+	attacks: [
+		{
+			name: {
+				ja: "きりさく",
+				'zh-tw': "劈開",
+			},
+			damage: 40,
+			cost: ["Colorless"],
 		},
-
-		damage: 40,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "擊倒"
+		{
+			name: {
+				ja: "はりたおす",
+				'zh-tw': "擊倒",
+			},
+			damage: 110,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 110,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560472,
+				tcgplayer: 569188,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒメグマ",
+	},
 
 	retreat: 3,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Uncommon",
+	dexId: [217],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/057.ts
+++ b/data-asia/S/S6H/057.ts
@@ -1,45 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "龍捲雲V"
+		ja: "トルネロスV",
+		'zh-tw': "龍捲雲V",
 	},
 
 	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Colorless"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "爆破之錘"
+	attacks: [
+		{
+			name: {
+				ja: "ふきぬける",
+				'zh-tw': "爆破之錘",
+			},
+			damage: "20+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "場にスタジアムが出ているなら、20ダメージ追加。",
+				'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。"
+		{
+			name: { ja: "ブラストハンマー" },
+			damage: 180,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
 		},
+	],
 
-		damage: 180,
-		cost: ["Colorless", "Colorless", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560473,
+				tcgplayer: 569189,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Double rare",
+	dexId: [641],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/058.ts
+++ b/data-asia/S/S6H/058.ts
@@ -1,44 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "龍捲雲VMAX"
+		ja: "トルネロスVMAX",
+		'zh-tw': "龍捲雲VMAX",
 	},
 
 	illustrator: "Mitsuhiro Arita",
 	category: "Pokemon",
 	hp: 320,
 	types: ["Colorless"],
+
 	stage: "VMAX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "極巨風塵"
+	attacks: [
+		{
+			name: {
+				ja: "ブラストウインド",
+				'zh-tw': "極巨風塵",
+			},
+			damage: 60,
+			cost: ["Colorless", "Colorless"],
 		},
-
-		effect: {
-			'zh-tw': "若場上有競技場卡，則增加120點傷害。然後，將那張競技場卡丟棄。"
+		{
+			name: { ja: "ダイフウジン" },
+			damage: "120+",
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "場にスタジアムが出ているなら、120ダメージ追加。その後、そのスタジアムをトラッシュする。",
+			},
 		},
+	],
 
-		damage: "120+",
-		cost: ["Colorless", "Colorless", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560474,
+				tcgplayer: 569190,
+			},
+		},
+	],
 
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "トルネロスV",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Triple Rare",
+	dexId: [641],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/059.ts
+++ b/data-asia/S/S6H/059.ts
@@ -1,11 +1,11 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "多麗米亞"
+		ja: "トリミアン",
+		'zh-tw': "多麗米亞",
 	},
 
 	illustrator: "Tika Matsuno",
@@ -14,41 +14,55 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "如果放著不管，體毛就會不斷變長，但牠只允許信賴的人幫自己修剪。"
+		ja: "放っておくと 体毛は どんどん 伸び続けるが 信頼した 者にしか カットは 許さない。",
+		'zh-tw': "如果放著不管，體毛就會不斷變長，但牠只允許信賴的人幫自己修剪。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "尋找朋友"
+	attacks: [
+		{
+			name: {
+				ja: "ともだちをさがす",
+				'zh-tw': "尋找朋友",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からポケモンを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		{
+			name: {
+				ja: "ファーアタック",
+				'zh-tw': "毛皮攻擊",
+			},
+			damage: 90,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-20」される。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-20」點。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "毛皮攻擊"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560475,
+				tcgplayer: 569191,
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-20」點。"
-		},
-
-		damage: 90,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "E",
+	rarity: "Common",
+	dexId: [676],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S6H/060.ts
+++ b/data-asia/S/S6H/060.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "生存組合"
+		ja: "サバイバルセット",
+		'zh-tw': "生存組合",
 	},
 
 	illustrator: "AYUMI ODASHIMA",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "查看自己的牌庫下方3張卡，以任意順序排列，放回牌庫上方。"
+		ja: "自分の山札を下から3枚見て、好きな順番に入れ替えて、山札の上にもどす。",
+		'zh-tw': "查看自己的牌庫下方3張卡，以任意順序排列，放回牌庫上方。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560476,
+				tcgplayer: 569192,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S6H/061.ts
+++ b/data-asia/S/S6H/061.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "粗硬頭盔"
+		ja: "いかついメット",
+		'zh-tw': "粗硬頭盔",
 	},
 
 	illustrator: "sadaji",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "當附有這張卡的寶可夢在戰鬥場受到對手的寶可夢招式的傷害時，選擇1個使用招式的寶可夢身上附加的能量，放回對手的手牌。"
+		ja: "このカードをつけているポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、ワザを使ったポケモンについているエネルギーを1個選び、相手の手札にもどす。",
+		'zh-tw': "當附有這張卡的寶可夢在戰鬥場受到對手的寶可夢招式的傷害時，選擇1個使用招式的寶可夢身上附加的能量，放回對手的手牌。",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560477,
+				tcgplayer: 569193,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Tool",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S6H/062.ts
+++ b/data-asia/S/S6H/062.ts
@@ -1,22 +1,44 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "一擊的卷軸 貫通之卷"
+		ja: "いちげきの巻物 貫通の巻",
+		'zh-tw': "一擊的卷軸 貫通之卷",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "附有這張卡的「一擊」寶可夢，可使用這張卡上寫的招式。[需要有足夠使用招式的能量。]火●●　槍彈突破　120這個招式的傷害不計算弱點・抵抗力、對手的戰鬥寶可夢身上的附加效果。"
+		ja: "このカードをつけている「いちげき」のポケモンは、このカードに書かれているワザを使える。［ワザを使うためのエネルギーは必要。］",
+		'zh-tw': "附有這張卡的「一擊」寶可夢，可使用這張卡上寫的招式。[需要有足夠使用招式的能量。]火●●　槍彈突破　120這個招式的傷害不計算弱點・抵抗力、對手的戰鬥寶可夢身上的附加效果。",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "E"
-}
+	attacks: [
+		{
+			name: { ja: "だんがんとっぱ" },
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、弱点・抵抗力と、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+	],
 
-export default card
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560478,
+				tcgplayer: 569194,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S6H/063.ts
+++ b/data-asia/S/S6H/063.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "防火手套"
+		ja: "耐火グローブ",
+		'zh-tw': "防火手套",
 	},
 
 	illustrator: "Toyste Beach",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "附有這張卡的寶可夢使用的招式，對對手的戰鬥場的【火】寶可夢造成的傷害「+30」點。"
+		ja: "このカードをつけているポケモンが使うワザの、相手のバトル場の[炎]ポケモンへのダメージは「+30」される。",
+		'zh-tw': "附有這張卡的寶可夢使用的招式，對對手的戰鬥場的【火】寶可夢造成的傷害「+30」點。",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560479,
+				tcgplayer: 569195,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Tool",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S6H/064.ts
+++ b/data-asia/S/S6H/064.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "破壞手套"
+		ja: "ブレイクグローブ",
+		'zh-tw': "破壞手套",
 	},
 
 	illustrator: "Toyste Beach",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "附有這張卡的寶可夢使用的招式，對對手的戰鬥場的【鋼】寶可夢造成的傷害「+30」點。"
+		ja: "このカードをつけているポケモンが使うワザの、相手のバトル場の[鋼]ポケモンへのダメージは「+30」される。",
+		'zh-tw': "附有這張卡的寶可夢使用的招式，對對手的戰鬥場的【鋼】寶可夢造成的傷害「+30」點。",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560480,
+				tcgplayer: 569196,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Tool",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S6H/065.ts
+++ b/data-asia/S/S6H/065.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "亞莎"
+		ja: "アスナ",
+		'zh-tw': "亞莎",
 	},
 
 	illustrator: "Megumi Mizutani",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "選擇對手的場上寶可夢身上附加的「特殊能量」卡與場上的「競技場」卡各1張，將其丟棄。"
+		ja: "相手の場のポケモンについている「特殊エネルギー」と場に出ている「スタジアム」を1枚ずつ選び、トラッシュする。",
+		'zh-tw': "選擇對手的場上寶可夢身上附加的「特殊能量」卡與場上的「競技場」卡各1張，將其丟棄。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560482,
+				tcgplayer: 569197,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S6H/066.ts
+++ b/data-asia/S/S6H/066.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "醫生"
+		ja: "ドクター",
+		'zh-tw': "醫生",
 	},
 
 	illustrator: "Megumi Mizutani",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的牌庫抽出2張卡。若對手的戰鬥寶可夢為「寶可夢【VMAX】」，則再抽出2張卡。"
+		ja: "自分の山札を2枚引く。相手のバトルポケモンが「ポケモンVMAX」なら、さらに2枚引く。",
+		'zh-tw': "從自己的牌庫抽出2張卡。若對手的戰鬥寶可夢為「寶可夢【VMAX】」，則再抽出2張卡。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560484,
+				tcgplayer: 569198,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S6H/067.ts
+++ b/data-asia/S/S6H/067.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "皮歐尼"
+		ja: "ピオニー",
+		'zh-tw': "皮歐尼",
 	},
 
 	illustrator: "Ken Sugimori",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "將自己的手牌全部丟棄，從自己的牌庫選擇最多2張訓練家卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		ja: "自分の手札をすべてトラッシュし、自分の山札からトレーナーズを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+		'zh-tw': "將自己的手牌全部丟棄，從自己的牌庫選擇最多2張訓練家卡，在給對手看過後加入手牌。並且重洗牌庫。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560486,
+				tcgplayer: 569199,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S6H/068.ts
+++ b/data-asia/S/S6H/068.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "美蓉"
+		ja: "メロン",
+		'zh-tw': "美蓉",
 	},
 
 	illustrator: "take",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的棄牌區選擇1張【水】能量卡，附於自己的「寶可夢【V】」身上。然後，從自己的牌庫抽出3張卡。"
+		ja: "自分のトラッシュから[水]エネルギーを1枚選び、自分の「ポケモンV」につける。その後、自分の山札を3枚引く。",
+		'zh-tw': "從自己的棄牌區選擇1張【水】能量卡，附於自己的「寶可夢【V】」身上。然後，從自己的牌庫抽出3張卡。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560489,
+				tcgplayer: 569200,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S6H/069.ts
+++ b/data-asia/S/S6H/069.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "通頂雪道"
+		ja: "頂への雪道",
+		'zh-tw': "通頂雪道",
 	},
 
 	illustrator: "Oswaldo KATO",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "雙方場上的「擁有規則的寶可夢」的特性全部消除。"
+		ja: "おたがいの場の「ルールを持つポケモン」の特性は、すべてなくなる。",
+		'zh-tw': "雙方場上的「擁有規則的寶可夢」的特性全部消除。",
 	},
 
-	trainerType: "Stadium",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560491,
+				tcgplayer: 569201,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Stadium",
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S6H/070.ts
+++ b/data-asia/S/S6H/070.ts
@@ -1,21 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S6H"
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "衝擊能量"
+		ja: "インパクトエネルギー",
+		'zh-tw': "衝擊能量",
 	},
 
+	illustrator: "",
 	category: "Energy",
+	energyType: "Special",
 
 	effect: {
-		'zh-tw': "這張卡只可附於「一擊」寶可夢身上，若附於「一擊」寶可夢以外的寶可夢身上，則將其丟棄。這張卡只要附於寶可夢身上，視為提供1個所有屬性的能量，附有這張卡的寶可夢不會【中毒】，受到的【中毒】會恢復。"
+		ja: "このカードは「いちげき」のポケモンにしかつけられず、「いちげき」のポケモン以外についているなら、トラッシュする。このカードは、ポケモンについているかぎり、すべてのタイプのエネルギー1個ぶんとしてはたらき、このカードをつけているポケモンはどくにならず、受けているどくは、すべて回復する。",
+		'zh-tw': "這張卡只可附於「一擊」寶可夢身上，若附於「一擊」寶可夢以外的寶可夢身上，則將其丟棄。這張卡只要附於寶可夢身上，視為提供1個所有屬性的能量，附有這張卡的寶可夢不會【中毒】，受到的【中毒】會恢復。",
 	},
 
-	energyType: "Special",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 560492,
+				tcgplayer: 569202,
+			},
+		},
+	],
 
-export default card
+	regulationMark: "E",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/S/S6H/071.ts
+++ b/data-asia/S/S6H/071.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ボルケニオンV",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ヒートブラスト" },
+			damage: 50,
+			cost: ["Fire", "Colorless"],
+		},
+		{
+			name: { ja: "ダイナマイトタックル" },
+			damage: "100+",
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンにダメカンが10個以上のっているなら、150ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560948,
+				tcgplayer: 569203,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [721],
+};
+
+export default card;

--- a/data-asia/S/S6H/072.ts
+++ b/data-asia/S/S6H/072.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "はくばバドレックスV",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つきさす" },
+			damage: 40,
+			cost: ["Water"],
+		},
+		{
+			name: { ja: "ブリザードランス" },
+			damage: 200,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560949,
+				tcgplayer: 569204,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [898],
+};
+
+export default card;

--- a/data-asia/S/S6H/073.ts
+++ b/data-asia/S/S6H/073.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "はくばバドレックスV",
+	},
+
+	illustrator: "OKACHEKE",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つきさす" },
+			damage: 40,
+			cost: ["Water"],
+		},
+		{
+			name: { ja: "ブリザードランス" },
+			damage: 200,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560950,
+				tcgplayer: 569205,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [898],
+};
+
+export default card;

--- a/data-asia/S/S6H/074.ts
+++ b/data-asia/S/S6H/074.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガラル ギャロップV",
+	},
+
+	illustrator: "Saki Hayashiro",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "リブラホーン" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、そのポケモンの残りHPが「100」になるように、ダメカンをのせる。",
+			},
+		},
+		{
+			name: { ja: "サイコキネシス" },
+			damage: "60+",
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数×30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560951,
+				tcgplayer: 569206,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [78],
+};
+
+export default card;

--- a/data-asia/S/S6H/075.ts
+++ b/data-asia/S/S6H/075.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガラル ギャロップV",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "リブラホーン" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、そのポケモンの残りHPが「100」になるように、ダメカンをのせる。",
+			},
+		},
+		{
+			name: { ja: "サイコキネシス" },
+			damage: "60+",
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数×30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560952,
+				tcgplayer: 569207,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [78],
+};
+
+export default card;

--- a/data-asia/S/S6H/076.ts
+++ b/data-asia/S/S6H/076.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サダイジャV",
+	},
+
+	illustrator: "PLANETA Tsuji",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "すなのぼうへき" },
+			effect: {
+				ja: "このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ランドクラッシュ" },
+			damage: 140,
+			cost: ["Fighting", "Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560953,
+				tcgplayer: 569208,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [844],
+};
+
+export default card;

--- a/data-asia/S/S6H/077.ts
+++ b/data-asia/S/S6H/077.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レパルダスV",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かくしヅメ" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。おたがいの場のポケモンについている「ポケモンのどうぐ」を1枚選び、トラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "シャドーリッパー" },
+			damage: 110,
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンと、ついているすべてのカードを、手札にもどす。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560954,
+				tcgplayer: 569209,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [510],
+};
+
+export default card;

--- a/data-asia/S/S6H/078.ts
+++ b/data-asia/S/S6H/078.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トルネロスV",
+	},
+
+	illustrator: "PLANETA Mochizuki",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふきぬける" },
+			damage: "20+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "場にスタジアムが出ているなら、20ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ブラストハンマー" },
+			damage: 180,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560955,
+				tcgplayer: 569210,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [641],
+};
+
+export default card;

--- a/data-asia/S/S6H/079.ts
+++ b/data-asia/S/S6H/079.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トルネロスV",
+	},
+
+	illustrator: "tetsuya koizumi",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふきぬける" },
+			damage: "20+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "場にスタジアムが出ているなら、20ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ブラストハンマー" },
+			damage: 180,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560956,
+				tcgplayer: 569211,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+	dexId: [641],
+};
+
+export default card;

--- a/data-asia/S/S6H/080.ts
+++ b/data-asia/S/S6H/080.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アスナ",
+	},
+
+	illustrator: "Ryuta Fuse",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手の場のポケモンについている「特殊エネルギー」と場に出ている「スタジアム」を1枚ずつ選び、トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560957,
+				tcgplayer: 569212,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S6H/081.ts
+++ b/data-asia/S/S6H/081.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドクター",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を2枚引く。相手のバトルポケモンが「ポケモンVMAX」なら、さらに2枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560958,
+				tcgplayer: 569213,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S6H/082.ts
+++ b/data-asia/S/S6H/082.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピオニー",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札をすべてトラッシュし、自分の山札からトレーナーズを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560959,
+				tcgplayer: 569214,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S6H/083.ts
+++ b/data-asia/S/S6H/083.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メロン",
+	},
+
+	illustrator: "Taira Akitsu",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュから[水]エネルギーを1枚選び、自分の「ポケモンV」につける。その後、自分の山札を3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560960,
+				tcgplayer: 569215,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/S/S6H/084.ts
+++ b/data-asia/S/S6H/084.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "はくばバドレックスVMAX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 320,
+	types: ["Water"],
+
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: { ja: "エンペラーライド" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数×30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ダイランス" },
+			damage: "10+",
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "のぞむなら、このポケモンについているエネルギーを2枚まで選び、トラッシュする。その場合、トラッシュした枚数×120ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560961,
+				tcgplayer: 569216,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "はくばバドレックスV",
+	},
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Hyper rare",
+	dexId: [898],
+};
+
+export default card;

--- a/data-asia/S/S6H/085.ts
+++ b/data-asia/S/S6H/085.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "はくばバドレックスVMAX",
+	},
+
+	illustrator: "Oswaldo KATO",
+	category: "Pokemon",
+	hp: 320,
+	types: ["Water"],
+
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: { ja: "エンペラーライド" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数×30ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ダイランス" },
+			damage: "10+",
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "のぞむなら、このポケモンについているエネルギーを2枚まで選び、トラッシュする。その場合、トラッシュした枚数×120ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560494,
+				tcgplayer: 569217,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "はくばバドレックスV",
+	},
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Secret Rare",
+	dexId: [898],
+};
+
+export default card;

--- a/data-asia/S/S6H/086.ts
+++ b/data-asia/S/S6H/086.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サダイジャVMAX",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 320,
+	types: ["Fighting"],
+
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: { ja: "サンドインパルス" },
+			damage: 60,
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のベンチポケモン全員にも、それぞれ20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "キョダイサイクロン" },
+			damage: 180,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "自分の場のポケモンについているエネルギーを好きなだけ選び、自分のポケモンに好きなようにつけ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560962,
+				tcgplayer: 569218,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "サダイジャV",
+	},
+
+	retreat: 3,
+	regulationMark: "E",
+	rarity: "Hyper rare",
+	dexId: [844],
+};
+
+export default card;

--- a/data-asia/S/S6H/087.ts
+++ b/data-asia/S/S6H/087.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トルネロスVMAX",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 320,
+	types: ["Colorless"],
+
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: { ja: "ブラストウインド" },
+			damage: 60,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ダイフウジン" },
+			damage: "120+",
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "場にスタジアムが出ているなら、120ダメージ追加。その後、そのスタジアムをトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560963,
+				tcgplayer: 569219,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "トルネロスV",
+	},
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Hyper rare",
+	dexId: [641],
+};
+
+export default card;

--- a/data-asia/S/S6H/088.ts
+++ b/data-asia/S/S6H/088.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アスナ",
+	},
+
+	illustrator: "Ryta Fuse",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手の場のポケモンについている「特殊エネルギー」と場に出ている「スタジアム」を1枚ずつ選び、トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560964,
+				tcgplayer: 569220,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Hyper rare",
+};
+
+export default card;

--- a/data-asia/S/S6H/089.ts
+++ b/data-asia/S/S6H/089.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドクター",
+	},
+
+	illustrator: "Sonosuke Skauma",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を2枚引く。相手のバトルポケモンが「ポケモンVMAX」なら、さらに2枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560965,
+				tcgplayer: 569221,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Hyper rare",
+};
+
+export default card;

--- a/data-asia/S/S6H/090.ts
+++ b/data-asia/S/S6H/090.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピオニー",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札をすべてトラッシュし、自分の山札からトレーナーズを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560966,
+				tcgplayer: 569222,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Hyper rare",
+};
+
+export default card;

--- a/data-asia/S/S6H/091.ts
+++ b/data-asia/S/S6H/091.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メロン",
+	},
+
+	illustrator: "Taira Akitsu",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュから[水]エネルギーを1枚選び、自分の「ポケモンV」につける。その後、自分の山札を3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560967,
+				tcgplayer: 569223,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Hyper rare",
+};
+
+export default card;

--- a/data-asia/S/S6H/092.ts
+++ b/data-asia/S/S6H/092.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドータクン",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Metal"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ひっぱたく" },
+			damage: 40,
+			cost: ["Metal"],
+		},
+		{
+			name: { ja: "メタルブロック" },
+			damage: 120,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが進化ポケモンから受けるワザのダメージは「-100」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560968,
+				tcgplayer: 569224,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ドーミラー",
+	},
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Secret Rare",
+	dexId: [437],
+};
+
+export default card;

--- a/data-asia/S/S6H/093.ts
+++ b/data-asia/S/S6H/093.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "おむかえちょうちん",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュから「いちげき」のサポートを1枚選び、相手に見せて、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560969,
+				tcgplayer: 569225,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "E",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/S/S6H/094.ts
+++ b/data-asia/S/S6H/094.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "いかついメット",
+	},
+
+	illustrator: "sadaji",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、ワザを使ったポケモンについているエネルギーを1個選び、相手の手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560970,
+				tcgplayer: 569226,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "E",
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/data-asia/S/S6H/095.ts
+++ b/data-asia/S/S6H/095.ts
@@ -1,0 +1,27 @@
+import { Card } from "../../../interfaces";
+import Set from "../S6H";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本水エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 560971,
+				tcgplayer: 577289,
+			},
+		},
+	],
+
+	rarity: "Secret Rare",
+};
+
+export default card;

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -236,6 +236,7 @@ export interface Card {
 			// Black White rare
 			| 'Black White Rare'
 			| 'Mega Hyper Rare'
+			| 'Triple Rare'
 			// Japanese Character Rares (since SM11b Dream League)
 			| 'Character Rare' | 'Character Super Rare'
 			// Pokémon TCG Pocket Rarities


### PR DESCRIPTION
## What

Refreshes the existing Japanese set **S6H 白銀のランス (Silver Lance)** from its primary sources. The curated content stays: every card keeps its `zh-tw` texts verbatim.

What changes across the 95 card files:

- `thirdParty.cardmarket` moves onto `variants` objects and 70 missing ids are filled in
- per card where missing: `dexId`, `evolveFrom`, `resistances`, the Japanese flavor text and the Japanese effect/attack texts straight from the official database and limitless

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (560417–560971)
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (569133–577289), keyed by the collection number each product carries in `extendedData`

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- 062 is a Pokémon Tool that grant an attack — modeled as `effect` + `attacks`, like their English prints
- All 95 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
