### PR TITLE
(data) Update Japanese SV set SV-P Scarlet & Violet Promotional Cards

### DIFF
--- a/data-asia/SV/SV-P.ts
+++ b/data-asia/SV/SV-P.ts
@@ -4,6 +4,7 @@ import serie from '../SV'
 const set: Set = {
 	id: 'SV-P',
 	name: {
+		ja: 'スカーレット&バイオレット プロモカード',
 		'zh-tw': '特典卡 朱&紫',
 		th: 'การ์ดโปรโม สการ์เล็ต แอนด์ ไวโอเล็ต',
 		id: 'Kartu Promo'
@@ -15,6 +16,7 @@ const set: Set = {
 		official: 0
 	},
 	releaseDate: {
+		ja: '2022-11-29',
 		'zh-tw': '2023-01-26',
 		id: '2023-03-03',
 		th: '2023-02-24'

--- a/data-asia/SV/SV-P/001.ts
+++ b/data-asia/SV/SV-P/001.ts
@@ -1,48 +1,61 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
+		ja: "ピカチュウ",
 		'zh-tw': "皮卡丘",
-		th: "วาไนเดอร์"
+		th: "วาไนเดอร์",
 	},
 
-	illustrator: "Anesaki Dynamic",
+	illustrator: "Atsushi Furusawa",
 	category: "Pokemon",
-	hp: 120,
-	types: ["Grass"],
+	hp: 60,
+	types: ["Lightning"],
 
 	description: {
+		ja: "甘えん坊なニャオハ のんびりやのホゲータ きれい好きなクワッス。 新しい仲間との冒険を ピカチュウも楽しみにしているみたい！",
 		'zh-tw': "愛撒嬌的新葉喵，溫溫吞吞的呆火鱷，愛乾淨的潤水鴨。皮卡丘好像也很期待即將和新夥伴們一起展開的冒險！",
-		th: "ใช้ใยในการห้อยตัวจากกิ่งไม้หรือเพดานและเคลื่อนไหวอย่างเงียบเชียบ จัดการเหยื่อก่อนที่พวกมันจะรู้ตัว"
+		th: "ใช้ใยในการห้อยตัวจากกิ่งไม้หรือเพดานและเคลื่อนไหวอย่างเงียบเชียบ จัดการเหยื่อก่อนที่พวกมันจะรู้ตัว",
 	},
 
-	stage: "Stage1",
+	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "一同冒險",
-			th: "ผูกรัดด้วยใย"
+	attacks: [
+		{
+			name: {
+				ja: "みんなでぼうけん",
+				'zh-tw': "一同冒險",
+				th: "ผูกรัดด้วยใย",
+			},
+			damage: "30+",
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "自分のベンチポケモンの数×10ダメージ追加。",
+				'zh-tw': "增加自己的備戰寶可夢的數量×10點傷害。",
+				th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว จะทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[ชา]",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加自己的備戰寶可夢的數量×10點傷害。",
-			th: "ทอยเหรียญ 1 ครั้งถ้าออกหัว จะทำให้โปเกมอนบนตำแหน่งต่อสู้ฝ่ายตรงข้ามเป็นสภาวะ[ชา]"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 687450,
+				tcgplayer: 587758,
+			},
 		},
-
-		damage: 30,
-		cost: ["Lightning", "Lightning", "Lightning"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "G"
-}
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [25],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV-P/002.ts
+++ b/data-asia/SV/SV-P/002.ts
@@ -1,44 +1,66 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "新葉喵"
+		ja: "ワナイダー",
+		'zh-tw': "新葉喵",
 	},
 
-	illustrator: "Yuu Nishida",
+	illustrator: "Anesaki Dynamic",
 	category: "Pokemon",
-	hp: 70,
+	hp: 120,
 	types: ["Grass"],
 
 	description: {
-		'zh-tw': "毛茸茸的體毛有著 近似於植物的成分。 會勤快地洗臉以防止乾燥。"
+		ja: "木の枝や 天井に 糸で 張りつき 音もなく 行動する。 獲物に 気づかれる前に 倒す。",
+		'zh-tw': "毛茸茸的體毛有著 近似於植物的成分。 會勤快地洗臉以防止乾燥。",
 	},
 
-	stage: "Basic",
+	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "小吸取"
+	attacks: [
+		{
+			name: {
+				ja: "いとでしばる",
+				'zh-tw': "小吸取",
+			},
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+				'zh-tw': "將這隻寶可夢恢復「10」HP。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將這隻寶可夢恢復「10」HP。"
+		{
+			name: { ja: "ジェットヘッド" },
+			damage: 100,
+			cost: ["Grass", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 10,
-		cost: ["Grass"]
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692248,
+				tcgplayer: 587759,
+			},
+		},
+	],
 
-	retreat: 1,
-	regulationMark: "G"
-}
+	evolveFrom: {
+		ja: "タマンチュラ",
+	},
 
-export default card
+	retreat: 2,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [918],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/003.ts
+++ b/data-asia/SV/SV-P/003.ts
@@ -1,44 +1,66 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "呆火鱷"
+		ja: "ウインディ",
+		'zh-tw': "呆火鱷",
 	},
 
 	illustrator: "Ryuta Fuse",
 	category: "Pokemon",
-	hp: 80,
+	hp: 130,
 	types: ["Fire"],
 
 	description: {
-		'zh-tw': "會躺在溫熱的岩石上， 用四角形的鱗片所吸收的 熱能來製造火之能量。"
+		ja: "草原を 駆け抜ける 様子は 人々の 心を 虜にしたと 昔の 絵巻に 記されていた。",
+		'zh-tw': "會躺在溫熱的岩石上， 用四角形的鱗片所吸收的 熱能來製造火之能量。",
 	},
 
-	stage: "Basic",
+	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "火焰灼燒"
+	attacks: [
+		{
+			name: {
+				ja: "かみくだく",
+				'zh-tw': "火焰灼燒",
+			},
+			damage: 30,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "將對手的戰鬥寶可夢【灼傷】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【灼傷】。"
+		{
+			name: { ja: "ほのおのたてがみ" },
+			damage: 120,
+			cost: ["Fire", "Fire", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Fire", "Fire", "Colorless"]
-	}],
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692249,
+				tcgplayer: 587760,
+			},
+		},
+	],
 
-	retreat: 2,
-	regulationMark: "G"
-}
+	evolveFrom: {
+		ja: "ガーディ",
+	},
 
-export default card
+	retreat: 3,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [59],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/004.ts
+++ b/data-asia/SV/SV-P/004.ts
@@ -1,44 +1,61 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "潤水鴨"
+		ja: "ヘイラッシャ",
+		'zh-tw': "潤水鴨",
 	},
 
-	illustrator: "Narumi Sato",
+	illustrator: "Shin Nagasawa",
 	category: "Pokemon",
-	hp: 70,
+	hp: 150,
 	types: ["Water"],
 
 	description: {
-		'zh-tw': "很久以前從遠方來到了 這裡棲息。羽毛分泌出的 凝膠有防水和防污的效果。"
+		ja: "大食らいだが エサを 取るのは 苦手。 シャリタツと コンビを 組んで 獲物を 捕らえるのだ。",
+		'zh-tw': "很久以前從遠方來到了 這裡棲息。羽毛分泌出的 凝膠有防水和防污的效果。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "水沫"
+	attacks: [
+		{
+			name: {
+				ja: "ぶちかます",
+				'zh-tw': "水沫",
+			},
+			damage: 60,
+			cost: ["Water", "Colorless", "Colorless"],
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則增加20點傷害。"
+		{
+			name: { ja: "ひっさつウェーブ" },
+			damage: "100+",
+			cost: ["Water", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、すべてオモテなら、100ダメージ追加。",
+			},
 		},
+	],
 
-		damage: "20+",
-		cost: ["Water", "Colorless"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692251,
+				tcgplayer: 587761,
+			},
+		},
+	],
 
-	retreat: 1,
-	regulationMark: "G"
-}
+	retreat: 4,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [977],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV-P/005.ts
+++ b/data-asia/SV/SV-P/005.ts
@@ -1,51 +1,64 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "操陷蛛"
+		ja: "ミライドン",
+		'zh-tw': "操陷蛛",
 	},
 
-	illustrator: "Anesaki Dynamic",
+	illustrator: "Kouki Saitou",
 	category: "Pokemon",
 	hp: 120,
-	types: ["Grass"],
+	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "用絲線吸附在樹枝或天花板上 無聲無息地移動。會在自己 被察覺到之前將獵物打倒。"
+		ja: "詳細は よく わかっていない。 モトトカゲに 似た 印象だが はるかに 強く 冷酷なのだ。",
+		'zh-tw': "用絲線吸附在樹枝或天花板上 無聲無息地移動。會在自己 被察覺到之前將獵物打倒。",
 	},
 
-	stage: "Stage1",
+	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "千絲束縛"
+	attacks: [
+		{
+			name: {
+				ja: "するどいキバ",
+				'zh-tw': "千絲束縛",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。"
+		{
+			name: {
+				ja: "ライトニングレーザー",
+				'zh-tw': "噴射頭擊",
+			},
+			damage: 90,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Grass"]
-	}, {
-		name: {
-			'zh-tw': "噴射頭擊"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692252,
+				tcgplayer: 587762,
+			},
 		},
+	],
 
-		damage: 100,
-		cost: ["Grass", "Colorless", "Colorless"]
-	}],
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [1008],
+};
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/006.ts
+++ b/data-asia/SV/SV-P/006.ts
@@ -1,51 +1,69 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "風速狗"
+		ja: "クエスパトラ",
+		'zh-tw': "風速狗",
 	},
 
-	illustrator: "Ryuta Fuse",
+	illustrator: "Sanosuke Sakuma",
 	category: "Pokemon",
-	hp: 130,
-	types: ["Fire"],
+	hp: 110,
+	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "根據過去的畫軸記載， 牠在草原上奔馳的姿態 擄獲了眾多人心。"
+		ja: "大きな 瞳から サイコパワーを 浴びせて 相手を 動けなくする。 見かけによらず 気性は 荒い。",
+		'zh-tw': "根據過去的畫軸記載， 牠在草原上奔馳的姿態 擄獲了眾多人心。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "咬碎"
+	attacks: [
+		{
+			name: {
+				ja: "オーロラゲイン",
+				'zh-tw': "咬碎",
+			},
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+				'zh-tw': "擲1次硬幣若為正面，則選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。"
+		{
+			name: {
+				ja: "ちょうねんりき",
+				'zh-tw': "火之鬃",
+			},
+			damage: 60,
+			cost: ["Psychic", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Fire", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "火之鬃"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692253,
+				tcgplayer: 587763,
+			},
 		},
+	],
 
-		damage: 120,
-		cost: ["Fire", "Fire", "Colorless"]
-	}],
+	evolveFrom: {
+		ja: "ヒラヒナ",
+	},
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	retreat: 0,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [956],
+};
 
-	retreat: 3,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/007.ts
+++ b/data-asia/SV/SV-P/007.ts
@@ -1,51 +1,65 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "吃吼霸"
+		ja: "コライドン",
+		'zh-tw': "吃吼霸",
 	},
 
-	illustrator: "Shin Nagasawa",
+	illustrator: "Kouki Saitou",
 	category: "Pokemon",
-	hp: 150,
-	types: ["Water"],
+	hp: 130,
+	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "雖然是個大胃王， 但不擅長捕食。 會和米立龍聯手捕捉獵物。"
+		ja: "拳で 大地を 引き裂いたと 古い 探検記に 記された ツバサノオウの 正体らしい。",
+		'zh-tw': "雖然是個大胃王， 但不擅長捕食。 會和米立龍聯手捕捉獵物。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "頭突"
+	attacks: [
+		{
+			name: {
+				ja: "ツメできりさく",
+				'zh-tw': "頭突",
+			},
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
-
-		damage: 60,
-		cost: ["Water", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "必殺波"
+		{
+			name: {
+				ja: "ランページファング",
+				'zh-tw': "必殺波",
+			},
+			damage: 190,
+			cost: ["Fighting", "Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを3個選び、トラッシュする。",
+				'zh-tw': "擲2次硬幣，若全部為正面，則增加100點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲2次硬幣，若全部為正面，則增加100點傷害。"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692254,
+				tcgplayer: 587764,
+			},
 		},
+	],
 
-		damage: "100+",
-		cost: ["Water", "Colorless", "Colorless", "Colorless"]
-	}],
+	retreat: 2,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [1007],
+};
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	retreat: 4,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/008.ts
+++ b/data-asia/SV/SV-P/008.ts
@@ -1,51 +1,69 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "密勒頓"
+		ja: "パフュートン",
+		'zh-tw': "密勒頓",
 	},
 
-	illustrator: "Kouki Saitou",
+	illustrator: "kirisAki",
 	category: "Pokemon",
 	hp: 120,
-	types: ["Lightning"],
+	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "詳情目前仍然不明。雖然給人 貌似摩托蜥的印象，但力量和 冷酷的程度可說是天壤之別。"
+		ja: "きめ細かく 艶やかな 肌が 自慢。 尻尾の 先端から 凝縮した 香りを 放つ。",
+		'zh-tw': "詳情目前仍然不明。雖然給人 貌似摩托蜥的印象，但力量和 冷酷的程度可說是天壤之別。",
 	},
 
-	stage: "Basic",
+	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "銳利之牙"
+	attacks: [
+		{
+			name: {
+				ja: "ぶつかる",
+				'zh-tw': "銳利之牙",
+			},
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
 		},
-
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "雷電鐳射"
+		{
+			name: {
+				ja: "レッグスタンプ",
+				'zh-tw': "雷電鐳射",
+			},
+			damage: 130,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、次の自分の番、このポケモンはワザが使えない。",
+				'zh-tw': "對手的1隻備戰寶可夢也受到30點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "對手的1隻備戰寶可夢也受到30點傷害。[在備戰區不計算弱點・抵抗力。]"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692255,
+				tcgplayer: 587765,
+			},
 		},
+	],
 
-		damage: 90,
-		cost: ["Lightning", "Lightning", "Colorless"]
-	}],
+	evolveFrom: {
+		ja: "グルトン",
+	},
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	retreat: 2,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [916],
+};
 
-	retreat: 1,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/009.ts
+++ b/data-asia/SV/SV-P/009.ts
@@ -1,56 +1,65 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "超能豔鴕"
+		ja: "モトトカゲex",
+		'zh-tw': "超能豔鴕",
 	},
 
-	illustrator: "Sanosuke Sakuma",
+	illustrator: "5ban Graphics",
 	category: "Pokemon",
-	hp: 110,
-	types: ["Psychic"],
+	hp: 210,
+	types: ["Colorless"],
 
-	description: {
-		'zh-tw': "會從大大的眼睛放出 精神力量讓對手無法動彈。 有別外表，性格非常粗暴。"
-	},
+	stage: "Basic",
 
-	stage: "Stage1",
-
-	attacks: [{
-		name: {
-			'zh-tw': "極光增輝"
+	attacks: [
+		{
+			name: {
+				ja: "パワーラン",
+				'zh-tw': "極光增輝",
+			},
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から基本エネルギーを1枚選び、このポケモンにつける。そして山札を切る。",
+				'zh-tw': "將這隻寶可夢恢復「30」HP。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將這隻寶可夢恢復「30」HP。"
+		{
+			name: {
+				ja: "フルスロットル",
+				'zh-tw': "超念力",
+			},
+			damage: 180,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "超念力"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 691009,
+				tcgplayer: 587766,
+			},
 		},
+	],
 
-		damage: 60,
-		cost: ["Psychic", "Colorless"]
-	}],
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [967],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
+	suffix: "EX",
+};
 
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
-
-	retreat: 0,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/010.ts
+++ b/data-asia/SV/SV-P/010.ts
@@ -1,51 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "故勒頓"
+		ja: "モンスターボール",
+		'zh-tw': "故勒頓",
 	},
 
-	illustrator: "Kouki Saitou",
-	category: "Pokemon",
-	hp: 130,
-	types: ["Fighting"],
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "牠似乎就是古老的探險記裡 提到的翼大王的真面目。 據記載，牠曾以拳頭擊裂大地。"
+	effect: {
+		ja: "コインを1回投げオモテなら、自分の山札からポケモンを1枚選び、相手に見せてから、手札に加える。そして山札を切る。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "利爪劈擊"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692256,
+				tcgplayer: 587767,
+			},
 		},
+	],
 
-		damage: 70,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "亂暴獠牙"
-		},
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Promo",
+};
 
-		effect: {
-			'zh-tw': "選擇3個這隻寶可夢身上附加的能量，將其丟棄。"
-		},
-
-		damage: 190,
-		cost: ["Fighting", "Fighting", "Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/011.ts
+++ b/data-asia/SV/SV-P/011.ts
@@ -1,51 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "飄香豚"
+		ja: "ポケモンいれかえ",
+		'zh-tw': "飄香豚",
 	},
 
-	illustrator: "kirisAki",
-	category: "Pokemon",
-	hp: 120,
-	types: ["Colorless"],
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "以自己細緻透亮的肌膚 為傲。會從尾巴的前端 釋放出凝縮的香氣。"
+	effect: {
+		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。",
 	},
 
-	stage: "Stage1",
-
-	attacks: [{
-		name: {
-			'zh-tw': "衝撞"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692257,
+				tcgplayer: 587768,
+			},
 		},
+	],
 
-		damage: 50,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "足踩踏"
-		},
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Promo",
+};
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為反面，則在下個自己的回合，這隻寶可夢無法使用招式。"
-		},
-
-		damage: 130,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/012.ts
+++ b/data-asia/SV/SV-P/012.ts
@@ -1,47 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "摩托蜥ex"
+		ja: "ネモ",
+		'zh-tw': "摩托蜥ex",
 	},
 
-	illustrator: "5ban Graphics",
-	category: "Pokemon",
-	hp: 210,
-	types: ["Colorless"],
-	stage: "Basic",
-	suffix: "EX",
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
 
-	attacks: [{
-		name: {
-			'zh-tw': "力量奔馳"
+	effect: {
+		ja: "自分の山札を3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 692258,
+				tcgplayer: 587769,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "#N/A"
-		},
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Promo",
+};
 
-		damage: 30,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "全速油門"
-		},
-
-		damage: 180,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/013.ts
+++ b/data-asia/SV/SV-P/013.ts
@@ -1,22 +1,58 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "精靈球"
+		ja: "ロトム",
+		'zh-tw': "精靈球",
 	},
 
-	illustrator: "Studio Bora Inc.",
-	category: "Trainer",
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Lightning"],
 
-	effect: {
-		'zh-tw': "擲1次硬幣若為正面，則從自己的牌庫選擇1張寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。"
+	description: {
+		ja: "特殊な モーターを 動かす 動力源として 長い あいだ 研究されていた ポケモン。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "G"
-}
+	stage: "Basic",
 
-export default card
+	attacks: [
+		{
+			name: { ja: "ジャンクハント" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュからグッズを1枚選び、相手に見せて、手札に加える。",
+			},
+		},
+		{
+			name: { ja: "でんきショック" },
+			damage: 20,
+			cost: ["Lightning"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 587770,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [479],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/014.ts
+++ b/data-asia/SV/SV-P/014.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "寶可夢交替"
+		ja: "クラッシュハンマー",
+		'zh-tw': "寶可夢交替",
 	},
 
-	illustrator: "Studio Bora Inc.",
+	illustrator: "Ayaka Yoshida",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "將自己的戰鬥寶可夢與備戰寶可夢互換。"
+		ja: "コインを1回投げオモテなら、相手のポケモンについているエネルギーを1個選び、トラッシュする。",
+		'zh-tw': "將自己的戰鬥寶可夢與備戰寶可夢互換。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "G"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 699711,
+				tcgplayer: 587771,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/015.ts
+++ b/data-asia/SV/SV-P/015.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "妮莫"
+		ja: "ネストボール",
+		'zh-tw': "妮莫",
 	},
 
-	illustrator: "Sanosuke Sakuma",
+	illustrator: "Toyste Beach",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "從自己的牌庫抽出3張卡。"
+		ja: "自分の山札にあるたねポケモンを1枚、ベンチに出す。そして山札を切る。",
+		'zh-tw': "從自己的牌庫抽出3張卡。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "G"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 699712,
+				tcgplayer: 587772,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/016.ts
+++ b/data-asia/SV/SV-P/016.ts
@@ -1,54 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洛托姆"
+		ja: "ふしぎなアメ",
+		'zh-tw': "洛托姆",
 	},
 
-	illustrator: "Kouki Saitou",
-	category: "Pokemon",
-	hp: 80,
-	types: ["Lightning"],
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "被當作驅動 特殊馬達的動力源， 而被長期研究的寶可夢。"
+	effect: {
+		ja: "自分のたねポケモン1匹から進化する1進化の上の2進化ポケモンを、手札から1枚選び、そのたねポケモンにのせて進化させる。[最初の自分の番と、この番出したばかりのたねポケモンには使えない。]",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "廢品搜尋"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 699713,
+				tcgplayer: 587773,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的棄牌區選擇1張物品卡，在給對手看過後加入手牌。"
-		},
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Promo",
+};
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "電擊"
-		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。"
-		},
-
-		damage: 20,
-		cost: ["Lightning"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/017.ts
+++ b/data-asia/SV/SV-P/017.ts
@@ -1,50 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "迷你芙"
+		ja: "ポケモンいれかえ",
+		'zh-tw': "迷你芙",
 	},
 
-	illustrator: "Misa Tsutsui",
-	category: "Pokemon",
-	hp: 60,
-	types: ["Grass"],
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "會從頭上的果實噴出油 來保護自己不受敵人攻擊。 油的味道苦澀到會讓人跳起來。"
+	effect: {
+		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "營養素"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 699714,
+				tcgplayer: 587774,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將自己的1隻寶可夢恢復「30」HP。"
-		},
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Promo",
+};
 
-		cost: ["Grass"]
-	}, {
-		name: {
-			'zh-tw': "噴汁"
-		},
-
-		damage: 20,
-		cost: ["Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/018.ts
+++ b/data-asia/SV/SV-P/018.ts
@@ -1,50 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "卡蒂狗"
+		ja: "学習装置",
+		'zh-tw': "卡蒂狗",
 	},
 
-	illustrator: "Uta",
-	category: "Pokemon",
-	hp: 90,
-	types: ["Fire"],
+	illustrator: "Toyste Beach",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "性格誠實，容易和人親近。 遇到敵人時牠會吼叫追咬， 試著把敵人趕走。"
+	effect: {
+		ja: "自分のバトルポケモンが、相手のポケモンからワザのダメージを受けてきぜつするたび、そのポケモンについている基本エネルギーを1枚選び、このカードをつけているポケモンにつけ替えてよい。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "燃起"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 699715,
+				tcgplayer: 587775,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多2張「基本【火】能量」卡，附於這隻寶可夢身上。並且重洗牌庫。"
-		},
+	trainerType: "Tool",
+	regulationMark: "G",
+	rarity: "Promo",
+};
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "火之爪"
-		},
-
-		damage: 70,
-		cost: ["Fire", "Fire", "Fire"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
-
-	retreat: 3,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/019.ts
+++ b/data-asia/SV/SV-P/019.ts
@@ -1,51 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "茸茸羊"
+		ja: "げんきのハチマキ",
+		'zh-tw': "茸茸羊",
 	},
 
-	illustrator: "0313",
-	category: "Pokemon",
-	hp: 90,
-	types: ["Lightning"],
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "儲存了過多電力的結果， 造成牠身體表面有些部分 連胎毛都長不出來。"
+	effect: {
+		ja: "このカードをつけているポケモンが使うワザの、相手のバトルポケモンへのダメージは「＋10」される。",
 	},
 
-	stage: "Stage1",
-
-	attacks: [{
-		name: {
-			'zh-tw': "劈哩啪啦"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 699716,
+				tcgplayer: 587776,
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Lightning"]
-	}, {
-		name: {
-			'zh-tw': "激電流"
-		},
+	trainerType: "Tool",
+	regulationMark: "G",
+	rarity: "Promo",
+};
 
-		effect: {
-			'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。"
-		},
-
-		damage: 80,
-		cost: ["Lightning", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/020.ts
+++ b/data-asia/SV/SV-P/020.ts
@@ -1,55 +1,32 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "墓揚犬"
+		ja: "ジニア",
+		'zh-tw': "墓揚犬",
 	},
 
-	illustrator: "Pani Kobayashi",
-	category: "Pokemon",
-	hp: 130,
-	types: ["Psychic"],
+	illustrator: "GIDORA",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "平時都在墳場裡睡覺。 在為數眾多的犬寶可夢中， 牠是對主人最為忠實的。"
+	effect: {
+		ja: "自分の山札から進化ポケモンを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
 	},
 
-	stage: "Stage1",
-
-	attacks: [{
-		name: {
-			'zh-tw': "掘出"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 587777,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的棄牌區選擇最多2張物品卡，在給對手看過後加入手牌。"
-		},
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Promo",
+};
 
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "陰森射擊"
-		},
-
-		damage: 100,
-		cost: ["Psychic", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
-
-	retreat: 3,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/021.ts
+++ b/data-asia/SV/SV-P/021.ts
@@ -1,52 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "毛崖蟹ex"
+		ja: "博士の研究",
+		'zh-tw': "毛崖蟹ex",
 	},
 
-	illustrator: "aky CG Works",
-	category: "Pokemon",
-	hp: 220,
-	types: ["Fighting"],
-	stage: "Basic",
-	suffix: "EX",
+	illustrator: "kirisAki",
+	category: "Trainer",
 
-	abilities: [{
-		type: "Ability",
+	effect: {
+		ja: "自分の手札をすべてトラッシュし、山札を7枚引く。",
+	},
 
-		name: {
-			'zh-tw': "反擊鉗"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 699718,
+				tcgplayer: 587778,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "當這隻寶可夢在戰鬥場上受到對手的寶可夢招式的傷害時，選擇1個使用招式的寶可夢身上附加的能量，將其丟棄。"
-		}
-	}],
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Promo",
+};
 
-	attacks: [{
-		name: {
-			'zh-tw': "落下壓制"
-		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則增加80點傷害。"
-		},
-
-		damage: "100+",
-		cost: ["Fighting", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
-
-	retreat: 3,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/022.ts
+++ b/data-asia/SV/SV-P/022.ts
@@ -1,48 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "噗隆隆"
+		ja: "博士の研究",
+		'zh-tw': "噗隆隆",
 	},
 
-	illustrator: "Mina Nakai",
-	category: "Pokemon",
-	hp: 60,
-	types: ["Metal"],
+	illustrator: "kirisAki",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "據說牠是神秘的毒寶可夢 鑽進了被放置在廢鐵工廠 的引擎裡而誕生的。"
+	effect: {
+		ja: "自分の手札をすべてトラッシュし、山札を7枚引く。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "毒瓦斯"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 699719,
+				tcgplayer: 587779,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。"
-		},
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Promo",
+};
 
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
-
-	retreat: 1,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/023.ts
+++ b/data-asia/SV/SV-P/023.ts
@@ -1,22 +1,56 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "寇沙"
+		ja: "ミニーブ",
+		'zh-tw': "寇沙",
 	},
 
-	illustrator: "GIDORA",
-	category: "Trainer",
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
 
-	effect: {
-		'zh-tw': "將自己的所有手牌放回牌庫並重洗。然後，從牌庫抽出比放回張數多1張的卡。"
+	description: {
+		ja: "頭の 実から オイルを 出して 敵から 身を 守る。 オイルは とびあがるほど 苦くて 渋い。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "G"
-}
+	stage: "Basic",
 
-export default card
+	attacks: [
+		{
+			name: { ja: "えいようそ" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分のポケモン1匹のHPを「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "しるをとばす" },
+			damage: 20,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693184,
+				tcgplayer: 587780,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [928],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/024.ts
+++ b/data-asia/SV/SV-P/024.ts
@@ -1,47 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "新葉喵"
+		ja: "ガーディ",
+		'zh-tw': "新葉喵",
 	},
 
-	illustrator: "Saya Tsuruta",
+	illustrator: "Uta",
 	category: "Pokemon",
-	hp: 70,
-	types: ["Grass"],
+	hp: 90,
+	types: ["Fire"],
 
 	description: {
-		'zh-tw': "毛茸茸的體毛有著近似於植物的成分。會勤快地洗臉以防止乾燥。"
+		ja: "人懐こく 誠実な 性格。 敵には ほえて かみつき 追い払おうとする。",
+		'zh-tw': "毛茸茸的體毛有著近似於植物的成分。會勤快地洗臉以防止乾燥。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "抓"
+	attacks: [
+		{
+			name: {
+				ja: "もえあがる",
+				'zh-tw': "抓",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から「基本[R]エネルギー」を2枚まで選び、このポケモンにつける。そして山札を切る。",
+			},
 		},
-
-		damage: 10,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "樹葉"
+		{
+			name: {
+				ja: "ほのおのツメ",
+				'zh-tw': "樹葉",
+			},
+			damage: 70,
+			cost: ["Fire", "Fire", "Fire"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Grass", "Colorless"]
-	}],
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693185,
+				tcgplayer: 587781,
+			},
+		},
+	],
 
-	retreat: 1,
-	regulationMark: "G"
-}
+	retreat: 3,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [58],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV-P/025.ts
+++ b/data-asia/SV/SV-P/025.ts
@@ -1,47 +1,68 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "呆火鱷"
+		ja: "モココ",
+		'zh-tw': "呆火鱷",
 	},
 
-	illustrator: "Akira Komayama",
+	illustrator: "0313",
 	category: "Pokemon",
-	hp: 80,
-	types: ["Fire"],
+	hp: 90,
+	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "火囊很小，因此能量會溢出來，在牠頭上的凹槽那裡搖曳晃動。"
+		ja: "電気を 蓄えすぎた 結果 体の 表面に 産毛すら 生えない 部分が できてしまった。",
+		'zh-tw': "火囊很小，因此能量會溢出來，在牠頭上的凹槽那裡搖曳晃動。",
 	},
 
-	stage: "Basic",
+	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "咬"
+	attacks: [
+		{
+			name: {
+				ja: "バチバチ",
+				'zh-tw': "咬",
+			},
+			damage: 30,
+			cost: ["Lightning"],
 		},
-
-		damage: 10,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "烈焰"
+		{
+			name: {
+				ja: "げきでんりゅう",
+				'zh-tw': "烈焰",
+			},
+			damage: 80,
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
 		},
+	],
 
-		damage: 50,
-		cost: ["Fire", "Fire", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693186,
+				tcgplayer: 587782,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "メリープ",
+	},
 
 	retreat: 2,
-	regulationMark: "G"
-}
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [180],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV-P/026.ts
+++ b/data-asia/SV/SV-P/026.ts
@@ -1,47 +1,67 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "潤水鴨"
+		ja: "ハカドッグ",
+		'zh-tw': "潤水鴨",
 	},
 
-	illustrator: "Mizue",
+	illustrator: "Pani Kobayashi",
 	category: "Pokemon",
-	hp: 70,
-	types: ["Water"],
+	hp: 130,
+	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "很久以前從遠方來到了這裡棲息。羽毛分泌出的凝膠有防水和防污的效果。"
+		ja: "普段は 墓場で 眠っている。 数いる 犬ポケモンの中でも もっとも 主に 忠実だ。",
+		'zh-tw': "很久以前從遠方來到了這裡棲息。羽毛分泌出的凝膠有防水和防污的效果。",
 	},
 
-	stage: "Basic",
+	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "拍擊"
+	attacks: [
+		{
+			name: {
+				ja: "ほりだす",
+				'zh-tw': "拍擊",
+			},
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュからグッズを2枚まで選び、相手に見せて、手札に加える。",
+			},
 		},
-
-		damage: 10,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "踢"
+		{
+			name: {
+				ja: "ホロウショット",
+				'zh-tw': "踢",
+			},
+			damage: 100,
+			cost: ["Psychic", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Water", "Colorless"]
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693187,
+				tcgplayer: 587783,
+			},
+		},
+	],
 
-	retreat: 1,
-	regulationMark: "G"
-}
+	evolveFrom: {
+		ja: "ボチ",
+	},
 
-export default card
+	retreat: 3,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [972],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/027.ts
+++ b/data-asia/SV/SV-P/027.ts
@@ -1,55 +1,64 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "布撥"
+		ja: "ガケガニex",
+		'zh-tw': "布撥",
 	},
 
-	illustrator: "Ryuta Fuse",
+	illustrator: "aky CG Works",
 	category: "Pokemon",
-	hp: 50,
-	types: ["Lightning"],
-
-	description: {
-		'zh-tw': "臉頰上的電囊尚未發達。 必須拼命摩擦前腳的肉球， 才終於能製造出電力。"
-	},
+	hp: 220,
+	types: ["Fighting"],
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "劈啪巴掌"
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はんげきバサミ" },
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、ワザを使ったポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。"
+	attacks: [
+		{
+			name: {
+				ja: "フォーリングプレス",
+				'zh-tw': "劈啪巴掌",
+			},
+			damage: "100+",
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、80ダメージ追加。",
+				'zh-tw': "擲1次硬幣若為正面，則選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		damage: 20,
-		cost: ["Lightning", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "劈啪巴掌"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693188,
+				tcgplayer: 587784,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。"
-		},
+	retreat: 3,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [950],
 
-		damage: 20,
-		cost: ["Lightning", "Colorless"]
-	}],
+	suffix: "EX",
+};
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/028.ts
+++ b/data-asia/SV/SV-P/028.ts
@@ -1,51 +1,55 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "密勒頓"
+		ja: "ブロロン",
+		'zh-tw': "密勒頓",
 	},
 
-	illustrator: "Akira Komayama",
+	illustrator: "Mina Nakai",
 	category: "Pokemon",
-	hp: 120,
-	types: ["Lightning"],
+	hp: 60,
+	types: ["Metal"],
 
 	description: {
-		'zh-tw': "詳情目前仍然不明。雖然給人 貌似摩托蜥的印象，但力量和 冷酷的程度可說是天壤之別。"
+		ja: "スクラップ工場に 放置された エンジンに 謎の 毒ポケモンが 入り込んで 生まれたと 言われる。",
+		'zh-tw': "詳情目前仍然不明。雖然給人 貌似摩托蜥的印象，但力量和 冷酷的程度可說是天壤之別。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "銳利之牙"
+	attacks: [
+		{
+			name: {
+				ja: "どくガス",
+				'zh-tw': "銳利之牙",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "雷電鐳射"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693189,
+				tcgplayer: 587785,
+			},
 		},
-
-		effect: {
-			'zh-tw': "對手的1隻備戰寶可夢也受到30點傷害。[在備戰區不計算弱點・抵抗力。]"
-		},
-
-		damage: 90,
-		cost: ["Lightning", "Lightning", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "G"
-}
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [965],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV-P/029.ts
+++ b/data-asia/SV/SV-P/029.ts
@@ -1,51 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "故勒頓"
+		ja: "コルサ",
+		'zh-tw': "故勒頓",
 	},
 
-	illustrator: "Mina Nakai",
-	category: "Pokemon",
-	hp: 130,
-	types: ["Fighting"],
+	illustrator: "GIDORA",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "牠似乎就是古老的探險記裡 提到的翼大王的真面目。 據記載，牠曾以拳頭擊裂大地。"
+	effect: {
+		ja: "自分の手札を数えたあと、すべて山札にもどして切る。その後、もどした枚数より1枚多くなるように、山札を引く。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "利爪劈擊"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 693190,
+				tcgplayer: 587786,
+			},
 		},
+	],
 
-		damage: 70,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "亂暴獠牙"
-		},
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Promo",
+};
 
-		effect: {
-			'zh-tw': "選擇3個這隻寶可夢身上附加的能量，將其丟棄。"
-		},
-
-		damage: 190,
-		cost: ["Fighting", "Fighting", "Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/030.ts
+++ b/data-asia/SV/SV-P/030.ts
@@ -1,40 +1,32 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "榛果球"
+		ja: "ペパー",
+		'zh-tw': "榛果球",
 	},
 
-	illustrator: "Nobuhiro Imagawa",
-	category: "Pokemon",
-	hp: 70,
-	types: ["Grass"],
+	illustrator: "GIDORA",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "最喜歡把樹皮疊在身上加厚外殼。就算因此變重也毫不在意。"
+	effect: {
+		ja: "自分の山札から「グッズ」と「ポケモンのどうぐ」を1枚ずつ選び、相手に見せて、手札に加える。そして山札を切る。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "滾動"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 587787,
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Grass", "Grass"]
-	}],
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Promo",
+};
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/031.ts
+++ b/data-asia/SV/SV-P/031.ts
@@ -1,47 +1,62 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "凍脊龍"
+		ja: "イーブイ",
+		'zh-tw': "凍脊龍",
 	},
 
-	illustrator: "Teeziro",
+	illustrator: "saino misaki",
 	category: "Pokemon",
-	hp: 90,
-	types: ["Water"],
+	hp: 60,
+	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "凍結周圍的空氣，以冰之面罩保護臉部，並將背鰭變成冰劍。"
+		ja: "環境の 変化に すぐさま 合わせられるよう いくつもの 進化の 可能性を 秘めている。",
+		'zh-tw': "凍結周圍的空氣，以冰之面罩保護臉部，並將背鰭變成冰劍。",
 	},
 
-	stage: "Stage1",
+	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "銳利鰭"
+	attacks: [
+		{
+			name: {
+				ja: "なかまをよぶ",
+				'zh-tw': "銳利鰭",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からたねポケモンを1枚選び、ベンチに出す。そして山札を切る。",
+			},
 		},
-
-		damage: 40,
-		cost: ["Water", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "冰霜粉碎"
+		{
+			name: {
+				ja: "たいあたり",
+				'zh-tw': "冰霜粉碎",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 80,
-		cost: ["Water", "Water", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 587788,
+			},
+		},
+	],
 
-	retreat: 2,
-	regulationMark: "G"
-}
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [133],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV-P/032.ts
+++ b/data-asia/SV/SV-P/032.ts
@@ -1,54 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "電肚蛙"
+		ja: "イーブイ",
+		'zh-tw': "電肚蛙",
 	},
 
-	illustrator: "Mizue",
+	illustrator: "saino misaki",
 	category: "Pokemon",
-	hp: 130,
-	types: ["Lightning"],
+	hp: 60,
+	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "只要伸縮肥嘟嘟的身體，就能讓肚子上的發電臍產生大量的電氣。"
+		ja: "環境の 変化に すぐさま 合わせられるよう いくつもの 進化の 可能性を 秘めている。",
+		'zh-tw': "只要伸縮肥嘟嘟的身體，就能讓肚子上的發電臍產生大量的電氣。",
 	},
 
-	stage: "Stage1",
+	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "電磁波"
+	attacks: [
+		{
+			name: {
+				ja: "なかまをよぶ",
+				'zh-tw': "電磁波",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からたねポケモンを1枚選び、ベンチに出す。そして山札を切る。",
+				'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。"
+		{
+			name: {
+				ja: "たいあたり",
+				'zh-tw': "雙峰伏特",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Lightning"]
-	}, {
-		name: {
-			'zh-tw': "雙峰伏特"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 587789,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若希望，將最多2張這隻寶可夢身上附加的【雷】能量卡丟棄，增加其張數×80點傷害。"
-		},
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [133],
+};
 
-		damage: "10+",
-		cost: ["Lightning", "Lightning", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	retreat: 3,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/033.ts
+++ b/data-asia/SV/SV-P/033.ts
@@ -1,49 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "來悲茶"
+		ja: "イーブイ",
+		'zh-tw': "來悲茶",
 	},
 
-	illustrator: "kurumitsu",
+	illustrator: "saino misaki",
 	category: "Pokemon",
-	hp: 30,
-	types: ["Psychic"],
+	hp: 60,
+	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "死於孤獨的死者之魂附在了喝剩的紅茶上。會在旅館或民宅出現。"
+		ja: "環境の 変化に すぐさま 合わせられるよう いくつもの 進化の 可能性を 秘めている。",
+		'zh-tw': "死於孤獨的死者之魂附在了喝剩的紅茶上。會在旅館或民宅出現。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "冷茶"
+	attacks: [
+		{
+			name: {
+				ja: "なかまをよぶ",
+				'zh-tw': "冷茶",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からたねポケモンを1枚選び、ベンチに出す。そして山札を切る。",
+				'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。"
+		{
+			name: { ja: "たいあたり" },
+			damage: 30,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 10,
-		cost: ["Psychic"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 587790,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "G"
-}
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [133],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV-P/034.ts
+++ b/data-asia/SV/SV-P/034.ts
@@ -1,50 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "泥泥鰍"
+		ja: "ルチャブル",
+		'zh-tw': "泥泥鰍",
 	},
 
-	illustrator: "ryoma uratsuka",
+	illustrator: "GOSSAN",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "２根鬍子是靈敏的雷達。即使在因為泥濘而渾濁的水中，也能偵查到獵物的位置。"
+		ja: "翼を 使い 軽やかに 跳び 相手を 華麗に 仕留める 技は 生まれ育った 森で 磨かれる。",
+		'zh-tw': "２根鬍子是靈敏的雷達。即使在因為泥濘而渾濁的水中，也能偵查到獵物的位置。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "躲藏"
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "フライングエントリー" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。相手のベンチポケモン2匹に、それぞれダメカンを1個のせる。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則在下個對手的回合，這隻寶可夢不會受到招式的傷害與效果的影響。"
+	attacks: [
+		{
+			name: {
+				ja: "つばさでうつ",
+				'zh-tw': "躲藏",
+			},
+			damage: 70,
+			cost: ["Fighting", "Colorless", "Colorless"],
 		},
+	],
 
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "擲泥"
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 691010,
+				tcgplayer: 587791,
+			},
 		},
+	],
 
-		damage: 20,
-		cost: ["Fighting", "Colorless"]
-	}],
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [701],
+};
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/035.ts
+++ b/data-asia/SV/SV-P/035.ts
@@ -1,51 +1,55 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "獒教父ex"
+		ja: "パモ",
+		'zh-tw': "獒教父ex",
 	},
 
-	illustrator: "PLANETA Mochizuki",
+	illustrator: "Ryuta Fuse",
 	category: "Pokemon",
-	hp: 260,
-	types: ["Darkness"],
-	stage: "Stage1",
-	suffix: "EX",
+	hp: 50,
+	types: ["Lightning"],
 
-	attacks: [{
-		name: {
-			'zh-tw': "膽怯"
+	description: {
+		ja: "頬の 電気袋は 未発達。 前脚の 肉球で 懸命に 擦ると ようやく 発電できる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: {
+				ja: "バチッとビンタ",
+				'zh-tw': "膽怯",
+			},
+			damage: 20,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢使用招式的傷害「-50」點。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢使用招式的傷害「-50」點。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 587792,
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "自尊心之牙"
-		},
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [921],
+};
 
-		effect: {
-			'zh-tw': "若自己的備戰寶可夢身上放置有傷害指示物，則增加120點傷害。"
-		},
-
-		damage: "100+",
-		cost: ["Darkness", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
-
-	retreat: 3,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/036.ts
+++ b/data-asia/SV/SV-P/036.ts
@@ -1,22 +1,49 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "秋明"
+		ja: "カルボウ",
+		'zh-tw': "秋明",
 	},
 
-	illustrator: "kantaro",
-	category: "Trainer",
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
 
-	effect: {
-		'zh-tw': "這張卡只有在對手的戰鬥寶可夢【中毒】時才可使用。 將自己的手牌全部放回牌庫並重洗。然後，從牌庫抽出7張卡。"
+	description: {
+		ja: "焼けた 木炭に 命が 宿り ポケモンになった。 燃える 闘志で 強敵にも 戦いを 挑む。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "G"
-}
+	stage: "Basic",
 
-export default card
+	attacks: [
+		{
+			name: { ja: "ヒートブラスト" },
+			damage: 60,
+			cost: ["Fire", "Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 695777,
+				tcgplayer: 587793,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [935],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/037.ts
+++ b/data-asia/SV/SV-P/037.ts
@@ -1,67 +1,32 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伊布"
+		ja: "基本草エネルギー",
+		'zh-tw': "伊布",
 	},
 
-	illustrator: "saino misaki",
-	category: "Pokemon",
-	hp: 60,
-	types: ["Colorless"],
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
 
-	description: {
-		'zh-tw': "為了能瞬即適應環境的變化， 這種寶可夢蘊含著 許多種進化的可能性。"
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "呼朋引伴"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 695778,
+				tcgplayer: 587794,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。"
-		},
+	rarity: "Promo",
+};
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "撞擊"
-		},
-
-		damage: 30,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "呼朋引伴"
-		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。"
-		},
-
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "撞擊"
-		},
-
-		damage: 30,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/038.ts
+++ b/data-asia/SV/SV-P/038.ts
@@ -1,46 +1,32 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "噴火龍VMAX"
+		ja: "基本炎エネルギー",
+		'zh-tw': "噴火龍VMAX",
 	},
 
-	illustrator: "Shiburingaru",
-	category: "Pokemon",
-	hp: 330,
-	types: ["Fire"],
-	stage: "VMAX",
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
 
-	attacks: [{
-		name: {
-			'zh-tw': "利爪劈擊"
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 695779,
+				tcgplayer: 587795,
+			},
 		},
+	],
 
-		damage: 100,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "超極巨地獄滅焰"
-		},
+	rarity: "Promo",
+};
 
-		effect: {
-			'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。"
-		},
-
-		damage: 300,
-		cost: ["Fire", "Fire", "Fire", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
-
-	retreat: 3,
-	regulationMark: "D"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/039.ts
+++ b/data-asia/SV/SV-P/039.ts
@@ -1,53 +1,31 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洗翠 火爆獸V"
+		ja: "基本水エネルギー",
+		'zh-tw': "洗翠 火爆獸V",
 	},
 
-	illustrator: "5ban Graphics",
-	category: "Pokemon",
-	hp: 210,
-	types: ["Psychic"],
-	stage: "Basic",
-	suffix: "V",
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
 
-	attacks: [{
-		name: {
-			'zh-tw': "灼熱"
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 587796,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【灼傷】。"
-		}
-	}, {
-		name: {
-			'zh-tw': "戰慄火焰"
-		},
+	rarity: "Promo",
+};
 
-		effect: {
-			'zh-tw': "在不看正面的情況下，從對手的手牌選擇1張，在看過那張卡正面後放回對手的牌庫並重洗。"
-		},
-
-		damage: 120,
-		cost: ["Psychic", "Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
-
-	retreat: 2,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/040.ts
+++ b/data-asia/SV/SV-P/040.ts
@@ -1,44 +1,32 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "皮卡丘"
+		ja: "基本雷エネルギー",
+		'zh-tw': "皮卡丘",
 	},
 
-	illustrator: "Jiro Sasumo",
-	category: "Pokemon",
-	hp: 70,
-	types: ["Lightning"],
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
 
-	description: {
-		'zh-tw': "雙頰上有儲存電力的囊袋。一旦生氣就會把儲存的電力 一口氣釋放出來。"
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "激戰電光"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 695781,
+				tcgplayer: 587797,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲硬幣直到出現反面，增加正面出現的次數×30點傷害。"
-		},
+	rarity: "Promo",
+};
 
-		damage: "30+",
-		cost: ["Lightning", "Lightning", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/041.ts
+++ b/data-asia/SV/SV-P/041.ts
@@ -1,55 +1,32 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "浩大鯨"
+		ja: "基本超エネルギー",
+		'zh-tw': "浩大鯨",
 	},
 
-	illustrator: "GOSSAN",
-	category: "Pokemon",
-	hp: 180,
-	types: ["Water"],
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
 
-	description: {
-		'zh-tw': "迴游在冰雪地帶的寶可夢。會用強韌的肌肉和厚實的 皮下脂肪保護自己的身體。"
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
 	},
 
-	stage: "Stage1",
-
-	attacks: [{
-		name: {
-			'zh-tw': "雪崩"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 695782,
+				tcgplayer: 587798,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "對手的所有備戰寶可夢也各受到10點傷害。[在備戰區不計算弱點・抵抗力。]"
-		},
+	rarity: "Promo",
+};
 
-		damage: 30,
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "回轉滑梯"
-		},
-
-		effect: {
-			'zh-tw': "擲3次硬幣，造成正面出現的次數×100點傷害。"
-		},
-
-		damage: "100×",
-		cost: ["Water", "Water", "Water"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
-
-	retreat: 3,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/042.ts
+++ b/data-asia/SV/SV-P/042.ts
@@ -1,46 +1,32 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "阿爾宙斯V"
+		ja: "基本闘エネルギー",
+		'zh-tw': "阿爾宙斯V",
 	},
 
-	illustrator: "N-DESIGN Inc.",
-	category: "Pokemon",
-	hp: 220,
-	types: ["Colorless"],
-	stage: "Basic",
-	suffix: "V",
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
 
-	attacks: [{
-		name: {
-			'zh-tw': "三重蓄能"
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 695783,
+				tcgplayer: 587799,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多3張基本能量卡，以任意方式附於自己的「寶可夢【V】」身上。並且重洗牌庫。"
-		},
+	rarity: "Promo",
+};
 
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "力量刀鋒"
-		},
-
-		damage: 130,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/043.ts
+++ b/data-asia/SV/SV-P/043.ts
@@ -1,50 +1,32 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "狠辣椒ex"
+		ja: "基本悪エネルギー",
+		'zh-tw': "狠辣椒ex",
 	},
 
-	illustrator: "PLANETA Mochizuki",
-	category: "Pokemon",
-	hp: 260,
-	types: ["Grass"],
-	stage: "Stage1",
-	suffix: "EX",
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
 
-	attacks: [{
-		name: {
-			'zh-tw': "辣味制約"
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 695784,
+				tcgplayer: 587800,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【灼傷】。在下個對手的回合，受到這個招式的寶可夢無法撤退。"
-		},
+	rarity: "Promo",
+};
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "雙頭粉碎"
-		},
-
-		effect: {
-			'zh-tw': "在不看正面的情況下，從對手的手牌選擇1張，將其丟棄。將對手的牌庫上方1張卡丟棄。"
-		},
-
-		damage: 140,
-		cost: ["Grass", "Grass"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/044.ts
+++ b/data-asia/SV/SV-P/044.ts
@@ -1,40 +1,32 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "利牙魚"
+		ja: "基本鋼エネルギー",
+		'zh-tw': "利牙魚",
 	},
 
-	illustrator: "Tonji Matsuno",
-	category: "Pokemon",
-	hp: 50,
-	types: ["Water"],
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
 
-	description: {
-		'zh-tw': "擁有銳利的牙齒和結實的下巴。船員們絕對不會去 靠近利牙魚棲息的地方。"
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "銳利之牙"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 695785,
+				tcgplayer: 587801,
+			},
 		},
+	],
 
-		damage: 20,
-		cost: ["Water"]
-	}],
+	rarity: "Promo",
+};
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/045.ts
+++ b/data-asia/SV/SV-P/045.ts
@@ -1,44 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "毒電嬰"
+		ja: "ふしぎなアメ",
+		'zh-tw': "毒電嬰",
 	},
 
-	illustrator: "Natsumi Yoshida",
-	category: "Pokemon",
-	hp: 70,
-	types: ["Lightning"],
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "就算喝下污水也能安然無恙。 那是因為牠會靠著體內的器官 把污水過濾成對自己無害的毒液。"
+	effect: {
+		ja: "自分のたねポケモン1匹から進化する1進化の上の2進化ポケモンを、手札から1枚選び、そのたねポケモンにのせて進化させる。[最初の自分の番と、この番出したばかりのたねポケモンには使えない。]",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "撞一下"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 695787,
+				tcgplayer: 587802,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢也受到10點傷害。"
-		},
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Promo",
+};
 
-		damage: 30,
-		cost: ["Lightning"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/046.ts
+++ b/data-asia/SV/SV-P/046.ts
@@ -1,46 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "皮寶寶"
+		ja: "ネモ",
+		'zh-tw': "皮寶寶",
 	},
 
-	illustrator: "Tika Matsuno",
-	category: "Pokemon",
-	hp: 30,
-	types: ["Psychic"],
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "有著如同星星一般的輪廓。因為這樣的外型，人們相信 牠是乘著流星而來的。"
+	effect: {
+		ja: "自分の山札を3枚引く。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "亮亮祈禱"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 695788,
+				tcgplayer: 587803,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多2張基本能量卡，在給對手看過後加入手牌。並且重洗牌庫。"
-		}
-	}],
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Promo",
+};
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
-
-	retreat: 0,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/047.ts
+++ b/data-asia/SV/SV-P/047.ts
@@ -1,51 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "沙基拉斯"
+		ja: "ネモ",
+		'zh-tw': "沙基拉斯",
 	},
 
-	illustrator: "Shiburingaru",
-	category: "Pokemon",
-	hp: 80,
-	types: ["Fighting"],
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "會以強勁的力道噴出在體內 壓縮好的氣體，好讓自己 能飛在空中大搞破壞的蛹。"
+	effect: {
+		ja: "自分の山札を3枚引く。",
 	},
 
-	stage: "Stage1",
-
-	attacks: [{
-		name: {
-			'zh-tw': "落石"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 695789,
+				tcgplayer: 587804,
+			},
 		},
+	],
 
-		damage: 20,
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "噴射衝撞"
-		},
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Promo",
+};
 
-		effect: {
-			'zh-tw': "自己的1隻備戰寶可夢也受到20點傷害。[在備戰區不計算弱點・抵抗力。]"
-		},
-
-		damage: 60,
-		cost: ["Fighting", "Fighting"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/048.ts
+++ b/data-asia/SV/SV-P/048.ts
@@ -1,59 +1,65 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "普隆隆姆"
+		ja: "ミライドン",
+		'zh-tw': "普隆隆姆",
 	},
 
-	illustrator: "Nisota Niso",
+	illustrator: "Akira Komayama",
 	category: "Pokemon",
-	hp: 140,
-	types: ["Metal"],
+	hp: 120,
+	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "在增加到了８個的汽缸裡 引爆混有毒素和岩石成分的 氣體來製造能量。"
+		ja: "詳細は よく わかっていない。 モトトカゲに 似た 印象だが はるかに 強く 冷酷なのだ。",
+		'zh-tw': "在增加到了８個的汽缸裡 引爆混有毒素和岩石成分的 氣體來製造能量。",
 	},
 
-	stage: "Stage1",
+	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "虛張聲勢"
+	attacks: [
+		{
+			name: {
+				ja: "するどいキバ",
+				'zh-tw': "虛張聲勢",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。"
+		{
+			name: {
+				ja: "ライトニングレーザー",
+				'zh-tw': "宏大衝撞",
+			},
+			damage: 90,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "若自己手牌的張數比對手手牌的張數多，則增加80點傷害。",
+			},
 		},
+	],
 
-		cost: ["Metal"]
-	}, {
-		name: {
-			'zh-tw': "宏大衝撞"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 695790,
+				tcgplayer: 587805,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若自己手牌的張數比對手手牌的張數多，則增加80點傷害。"
-		},
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [1008],
+};
 
-		damage: "70+",
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
-
-	retreat: 3,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/049.ts
+++ b/data-asia/SV/SV-P/049.ts
@@ -1,22 +1,57 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "月光丘陵"
+		ja: "コライドン",
+		'zh-tw': "月光丘陵",
 	},
 
-	illustrator: "AYUMI ODASHIMA",
-	category: "Trainer",
+	illustrator: "Mina Nakai",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
 
-	effect: {
-		'zh-tw': "雙方玩家在每個自己的回合時，可使用1次，若從自己的手牌將1張「基本【超】能量」卡丟棄，則可將自己的所有寶可夢各恢復「30」HP。"
+	description: {
+		ja: "拳で 大地を 引き裂いたと 古い 探検記に 記された ツバサノオウの 正体らしい。",
 	},
 
-	trainerType: "Stadium",
-	regulationMark: "G"
-}
+	stage: "Basic",
 
-export default card
+	attacks: [
+		{
+			name: { ja: "ツメできりさく" },
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ランページファング" },
+			damage: 190,
+			cost: ["Fighting", "Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを3個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 695791,
+				tcgplayer: 587806,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [1007],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/050.ts
+++ b/data-asia/SV/SV-P/050.ts
@@ -1,50 +1,53 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "名偵探皮卡丘"
+		ja: "クヌギダマ",
+		'zh-tw': "名偵探皮卡丘",
 	},
 
-	illustrator: "MINAMINAMI Take",
+	illustrator: "Nobuhiro Imagawa",
 	category: "Pokemon",
-	hp: 90,
-	types: ["Lightning"],
+	hp: 70,
+	types: ["Grass"],
 
 	description: {
-		'zh-tw': "調查工作需要毅力。憑著不屈不撓的調查，找出案件的線索！"
+		ja: "木の 皮を 重ね合わせて 殻を 分厚くするのが 大好き。 重くなっても 気にしない。",
+		'zh-tw': "調查工作需要毅力。憑著不屈不撓的調查，找出案件的線索！",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "徹底調查"
+	attacks: [
+		{
+			name: {
+				ja: "ころがる",
+				'zh-tw': "徹底調查",
+			},
+			damage: 30,
+			cost: ["Grass", "Grass"],
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲硬幣直到出現反面，從自己的牌庫抽出與正面出現的次數相同數量的卡。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705376,
+				tcgplayer: 587807,
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "騎行衝刺"
-		},
+	retreat: 2,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [204],
+};
 
-		damage: 50,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/051.ts
+++ b/data-asia/SV/SV-P/051.ts
@@ -1,51 +1,64 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "比克提尼ex"
+		ja: "セゴール",
+		'zh-tw': "比克提尼ex",
 	},
 
-	illustrator: "Saki Hayashiro",
+	illustrator: "Teeziro",
 	category: "Pokemon",
-	hp: 190,
-	types: ["Fire"],
-	stage: "Basic",
-	suffix: "EX",
+	hp: 90,
+	types: ["Water"],
 
-	attacks: [{
-		name: {
-			'zh-tw': "狡兔三窟"
+	description: {
+		ja: "まわりの 空気を 凍らせて 氷のマスクで 顔を 守り 背びれを 氷の剣に 変える。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: {
+				ja: "するどいひれ",
+				'zh-tw': "狡兔三窟",
+			},
+			damage: 40,
+			cost: ["Water", "Colorless"],
 		},
-
-		effect: {
-			'zh-tw': "若希望，將這隻寶可夢與備戰寶可夢互換。"
+		{
+			name: {
+				ja: "フロストスマッシュ",
+				'zh-tw': "勝利火焰",
+			},
+			damage: 80,
+			cost: ["Water", "Water", "Colorless"],
 		},
+	],
 
-		damage: 30,
-		cost: ["Fire"]
-	}, {
-		name: {
-			'zh-tw': "勝利火焰"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705377,
+				tcgplayer: 587808,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。"
-		},
+	evolveFrom: {
+		ja: "セビエ",
+	},
 
-		damage: 220,
-		cost: ["Fire", "Fire", "Colorless"]
-	}],
+	retreat: 2,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [997],
+};
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/052.ts
+++ b/data-asia/SV/SV-P/052.ts
@@ -1,51 +1,71 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "比克提尼ex"
+		ja: "ハラバリー",
+		'zh-tw': "比克提尼ex",
 	},
 
-	illustrator: "Saya Tsuruta",
+	illustrator: "Mizue",
 	category: "Pokemon",
-	hp: 190,
-	types: ["Fire"],
-	stage: "Basic",
-	suffix: "EX",
+	hp: 130,
+	types: ["Lightning"],
 
-	attacks: [{
-		name: {
-			'zh-tw': "狡兔三窟"
+	description: {
+		ja: "ブヨンブヨンの 体を 伸び縮み させると お腹の へそダイナモが 大電力を 発生させる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: {
+				ja: "でんじは",
+				'zh-tw': "狡兔三窟",
+			},
+			cost: ["Lightning"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+				'zh-tw': "若希望，將這隻寶可夢與備戰寶可夢互換。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "若希望，將這隻寶可夢與備戰寶可夢互換。"
+		{
+			name: {
+				ja: "ふたこぶボルト",
+				'zh-tw': "勝利火焰",
+			},
+			damage: "10+",
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "のぞむなら、このポケモンについている[L]エネルギーを2枚までトラッシュし、その枚数×80ダメージ追加。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。",
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Fire"]
-	}, {
-		name: {
-			'zh-tw': "勝利火焰"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705378,
+				tcgplayer: 587809,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。"
-		},
+	evolveFrom: {
+		ja: "ズピカ",
+	},
 
-		damage: 220,
-		cost: ["Fire", "Fire", "Colorless"]
-	}],
+	retreat: 3,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [939],
+};
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/053.ts
+++ b/data-asia/SV/SV-P/053.ts
@@ -1,22 +1,52 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "妮莫"
+		ja: "ヤバチャ",
+		'zh-tw': "妮莫",
 	},
 
-	illustrator: "Sanosuke Sakuma",
-	category: "Trainer",
+	illustrator: "kurumitsu",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Psychic"],
 
-	effect: {
-		'zh-tw': "從自己的牌庫抽出3張卡。"
+	description: {
+		ja: "寂しく 死んだ者の 魂が 飲み残しの 紅茶に 取り憑いた。 ホテルや 民家に 現れる。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "G"
-}
+	stage: "Basic",
 
-export default card
+	attacks: [
+		{
+			name: { ja: "さめたおちゃ" },
+			damage: 10,
+			cost: ["Psychic"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705379,
+				tcgplayer: 587810,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [854],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/054.ts
+++ b/data-asia/SV/SV-P/054.ts
@@ -1,22 +1,56 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "妮莫"
+		ja: "ドジョッチ",
+		'zh-tw': "妮莫",
 	},
 
-	illustrator: "Sanosuke Sakuma",
-	category: "Trainer",
+	illustrator: "ryoma uratsuka",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
 
-	effect: {
-		'zh-tw': "從自己的牌庫抽出3張卡。"
+	description: {
+		ja: "２本のヒゲは 敏感なレーダー。 泥で 濁った 水の 中でも 獲物の 位置を 察知するぞ。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "G"
-}
+	stage: "Basic",
 
-export default card
+	attacks: [
+		{
+			name: { ja: "かくれる" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+		{
+			name: { ja: "どろかけ" },
+			damage: 20,
+			cost: ["Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705380,
+				tcgplayer: 587811,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [339],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/055.ts
+++ b/data-asia/SV/SV-P/055.ts
@@ -1,57 +1,66 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "閃電鳥ex"
+		ja: "マフィティフex",
+		'zh-tw': "閃電鳥ex",
 	},
 
-	illustrator: "takuyoa",
+	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
-	hp: 200,
-	types: ["Lightning"],
-	stage: "Basic",
+	hp: 260,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: {
+				ja: "ひるませる",
+				'zh-tw': "閃電連彈",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-50」される。",
+				'zh-tw': "對手的身上放置有傷害指示物的1隻備戰寶可夢也受到90點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
+		},
+		{
+			name: { ja: "プライドファング" },
+			damage: "100+",
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチポケモンにダメカンがのっているなら、120ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705381,
+				tcgplayer: 587812,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "オラチフ",
+	},
+
+	retreat: 3,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [943],
+
 	suffix: "EX",
+};
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "伏特浮游"
-		},
-
-		effect: {
-			'zh-tw': "若這隻寶可夢身上附有【雷】能量卡，則這隻寶可夢【撤退】所需的能量全部消除。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "閃電連彈"
-		},
-
-		effect: {
-			'zh-tw': "對手的身上放置有傷害指示物的1隻備戰寶可夢也受到90點傷害。[在備戰區不計算弱點・抵抗力。]"
-		},
-
-		damage: 120,
-		cost: ["Lightning", "Lightning", "Lightning"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
-
-	retreat: 2,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/056.ts
+++ b/data-asia/SV/SV-P/056.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シュウメイ",
+	},
+
+	illustrator: "kantaro",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、相手のバトルポケモンがどくのときにしか使えない。自分の手札をすべて山札にもどして切る。その後、山札を7枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 705382,
+				tcgplayer: 587813,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/057.ts
+++ b/data-asia/SV/SV-P/057.ts
@@ -1,54 +1,25 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "臺北的皮卡丘"
+		ja: "ボタン",
+		'zh-tw': "臺北的皮卡丘",
 	},
 
-	illustrator: "REOspikee",
-	category: "Pokemon",
-	hp: 60,
-	types: ["Lightning"],
+	illustrator: "yuu",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "在森林裡和夥伴們一起生活。會把電力 儲存在兩頰的電囊裡。"
+	effect: {
+		ja: "自分の場のたねポケモンを1匹選び、そのポケモンと、ついているすべてのカードを、手札にもどす。",
 	},
 
-	stage: "Basic",
+	variants: [{ type: "normal" }],
 
-	attacks: [{
-		name: {
-			'zh-tw': "新開幕"
-		},
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Promo",
+};
 
-		effect: {
-			'zh-tw': "雙方玩家各將自己的牌庫上方1張卡翻到正面，在給對手看過後加入手牌。"
-		},
-
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "樂享伏特"
-		},
-
-		effect: {
-			'zh-tw': "擲3次硬幣，造成正面出現的次數×30點傷害。"
-		},
-
-		damage: "30×",
-		cost: ["Lightning", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/058.ts
+++ b/data-asia/SV/SV-P/058.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハルクジラ",
+	},
+
+	illustrator: "GOSSAN",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Water"],
+
+	description: {
+		ja: "氷雪地帯を 回遊する。 強靭な 筋肉と ぶ厚い 皮下脂肪で 体を 守る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ゆきなだれ" },
+			damage: 30,
+			cost: ["Water"],
+			effect: {
+				ja: "相手のベンチポケモン全員にも、それぞれ10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ローリングスライダー" },
+			damage: "100×",
+			cost: ["Water", "Water", "Water"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数×100ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 708469,
+				tcgplayer: 587816,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アルクジラ",
+	},
+
+	retreat: 4,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [975],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/059.ts
+++ b/data-asia/SV/SV-P/059.ts
@@ -1,54 +1,53 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "爆香猴"
+		ja: "フシギダネ",
+		'zh-tw': "爆香猴",
 	},
 
-	illustrator: "0313",
+	illustrator: "OKACHEKE",
 	category: "Pokemon",
 	hp: 70,
-	types: ["Fire"],
+	types: ["Grass"],
 
 	description: {
-		'zh-tw': "在火山的洞穴裡生活。 頭上的毛髮叢中熊熊燃燒著， 溫度高達３００度。"
+		ja: "生まれて しばらくの あいだ 背中の タネに つまった 栄養を とって 育つ。",
+		'zh-tw': "在火山的洞穴裡生活。 頭上的毛髮叢中熊熊燃燒著， 溫度高達３００度。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "呼朋引伴"
+	attacks: [
+		{
+			name: {
+				ja: "つるのムチ",
+				'zh-tw': "呼朋引伴",
+			},
+			damage: 50,
+			cost: ["Grass", "Colorless", "Colorless"],
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 720939,
+				tcgplayer: 587817,
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "灼燒"
-		},
+	retreat: 2,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [1],
+};
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【灼傷】。"
-		},
-
-		damage: 20,
-		cost: ["Fire", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/060.ts
+++ b/data-asia/SV/SV-P/060.ts
@@ -1,40 +1,56 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "墨海馬"
+		ja: "ヒトカゲ",
+		'zh-tw': "墨海馬",
 	},
 
-	illustrator: "MAHOU",
+	illustrator: "NC Empire",
 	category: "Pokemon",
-	hp: 60,
-	types: ["Water"],
+	hp: 70,
+	types: ["Fire"],
 
 	description: {
-		'zh-tw': "會在水中跳舞似地游動來 製造漩渦。玩耍時會和夥伴 比賽誰做出的漩渦比較大。"
+		ja: "生まれたときから しっぽに 炎が ともっている。 炎が 消えたとき その 命は 終わって しまう。",
+		'zh-tw': "會在水中跳舞似地游動來 製造漩渦。玩耍時會和夥伴 比賽誰做出的漩渦比較大。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "鉤住"
+	attacks: [
+		{
+			name: {
+				ja: "ひのこ",
+				'zh-tw': "鉤住",
+			},
+			damage: 40,
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
 		},
+	],
 
-		damage: 20,
-		cost: ["Water"]
-	}],
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 720940,
+				tcgplayer: 587818,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "G"
-}
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [4],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV-P/061.ts
+++ b/data-asia/SV/SV-P/061.ts
@@ -1,48 +1,57 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "哭哭面具"
+		ja: "ゼニガメ",
+		'zh-tw': "哭哭面具",
 	},
 
-	illustrator: "aoki",
+	illustrator: "Gemi",
 	category: "Pokemon",
 	hp: 70,
-	types: ["Psychic"],
+	types: ["Water"],
 
 	description: {
-		'zh-tw': "古代人的靈魂變成了寶可夢。 為了尋找認得自己長相的人 而在遺跡裡徘徊。"
+		ja: "危なくなると 甲羅に 手足を 引っこめて 身を 守りながら 口から 水を 吹き出している。",
+		'zh-tw': "古代人的靈魂變成了寶可夢。 為了尋找認得自己長相的人 而在遺跡裡徘徊。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "不祥之眼"
+	attacks: [
+		{
+			name: {
+				ja: "あわ",
+				'zh-tw': "不祥之眼",
+			},
+			damage: 20,
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+				'zh-tw': "在對手的1隻寶可夢身上放置3個傷害指示物。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在對手的1隻寶可夢身上放置3個傷害指示物。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 720941,
+				tcgplayer: 587819,
+			},
 		},
-
-		cost: ["Psychic", "Psychic"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "G"
-}
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [7],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV-P/062.ts
+++ b/data-asia/SV/SV-P/062.ts
@@ -1,55 +1,56 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "巨鍛匠"
+		ja: "イーブイ",
+		'zh-tw': "巨鍛匠",
 	},
 
-	illustrator: "DOM",
+	illustrator: "YU NAGABA",
 	category: "Pokemon",
-	hp: 140,
-	types: ["Psychic"],
+	hp: 50,
+	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "智商高超，性格豪邁。 會用錘子打飛岩石來攻擊 飛在空中的鋼鎧鴉。"
+		ja: "環境の 変化に すぐさま 合わせられるよう いくつもの 進化の 可能性を 秘めている。",
+		'zh-tw': "智商高超，性格豪邁。 會用錘子打飛岩石來攻擊 飛在空中的鋼鎧鴉。",
 	},
 
-	stage: "Stage2",
+	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "拍落"
+	attacks: [
+		{
+			name: {
+				ja: "れんぞくダッシュ",
+				'zh-tw': "拍落",
+			},
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数×20ダメージ追加。",
+				'zh-tw': "在不看正面的情況下，選擇1張對手的手牌，將其丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在不看正面的情況下，選擇1張對手的手牌，將其丟棄。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 587820,
+			},
 		},
+	],
 
-		damage: 40,
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "狂野壓制"
-		},
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [133],
+};
 
-		effect: {
-			'zh-tw': "這隻寶可夢也受到60點傷害。"
-		},
-
-		damage: 220,
-		cost: ["Psychic", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/063.ts
+++ b/data-asia/SV/SV-P/063.ts
@@ -1,52 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鹽石巨靈ex"
+		ja: "シャワーズ",
+		'zh-tw': "鹽石巨靈ex",
 	},
 
-	illustrator: "5ban Graphics",
+	illustrator: "YU NAGABA",
 	category: "Pokemon",
-	hp: 340,
-	types: ["Fighting"],
-	stage: "Stage2",
-	suffix: "EX",
+	hp: 120,
+	types: ["Water"],
 
-	abilities: [{
-		type: "Ability",
+	description: {
+		ja: "水辺に 棲むが 尻尾には 魚のような ひれが 残っていて 人魚と 間違う 人もいる。",
+	},
 
-		name: {
-			'zh-tw': "鹽味之軀"
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: {
+				ja: "アクアバレット",
+				'zh-tw': "障礙之錘",
+			},
+			damage: 90,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-60」點。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢不會陷入特殊狀態。"
-		}
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	attacks: [{
-		name: {
-			'zh-tw': "障礙之錘"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 708478,
+				tcgplayer: 587821,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-60」點。"
-		},
+	evolveFrom: {
+		ja: "イーブイ",
+	},
 
-		damage: 170,
-		cost: ["Fighting", "Colorless", "Colorless"]
-	}],
+	retreat: 2,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [134],
+};
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
-
-	retreat: 4,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/064.ts
+++ b/data-asia/SV/SV-P/064.ts
@@ -1,44 +1,61 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "多邊獸Ⅱ"
+		ja: "サンダース",
+		'zh-tw': "多邊獸Ⅱ",
 	},
 
-	illustrator: "GOSSAN",
+	illustrator: "YU NAGABA",
 	category: "Pokemon",
 	hp: 90,
-	types: ["Colorless"],
+	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "搭載了ＡＩ功能後，開始 說起了只有多邊獸Ⅱ彼此 之間才能了解的神秘語言。"
+		ja: "細胞が 出している 弱い 電気を ひとまとめにして 強力な 電撃を 放つ。",
+		'zh-tw': "搭載了ＡＩ功能後，開始 說起了只有多邊獸Ⅱ彼此 之間才能了解的神秘語言。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "力量球"
+	attacks: [
+		{
+			name: {
+				ja: "かみなりのキバ",
+				'zh-tw': "力量球",
+			},
+			damage: 60,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+				'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 708479,
+				tcgplayer: 587822,
+			},
 		},
+	],
 
-		damage: 50,
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "イーブイ",
+	},
 
 	retreat: 1,
-	regulationMark: "G"
-}
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [135],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV-P/065.ts
+++ b/data-asia/SV/SV-P/065.ts
@@ -1,22 +1,56 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "蕾荷"
+		ja: "ブースター",
+		'zh-tw': "蕾荷",
 	},
 
-	illustrator: "hncl",
-	category: "Trainer",
+	illustrator: "YU NAGABA",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fire"],
 
-	effect: {
-		'zh-tw': "查看自己的牌庫上方5張卡，從其中選擇任意數量的卡，將其丟棄。將剩餘卡以任意順序排列，放回牌庫上方。"
+	description: {
+		ja: "吸いこんだ 空気を 体内の 炎袋に 送りこみ １７００度の 炎にして 吹く。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "G"
-}
+	stage: "Stage1",
 
-export default card
+	attacks: [
+		{
+			name: { ja: "ほのおのうず" },
+			damage: 120,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 708480,
+				tcgplayer: 587823,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 2,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [136],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/066.ts
+++ b/data-asia/SV/SV-P/066.ts
@@ -1,57 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "天然鳥"
+		ja: "エーフィ",
+		'zh-tw': "天然鳥",
 	},
 
-	illustrator: "DOM",
+	illustrator: "YU NAGABA",
 	category: "Pokemon",
-	hp: 100,
+	hp: 110,
 	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "能夠看穿過去和未來。日復一日注視著太陽動向的奇異寶可夢。"
+		ja: "相手の 動きを 予知するとき ふたまたに なっている 尻尾の 先は 微妙に 揺れている。",
+		'zh-tw': "能夠看穿過去和未來。日復一日注視著太陽動向的奇異寶可夢。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "虛寂意識"
+	attacks: [
+		{
+			name: {
+				ja: "サイケこうせん",
+				'zh-tw': "超念力",
+			},
+			damage: 80,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時可使用1次。從自己的手牌選擇1張「基本【超】能量」卡，附於備戰寶可夢身上。然後，從自己的牌庫抽出2張卡。"
-		}
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	attacks: [{
-		name: {
-			'zh-tw': "超念力"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 708481,
+				tcgplayer: 587824,
+			},
 		},
+	],
 
-		damage: 80,
-		cost: ["Psychic", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "イーブイ",
+	},
 
 	retreat: 1,
-	regulationMark: "G"
-}
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [196],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV-P/067.ts
+++ b/data-asia/SV/SV-P/067.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブラッキー",
+	},
+
+	illustrator: "YU NAGABA",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Darkness"],
+
+	description: {
+		ja: "月の 波動を 体に 浴びると 輪っか模様が ほのかに 輝き 不思議な 力に 目覚めるのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "シャドーコープ" },
+			damage: 90,
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 708482,
+				tcgplayer: 587825,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [197],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/068.ts
+++ b/data-asia/SV/SV-P/068.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リーフィア",
+	},
+
+	illustrator: "YU NAGABA",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Grass"],
+
+	description: {
+		ja: "晴れた 日に 寝ている リーフィアは 光合成をして きれいな 空気を 作り出しているのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "アロマウインド" },
+			damage: 90,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンの特殊状態を、すべて回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 708483,
+				tcgplayer: 587826,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [470],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/069.ts
+++ b/data-asia/SV/SV-P/069.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グレイシア",
+	},
+
+	illustrator: "YU NAGABA",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Water"],
+
+	description: {
+		ja: "体温を 自在に コントロールし 大気の 水分を 凍らせて ダイヤモンドダストを 巻き起こす。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "こごえるかぜ" },
+			damage: 60,
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 708484,
+				tcgplayer: 587827,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [471],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/070.ts
+++ b/data-asia/SV/SV-P/070.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニンフィア",
+	},
+
+	illustrator: "YU NAGABA",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Psychic"],
+
+	description: {
+		ja: "敵意を 消す 癒しの 波動を リボンのような 触角から 相手の 体に 送り込む。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "いやしのひかり" },
+			damage: 100,
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "自分のポケモン全員のHPを、それぞれ「10」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 708485,
+				tcgplayer: 587828,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [700],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/071.ts
+++ b/data-asia/SV/SV-P/071.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モクロー",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "狭くて 暗い場所が 落ち着く。 トレーナーの ふところや バッグを 巣の 代わりに することも あるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "するどいはね" },
+			damage: 20,
+			cost: ["Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 727979,
+				tcgplayer: 587829,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [722],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/072.ts
+++ b/data-asia/SV/SV-P/072.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カルボウ",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "焼けた 木炭に 命が 宿り ポケモンになった。 燃える 闘志で 強敵にも 戦いを 挑む。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なぐる" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "かえん" },
+			damage: 20,
+			cost: ["Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 727981,
+				tcgplayer: 587830,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [935],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/073.ts
+++ b/data-asia/SV/SV-P/073.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケロマツ",
+	},
+
+	illustrator: "Atsuya Uki",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "繊細な 泡で 体を 包み 肌を 守る。のんきに 見せかけて 抜け目なく 周囲を うかがう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はねてみる" },
+			damage: 30,
+			cost: ["Water"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 727982,
+				tcgplayer: 587831,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [656],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/074.ts
+++ b/data-asia/SV/SV-P/074.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウ",
+	},
+
+	illustrator: "OKACHEKE",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "両頬には 電気を 溜めこむ 袋がある。 怒ると 溜めこんだ 電気を 一気に 放ってくる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なきごえ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-20」される。",
+			},
+		},
+		{
+			name: { ja: "ピカボルト" },
+			damage: 30,
+			cost: ["Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 727983,
+				tcgplayer: 587832,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/075.ts
+++ b/data-asia/SV/SV-P/075.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピッピ",
+	},
+
+	illustrator: "Yuka Morii",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "愛くるしい しぐさと 鳴き声で かわいいと 大人気の ポケモン。 だが めったに 見つからない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "にどビンタ" },
+			damage: "30×",
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 587833,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [35],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/076.ts
+++ b/data-asia/SV/SV-P/076.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リオル",
+	},
+
+	illustrator: "chibi",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "仲間同士で 波動を 出して コミュニケーションを とっている。 一晩中 走り続けられる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "パンチ" },
+			damage: 10,
+			cost: ["Fighting"],
+		},
+		{
+			name: { ja: "とつげき" },
+			damage: 50,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "このポケモンにも20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 587834,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [447],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/077.ts
+++ b/data-asia/SV/SV-P/077.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デルビル",
+	},
+
+	illustrator: "Kurata So",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "様々な 鳴き声を 使い分け 仲間と コミュニケーションしながら 狩りを おこなう 賢さを持つ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かみつく" },
+			damage: 10,
+			cost: ["Darkness"],
+		},
+		{
+			name: { ja: "やみのキバ" },
+			damage: 70,
+			cost: ["Darkness", "Darkness", "Darkness"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 727986,
+				tcgplayer: 587835,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [228],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/078.ts
+++ b/data-asia/SV/SV-P/078.ts
@@ -1,44 +1,49 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鐵頭殼ex"
+		ja: "メルタン",
+		'zh-tw': "鐵頭殼ex",
 	},
 
-	illustrator: "5ban Graphics",
+	illustrator: "Nobuhiro Imagawa",
 	category: "Pokemon",
-	hp: 220,
-	types: ["Psychic"],
+	hp: 70,
+	types: ["Metal"],
+
+	description: {
+		ja: "群れになって 生活するが 時が くると １匹の 強い メルタンが 仲間たちを 取りこみ 進化する。",
+	},
+
 	stage: "Basic",
-	suffix: "EX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "鈷藍指令"
+	attacks: [
+		{
+			name: { ja: "とかす" },
+			damage: 20,
+			cost: ["Metal"],
 		},
+	],
 
-		effect: {
-			'zh-tw': "只要這隻寶可夢在場上，自己的「未來」寶可夢（「鐵頭殼ex」除外）使用的招式，對對手的戰鬥寶可夢造成的傷害「+20」點。"
-		}
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 727987,
+				tcgplayer: 587836,
+			},
+		},
+	],
 
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [808],
+};
 
-	retreat: 2,
-	regulationMark: "H"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/079.ts
+++ b/data-asia/SV/SV-P/079.ts
@@ -1,39 +1,32 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "故勒頓"
+		ja: "基本草エネルギー",
+		'zh-tw': "故勒頓",
 	},
 
-	illustrator: "Teeziro",
-	category: "Pokemon",
-	hp: 140,
-	types: ["Dragon"],
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
 
-	description: {
-		'zh-tw': "牠似乎就是古老的探險記裡 提到的翼大王的真面目。 據記載，牠曾以拳頭擊裂大地。"
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "撕裂"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 727988,
+				tcgplayer: 587837,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這個招式的傷害不計算對手的戰鬥寶可夢身上的附加效果。"
-		},
+	rarity: "Promo",
+};
 
-		damage: 130,
-		cost: ["Fire", "Fighting", "Colorless"]
-	}],
-
-	retreat: 2,
-	regulationMark: "H"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/080.ts
+++ b/data-asia/SV/SV-P/080.ts
@@ -1,39 +1,32 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "密勒頓"
+		ja: "基本炎エネルギー",
+		'zh-tw': "密勒頓",
 	},
 
-	illustrator: "GOSSAN",
-	category: "Pokemon",
-	hp: 110,
-	types: ["Dragon"],
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
 
-	description: {
-		'zh-tw': "牠似乎就是古書裡所提及的 鐵大蛇。傳說牠曾用雷電 將大地化成了一片灰。"
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "暴衝高點"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 727989,
+				tcgplayer: 587838,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多2張基本能量卡，以任意方式附於自己的「未來」寶可夢身上。並且重洗牌庫。"
-		},
+	rarity: "Promo",
+};
 
-		damage: 40,
-		cost: ["Colorless"]
-	}],
-
-	retreat: 2,
-	regulationMark: "H"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/081.ts
+++ b/data-asia/SV/SV-P/081.ts
@@ -1,34 +1,32 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "猛雷鼓ex"
+		ja: "基本水エネルギー",
+		'zh-tw': "猛雷鼓ex",
 	},
 
-	illustrator: "aky CG Works",
-	category: "Pokemon",
-	hp: 240,
-	types: ["Dragon"],
-	stage: "Basic",
-	suffix: "EX",
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
 
-	attacks: [{
-		name: {
-			'zh-tw': "濺射咆哮"
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 727990,
+				tcgplayer: 587839,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將自己的手牌全部丟棄，從牌庫抽出6張卡。"
-		},
+	rarity: "Promo",
+};
 
-		cost: ["Colorless"]
-	}],
-
-	retreat: 3,
-	regulationMark: "H"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/082.ts
+++ b/data-asia/SV/SV-P/082.ts
@@ -1,22 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "交替推車"
+		ja: "基本雷エネルギー",
+		'zh-tw': "交替推車",
 	},
 
-	illustrator: "Toyste Beach",
-	category: "Trainer",
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
 
 	effect: {
-		'zh-tw': "將自己的戰鬥場的【基礎】寶可夢與備戰寶可夢互換。然後，將換入備戰區的寶可夢恢復「30」HP。"
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+		'zh-tw': "將自己的戰鬥場的【基礎】寶可夢與備戰寶可夢互換。然後，將換入備戰區的寶可夢恢復「30」HP。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 727991,
+				tcgplayer: 587840,
+			},
+		},
+	],
 
-export default card
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/083.ts
+++ b/data-asia/SV/SV-P/083.ts
@@ -1,22 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "反擊捕捉器"
+		ja: "基本超エネルギー",
+		'zh-tw': "反擊捕捉器",
 	},
 
-	illustrator: "Toyste Beach",
-	category: "Trainer",
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
 
 	effect: {
-		'zh-tw': "這張卡只有在自己剩餘獎賞卡的張數比對手剩餘獎賞卡的張數多時才可使用。 選擇1隻對手的備戰寶可夢，與戰鬥寶可夢互換。"
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+		'zh-tw': "這張卡只有在自己剩餘獎賞卡的張數比對手剩餘獎賞卡的張數多時才可使用。 選擇1隻對手的備戰寶可夢，與戰鬥寶可夢互換。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "G"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 727992,
+				tcgplayer: 587841,
+			},
+		},
+	],
 
-export default card
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/084.ts
+++ b/data-asia/SV/SV-P/084.ts
@@ -1,22 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "大地之容器"
+		ja: "基本闘エネルギー",
+		'zh-tw': "大地之容器",
 	},
 
-	illustrator: "AYUMI ODASHIMA",
-	category: "Trainer",
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
 
 	effect: {
-		'zh-tw': "這張卡必須將自己的1張手牌丟棄才可使用。 從自己的牌庫選擇最多2張基本能量卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+		'zh-tw': "這張卡必須將自己的1張手牌丟棄才可使用。 從自己的牌庫選擇最多2張基本能量卡，在給對手看過後加入手牌。並且重洗牌庫。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "G"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 727993,
+				tcgplayer: 587842,
+			},
+		},
+	],
 
-export default card
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/085.ts
+++ b/data-asia/SV/SV-P/085.ts
@@ -1,22 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "高科技雷達"
+		ja: "基本悪エネルギー",
+		'zh-tw': "高科技雷達",
 	},
 
-	illustrator: "inose yukie",
-	category: "Trainer",
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
 
 	effect: {
-		'zh-tw': "這張卡必須將自己的1張手牌丟棄才可使用。 從自己的牌庫選擇最多2張「未來」寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+		'zh-tw': "這張卡必須將自己的1張手牌丟棄才可使用。 從自己的牌庫選擇最多2張「未來」寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "G"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 727994,
+				tcgplayer: 587843,
+			},
+		},
+	],
 
-export default card
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/086.ts
+++ b/data-asia/SV/SV-P/086.ts
@@ -1,21 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雙重渦輪能量"
+		ja: "基本鋼エネルギー",
+		'zh-tw': "雙重渦輪能量",
 	},
 
+	illustrator: "",
 	category: "Energy",
+	energyType: "Normal",
 
 	effect: {
-		'zh-tw': "只要這張卡附於寶可夢身上，視為提供2個【無】能量。 附有這張卡的寶可夢使用的招式，對對手的寶可夢造成的傷害「-20」點。"
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+		'zh-tw': "只要這張卡附於寶可夢身上，視為提供2個【無】能量。 附有這張卡的寶可夢使用的招式，對對手的寶可夢造成的傷害「-20」點。",
 	},
 
-	energyType: "Special",
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 727995,
+				tcgplayer: 587844,
+			},
+		},
+	],
 
-export default card
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/087.ts
+++ b/data-asia/SV/SV-P/087.ts
@@ -1,50 +1,64 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "烏波"
+		ja: "シルシュルー",
+		'zh-tw': "烏波",
 	},
 
-	illustrator: "Saboteri",
+	illustrator: "Hitoshi Ariga",
 	category: "Pokemon",
-	hp: 60,
-	types: ["Water"],
+	hp: 50,
+	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "在冰冷的水中生活。 當周遭的天氣變涼時， 也會來到陸地上覓食。"
+		ja: "温厚だが 怒らせると 毒が 染みこんだ 鋭い 前歯で 咬みつき 痺れさせてくるぞ。",
+		'zh-tw': "在冰冷的水中生活。 當周遭的天氣變涼時， 也會來到陸地上覓食。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "打水"
+	attacks: [
+		{
+			name: {
+				ja: "ひっかく",
+				'zh-tw': "打水",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
-
-		effect: {
-			'zh-tw': "從自己的棄牌區選擇最多3張「基本【水】能量」卡，在給對手看過後放回牌庫並重洗。"
+		{
+			name: {
+				ja: "どくのまえば",
+				'zh-tw': "頭錘",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
 		},
+	],
 
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "頭錘"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719856,
+				tcgplayer: 587845,
+			},
 		},
-
-		damage: 10,
-		cost: ["Water"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "H"
-}
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [944],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV-P/088.ts
+++ b/data-asia/SV/SV-P/088.ts
@@ -1,46 +1,69 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "沼王"
+		ja: "タギングルex",
+		'zh-tw': "沼王",
 	},
 
-	illustrator: "Saboteri",
+	illustrator: "aky CG Works",
 	category: "Pokemon",
-	hp: 120,
-	types: ["Water"],
+	hp: 250,
+	types: ["Colorless"],
+
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "滾動"
+	attacks: [
+		{
+			name: {
+				ja: "しびれるだえき",
+				'zh-tw': "滾動",
+			},
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
 		},
-
-		damage: 30,
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "濕透頭擊"
+		{
+			name: {
+				ja: "ポイポポイズン",
+				'zh-tw': "濕透頭擊",
+			},
+			damage: 180,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。次の自分の番、このポケモンは「ポイポポイズン」が使えない。",
+				'zh-tw': "將自己的牌庫上方3張卡丟棄，造成其中能量卡的張數×80點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將自己的牌庫上方3張卡丟棄，造成其中能量卡的張數×80點傷害。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 719857,
+				tcgplayer: 587846,
+			},
 		},
+	],
 
-		damage: "80×",
-		cost: ["Water", "Colorless", "Colorless"]
-	}],
+	evolveFrom: {
+		ja: "シルシュルー",
+	},
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [945],
 
-	retreat: 3,
-	regulationMark: "H"
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV-P/089.ts
+++ b/data-asia/SV/SV-P/089.ts
@@ -1,56 +1,65 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鑰圈兒"
+		ja: "スコヴィランex",
+		'zh-tw': "鑰圈兒",
 	},
 
-	illustrator: "GOSSAN",
+	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
-	hp: 70,
-	types: ["Psychic"],
+	hp: 260,
+	types: ["Grass"],
 
-	description: {
-		'zh-tw': "過去的貴族會將掌管金庫 鑰匙的鑰圈兒一代代地 傳承下去，並對其呵護備至。"
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: {
+				ja: "からくちバインド",
+				'zh-tw': "狙落",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。次の相手の番、このワザを受けたポケモンは、にげられない。",
+				'zh-tw': "在造成傷害前，將對手的戰鬥寶可夢身上附加的「寶可夢道具」卡丟棄。",
+			},
+		},
+		{
+			name: { ja: "ツーヘッドクラッシュ" },
+			damage: 140,
+			cost: ["Grass", "Grass"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、トラッシュする。相手の山札を上から1枚トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 723903,
+				tcgplayer: 587847,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カプサイジ",
 	},
 
-	stage: "Basic",
+	retreat: 2,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [952],
 
-	abilities: [{
-		type: "Ability",
+	suffix: "EX",
+};
 
-		name: {
-			'zh-tw': "惡作劇之鎖"
-		},
-
-		effect: {
-			'zh-tw': "只要這隻寶可夢在戰鬥場上，雙方場上的【基礎】寶可夢的特性（「惡作劇之鎖」除外）全部消除。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "狙落"
-		},
-
-		effect: {
-			'zh-tw': "在造成傷害前，將對手的戰鬥寶可夢身上附加的「寶可夢道具」卡丟棄。"
-		},
-
-		damage: 10,
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/090.ts
+++ b/data-asia/SV/SV-P/090.ts
@@ -1,51 +1,52 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "纏紅鶴ex"
+		ja: "キバニア",
+		'zh-tw': "纏紅鶴ex",
 	},
 
-	illustrator: "N-DESIGN Inc.",
+	illustrator: "Tonji Matsuno",
 	category: "Pokemon",
-	hp: 200,
-	types: ["Colorless"],
+	hp: 50,
+	types: ["Water"],
+
+	description: {
+		ja: "鋭い キバと たくましい 顎を もつ。 船乗りたちは キバニアの すみかには けっして 近づかない。",
+	},
+
 	stage: "Basic",
-	suffix: "EX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "恰好喙"
+	attacks: [
+		{
+			name: {
+				ja: "するどいキバ",
+				'zh-tw': "恰好喙",
+			},
+			damage: 20,
+			cost: ["Water"],
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢與對手的戰鬥寶可夢身上附加的能量數量相同，則增加100點傷害。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 723905,
+				tcgplayer: 587848,
+			},
 		},
-
-		damage: "30+",
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "勇鳥猛攻"
-		},
-
-		effect: {
-			'zh-tw': "這隻寶可夢也受到30點傷害。"
-		},
-
-		damage: 200,
-		cost: ["Colorless", "Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "H"
-}
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [318],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV-P/091.ts
+++ b/data-asia/SV/SV-P/091.ts
@@ -1,22 +1,51 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "巢穴球"
+		ja: "エレズン",
+		'zh-tw': "巢穴球",
 	},
 
-	illustrator: "Toyste Beach",
-	category: "Trainer",
+	illustrator: "Natsumi Yoshida",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
 
-	effect: {
-		'zh-tw': "從自己的牌庫選擇1張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。"
+	description: {
+		ja: "汚れた 水を 飲んでも 平気。 体内の 器官で 自分には 無害の 毒液に ろ過するぞ。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "G"
-}
+	stage: "Basic",
 
-export default card
+	attacks: [
+		{
+			name: { ja: "ちょっとつっこむ" },
+			damage: 30,
+			cost: ["Lightning"],
+			effect: {
+				ja: "このポケモンにも10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 587849,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [848],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/092.ts
+++ b/data-asia/SV/SV-P/092.ts
@@ -1,22 +1,51 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "寶可夢交替"
+		ja: "ピィ",
+		'zh-tw': "寶可夢交替",
 	},
 
-	illustrator: "Studio Bora Inc.",
-	category: "Trainer",
+	illustrator: "Tika Matsuno",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Psychic"],
 
-	effect: {
-		'zh-tw': "將自己的戰鬥寶可夢與備戰寶可夢互換。"
+	description: {
+		ja: "お星さまのような シルエット。 その姿から 流れ星に乗って やって来ると 信じられている。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "G"
-}
+	stage: "Basic",
 
-export default card
+	attacks: [
+		{
+			name: { ja: "キラキラいのる" },
+			cost: [],
+			effect: {
+				ja: "自分の山札から基本エネルギーを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 723904,
+				tcgplayer: 587850,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [173],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/093.ts
+++ b/data-asia/SV/SV-P/093.ts
@@ -1,22 +1,61 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "泰姆"
+		ja: "サナギラス",
+		'zh-tw': "泰姆",
 	},
 
-	illustrator: "Akira Komayama",
-	category: "Trainer",
+	illustrator: "Shiburingaru",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
 
-	effect: {
-		'zh-tw': "從自己的手牌選擇1張寶可夢卡，向對手宣言那隻寶可夢的名稱後，翻到反面放置。對手回答那隻寶可夢的HP。將翻到反面的寶可夢卡翻到正面，若正確，則對手從牌庫抽出4張卡。若不正確，則自己從牌庫抽出4張卡。然後，將放置的卡放回自己的手牌。"
+	description: {
+		ja: "体内で 圧縮させた ガスを 勢いよく 噴出させ 飛んで 暴れまわる サナギだ。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "H"
-}
+	stage: "Stage1",
 
-export default card
+	attacks: [
+		{
+			name: { ja: "いわおとし" },
+			damage: 20,
+			cost: ["Fighting"],
+		},
+		{
+			name: { ja: "ふんしゃタックル" },
+			damage: 60,
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "自分のベンチポケモン1匹にも、20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 723907,
+				tcgplayer: 587851,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヨーギラス",
+	},
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [247],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/094.ts
+++ b/data-asia/SV/SV-P/094.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブロロローム",
+	},
+
+	illustrator: "Nisota Niso",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Metal"],
+
+	description: {
+		ja: "毒素と 岩の 成分を 混ぜた ガスを ８つに 増えた シリンダーで 爆発させ エネルギーを 作る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "いばる" },
+			cost: ["Metal"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ヒュージタックル" },
+			damage: "70+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の手札の枚数が、相手の手札の枚数より多いなら、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 723908,
+				tcgplayer: 587852,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ブロロン",
+	},
+
+	retreat: 3,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [966],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/095.ts
+++ b/data-asia/SV/SV-P/095.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "月明かりの丘",
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の手札から「基本[P]エネルギー」を1枚トラッシュするなら、自分のポケモン全員のHPを、それぞれ「30」回復してよい。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 723909,
+				tcgplayer: 587853,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/096.ts
+++ b/data-asia/SV/SV-P/096.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グルーシャ",
+	},
+
+	illustrator: "GIDORA",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札が5枚になるように、山札を引く。自分の場のポケモンにエネルギーが1枚もついていないなら、7枚になるように引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 723910,
+				tcgplayer: 587854,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/097.ts
+++ b/data-asia/SV/SV-P/097.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モトトカゲ",
+	},
+
+	illustrator: "Hasuno",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Colorless"],
+
+	description: {
+		ja: "大昔から 人を 背中に 乗せていたらしい。 １万年前の 壁画に 様子が 描かれている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ガンガンダッシュ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数ぶん、自分の山札を引く。",
+			},
+		},
+		{
+			name: { ja: "パワータックル" },
+			damage: 120,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 723911,
+				tcgplayer: 587855,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [967],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/098.ts
+++ b/data-asia/SV/SV-P/098.ts
@@ -1,48 +1,61 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV-P"
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "拉帝亞斯"
+		ja: "名探偵ピカチュウ",
+		'zh-tw': "拉帝亞斯",
 	},
 
-	illustrator: "hncl",
+	illustrator: "MINAMINAMI Take",
 	category: "Pokemon",
-	hp: 110,
-	types: ["Psychic"],
+	hp: 90,
+	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "透過心靈感應和人類交流情感。 會用能令光線折射的羽毛 變化成其他的樣子。"
+		ja: "調査には 根気が 必要。 粘り強い調査で 事件の手がかりを 探し出せ！",
+		'zh-tw': "透過心靈感應和人類交流情感。 會用能令光線折射的羽毛 變化成其他的樣子。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "0"
+	attacks: [
+		{
+			name: {
+				ja: "てっていちょうさ",
+				'zh-tw': "0",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数ぶん、自分の山札を引く。",
+				'zh-tw': "‌若這隻寶可夢身上附有【超】能量，則將這隻寶可夢【撤退】所需的能量全部消除。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "‌若這隻寶可夢身上附有【超】能量，則將這隻寶可夢【撤退】所需的能量全部消除。"
+		{
+			name: { ja: "ライドダッシュ" },
+			damage: 50,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 0
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 727072,
+				tcgplayer: 587856,
+			},
+		},
+	],
 
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [25],
+};
 
-	retreat: 2,
-	regulationMark: "G"
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV-P/099.ts
+++ b/data-asia/SV/SV-P/099.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コレクレー",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Psychic"],
+
+	description: {
+		ja: "およそ１５００年前 宝箱の中で 生まれた。 宝を 盗む 不埒者の 生気を 吸い取る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なかまをよぶ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からたねポケモンを1枚選び、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "どつく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 731903,
+				tcgplayer: 587857,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [999],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/100.ts
+++ b/data-asia/SV/SV-P/100.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本草エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 731904,
+				tcgplayer: 692375,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/101.ts
+++ b/data-asia/SV/SV-P/101.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本炎エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 731905,
+				tcgplayer: 692376,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/102.ts
+++ b/data-asia/SV/SV-P/102.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本水エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 692377,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/103.ts
+++ b/data-asia/SV/SV-P/103.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本雷エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 731907,
+				tcgplayer: 692378,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/104.ts
+++ b/data-asia/SV/SV-P/104.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本超エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 731908,
+				tcgplayer: 692379,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/105.ts
+++ b/data-asia/SV/SV-P/105.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本闘エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 731909,
+				tcgplayer: 692380,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/106.ts
+++ b/data-asia/SV/SV-P/106.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本悪エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 731910,
+				tcgplayer: 692381,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/107.ts
+++ b/data-asia/SV/SV-P/107.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本鋼エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 731911,
+				tcgplayer: 692382,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/108.ts
+++ b/data-asia/SV/SV-P/108.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サンダーex",
+	},
+
+	illustrator: "takuyoa",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ボルトフロート" },
+			effect: {
+				ja: "このポケモンに[L]エネルギーがついているなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "いなずまれんだん" },
+			damage: 120,
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "ダメカンがのっている相手のベンチポケモン1匹にも、90ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 725816,
+				tcgplayer: 587858,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [145],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/109.ts
+++ b/data-asia/SV/SV-P/109.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "まけんきハチマキ",
+	},
+
+	illustrator: "inose yukie",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のサイドの残り枚数が、相手のサイドの残り枚数より多いなら、このカードをつけているポケモンが使うワザの、相手のバトルポケモンへのダメージは「+30」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 587859,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/110.ts
+++ b/data-asia/SV/SV-P/110.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "おいわいファンファーレ",
+	},
+
+	illustrator: "Yuu Nishida",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分のポケモン全員のHPを、それぞれ「10」回復してよい。その場合、自分の番は終わる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 724964,
+				tcgplayer: 587860,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/111.ts
+++ b/data-asia/SV/SV-P/111.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バオップ",
+	},
+
+	illustrator: "0313",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "火山の 洞穴で 暮らす。 頭の ふさの 中が 燃えていて ３００度の 高温になる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なかまをよぶ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からたねポケモンを1枚選び、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "やきこがす" },
+			damage: 20,
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 740412,
+				tcgplayer: 587861,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [513],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/112.ts
+++ b/data-asia/SV/SV-P/112.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タッツー",
+	},
+
+	illustrator: "MAHOU",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "水中を 踊るように 泳いで 渦を つくる。 仲間と 渦の 大きさを 競って 遊ぶ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっかける" },
+			damage: 20,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 740413,
+				tcgplayer: 587862,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [116],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/113.ts
+++ b/data-asia/SV/SV-P/113.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デスマス",
+	},
+
+	illustrator: "aoki",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "古代人の 魂が ポケモンに なった。 自分の 顔を 知る 人を 探し 遺跡を さまよう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふきつなめ" },
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "相手のポケモン1匹に、ダメカンを3個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 740414,
+				tcgplayer: 587863,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [562],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/114.ts
+++ b/data-asia/SV/SV-P/114.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デカヌチャン",
+	},
+
+	illustrator: "DOM",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Psychic"],
+
+	description: {
+		ja: "知能が 高く とても 豪快。 ハンマーで 岩を 殴り飛ばして 空飛ぶ アーマーガアを 狙う。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "はたきおとす" },
+			damage: 40,
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "ワイルドプレス" },
+			damage: 220,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも60ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 740415,
+				tcgplayer: 587864,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ナカヌチャン",
+	},
+
+	retreat: 2,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [959],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/115.ts
+++ b/data-asia/SV/SV-P/115.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キョジオーンex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 340,
+	types: ["Fighting"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ソルティボディ" },
+			effect: {
+				ja: "このポケモンは特殊状態にならない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ブロックハンマー" },
+			damage: 170,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-60」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 740416,
+				tcgplayer: 587865,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジオヅム",
+	},
+
+	retreat: 4,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [934],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/116.ts
+++ b/data-asia/SV/SV-P/116.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポリゴン2",
+	},
+
+	illustrator: "GOSSAN",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ＡＩ機能を 搭載した 結果 ポリゴン２ 同士にしか わからない 謎の 言語を 話しはじめた。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "パワーボール" },
+			damage: 50,
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 740417,
+				tcgplayer: 587866,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ポリゴン",
+	},
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [233],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/117.ts
+++ b/data-asia/SV/SV-P/117.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レホール",
+	},
+
+	illustrator: "hncl",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から5枚見て、その中からカードを好きなだけ選び、トラッシュする。残りのカードは好きな順番に入れ替えて、山札の上にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 740418,
+				tcgplayer: 587867,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/118.ts
+++ b/data-asia/SV/SV-P/118.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポピー",
+	},
+
+	illustrator: "yuu",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の場のポケモン1匹についているエネルギーを2個まで選び、自分の別のポケモン1匹につけ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 587868,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/119.ts
+++ b/data-asia/SV/SV-P/119.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラティアス",
+	},
+
+	illustrator: "hncl",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Psychic"],
+
+	description: {
+		ja: "テレパシーで 人間と 気持ちを 通わせる。 光を 屈折させる 羽毛で 別の 姿に 変わる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ミストフロート" },
+			effect: {
+				ja: "このポケモンに[P]エネルギーがついているなら、このポケモンのにげるためのエネルギーは、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ねんどうだん" },
+			damage: 100,
+			cost: ["Psychic", "Psychic", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 740420,
+				tcgplayer: 587869,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [380],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/120.ts
+++ b/data-asia/SV/SV-P/120.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウ",
+	},
+
+	illustrator: "Jiro Sasumo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "両頬には 電気を 溜めこむ 袋がある。 怒ると 溜めこんだ 電気を 一気に 放ってくる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "げきとうスパーク" },
+			damage: "30+",
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数×30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 731912,
+				tcgplayer: 587870,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/121.ts
+++ b/data-asia/SV/SV-P/121.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウパー",
+	},
+
+	illustrator: "Saboteri",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "冷たい 水の中で 生活。 あたりが 涼しくなると エサを 探しに 地上にも 現れる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みずくみ" },
+			cost: ["Water"],
+			effect: {
+				ja: "自分のトラッシュから「基本[W]エネルギー」を3枚まで選び、相手に見せて、山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "ずつき" },
+			damage: 10,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 751819,
+				tcgplayer: 587871,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [194],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/122.ts
+++ b/data-asia/SV/SV-P/122.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヌオー",
+	},
+
+	illustrator: "Saboteri",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "船底や 川の岩に 頭を ぶつけまくっても 気にせず 気ままに 泳いでいる のんきな ポケモン。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ころがる" },
+			damage: 30,
+			cost: ["Water"],
+		},
+		{
+			name: { ja: "ずぶぬれヘッド" },
+			damage: "80×",
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札を上から3枚トラッシュし、その中にあるエネルギーの枚数×80ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 751820,
+				tcgplayer: 587872,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ウパー",
+	},
+
+	retreat: 3,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [195],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/123.ts
+++ b/data-asia/SV/SV-P/123.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クレッフィ",
+	},
+
+	illustrator: "GOSSAN",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "昔の 貴族は 金庫の カギを 管理させる クレッフィを 代々 引き継ぎ 大切に 扱った。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "いたずらロック" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、おたがいの場のたねポケモンの特性（「いたずらロック」をのぞく）は、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ねらいおとす" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "ダメージを与える前に、相手のバトルポケモンについている「ポケモンのどうぐ」をトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 751821,
+				tcgplayer: 587873,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [707],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/124.ts
+++ b/data-asia/SV/SV-P/124.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カラミンゴex",
+	},
+
+	illustrator: "N-DESIGN Inc.",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ジャストビーク" },
+			damage: "30+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンと相手のバトルポケモンについているエネルギーの数が同じなら、100ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ブレイブバード" },
+			damage: 200,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 751822,
+				tcgplayer: 587874,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [973],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/125.ts
+++ b/data-asia/SV/SV-P/125.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネストボール",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札にあるたねポケモンを1枚、ベンチに出す。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 751823,
+				tcgplayer: 587875,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/126.ts
+++ b/data-asia/SV/SV-P/126.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモンいれかえ",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 751824,
+				tcgplayer: 587876,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/127.ts
+++ b/data-asia/SV/SV-P/127.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タイム",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札からポケモンを1枚選び、そのポケモンの名前を相手に伝えてから、ウラにして置く。相手はそのポケモンのHPを答える。ウラにしたポケモンをオモテにして、正解なら、相手は山札を4枚引く。不正解なら、自分は山札を4枚引く。その後、置いたカードを自分の手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 587877,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "H",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/128.ts
+++ b/data-asia/SV/SV-P/128.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チリ",
+	},
+
+	illustrator: "GIDORA",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から4枚見て、その中からカードを2枚選び、手札に加える。残りのカードはすべてウラにして切り、山札の下にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 692383,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/129.ts
+++ b/data-asia/SV/SV-P/129.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パチリス",
+	},
+
+	illustrator: "Yuya Oka",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "溜まった 電気を 分け与えようと 頬袋を こすり合わせる パチリスを 見かけることも ある。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぱちぱちチャージ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数ぶんまで、自分のトラッシュから「基本[L]エネルギー」を選び、ベンチポケモンに好きなようにつける。",
+			},
+		},
+		{
+			name: { ja: "プチボルト" },
+			damage: 30,
+			cost: ["Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 754795,
+				tcgplayer: 587878,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [417],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/130.ts
+++ b/data-asia/SV/SV-P/130.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キバナ",
+	},
+
+	illustrator: "hncl",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、前の相手の番に、自分のポケモンがきぜつしていなければ使えない。自分のトラッシュから基本エネルギーを1枚選び、自分のポケモンにつける。その後、自分の山札から好きなカードを1枚選び、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 749911,
+				tcgplayer: 587879,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/131.ts
+++ b/data-asia/SV/SV-P/131.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソーナンス",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Psychic"],
+
+	description: {
+		ja: "光や ショックを 嫌う。 攻撃されると 体が ふくらみ 反撃が 強力に なる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "がまんのかべ" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、おたがいの場・手札・トラッシュにあるポケモン（[超]ポケモンはのぞく）の特性は、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "サイコダメージ" },
+			damage: "10+",
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにのっているダメカンの数x10ダメージを追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 749912,
+				tcgplayer: 587880,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Promo",
+	dexId: [202],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/132.ts
+++ b/data-asia/SV/SV-P/132.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダストダス",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Psychic"],
+
+	description: {
+		ja: "左腕で 相手を 絞めつけて 口から 吐き出す 悪臭の 毒ガスで とどめを 刺すのだ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ダストオキシン" },
+			effect: {
+				ja: "このポケモンに「ポケモンのどうぐ」がついているなら、おたがいの場・手札・トラッシュのカードに書かれている特性（「ダストオキシン」をのぞく）は、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ヘドロなげ" },
+			damage: 60,
+			cost: ["Psychic", "Psychic", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 749913,
+				tcgplayer: 587881,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤブクロン",
+	},
+
+	retreat: 3,
+	rarity: "Promo",
+	dexId: [659],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/133.ts
+++ b/data-asia/SV/SV-P/133.ts
@@ -1,0 +1,66 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カプ・テテフGX",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ワンダータッチ" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の山札にあるサポートを1枚、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エナジードライブ" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "おたがいのバトルポケモンについているエネルギーの数x20ダメージ。このワザのダメージは弱点・抵抗力を計算しない。",
+			},
+		},
+		{
+			name: { ja: "カプキュアーGX" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分のベンチポケモン2匹のHPを、すべて回復する。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 749914,
+				tcgplayer: 587882,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "A",
+	rarity: "Promo",
+	dexId: [786],
+
+	suffix: "GX",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/134.ts
+++ b/data-asia/SV/SV-P/134.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カイリューEX",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ひきあげる" },
+			effect: {
+				ja: "この特性は、このカードを手札からベンチに出したとき、1回使える。自分のトラッシュからたねポケモン（「カイリューEX」をのぞく）を2枚選び、相手に見せてから、手札に加える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "はかいこうせん" },
+			damage: 130,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 749915,
+				tcgplayer: 587883,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Promo",
+	dexId: [149],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/135.ts
+++ b/data-asia/SV/SV-P/135.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トレーナーズポスト",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から4枚見る。その中からトレーナーズ（「トレーナーズポスト」をのぞく）を1枚選び、相手に見せてから、手札に加える。残りのカードは山札にもどし、山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 587884,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/136.ts
+++ b/data-asia/SV/SV-P/136.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バトルコンプレッサー",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から好きなカードを3枚まで選び、トラッシュする。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 749917,
+				tcgplayer: 587885,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/137.ts
+++ b/data-asia/SV/SV-P/137.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バトルサーチャー",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュからサポートを1枚選び、相手に見せてから、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 749918,
+				tcgplayer: 587886,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/138.ts
+++ b/data-asia/SV/SV-P/138.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "かるいし",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンのにげるために必要なエネルギーは、すべてなくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 749919,
+				tcgplayer: 587887,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/139.ts
+++ b/data-asia/SV/SV-P/139.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミツル",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の場のポケモン1匹（「ポケモンEX」をのぞく）から進化するカードを、自分の山札から1枚選び、そのポケモンにのせて進化させる。そして山札を切る。（最初の自分の番や、出したばかりのポケモンにも使える。）",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 587888,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/140.ts
+++ b/data-asia/SV/SV-P/140.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サイレントラボ",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの場・手札・トラッシュにあるたねポケモンの特性は、すべてなくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 749921,
+				tcgplayer: 587889,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/141.ts
+++ b/data-asia/SV/SV-P/141.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スカイフィールド",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーがベンチに出せるポケモンの数は、8匹になる。（このカードがトラッシュされたとき、ベンチに6匹以上いるプレイヤーは、ベンチが5匹になるまでポケモンをトラッシュする。トラッシュするのは、このカードの持ち主から。）",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 749922,
+				tcgplayer: 692384,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/142.ts
+++ b/data-asia/SV/SV-P/142.ts
@@ -1,0 +1,23 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダブルドラゴンエネルギー",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは[竜]ポケモンにしかつけられず、ついているかぎりすべてのタイプのエネルギー2個ぶんとしてはたらく。（このカードが[竜]ポケモン以外についているなら、トラッシュする。）",
+	},
+
+	variants: [{ type: "normal" }],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/143.ts
+++ b/data-asia/SV/SV-P/143.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エネルギーシール",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Trainer",
+
+	effect: {
+		ja: "コインを1回投げオモテなら、自分のトラッシュから基本エネルギーを1枚選び、ベンチポケモンにつける。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 761017,
+				tcgplayer: 687696,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/144.ts
+++ b/data-asia/SV/SV-P/144.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スナッチアーム",
+	},
+
+	illustrator: "inose yukie",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手の手札を見て、その中からポケモンを1枚選び、相手の山札の下にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 761018,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/145.ts
+++ b/data-asia/SV/SV-P/145.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "勇気のおまもり",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているたねポケモンの最大HPは「+50」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 761019,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/146.ts
+++ b/data-asia/SV/SV-P/146.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ワザマシン エヴォリューション",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンは、このカードに書かれているワザを使える。［ワザを使うためのエネルギーは必要。］ポケモンについているこのカードは、自分の番の終わりにトラッシュする。[C] エヴォリューション 自分のベンチポケモンを2匹まで選び、そのポケモンから進化するカードを、自分の山札から1枚ずつ選び、それぞれにのせて進化させる。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 761020,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/148.ts
+++ b/data-asia/SV/SV-P/148.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オーガポン みどりのめん",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Grass"],
+
+	description: {
+		ja: "いたずら好きで 好奇心旺盛。 仮面に こめられた タイプの エネルギーを 引き出して 戦う。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "やまあるき" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から基本エネルギーを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "おにがえし" },
+			damage: "20+",
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンの数×20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 765991,
+				tcgplayer: 587891,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [1017],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/149.ts
+++ b/data-asia/SV/SV-P/149.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "鬼の仮面",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュから、名前に「オーガポン」とつく「ポケモンex」を1枚選び、自分の場の、名前に「オーガポン」とつく「ポケモンex」1匹と入れ替える（ついているカード・ダメカン・特殊状態・効果などは、すべて引きつぐ）。入れ替えたポケモンはトラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 765993,
+				tcgplayer: 587892,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "H",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/150.ts
+++ b/data-asia/SV/SV-P/150.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "なかよしポフィン",
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から、HPが「70」以下のたねポケモンを2枚まで選び、ベンチに出す。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 751827,
+				tcgplayer: 587893,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "H",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/151.ts
+++ b/data-asia/SV/SV-P/151.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミライドン",
+	},
+
+	illustrator: "GOSSAN",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Dragon"],
+
+	description: {
+		ja: "古い 書物に 名が ある テツノオロチらしい。 雷で 大地を 灰に 変えたという。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アクセルピーク" },
+			damage: 40,
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から基本エネルギーを2枚まで選び、自分の「未来」のポケモンに好きなようにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "スパーキングアタック" },
+			damage: 160,
+			cost: ["Lightning", "Lightning", "Psychic"],
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 751828,
+				tcgplayer: 587894,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [1008],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/152.ts
+++ b/data-asia/SV/SV-P/152.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コライドン",
+	},
+
+	illustrator: "Teeziro",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Dragon"],
+
+	description: {
+		ja: "拳で 大地を 引き裂いたと 古い 探検記に 記された ツバサノオウの 正体らしい。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "げんせいらんだ" },
+			damage: "30×",
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "自分の場の「古代」のポケモンの数×30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ひきさく" },
+			damage: 130,
+			cost: ["Fire", "Fighting", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 751829,
+				tcgplayer: 587895,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [1007],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/153.ts
+++ b/data-asia/SV/SV-P/153.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネモ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 764618,
+				tcgplayer: 587896,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "H",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/155.ts
+++ b/data-asia/SV/SV-P/155.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タイカイデンex",
+	},
+
+	illustrator: "PLANETA Yamashita",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Lightning"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "Attack" },
+			damage: 1,
+			cost: ["Lightning"],
+		},
+		{
+			name: { ja: "サンダーランス" },
+			damage: "40+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[L]エネルギーの数×40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 766671,
+				tcgplayer: 587898,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カイデン",
+	},
+
+	retreat: 0,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [941],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/156.ts
+++ b/data-asia/SV/SV-P/156.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミミッキュ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "陽の 当たらない 暗がりに 棲む。 人前に 出るときは ピカチュウに 似せた 布で 全身を 隠す。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しんぴのまもり" },
+			effect: {
+				ja: "このポケモンは、相手の「ポケモンex・V」からワザのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ゴーストアイ" },
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンに、ダメカンを7個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 766672,
+				tcgplayer: 587899,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [778],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/157.ts
+++ b/data-asia/SV/SV-P/157.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ズルッグ",
+	},
+
+	illustrator: "OKUBO",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "視線が 合ったら 危険！ 相手を 選ばず 頭突きで 襲ってくる 厄介者だ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "いっぱつげり" },
+			damage: 30,
+			cost: ["Darkness"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 766673,
+				tcgplayer: 587900,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [559],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/158.ts
+++ b/data-asia/SV/SV-P/158.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ズルズキン",
+	},
+
+	illustrator: "OKUBO",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Darkness"],
+
+	description: {
+		ja: "やる気の なさげな キックは ローブシンの もつ コンクリートも 砕くほどの 破壊力。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かっぱらう" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のベンチポケモンの数ぶんまで、自分の山札から好きなカードを選び、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "とびひざげり" },
+			damage: 100,
+			cost: ["Darkness", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 766674,
+				tcgplayer: 587901,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ズルッグ",
+	},
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [560],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/159.ts
+++ b/data-asia/SV/SV-P/159.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ふしぎなアメ",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のたねポケモン1匹から進化する1進化の上の2進化ポケモンを、手札から1枚選び、そのたねポケモンにのせて進化させる。[最初の自分の番と、この番出したばかりのたねポケモンには使えない。]",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 766675,
+				tcgplayer: 587902,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "H",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/160.ts
+++ b/data-asia/SV/SV-P/160.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロトりぼう",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から4枚見て、その中からサポートを好きなだけ選び、相手に見せて、手札に加える。残りのカードは山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 766676,
+				tcgplayer: 587903,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/161.ts
+++ b/data-asia/SV/SV-P/161.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナンジャモ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、それぞれ自分の手札をすべてウラにして切り、山札の下にもどす。その後、それぞれ自分のサイドの残り枚数ぶん、山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 587904,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "H",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/162.ts
+++ b/data-asia/SV/SV-P/162.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ザルード",
+	},
+
+	illustrator: "Uninori",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Grass"],
+
+	description: {
+		ja: "群れを つくり 密林で 暮らす。 とても 攻撃的で 森にすむ ポケモンたちから 恐れられている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もぎとる" },
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の山札から「基本[G]エネルギー」を3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ハンマーウィップ" },
+			damage: 130,
+			cost: ["Grass", "Grass", "Grass"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 770947,
+				tcgplayer: 587905,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [893],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/163.ts
+++ b/data-asia/SV/SV-P/163.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤンヤンマ",
+	},
+
+	illustrator: "Dsuke",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "大きな 目玉は 動かさなくても あらゆる 方向を 見渡せるので 敵や エサも すぐ 見つけられる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "サイレントウイング" },
+			damage: 20,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "相手の手札を見る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 587906,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [193],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/164.ts
+++ b/data-asia/SV/SV-P/164.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガヤンマ",
+	},
+
+	illustrator: "Dsuke",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Grass"],
+
+	description: {
+		ja: "あごの 力は けたはずれ。 高速で 飛んで すれ違いざまに 相手を かみちぎるのが 得意。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ジャイロソニック" },
+			damage: 110,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 778392,
+				tcgplayer: 587907,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤンヤンマ",
+	},
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [469],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/165.ts
+++ b/data-asia/SV/SV-P/165.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミガルーサex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひれカッター" },
+			damage: 30,
+			cost: ["Water"],
+		},
+		{
+			name: { ja: "パージストライク" },
+			damage: "120+",
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "のぞむなら、自分の手札をすべてトラッシュする。トラッシュした場合、120ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 778393,
+				tcgplayer: 587908,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [976],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/166.ts
+++ b/data-asia/SV/SV-P/166.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メタモン",
+	},
+
+	illustrator: "KIYOTAKA OSHIYAMA",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "変身は 完璧なのだが 笑わされて 力が 抜けると 変身は 解けてしまう。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "へんしんスタート" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、最初の自分の番にだけ1回使える。自分の山札からたねポケモン（「メタモン」をのぞく）を1枚選ぶ。その後、このポケモンと、ついているすべてのカードをトラッシュし、このポケモンがいた場所に、選んだポケモンを出す。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ぺとっ" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 587909,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [132],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/167.ts
+++ b/data-asia/SV/SV-P/167.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "すごいつりざお",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュからポケモンと基本エネルギーを合計3枚選び、相手に見せてから、山札にもどす。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 778395,
+				tcgplayer: 587910,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/168.ts
+++ b/data-asia/SV/SV-P/168.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "博士の研究",
+	},
+
+	illustrator: "kirisAki",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札をすべてトラッシュし、山札を7枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 778396,
+				tcgplayer: 587911,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/169.ts
+++ b/data-asia/SV/SV-P/169.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "博士の研究",
+	},
+
+	illustrator: "kirisAki",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札をすべてトラッシュし、山札を7枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 778397,
+				tcgplayer: 587912,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/170.ts
+++ b/data-asia/SV/SV-P/170.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビリオとネア",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を2枚引く。その後、自分の手札が10枚以上あるなら、さらに2枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 778398,
+				tcgplayer: 587913,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "H",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/171.ts
+++ b/data-asia/SV/SV-P/171.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼイユ",
+	},
+
+	illustrator: "kantaro",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、先攻プレイヤーの最初の番でも使える。自分の手札をすべてトラッシュし、山札を5枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 587914,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "H",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/172.ts
+++ b/data-asia/SV/SV-P/172.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガルーラ",
+	},
+
+	illustrator: "Uta",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "腹の 袋に 子どもが いるが フットワークは とても 軽い。 素早いジャブで 相手を 威嚇。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なかまをよぶ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からたねポケモンを1枚選び、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "メガトンパンチ" },
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 786657,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [115],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/173.ts
+++ b/data-asia/SV/SV-P/173.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨルノズク",
+	},
+
+	illustrator: "matazo",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Colorless"],
+
+	description: {
+		ja: "非常に 柔らかい 羽は 飛ぶとき 音を 出さないので こっそり 獲物に 近づける。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ほうせきさがし" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、自分の場に「テラスタル」のポケモンがいるなら、1回使える。自分の山札からトレーナーズを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スピードウイング" },
+			damage: 60,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 778400,
+				tcgplayer: 587915,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ホーホー",
+	},
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [164],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/174.ts
+++ b/data-asia/SV/SV-P/174.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "おいわいファンファーレ",
+	},
+
+	illustrator: "Yuu Nishida",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分のポケモン全員のHPを、それぞれ「10」回復してよい。その場合、自分の番は終わる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 781842,
+				tcgplayer: 587916,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "H",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/175.ts
+++ b/data-asia/SV/SV-P/175.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本草エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 778401,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/176.ts
+++ b/data-asia/SV/SV-P/176.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本炎エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 778402,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/177.ts
+++ b/data-asia/SV/SV-P/177.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本水エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 778403,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/178.ts
+++ b/data-asia/SV/SV-P/178.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本雷エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 778404,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/179.ts
+++ b/data-asia/SV/SV-P/179.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本超エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 778405,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/180.ts
+++ b/data-asia/SV/SV-P/180.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本闘エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 778406,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/181.ts
+++ b/data-asia/SV/SV-P/181.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本悪エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 778407,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/182.ts
+++ b/data-asia/SV/SV-P/182.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本鋼エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 778408,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/183.ts
+++ b/data-asia/SV/SV-P/183.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラ ナッシーex",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 300,
+	types: ["Dragon"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "トロピカルフィーバー" },
+			damage: 150,
+			cost: ["Grass", "Water"],
+			effect: {
+				ja: "自分の手札から基本エネルギーを好きなだけ選び、自分のポケモンに好きなようにつける。",
+			},
+		},
+		{
+			name: { ja: "ブンブンスフェーン" },
+			cost: ["Grass", "Water", "Fighting"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトル場のたねポケモンをきぜつさせる。ウラなら、相手のベンチのたねポケモンを1匹選び、きぜつさせる。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793379,
+				tcgplayer: 587917,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タマタマ",
+	},
+
+	retreat: 3,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [103],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/184.ts
+++ b/data-asia/SV/SV-P/184.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ベラカスex",
+	},
+
+	illustrator: "N-DESIGN Inc.",
+	category: "Pokemon",
+	hp: 250,
+	types: ["Grass"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "さかさまドロー" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を下から3枚引く。",
+			},
+		},
+		{
+			name: { ja: "サイコキネシス" },
+			damage: "20+",
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数×90ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793380,
+				tcgplayer: 672425,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シガロコ",
+	},
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [954],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/185.ts
+++ b/data-asia/SV/SV-P/185.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テツノツツミ",
+	},
+
+	illustrator: "Oswaldo KATO",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Water"],
+
+	description: {
+		ja: "古い 書物に 登場する 謎の 物体に 似た ポケモン。 目撃例は 過去 ２件のみ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ハイパーブロアー" },
+			effect: {
+				ja: "このポケモンがベンチにいるなら、自分の番に1回使える。相手のバトルポケモンをベンチポケモンと入れ替える（バトル場に出すポケモンは相手が選ぶ）。その後、このポケモンと、ついているすべてのカードを、トラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "れいきゃくジェット" },
+			damage: 80,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けた進化ポケモンは、ワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793381,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [991],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/186.ts
+++ b/data-asia/SV/SV-P/186.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒポポタス",
+	},
+
+	illustrator: "Minahamu",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fighting"],
+
+	description: {
+		ja: "砂で 体を 覆うことで ばい菌から 身を 守る。 砂漠の 砂の 中を 移動。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つきとばす" },
+			damage: 10,
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793382,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [449],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/187.ts
+++ b/data-asia/SV/SV-P/187.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カバルドン",
+	},
+
+	illustrator: "Minahamu",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Fighting"],
+
+	description: {
+		ja: "大きく 口を 開けて 自分の 強さを アピール。 大量の 砂を 巻き上げて 攻撃する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 60,
+			cost: ["Fighting", "Fighting"],
+		},
+		{
+			name: { ja: "おおすなあらし" },
+			damage: 150,
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "ダメカンがのっているおたがいのベンチポケモン全員にも、それぞれ40ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793383,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒポポタス",
+	},
+
+	retreat: 4,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [450],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/188.ts
+++ b/data-asia/SV/SV-P/188.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ボスの指令",
+	},
+
+	illustrator: "NC Empire",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793384,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/189.ts
+++ b/data-asia/SV/SV-P/189.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "わざマシンマシン",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から、名前に「ワザマシン」とつく「ポケモンのどうぐ」を3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793385,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "H",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/190.ts
+++ b/data-asia/SV/SV-P/190.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジェットエネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、ポケモンについているかぎり、[C]エネルギー1個ぶんとしてはたらく。このカードを手札からベンチポケモンにつけたとき、このカードをつけたポケモンを、バトルポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793386,
+			},
+		},
+	],
+
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/191.ts
+++ b/data-asia/SV/SV-P/191.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アカマツ",
+	},
+
+	illustrator: "GIDORA",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から、それぞれちがうタイプの基本エネルギーを2枚まで選び、相手に見せて、どちらか1枚を手札に加え、残りのエネルギーを自分のポケモンにつける。そして山札を切る。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Supporter",
+	regulationMark: "H",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/192.ts
+++ b/data-asia/SV/SV-P/192.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャース",
+	},
+
+	illustrator: "Uninori",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "眩しく 光るものが 大好き。 光るものを 見つけたとき なぜか 額の小判も 輝く。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みだれひっかき" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数×20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807419,
+				tcgplayer: 650395,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [52],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/193.ts
+++ b/data-asia/SV/SV-P/193.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パルデア ウパー",
+	},
+
+	illustrator: "OKACHEKE",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "単独行動は 危険なので ３、４匹が 一列に 並んで 助け合いながら 沼地を 歩く。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ころばす" },
+			damage: "10+",
+			cost: ["Darkness"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807420,
+				tcgplayer: 656026,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [194],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/194.ts
+++ b/data-asia/SV/SV-P/194.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スイクン",
+	},
+
+	illustrator: "Kuroimori",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "世界中を 駆け巡り 汚れた 水を 清めている。 北風と ともに 走り去る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かけぬける" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "オーロラビーム" },
+			damage: 100,
+			cost: ["Water", "Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807421,
+				tcgplayer: 696737,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [245],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/195.ts
+++ b/data-asia/SV/SV-P/195.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュラルドン",
+	},
+
+	illustrator: "Takeshi Nakamura",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Metal"],
+
+	description: {
+		ja: "金属の ボディは 頑丈だが 熱が こもってしまうので 尻尾の スリットから 放熱している。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぶちかます" },
+			damage: 30,
+			cost: ["Metal"],
+		},
+		{
+			name: { ja: "レイジングハンマー" },
+			damage: "80+",
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数×10ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807422,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [884],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/196.ts
+++ b/data-asia/SV/SV-P/196.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イーブイ",
+	},
+
+	illustrator: "Susumu Maeya",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "不規則な 遺伝子を 持つ。 石から出る 放射線によって 体が 突然変異を 起こす。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "カラフルキャッチ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から、それぞれちがうタイプの基本エネルギーを3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ずつき" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 587918,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [133],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/197.ts
+++ b/data-asia/SV/SV-P/197.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウ",
+	},
+
+	illustrator: "Atsushi Furusawa",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "両頬には 電気を 溜めこむ 袋がある。 怒ると 溜めこんだ 電気を 一気に 放ってくる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "げきとうスパーク" },
+			damage: "30+",
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数×30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 783439,
+				tcgplayer: 587919,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/198.ts
+++ b/data-asia/SV/SV-P/198.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イーブイ",
+	},
+
+	illustrator: "Susumu Maeya",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "様々な 姿に 進化する。 イーブイの 遺伝子は 進化の 秘密を 解き明かす カギだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "カラフルキャッチ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から、それぞれちがうタイプの基本エネルギーを3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ずつき" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 687693,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [133],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/199.ts
+++ b/data-asia/SV/SV-P/199.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リーリエのキュワワー",
+	},
+
+	illustrator: "Narumi Sato",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "ツルを 使って 花を 摘みとる。 体に つけた 花からは 癒しの 効果が 現れる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はなまねき" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からたねポケモンの「リーリエのポケモン」を好きなだけ選び、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ぱっときえる" },
+			damage: 30,
+			cost: ["Psychic"],
+			effect: {
+				ja: "このポケモンと、ついているすべてのカードを、手札にもどす。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807423,
+				tcgplayer: 683009,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [764],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/200.ts
+++ b/data-asia/SV/SV-P/200.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "Nのゾロア",
+	},
+
+	illustrator: "Jiro Sasumo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Darkness"],
+
+	description: {
+		ja: "相手の 姿に 化けてみせて 驚かせる。 無口な 子どもに 化けていることが 多いらしい。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっかく" },
+			damage: 20,
+			cost: ["Darkness"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807424,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [570],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/201.ts
+++ b/data-asia/SV/SV-P/201.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シャリタツ",
+	},
+
+	illustrator: "Jerky",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Dragon"],
+
+	description: {
+		ja: "非常に 悪賢い ポケモン。 弱ったふりで 獲物を おびき寄せ 仲間の ポケモンに 襲わせる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "きゃくよせ" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。自分の山札を上から6枚見て、その中からサポートを1枚選び、相手に見せて、手札に加える。残りのカードは山札にもどして切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "なみのり" },
+			damage: 50,
+			cost: ["Fire", "Water"],
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 783440,
+				tcgplayer: 626015,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [978],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/202.ts
+++ b/data-asia/SV/SV-P/202.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本草エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807425,
+				tcgplayer: 628329,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/203.ts
+++ b/data-asia/SV/SV-P/203.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本炎エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807426,
+				tcgplayer: 628330,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/204.ts
+++ b/data-asia/SV/SV-P/204.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本水エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807427,
+				tcgplayer: 628332,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/205.ts
+++ b/data-asia/SV/SV-P/205.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本雷エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807428,
+				tcgplayer: 628334,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/206.ts
+++ b/data-asia/SV/SV-P/206.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本超エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807429,
+				tcgplayer: 628335,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/207.ts
+++ b/data-asia/SV/SV-P/207.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本闘エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807430,
+				tcgplayer: 628336,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/208.ts
+++ b/data-asia/SV/SV-P/208.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本悪エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807431,
+				tcgplayer: 628337,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/209.ts
+++ b/data-asia/SV/SV-P/209.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本鋼エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807432,
+				tcgplayer: 628338,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/210.ts
+++ b/data-asia/SV/SV-P/210.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハッサムex",
+	},
+
+	illustrator: "PLANETA Tsuji",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Metal"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "はがねのつばさ" },
+			damage: 70,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-50」される。",
+			},
+		},
+		{
+			name: { ja: "クロスブレイカー" },
+			damage: "120×",
+			cost: ["Metal", "Metal"],
+			effect: {
+				ja: "このポケモンについている[M]エネルギーを2枚までトラッシュし、その枚数×120ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 783441,
+				tcgplayer: 626014,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ストライク",
+	},
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [212],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/211.ts
+++ b/data-asia/SV/SV-P/211.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "改造ハンマー",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のポケモンについている特殊エネルギーを1個選び、トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 626016,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "H",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/212.ts
+++ b/data-asia/SV/SV-P/212.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼブライカ",
+	},
+
+	illustrator: "Krgc",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Lightning"],
+
+	description: {
+		ja: "雷鳴を 聞くと 群れの シママが 雷から 充電できるように 群れで 雷雲を 追いかける。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ぜんそくりょく" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札をすべてトラッシュし、山札を6枚引く。",
+			},
+		},
+		{
+			name: { ja: "ヘッドボルト" },
+			damage: 70,
+			cost: ["Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807433,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シママ",
+	},
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [523],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/213.ts
+++ b/data-asia/SV/SV-P/213.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャオハ",
+	},
+
+	illustrator: "Yuu Nishida",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "フワフワの 体毛は 植物に 近い 成分。 こまめに 顔を 洗って 乾燥を 防ぐ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "プチドレイン" },
+			damage: 10,
+			cost: ["Grass"],
+			effect: {
+				ja: "このポケモンのHPを「10」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 780797,
+				tcgplayer: 587920,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [906],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/214.ts
+++ b/data-asia/SV/SV-P/214.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホゲータ",
+	},
+
+	illustrator: "Ryuta Fuse",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "温かい 岩の上で 寝転び 四角い うろこから 取り込んだ 熱で 炎エネルギーを 作る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ほのおでこがす" },
+			damage: 30,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 780798,
+				tcgplayer: 587921,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [909],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/215.ts
+++ b/data-asia/SV/SV-P/215.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クワッス",
+	},
+
+	illustrator: "Narumi Sato",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "昔 遠い 土地から やって来て 棲みついた。 羽から 分泌する ジェルは 水と 汚れを 弾く。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みずしぶき" },
+			damage: "20+",
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 780799,
+				tcgplayer: 587922,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [912],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/216.ts
+++ b/data-asia/SV/SV-P/216.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウ",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "何匹かが 集まっていると そこに 猛烈な 電気が 溜まり 稲妻が 落ちることがあるという。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "でんじスパーク" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手のポケモン1匹に、10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 780800,
+				tcgplayer: 587923,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/217.ts
+++ b/data-asia/SV/SV-P/217.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パモ",
+	},
+
+	illustrator: "kantaro",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "手の 肉球が 放電器官。 後ろ脚で ようやく 立ち上がると 手のひらから 電撃を 放つ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なぐる" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "エレキック" },
+			damage: 20,
+			cost: ["Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 587924,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [921],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/218.ts
+++ b/data-asia/SV/SV-P/218.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウ",
+	},
+
+	illustrator: "saino misaki",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "両頬には 電気を 溜めこむ 袋がある。 怒ると 溜めこんだ 電気を 一気に 放ってくる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なきごえ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-20」される。",
+			},
+		},
+		{
+			name: { ja: "ピカボルト" },
+			damage: 30,
+			cost: ["Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 780802,
+				tcgplayer: 587925,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "G",
+	rarity: "Promo",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/219.ts
+++ b/data-asia/SV/SV-P/219.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カイ",
+	},
+
+	illustrator: "Taira Akitsu",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から[W]ポケモンとグッズをそれぞれ1枚ずつ選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 687685,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/220.ts
+++ b/data-asia/SV/SV-P/220.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キリンリキ",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "尻尾にも 小さな 脳がある。 近寄ると においに 反応して かみついて くるので 注意。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ロストおくり" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のトラッシュにある好きなカードを2枚、ロストゾーンに置く。",
+			},
+		},
+		{
+			name: { ja: "マインドショック" },
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは弱点・抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 804750,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "B",
+	rarity: "Promo",
+	dexId: [203],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/221.ts
+++ b/data-asia/SV/SV-P/221.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダストダス",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Psychic"],
+
+	description: {
+		ja: "左腕で 相手を 絞めつけて 口から 吐き出す 悪臭の 毒ガスで とどめを 刺すのだ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ダストオキシン" },
+			effect: {
+				ja: "このポケモンに「ポケモンのどうぐ」がついているなら、おたがいの場・手札・トラッシュのカードに書かれている特性（「ダストオキシン」をのぞく）は、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ヘドロなげ" },
+			damage: 60,
+			cost: ["Psychic", "Psychic", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 804751,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤブクロン",
+	},
+
+	retreat: 3,
+	rarity: "Promo",
+	dexId: [569],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/222.ts
+++ b/data-asia/SV/SV-P/222.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クロバットV",
+	},
+
+	illustrator: "PLANETA Mochizuki",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ナイトアセット" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の手札が6枚になるように、山札を引く。この番、すでに別の「ナイトアセット」を使っていたなら、この特性は使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "どくのキバ" },
+			damage: 70,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 804752,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [169],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/223.ts
+++ b/data-asia/SV/SV-P/223.ts
@@ -1,0 +1,23 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トレーナーズポスト",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から4枚見る。その中からトレーナーズ（「トレーナーズポスト」をのぞく）を1枚選び、相手に見せてから、手札に加える。残りのカードは山札にもどし、山札を切る。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Item",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/224.ts
+++ b/data-asia/SV/SV-P/224.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パソコン通信",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札から好きなカードを1枚選び、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 804754,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/225.ts
+++ b/data-asia/SV/SV-P/225.ts
@@ -1,0 +1,23 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バトルコンプレッサー",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から好きなカードを3枚まで選び、トラッシュする。そして山札を切る。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Item",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/226.ts
+++ b/data-asia/SV/SV-P/226.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バトルサーチャー",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュからサポートを1枚選び、相手に見せてから、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 804756,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/227.ts
+++ b/data-asia/SV/SV-P/227.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "かるいし",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンのにげるために必要なエネルギーは、すべてなくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 804757,
+				tcgplayer: 676123,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/228.ts
+++ b/data-asia/SV/SV-P/228.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ちからのハチマキ",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンが使うワザの、相手のバトルポケモンへのダメージは「+20」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 804758,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/229.ts
+++ b/data-asia/SV/SV-P/229.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモンレンジャー",
+	},
+
+	illustrator: "Yusuke Ohmura",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーと、おたがいのポケモンにかかっているワザの効果は、すべてなくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 804759,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/230.ts
+++ b/data-asia/SV/SV-P/230.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サイレントラボ",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの場・手札・トラッシュにあるたねポケモンの特性は、すべてなくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 804760,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/231.ts
+++ b/data-asia/SV/SV-P/231.ts
@@ -1,0 +1,23 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダブルドラゴンエネルギー",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは[竜]ポケモンにしかつけられず、ついているかぎりすべてのタイプのエネルギー2個ぶんとしてはたらく。（このカードが[竜]ポケモン以外についているなら、トラッシュする。）",
+	},
+
+	variants: [{ type: "normal" }],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/232.ts
+++ b/data-asia/SV/SV-P/232.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナンジャモのカイデン",
+	},
+
+	illustrator: "mingo",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "翼の 骨は 風を 受けると 電気を 作る。 海に 飛び込み 獲物を 感電させて 捕らえる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "でんこうせっか" },
+			damage: "10+",
+			cost: ["Lightning"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807434,
+				tcgplayer: 615009,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [940],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/233.ts
+++ b/data-asia/SV/SV-P/233.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホップのバチンウニex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はんげきばり" },
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、ワザを使ったポケモンにダメカンを3個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スパイクサンダー" },
+			damage: 120,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "自分の山札を2枚引く。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807435,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [871],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/234.ts
+++ b/data-asia/SV/SV-P/234.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フワンテ",
+	},
+
+	illustrator: "Shimaris Yukichi",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "風船と 間違えて フワンテを 持っていた 小さな 子どもが 消えてしまうことが あるという。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっぱる" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807436,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [425],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/235.ts
+++ b/data-asia/SV/SV-P/235.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フワライド",
+	},
+
+	illustrator: "Shimaris Yukichi",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Psychic"],
+
+	description: {
+		ja: "体の 中で ガスを 作ったり 吐き出したり することで 空を 飛ぶ 高さを 調節する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ぶきみなかぜ" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "バルーンリターン" },
+			damage: 110,
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "このポケモンと、ついているすべてのカードを、手札にもどす。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807437,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "フワンテ",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [426],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/236.ts
+++ b/data-asia/SV/SV-P/236.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シャリタツ",
+	},
+
+	illustrator: "Jerky",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Dragon"],
+
+	description: {
+		ja: "非常に 悪賢い ポケモン。 弱ったふりで 獲物を おびき寄せ 仲間の ポケモンに 襲わせる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "きゃくよせ" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。自分の山札を上から6枚見て、その中からサポートを1枚選び、相手に見せて、手札に加える。残りのカードは山札にもどして切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "なみのり" },
+			damage: 50,
+			cost: ["Fire", "Water"],
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807438,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [978],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/237.ts
+++ b/data-asia/SV/SV-P/237.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "なかよしポフィン",
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から、HPが「70」以下のたねポケモンを2枚まで選び、ベンチに出す。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807439,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "H",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/238.ts
+++ b/data-asia/SV/SV-P/238.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ペパー",
+	},
+
+	illustrator: "GIDORA",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から「グッズ」と「ポケモンのどうぐ」を1枚ずつ選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/239.ts
+++ b/data-asia/SV/SV-P/239.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモンセンターのお姉さん",
+	},
+
+	illustrator: "Tomowaka",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のポケモンを1匹選び、そのポケモンのHPを「60」回復し、特殊状態もすべて回復する。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 807441,
+				tcgplayer: 683008,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/240.ts
+++ b/data-asia/SV/SV-P/240.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カキツバタ",
+	},
+
+	illustrator: "GIDORA",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から7枚見て、その中からポケモンとトレーナーズを1枚ずつ選び、相手に見せて、手札に加える。残りのカードは山札にもどして切る。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Supporter",
+	regulationMark: "H",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/241.ts
+++ b/data-asia/SV/SV-P/241.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オーダイル",
+	},
+
+	illustrator: "Acorviart",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Water"],
+
+	description: {
+		ja: "大きく 力強い あごで 噛みつくと そのまま 首を振って 相手を ずたずたに 引きちぎる。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ディープダイビング" },
+			damage: 140,
+			cost: ["Water", "Water", "Water", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 810561,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アリゲイツ",
+	},
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [160],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/242.ts
+++ b/data-asia/SV/SV-P/242.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウ",
+	},
+
+	illustrator: "Kazuki Minami",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "両頬には 電気を 溜めこむ 袋がある。 怒ると 溜めこんだ 電気を 一気に 放ってくる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "くつろぐ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「20」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 810562,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/243.ts
+++ b/data-asia/SV/SV-P/243.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ストリンダーex",
+	},
+
+	illustrator: "Anderson",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Lightning"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ストラムサンダー" },
+			damage: 240,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 810563,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "エレズン",
+	},
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [849],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/244.ts
+++ b/data-asia/SV/SV-P/244.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "なかよしポフィン",
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から、HPが「70」以下のたねポケモンを2枚まで選び、ベンチに出す。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 838358,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "H",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/245.ts
+++ b/data-asia/SV/SV-P/245.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハイパーボール",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札からポケモンを1枚選び、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 838359,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/246.ts
+++ b/data-asia/SV/SV-P/246.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ふしぎなアメ",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のたねポケモン1匹から進化する1進化の上の2進化ポケモンを、手札から1枚選び、そのたねポケモンにのせて進化させる。[最初の自分の番と、この番出したばかりのたねポケモンには使えない。]",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 838360,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/247.ts
+++ b/data-asia/SV/SV-P/247.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケギア3.0",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から7枚見る。その中にあるサポートを1枚、相手に見せてから、手札に加えてよい。残りのカードは山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 838361,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/248.ts
+++ b/data-asia/SV/SV-P/248.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモンいれかえ",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 838362,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/249.ts
+++ b/data-asia/SV/SV-P/249.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "からておうの稽古",
+	},
+
+	illustrator: "GOSSAN",
+	category: "Trainer",
+
+	effect: {
+		ja: "この番、自分のポケモンが使うワザの、相手のバトル場の「ポケモンex」へのダメージは「+40」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 838363,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "H",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/250.ts
+++ b/data-asia/SV/SV-P/250.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモンセンターのお姉さん",
+	},
+
+	illustrator: "Tomowaka",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のポケモンを1匹選び、そのポケモンのHPを「60」回復し、特殊状態もすべて回復する。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 838364,
+				tcgplayer: 696782,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/251.ts
+++ b/data-asia/SV/SV-P/251.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エキサイトスタジアム",
+	},
+
+	illustrator: "imoniii",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの場のたねポケモン全員の最大HPは、それぞれ「＋30」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 838365,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "H",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/252.ts
+++ b/data-asia/SV/SV-P/252.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネモ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を3枚引く。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/253.ts
+++ b/data-asia/SV/SV-P/253.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネモ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 813951,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/254.ts
+++ b/data-asia/SV/SV-P/254.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒビキのホウオウex",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "こんじきのほのお" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札から「基本[R]エネルギー」を2枚まで選び、ベンチの「ヒビキのポケモン」1匹につける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "シャイニングフェザー" },
+			damage: 160,
+			cost: ["Fire", "Fire", "Fire", "Fire"],
+			effect: {
+				ja: "自分のポケモン全員のHPを、それぞれ「50」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 813952,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [250],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/255.ts
+++ b/data-asia/SV/SV-P/255.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シロナのガブリアスex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Fighting"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "スクリューダイブ" },
+			damage: 100,
+			cost: ["Fighting"],
+			effect: {
+				ja: "のぞむなら、自分の手札が6枚になるように、山札を引く。",
+			},
+		},
+		{
+			name: { ja: "リューノバスター" },
+			damage: 260,
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、すべてトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 813953,
+				tcgplayer: 659979,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シロナのガバイト",
+	},
+
+	retreat: 0,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [445],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/256.ts
+++ b/data-asia/SV/SV-P/256.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ペパーのマフィティフex",
+	},
+
+	illustrator: "akagi",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ハッスルタックル" },
+			damage: "30+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンにダメカンがのっていないなら、120ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "おやぶんヘッド" },
+			damage: 210,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「おやぶんヘッド」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 813954,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ペパーのオラチフ",
+	},
+
+	retreat: 3,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [943],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/257.ts
+++ b/data-asia/SV/SV-P/257.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナンジャモのズピカ",
+	},
+
+	illustrator: "kurumitsu",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "尻尾を 振って 発電する。 危険を 感じると 頭を 点滅させて 仲間に 伝える。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "プチでんき" },
+			damage: 30,
+			cost: ["Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 813955,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [938],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/258.ts
+++ b/data-asia/SV/SV-P/258.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガチグマ アカツキex",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ろうれんのわざ" },
+			effect: {
+				ja: "相手がすでにとったサイドの枚数ぶん、このポケモンが「ブラッドムーン」を使うための[C]エネルギーは少なくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ブラッドムーン" },
+			damage: 240,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 813949,
+				tcgplayer: 676108,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [901],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/259.ts
+++ b/data-asia/SV/SV-P/259.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のニャース",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "昼間は 寝てばかりいる。 夜になると 目が 輝き 縄張りを 歩きまわる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ねこばば" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、そのカードのオモテを見て、相手の山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "みだれひっかき" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数×20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 826853,
+				tcgplayer: 659980,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [52],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/260.ts
+++ b/data-asia/SV/SV-P/260.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トウホクのピカチュウ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "両頬には 電気を 溜めこむ 袋がある。 怒ると 溜めこんだ 電気を 一気に 放ってくる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "リニューアルオープン！" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札を2枚引く。",
+			},
+		},
+		{
+			name: { ja: "おどりまわる" },
+			damage: "30×",
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数×30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 830066,
+				tcgplayer: 650726,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/261.ts
+++ b/data-asia/SV/SV-P/261.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒロシマのピカチュウ",
+	},
+
+	illustrator: "REOspikee",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "両頬には 電気を 溜めこむ 袋がある。 怒ると 溜めこんだ 電気を 一気に 放ってくる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "リニューアルオープン！" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札を2枚引く。",
+			},
+		},
+		{
+			name: { ja: "のりこなす" },
+			damage: "30+",
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 830067,
+				tcgplayer: 650763,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/262.ts
+++ b/data-asia/SV/SV-P/262.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コダック",
+	},
+
+	illustrator: "Jiro Sasumo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "いつも 頭痛に 悩まされている。 この 頭痛が 激しくなると 不思議な 力を 使いはじめる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しめりけ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、おたがいのポケモン全員は、そのポケモン自身をきぜつさせる効果の特性が、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821707,
+				tcgplayer: 654781,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [54],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/263.ts
+++ b/data-asia/SV/SV-P/263.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴルダック",
+	},
+
+	illustrator: "Jiro Sasumo",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "水かきのついた 長い 手足を 使い 全力で 泳ぎだすと なぜか 額が 光り輝く。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しめりけ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、おたがいのポケモン全員は、そのポケモン自身をきぜつさせる効果の特性が、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ハイドロポンプ" },
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[W]エネルギーの数×20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821708,
+				tcgplayer: 654782,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コダック",
+	},
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [55],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/264.ts
+++ b/data-asia/SV/SV-P/264.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハバタクカミ",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "とある 書物に 登場する ハバタクカミという 生物と 似た 特徴を 持つ ポケモン。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "あんやのはばたき" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手のバトルポケモンの特性（「あんやのはばたき」をのぞく）は、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "たたりとばす" },
+			damage: 90,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "ダメカン2個を、相手のベンチポケモンに好きなようにのせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821709,
+				tcgplayer: 678727,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Promo",
+	dexId: [987],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/265.ts
+++ b/data-asia/SV/SV-P/265.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のガルーラex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "れんぞくパンチ" },
+			damage: "30×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを4回投げ、オモテの数×30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "バッドインパクト" },
+			damage: "120+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "この番に、手札から、名前に「ロケット団」とつくサポートを出して使っていたなら、100ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821710,
+				tcgplayer: 688209,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [115],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/266.ts
+++ b/data-asia/SV/SV-P/266.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "夜のタンカ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュからポケモンまたは基本エネルギーを1枚選び、相手に見せて、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821711,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "H",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/267.ts
+++ b/data-asia/SV/SV-P/267.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のさいみん装置",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけている「ロケット団のポケモン」が、バトル場で相手のポケモンからワザのダメージを受けたとき、ワザを使ったポケモンをねむりにする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821712,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "I",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/268.ts
+++ b/data-asia/SV/SV-P/268.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スグリ",
+	},
+
+	illustrator: "GIDORA",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、2つの効果から1つを選んで使う。◆自分のバトルポケモンをベンチポケモンと入れ替える。◆この番、自分のポケモンが使うワザの、相手のバトル場の「ポケモンex・V」へのダメージは「+30」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 821713,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "H",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/269.ts
+++ b/data-asia/SV/SV-P/269.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アイリスの闘志",
+	},
+
+	illustrator: "yuu",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を1枚トラッシュしなければ使えない。自分の手札が6枚になるように、山札を引く。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/270.ts
+++ b/data-asia/SV/SV-P/270.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ロケット団のサカキ",
+	},
+
+	illustrator: "DOM",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトル場の「ロケット団のポケモン」を、ベンチの「ロケット団のポケモン」と入れ替える。その後、相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 827162,
+				tcgplayer: 639660,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/271.ts
+++ b/data-asia/SV/SV-P/271.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビクティニ",
+	},
+
+	illustrator: "Amelicart",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "勝利を もたらす ポケモン。 ビクティニを 連れた トレーナーは どんな 勝負にも 勝てるという。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "Vフォース" },
+			damage: 120,
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "自分のベンチポケモンが4匹以下なら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 829091,
+				tcgplayer: 648603,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [494],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/272.ts
+++ b/data-asia/SV/SV-P/272.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エネルギー転送",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から基本エネルギーを1枚選び、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 838366,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/273.ts
+++ b/data-asia/SV/SV-P/273.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "きずぐすり",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のポケモン1匹のHPを「30」回復する。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 838367,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/274.ts
+++ b/data-asia/SV/SV-P/274.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クラッシュハンマー",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Trainer",
+
+	effect: {
+		ja: "コインを1回投げオモテなら、相手のポケモンについているエネルギーを1個選び、トラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 838368,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/275.ts
+++ b/data-asia/SV/SV-P/275.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハイパーボール",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、自分の手札を2枚トラッシュしなければ使えない。自分の山札からポケモンを1枚選び、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 838369,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/276.ts
+++ b/data-asia/SV/SV-P/276.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモンいれかえ",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 838370,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/277.ts
+++ b/data-asia/SV/SV-P/277.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモンキャッチャー",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Item",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/278.ts
+++ b/data-asia/SV/SV-P/278.ts
@@ -1,0 +1,24 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ボスの指令",
+	},
+
+	illustrator: "NC Empire",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+	},
+
+	variants: [{ type: "normal" }],
+
+	trainerType: "Supporter",
+	regulationMark: "G",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/279.ts
+++ b/data-asia/SV/SV-P/279.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チェレン",
+	},
+
+	illustrator: "REND",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 829090,
+				tcgplayer: 644687,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "I",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/280.ts
+++ b/data-asia/SV/SV-P/280.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本草エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 838373,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/281.ts
+++ b/data-asia/SV/SV-P/281.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本炎エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 838374,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/282.ts
+++ b/data-asia/SV/SV-P/282.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本水エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 838375,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/283.ts
+++ b/data-asia/SV/SV-P/283.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本雷エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 838376,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/284.ts
+++ b/data-asia/SV/SV-P/284.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本超エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 838377,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/285.ts
+++ b/data-asia/SV/SV-P/285.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本闘エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 838378,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/286.ts
+++ b/data-asia/SV/SV-P/286.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本悪エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 838379,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/287.ts
+++ b/data-asia/SV/SV-P/287.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本鋼エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 838380,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/SV/SV-P/288.ts
+++ b/data-asia/SV/SV-P/288.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビクティニ",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "勝利を もたらす ポケモン。 ビクティニを 連れた トレーナーは どんな 勝負にも 勝てるという。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "Vフォース" },
+			damage: 120,
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "自分のベンチポケモンが4匹以下なら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 829092,
+				tcgplayer: 643120,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [494],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/289.ts
+++ b/data-asia/SV/SV-P/289.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フクオカのピカチュウ",
+	},
+
+	illustrator: "Nelnal",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "両頬には 電気を 溜めこむ 袋がある。 怒ると 溜めこんだ 電気を 一気に 放ってくる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "リニューアルオープン！" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札を2枚引く。",
+			},
+		},
+		{
+			name: { ja: "たべあるく" },
+			damage: 30,
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 830068,
+				tcgplayer: 658431,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "I",
+	rarity: "Promo",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/SV/SV-P/290.ts
+++ b/data-asia/SV/SV-P/290.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ツツジ",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、相手のサイドの残り枚数が3枚以下のときにしか使えない。おたがいのプレイヤーは、それぞれ手札をすべて山札にもどして切る。その後、自分は6枚、相手は2枚、山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 830069,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Promo",
+};
+
+export default card;


### PR DESCRIPTION
## What

Refreshes the existing Japanese set **SV-P スカーレット&バイオレット プロモカード (Scarlet & Violet Promotional Cards)** from its primary sources. The curated content stays: every card keeps its `zh-tw`/`th` texts verbatim.

What changes across the 301 card files:

- `thirdParty.cardmarket` moves onto `variants` objects and 71 missing ids are filled in
- per card where missing: `dexId`, `evolveFrom`, `resistances`, the Japanese flavor text and the Japanese effect/attack texts straight from the official database and limitless

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (687450–855025)
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (587758–696782), keyed by the collection number each product carries in `extendedData`

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- `tsc --noEmit` reports the same 13 pre-existing errors as upstream/master — this change adds none. They are `rarity` being required by `interfaces.d.ts` while these older hand-written files omit it, which is out of scope here.
