### PR TITLE
(data) Update Japanese SV set SV8 Super Electric Breaker

### DIFF
--- a/data-asia/SV/SV8/001.ts
+++ b/data-asia/SV/SV8/001.ts
@@ -1,59 +1,61 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "タマタマ",
 		'zh-tw': "蛋蛋",
-		'zh-cn': "蛋蛋"
+		'zh-cn': "蛋蛋",
 	},
 
 	illustrator: "OKUBO",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [102],
 	hp: 50,
 	types: ["Grass"],
 
 	description: {
 		ja: "タマタマだけに 伝わる テレパシーを 出し合っているので どんなときでも ６匹 集まれる。",
 		'zh-tw': "會發出只有蛋蛋才能收到的 心靈感應，因此不論何時 都能６隻聚集在一起。",
-		'zh-cn': "會發出只有蛋蛋才能收到的 心靈感應，因此不論何時 都能６隻聚集在一起。"
+		'zh-cn': "會發出只有蛋蛋才能收到的 心靈感應，因此不論何時 都能６隻聚集在一起。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "すいとる",
-			'zh-tw': "吸取",
-			'zh-cn': "吸取"
+	attacks: [
+		{
+			name: {
+				ja: "すいとる",
+				'zh-tw': "吸取",
+				'zh-cn': "吸取",
+			},
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「10」回復する。",
+				'zh-tw': "將這隻寶可夢恢復「10」HP。",
+				'zh-cn': "將這隻寶可夢恢復「10」HP。",
+			},
 		},
+	],
 
-		damage: 10,
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンのHPを「10」回復する。",
-			'zh-tw': "將這隻寶可夢恢復「10」HP。",
-			'zh-cn': "將這隻寶可夢恢復「10」HP。"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793435,
+				tcgplayer: 587581,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [102],
+};
 
-	thirdParty: {
-		cardmarket: 793435
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/002.ts
+++ b/data-asia/SV/SV8/002.ts
@@ -1,59 +1,65 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ナッシー",
 		'zh-tw': "椰蛋樹",
-		'zh-cn': "椰蛋樹"
+		'zh-cn': "椰蛋樹",
 	},
 
 	illustrator: "Oswaldo KATO",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [103],
 	hp: 130,
 	types: ["Grass"],
 
 	description: {
 		ja: "ごくまれに 頭の どれか ひとつが 地面に 落ちると タマタマになって 動きだすという。",
 		'zh-tw': "聽說在極少數的情況下， 當其中一顆頭掉落到地面， 就會變成蛋蛋並且動起來。",
-		'zh-cn': "聽說在極少數的情況下， 當其中一顆頭掉落到地面， 就會變成蛋蛋並且動起來。"
+		'zh-cn': "聽說在極少數的情況下， 當其中一顆頭掉落到地面， 就會變成蛋蛋並且動起來。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Grass"],
-
-		name: {
-			ja: "たまなげアワー",
-			'zh-tw': "投球時刻",
-			'zh-cn': "投球時刻"
+	attacks: [
+		{
+			name: {
+				ja: "たまなげアワー",
+				'zh-tw': "投球時刻",
+				'zh-cn': "投球時刻",
+			},
+			damage: "60×",
+			cost: ["Grass"],
+			effect: {
+				ja: "おたがいのバトルポケモンについているエネルギーの数ぶんコインを投げ、オモテの数×60ダメージ。",
+				'zh-tw': "擲與雙方的戰鬥寶可夢身上附加的能量的數量相同次數的硬幣，造成正面出現的次數×60點傷害。",
+				'zh-cn': "擲與雙方的戰鬥寶可夢身上附加的能量的數量相同次數的硬幣，造成正面出現的次數×60點傷害。",
+			},
 		},
+	],
 
-		damage: "60×",
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "おたがいのバトルポケモンについているエネルギーの数ぶんコインを投げ、オモテの数×60ダメージ。",
-			'zh-tw': "擲與雙方的戰鬥寶可夢身上附加的能量的數量相同次數的硬幣，造成正面出現的次數×60點傷害。",
-			'zh-cn': "擲與雙方的戰鬥寶可夢身上附加的能量的數量相同次數的硬幣，造成正面出現的次數×60點傷害。"
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793436,
+				tcgplayer: 587582,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "タマタマ",
+	},
 
 	retreat: 2,
 	regulationMark: "H",
+	rarity: "Uncommon",
+	dexId: [103],
+};
 
-	thirdParty: {
-		cardmarket: 793436
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/003.ts
+++ b/data-asia/SV/SV8/003.ts
@@ -1,68 +1,73 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "アイアントex",
 		'zh-tw': "鐵蟻ex",
-		'zh-cn': "鐵蟻ex"
+		'zh-cn': "鐵蟻ex",
 	},
 
 	illustrator: "PLANETA Tsuji",
-	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 190,
 	types: ["Grass"],
+
 	stage: "Basic",
-	suffix: "EX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "いきなりけずる",
-			'zh-tw': "突然削退",
-			'zh-cn': "突然削退"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "いきなりけずる",
+				'zh-tw': "突然削退",
+				'zh-cn': "突然削退",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。相手の山札を上から1枚トラッシュする。",
+				'zh-tw': "在自己的回合，從手牌將這張卡放置於備戰區時，可使用1次。將對手的牌庫上方1張卡丟棄。",
+				'zh-cn': "在自己的回合，從手牌將這張卡放置於備戰區時，可使用1次。將對手的牌庫上方1張卡丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。相手の山札を上から1枚トラッシュする。",
-			'zh-tw': "在自己的回合，從手牌將這張卡放置於備戰區時，可使用1次。將對手的牌庫上方1張卡丟棄。",
-			'zh-cn': "在自己的回合，從手牌將這張卡放置於備戰區時，可使用1次。將對手的牌庫上方1張卡丟棄。"
-		}
-	}],
-
-	attacks: [{
-		cost: ["Grass", "Colorless", "Colorless"],
-
-		name: {
-			ja: "リベンジクラッシュ",
-			'zh-tw': "復仇粉碎",
-			'zh-cn': "復仇粉碎"
+	attacks: [
+		{
+			name: {
+				ja: "リベンジクラッシュ",
+				'zh-tw': "復仇粉碎",
+				'zh-cn': "復仇粉碎",
+			},
+			damage: "120+",
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手がすでにとったサイドの枚数×30ダメージ追加。",
+				'zh-tw': "增加對手已經獲得的獎賞卡的張數×30點傷害。",
+				'zh-cn': "增加對手已經獲得的獎賞卡的張數×30點傷害。",
+			},
 		},
+	],
 
-		damage: "120+",
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手がすでにとったサイドの枚数×30ダメージ追加。",
-			'zh-tw': "增加對手已經獲得的獎賞卡的張數×30點傷害。",
-			'zh-cn': "增加對手已經獲得的獎賞卡的張數×30點傷害。"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793437,
+				tcgplayer: 587583,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "H",
+	rarity: "Double rare",
+	dexId: [632],
 
-	thirdParty: {
-		cardmarket: 793437
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/004.ts
+++ b/data-asia/SV/SV8/004.ts
@@ -1,57 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "コフキムシ",
 		'zh-tw': "粉蝶蟲",
-		'zh-cn': "粉蝶蟲"
+		'zh-cn': "粉蝶蟲",
 	},
 
 	illustrator: "Iori Suzuki",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [664],
 	hp: 40,
 	types: ["Grass"],
 
 	description: {
 		ja: "毒の粉を まき散らして 敵を 追い払う。 棲んでいる 土地により エサにする 植物が 違う。",
 		'zh-tw': "會灑出毒粉趕走敵人。 棲息的土地不同，作為 食糧的植物也就不同。",
-		'zh-cn': "會灑出毒粉趕走敵人。 棲息的土地不同，作為 食糧的植物也就不同。"
+		'zh-cn': "會灑出毒粉趕走敵人。 棲息的土地不同，作為 食糧的植物也就不同。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "なかまをよぶ",
-			'zh-tw': "呼朋引伴",
-			'zh-cn': "呼朋引伴"
+	attacks: [
+		{
+			name: {
+				ja: "なかまをよぶ",
+				'zh-tw': "呼朋引伴",
+				'zh-cn': "呼朋引伴",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からたねポケモンを1枚選び、ベンチに出す。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇1張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。",
+				'zh-cn': "從自己的牌庫選擇1張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。",
+			},
 		},
+	],
 
-		effect: {
-			ja: "自分の山札からたねポケモンを1枚選び、ベンチに出す。そして山札を切る。",
-			'zh-tw': "從自己的牌庫選擇1張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。",
-			'zh-cn': "從自己的牌庫選擇1張【基礎】寶可夢卡，放置於備戰區。並且重洗牌庫。"
-		}
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793438,
+				tcgplayer: 587584,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [664],
+};
 
-	thirdParty: {
-		cardmarket: 793438
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/005.ts
+++ b/data-asia/SV/SV8/005.ts
@@ -1,67 +1,73 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "コフーライ",
 		'zh-tw': "粉蝶蛹",
-		'zh-cn': "粉蝶蛹"
+		'zh-cn': "粉蝶蛹",
 	},
 
 	illustrator: "tono",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [665],
 	hp: 80,
 	types: ["Grass"],
 
 	description: {
 		ja: "決まった 棲み処を 持たない。 気の向くまま 野山を 歩きまわり 進化の エネルギーを 蓄える。",
 		'zh-tw': "沒有固定的住處。 會隨心所欲地在山野走來走去， 蓄積進化時所需的能量。",
-		'zh-cn': "沒有固定的住處。 會隨心所欲地在山野走來走去， 蓄積進化時所需的能量。"
+		'zh-cn': "沒有固定的住處。 會隨心所欲地在山野走來走去， 蓄積進化時所需的能量。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "あるきまわる",
-			'zh-tw': "走來走去",
-			'zh-cn': "走來走去"
+	attacks: [
+		{
+			name: {
+				ja: "あるきまわる",
+				'zh-tw': "走來走去",
+				'zh-cn': "走來走去",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+				'zh-tw': "將這隻寶可夢與備戰寶可夢互換。",
+				'zh-cn': "將這隻寶可夢與備戰寶可夢互換。",
+			},
 		},
-
-		effect: {
-			ja: "このポケモンをベンチポケモンと入れ替える。",
-			'zh-tw': "將這隻寶可夢與備戰寶可夢互換。",
-			'zh-cn': "將這隻寶可夢與備戰寶可夢互換。"
-		}
-	}, {
-		cost: ["Grass"],
-
-		name: {
-			ja: "たいあたり",
-			'zh-tw': "撞擊",
-			'zh-cn': "撞擊"
+		{
+			name: {
+				ja: "たいあたり",
+				'zh-tw': "撞擊",
+				'zh-cn': "撞擊",
+			},
+			damage: 30,
+			cost: ["Grass"],
 		},
+	],
 
-		damage: 30
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793439,
+				tcgplayer: 587585,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コフキムシ",
+	},
 
 	retreat: 3,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [665],
+};
 
-	thirdParty: {
-		cardmarket: 793439
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/006.ts
+++ b/data-asia/SV/SV8/006.ts
@@ -1,67 +1,73 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ビビヨン",
 		'zh-tw': "彩粉蝶",
-		'zh-cn': "彩粉蝶"
+		'zh-cn': "彩粉蝶",
 	},
 
 	illustrator: "Amelicart",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [666],
 	hp: 120,
 	types: ["Grass"],
 
 	description: {
 		ja: "不思議な 土地で 生まれた。 色鮮やかな 毒の りんぷんを 翅から 散らして 戦う。",
 		'zh-tw': "誕生在神奇的地方。 會從翅膀灑出色彩鮮豔的 毒鱗粉來戰鬥。",
-		'zh-cn': "誕生在神奇的地方。 會從翅膀灑出色彩鮮豔的 毒鱗粉來戰鬥。"
+		'zh-cn': "誕生在神奇的地方。 會從翅膀灑出色彩鮮豔的 毒鱗粉來戰鬥。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "エボルパウダー",
-			'zh-tw': "進化粉",
-			'zh-cn': "進化粉"
+	attacks: [
+		{
+			name: {
+				ja: "エボルパウダー",
+				'zh-tw': "進化粉",
+				'zh-cn': "進化粉",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のベンチポケモン全員からそれぞれ進化するカードを、自分の山札から1枚ずつ選び、それぞれにのせて進化させる。そして山札を切る。",
+				'zh-tw': "從自己的牌庫，選擇自己的所有備戰寶可夢進化而來的卡各1張，放置於各自身上完成進化。並且重洗牌庫。",
+				'zh-cn': "從自己的牌庫，選擇自己的所有備戰寶可夢進化而來的卡各1張，放置於各自身上完成進化。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			ja: "自分のベンチポケモン全員からそれぞれ進化するカードを、自分の山札から1枚ずつ選び、それぞれにのせて進化させる。そして山札を切る。",
-			'zh-tw': "從自己的牌庫，選擇自己的所有備戰寶可夢進化而來的卡各1張，放置於各自身上完成進化。並且重洗牌庫。",
-			'zh-cn': "從自己的牌庫，選擇自己的所有備戰寶可夢進化而來的卡各1張，放置於各自身上完成進化。並且重洗牌庫。"
-		}
-	}, {
-		cost: ["Grass"],
-
-		name: {
-			ja: "カッターウインド",
-			'zh-tw': "利刃之風",
-			'zh-cn': "利刃之風"
+		{
+			name: {
+				ja: "カッターウインド",
+				'zh-tw': "利刃之風",
+				'zh-cn': "利刃之風",
+			},
+			damage: 90,
+			cost: ["Grass"],
 		},
+	],
 
-		damage: 90
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793440,
+				tcgplayer: 587586,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コフーライ",
+	},
 
 	retreat: 1,
 	regulationMark: "H",
+	rarity: "Uncommon",
+	dexId: [666],
+};
 
-	thirdParty: {
-		cardmarket: 793440
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/007.ts
+++ b/data-asia/SV/SV8/007.ts
@@ -1,49 +1,56 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "カプサイジ",
 		'zh-tw': "熱辣娃",
-		'zh-cn': "熱辣娃"
+		'zh-cn': "熱辣娃",
 	},
 
 	illustrator: "Julie Hang",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [951],
 	hp: 70,
 	types: ["Grass"],
 
 	description: {
 		ja: "パルデアの 郷土料理は 抜け落ちた カプサイジの 前歯が 使われているので 激辛なのだ。",
 		'zh-tw': "帕底亞當地會用熱辣娃 掉落的門牙來做料理， 所以超級無敵霹靂辣。",
-		'zh-cn': "帕底亞當地會用熱辣娃 掉落的門牙來做料理， 所以超級無敵霹靂辣。"
+		'zh-cn': "帕底亞當地會用熱辣娃 掉落的門牙來做料理， 所以超級無敵霹靂辣。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "とびだしヘッド",
-			'zh-tw': "魯莽頭擊",
-			'zh-cn': "魯莽頭擊"
+	attacks: [
+		{
+			name: {
+				ja: "とびだしヘッド",
+				'zh-tw': "魯莽頭擊",
+				'zh-cn': "魯莽頭擊",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 20
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793441,
+				tcgplayer: 587587,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Common",
+	dexId: [951],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/008.ts
+++ b/data-asia/SV/SV8/008.ts
@@ -1,63 +1,69 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "シガロコ",
 		'zh-tw': "蟲滾泥",
-		'zh-cn': "蟲滾泥"
+		'zh-cn': "蟲滾泥",
 	},
 
 	illustrator: "Toshinao Aoki",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [953],
 	hp: 40,
 	types: ["Grass"],
 
 	description: {
 		ja: "泥玉を 転がしながら 進化の エネルギーを 熟成させる。 やがて 進化のときを 迎える。",
 		'zh-tw': "會一邊滾著泥巴球， 一邊使進化的能量成熟。 最終會迎接進化的時刻。",
-		'zh-cn': "會一邊滾著泥巴球， 一邊使進化的能量成熟。 最終會迎接進化的時刻。"
+		'zh-cn': "會一邊滾著泥巴球， 一邊使進化的能量成熟。 最終會迎接進化的時刻。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "もってくる",
-			'zh-tw': "呼喚",
-			'zh-cn': "呼喚"
+	attacks: [
+		{
+			name: {
+				ja: "もってくる",
+				'zh-tw': "呼喚",
+				'zh-cn': "呼喚",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+				'zh-tw': "從自己的牌庫抽出1張卡。",
+				'zh-cn': "從自己的牌庫抽出1張卡。",
+			},
 		},
-
-		effect: {
-			ja: "自分の山札を1枚引く。",
-			'zh-tw': "從自己的牌庫抽出1張卡。",
-			'zh-cn': "從自己的牌庫抽出1張卡。"
-		}
-	}, {
-		cost: ["Grass"],
-
-		name: {
-			ja: "ころがる",
-			'zh-tw': "滾動",
-			'zh-cn': "滾動"
+		{
+			name: {
+				ja: "ころがる",
+				'zh-tw': "滾動",
+				'zh-cn': "滾動",
+			},
+			damage: 10,
+			cost: ["Grass"],
 		},
+	],
 
-		damage: 10
-	}],
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793442,
+				tcgplayer: 587588,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Common",
+	dexId: [953],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/009.ts
+++ b/data-asia/SV/SV8/009.ts
@@ -1,69 +1,78 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ベラカス",
 		'zh-tw': "蟲甲聖",
-		'zh-cn': "蟲甲聖"
+		'zh-cn': "蟲甲聖",
 	},
 
 	illustrator: "Masako Tomii",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [954],
 	hp: 70,
 	types: ["Grass"],
 
 	description: {
 		ja: "玉の中に 赤ん坊が 眠る。 心地よく 眠れるように 脚で 玉を まわして あやしているのだ。",
 		'zh-tw': "為了讓在球裡睡覺的寶寶 可以睡得更加香甜，會用腳 轉著球，讓寶寶感到安穩。",
-		'zh-cn': "為了讓在球裡睡覺的寶寶 可以睡得更加香甜，會用腳 轉著球，讓寶寶感到安穩。"
+		'zh-cn': "為了讓在球裡睡覺的寶寶 可以睡得更加香甜，會用腳 轉著球，讓寶寶感到安穩。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "トリプルドロー",
-			'zh-tw': "三重抽出",
-			'zh-cn': "三重抽出"
+	attacks: [
+		{
+			name: {
+				ja: "トリプルドロー",
+				'zh-tw': "三重抽出",
+				'zh-cn': "三重抽出",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を3枚引く。",
+				'zh-tw': "從自己的牌庫抽出3張卡。",
+				'zh-cn': "從自己的牌庫抽出3張卡。",
+			},
 		},
-
-		effect: {
-			ja: "自分の山札を3枚引く。",
-			'zh-tw': "從自己的牌庫抽出3張卡。",
-			'zh-cn': "從自己的牌庫抽出3張卡。"
-		}
-	}, {
-		cost: ["Grass"],
-
-		name: {
-			ja: "どんでんがえし",
-			'zh-tw': "絕地反攻",
-			'zh-cn': "絕地反攻"
+		{
+			name: {
+				ja: "どんでんがえし",
+				'zh-tw': "絕地反攻",
+				'zh-cn': "絕地反攻",
+			},
+			damage: "40+",
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の山札の残り枚数が3枚以下なら、200ダメージ追加。",
+				'zh-tw': "若自己的牌庫的剩餘張數為3張以下，則增加200點傷害。",
+				'zh-cn': "若自己的牌庫的剩餘張數為3張以下，則增加200點傷害。",
+			},
 		},
+	],
 
-		damage: "40+",
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "自分の山札の残り枚数が3枚以下なら、200ダメージ追加。",
-			'zh-tw': "若自己的牌庫的剩餘張數為3張以下，則增加200點傷害。",
-			'zh-cn': "若自己的牌庫的剩餘張數為3張以下，則增加200點傷害。"
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793443,
+				tcgplayer: 587589,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "シガロコ",
+	},
 
 	retreat: 1,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Rare",
+	dexId: [954],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/010.ts
+++ b/data-asia/SV/SV8/010.ts
@@ -1,71 +1,75 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "チオンジェン",
 		'zh-tw': "古簡蝸",
-		'zh-cn': "古簡蝸"
+		'zh-cn': "古簡蝸",
 	},
 
 	illustrator: "danciao",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [1001],
 	hp: 130,
 	types: ["Grass"],
 
 	description: {
 		ja: "草木の エネルギーを 吸い上げる。 周囲の 森は たちどころに 枯れ果て 田畑は 不作となる。",
 		'zh-tw': "會吸取草木的能量， 使周圍的森林霎時乾枯， 田地的農作物歉收。",
-		'zh-cn': "會吸取草木的能量， 使周圍的森林霎時乾枯， 田地的農作物歉收。"
+		'zh-cn': "會吸取草木的能量， 使周圍的森林霎時乾枯， 田地的農作物歉收。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Grass", "Colorless"],
-
-		name: {
-			ja: "グリードハザード",
-			'zh-tw': "貪婪危害",
-			'zh-cn': "貪婪危害"
+	attacks: [
+		{
+			name: {
+				ja: "グリードハザード",
+				'zh-tw': "貪婪危害",
+				'zh-cn': "貪婪危害",
+			},
+			damage: 20,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "自分の山札の残り枚数が3枚以下なら、相手のベンチポケモン2匹にも、それぞれ120ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "若自己的牌庫的剩餘張數為3張以下，則對手的2隻備戰寶可夢也各受到120點傷害。[在備戰區不計算弱點・抵抗力。]",
+				'zh-cn': "若自己的牌庫的剩餘張數為3張以下，則對手的2隻備戰寶可夢也各受到120點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
-
-		damage: 20,
-
-		effect: {
-			ja: "自分の山札の残り枚数が3枚以下なら、相手のベンチポケモン2匹にも、それぞれ120ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
-			'zh-tw': "若自己的牌庫的剩餘張數為3張以下，則對手的2隻備戰寶可夢也各受到120點傷害。[在備戰區不計算弱點・抵抗力。]",
-			'zh-cn': "若自己的牌庫的剩餘張數為3張以下，則對手的2隻備戰寶可夢也各受到120點傷害。[在備戰區不計算弱點・抵抗力。]"
-		}
-	}, {
-		cost: ["Grass", "Grass", "Colorless"],
-
-		name: {
-			ja: "まきこみウィップ",
-			'zh-tw': "捲入鞭打",
-			'zh-cn': "捲入鞭打"
+		{
+			name: {
+				ja: "まきこみウィップ",
+				'zh-tw': "捲入鞭打",
+				'zh-cn': "捲入鞭打",
+			},
+			damage: 130,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "自分の山札を上から3枚トラッシュする。",
+				'zh-tw': "將自己的牌庫上方3張卡丟棄。",
+				'zh-cn': "將自己的牌庫上方3張卡丟棄。",
+			},
 		},
+	],
 
-		damage: 130,
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "自分の山札を上から3枚トラッシュする。",
-			'zh-tw': "將自己的牌庫上方3張卡丟棄。",
-			'zh-cn': "將自己的牌庫上方3張卡丟棄。"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793444,
+				tcgplayer: 587590,
+			},
+		},
+	],
 
 	retreat: 3,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Uncommon",
+	dexId: [1001],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/011.ts
+++ b/data-asia/SV/SV8/011.ts
@@ -1,65 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "パルデア ケンタロス",
 		'zh-tw': "帕底亞 肯泰羅",
-		'zh-cn': "帕底亞 肯泰羅"
+		'zh-cn': "帕底亞 肯泰羅",
 	},
 
 	illustrator: "Taiga Kasai",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [128],
 	hp: 130,
 	types: ["Fire"],
 
 	description: {
 		ja: "高温の 鼻息を 吹きだすので ブレイズ種と 名づけられた。 ３本の 尻尾を 束ねている。",
 		'zh-tw': "噴出的鼻息溫度很高， 因此被命名為火熾種。 ３根尾巴總是束在一起。",
-		'zh-cn': "噴出的鼻息溫度很高， 因此被命名為火熾種。 ３根尾巴總是束在一起。"
+		'zh-cn': "噴出的鼻息溫度很高， 因此被命名為火熾種。 ３根尾巴總是束在一起。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Fire"],
-
-		name: {
-			ja: "うしろげり",
-			'zh-tw': "後踢",
-			'zh-cn': "後踢"
+	attacks: [
+		{
+			name: {
+				ja: "うしろげり",
+				'zh-tw': "後踢",
+				'zh-cn': "後踢",
+			},
+			damage: 30,
+			cost: ["Fire"],
 		},
-
-		damage: 30
-	}, {
-		cost: ["Fire", "Colorless", "Colorless"],
-
-		name: {
-			ja: "きあいタックル",
-			'zh-tw': "真氣衝撞",
-			'zh-cn': "真氣衝撞"
+		{
+			name: {
+				ja: "きあいタックル",
+				'zh-tw': "真氣衝撞",
+				'zh-cn': "真氣衝撞",
+			},
+			damage: "90+",
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが1進化ポケモンなら、90ダメージ追加。",
+				'zh-tw': "若對手的戰鬥寶可夢為【1階進化】寶可夢，則增加90點傷害。",
+				'zh-cn': "若對手的戰鬥寶可夢為【1階進化】寶可夢，則增加90點傷害。",
+			},
 		},
+	],
 
-		damage: "90+",
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンが1進化ポケモンなら、90ダメージ追加。",
-			'zh-tw': "若對手的戰鬥寶可夢為【1階進化】寶可夢，則增加90點傷害。",
-			'zh-cn': "若對手的戰鬥寶可夢為【1階進化】寶可夢，則增加90點傷害。"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793445,
+				tcgplayer: 587591,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Uncommon",
+	dexId: [128],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/012.ts
+++ b/data-asia/SV/SV8/012.ts
@@ -1,69 +1,72 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ビクティニ",
 		'zh-tw': "比克提尼",
-		'zh-cn': "比克提尼"
+		'zh-cn': "比克提尼",
 	},
 
 	illustrator: "0313",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [494],
 	hp: 70,
 	types: ["Fire"],
 
 	description: {
 		ja: "勝利を もたらす ポケモン。 ビクティニを 連れた トレーナーは どんな 勝負にも 勝てるという。",
 		'zh-tw': "帶來勝利的寶可夢。 據說帶著比克提尼的訓練家， 不論任何比賽必能取得勝利。",
-		'zh-cn': "帶來勝利的寶可夢。 據說帶著比克提尼的訓練家， 不論任何比賽必能取得勝利。"
+		'zh-cn': "帶來勝利的寶可夢。 據說帶著比克提尼的訓練家， 不論任何比賽必能取得勝利。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "ビクトリーエール",
-			'zh-tw': "勝利聲援",
-			'zh-cn': "勝利聲援"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ビクトリーエール",
+				'zh-tw': "勝利聲援",
+				'zh-cn': "勝利聲援",
+			},
+			effect: {
+				ja: "このポケモンがいるかぎり、自分の[R]タイプの進化ポケモンが使うワザの、相手のバトルポケモンへのダメージは「+10」される。",
+				'zh-tw': "只要這隻寶可夢在場上，自己的【火】屬性的進化寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+10」點。",
+				'zh-cn': "只要這隻寶可夢在場上，自己的【火】屬性的進化寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+10」點。",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンがいるかぎり、自分のタイプの進化ポケモンが使うワザの、相手のバトルポケモンへのダメージは「+10」される。",
-			'zh-tw': "只要這隻寶可夢在場上，自己的【火】屬性的進化寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+10」點。",
-			'zh-cn': "只要這隻寶可夢在場上，自己的【火】屬性的進化寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+10」點。"
-		}
-	}],
-
-	attacks: [{
-		cost: ["Fire", "Colorless"],
-
-		name: {
-			ja: "ほのお",
-			'zh-tw': "火焰",
-			'zh-cn': "火焰"
+	attacks: [
+		{
+			name: {
+				ja: "ほのお",
+				'zh-tw': "火焰",
+				'zh-cn': "火焰",
+			},
+			damage: 30,
+			cost: ["Fire", "Colorless"],
 		},
+	],
 
-		damage: 30
-	}],
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793446,
+				tcgplayer: 587592,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "H",
+	rarity: "Uncommon",
+	dexId: [494],
+};
 
-	thirdParty: {
-		cardmarket: 793446
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/013.ts
+++ b/data-asia/SV/SV8/013.ts
@@ -1,63 +1,65 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "メラルバ",
 		'zh-tw': "燃燒蟲",
-		'zh-cn': "燃燒蟲"
+		'zh-cn': "燃燒蟲",
 	},
 
 	illustrator: "MARINA Chikazawa",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [636],
 	hp: 70,
 	types: ["Fire"],
 
 	description: {
 		ja: "大昔は 太陽の遣い と 崇められたが しばしば 山火事を 起こすこともあり 煙たがられた。",
 		'zh-tw': "在遙遠的過去曾被信奉成 太陽的使者，但卻因為常常 引發森林大火而遭人們疏遠。",
-		'zh-cn': "在遙遠的過去曾被信奉成 太陽的使者，但卻因為常常 引發森林大火而遭人們疏遠。"
+		'zh-cn': "在遙遠的過去曾被信奉成 太陽的使者，但卻因為常常 引發森林大火而遭人們疏遠。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "ぶつかる",
-			'zh-tw': "衝撞",
-			'zh-cn': "衝撞"
+	attacks: [
+		{
+			name: {
+				ja: "ぶつかる",
+				'zh-tw': "衝撞",
+				'zh-cn': "衝撞",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
-
-		damage: 10
-	}, {
-		cost: ["Fire", "Colorless"],
-
-		name: {
-			ja: "ひをはく",
-			'zh-tw': "吐火",
-			'zh-cn': "吐火"
+		{
+			name: {
+				ja: "ひをはく",
+				'zh-tw': "吐火",
+				'zh-cn': "吐火",
+			},
+			damage: 20,
+			cost: ["Fire", "Colorless"],
 		},
+	],
 
-		damage: 20
-	}],
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793447,
+				tcgplayer: 587593,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [636],
+};
 
-	thirdParty: {
-		cardmarket: 793447
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/014.ts
+++ b/data-asia/SV/SV8/014.ts
@@ -1,75 +1,79 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ウルガモス",
 		'zh-tw': "火神蛾",
-		'zh-cn': "火神蛾"
+		'zh-cn': "火神蛾",
 	},
 
 	illustrator: "matazo",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [637],
 	hp: 140,
 	types: ["Fire"],
 
 	description: {
 		ja: "炎の りんぷんを まき散らす。 危険なのは 高熱よりも あたりの 酸素が なくなること。",
 		'zh-tw': "會朝四周灑出火焰鱗粉。 最危險的不是高溫， 而是會耗盡周圍的氧氣。",
-		'zh-cn': "會朝四周灑出火焰鱗粉。 最危險的不是高溫， 而是會耗盡周圍的氧氣。"
+		'zh-cn': "會朝四周灑出火焰鱗粉。 最危險的不是高溫， 而是會耗盡周圍的氧氣。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "きゅうけつ",
-			'zh-tw': "吸血",
-			'zh-cn': "吸血"
+	attacks: [
+		{
+			name: {
+				ja: "きゅうけつ",
+				'zh-tw': "吸血",
+				'zh-cn': "吸血",
+			},
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンに与えたダメージぶん、このポケモンのHPを回復する。",
+				'zh-tw': "將這隻寶可夢恢復對對手的戰鬥寶可夢造成的傷害相同數值的HP。",
+				'zh-cn': "將這隻寶可夢恢復對對手的戰鬥寶可夢造成的傷害相同數值的HP。",
+			},
 		},
-
-		damage: 30,
-
-		effect: {
-			ja: "相手のバトルポケモンに与えたダメージぶん、このポケモンのHPを回復する。",
-			'zh-tw': "將這隻寶可夢恢復對對手的戰鬥寶可夢造成的傷害相同數值的HP。",
-			'zh-cn': "將這隻寶可夢恢復對對手的戰鬥寶可夢造成的傷害相同數值的HP。"
-		}
-	}, {
-		cost: ["Fire", "Colorless", "Colorless"],
-
-		name: {
-			ja: "どとうのはばたき",
-			'zh-tw': "怒濤羽擊",
-			'zh-cn': "怒濤羽擊"
+		{
+			name: {
+				ja: "どとうのはばたき",
+				'zh-tw': "怒濤羽擊",
+				'zh-cn': "怒濤羽擊",
+			},
+			damage: 150,
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも50ダメージ。",
+				'zh-tw': "這隻寶可夢也受到50點傷害。",
+				'zh-cn': "這隻寶可夢也受到50點傷害。",
+			},
 		},
+	],
 
-		damage: 150,
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンにも50ダメージ。",
-			'zh-tw': "這隻寶可夢也受到50點傷害。",
-			'zh-cn': "這隻寶可夢也受到50點傷害。"
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793448,
+				tcgplayer: 587594,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "メラルバ",
+	},
 
 	retreat: 2,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [637],
+};
 
-	thirdParty: {
-		cardmarket: 793448
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/015.ts
+++ b/data-asia/SV/SV8/015.ts
@@ -1,59 +1,65 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ヤクデ",
 		'zh-tw': "燒火蚣",
-		'zh-cn': "燒火蚣"
+		'zh-cn': "燒火蚣",
 	},
 
 	illustrator: "Minahamu",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [850],
 	hp: 80,
 	types: ["Fire"],
 
 	description: {
 		ja: "体に 溜めた 可燃ガスで 発熱。 とくに お腹の 黄色い 部分が 熱いのだ。",
 		'zh-tw': "靠儲存在體內的可燃氣體 來發熱。熱度最高的是 腹部的黃色部分。",
-		'zh-cn': "靠儲存在體內的可燃氣體 來發熱。熱度最高的是 腹部的黃色部分。"
+		'zh-cn': "靠儲存在體內的可燃氣體 來發熱。熱度最高的是 腹部的黃色部分。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Fire"],
-
-		name: {
-			ja: "ひだね",
-			'zh-tw': "火種",
-			'zh-cn': "火種"
+	attacks: [
+		{
+			name: {
+				ja: "ひだね",
+				'zh-tw': "火種",
+				'zh-cn': "火種",
+			},
+			damage: 10,
+			cost: ["Fire"],
 		},
-
-		damage: 10
-	}, {
-		cost: ["Colorless", "Colorless", "Colorless"],
-
-		name: {
-			ja: "ひっかける",
-			'zh-tw': "鉤住",
-			'zh-cn': "鉤住"
+		{
+			name: {
+				ja: "ひっかける",
+				'zh-tw': "鉤住",
+				'zh-cn': "鉤住",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 30
-	}],
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793449,
+				tcgplayer: 587595,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Common",
+	dexId: [850],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/016.ts
+++ b/data-asia/SV/SV8/016.ts
@@ -1,65 +1,74 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "マルヤクデ",
 		'zh-tw': "焚焰蚣",
-		'zh-cn': "焚焰蚣"
+		'zh-cn': "焚焰蚣",
 	},
 
 	illustrator: "Aliya Chen",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [851],
 	hp: 130,
 	types: ["Fire"],
 
 	description: {
 		ja: "発熱時の 体温は およそ ８００度。 体を 鞭のように しならせて 跳びかかってくるぞ。",
 		'zh-tw': "發熱時的體溫大約有８００度。 會像鞭子那樣彎曲身體， 朝著敵人彈跳過去。",
-		'zh-cn': "發熱時的體溫大約有８００度。 會像鞭子那樣彎曲身體， 朝著敵人彈跳過去。"
+		'zh-cn': "發熱時的體溫大約有８００度。 會像鞭子那樣彎曲身體， 朝著敵人彈跳過去。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Fire"],
-
-		name: {
-			ja: "もえるねっぱ",
-			'zh-tw': "燃燒熱浪",
-			'zh-cn': "燃燒熱浪"
+	attacks: [
+		{
+			name: {
+				ja: "もえるねっぱ",
+				'zh-tw': "燃燒熱浪",
+				'zh-cn': "燃燒熱浪",
+			},
+			damage: 130,
+			cost: ["Fire"],
+			effect: {
+				ja: "自分のベンチポケモン全員にも、それぞれ30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "自己的所有備戰寶可夢也各受到30點傷害。[在備戰區不計算弱點・抵抗力。]",
+				'zh-cn': "自己的所有備戰寶可夢也各受到30點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
-
-		damage: 130,
-
-		effect: {
-			ja: "自分のベンチポケモン全員にも、それぞれ30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
-			'zh-tw': "自己的所有備戰寶可夢也各受到30點傷害。[在備戰區不計算弱點・抵抗力。]",
-			'zh-cn': "自己的所有備戰寶可夢也各受到30點傷害。[在備戰區不計算弱點・抵抗力。]"
-		}
-	}, {
-		cost: ["Colorless", "Colorless", "Colorless"],
-
-		name: {
-			ja: "ヒートブラスト",
-			'zh-tw': "高溫爆破",
-			'zh-cn': "高溫爆破"
+		{
+			name: {
+				ja: "ヒートブラスト",
+				'zh-tw': "高溫爆破",
+				'zh-cn': "高溫爆破",
+			},
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 80
-	}],
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793450,
+				tcgplayer: 587596,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤクデ",
+	},
 
 	retreat: 2,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Common",
+	dexId: [851],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/017.ts
+++ b/data-asia/SV/SV8/017.ts
@@ -1,55 +1,61 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ホゲータ",
 		'zh-tw': "呆火鱷",
-		'zh-cn': "呆火鱷"
+		'zh-cn': "呆火鱷",
 	},
 
 	illustrator: "Tomomi Ozaki",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [909],
 	hp: 80,
 	types: ["Fire"],
 
 	description: {
 		ja: "炎袋が 小さく あふれ出た エネルギーが 頭の くぼみから 放出され ゆらゆら 揺れる。",
 		'zh-tw': "火囊很小，因此能量會 溢出來，在牠頭上的 凹槽那裡搖曳晃動。",
-		'zh-cn': "火囊很小，因此能量會 溢出來，在牠頭上的 凹槽那裡搖曳晃動。"
+		'zh-cn': "火囊很小，因此能量會 溢出來，在牠頭上的 凹槽那裡搖曳晃動。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Fire", "Colorless"],
-
-		name: {
-			ja: "ねつでこがす",
-			'zh-tw': "熱灼燒",
-			'zh-cn': "熱灼燒"
+	attacks: [
+		{
+			name: {
+				ja: "ねつでこがす",
+				'zh-tw': "熱灼燒",
+				'zh-cn': "熱灼燒",
+			},
+			damage: 20,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【灼傷】。",
+				'zh-cn': "將對手的戰鬥寶可夢【灼傷】。",
+			},
 		},
+	],
 
-		damage: 20,
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンをやけどにする。",
-			'zh-tw': "將對手的戰鬥寶可夢【灼傷】。",
-			'zh-cn': "將對手的戰鬥寶可夢【灼傷】。"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793451,
+				tcgplayer: 587597,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Common",
+	dexId: [909],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/018.ts
+++ b/data-asia/SV/SV8/018.ts
@@ -1,55 +1,65 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "アチゲータ",
 		'zh-tw': "炙燙鱷",
-		'zh-cn': "炙燙鱷"
+		'zh-cn': "炙燙鱷",
 	},
 
 	illustrator: "Atsuya Uki",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [910],
 	hp: 110,
 	types: ["Fire"],
 
 	description: {
 		ja: "声帯と 炎袋の 弁は 密接な 関係。 だみ声を 上げながら 炎を 吐き散らす。",
 		'zh-tw': "聲帶和火囊的閥緊鄰在一起。 會一邊發出嘶啞的聲音， 一邊噴灑火焰。",
-		'zh-cn': "聲帶和火囊的閥緊鄰在一起。 會一邊發出嘶啞的聲音， 一邊噴灑火焰。"
+		'zh-cn': "聲帶和火囊的閥緊鄰在一起。 會一邊發出嘶啞的聲音， 一邊噴灑火焰。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Fire", "Colorless"],
-
-		name: {
-			ja: "ヒートブレス",
-			'zh-tw': "高溫吐息",
-			'zh-cn': "高溫吐息"
+	attacks: [
+		{
+			name: {
+				ja: "ヒートブレス",
+				'zh-tw': "高溫吐息",
+				'zh-cn': "高溫吐息",
+			},
+			damage: "30+",
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、50ダメージ追加。",
+				'zh-tw': "擲1次硬幣若為正面，則增加50點傷害。",
+				'zh-cn': "擲1次硬幣若為正面，則增加50點傷害。",
+			},
 		},
+	],
 
-		damage: "30+",
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "コインを1回投げオモテなら、50ダメージ追加。",
-			'zh-tw': "擲1次硬幣若為正面，則增加50點傷害。",
-			'zh-cn': "擲1次硬幣若為正面，則增加50點傷害。"
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793452,
+				tcgplayer: 587598,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ホゲータ",
+	},
 
 	retreat: 3,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Common",
+	dexId: [910],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/019.ts
+++ b/data-asia/SV/SV8/019.ts
@@ -1,73 +1,81 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ラウドボーン",
 		'zh-tw': "骨紋巨聲鱷",
-		'zh-cn': "骨紋巨聲鱷"
+		'zh-cn': "骨紋巨聲鱷",
 	},
 
 	illustrator: "akagi",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [911],
 	hp: 180,
 	types: ["Fire"],
 
 	description: {
 		ja: "優しい 歌声は 聴いた者の 魂を 癒す。 ３０００度の 炎で 敵を 焼き尽くす。",
 		'zh-tw': "溫柔的歌聲能療癒聽者的靈魂。 會使用３０００度的火焰 將敵人燒成灰燼。",
-		'zh-cn': "溫柔的歌聲能療癒聽者的靈魂。 會使用３０００度的火焰 將敵人燒成灰燼。"
+		'zh-cn': "溫柔的歌聲能療癒聽者的靈魂。 會使用３０００度的火焰 將敵人燒成灰燼。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "てんねん",
-			'zh-tw': "純樸",
-			'zh-cn': "純樸"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "てんねん",
+				'zh-tw': "純樸",
+				'zh-cn': "純樸",
+			},
+			effect: {
+				ja: "このポケモンは、相手のポケモンが使うワザの効果を受けない。",
+				'zh-tw': "這隻寶可夢不會受到對手的寶可夢使用招式的效果的影響。",
+				'zh-cn': "這隻寶可夢不會受到對手的寶可夢使用招式的效果的影響。",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンは、相手のポケモンが使うワザの効果を受けない。",
-			'zh-tw': "這隻寶可夢不會受到對手的寶可夢使用招式的效果的影響。",
-			'zh-cn': "這隻寶可夢不會受到對手的寶可夢使用招式的效果的影響。"
-		}
-	}],
-
-	attacks: [{
-		cost: ["Fire", "Colorless"],
-
-		name: {
-			ja: "フレアリサイタル",
-			'zh-tw': "純樸",
-			'zh-tw': "閃焰獨唱會",
-			'zh-cn': "閃焰獨唱會"
+	attacks: [
+		{
+			name: {
+				ja: "フレアリサイタル",
+				'zh-tw': "閃焰獨唱會",
+				'zh-cn': "閃焰獨唱會",
+			},
+			damage: "60+",
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "おたがいのベンチポケモンの数×20ダメージ追加。",
+				'zh-tw': "增加雙方的備戰寶可夢的數量×20點傷害。",
+				'zh-cn': "增加雙方的備戰寶可夢的數量×20點傷害。",
+			},
 		},
+	],
 
-		damage: "60+",
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "おたがいのベンチポケモンの数×20ダメージ追加。",
-			'zh-tw': "這隻寶可夢不會受到對手的寶可夢使用招式的效果的影響。",
-			'zh-tw': "增加雙方的備戰寶可夢的數量×20點傷害。",
-			'zh-cn': "增加雙方的備戰寶可夢的數量×20點傷害。"
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793453,
+				tcgplayer: 587599,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "アチゲータ",
+	},
 
 	retreat: 3,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Rare",
+	dexId: [911],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/020.ts
+++ b/data-asia/SV/SV8/020.ts
@@ -1,65 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "カルボウ",
 		'zh-tw': "炭小侍",
-		'zh-cn': "炭小侍"
+		'zh-cn': "炭小侍",
 	},
 
 	illustrator: "Mékayu",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [935],
 	hp: 80,
 	types: ["Fire"],
 
 	description: {
 		ja: "戦いになると 火力が 上がり 摂氏１０００度に 達する。 油分の多い 木の実を 好む。",
 		'zh-tw': "在進入戰鬥狀態後， 火力會上升至攝氏１０００度。 喜歡吃油脂含量高的樹果。",
-		'zh-cn': "在進入戰鬥狀態後， 火力會上升至攝氏１０００度。 喜歡吃油脂含量高的樹果。"
+		'zh-cn': "在進入戰鬥狀態後， 火力會上升至攝氏１０００度。 喜歡吃油脂含量高的樹果。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Fire"],
-
-		name: {
-			ja: "なぐる",
-			'zh-tw': "打擊",
-			'zh-cn': "打擊"
+	attacks: [
+		{
+			name: {
+				ja: "なぐる",
+				'zh-tw': "打擊",
+				'zh-cn': "打擊",
+			},
+			damage: 10,
+			cost: ["Fire"],
 		},
-
-		damage: 10
-	}, {
-		cost: ["Fire", "Fire", "Colorless"],
-
-		name: {
-			ja: "かえんほうしゃ",
-			'zh-tw': "噴射火焰",
-			'zh-cn': "噴射火焰"
+		{
+			name: {
+				ja: "かえんほうしゃ",
+				'zh-tw': "噴射火焰",
+				'zh-cn': "噴射火焰",
+			},
+			damage: 70,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。",
+				'zh-cn': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		damage: 70,
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
-			'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。",
-			'zh-cn': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793454,
+				tcgplayer: 587600,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Common",
+	dexId: [935],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/021.ts
+++ b/data-asia/SV/SV8/021.ts
@@ -1,63 +1,73 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "グレンアルマ",
 		'zh-tw': "紅蓮鎧騎",
-		'zh-cn': "紅蓮鎧騎"
+		'zh-cn': "紅蓮鎧騎",
 	},
 
 	illustrator: "DOM",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [936],
 	hp: 140,
 	types: ["Fire"],
 
 	description: {
 		ja: "エスパーと 炎の エネルギーで 強化された 鎧を まとう。 灼熱の 火の玉を 放つ。",
 		'zh-tw': "身上包裹著受到超能力 和火焰能量強化的鎧甲。 會釋放熾熱的火球。",
-		'zh-cn': "身上包裹著受到超能力 和火焰能量強化的鎧甲。 會釋放熾熱的火球。"
+		'zh-cn': "身上包裹著受到超能力 和火焰能量強化的鎧甲。 會釋放熾熱的火球。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "かえん",
-			'zh-tw': "烈焰",
-			'zh-cn': "烈焰"
+	attacks: [
+		{
+			name: {
+				ja: "かえん",
+				'zh-tw': "烈焰",
+				'zh-cn': "烈焰",
+			},
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
 		},
-
-		damage: 50
-	}, {
-		cost: ["Fire", "Fire", "Colorless"],
-
-		name: {
-			ja: "グレンブラスター",
-			'zh-tw': "紅蓮引爆",
-			'zh-cn': "紅蓮引爆"
+		{
+			name: {
+				ja: "グレンブラスター",
+				'zh-tw': "紅蓮引爆",
+				'zh-cn': "紅蓮引爆",
+			},
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[R]エネルギーをすべてトラッシュし、相手のベンチポケモン1匹に、180ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "將這隻寶可夢身上附加的【火】能量卡全部丟棄，對手的1隻備戰寶可夢受到180點傷害。[在備戰區不計算弱點・抵抗力。]",
+				'zh-cn': "將這隻寶可夢身上附加的【火】能量卡全部丟棄，對手的1隻備戰寶可夢受到180點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンについているエネルギーをすべてトラッシュし、相手のベンチポケモン1匹に、180ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
-			'zh-tw': "將這隻寶可夢身上附加的【火】能量卡全部丟棄，對手的1隻備戰寶可夢受到180點傷害。[在備戰區不計算弱點・抵抗力。]",
-			'zh-cn': "將這隻寶可夢身上附加的【火】能量卡全部丟棄，對手的1隻備戰寶可夢受到180點傷害。[在備戰區不計算弱點・抵抗力。]"
-		}
-	}],
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793455,
+				tcgplayer: 587601,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カルボウ",
+	},
 
 	retreat: 2,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Uncommon",
+	dexId: [936],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/022.ts
+++ b/data-asia/SV/SV8/022.ts
@@ -1,69 +1,78 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ソウブレイズ",
 		'zh-tw': "蒼炎刃鬼",
-		'zh-cn': "蒼炎刃鬼"
+		'zh-cn': "蒼炎刃鬼",
 	},
 
 	illustrator: "kantaro",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [937],
 	hp: 140,
 	types: ["Fire"],
 
 	description: {
 		ja: "怨念の 染みついた 古い 鎧により 進化した 姿。 容赦なく 敵を 切り刻む。",
 		'zh-tw': "憑藉滲進怨念的舊鎧甲 而進化成的樣子。 會毫不留情地斬斷敵人。",
-		'zh-cn': "憑藉滲進怨念的舊鎧甲 而進化成的樣子。 會毫不留情地斬斷敵人。"
+		'zh-cn': "憑藉滲進怨念的舊鎧甲 而進化成的樣子。 會毫不留情地斬斷敵人。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "ブレイズカース",
-			'zh-tw': "火焰咒詛",
-			'zh-cn': "火焰咒詛"
+	attacks: [
+		{
+			name: {
+				ja: "ブレイズカース",
+				'zh-tw': "火焰咒詛",
+				'zh-cn': "火焰咒詛",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のポケモン全員についている特殊エネルギーを、すべてトラッシュする。",
+				'zh-tw': "將對手的所有寶可夢身上附加的特殊能量卡全部丟棄。",
+				'zh-cn': "將對手的所有寶可夢身上附加的特殊能量卡全部丟棄。",
+			},
 		},
-
-		effect: {
-			ja: "相手のポケモン全員についている特殊エネルギーを、すべてトラッシュする。",
-			'zh-tw': "將對手的所有寶可夢身上附加的特殊能量卡全部丟棄。",
-			'zh-cn': "將對手的所有寶可夢身上附加的特殊能量卡全部丟棄。"
-		}
-	}, {
-		cost: ["Fire", "Fire", "Colorless"],
-
-		name: {
-			ja: "こくえんぎり",
-			'zh-tw': "黑煙斬",
-			'zh-cn': "黑煙斬"
+		{
+			name: {
+				ja: "こくえんぎり",
+				'zh-tw': "黑煙斬",
+				'zh-cn': "黑煙斬",
+			},
+			damage: 160,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。",
+				'zh-cn': "在下個自己的回合，這隻寶可夢無法使用招式。",
+			},
 		},
+	],
 
-		damage: 160,
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "次の自分の番、このポケモンはワザが使えない。",
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。",
-			'zh-cn': "在下個自己的回合，這隻寶可夢無法使用招式。"
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793456,
+				tcgplayer: 587602,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "カルボウ",
+	},
 
 	retreat: 2,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Uncommon",
+	dexId: [937],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/023.ts
+++ b/data-asia/SV/SV8/023.ts
@@ -1,64 +1,77 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "スコヴィランex",
 		'zh-tw': "狠辣椒ex",
-		'zh-cn': "狠辣椒ex"
+		'zh-cn': "狠辣椒ex",
 	},
 
 	illustrator: "PLANETA Mochizuki",
-	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 260,
 	types: ["Fire"],
+
 	stage: "Stage1",
-	suffix: "EX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "ダブルタイプ",
-			'zh-tw': "雙重屬性",
-			'zh-cn': "雙重屬性"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ダブルタイプ",
+				'zh-tw': "雙重屬性",
+				'zh-cn': "雙重屬性",
+			},
+			effect: {
+				ja: "このポケモンは、場にいるかぎり[G]と[R]の2つのタイプになる。",
+				'zh-tw': "只要這隻寶可夢在場上，改為【草】與【火】2種屬性。",
+				'zh-cn': "只要這隻寶可夢在場上，改為【草】與【火】2種屬性。",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンは、場にいるかぎりとの2つのタイプになる。",
-			'zh-tw': "只要這隻寶可夢在場上，改為【草】與【火】2種屬性。",
-			'zh-cn': "只要這隻寶可夢在場上，改為【草】與【火】2種屬性。"
-		}
-	}],
-
-	attacks: [{
-		cost: ["Fire", "Fire"],
-
-		name: {
-			ja: "スパイシーレイジ",
-			'zh-tw': "香料激怒",
-			'zh-cn': "香料激怒"
+	attacks: [
+		{
+			name: {
+				ja: "スパイシーレイジ",
+				'zh-tw': "香料激怒",
+				'zh-cn': "香料激怒",
+			},
+			damage: "10+",
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数×70ダメージ追加。",
+				'zh-tw': "增加這隻寶可夢身上放置的傷害指示物的數量×70點傷害。",
+				'zh-cn': "增加這隻寶可夢身上放置的傷害指示物的數量×70點傷害。",
+			},
 		},
+	],
 
-		damage: "10+",
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンにのっているダメカンの数×70ダメージ追加。",
-			'zh-tw': "增加這隻寶可夢身上放置的傷害指示物的數量×70點傷害。",
-			'zh-cn': "增加這隻寶可夢身上放置的傷害指示物的數量×70點傷害。"
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793457,
+				tcgplayer: 587603,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "カプサイジ",
+	},
 
 	retreat: 2,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Double rare",
+	dexId: [952],
 
-export default card
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV8/024.ts
+++ b/data-asia/SV/SV8/024.ts
@@ -1,65 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "パルデア ケンタロス",
 		'zh-tw': "帕底亞 肯泰羅",
-		'zh-cn': "帕底亞 肯泰羅"
+		'zh-cn': "帕底亞 肯泰羅",
 	},
 
 	illustrator: "toi8",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [128],
 	hp: 130,
 	types: ["Water"],
 
 	description: {
 		ja: "ツノから 水を 吹きだし 泳ぐ。 脂肪分が 多く 浮きやすいのが ウォーター種の 特徴。",
 		'zh-tw': "會從角噴出水來游泳。 脂肪含量高而容易浮在水上 是水瀾種的特徵。",
-		'zh-cn': "會從角噴出水來游泳。 脂肪含量高而容易浮在水上 是水瀾種的特徵。"
+		'zh-cn': "會從角噴出水來游泳。 脂肪含量高而容易浮在水上 是水瀾種的特徵。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "かちあげホーン",
-			'zh-tw': "上搗角擊",
-			'zh-cn': "上搗角擊"
+	attacks: [
+		{
+			name: {
+				ja: "かちあげホーン",
+				'zh-tw': "上搗角擊",
+				'zh-cn': "上搗角擊",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、相手のバトル場の2進化ポケモンについているエネルギーを2個選び、相手の手札にもどす。",
+				'zh-tw': "若希望，選擇2個對手的戰鬥場的【2階進化】寶可夢身上附加的能量，放回對手的手牌。",
+				'zh-cn': "若希望，選擇2個對手的戰鬥場的【2階進化】寶可夢身上附加的能量，放回對手的手牌。",
+			},
 		},
-
-		damage: 30,
-
-		effect: {
-			ja: "のぞむなら、相手のバトル場の2進化ポケモンについているエネルギーを2個選び、相手の手札にもどす。",
-			'zh-tw': "若希望，選擇2個對手的戰鬥場的【2階進化】寶可夢身上附加的能量，放回對手的手牌。",
-			'zh-cn': "若希望，選擇2個對手的戰鬥場的【2階進化】寶可夢身上附加的能量，放回對手的手牌。"
-		}
-	}, {
-		cost: ["Water", "Water", "Colorless"],
-
-		name: {
-			ja: "ジェットヘッド",
-			'zh-tw': "噴射頭擊",
-			'zh-cn': "噴射頭擊"
+		{
+			name: {
+				ja: "ジェットヘッド",
+				'zh-tw': "噴射頭擊",
+				'zh-cn': "噴射頭擊",
+			},
+			damage: 100,
+			cost: ["Water", "Water", "Colorless"],
 		},
+	],
 
-		damage: 100
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793458,
+				tcgplayer: 587604,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Uncommon",
+	dexId: [128],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/025.ts
+++ b/data-asia/SV/SV8/025.ts
@@ -1,57 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ヒンバス",
 		'zh-tw': "醜醜魚",
-		'zh-cn': "醜醜魚"
+		'zh-cn': "醜醜魚",
 	},
 
 	illustrator: "Kedamahadaitai Yawarakai",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [349],
 	hp: 30,
 	types: ["Water"],
 
 	description: {
 		ja: "一番 みすぼらしい ポケモン。 水草の 多い 川底で 大勢 集まって 暮らしている。",
 		'zh-tw': "最寒酸的寶可夢。 在有許多水草的河底 群聚而居。",
-		'zh-cn': "最寒酸的寶可夢。 在有許多水草的河底 群聚而居。"
+		'zh-cn': "最寒酸的寶可夢。 在有許多水草的河底 群聚而居。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "はねにげ",
-			'zh-tw': "躍起逃走",
-			'zh-cn': "躍起逃走"
+	attacks: [
+		{
+			name: {
+				ja: "はねにげ",
+				'zh-tw': "躍起逃走",
+				'zh-cn': "躍起逃走",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+				'zh-tw': "將這隻寶可夢與備戰寶可夢互換。",
+				'zh-cn': "將這隻寶可夢與備戰寶可夢互換。",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンをベンチポケモンと入れ替える。",
-			'zh-tw': "將這隻寶可夢與備戰寶可夢互換。",
-			'zh-cn': "將這隻寶可夢與備戰寶可夢互換。"
-		}
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793459,
+				tcgplayer: 587605,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [349],
+};
 
-	thirdParty: {
-		cardmarket: 793459
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/026.ts
+++ b/data-asia/SV/SV8/026.ts
@@ -1,68 +1,77 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ミロカロスex",
 		'zh-tw': "美納斯ex",
-		'zh-cn': "美納斯ex"
+		'zh-cn': "美納斯ex",
 	},
 
 	illustrator: "hncl",
-	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 270,
 	types: ["Water"],
+
 	stage: "Stage1",
-	suffix: "EX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "きらめくウロコ",
-			'zh-tw': "‌璀璨鱗片",
-			'zh-cn': "‌璀璨鱗片"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "きらめくウロコ",
+				'zh-tw': "‌璀璨鱗片",
+				'zh-cn': "‌璀璨鱗片",
+			},
+			effect: {
+				ja: "このポケモンは、相手の「テラスタル」のポケモンからワザのダメージや効果を受けない。",
+				'zh-tw': "這隻寶可夢不會受到對手的「太晶」寶可夢招式的傷害與效果的影響。",
+				'zh-cn': "這隻寶可夢不會受到對手的「太晶」寶可夢招式的傷害與效果的影響。",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンは、相手の「テラスタル」のポケモンからワザのダメージや効果を受けない。",
-			'zh-tw': "這隻寶可夢不會受到對手的「太晶」寶可夢招式的傷害與效果的影響。",
-			'zh-cn': "這隻寶可夢不會受到對手的「太晶」寶可夢招式的傷害與效果的影響。"
-		}
-	}],
-
-	attacks: [{
-		cost: ["Water", "Colorless", "Colorless"],
-
-		name: {
-			ja: "ヒプノスプラッシュ",
-			'zh-tw': "昏睡飛濺",
-			'zh-cn': "昏睡飛濺"
+	attacks: [
+		{
+			name: {
+				ja: "ヒプノスプラッシュ",
+				'zh-tw': "昏睡飛濺",
+				'zh-cn': "昏睡飛濺",
+			},
+			damage: 160,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【睡眠】。",
+				'zh-cn': "將對手的戰鬥寶可夢【睡眠】。",
+			},
 		},
+	],
 
-		damage: 160,
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンをねむりにする。",
-			'zh-tw': "將對手的戰鬥寶可夢【睡眠】。",
-			'zh-cn': "將對手的戰鬥寶可夢【睡眠】。"
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793460,
+				tcgplayer: 587606,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ヒンバス",
+	},
 
 	retreat: 2,
 	regulationMark: "H",
+	rarity: "Double rare",
+	dexId: [350],
 
-	thirdParty: {
-		cardmarket: 793460
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/027.ts
+++ b/data-asia/SV/SV8/027.ts
@@ -1,59 +1,61 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "タマザラシ",
 		'zh-tw': "海豹球",
-		'zh-cn': "海豹球"
+		'zh-cn': "海豹球",
 	},
 
 	illustrator: "Teeziro",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [363],
 	hp: 70,
 	types: ["Water"],
 
 	description: {
 		ja: "ぶ厚い 脂肪に 包まれた 見事に まんまるな 体。 歩くより 転がるほうが 速い。",
 		'zh-tw': "身體被厚厚的脂肪包裹著， 圓得令人讚嘆。用翻滾的 方式移動反而比走路還要快。",
-		'zh-cn': "身體被厚厚的脂肪包裹著， 圓得令人讚嘆。用翻滾的 方式移動反而比走路還要快。"
+		'zh-cn': "身體被厚厚的脂肪包裹著， 圓得令人讚嘆。用翻滾的 方式移動反而比走路還要快。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Water"],
-
-		name: {
-			ja: "こなゆき",
-			'zh-tw': "細雪",
-			'zh-cn': "細雪"
+	attacks: [
+		{
+			name: {
+				ja: "こなゆき",
+				'zh-tw': "細雪",
+				'zh-cn': "細雪",
+			},
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【睡眠】。",
+				'zh-cn': "將對手的戰鬥寶可夢【睡眠】。",
+			},
 		},
+	],
 
-		damage: 10,
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンをねむりにする。",
-			'zh-tw': "將對手的戰鬥寶可夢【睡眠】。",
-			'zh-cn': "將對手的戰鬥寶可夢【睡眠】。"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793461,
+				tcgplayer: 587607,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [363],
+};
 
-	thirdParty: {
-		cardmarket: 793461
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/028.ts
+++ b/data-asia/SV/SV8/028.ts
@@ -1,63 +1,69 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "トドグラー",
 		'zh-tw': "海魔獅",
-		'zh-cn': "海魔獅"
+		'zh-cn': "海魔獅",
 	},
 
 	illustrator: "Mina Nakai",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [364],
 	hp: 100,
 	types: ["Water"],
 
 	description: {
 		ja: "流氷の 上で 生活。 泳ぎながら 獲物の 匂いを 嗅ぎわけて 見つけだし 捕まえる。",
 		'zh-tw': "在浮冰上生活。能夠一邊 游泳一邊嗅出獵物的氣味， 把對方找出來獵捕。",
-		'zh-cn': "在浮冰上生活。能夠一邊 游泳一邊嗅出獵物的氣味， 把對方找出來獵捕。"
+		'zh-cn': "在浮冰上生活。能夠一邊 游泳一邊嗅出獵物的氣味， 把對方找出來獵捕。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Water"],
-
-		name: {
-			ja: "つきたおし",
-			'zh-tw': "撞倒",
-			'zh-cn': "撞倒"
+	attacks: [
+		{
+			name: {
+				ja: "つきたおし",
+				'zh-tw': "撞倒",
+				'zh-cn': "撞倒",
+			},
+			damage: 30,
+			cost: ["Water"],
 		},
-
-		damage: 30
-	}, {
-		cost: ["Water", "Water"],
-
-		name: {
-			ja: "アイスボール",
-			'zh-tw': "冰球",
-			'zh-cn': "冰球"
+		{
+			name: {
+				ja: "アイスボール",
+				'zh-tw': "冰球",
+				'zh-cn': "冰球",
+			},
+			damage: 60,
+			cost: ["Water", "Water"],
 		},
+	],
 
-		damage: 60
-	}],
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793462,
+				tcgplayer: 587608,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "タマザラシ",
+	},
 
 	retreat: 3,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [364],
+};
 
-	thirdParty: {
-		cardmarket: 793462
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/029.ts
+++ b/data-asia/SV/SV8/029.ts
@@ -1,75 +1,79 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "トドゼルガ",
 		'zh-tw': "帝牙海獅",
-		'zh-cn': "帝牙海獅"
+		'zh-cn': "帝牙海獅",
 	},
 
 	illustrator: "Mitsuhiro Arita",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [365],
 	hp: 170,
 	types: ["Water"],
 
 	description: {
 		ja: "２、３０匹で 群れを つくる。 敵に 襲われると リーダーは 体を 張って 群れを 守る。",
 		'zh-tw': "會由２、３０隻群居生活。 受到敵人攻擊時，首領會 奮不顧身地保護群體。",
-		'zh-cn': "會由２、３０隻群居生活。 受到敵人攻擊時，首領會 奮不顧身地保護群體。"
+		'zh-cn': "會由２、３０隻群居生活。 受到敵人攻擊時，首領會 奮不顧身地保護群體。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		cost: ["Water"],
-
-		name: {
-			ja: "とうけつファング",
-			'zh-tw': "凍結獠牙",
-			'zh-cn': "凍結獠牙"
+	attacks: [
+		{
+			name: {
+				ja: "とうけつファング",
+				'zh-tw': "凍結獠牙",
+				'zh-cn': "凍結獠牙",
+			},
+			damage: 60,
+			cost: ["Water"],
+			effect: {
+				ja: "次の相手の番、ついているエネルギーが2個以下のポケモン全員は、ワザが使えない。（新しく場に出したポケモンもふくむ。）",
+				'zh-tw': "在下個對手的回合，身上附加的能量為2個以下的所有寶可夢無法使用招式。（包含新上場的寶可夢。）",
+				'zh-cn': "在下個對手的回合，身上附加的能量為2個以下的所有寶可夢無法使用招式。（包含新上場的寶可夢。）",
+			},
 		},
-
-		damage: 60,
-
-		effect: {
-			ja: "次の相手の番、ついているエネルギーが2個以下のポケモン全員は、ワザが使えない。（新しく場に出したポケモンもふくむ。）",
-			'zh-tw': "在下個對手的回合，身上附加的能量為2個以下的所有寶可夢無法使用招式。（包含新上場的寶可夢。）",
-			'zh-cn': "在下個對手的回合，身上附加的能量為2個以下的所有寶可夢無法使用招式。（包含新上場的寶可夢。）"
-		}
-	}, {
-		cost: ["Water", "Water"],
-
-		name: {
-			ja: "メガトンフォール",
-			'zh-tw': "百萬噸墜落",
-			'zh-cn': "百萬噸墜落"
+		{
+			name: {
+				ja: "メガトンフォール",
+				'zh-tw': "百萬噸墜落",
+				'zh-cn': "百萬噸墜落",
+			},
+			damage: 170,
+			cost: ["Water", "Water"],
+			effect: {
+				ja: "このポケモンにも50ダメージ。",
+				'zh-tw': "這隻寶可夢也受到50點傷害。",
+				'zh-cn': "這隻寶可夢也受到50點傷害。",
+			},
 		},
+	],
 
-		damage: 170,
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンにも50ダメージ。",
-			'zh-tw': "這隻寶可夢也受到50點傷害。",
-			'zh-cn': "這隻寶可夢也受到50點傷害。"
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793463,
+				tcgplayer: 587609,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "トドグラー",
+	},
 
 	retreat: 3,
 	regulationMark: "H",
+	rarity: "Uncommon",
+	dexId: [365],
+};
 
-	thirdParty: {
-		cardmarket: 793463
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/030.ts
+++ b/data-asia/SV/SV8/030.ts
@@ -1,53 +1,56 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "カラナクシ",
 		'zh-tw': "無殼海兔",
-		'zh-cn': "無殼海兔"
+		'zh-cn': "無殼海兔",
 	},
 
 	illustrator: "Shinya Komatsu",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [422],
 	hp: 70,
 	types: ["Water"],
 
 	description: {
 		ja: "磯辺で 見かけることが 多い。 ある程度の 時間であれば 陸上でも 活動できる。",
 		'zh-tw': "經常能在岩岸發現牠的身影。 即使是在陸地上，也有辦法 活動上一定程度的時間。",
-		'zh-cn': "經常能在岩岸發現牠的身影。 即使是在陸地上，也有辦法 活動上一定程度的時間。"
+		'zh-cn': "經常能在岩岸發現牠的身影。 即使是在陸地上，也有辦法 活動上一定程度的時間。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "うちみず",
-			'zh-tw': "潑灑清水",
-			'zh-cn': "潑灑清水"
+	attacks: [
+		{
+			name: {
+				ja: "うちみず",
+				'zh-tw': "潑灑清水",
+				'zh-cn': "潑灑清水",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 30
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793464,
+				tcgplayer: 587610,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [422],
+};
 
-	thirdParty: {
-		cardmarket: 793464
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/031.ts
+++ b/data-asia/SV/SV8/031.ts
@@ -1,55 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "テツノツツミ",
 		'zh-tw': "鐵包袱",
-		'zh-cn': "鐵包袱"
+		'zh-cn': "鐵包袱",
 	},
 
 	illustrator: "rika",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [991],
 	hp: 100,
 	types: ["Water"],
 
 	description: {
 		ja: "古い 書物に 登場する 謎の 物体に 似た ポケモン。 目撃例は 過去 ２件のみ。",
 		'zh-tw': "與古書裡記載的神秘物體 長得很相像的寶可夢。 過去只被目擊過２次。",
-		'zh-cn': "與古書裡記載的神秘物體 長得很相像的寶可夢。 過去只被目擊過２次。"
+		'zh-cn': "與古書裡記載的神秘物體 長得很相像的寶可夢。 過去只被目擊過２次。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Water", "Water", "Colorless"],
-
-		name: {
-			ja: "ガストコリジョン",
-			'zh-tw': "瞬風衝激",
-			'zh-cn': "瞬風衝激"
+	attacks: [
+		{
+			name: {
+				ja: "ガストコリジョン 200-",
+				'zh-tw': "瞬風衝激",
+				'zh-cn': "瞬風衝激",
+			},
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンのにげるためのエネルギーの数×50ダメージぶん、このワザのダメージは小さくなる。",
+				'zh-tw': "減少對手的戰鬥寶可夢【撤退】所需的能量的數量×50點傷害。",
+				'zh-cn': "減少對手的戰鬥寶可夢【撤退】所需的能量的數量×50點傷害。",
+			},
 		},
+	],
 
-		damage: "200-",
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンのにげるためのエネルギーの数×50ダメージぶん、このワザのダメージは小さくなる。",
-			'zh-tw': "減少對手的戰鬥寶可夢【撤退】所需的能量的數量×50點傷害。",
-			'zh-cn': "減少對手的戰鬥寶可夢【撤退】所需的能量的數量×50點傷害。"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793465,
+				tcgplayer: 587611,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Uncommon",
+	dexId: [991],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/032.ts
+++ b/data-asia/SV/SV8/032.ts
@@ -1,71 +1,77 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "パオジアン",
 		'zh-tw': "古劍豹",
-		'zh-cn': "古劍豹"
+		'zh-cn': "古劍豹",
 	},
 
 	illustrator: "Yuya Oka",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [1002],
 	hp: 120,
 	types: ["Water"],
 
 	description: {
 		ja: "大昔に 剣によって 露と消えた 者たちの 憎しみが 雪を まとい ポケモンになった。",
 		'zh-tw': "遙遠過去喪命於劍下者 的憎恨之情纏繞在雪上， 變成了寶可夢。",
-		'zh-cn': "遙遠過去喪命於劍下者 的憎恨之情纏繞在雪上， 變成了寶可夢。"
+		'zh-cn': "遙遠過去喪命於劍下者 的憎恨之情纏繞在雪上， 變成了寶可夢。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "ゆきにしずめる",
-			'zh-tw': "‌‌沉雪",
-			'zh-cn': "‌‌沉雪"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ゆきにしずめる",
+				'zh-tw': "‌‌沉雪",
+				'zh-cn': "‌‌沉雪",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。場に出ているスタジアムをトラッシュする。",
+				'zh-tw': "在自己的回合，從手牌將這張卡放置於備戰區時，可使用1次。將場上的競技場卡丟棄。",
+				'zh-cn': "在自己的回合，從手牌將這張卡放置於備戰區時，可使用1次。將場上的競技場卡丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。場に出ているスタジアムをトラッシュする。",
-			'zh-tw': "在自己的回合，從手牌將這張卡放置於備戰區時，可使用1次。將場上的競技場卡丟棄。",
-			'zh-cn': "在自己的回合，從手牌將這張卡放置於備戰區時，可使用1次。將場上的競技場卡丟棄。"
-		}
-	}],
-
-	attacks: [{
-		cost: ["Water", "Water", "Colorless"],
-
-		name: {
-			ja: "アイシクルループ",
-			'zh-tw': "冰柱閉環",
-			'zh-cn': "冰柱閉環"
+	attacks: [
+		{
+			name: {
+				ja: "アイシクルループ",
+				'zh-tw': "冰柱閉環",
+				'zh-cn': "冰柱閉環",
+			},
+			damage: 120,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、手札にもどす。",
+				'zh-tw': "選擇1個這隻寶可夢身上附加的能量，放回手牌。",
+				'zh-cn': "選擇1個這隻寶可夢身上附加的能量，放回手牌。",
+			},
 		},
+	],
 
-		damage: 120,
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンについているエネルギーを1個選び、手札にもどす。",
-			'zh-tw': "選擇1個這隻寶可夢身上附加的能量，放回手牌。",
-			'zh-cn': "選擇1個這隻寶可夢身上附加的能量，放回手牌。"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793466,
+				tcgplayer: 587612,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Rare",
+	dexId: [1002],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/033.ts
+++ b/data-asia/SV/SV8/033.ts
@@ -1,68 +1,73 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ピカチュウex",
 		'zh-tw': "皮卡丘ex",
-		'zh-cn': "皮卡丘ex"
+		'zh-cn': "皮卡丘ex",
 	},
 
 	illustrator: "aky CG Works",
-	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Lightning"],
+
 	stage: "Basic",
-	suffix: "EX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "がんばりハート",
-			'zh-tw': "‌‌勤奮之心",
-			'zh-cn': "‌‌勤奮之心"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "がんばりハート",
+				'zh-tw': "‌‌勤奮之心",
+				'zh-cn': "‌‌勤奮之心",
+			},
+			effect: {
+				ja: "このポケモンのHPがまんたんの状態で、このポケモンがワザのダメージを受けてきぜつするとき、きぜつせず、残りHPが「10」の状態で場に残る。",
+				'zh-tw': "‌這隻寶可夢的HP是全滿的狀態下，這隻寶可夢受到招式的傷害而【昏厥】時，這隻寶可夢不會【昏厥】，而是以剩餘HP為「10」的狀態留在場上。",
+				'zh-cn': "‌這隻寶可夢的HP是全滿的狀態下，這隻寶可夢受到招式的傷害而【昏厥】時，這隻寶可夢不會【昏厥】，而是以剩餘HP為「10」的狀態留在場上。",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンのHPがまんたんの状態で、このポケモンがワザのダメージを受けてきぜつするとき、きぜつせず、残りHPが「10」の状態で場に残る。",
-			'zh-tw': "‌這隻寶可夢的HP是全滿的狀態下，這隻寶可夢受到招式的傷害而【昏厥】時，這隻寶可夢不會【昏厥】，而是以剩餘HP為「10」的狀態留在場上。",
-			'zh-cn': "‌這隻寶可夢的HP是全滿的狀態下，這隻寶可夢受到招式的傷害而【昏厥】時，這隻寶可夢不會【昏厥】，而是以剩餘HP為「10」的狀態留在場上。"
-		}
-	}],
-
-	attacks: [{
-		cost: ["Grass", "Lightning", "Metal"],
-
-		name: {
-			ja: "トパーズボルト",
-			'zh-tw': "黃玉伏特",
-			'zh-cn': "黃玉伏特"
+	attacks: [
+		{
+			name: {
+				ja: "トパーズボルト",
+				'zh-tw': "黃玉伏特",
+				'zh-cn': "黃玉伏特",
+			},
+			damage: 300,
+			cost: ["Grass", "Lightning", "Metal"],
+			effect: {
+				ja: "このポケモンについているエネルギーを3個選び、トラッシュする。",
+				'zh-tw': "選擇3個這隻寶可夢身上附加的能量，將其丟棄。",
+				'zh-cn': "選擇3個這隻寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		damage: 300,
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンについているエネルギーを3個選び、トラッシュする。",
-			'zh-tw': "選擇3個這隻寶可夢身上附加的能量，將其丟棄。",
-			'zh-cn': "選擇3個這隻寶可夢身上附加的能量，將其丟棄。"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793467,
+				tcgplayer: 587613,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "H",
+	rarity: "Double rare",
+	dexId: [25],
 
-	thirdParty: {
-		cardmarket: 793467
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/034.ts
+++ b/data-asia/SV/SV8/034.ts
@@ -1,53 +1,56 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "コイル",
 		'zh-tw': "小磁怪",
-		'zh-cn': "小磁怪"
+		'zh-cn': "小磁怪",
 	},
 
 	illustrator: "Hoshino KURO",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [81],
 	hp: 60,
 	types: ["Lightning"],
 
 	description: {
 		ja: "空中に 浮いたまま 移動して 左右の ユニットから 電磁波などを 放射する。",
 		'zh-tw': "會浮在空中移動， 從左右兩邊的組件發射 電磁波之類的東西。",
-		'zh-cn': "會浮在空中移動， 從左右兩邊的組件發射 電磁波之類的東西。"
+		'zh-cn': "會浮在空中移動， 從左右兩邊的組件發射 電磁波之類的東西。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Lightning"],
-
-		name: {
-			ja: "ピッカリだま",
-			'zh-tw': "光彈",
-			'zh-cn': "光彈"
+	attacks: [
+		{
+			name: {
+				ja: "ピッカリだま",
+				'zh-tw': "光彈",
+				'zh-cn': "光彈",
+			},
+			damage: 20,
+			cost: ["Lightning"],
 		},
+	],
 
-		damage: 20
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793468,
+				tcgplayer: 587614,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [81],
+};
 
-	thirdParty: {
-		cardmarket: 793468
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/035.ts
+++ b/data-asia/SV/SV8/035.ts
@@ -1,69 +1,76 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "レアコイル",
 		'zh-tw': "三合一磁怪",
-		'zh-cn': "三合一磁怪"
+		'zh-cn': "三合一磁怪",
 	},
 
 	illustrator: "Nisota Niso",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [82],
 	hp: 100,
 	types: ["Lightning"],
 
 	description: {
 		ja: "連結した タイプの コイルは 太陽の 黒点が 多いとき たくさん 現れると 言われる。",
 		'zh-tw': "據說太陽黑子多的時候， 這類連結在一起的小磁怪 會大量出現。",
-		'zh-cn': "據說太陽黑子多的時候， 這類連結在一起的小磁怪 會大量出現。"
+		'zh-cn': "據說太陽黑子多的時候， 這類連結在一起的小磁怪 會大量出現。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "かじょうほうでん",
-			'zh-tw': "‌‌‌過度放電",
-			'zh-cn': "‌‌‌過度放電"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "かじょうほうでん",
+				'zh-tw': "‌‌‌過度放電",
+				'zh-cn': "‌‌‌過度放電",
+			},
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、このポケモンをきぜつさせる。自分のトラッシュから基本エネルギーを3枚まで選び、自分の[L]ポケモンに好きなようにつける。",
+				'zh-tw': "在自己的回合時可使用1次，若使用，則將這隻寶可夢【昏厥】。從自己的棄牌區選擇最多3張基本能量卡，以任意方式附於自己的【雷】寶可夢身上。",
+				'zh-cn': "在自己的回合時可使用1次，若使用，則將這隻寶可夢【昏厥】。從自己的棄牌區選擇最多3張基本能量卡，以任意方式附於自己的【雷】寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			ja: "自分の番に1回使えて、使ったなら、このポケモンをきぜつさせる。自分のトラッシュから基本エネルギーを3枚まで選び、自分のポケモンに好きなようにつける。",
-			'zh-tw': "在自己的回合時可使用1次，若使用，則將這隻寶可夢【昏厥】。從自己的棄牌區選擇最多3張基本能量卡，以任意方式附於自己的【雷】寶可夢身上。",
-			'zh-cn': "在自己的回合時可使用1次，若使用，則將這隻寶可夢【昏厥】。從自己的棄牌區選擇最多3張基本能量卡，以任意方式附於自己的【雷】寶可夢身上。"
-		}
-	}],
-
-	attacks: [{
-		cost: ["Lightning", "Colorless"],
-
-		name: {
-			ja: "ライトニングボール",
-			'zh-tw': "雷電球",
-			'zh-cn': "雷電球"
+	attacks: [
+		{
+			name: {
+				ja: "ライトニングボール",
+				'zh-tw': "雷電球",
+				'zh-cn': "雷電球",
+			},
+			damage: 40,
+			cost: ["Lightning", "Colorless"],
 		},
+	],
 
-		damage: 40
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793469,
+				tcgplayer: 587615,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コイル",
+	},
 
 	retreat: 1,
 	regulationMark: "H",
+	rarity: "Uncommon",
+	dexId: [82],
+};
 
-	thirdParty: {
-		cardmarket: 793469
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/036.ts
+++ b/data-asia/SV/SV8/036.ts
@@ -1,75 +1,79 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ジバコイル",
 		'zh-tw': "自爆磁怪",
-		'zh-cn': "自爆磁怪"
+		'zh-cn': "自爆磁怪",
 	},
 
 	illustrator: "Po-Suzuki",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [462],
 	hp: 170,
 	types: ["Lightning"],
 
 	description: {
 		ja: "特殊な 磁場で レアコイルの 分子 構造が 組み換えられて ジバコイルに 進化した。",
 		'zh-tw': "在特殊磁場的影響下， 三合一磁怪的分子構造受到重組， 從而進化成了自爆磁怪。",
-		'zh-cn': "在特殊磁場的影響下， 三合一磁怪的分子構造受到重組， 從而進化成了自爆磁怪。"
+		'zh-cn': "在特殊磁場的影響下， 三合一磁怪的分子構造受到重組， 從而進化成了自爆磁怪。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		cost: ["Lightning", "Colorless", "Colorless"],
-
-		name: {
-			ja: "きょうりょくじば",
-			'zh-tw': "強勁磁場",
-			'zh-cn': "強勁磁場"
+	attacks: [
+		{
+			name: {
+				ja: "きょうりょくじば",
+				'zh-tw': "強勁磁場",
+				'zh-cn': "強勁磁場",
+			},
+			damage: 80,
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。次の相手の番、このワザを受けたポケモンは、にげられない。",
+				'zh-tw': "將對手的戰鬥寶可夢【混亂】。在下個對手的回合，受到這個招式的寶可夢無法撤退。",
+				'zh-cn': "將對手的戰鬥寶可夢【混亂】。在下個對手的回合，受到這個招式的寶可夢無法撤退。",
+			},
 		},
-
-		damage: 80,
-
-		effect: {
-			ja: "相手のバトルポケモンをこんらんにする。次の相手の番、このワザを受けたポケモンは、にげられない。",
-			'zh-tw': "將對手的戰鬥寶可夢【混亂】。在下個對手的回合，受到這個招式的寶可夢無法撤退。",
-			'zh-cn': "將對手的戰鬥寶可夢【混亂】。在下個對手的回合，受到這個招式的寶可夢無法撤退。"
-		}
-	}, {
-		cost: ["Lightning", "Colorless", "Colorless", "Colorless"],
-
-		name: {
-			ja: "でんじほう",
-			'zh-tw': "電磁炮",
-			'zh-cn': "電磁炮"
+		{
+			name: {
+				ja: "でんじほう",
+				'zh-tw': "電磁炮",
+				'zh-cn': "電磁炮",
+			},
+			damage: 180,
+			cost: ["Lightning", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「でんじほう」が使えない。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「電磁炮」。",
+				'zh-cn': "在下個自己的回合，這隻寶可夢無法使用「電磁炮」。",
+			},
 		},
+	],
 
-		damage: 180,
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "次の自分の番、このポケモンは「でんじほう」が使えない。",
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「電磁炮」。",
-			'zh-cn': "在下個自己的回合，這隻寶可夢無法使用「電磁炮」。"
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793470,
+				tcgplayer: 587616,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "レアコイル",
+	},
 
 	retreat: 3,
 	regulationMark: "H",
+	rarity: "Uncommon",
+	dexId: [462],
+};
 
-	thirdParty: {
-		cardmarket: 793470
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/037.ts
+++ b/data-asia/SV/SV8/037.ts
@@ -1,73 +1,74 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ロトム",
 		'zh-tw': "洛托姆",
-		'zh-cn': "洛托姆"
+		'zh-cn': "洛托姆",
 	},
 
 	illustrator: "Shinya Mizuno",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [479],
 	hp: 80,
 	types: ["Lightning"],
 
 	description: {
 		ja: "特殊な モーターを 動かす 動力源として 長い あいだ 研究されていた ポケモン。",
 		'zh-tw': "被當作驅動 特殊馬達的動力源， 而被長期研究的寶可夢。",
-		'zh-cn': "被當作驅動 特殊馬達的動力源， 而被長期研究的寶可夢。"
+		'zh-cn': "被當作驅動 特殊馬達的動力源， 而被長期研究的寶可夢。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Lightning"],
-
-		name: {
-			ja: "クラッシュパルス",
-			'zh-tw': "粉碎脈衝",
-			'zh-cn': "粉碎脈衝"
+	attacks: [
+		{
+			name: {
+				ja: "クラッシュパルス",
+				'zh-tw': "粉碎脈衝",
+				'zh-cn': "粉碎脈衝",
+			},
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手の手札を見て、その中にある「グッズ」と「ポケモンのどうぐ」を、すべてトラッシュする。",
+				'zh-tw': "查看對手的手牌，將其中的「物品」卡與「寶可夢道具」卡全部丟棄。",
+				'zh-cn': "查看對手的手牌，將其中的「物品」卡與「寶可夢道具」卡全部丟棄。",
+			},
 		},
-
-		effect: {
-			ja: "相手の手札を見て、その中にある「グッズ」と「ポケモンのどうぐ」を、すべてトラッシュする。",
-			'zh-tw': "查看對手的手牌，將其中的「物品」卡與「寶可夢道具」卡全部丟棄。",
-			'zh-cn': "查看對手的手牌，將其中的「物品」卡與「寶可夢道具」卡全部丟棄。"
-		}
-	}, {
-		cost: ["Lightning"],
-
-		name: {
-			ja: "エネショート",
-			'zh-tw': "能量短路",
-			'zh-cn': "能量短路"
+		{
+			name: {
+				ja: "エネショート",
+				'zh-tw': "能量短路",
+				'zh-cn': "能量短路",
+			},
+			damage: "20×",
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数×20ダメージ。",
+				'zh-tw': "造成對手的戰鬥寶可夢身上附加的能量的數量×20點傷害。",
+				'zh-cn': "造成對手的戰鬥寶可夢身上附加的能量的數量×20點傷害。",
+			},
 		},
+	],
 
-		damage: "20×",
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンについているエネルギーの数×20ダメージ。",
-			'zh-tw': "造成對手的戰鬥寶可夢身上附加的能量的數量×20點傷害。",
-			'zh-cn': "造成對手的戰鬥寶可夢身上附加的能量的數量×20點傷害。"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793471,
+				tcgplayer: 587617,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [479],
+};
 
-	thirdParty: {
-		cardmarket: 793471
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/038.ts
+++ b/data-asia/SV/SV8/038.ts
@@ -1,67 +1,69 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "シママ",
 		'zh-tw': "斑斑馬",
-		'zh-cn': "斑斑馬"
+		'zh-cn': "斑斑馬",
 	},
 
 	illustrator: "kamonabe",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [522],
 	hp: 70,
 	types: ["Lightning"],
 
 	description: {
 		ja: "落雷の 多い 土地を 好む。 たてがみで 雷を 受け止め 体に 電気を 溜めこむのだ。",
 		'zh-tw': "喜歡經常發生落雷的土地。 會用鬃毛接下雷電， 把電力儲存到體內。",
-		'zh-cn': "喜歡經常發生落雷的土地。 會用鬃毛接下雷電， 把電力儲存到體內。"
+		'zh-cn': "喜歡經常發生落雷的土地。 會用鬃毛接下雷電， 把電力儲存到體內。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "くわえる",
-			'zh-tw': "叼",
-			'zh-cn': "叼"
+	attacks: [
+		{
+			name: {
+				ja: "くわえる",
+				'zh-tw': "叼",
+				'zh-cn': "叼",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+				'zh-tw': "從自己的牌庫抽出1張卡。",
+				'zh-cn': "從自己的牌庫抽出1張卡。",
+			},
 		},
-
-		effect: {
-			ja: "自分の山札を1枚引く。",
-			'zh-tw': "從自己的牌庫抽出1張卡。",
-			'zh-cn': "從自己的牌庫抽出1張卡。"
-		}
-	}, {
-		cost: ["Lightning", "Colorless"],
-
-		name: {
-			ja: "バチバチ",
-			'zh-tw': "劈哩啪啦",
-			'zh-cn': "劈哩啪啦"
+		{
+			name: {
+				ja: "バチバチ",
+				'zh-tw': "劈哩啪啦",
+				'zh-cn': "劈哩啪啦",
+			},
+			damage: 20,
+			cost: ["Lightning", "Colorless"],
 		},
+	],
 
-		damage: 20
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793472,
+				tcgplayer: 587618,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [522],
+};
 
-	thirdParty: {
-		cardmarket: 793472
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/039.ts
+++ b/data-asia/SV/SV8/039.ts
@@ -1,63 +1,69 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ゼブライカ",
 		'zh-tw': "雷電斑馬",
-		'zh-cn': "雷電斑馬"
+		'zh-cn': "雷電斑馬",
 	},
 
 	illustrator: "Sanosuke Sakuma",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [523],
 	hp: 130,
 	types: ["Lightning"],
 
 	description: {
 		ja: "雷鳴を 聞くと 群れの シママが 雷から 充電できるように 群れで 雷雲を 追いかける。",
 		'zh-tw': "為了讓群體裡的斑斑馬能 透過雷電充電，只要一聽到 雷鳴聲，就會成群追趕雷雲。",
-		'zh-cn': "為了讓群體裡的斑斑馬能 透過雷電充電，只要一聽到 雷鳴聲，就會成群追趕雷雲。"
+		'zh-cn': "為了讓群體裡的斑斑馬能 透過雷電充電，只要一聽到 雷鳴聲，就會成群追趕雷雲。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Lightning"],
-
-		name: {
-			ja: "キック",
-			'zh-tw': "踢",
-			'zh-cn': "踢"
+	attacks: [
+		{
+			name: {
+				ja: "キック",
+				'zh-tw': "踢",
+				'zh-cn': "踢",
+			},
+			damage: 30,
+			cost: ["Lightning"],
 		},
-
-		damage: 30
-	}, {
-		cost: ["Lightning", "Lightning", "Colorless"],
-
-		name: {
-			ja: "マッハボルト",
-			'zh-tw': "音速伏特",
-			'zh-cn': "音速伏特"
+		{
+			name: {
+				ja: "マッハボルト",
+				'zh-tw': "音速伏特",
+				'zh-cn': "音速伏特",
+			},
+			damage: 120,
+			cost: ["Lightning", "Lightning", "Colorless"],
 		},
+	],
 
-		damage: 120
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793473,
+				tcgplayer: 587619,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シママ",
+	},
 
 	retreat: 1,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [523],
+};
 
-	thirdParty: {
-		cardmarket: 793473
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/040.ts
+++ b/data-asia/SV/SV8/040.ts
@@ -1,59 +1,61 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "マッギョ",
 		'zh-tw': "泥巴魚",
-		'zh-cn': "泥巴魚"
+		'zh-cn': "泥巴魚",
 	},
 
 	illustrator: "Miki Tanaka",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [618],
 	hp: 110,
 	types: ["Lightning"],
 
 	description: {
 		ja: "干潟が すみか。 泥に 棲む 細菌に よって 電気を つくる 器官が 発達した。",
 		'zh-tw': "潮間帶便是牠的巢穴。 製造電的器官由於 泥裡的細菌而發達起來。",
-		'zh-cn': "潮間帶便是牠的巢穴。 製造電的器官由於 泥裡的細菌而發達起來。"
+		'zh-cn': "潮間帶便是牠的巢穴。 製造電的器官由於 泥裡的細菌而發達起來。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Lightning", "Colorless"],
-
-		name: {
-			ja: "バチッとしびれる",
-			'zh-tw': "劈啪麻痺",
-			'zh-cn': "劈啪麻痺"
+	attacks: [
+		{
+			name: {
+				ja: "バチッとしびれる",
+				'zh-tw': "劈啪麻痺",
+				'zh-cn': "劈啪麻痺",
+			},
+			damage: 50,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。さらに、そのポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。再選擇1個那隻寶可夢身上附加的能量，將其丟棄。",
+				'zh-cn': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。再選擇1個那隻寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		damage: 50,
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。さらに、そのポケモンについているエネルギーを1個選び、トラッシュする。",
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。再選擇1個那隻寶可夢身上附加的能量，將其丟棄。",
-			'zh-cn': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。再選擇1個那隻寶可夢身上附加的能量，將其丟棄。"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793474,
+				tcgplayer: 587620,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [618],
+};
 
-	thirdParty: {
-		cardmarket: 793474
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/041.ts
+++ b/data-asia/SV/SV8/041.ts
@@ -1,73 +1,74 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "カプ・コケコ",
 		'zh-tw': "卡璞・鳴鳴",
-		'zh-cn': "卡璞・鳴鳴"
+		'zh-cn': "卡璞・鳴鳴",
 	},
 
 	illustrator: "Souichirou Gunjima",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [785],
 	hp: 120,
 	types: ["Lightning"],
 
 	description: {
 		ja: "守り神と 呼ばれるが 気分を 害する 人間や ポケモンには 襲い掛かる 荒ぶる神 でもある。",
 		'zh-tw': "雖被稱為守護神，但會去 襲擊惹自己不開心的人或寶可夢， 是個性情凶悍的神。",
-		'zh-cn': "雖被稱為守護神，但會去 襲擊惹自己不開心的人或寶可夢， 是個性情凶悍的神。"
+		'zh-cn': "雖被稱為守護神，但會去 襲擊惹自己不開心的人或寶可夢， 是個性情凶悍的神。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "かみなりをよぶ",
-			'zh-tw': "召喚雷電",
-			'zh-cn': "召喚雷電"
+	attacks: [
+		{
+			name: {
+				ja: "かみなりをよぶ",
+				'zh-tw': "召喚雷電",
+				'zh-cn': "召喚雷電",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から[L]ポケモンを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多2張【雷】寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。",
+				'zh-cn': "從自己的牌庫選擇最多2張【雷】寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			ja: "自分の山札からポケモンを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
-			'zh-tw': "從自己的牌庫選擇最多2張【雷】寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。",
-			'zh-cn': "從自己的牌庫選擇最多2張【雷】寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。"
-		}
-	}, {
-		cost: ["Lightning", "Lightning", "Colorless"],
-
-		name: {
-			ja: "サイドカウンター",
-			'zh-tw': "獎賞反擊",
-			'zh-cn': "獎賞反擊"
+		{
+			name: {
+				ja: "サイドカウンター",
+				'zh-tw': "獎賞反擊",
+				'zh-cn': "獎賞反擊",
+			},
+			damage: "90+",
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "自分のサイドの残り枚数が、相手のサイドの残り枚数より多いなら、90ダメージ追加。",
+				'zh-tw': "若自己剩餘獎賞卡的張數，比對手剩餘獎賞卡的張數多，則增加90點傷害。",
+				'zh-cn': "若自己剩餘獎賞卡的張數，比對手剩餘獎賞卡的張數多，則增加90點傷害。",
+			},
 		},
+	],
 
-		damage: "90+",
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "自分のサイドの残り枚数が、相手のサイドの残り枚数より多いなら、90ダメージ追加。",
-			'zh-tw': "若自己剩餘獎賞卡的張數，比對手剩餘獎賞卡的張數多，則增加90點傷害。",
-			'zh-cn': "若自己剩餘獎賞卡的張數，比對手剩餘獎賞卡的張數多，則增加90點傷害。"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793475,
+				tcgplayer: 587621,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "H",
+	rarity: "Rare",
+	dexId: [785],
+};
 
-	thirdParty: {
-		cardmarket: 793475
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/042.ts
+++ b/data-asia/SV/SV8/042.ts
@@ -1,60 +1,61 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "カイデン",
 		'zh-tw': "電海燕",
-		'zh-cn': "電海燕"
+		'zh-cn': "電海燕",
 	},
 
 	illustrator: "Pani Kobayashi",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [940],
 	hp: 60,
 	types: ["Lightning"],
 
 	description: {
 		ja: "海岸の 崖に 巣を 作る。 巣は パチパチ 弾ける 不思議な 食感で 人気の 珍味。",
 		'zh-tw': "會在海岸的懸崖上築巢。 吃起來劈哩啪啦跳的神奇口感， 讓牠的巢成了受歡迎的珍奇美食。",
-		'zh-cn': "會在海岸的懸崖上築巢。 吃起來劈哩啪啦跳的神奇口感， 讓牠的巢成了受歡迎的珍奇美食。"
+		'zh-cn': "會在海岸的懸崖上築巢。 吃起來劈哩啪啦跳的神奇口感， 讓牠的巢成了受歡迎的珍奇美食。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Lightning"],
-
-		name: {
-			ja: "つばめがえし",
-			'zh-tw': "燕返",
-			'zh-cn': "燕返"
+	attacks: [
+		{
+			name: {
+				ja: "つばめがえし",
+				'zh-tw': "燕返",
+				'zh-cn': "燕返",
+			},
+			damage: "10+",
+			cost: ["Lightning"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+				'zh-tw': "擲1次硬幣若為正面，則增加20點傷害。",
+				'zh-cn': "擲1次硬幣若為正面，則增加20點傷害。",
+			},
 		},
+	],
 
-		damage: "10+",
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-		effect: {
-			ja: "コインを1回投げオモテなら、20ダメージ追加。",
-			'zh-tw': "擲1次硬幣若為正面，則增加20點傷害。",
-			'zh-cn': "擲1次硬幣若為正面，則增加20點傷害。"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793476,
+				tcgplayer: 587622,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Common",
+	dexId: [940],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/043.ts
+++ b/data-asia/SV/SV8/043.ts
@@ -1,70 +1,74 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "タイカイデン",
 		'zh-tw': "大電海燕",
-		'zh-cn': "大電海燕"
+		'zh-cn': "大電海燕",
 	},
 
 	illustrator: "KEIICHIRO ITO",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [941],
 	hp: 120,
 	types: ["Lightning"],
 
 	description: {
 		ja: "のど袋に 翼で 作った 電気を 溜める。 羽の 油分が とても 少なく 泳ぎは 苦手。",
 		'zh-tw': "會把翅膀製造的電儲存到喉囊裡。 由於羽毛含的油脂少之又少， 導致牠不是很擅長游泳。",
-		'zh-cn': "會把翅膀製造的電儲存到喉囊裡。 由於羽毛含的油脂少之又少， 導致牠不是很擅長游泳。"
+		'zh-cn': "會把翅膀製造的電儲存到喉囊裡。 由於羽毛含的油脂少之又少， 導致牠不是很擅長游泳。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "かっくう",
-			'zh-tw': "滑翔",
-			'zh-cn': "滑翔"
+	attacks: [
+		{
+			name: {
+				ja: "かっくう",
+				'zh-tw': "滑翔",
+				'zh-cn': "滑翔",
+			},
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
 		},
-
-		damage: 50
-	}, {
-		cost: ["Lightning", "Lightning", "Colorless"],
-
-		name: {
-			ja: "ストームボルト",
-			'zh-tw': "風暴伏特",
-			'zh-cn': "風暴伏特"
+		{
+			name: {
+				ja: "ストームボルト",
+				'zh-tw': "風暴伏特",
+				'zh-cn': "風暴伏特",
+			},
+			damage: 160,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーをすべて、ベンチポケモンに好きなようにつけ替える。",
+				'zh-tw': "將這隻寶可夢身上附加的所有能量卡，以任意方式改附於備戰寶可夢身上。",
+				'zh-cn': "將這隻寶可夢身上附加的所有能量卡，以任意方式改附於備戰寶可夢身上。",
+			},
 		},
+	],
 
-		damage: 160,
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-		effect: {
-			ja: "このポケモンについているエネルギーをすべて、ベンチポケモンに好きなようにつけ替える。",
-			'zh-tw': "將這隻寶可夢身上附加的所有能量卡，以任意方式改附於備戰寶可夢身上。",
-			'zh-cn': "將這隻寶可夢身上附加的所有能量卡，以任意方式改附於備戰寶可夢身上。"
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793477,
+				tcgplayer: 587623,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "カイデン",
+	},
 
 	retreat: 1,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Uncommon",
+	dexId: [941],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/044.ts
+++ b/data-asia/SV/SV8/044.ts
@@ -1,65 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ミライドン",
 		'zh-tw': "密勒頓",
-		'zh-cn': "密勒頓"
+		'zh-cn': "密勒頓",
 	},
 
 	illustrator: "Nurikabe",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [1008],
 	hp: 120,
 	types: ["Lightning"],
 
 	description: {
 		ja: "古い 書物に 名が ある テツノオロチらしい。 雷で 大地を 灰に 変えたという。",
 		'zh-tw': "牠似乎就是古書裡所提及的 鐵大蛇。傳說牠曾用雷電 將大地化成了一片灰。",
-		'zh-cn': "牠似乎就是古書裡所提及的 鐵大蛇。傳說牠曾用雷電 將大地化成了一片灰。"
+		'zh-cn': "牠似乎就是古書裡所提及的 鐵大蛇。傳說牠曾用雷電 將大地化成了一片灰。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Lightning", "Colorless"],
-
-		name: {
-			ja: "プロテクトコード",
-			'zh-tw': "防護代碼",
-			'zh-cn': "防護代碼"
+	attacks: [
+		{
+			name: {
+				ja: "プロテクトコード",
+				'zh-tw': "防護代碼",
+				'zh-cn': "防護代碼",
+			},
+			damage: 40,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "次の相手の番、自分の「未来」のポケモン全員は、「ポケモンex」からワザのダメージを受けない。このポケモンがバトル場をはなれたら、この効果はなくなる。",
+				'zh-tw': "在下個對手的回合，自己的所有「未來」寶可夢不會受到「寶可夢【ex】」招式的傷害。若這隻寶可夢離開戰鬥場，則這個效果消除。",
+				'zh-cn': "在下個對手的回合，自己的所有「未來」寶可夢不會受到「寶可夢【ex】」招式的傷害。若這隻寶可夢離開戰鬥場，則這個效果消除。",
+			},
 		},
-
-		damage: 40,
-
-		effect: {
-			ja: "次の相手の番、自分の「未来」のポケモン全員は、「ポケモンex」からワザのダメージを受けない。このポケモンがバトル場をはなれたら、この効果はなくなる。",
-			'zh-tw': "在下個對手的回合，自己的所有「未來」寶可夢不會受到「寶可夢【ex】」招式的傷害。若這隻寶可夢離開戰鬥場，則這個效果消除。",
-			'zh-cn': "在下個對手的回合，自己的所有「未來」寶可夢不會受到「寶可夢【ex】」招式的傷害。若這隻寶可夢離開戰鬥場，則這個效果消除。"
-		}
-	}, {
-		cost: ["Lightning", "Colorless", "Colorless"],
-
-		name: {
-			ja: "サンダークロー",
-			'zh-tw': "閃電爪",
-			'zh-cn': "閃電爪"
+		{
+			name: {
+				ja: "サンダークロー",
+				'zh-tw': "閃電爪",
+				'zh-cn': "閃電爪",
+			},
+			damage: 100,
+			cost: ["Lightning", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 100
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793478,
+				tcgplayer: 587624,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Uncommon",
+	dexId: [1008],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/045.ts
+++ b/data-asia/SV/SV8/045.ts
@@ -1,53 +1,56 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "トゲピー",
 		'zh-tw': "波克比",
-		'zh-cn': "波克比"
+		'zh-cn': "波克比",
 	},
 
 	illustrator: "Yoko Hishida",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [175],
 	hp: 50,
 	types: ["Psychic"],
 
 	description: {
 		ja: "殻の中に 幸せが たくさん つまっているらしく 優しくされると 幸運を 分け与える という。",
 		'zh-tw': "殼內好像塞滿了許多幸福， 據說只要溫柔地對待牠， 牠就會把幸運分給對方。",
-		'zh-cn': "殼內好像塞滿了許多幸福， 據說只要溫柔地對待牠， 牠就會把幸運分給對方。"
+		'zh-cn': "殼內好像塞滿了許多幸福， 據說只要溫柔地對待牠， 牠就會把幸運分給對方。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "はたく",
-			'zh-tw': "拍擊",
-			'zh-cn': "拍擊"
+	attacks: [
+		{
+			name: {
+				ja: "はたく",
+				'zh-tw': "拍擊",
+				'zh-cn': "拍擊",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 30
-	}],
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793479,
+				tcgplayer: 587625,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [175],
+};
 
-	thirdParty: {
-		cardmarket: 793479
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/046.ts
+++ b/data-asia/SV/SV8/046.ts
@@ -1,59 +1,65 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "トゲチック",
 		'zh-tw': "波克基古",
-		'zh-cn': "波克基古"
+		'zh-cn': "波克基古",
 	},
 
 	illustrator: "Teeziro",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [176],
 	hp: 90,
 	types: ["Psychic"],
 
 	description: {
 		ja: "心優しい 人の 前に 幸せを もたらすため 姿を 現すと 言われている。",
 		'zh-tw': "據說牠會為了將 幸福帶給心地善良 的人而現身。",
-		'zh-cn': "據說牠會為了將 幸福帶給心地善良 的人而現身。"
+		'zh-cn': "據說牠會為了將 幸福帶給心地善良 的人而現身。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "ドレインキッス",
-			'zh-tw': "吸取之吻",
-			'zh-cn': "吸取之吻"
+	attacks: [
+		{
+			name: {
+				ja: "ドレインキッス",
+				'zh-tw': "吸取之吻",
+				'zh-cn': "吸取之吻",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+				'zh-tw': "將這隻寶可夢恢復「30」HP。",
+				'zh-cn': "將這隻寶可夢恢復「30」HP。",
+			},
 		},
+	],
 
-		damage: 30,
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンのHPを「30」回復する。",
-			'zh-tw': "將這隻寶可夢恢復「30」HP。",
-			'zh-cn': "將這隻寶可夢恢復「30」HP。"
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793480,
+				tcgplayer: 587626,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "トゲピー",
+	},
 
 	retreat: 1,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [176],
+};
 
-	thirdParty: {
-		cardmarket: 793480
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/047.ts
+++ b/data-asia/SV/SV8/047.ts
@@ -1,69 +1,76 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "トゲキッス",
 		'zh-tw': "波克基斯",
-		'zh-cn': "波克基斯"
+		'zh-cn': "波克基斯",
 	},
 
 	illustrator: "Narano",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [468],
 	hp: 140,
 	types: ["Psychic"],
 
 	description: {
 		ja: "争い事や もめ事が 起こる 場所には 姿を 見せない。 近ごろは ほとんど 見かけない。",
 		'zh-tw': "不會出現在發生 爭端和紛亂的地方。 近來幾乎見不到牠的身影。",
-		'zh-cn': "不會出現在發生 爭端和紛亂的地方。 近來幾乎見不到牠的身影。"
+		'zh-cn': "不會出現在發生 爭端和紛亂的地方。 近來幾乎見不到牠的身影。",
 	},
 
 	stage: "Stage2",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "ワンダーキッス",
-			'zh-tw': "奇跡之吻",
-			'zh-cn': "奇跡之吻"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ワンダーキッス",
+				'zh-tw': "奇跡之吻",
+				'zh-cn': "奇跡之吻",
+			},
+			effect: {
+				ja: "このポケモンがいるかぎり、相手のバトルポケモンがきぜつするたび、自分はコインを1回投げる。オモテなら、サイドを1枚多くとる。この効果は、この特性を持つポケモンが何匹いても、重ならない。",
+				'zh-tw': "只要這隻寶可夢在場上，每次當對手的戰鬥寶可夢【昏厥】時，自己擲1次硬幣。若為正面，則多獲得1張獎賞卡。無論有多少隻擁有這個特性的寶可夢，這個效果也不會重複。",
+				'zh-cn': "只要這隻寶可夢在場上，每次當對手的戰鬥寶可夢【昏厥】時，自己擲1次硬幣。若為正面，則多獲得1張獎賞卡。無論有多少隻擁有這個特性的寶可夢，這個效果也不會重複。",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンがいるかぎり、相手のバトルポケモンがきぜつするたび、自分はコインを1回投げる。オモテなら、サイドを1枚多くとる。この効果は、この特性を持つポケモンが何匹いても、重ならない。",
-			'zh-tw': "只要這隻寶可夢在場上，每次當對手的戰鬥寶可夢【昏厥】時，自己擲1次硬幣。若為正面，則多獲得1張獎賞卡。無論有多少隻擁有這個特性的寶可夢，這個效果也不會重複。",
-			'zh-cn': "只要這隻寶可夢在場上，每次當對手的戰鬥寶可夢【昏厥】時，自己擲1次硬幣。若為正面，則多獲得1張獎賞卡。無論有多少隻擁有這個特性的寶可夢，這個效果也不會重複。"
-		}
-	}],
-
-	attacks: [{
-		cost: ["Colorless", "Colorless", "Colorless"],
-
-		name: {
-			ja: "スピードウイング",
-			'zh-tw': "高速之翼",
-			'zh-cn': "高速之翼"
+	attacks: [
+		{
+			name: {
+				ja: "スピードウイング",
+				'zh-tw': "高速之翼",
+				'zh-cn': "高速之翼",
+			},
+			damage: 140,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 140
-	}],
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793481,
+				tcgplayer: 587627,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "トゲチック",
+	},
 
 	retreat: 1,
 	regulationMark: "H",
+	rarity: "Rare",
+	dexId: [468],
+};
 
-	thirdParty: {
-		cardmarket: 793481
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/048.ts
+++ b/data-asia/SV/SV8/048.ts
@@ -1,62 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ユクシー",
 		'zh-tw': "由克希",
-		'zh-cn': "由克希"
+		'zh-cn': "由克希",
 	},
 
 	illustrator: "HYOGONOSUKE",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [480],
 	hp: 70,
 	types: ["Psychic"],
 
 	description: {
 		ja: "知識の神と 呼ばれている。 目を 合わせた 者の 記憶を 消してしまう 力を 持つという。",
 		'zh-tw': "被稱為知識之神。 擁有將與自己視線相對者的 記憶消去的力量。",
-		'zh-cn': "被稱為知識之神。 擁有將與自己視線相對者的 記憶消去的力量。"
+		'zh-cn': "被稱為知識之神。 擁有將與自己視線相對者的 記憶消去的力量。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Psychic"],
-
-		name: {
-			ja: "いたみのきおく",
-			'zh-tw': "痛楚記憶",
-			'zh-cn': "痛楚記憶"
+	attacks: [
+		{
+			name: {
+				ja: "いたみのきおく",
+				'zh-tw': "痛楚記憶",
+				'zh-cn': "痛楚記憶",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれダメカンを2個のせる。",
+				'zh-tw': "在對手的所有寶可夢身上各放置2個傷害指示物。",
+				'zh-cn': "在對手的所有寶可夢身上各放置2個傷害指示物。",
+			},
 		},
+	],
 
-		effect: {
-			ja: "相手のポケモン全員に、それぞれダメカンを2個のせる。",
-			'zh-tw': "在對手的所有寶可夢身上各放置2個傷害指示物。",
-			'zh-cn': "在對手的所有寶可夢身上各放置2個傷害指示物。"
-		}
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793482,
+				tcgplayer: 587628,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [480],
+};
 
-	thirdParty: {
-		cardmarket: 793482
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/049.ts
+++ b/data-asia/SV/SV8/049.ts
@@ -1,78 +1,74 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "エムリット",
 		'zh-tw': "艾姆利多",
-		'zh-cn': "艾姆利多"
+		'zh-cn': "艾姆利多",
 	},
 
 	illustrator: "HYOGONOSUKE",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [481],
 	hp: 70,
 	types: ["Psychic"],
 
 	description: {
 		ja: "悲しみの 苦しさと 喜びの 尊さを 人々に 教えた。 感情の神と 呼ばれている。",
 		'zh-tw': "教導了人們悲傷的痛苦 以及喜悅的珍貴。 被稱為感情之神。",
-		'zh-cn': "教導了人們悲傷的痛苦 以及喜悅的珍貴。 被稱為感情之神。"
+		'zh-cn': "教導了人們悲傷的痛苦 以及喜悅的珍貴。 被稱為感情之神。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "こころをみたす",
-			'zh-tw': "滿載心田",
-			'zh-cn': "滿載心田"
+	attacks: [
+		{
+			name: {
+				ja: "こころをみたす",
+				'zh-tw': "滿載心田",
+				'zh-cn': "滿載心田",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札から「基本[P]エネルギー」を2枚まで選び、自分のポケモンに好きなようにつける。",
+				'zh-tw': "從自己的手牌選擇最多2張「基本【超】能量」卡，以任意方式附於自己的寶可夢身上。",
+				'zh-cn': "從自己的手牌選擇最多2張「基本【超】能量」卡，以任意方式附於自己的寶可夢身上。",
+			},
 		},
-
-		effect: {
-			ja: "自分の手札から「基本エネルギー」を2枚まで選び、自分のポケモンに好きなようにつける。",
-			'zh-tw': "從自己的手牌選擇最多2張「基本【超】能量」卡，以任意方式附於自己的寶可夢身上。",
-			'zh-cn': "從自己的手牌選擇最多2張「基本【超】能量」卡，以任意方式附於自己的寶可夢身上。"
-		}
-	}, {
-		cost: ["Psychic", "Psychic"],
-
-		name: {
-			ja: "ゴッドバースト",
-			'zh-tw': "神之爆炸",
-			'zh-cn': "神之爆炸"
+		{
+			name: {
+				ja: "ゴッドバースト",
+				'zh-tw': "神之爆炸",
+				'zh-cn': "神之爆炸",
+			},
+			damage: 160,
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "自分のベンチに「ユクシー」「アグノム」がいないなら、このワザは失敗。",
+				'zh-tw': "若自己的備戰區沒有「由克希」「亞克諾姆」，則這個招式失敗。",
+				'zh-cn': "若自己的備戰區沒有「由克希」「亞克諾姆」，則這個招式失敗。",
+			},
 		},
+	],
 
-		damage: 160,
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-		effect: {
-			ja: "自分のベンチに「ユクシー」「アグノム」がいないなら、このワザは失敗。",
-			'zh-tw': "若自己的備戰區沒有「由克希」「亞克諾姆」，則這個招式失敗。",
-			'zh-cn': "若自己的備戰區沒有「由克希」「亞克諾姆」，則這個招式失敗。"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793483,
+				tcgplayer: 587629,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [481],
+};
 
-	thirdParty: {
-		cardmarket: 793483
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/050.ts
+++ b/data-asia/SV/SV8/050.ts
@@ -1,64 +1,61 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "アグノム",
 		'zh-tw': "亞克諾姆",
-		'zh-cn': "亞克諾姆"
+		'zh-cn': "亞克諾姆",
 	},
 
 	illustrator: "HYOGONOSUKE",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [482],
 	hp: 70,
 	types: ["Psychic"],
 
 	description: {
 		ja: "意思の神と 呼ばれている。 湖の 底で 眠り続け 世界の バランスを とっている。",
 		'zh-tw': "被稱為意志之神。 在湖底沉睡著， 維持世界的平衡。",
-		'zh-cn': "被稱為意志之神。 在湖底沉睡著， 維持世界的平衡。"
+		'zh-cn': "被稱為意志之神。 在湖底沉睡著， 維持世界的平衡。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Psychic", "Colorless"],
-
-		name: {
-			ja: "マインドキネシス",
-			'zh-tw': "意志強念",
-			'zh-cn': "意志強念"
+	attacks: [
+		{
+			name: {
+				ja: "マインドキネシス",
+				'zh-tw': "意志強念",
+				'zh-cn': "意志強念",
+			},
+			damage: "10+",
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手のポケモン全員にのっているダメカンの数×10ダメージ追加。",
+				'zh-tw': "增加對手的所有寶可夢身上放置的傷害指示物的數量×10點傷害。",
+				'zh-cn': "增加對手的所有寶可夢身上放置的傷害指示物的數量×10點傷害。",
+			},
 		},
+	],
 
-		damage: "10+",
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-		effect: {
-			ja: "相手のポケモン全員にのっているダメカンの数×10ダメージ追加。",
-			'zh-tw': "增加對手的所有寶可夢身上放置的傷害指示物的數量×10點傷害。",
-			'zh-cn': "增加對手的所有寶可夢身上放置的傷害指示物的數量×10點傷害。"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793484,
+				tcgplayer: 587630,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [482],
+};
 
-	thirdParty: {
-		cardmarket: 793484
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/051.ts
+++ b/data-asia/SV/SV8/051.ts
@@ -1,68 +1,65 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "デスマス",
 		'zh-tw': "哭哭面具",
-		'zh-cn': "哭哭面具"
+		'zh-cn': "哭哭面具",
 	},
 
 	illustrator: "IKEDA Saki",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [562],
 	hp: 70,
 	types: ["Psychic"],
 
 	description: {
 		ja: "夜な夜な 遺跡を さまよう。 もっている マスクは 人 だった ころの 自分の 顔 だという。",
 		'zh-tw': "每天夜裡都在遺跡中徘徊。 據說牠拿著的面具 是牠還是人類時的臉。",
-		'zh-cn': "每天夜裡都在遺跡中徘徊。 據說牠拿著的面具 是牠還是人類時的臉。"
+		'zh-cn': "每天夜裡都在遺跡中徘徊。 據說牠拿著的面具 是牠還是人類時的臉。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Psychic"],
-
-		name: {
-			ja: "つぶやく",
-			'zh-tw': "囈語",
-			'zh-cn': "囈語"
+	attacks: [
+		{
+			name: {
+				ja: "つぶやく",
+				'zh-tw': "囈語",
+				'zh-cn': "囈語",
+			},
+			damage: 10,
+			cost: ["Psychic"],
 		},
-
-		damage: 10
-	}, {
-		cost: ["Psychic", "Colorless"],
-
-		name: {
-			ja: "ちょっとうらむ",
-			'zh-tw': "咒怨一下",
-			'zh-cn': "咒怨一下"
+		{
+			name: {
+				ja: "ちょっとうらむ",
+				'zh-tw': "咒怨一下",
+				'zh-cn': "咒怨一下",
+			},
+			damage: 20,
+			cost: ["Psychic", "Colorless"],
 		},
+	],
 
-		damage: 20
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793485,
+				tcgplayer: 587631,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [562],
+};
 
-	thirdParty: {
-		cardmarket: 793485
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/052.ts
+++ b/data-asia/SV/SV8/052.ts
@@ -1,72 +1,73 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "デスカーン",
 		'zh-tw': "死神棺",
-		'zh-cn': "死神棺"
+		'zh-cn': "死神棺",
 	},
 
 	illustrator: "Shiburingaru",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [563],
 	hp: 120,
 	types: ["Psychic"],
 
 	description: {
 		ja: "ピカピカの 黄金の 体。 もはや 人間だった ことは 思い出すことは ないと いう。",
 		'zh-tw': "擁有閃亮亮的黃金身軀。 據說牠已再也無法記起 自己曾經是人類。",
-		'zh-cn': "擁有閃亮亮的黃金身軀。 據說牠已再也無法記起 自己曾經是人類。"
+		'zh-cn': "擁有閃亮亮的黃金身軀。 據說牠已再也無法記起 自己曾經是人類。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Psychic"],
-
-		name: {
-			ja: "めいふのおきて",
-			'zh-tw': "冥府之律",
-			'zh-cn': "冥府之律"
+	attacks: [
+		{
+			name: {
+				ja: "めいふのおきて",
+				'zh-tw': "冥府之律",
+				'zh-cn': "冥府之律",
+			},
+			cost: ["Psychic"],
+			effect: {
+				ja: "おたがいの特性を持つポケモン全員に、それぞれダメカンを6個のせる。",
+				'zh-tw': "在雙方的所有擁有特性的寶可夢身上，各放置6個傷害指示物。",
+				'zh-cn': "在雙方的所有擁有特性的寶可夢身上，各放置6個傷害指示物。",
+			},
 		},
-
-		effect: {
-			ja: "おたがいの特性を持つポケモン全員に、それぞれダメカンを6個のせる。",
-			'zh-tw': "在雙方的所有擁有特性的寶可夢身上，各放置6個傷害指示物。",
-			'zh-cn': "在雙方的所有擁有特性的寶可夢身上，各放置6個傷害指示物。"
-		}
-	}, {
-		cost: ["Psychic", "Colorless", "Colorless"],
-
-		name: {
-			ja: "ホロウショット",
-			'zh-tw': "陰森射擊",
-			'zh-cn': "陰森射擊"
+		{
+			name: {
+				ja: "ホロウショット",
+				'zh-tw': "陰森射擊",
+				'zh-cn': "陰森射擊",
+			},
+			damage: 100,
+			cost: ["Psychic", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 100
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793486,
+				tcgplayer: 587632,
+			},
+		},
+	],
 
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "デスマス",
+	},
 
 	retreat: 2,
 	regulationMark: "H",
+	rarity: "Rare",
+	dexId: [563],
+};
 
-	thirdParty: {
-		cardmarket: 793486
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/053.ts
+++ b/data-asia/SV/SV8/053.ts
@@ -1,72 +1,69 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ニャスパー",
 		'zh-tw': "妙喵",
-		'zh-cn': "妙喵"
+		'zh-cn': "妙喵",
 	},
 
 	illustrator: "Natsumi Yoshida",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [677],
 	hp: 60,
 	types: ["Psychic"],
 
 	description: {
 		ja: "無表情だが 内面では サイコパワーを 抑えこむのに 必死に なっているのだ。",
 		'zh-tw': "雖然看起來面無表情， 但其實內心正非常努力地 在控制自己的精神力量。",
-		'zh-cn': "雖然看起來面無表情， 但其實內心正非常努力地 在控制自己的精神力量。"
+		'zh-cn': "雖然看起來面無表情， 但其實內心正非常努力地 在控制自己的精神力量。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "みすかす",
-			'zh-tw': "看透",
-			'zh-cn': "看透"
+	attacks: [
+		{
+			name: {
+				ja: "みすかす",
+				'zh-tw': "看透",
+				'zh-cn': "看透",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手の手札を見る。",
+				'zh-tw': "查看對手的手牌。",
+				'zh-cn': "查看對手的手牌。",
+			},
 		},
-
-		effect: {
-			ja: "相手の手札を見る。",
-			'zh-tw': "查看對手的手牌。",
-			'zh-cn': "查看對手的手牌。"
-		}
-	}, {
-		cost: ["Psychic", "Colorless"],
-
-		name: {
-			ja: "サイコショット",
-			'zh-tw': "精神射擊",
-			'zh-cn': "精神射擊"
+		{
+			name: {
+				ja: "サイコショット",
+				'zh-tw': "精神射擊",
+				'zh-cn': "精神射擊",
+			},
+			damage: 20,
+			cost: ["Psychic", "Colorless"],
 		},
+	],
 
-		damage: 20
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793487,
+				tcgplayer: 587633,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [677],
+};
 
-	thirdParty: {
-		cardmarket: 793487
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/054.ts
+++ b/data-asia/SV/SV8/054.ts
@@ -1,74 +1,76 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ニャオニクス",
 		'zh-tw': "超能妙喵",
-		'zh-cn': "超能妙喵"
+		'zh-cn': "超能妙喵",
 	},
 
 	illustrator: "Yoriyuki Ikegami",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [678],
 	hp: 90,
 	types: ["Psychic"],
 
 	description: {
 		ja: "強力な サイコパワーを 出し続けていると ニャオニクスの 肉体にも ダメージが およぶ。",
 		'zh-tw': "如果持續不斷釋放強大的 精神力量，超能妙喵的 肉體也會受到傷害。",
-		'zh-cn': "如果持續不斷釋放強大的 精神力量，超能妙喵的 肉體也會受到傷害。"
+		'zh-cn': "如果持續不斷釋放強大的 精神力量，超能妙喵的 肉體也會受到傷害。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "さそうしっぽ",
-			'zh-tw': "誘導之尾",
-			'zh-cn': "誘導之尾"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "さそうしっぽ",
+				'zh-tw': "誘導之尾",
+				'zh-cn': "誘導之尾",
+			},
+			effect: {
+				ja: "自分の番に、自分の手札から「のんびりじゃらし」を1枚トラッシュするなら、1回使える。相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+				'zh-tw': "在自己的回合，若從自己的手牌將1張「悠哉尾草棒」丟棄，則可使用1次。選擇1隻對手的備戰寶可夢，與戰鬥寶可夢互換。",
+				'zh-cn': "在自己的回合，若從自己的手牌將1張「悠哉尾草棒」丟棄，則可使用1次。選擇1隻對手的備戰寶可夢，與戰鬥寶可夢互換。",
+			},
 		},
+	],
 
-		effect: {
-			ja: "自分の番に、自分の手札から「のんびりじゃらし」を1枚トラッシュするなら、1回使える。相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
-			'zh-tw': "在自己的回合，若從自己的手牌將1張「悠哉尾草棒」丟棄，則可使用1次。選擇1隻對手的備戰寶可夢，與戰鬥寶可夢互換。",
-			'zh-cn': "在自己的回合，若從自己的手牌將1張「悠哉尾草棒」丟棄，則可使用1次。選擇1隻對手的備戰寶可夢，與戰鬥寶可夢互換。"
-		}
-	}],
-
-	attacks: [{
-		cost: ["Psychic", "Colorless", "Colorless"],
-
-		name: {
-			ja: "サイコショット",
-			'zh-tw': "精神射擊",
-			'zh-cn': "精神射擊"
+	attacks: [
+		{
+			name: {
+				ja: "サイコショット",
+				'zh-tw': "精神射擊",
+				'zh-cn': "精神射擊",
+			},
+			damage: 80,
+			cost: ["Psychic", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 80
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793488,
+				tcgplayer: 587634,
+			},
+		},
+	],
 
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ニャスパー",
+	},
 
 	retreat: 1,
 	regulationMark: "H",
+	rarity: "Uncommon",
+	dexId: [678],
+};
 
-	thirdParty: {
-		cardmarket: 793488
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/055.ts
+++ b/data-asia/SV/SV8/055.ts
@@ -1,67 +1,69 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "デデンネ",
 		'zh-tw': "咚咚鼠",
-		'zh-cn': "咚咚鼠"
+		'zh-cn': "咚咚鼠",
 	},
 
 	illustrator: "Uninori",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [702],
 	hp: 70,
 	types: ["Psychic"],
 
 	description: {
 		ja: "ほっぺの ヒゲから 電波を 飛ばし 仲間と 連絡を とりあう。 電気が 減ると 丸まり 眠る。",
 		'zh-tw': "會從雙頰上的鬍鬚發出電波 來與同伴相互聯絡。 電力變少時會蜷縮起來睡覺。",
-		'zh-cn': "會從雙頰上的鬍鬚發出電波 來與同伴相互聯絡。 電力變少時會蜷縮起來睡覺。"
+		'zh-cn': "會從雙頰上的鬍鬚發出電波 來與同伴相互聯絡。 電力變少時會蜷縮起來睡覺。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "でんじソナー",
-			'zh-tw': "電磁聲納",
-			'zh-cn': "電磁聲納"
+	attacks: [
+		{
+			name: {
+				ja: "でんじソナー",
+				'zh-tw': "電磁聲納",
+				'zh-cn': "電磁聲納",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュからトレーナーズを1枚選び、相手に見せて、手札に加える。",
+				'zh-tw': "從自己的棄牌區選擇1張訓練家卡，在給對手看過後加入手牌。",
+				'zh-cn': "從自己的棄牌區選擇1張訓練家卡，在給對手看過後加入手牌。",
+			},
 		},
-
-		effect: {
-			ja: "自分のトラッシュからトレーナーズを1枚選び、相手に見せて、手札に加える。",
-			'zh-tw': "從自己的棄牌區選擇1張訓練家卡，在給對手看過後加入手牌。",
-			'zh-cn': "從自己的棄牌區選擇1張訓練家卡，在給對手看過後加入手牌。"
-		}
-	}, {
-		cost: ["Psychic"],
-
-		name: {
-			ja: "かじる",
-			'zh-tw': "咬",
-			'zh-cn': "咬"
+		{
+			name: {
+				ja: "かじる",
+				'zh-tw': "咬",
+				'zh-cn': "咬",
+			},
+			damage: 30,
+			cost: ["Psychic"],
 		},
+	],
 
-		damage: 30
-	}],
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793489,
+				tcgplayer: 587635,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [702],
+};
 
-	thirdParty: {
-		cardmarket: 793489
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/056.ts
+++ b/data-asia/SV/SV8/056.ts
@@ -1,58 +1,56 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "スナバァ",
 		'zh-tw': "沙丘娃",
-		'zh-cn': "沙丘娃"
+		'zh-cn': "沙丘娃",
 	},
 
 	illustrator: "Koji Nakata",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [769],
 	hp: 90,
 	types: ["Psychic"],
 
 	description: {
 		ja: "獲物の 目を 砂で 潰し その隙に 近づこうとするが 動きが 遅いので 逃げられる。",
 		'zh-tw': "會用沙子攻擊獵物的眼睛後 趁機接近，但卻總是因為 行動緩慢而讓獵物逃走。",
-		'zh-cn': "會用沙子攻擊獵物的眼睛後 趁機接近，但卻總是因為 行動緩慢而讓獵物逃走。"
+		'zh-cn': "會用沙子攻擊獵物的眼睛後 趁機接近，但卻總是因為 行動緩慢而讓獵物逃走。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless", "Colorless"],
-
-		name: {
-			ja: "すなしぶき",
-			'zh-tw': "沙沫",
-			'zh-cn': "沙沫"
+	attacks: [
+		{
+			name: {
+				ja: "すなしぶき",
+				'zh-tw': "沙沫",
+				'zh-cn': "沙沫",
+			},
+			damage: 50,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 50
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793490,
+				tcgplayer: 587636,
+			},
+		},
+	],
 
 	retreat: 3,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [769],
+};
 
-	thirdParty: {
-		cardmarket: 793490
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/057.ts
+++ b/data-asia/SV/SV8/057.ts
@@ -1,71 +1,74 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "シロデスナex",
 		'zh-tw': "噬沙堡爺ex",
-		'zh-cn': "噬沙堡爺ex"
+		'zh-cn': "噬沙堡爺ex",
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 280,
 	types: ["Psychic"],
+
 	stage: "Stage1",
-	suffix: "EX",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless", "Colorless"],
-
-		name: {
-			ja: "すなじごく",
-			'zh-tw': "流沙地獄",
-			'zh-cn': "流沙地獄"
+	attacks: [
+		{
+			name: {
+				ja: "すなじごく",
+				'zh-tw': "流沙地獄",
+				'zh-cn': "流沙地獄",
+			},
+			damage: 160,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。",
+				'zh-cn': "在下個對手的回合，受到這個招式的寶可夢無法撤退。",
+			},
 		},
-
-		damage: 160,
-
-		effect: {
-			ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。",
-			'zh-cn': "在下個對手的回合，受到這個招式的寶可夢無法撤退。"
-		}
-	}, {
-		cost: ["Water", "Psychic", "Fighting"],
-
-		name: {
-			ja: "バライトジェイル",
-			'zh-tw': "重晶石之獄",
-			'zh-cn': "重晶石之獄"
+		{
+			name: {
+				ja: "バライトジェイル",
+				'zh-tw': "重晶石之獄",
+				'zh-cn': "重晶石之獄",
+			},
+			cost: ["Water", "Psychic", "Fighting"],
+			effect: {
+				ja: "相手のベンチポケモン全員に、それぞれ残りHPが「100」になるように、ダメカンをのせる。",
+				'zh-tw': "在對手的所有備戰寶可夢身上放置傷害指示物直到各自的剩餘HP變為「100」為止。",
+				'zh-cn': "在對手的所有備戰寶可夢身上放置傷害指示物直到各自的剩餘HP變為「100」為止。",
+			},
 		},
+	],
 
-		effect: {
-			ja: "相手のベンチポケモン全員に、それぞれ残りHPが「100」になるように、ダメカンをのせる。",
-			'zh-tw': "在對手的所有備戰寶可夢身上放置傷害指示物直到各自的剩餘HP變為「100」為止。",
-			'zh-cn': "在對手的所有備戰寶可夢身上放置傷害指示物直到各自的剩餘HP變為「100」為止。"
-		}
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793491,
+				tcgplayer: 587637,
+			},
+		},
+	],
 
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "スナバァ",
+	},
 
 	retreat: 4,
 	regulationMark: "H",
+	rarity: "Double rare",
+	dexId: [770],
 
-	thirdParty: {
-		cardmarket: 793491
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/058.ts
+++ b/data-asia/SV/SV8/058.ts
@@ -1,70 +1,72 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "イエッサン",
 		'zh-tw': "愛管侍",
-		'zh-cn': "愛管侍"
+		'zh-cn': "愛管侍",
 	},
 
 	illustrator: "Sekio",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [876],
 	hp: 100,
 	types: ["Psychic"],
 
 	description: {
 		ja: "つねに トレーナーの そばに いる。 サイコパワーで 行動を 予知して 身のまわりの 世話をする。",
 		'zh-tw': "時時刻刻都待在訓練家身邊。 牠會以精神力量預知訓練家 的行動，以照料其日常起居。",
-		'zh-cn': "時時刻刻都待在訓練家身邊。 牠會以精神力量預知訓練家 的行動，以照料其日常起居。"
+		'zh-cn': "時時刻刻都待在訓練家身邊。 牠會以精神力量預知訓練家 的行動，以照料其日常起居。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "せわやきヒール",
-			'zh-tw': "悉心治癒",
-			'zh-cn': "悉心治癒"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "せわやきヒール",
+				'zh-tw': "悉心治癒",
+				'zh-cn': "悉心治癒",
+			},
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分のバトルポケモンのHPを「30」回復し、特殊状態も1つ回復する。",
+				'zh-tw': "在自己的回合，從手牌將這張卡放置於備戰區時，可使用1次。將自己的戰鬥寶可夢恢復「30」HP，特殊狀態也恢復1個。",
+				'zh-cn': "在自己的回合，從手牌將這張卡放置於備戰區時，可使用1次。將自己的戰鬥寶可夢恢復「30」HP，特殊狀態也恢復1個。",
+			},
 		},
+	],
 
-		effect: {
-			ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分のバトルポケモンのHPを「30」回復し、特殊状態も1つ回復する。",
-			'zh-tw': "在自己的回合，從手牌將這張卡放置於備戰區時，可使用1次。將自己的戰鬥寶可夢恢復「30」HP，特殊狀態也恢復1個。",
-			'zh-cn': "在自己的回合，從手牌將這張卡放置於備戰區時，可使用1次。將自己的戰鬥寶可夢恢復「30」HP，特殊狀態也恢復1個。"
-		}
-	}],
-
-	attacks: [{
-		cost: ["Psychic", "Colorless"],
-
-		name: {
-			ja: "ちょうねんりき",
-			'zh-tw': "超念力",
-			'zh-cn': "超念力"
+	attacks: [
+		{
+			name: {
+				ja: "ちょうねんりき",
+				'zh-tw': "超念力",
+				'zh-cn': "超念力",
+			},
+			damage: 50,
+			cost: ["Psychic", "Colorless"],
 		},
+	],
 
-		damage: 50
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793492,
+				tcgplayer: 587638,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Uncommon",
+	dexId: [876],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/059.ts
+++ b/data-asia/SV/SV8/059.ts
@@ -1,69 +1,74 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ハバタクカミ",
 		'zh-tw': "振翼髮",
-		'zh-cn': "振翼髮"
+		'zh-cn': "振翼髮",
 	},
 
 	illustrator: "Ebila",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [987],
 	hp: 90,
 	types: ["Psychic"],
 
 	description: {
 		ja: "とある 書物に 登場する ハバタクカミという 生物と 似た 特徴を 持つ ポケモン。",
 		'zh-tw': "與某本書裡記載的一種 叫做振翼髮的生物有著 相似特徵的寶可夢。",
-		'zh-cn': "與某本書裡記載的一種 叫做振翼髮的生物有著 相似特徵的寶可夢。"
+		'zh-cn': "與某本書裡記載的一種 叫做振翼髮的生物有著 相似特徵的寶可夢。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "まどわしうつす",
-			'zh-tw': "蠱惑挪移",
-			'zh-cn': "蠱惑挪移"
+	attacks: [
+		{
+			name: {
+				ja: "まどわしうつす",
+				'zh-tw': "蠱惑挪移",
+				'zh-cn': "蠱惑挪移",
+			},
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチの「古代」のポケモンを1匹選び、選んだポケモンにのっているダメカンをすべて、相手のバトルポケモンにのせ替える。",
+				'zh-tw': "選擇1隻自己的備戰區的「古代」寶可夢，將所選的寶可夢身上放置的傷害指示物，全部改放於對手的戰鬥寶可夢身上。",
+				'zh-cn': "選擇1隻自己的備戰區的「古代」寶可夢，將所選的寶可夢身上放置的傷害指示物，全部改放於對手的戰鬥寶可夢身上。",
+			},
 		},
-
-		effect: {
-			ja: "自分のベンチの「古代」のポケモンを1匹選び、選んだポケモンにのっているダメカンをすべて、相手のバトルポケモンにのせ替える。",
-			'zh-tw': "選擇1隻自己的備戰區的「古代」寶可夢，將所選的寶可夢身上放置的傷害指示物，全部改放於對手的戰鬥寶可夢身上。",
-			'zh-cn': "選擇1隻自己的備戰區的「古代」寶可夢，將所選的寶可夢身上放置的傷害指示物，全部改放於對手的戰鬥寶可夢身上。"
-		}
-	}, {
-		cost: ["Psychic", "Psychic"],
-
-		name: {
-			ja: "ムーンフォース",
-			'zh-tw': "月亮之力",
-			'zh-cn': "月亮之力"
+		{
+			name: {
+				ja: "ムーンフォース",
+				'zh-tw': "月亮之力",
+				'zh-cn': "月亮之力",
+			},
+			damage: 70,
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-30」される。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢使用招式的傷害「-30」點。",
+				'zh-cn': "在下個對手的回合，受到這個招式的寶可夢使用招式的傷害「-30」點。",
+			},
 		},
+	],
 
-		damage: 70,
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-30」される。",
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢使用招式的傷害「-30」點。",
-			'zh-cn': "在下個對手的回合，受到這個招式的寶可夢使用招式的傷害「-30」點。"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793493,
+				tcgplayer: 587639,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Uncommon",
+	dexId: [987],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/060.ts
+++ b/data-asia/SV/SV8/060.ts
@@ -1,59 +1,61 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "マンキー",
 		'zh-tw': "猴怪",
-		'zh-cn': "猴怪"
+		'zh-cn': "猴怪",
 	},
 
 	illustrator: "Apios",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [56],
 	hp: 60,
 	types: ["Fighting"],
 
 	description: {
 		ja: "普段は 機嫌が 良くても ちょっとしたことで いきなり 暴れだすから 怖いのだ。",
 		'zh-tw': "平時就算心情再怎麼好， 也會因為一點芝麻小事 而突然暴怒，令人害怕。",
-		'zh-cn': "平時就算心情再怎麼好， 也會因為一點芝麻小事 而突然暴怒，令人害怕。"
+		'zh-cn': "平時就算心情再怎麼好， 也會因為一點芝麻小事 而突然暴怒，令人害怕。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "ダブルチョップ",
-			'zh-tw': "二連劈",
-			'zh-cn': "二連劈"
+	attacks: [
+		{
+			name: {
+				ja: "ダブルチョップ",
+				'zh-tw': "二連劈",
+				'zh-cn': "二連劈",
+			},
+			damage: "10×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×10ダメージ。",
+				'zh-tw': "擲2次硬幣，造成正面出現的次數×10點傷害。",
+				'zh-cn': "擲2次硬幣，造成正面出現的次數×10點傷害。",
+			},
 		},
+	],
 
-		damage: "10×",
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "コインを2回投げ、オモテの数×10ダメージ。",
-			'zh-tw': "擲2次硬幣，造成正面出現的次數×10點傷害。",
-			'zh-cn': "擲2次硬幣，造成正面出現的次數×10點傷害。"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793494,
+				tcgplayer: 587640,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [56],
+};
 
-	thirdParty: {
-		cardmarket: 793494
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/061.ts
+++ b/data-asia/SV/SV8/061.ts
@@ -1,69 +1,74 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "オコリザル",
 		'zh-tw': "火爆猴",
-		'zh-cn': "火爆猴"
+		'zh-cn': "火爆猴",
 	},
 
 	illustrator: "Felicia Chen",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [57],
 	hp: 110,
 	types: ["Fighting"],
 
 	description: {
 		ja: "ある研究者の 学説では モンスターボールの 中でも オコリザルは 怒っているらしい。",
 		'zh-tw': "某位研究者的學說中提到， 即使在精靈球裡， 火爆猴好像也在發怒。",
-		'zh-cn': "某位研究者的學說中提到， 即使在精靈球裡， 火爆猴好像也在發怒。"
+		'zh-cn': "某位研究者的學說中提到， 即使在精靈球裡， 火爆猴好像也在發怒。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Fighting"],
-
-		name: {
-			ja: "あしばらい",
-			'zh-tw': "掃腿",
-			'zh-cn': "掃腿"
+	attacks: [
+		{
+			name: {
+				ja: "あしばらい",
+				'zh-tw': "掃腿",
+				'zh-cn': "掃腿",
+			},
+			damage: 30,
+			cost: ["Fighting"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "擲1次硬幣若為正面，則選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。",
+				'zh-cn': "擲1次硬幣若為正面，則選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
-
-		damage: 30,
-
-		effect: {
-			ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
-			'zh-tw': "擲1次硬幣若為正面，則選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。",
-			'zh-cn': "擲1次硬幣若為正面，則選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。"
-		}
-	}, {
-		cost: ["Fighting", "Colorless"],
-
-		name: {
-			ja: "メガトンパンチ",
-			'zh-tw': "百萬噸重拳",
-			'zh-cn': "百萬噸重拳"
+		{
+			name: {
+				ja: "メガトンパンチ",
+				'zh-tw': "百萬噸重拳",
+				'zh-cn': "百萬噸重拳",
+			},
+			damage: 70,
+			cost: ["Fighting", "Colorless"],
 		},
+	],
 
-		damage: 70
-	}],
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793495,
+				tcgplayer: 587641,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マンキー",
+	},
 
 	retreat: 2,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [57],
+};
 
-	thirdParty: {
-		cardmarket: 793495
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/062.ts
+++ b/data-asia/SV/SV8/062.ts
@@ -1,69 +1,78 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "コノヨザル",
 		'zh-tw': "棄世猴",
-		'zh-cn': "棄世猴"
+		'zh-cn': "棄世猴",
 	},
 
 	illustrator: "SIE NANAHARA",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [979],
 	hp: 140,
 	types: ["Fighting"],
 
 	description: {
 		ja: "心に 秘めた 怒りのパワーを こぶしに 込めて 叩きつけると 相手を 骨の髄から 砕く。",
 		'zh-tw': "會將隱藏在心中的憤怒之力 注入拳頭發動攻擊，其威力 會深入骨髓，將對手打個粉碎。",
-		'zh-cn': "會將隱藏在心中的憤怒之力 注入拳頭發動攻擊，其威力 會深入骨髓，將對手打個粉碎。"
+		'zh-cn': "會將隱藏在心中的憤怒之力 注入拳頭發動攻擊，其威力 會深入骨髓，將對手打個粉碎。",
 	},
 
 	stage: "Stage2",
 
-	attacks: [{
-		cost: ["Fighting"],
-
-		name: {
-			ja: "あばれまわる",
-			'zh-tw': "暴走",
-			'zh-cn': "暴走"
+	attacks: [
+		{
+			name: {
+				ja: "あばれまわる",
+				'zh-tw': "暴走",
+				'zh-cn': "暴走",
+			},
+			damage: 130,
+			cost: ["Fighting"],
+			effect: {
+				ja: "このポケモンをこんらんにする。",
+				'zh-tw': "將這隻寶可夢【混亂】。",
+				'zh-cn': "將這隻寶可夢【混亂】。",
+			},
 		},
-
-		damage: 130,
-
-		effect: {
-			ja: "このポケモンをこんらんにする。",
-			'zh-tw': "將這隻寶可夢【混亂】。",
-			'zh-cn': "將這隻寶可夢【混亂】。"
-		}
-	}, {
-		cost: ["Fighting", "Colorless"],
-
-		name: {
-			ja: "みちづれファイト",
-			'zh-tw': "同命戰鬥",
-			'zh-cn': "同命戰鬥"
+		{
+			name: {
+				ja: "みちづれファイト",
+				'zh-tw': "同命戰鬥",
+				'zh-cn': "同命戰鬥",
+			},
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "おたがいのバトルポケモンをきぜつさせる。",
+				'zh-tw': "將雙方的戰鬥寶可夢【昏厥】。",
+				'zh-cn': "將雙方的戰鬥寶可夢【昏厥】。",
+			},
 		},
+	],
 
-		effect: {
-			ja: "おたがいのバトルポケモンをきぜつさせる。",
-			'zh-tw': "將雙方的戰鬥寶可夢【昏厥】。",
-			'zh-cn': "將雙方的戰鬥寶可夢【昏厥】。"
-		}
-	}],
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793496,
+				tcgplayer: 587642,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "オコリザル",
+	},
 
 	retreat: 2,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Uncommon",
+	dexId: [979],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/063.ts
+++ b/data-asia/SV/SV8/063.ts
@@ -1,65 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "パルデア ケンタロス",
 		'zh-tw': "帕底亞 肯泰羅",
-		'zh-cn': "帕底亞 肯泰羅"
+		'zh-cn': "帕底亞 肯泰羅",
 	},
 
 	illustrator: "Uta",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [128],
 	hp: 130,
 	types: ["Fighting"],
 
 	description: {
 		ja: "ぶ厚く 力強い 筋肉と 気性の 荒さが 特徴。 コンバット種と 呼ばれる。",
 		'zh-tw': "特徵是厚實有力的肌肉， 以及粗魯暴躁的性格。 這種樣子被稱為鬥戰種。",
-		'zh-cn': "特徵是厚實有力的肌肉， 以及粗魯暴躁的性格。 這種樣子被稱為鬥戰種。"
+		'zh-cn': "特徵是厚實有力的肌肉， 以及粗魯暴躁的性格。 這種樣子被稱為鬥戰種。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Fighting", "Colorless"],
-
-		name: {
-			ja: "けとばす",
-			'zh-tw': "踢飛",
-			'zh-cn': "踢飛"
+	attacks: [
+		{
+			name: {
+				ja: "けとばす",
+				'zh-tw': "踢飛",
+				'zh-cn': "踢飛",
+			},
+			damage: 40,
+			cost: ["Fighting", "Colorless"],
 		},
-
-		damage: 40
-	}, {
-		cost: ["Fighting", "Colorless", "Colorless"],
-
-		name: {
-			ja: "ブロックスタンプ",
-			'zh-tw': "障礙踩踏",
-			'zh-cn': "障礙踩踏"
+		{
+			name: {
+				ja: "ブロックスタンプ",
+				'zh-tw': "障礙踩踏",
+				'zh-cn': "障礙踩踏",
+			},
+			damage: 90,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたたねポケモンは、ワザが使えない。",
+				'zh-tw': "在下個對手的回合，受到這個招式的【基礎】寶可夢，無法使用招式。",
+				'zh-cn': "在下個對手的回合，受到這個招式的【基礎】寶可夢，無法使用招式。",
+			},
 		},
+	],
 
-		damage: 90,
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "次の相手の番、このワザを受けたたねポケモンは、ワザが使えない。",
-			'zh-tw': "在下個對手的回合，受到這個招式的【基礎】寶可夢，無法使用招式。",
-			'zh-cn': "在下個對手的回合，受到這個招式的【基礎】寶可夢，無法使用招式。"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793497,
+				tcgplayer: 587643,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Uncommon",
+	dexId: [128],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/064.ts
+++ b/data-asia/SV/SV8/064.ts
@@ -1,53 +1,56 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ゴマゾウ",
 		'zh-tw': "小小象",
-		'zh-cn': "小小象"
+		'zh-cn': "小小象",
 	},
 
 	illustrator: "ryoma uratsuka",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [231],
 	hp: 80,
 	types: ["Fighting"],
 
 	description: {
 		ja: "見た目より ずっと 力持ち。 振りまわす 鼻に ぶつかると 腕の 骨が もっていかれる。",
 		'zh-tw': "有別於外表的大力士。 如果被牠甩動的鼻子揮中， 手臂的骨頭就會支離破碎。",
-		'zh-cn': "有別於外表的大力士。 如果被牠甩動的鼻子揮中， 手臂的骨頭就會支離破碎。"
+		'zh-cn': "有別於外表的大力士。 如果被牠甩動的鼻子揮中， 手臂的骨頭就會支離破碎。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Fighting"],
-
-		name: {
-			ja: "ずつき",
-			'zh-tw': "頭錘",
-			'zh-cn': "頭錘"
+	attacks: [
+		{
+			name: {
+				ja: "ずつき",
+				'zh-tw': "頭錘",
+				'zh-cn': "頭錘",
+			},
+			damage: 20,
+			cost: ["Fighting"],
 		},
+	],
 
-		damage: 20
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793498,
+				tcgplayer: 587644,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [231],
+};
 
-	thirdParty: {
-		cardmarket: 793498
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/065.ts
+++ b/data-asia/SV/SV8/065.ts
@@ -1,75 +1,79 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ドンファン",
 		'zh-tw': "頓甲",
-		'zh-cn': "頓甲"
+		'zh-cn': "頓甲",
 	},
 
 	illustrator: "GOSSAN",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [232],
 	hp: 150,
 	types: ["Fighting"],
 
 	description: {
 		ja: "普段は 落ち着いているが 一度 怒らせると 体を 丸めて 回転しながら 突っ込んでくる。",
 		'zh-tw': "雖然平時性情穩重， 但一旦被激怒就會滾著 蜷起的身體猛衝過來。",
-		'zh-cn': "雖然平時性情穩重， 但一旦被激怒就會滾著 蜷起的身體猛衝過來。"
+		'zh-cn': "雖然平時性情穩重， 但一旦被激怒就會滾著 蜷起的身體猛衝過來。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Fighting"],
-
-		name: {
-			ja: "うちのめす",
-			'zh-tw': "打垮",
-			'zh-cn': "打垮"
+	attacks: [
+		{
+			name: {
+				ja: "うちのめす",
+				'zh-tw': "打垮",
+				'zh-cn': "打垮",
+			},
+			damage: 40,
+			cost: ["Fighting"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+				'zh-tw': "這個招式的傷害不計算對手的戰鬥寶可夢身上的附加效果。",
+				'zh-cn': "這個招式的傷害不計算對手的戰鬥寶可夢身上的附加效果。",
+			},
 		},
-
-		damage: 40,
-
-		effect: {
-			ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
-			'zh-tw': "這個招式的傷害不計算對手的戰鬥寶可夢身上的附加效果。",
-			'zh-cn': "這個招式的傷害不計算對手的戰鬥寶可夢身上的附加效果。"
-		}
-	}, {
-		cost: ["Fighting", "Colorless", "Colorless"],
-
-		name: {
-			ja: "ガードローリング",
-			'zh-tw': "防守回轉",
-			'zh-cn': "防守回轉"
+		{
+			name: {
+				ja: "ガードローリング",
+				'zh-tw': "防守回轉",
+				'zh-cn': "防守回轉",
+			},
+			damage: 120,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。次の相手の番、このポケモンが受けるワザのダメージは「-100」される。",
+				'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。在下個對手的回合，這隻寶可夢受到招式的傷害「-100」點。",
+				'zh-cn': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。在下個對手的回合，這隻寶可夢受到招式的傷害「-100」點。",
+			},
 		},
+	],
 
-		damage: 120,
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンについているエネルギーを2個選び、トラッシュする。次の相手の番、このポケモンが受けるワザのダメージは「-100」される。",
-			'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。在下個對手的回合，這隻寶可夢受到招式的傷害「-100」點。",
-			'zh-cn': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。在下個對手的回合，這隻寶可夢受到招式的傷害「-100」點。"
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793499,
+				tcgplayer: 587645,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ゴマゾウ",
+	},
 
 	retreat: 4,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [232],
+};
 
-	thirdParty: {
-		cardmarket: 793499
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/066.ts
+++ b/data-asia/SV/SV8/066.ts
@@ -1,69 +1,76 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "トリトドン",
 		'zh-tw': "海兔獸",
-		'zh-cn': "海兔獸"
+		'zh-cn': "海兔獸",
 	},
 
 	illustrator: "Scav",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [423],
 	hp: 130,
 	types: ["Fighting"],
 
 	description: {
 		ja: "浅い 磯辺に 現れる。 獲物を 捕らえると 粘液で ゆっくりと 溶かし すするのだ。",
 		'zh-tw': "能在水淺的岩岸發現牠。 會用黏液慢慢溶解 並吸食捕捉到的獵物。",
-		'zh-cn': "能在水淺的岩岸發現牠。 會用黏液慢慢溶解 並吸食捕捉到的獵物。"
+		'zh-cn': "能在水淺的岩岸發現牠。 會用黏液慢慢溶解 並吸食捕捉到的獵物。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "ねんちゃくしばり",
-			'zh-tw': "黏著束縛",
-			'zh-cn': "黏著束縛"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ねんちゃくしばり",
+				'zh-tw': "黏著束縛",
+				'zh-cn': "黏著束縛",
+			},
+			effect: {
+				ja: "このポケモンがベンチにいるかぎり、おたがいのベンチの2進化ポケモンの特性は、すべてなくなる。",
+				'zh-tw': "只要這隻寶可夢在備戰區，雙方的備戰區的【2階進化】寶可夢的特性全部消除。",
+				'zh-cn': "只要這隻寶可夢在備戰區，雙方的備戰區的【2階進化】寶可夢的特性全部消除。",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンがベンチにいるかぎり、おたがいのベンチの2進化ポケモンの特性は、すべてなくなる。",
-			'zh-tw': "只要這隻寶可夢在備戰區，雙方的備戰區的【2階進化】寶可夢的特性全部消除。",
-			'zh-cn': "只要這隻寶可夢在備戰區，雙方的備戰區的【2階進化】寶可夢的特性全部消除。"
-		}
-	}],
-
-	attacks: [{
-		cost: ["Fighting", "Colorless", "Colorless"],
-
-		name: {
-			ja: "マッドショット",
-			'zh-tw': "泥巴射擊",
-			'zh-cn': "泥巴射擊"
+	attacks: [
+		{
+			name: {
+				ja: "マッドショット",
+				'zh-tw': "泥巴射擊",
+				'zh-cn': "泥巴射擊",
+			},
+			damage: 80,
+			cost: ["Fighting", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 80
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793500,
+				tcgplayer: 587646,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カラナクシ",
+	},
 
 	retreat: 3,
 	regulationMark: "H",
+	rarity: "Rare",
+	dexId: [423],
+};
 
-	thirdParty: {
-		cardmarket: 793500
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/067.ts
+++ b/data-asia/SV/SV8/067.ts
@@ -1,55 +1,61 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "キラーメ",
 		'zh-tw': "晶光芽",
-		'zh-cn': "晶光芽"
+		'zh-cn': "晶光芽",
 	},
 
 	illustrator: "Eri Kamei",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [969],
 	hp: 70,
 	types: ["Fighting"],
 
 	description: {
 		ja: "毒成分の 結晶が まるで 花びらに 見える。 花粉のように 毒の粉を ばらまき 身を守る。",
 		'zh-tw': "以毒構成的結晶看似花瓣。 會如灑花粉般地灑出毒粉 來保護自身安全。",
-		'zh-cn': "以毒構成的結晶看似花瓣。 會如灑花粉般地灑出毒粉 來保護自身安全。"
+		'zh-cn': "以毒構成的結晶看似花瓣。 會如灑花粉般地灑出毒粉 來保護自身安全。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Fighting"],
-
-		name: {
-			ja: "いわとばし",
-			'zh-tw': "岩石投擲",
-			'zh-cn': "岩石投擲"
+	attacks: [
+		{
+			name: {
+				ja: "いわとばし",
+				'zh-tw': "岩石投擲",
+				'zh-cn': "岩石投擲",
+			},
+			damage: 10,
+			cost: ["Fighting"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+				'zh-tw': "這個招式的傷害不計算抵抗力。",
+				'zh-cn': "這個招式的傷害不計算抵抗力。",
+			},
 		},
+	],
 
-		damage: 10,
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このワザのダメージは抵抗力を計算しない。",
-			'zh-tw': "這個招式的傷害不計算抵抗力。",
-			'zh-cn': "這個招式的傷害不計算抵抗力。"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793501,
+				tcgplayer: 587647,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Common",
+	dexId: [969],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/068.ts
+++ b/data-asia/SV/SV8/068.ts
@@ -1,65 +1,74 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "キラフロル",
 		'zh-tw': "晶光花",
-		'zh-cn': "晶光花"
+		'zh-cn': "晶光花",
 	},
 
 	illustrator: "takashi shiraishi",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [970],
 	hp: 130,
 	types: ["Fighting"],
 
 	description: {
 		ja: "毒エネルギーが 結晶化した 花びらは テラスタルの 宝石に 似ていると 最近 判明した。",
 		'zh-tw': "最近發現牠的毒能量 結晶化後所形成的花瓣 與太晶的寶石類似。",
-		'zh-cn': "最近發現牠的毒能量 結晶化後所形成的花瓣 與太晶的寶石類似。"
+		'zh-cn': "最近發現牠的毒能量 結晶化後所形成的花瓣 與太晶的寶石類似。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "むしばむはへん",
-			'zh-tw': "侵蝕碎塊",
-			'zh-cn': "侵蝕碎塊"
+	attacks: [
+		{
+			name: {
+				ja: "むしばむはへん",
+				'zh-tw': "侵蝕碎塊",
+				'zh-cn': "侵蝕碎塊",
+			},
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。次の相手の番、このワザを受けたポケモンは、手札から出すエネルギーをつけられない。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】。在下個對手的回合，受到這個招式的寶可夢，無法附上從手牌使出的能量卡。",
+				'zh-cn': "將對手的戰鬥寶可夢【中毒】。在下個對手的回合，受到這個招式的寶可夢，無法附上從手牌使出的能量卡。",
+			},
 		},
-
-		damage: 20,
-
-		effect: {
-			ja: "相手のバトルポケモンをどくにする。次の相手の番、このワザを受けたポケモンは、手札から出すエネルギーをつけられない。",
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。在下個對手的回合，受到這個招式的寶可夢，無法附上從手牌使出的能量卡。",
-			'zh-cn': "將對手的戰鬥寶可夢【中毒】。在下個對手的回合，受到這個招式的寶可夢，無法附上從手牌使出的能量卡。"
-		}
-	}, {
-		cost: ["Fighting", "Colorless"],
-
-		name: {
-			ja: "いわおとし",
-			'zh-tw': "落石",
-			'zh-cn': "落石"
+		{
+			name: {
+				ja: "いわおとし",
+				'zh-tw': "落石",
+				'zh-cn': "落石",
+			},
+			damage: 60,
+			cost: ["Fighting", "Colorless"],
 		},
+	],
 
-		damage: 60
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793502,
+				tcgplayer: 587648,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "キラーメ",
+	},
 
 	retreat: 2,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Common",
+	dexId: [970],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/069.ts
+++ b/data-asia/SV/SV8/069.ts
@@ -1,65 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "コライドン",
 		'zh-tw': "故勒頓",
-		'zh-cn': "故勒頓"
+		'zh-cn': "故勒頓",
 	},
 
 	illustrator: "Ryuta Fuse",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [1007],
 	hp: 130,
 	types: ["Fighting"],
 
 	description: {
 		ja: "拳で 大地を 引き裂いたと 古い 探検記に 記された ツバサノオウの 正体らしい。",
 		'zh-tw': "牠似乎就是古老的探險記裡 提到的翼大王的真面目。 據記載，牠曾以拳頭擊裂大地。",
-		'zh-cn': "牠似乎就是古老的探險記裡 提到的翼大王的真面目。 據記載，牠曾以拳頭擊裂大地。"
+		'zh-cn': "牠似乎就是古老的探險記裡 提到的翼大王的真面目。 據記載，牠曾以拳頭擊裂大地。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "はじょうもうこう",
-			'zh-tw': "輪番狂攻",
-			'zh-cn': "輪番狂攻"
+	attacks: [
+		{
+			name: {
+				ja: "はじょうもうこう",
+				'zh-tw': "輪番狂攻",
+				'zh-cn': "輪番狂攻",
+			},
+			damage: "30+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "前の自分の番、このポケモン以外の「古代」のポケモンがワザを使っていたなら、150ダメージ追加。",
+				'zh-tw': "在上個自己的回合，若這隻寶可夢以外的「古代」寶可夢使用了招式，則增加150點傷害。",
+				'zh-cn': "在上個自己的回合，若這隻寶可夢以外的「古代」寶可夢使用了招式，則增加150點傷害。",
+			},
 		},
-
-		damage: "30+",
-
-		effect: {
-			ja: "前の自分の番、このポケモン以外の「古代」のポケモンがワザを使っていたなら、150ダメージ追加。",
-			'zh-tw': "在上個自己的回合，若這隻寶可夢以外的「古代」寶可夢使用了招式，則增加150點傷害。",
-			'zh-cn': "在上個自己的回合，若這隻寶可夢以外的「古代」寶可夢使用了招式，則增加150點傷害。"
-		}
-	}, {
-		cost: ["Fighting", "Fighting", "Colorless"],
-
-		name: {
-			ja: "ぶちかます",
-			'zh-tw': "頭突",
-			'zh-cn': "頭突"
+		{
+			name: {
+				ja: "ぶちかます",
+				'zh-tw': "頭突",
+				'zh-cn': "頭突",
+			},
+			damage: 110,
+			cost: ["Fighting", "Fighting", "Colorless"],
 		},
+	],
 
-		damage: 110
-	}],
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793503,
+				tcgplayer: 587649,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Uncommon",
+	dexId: [1007],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/070.ts
+++ b/data-asia/SV/SV8/070.ts
@@ -1,67 +1,69 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "モノズ",
 		'zh-tw': "單首龍",
-		'zh-cn': "單首龍"
+		'zh-cn': "單首龍",
 	},
 
 	illustrator: "YASHIRO Nanaco",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [633],
 	hp: 70,
 	types: ["Darkness"],
 
 	description: {
 		ja: "棲み処は 洞窟の 奥深く。 エサも 少ないので 動くものは なんでも 食いつき 食べようとする。",
 		'zh-tw': "棲息的洞窟深處缺乏食糧， 因此只要是會動的東西， 牠都會想去咬住吃掉。",
-		'zh-cn': "棲息的洞窟深處缺乏食糧， 因此只要是會動的東西， 牠都會想去咬住吃掉。"
+		'zh-cn': "棲息的洞窟深處缺乏食糧， 因此只要是會動的東西， 牠都會想去咬住吃掉。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Darkness"],
-
-		name: {
-			ja: "ふみならす",
-			'zh-tw': "踩落",
-			'zh-cn': "踩落"
+	attacks: [
+		{
+			name: {
+				ja: "ふみならす",
+				'zh-tw': "踩落",
+				'zh-cn': "踩落",
+			},
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手の山札を上から1枚トラッシュする。",
+				'zh-tw': "將對手的牌庫上方1張卡丟棄。",
+				'zh-cn': "將對手的牌庫上方1張卡丟棄。",
+			},
 		},
-
-		effect: {
-			ja: "相手の山札を上から1枚トラッシュする。",
-			'zh-tw': "將對手的牌庫上方1張卡丟棄。",
-			'zh-cn': "將對手的牌庫上方1張卡丟棄。"
-		}
-	}, {
-		cost: ["Darkness", "Colorless"],
-
-		name: {
-			ja: "かみつく",
-			'zh-tw': "咬住",
-			'zh-cn': "咬住"
+		{
+			name: {
+				ja: "かみつく",
+				'zh-tw': "咬住",
+				'zh-cn': "咬住",
+			},
+			damage: 20,
+			cost: ["Darkness", "Colorless"],
 		},
+	],
 
-		damage: 20
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793504,
+				tcgplayer: 587650,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [633],
+};
 
-	thirdParty: {
-		cardmarket: 793504
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/071.ts
+++ b/data-asia/SV/SV8/071.ts
@@ -1,67 +1,73 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ジヘッド",
 		'zh-tw': "雙首暴龍",
-		'zh-cn': "雙首暴龍"
+		'zh-cn': "雙首暴龍",
 	},
 
 	illustrator: "chibi",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [634],
 	hp: 100,
 	types: ["Darkness"],
 
 	description: {
 		ja: "２つの 頭は 好みが 違う。 頭同士 争うことで だれの 力も 借りずに 強くなるのだ。",
 		'zh-tw': "２顆頭各有喜好。 由於頭之間會互相爭鬥， 因此不靠外力也能變強。",
-		'zh-cn': "２顆頭各有喜好。 由於頭之間會互相爭鬥， 因此不靠外力也能變強。"
+		'zh-cn': "２顆頭各有喜好。 由於頭之間會互相爭鬥， 因此不靠外力也能變強。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Darkness"],
-
-		name: {
-			ja: "ふみならす",
-			'zh-tw': "踩落",
-			'zh-cn': "踩落"
+	attacks: [
+		{
+			name: {
+				ja: "ふみならす",
+				'zh-tw': "踩落",
+				'zh-cn': "踩落",
+			},
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手の山札を上から2枚トラッシュする。",
+				'zh-tw': "將對手的牌庫上方2張卡丟棄。",
+				'zh-cn': "將對手的牌庫上方2張卡丟棄。",
+			},
 		},
-
-		effect: {
-			ja: "相手の山札を上から2枚トラッシュする。",
-			'zh-tw': "將對手的牌庫上方2張卡丟棄。",
-			'zh-cn': "將對手的牌庫上方2張卡丟棄。"
-		}
-	}, {
-		cost: ["Darkness", "Colorless", "Colorless"],
-
-		name: {
-			ja: "やみのキバ",
-			'zh-tw': "暗之牙",
-			'zh-cn': "暗之牙"
+		{
+			name: {
+				ja: "やみのキバ",
+				'zh-tw': "暗之牙",
+				'zh-cn': "暗之牙",
+			},
+			damage: 60,
+			cost: ["Darkness", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 60
-	}],
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793505,
+				tcgplayer: 587651,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "モノズ",
+	},
 
 	retreat: 2,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [634],
+};
 
-	thirdParty: {
-		cardmarket: 793505
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/072.ts
+++ b/data-asia/SV/SV8/072.ts
@@ -1,68 +1,75 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "サザンドラex",
 		'zh-tw': "三首惡龍ex",
-		'zh-cn': "三首惡龍ex"
+		'zh-cn': "三首惡龍ex",
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Darkness"],
+
 	stage: "Stage2",
-	suffix: "EX",
 
-	attacks: [{
-		cost: ["Darkness", "Colorless"],
-
-		name: {
-			ja: "クラッシュヘッズ",
-			'zh-tw': "粉碎頭",
-			'zh-cn': "粉碎頭"
+	attacks: [
+		{
+			name: {
+				ja: "クラッシュヘッズ",
+				'zh-tw': "粉碎頭",
+				'zh-cn': "粉碎頭",
+			},
+			damage: 200,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手の山札を上から3枚トラッシュする。",
+				'zh-tw': "將對手的牌庫上方3張卡丟棄。",
+				'zh-cn': "將對手的牌庫上方3張卡丟棄。",
+			},
 		},
-
-		damage: 200,
-
-		effect: {
-			ja: "相手の山札を上から3枚トラッシュする。",
-			'zh-tw': "將對手的牌庫上方3張卡丟棄。",
-			'zh-cn': "將對手的牌庫上方3張卡丟棄。"
-		}
-	}, {
-		cost: ["Psychic", "Darkness", "Metal", "Colorless"],
-
-		name: {
-			ja: "オブシディアン",
-			'zh-tw': "黑曜石",
-			'zh-cn': "黑曜石"
+		{
+			name: {
+				ja: "オブシディアン",
+				'zh-tw': "黑曜石",
+				'zh-cn': "黑曜石",
+			},
+			damage: 130,
+			cost: ["Psychic", "Darkness", "Metal", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン2匹にも、それぞれ130ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的2隻備戰寶可夢也各受到130點傷害。[在備戰區不計算弱點・抵抗力。]",
+				'zh-cn': "對手的2隻備戰寶可夢也各受到130點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		damage: 130,
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のベンチポケモン2匹にも、それぞれ130ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
-			'zh-tw': "對手的2隻備戰寶可夢也各受到130點傷害。[在備戰區不計算弱點・抵抗力。]",
-			'zh-cn': "對手的2隻備戰寶可夢也各受到130點傷害。[在備戰區不計算弱點・抵抗力。]"
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793506,
+				tcgplayer: 587652,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ジヘッド",
+	},
 
 	retreat: 3,
 	regulationMark: "H",
+	rarity: "Double rare",
+	dexId: [635],
 
-	thirdParty: {
-		cardmarket: 793506
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/073.ts
+++ b/data-asia/SV/SV8/073.ts
@@ -1,49 +1,56 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "シルシュルー",
 		'zh-tw': "滋汁鼴",
-		'zh-cn': "滋汁鼴"
+		'zh-cn': "滋汁鼴",
 	},
 
 	illustrator: "Yukiko Baba",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [944],
 	hp: 60,
 	types: ["Darkness"],
 
 	description: {
 		ja: "縄張りに 敵が 近づかないよう 刺激臭がする 毒液で 巣の まわりに 図形を 描く。",
 		'zh-tw': "為了不讓敵人靠近地盤， 會用有刺鼻臭味的毒液， 在巢的周圍描繪圖形。",
-		'zh-cn': "為了不讓敵人靠近地盤， 會用有刺鼻臭味的毒液， 在巢的周圍描繪圖形。"
+		'zh-cn': "為了不讓敵人靠近地盤， 會用有刺鼻臭味的毒液， 在巢的周圍描繪圖形。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Darkness"],
-
-		name: {
-			ja: "しるをとばす",
-			'zh-tw': "噴汁",
-			'zh-cn': "噴汁"
+	attacks: [
+		{
+			name: {
+				ja: "しるをとばす",
+				'zh-tw': "噴汁",
+				'zh-cn': "噴汁",
+			},
+			damage: 20,
+			cost: ["Darkness"],
 		},
+	],
 
-		damage: 20
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793507,
+				tcgplayer: 587653,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Common",
+	dexId: [944],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/074.ts
+++ b/data-asia/SV/SV8/074.ts
@@ -1,69 +1,78 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "タギングル",
 		'zh-tw': "塗標客",
-		'zh-cn': "塗標客"
+		'zh-cn': "塗標客",
 	},
 
 	illustrator: "NC Empire",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [945],
 	hp: 100,
 	types: ["Darkness"],
 
 	description: {
 		ja: "タギングルが 描く 模様は 個体によって 異なり 生涯 同じ 模様を 描き続ける。",
 		'zh-tw': "塗標客畫的圖案 會依個體而有所不同。 一生不斷畫著相同圖案。",
-		'zh-cn': "塗標客畫的圖案 會依個體而有所不同。 一生不斷畫著相同圖案。"
+		'zh-cn': "塗標客畫的圖案 會依個體而有所不同。 一生不斷畫著相同圖案。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "いたずらペイント",
-			'zh-tw': "惡作劇作畫",
-			'zh-cn': "惡作劇作畫"
+	attacks: [
+		{
+			name: {
+				ja: "いたずらペイント",
+				'zh-tw': "惡作劇作畫",
+				'zh-cn': "惡作劇作畫",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のトラッシュからエネルギーを3枚まで選び、相手のポケモンに好きなようにつける。",
+				'zh-tw': "從對手的棄牌區選擇最多3張能量卡，以任意方式附於對手的寶可夢身上。",
+				'zh-cn': "從對手的棄牌區選擇最多3張能量卡，以任意方式附於對手的寶可夢身上。",
+			},
 		},
-
-		effect: {
-			ja: "相手のトラッシュからエネルギーを3枚まで選び、相手のポケモンに好きなようにつける。",
-			'zh-tw': "從對手的棄牌區選擇最多3張能量卡，以任意方式附於對手的寶可夢身上。",
-			'zh-cn': "從對手的棄牌區選擇最多3張能量卡，以任意方式附於對手的寶可夢身上。"
-		}
-	}, {
-		cost: ["Darkness", "Darkness"],
-
-		name: {
-			ja: "エナジーグラフィティ",
-			'zh-tw': "能量塗鴉",
-			'zh-cn': "能量塗鴉"
+		{
+			name: {
+				ja: "エナジーグラフィティ",
+				'zh-tw': "能量塗鴉",
+				'zh-cn': "能量塗鴉",
+			},
+			damage: "40×",
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "相手のポケモン全員についているエネルギーの数×40ダメージ。",
+				'zh-tw': "造成對手的所有寶可夢身上附加的能量的數量×40點傷害。",
+				'zh-cn': "造成對手的所有寶可夢身上附加的能量的數量×40點傷害。",
+			},
 		},
+	],
 
-		damage: "40×",
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のポケモン全員についているエネルギーの数×40ダメージ。",
-			'zh-tw': "造成對手的所有寶可夢身上附加的能量的數量×40點傷害。",
-			'zh-cn': "造成對手的所有寶可夢身上附加的能量的數量×40點傷害。"
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793508,
+				tcgplayer: 587654,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "シルシュルー",
+	},
 
 	retreat: 1,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Uncommon",
+	dexId: [945],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/075.ts
+++ b/data-asia/SV/SV8/075.ts
@@ -1,71 +1,77 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "モモワロウ",
 		'zh-tw': "桃歹郎",
-		'zh-cn': "桃歹郎"
+		'zh-cn': "桃歹郎",
 	},
 
 	illustrator: "Souichirou Gunjima",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [1025],
 	hp: 80,
 	types: ["Darkness"],
 
 	description: {
 		ja: "モモ型の 殻は 猛毒の 貯蔵庫。 毒の 餅を 作り 人や ポケモンに ふるまう。",
 		'zh-tw': "桃形的殼是劇毒的儲藏庫。 會製作帶毒的麻糬 送給人和寶可夢吃。",
-		'zh-cn': "桃形的殼是劇毒的儲藏庫。 會製作帶毒的麻糬 送給人和寶可夢吃。"
+		'zh-cn': "桃形的殼是劇毒的儲藏庫。 會製作帶毒的麻糬 送給人和寶可夢吃。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "もうどくしはい",
-			'zh-tw': "劇毒支配",
-			'zh-cn': "劇毒支配"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "もうどくしはい",
+				'zh-tw': "劇毒支配",
+				'zh-cn': "劇毒支配",
+			},
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手のどくのポケモンは、どくでのせるダメカンの数が5個多くなる。",
+				'zh-tw': "只要這隻寶可夢在戰鬥場上，對手的【中毒】的寶可夢，因【中毒】而放置的傷害指示物的數量增加5個。",
+				'zh-cn': "只要這隻寶可夢在戰鬥場上，對手的【中毒】的寶可夢，因【中毒】而放置的傷害指示物的數量增加5個。",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンがバトル場にいるかぎり、相手のどくのポケモンは、どくでのせるダメカンの数が5個多くなる。",
-			'zh-tw': "只要這隻寶可夢在戰鬥場上，對手的【中毒】的寶可夢，因【中毒】而放置的傷害指示物的數量增加5個。",
-			'zh-cn': "只要這隻寶可夢在戰鬥場上，對手的【中毒】的寶可夢，因【中毒】而放置的傷害指示物的數量增加5個。"
-		}
-	}],
-
-	attacks: [{
-		cost: ["Darkness", "Colorless"],
-
-		name: {
-			ja: "ポイズンチェーン",
-			'zh-tw': "猛毒連鎖",
-			'zh-cn': "猛毒連鎖"
+	attacks: [
+		{
+			name: {
+				ja: "ポイズンチェーン",
+				'zh-tw': "猛毒連鎖",
+				'zh-cn': "猛毒連鎖",
+			},
+			damage: 10,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。次の相手の番、このワザを受けたポケモンは、にげられない。",
+				'zh-tw': "將對手的戰鬥寶可夢【中毒】。在下個對手的回合，受到這個招式的寶可夢無法撤退。",
+				'zh-cn': "將對手的戰鬥寶可夢【中毒】。在下個對手的回合，受到這個招式的寶可夢無法撤退。",
+			},
 		},
+	],
 
-		damage: 10,
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "相手のバトルポケモンをどくにする。次の相手の番、このワザを受けたポケモンは、にげられない。",
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。在下個對手的回合，受到這個招式的寶可夢無法撤退。",
-			'zh-cn': "將對手的戰鬥寶可夢【中毒】。在下個對手的回合，受到這個招式的寶可夢無法撤退。"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793509,
+				tcgplayer: 587655,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Uncommon",
+	dexId: [1025],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/076.ts
+++ b/data-asia/SV/SV8/076.ts
@@ -1,58 +1,61 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "アローラ ディグダ",
 		'zh-tw': "阿羅拉 地鼠",
-		'zh-cn': "阿羅拉 地鼠"
+		'zh-cn': "阿羅拉 地鼠",
 	},
 
 	illustrator: "Akino Fukuji",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [50],
 	hp: 50,
 	types: ["Metal"],
 
 	description: {
 		ja: "金色の 髭は センサー機能を 持っている。 穴から だして 周りの 様子を うかがっている。",
 		'zh-tw': "金色的鬍子擁有感應器的功能。 會從洞裡伸出，查探周圍的狀態。",
-		'zh-cn': "金色的鬍子擁有感應器的功能。 會從洞裡伸出，查探周圍的狀態。"
+		'zh-cn': "金色的鬍子擁有感應器的功能。 會從洞裡伸出，查探周圍的狀態。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			ja: "ふいをつく",
-			'zh-tw': "偷襲",
-			'zh-cn': "偷襲"
+	attacks: [
+		{
+			name: {
+				ja: "ふいをつく",
+				'zh-tw': "偷襲",
+				'zh-cn': "偷襲",
+			},
+			damage: 30,
+			cost: [],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+				'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。",
+				'zh-cn': "擲1次硬幣若為反面，則這個招式失敗。",
+			},
 		},
+	],
 
-		damage: 30,
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
 
-		effect: {
-			ja: "コインを1回投げウラなら、このワザは失敗。",
-			'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。",
-			'zh-cn': "擲1次硬幣若為反面，則這個招式失敗。"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793510,
+				tcgplayer: 587656,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Common",
+	dexId: [50],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/077.ts
+++ b/data-asia/SV/SV8/077.ts
@@ -1,58 +1,65 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "アローラ ダグトリオ",
 		'zh-tw': "阿羅拉 三地鼠",
-		'zh-cn': "阿羅拉 三地鼠"
+		'zh-cn': "阿羅拉 三地鼠",
 	},
 
 	illustrator: "Dsuke",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [51],
 	hp: 110,
 	types: ["Metal"],
 
 	description: {
 		ja: "金属質の 髭は 重いので 素早さは いまいちだが 硬い 岩盤も 掘りぬくパワーを 持つ。",
 		'zh-tw': "金屬材質的鬍鬚很重， 所以速度並不快， 但擁有能夠挖穿堅硬岩盤的力量。",
-		'zh-cn': "金屬材質的鬍鬚很重， 所以速度並不快， 但擁有能夠挖穿堅硬岩盤的力量。"
+		'zh-cn': "金屬材質的鬍鬚很重， 所以速度並不快， 但擁有能夠挖穿堅硬岩盤的力量。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			ja: "スリービンゴ",
-			'zh-tw': "三賓果",
-			'zh-cn': "三賓果"
+	attacks: [
+		{
+			name: {
+				ja: "スリービンゴ",
+				'zh-tw': "三賓果",
+				'zh-cn': "三賓果",
+			},
+			damage: 120,
+			cost: [],
+			effect: {
+				ja: "自分の手札が3枚でないなら、このワザは失敗。",
+				'zh-tw': "若自己的手牌不是3張，則這個招式失敗。",
+				'zh-cn': "若自己的手牌不是3張，則這個招式失敗。",
+			},
 		},
+	],
 
-		damage: 120,
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
 
-		effect: {
-			ja: "自分の手札が3枚でないなら、このワザは失敗。",
-			'zh-tw': "若自己的手牌不是3張，則這個招式失敗。",
-			'zh-cn': "若自己的手牌不是3張，則這個招式失敗。"
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793511,
+				tcgplayer: 587657,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "アローラディグダ",
+	},
 
 	retreat: 2,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Uncommon",
+	dexId: [51],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/078.ts
+++ b/data-asia/SV/SV8/078.ts
@@ -1,64 +1,61 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ドーミラー",
 		'zh-tw': "銅鏡怪",
-		'zh-cn': "銅鏡怪"
+		'zh-cn': "銅鏡怪",
 	},
 
 	illustrator: "Nabatame Kazutaka",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [436],
 	hp: 60,
 	types: ["Metal"],
 
 	description: {
 		ja: "古い お墓から みつかる。 背中の 模様には 神秘的な 力が 宿っていると いわれる。",
 		'zh-tw': "能在古墓發現到牠。 據說牠背上的花紋 寄宿著神秘的力量。",
-		'zh-cn': "能在古墓發現到牠。 據說牠背上的花紋 寄宿著神秘的力量。"
+		'zh-cn': "能在古墓發現到牠。 據說牠背上的花紋 寄宿著神秘的力量。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Metal", "Colorless"],
-
-		name: {
-			ja: "シールドアタック",
-			'zh-tw': "盾牌攻擊",
-			'zh-cn': "盾牌攻擊"
+	attacks: [
+		{
+			name: {
+				ja: "シールドアタック",
+				'zh-tw': "盾牌攻擊",
+				'zh-cn': "盾牌攻擊",
+			},
+			damage: "20+",
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+				'zh-tw': "擲1次硬幣若為正面，則增加20點傷害。",
+				'zh-cn': "擲1次硬幣若為正面，則增加20點傷害。",
+			},
 		},
+	],
 
-		damage: "20+",
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
 
-		effect: {
-			ja: "コインを1回投げオモテなら、20ダメージ追加。",
-			'zh-tw': "擲1次硬幣若為正面，則增加20點傷害。",
-			'zh-cn': "擲1次硬幣若為正面，則增加20點傷害。"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793512,
+				tcgplayer: 587658,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [436],
+};
 
-	thirdParty: {
-		cardmarket: 793512
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/079.ts
+++ b/data-asia/SV/SV8/079.ts
@@ -1,74 +1,74 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ドータクン",
 		'zh-tw': "青銅鐘",
-		'zh-cn': "青銅鐘"
+		'zh-cn': "青銅鐘",
 	},
 
 	illustrator: "kawayoo",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [437],
 	hp: 130,
 	types: ["Metal"],
 
 	description: {
 		ja: "別世界への 穴を 開けて そこから 雨を 降らしていた。 そのため 豊作の神 とされる。",
 		'zh-tw': "打開通往其他世界的洞， 從那裡降下雨來。 因此被叫做豐收之神。",
-		'zh-cn': "打開通往其他世界的洞， 從那裡降下雨來。 因此被叫做豐收之神。"
+		'zh-cn': "打開通往其他世界的洞， 從那裡降下雨來。 因此被叫做豐收之神。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Metal", "Colorless"],
-
-		name: {
-			ja: "かいてんアタック",
-			'zh-tw': "迴轉攻擊",
-			'zh-cn': "迴轉攻擊"
+	attacks: [
+		{
+			name: {
+				ja: "かいてんアタック",
+				'zh-tw': "迴轉攻擊",
+				'zh-cn': "迴轉攻擊",
+			},
+			damage: 50,
+			cost: ["Metal", "Colorless"],
 		},
-
-		damage: 50
-	}, {
-		cost: ["Metal", "Colorless", "Colorless"],
-
-		name: {
-			ja: "ダブルインパクト",
-			'zh-tw': "雙重衝擊",
-			'zh-cn': "雙重衝擊"
+		{
+			name: {
+				ja: "ダブルインパクト",
+				'zh-tw': "雙重衝擊",
+				'zh-cn': "雙重衝擊",
+			},
+			damage: "100×",
+			cost: ["Metal", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×100ダメージ。",
+				'zh-tw': "擲2次硬幣，造成正面出現的次數×100點傷害。",
+				'zh-cn': "擲2次硬幣，造成正面出現的次數×100點傷害。",
+			},
 		},
+	],
 
-		damage: "100×",
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
 
-		effect: {
-			ja: "コインを2回投げ、オモテの数×100ダメージ。",
-			'zh-tw': "擲2次硬幣，造成正面出現的次數×100點傷害。",
-			'zh-cn': "擲2次硬幣，造成正面出現的次數×100點傷害。"
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793513,
+				tcgplayer: 587659,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "ドーミラー",
+	},
 
 	retreat: 3,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [437],
+};
 
-	thirdParty: {
-		cardmarket: 793513
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/080.ts
+++ b/data-asia/SV/SV8/080.ts
@@ -1,66 +1,75 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ムゲンダイナ",
 		'zh-tw': "無極汰那",
-		'zh-cn': "無極汰那"
+		'zh-cn': "無極汰那",
 	},
 
 	illustrator: "AKIRA EGAWA",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [890],
 	hp: 150,
 	types: ["Dragon"],
 
 	description: {
 		ja: "胸の コアが ガラル地方の 大地から 涌きだす エネルギーを 吸収して 活動している。",
 		'zh-tw': "會用胸部的核心吸收 伽勒爾的大地湧出的能量， 藉以保持自己的活力。",
-		'zh-cn': "會用胸部的核心吸收 伽勒爾的大地湧出的能量， 藉以保持自己的活力。"
+		'zh-cn': "會用胸部的核心吸收 伽勒爾的大地湧出的能量， 藉以保持自己的活力。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Darkness"],
-
-		name: {
-			ja: "ダイナブラスト",
-			'zh-tw': "汰那爆破",
-			'zh-cn': "汰那爆破"
+	attacks: [
+		{
+			name: {
+				ja: "ダイナブラスト",
+				'zh-tw': "汰那爆破",
+				'zh-cn': "汰那爆破",
+			},
+			damage: "10+",
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンが「ポケモンex」なら、80ダメージ追加。",
+				'zh-tw': "若對手的戰鬥寶可夢為「寶可夢【ex】」，則增加80點傷害。",
+				'zh-cn': "若對手的戰鬥寶可夢為「寶可夢【ex】」，則增加80點傷害。",
+			},
 		},
-
-		damage: "10+",
-
-		effect: {
-			ja: "相手のバトルポケモンが「ポケモンex」なら、80ダメージ追加。",
-			'zh-tw': "若對手的戰鬥寶可夢為「寶可夢【ex】」，則增加80點傷害。",
-			'zh-cn': "若對手的戰鬥寶可夢為「寶可夢【ex】」，則增加80點傷害。"
-		}
-	}, {
-		cost: ["Fire", "Darkness", "Darkness"],
-
-		name: {
-			ja: "ワールドエンド",
-			'zh-tw': "世界之末",
-			'zh-cn': "世界之末"
+		{
+			name: {
+				ja: "ワールドエンド",
+				'zh-tw': "世界之末",
+				'zh-cn': "世界之末",
+			},
+			damage: 230,
+			cost: ["Fire", "Darkness", "Darkness"],
+			effect: {
+				ja: "場に出ているスタジアムをトラッシュする。トラッシュできないなら、このワザは失敗。",
+				'zh-tw': "將場上的競技場卡丟棄。若無法丟棄，則這個招式失敗。",
+				'zh-cn': "將場上的競技場卡丟棄。若無法丟棄，則這個招式失敗。",
+			},
 		},
+	],
 
-		damage: 230,
+	weaknesses: [],
+	resistances: [],
 
-		effect: {
-			ja: "場に出ているスタジアムをトラッシュする。トラッシュできないなら、このワザは失敗。",
-			'zh-tw': "將場上的競技場卡丟棄。若無法丟棄，則這個招式失敗。",
-			'zh-cn': "將場上的競技場卡丟棄。若無法丟棄，則這個招式失敗。"
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793514,
+				tcgplayer: 587660,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Rare",
+	dexId: [890],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/081.ts
+++ b/data-asia/SV/SV8/081.ts
@@ -1,57 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "シャリタツex",
 		'zh-tw': "米立龍ex",
-		'zh-cn': "米立龍ex"
+		'zh-cn': "米立龍ex",
 	},
 
 	illustrator: "5ban Graphics",
-	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 160,
 	types: ["Dragon"],
+
 	stage: "Basic",
-	suffix: "EX",
 
-	attacks: [{
-		cost: ["Fire", "Water"],
-
-		name: {
-			ja: "ふいうちポンプ",
-			'zh-tw': "突襲水泵",
-			'zh-cn': "突襲水泵"
+	attacks: [
+		{
+			name: {
+				ja: "ふいうちポンプ",
+				'zh-tw': "突襲水泵",
+				'zh-cn': "突襲水泵",
+			},
+			damage: 100,
+			cost: ["Fire", "Water"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+				'zh-tw': "這個招式的傷害不計算對手的戰鬥寶可夢身上的附加效果。",
+				'zh-cn': "這個招式的傷害不計算對手的戰鬥寶可夢身上的附加效果。",
+			},
 		},
-
-		damage: 100,
-
-		effect: {
-			ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
-			'zh-tw': "這個招式的傷害不計算對手的戰鬥寶可夢身上的附加效果。",
-			'zh-cn': "這個招式的傷害不計算對手的戰鬥寶可夢身上的附加效果。"
-		}
-	}, {
-		cost: ["Fire", "Water", "Darkness"],
-
-		name: {
-			ja: "シナバールアー",
-			'zh-tw': "硃砂誘餌",
-			'zh-cn': "硃砂誘餌"
+		{
+			name: {
+				ja: "シナバールアー",
+				'zh-tw': "硃砂誘餌",
+				'zh-cn': "硃砂誘餌",
+			},
+			cost: ["Fire", "Water", "Darkness"],
+			effect: {
+				ja: "自分の山札を上から10枚見て、その中からポケモンを好きなだけ選び、ベンチに出す。残りのカードは山札にもどして切る。",
+				'zh-tw': "查看自己的牌庫上方10張卡，從其中選擇任意數量的寶可夢卡，放置於備戰區。將剩餘卡放回牌庫並重洗。",
+				'zh-cn': "查看自己的牌庫上方10張卡，從其中選擇任意數量的寶可夢卡，放置於備戰區。將剩餘卡放回牌庫並重洗。",
+			},
 		},
+	],
 
-		effect: {
-			ja: "自分の山札を上から10枚見て、その中からポケモンを好きなだけ選び、ベンチに出す。残りのカードは山札にもどして切る。",
-			'zh-tw': "查看自己的牌庫上方10張卡，從其中選擇任意數量的寶可夢卡，放置於備戰區。將剩餘卡放回牌庫並重洗。",
-			'zh-cn': "查看自己的牌庫上方10張卡，從其中選擇任意數量的寶可夢卡，放置於備戰區。將剩餘卡放回牌庫並重洗。"
-		}
-	}],
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793515,
+				tcgplayer: 587661,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Double rare",
+	dexId: [978],
 
-export default card
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV8/082.ts
+++ b/data-asia/SV/SV8/082.ts
@@ -1,57 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ナマケロ",
 		'zh-tw': "懶人獺",
-		'zh-cn': "懶人獺"
+		'zh-cn': "懶人獺",
 	},
 
 	illustrator: "Aya Kusube",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [287],
 	hp: 60,
 	types: ["Colorless"],
 
 	description: {
 		ja: "ナマケロの 怠けた 様子は 見ている 人の 怠け心を 存分に 刺激するのだ。",
 		'zh-tw': "懶人獺慵懶的樣子 會深深地刺激 看著牠的人的懶惰之心。",
-		'zh-cn': "懶人獺慵懶的樣子 會深深地刺激 看著牠的人的懶惰之心。"
+		'zh-cn': "懶人獺慵懶的樣子 會深深地刺激 看著牠的人的懶惰之心。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "のんびりする",
-			'zh-tw': "悠哉",
-			'zh-cn': "悠哉"
+	attacks: [
+		{
+			name: {
+				ja: "のんびりする",
+				'zh-tw': "悠哉",
+				'zh-cn': "悠哉",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「60」回復する。次の自分の番、このポケモンはにげられない。",
+				'zh-tw': "將這隻寶可夢恢復「60」HP。在下個自己的回合，這隻寶可夢無法撤退。",
+				'zh-cn': "將這隻寶可夢恢復「60」HP。在下個自己的回合，這隻寶可夢無法撤退。",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンのHPを「60」回復する。次の自分の番、このポケモンはにげられない。",
-			'zh-tw': "將這隻寶可夢恢復「60」HP。在下個自己的回合，這隻寶可夢無法撤退。",
-			'zh-cn': "將這隻寶可夢恢復「60」HP。在下個自己的回合，這隻寶可夢無法撤退。"
-		}
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793516,
+				tcgplayer: 587662,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [287],
+};
 
-	thirdParty: {
-		cardmarket: 793516
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/083.ts
+++ b/data-asia/SV/SV8/083.ts
@@ -1,53 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ヤルキモノ",
 		'zh-tw': "過動猿",
-		'zh-cn': "過動猿"
+		'zh-cn': "過動猿",
 	},
 
 	illustrator: "Kurata So",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [288],
 	hp: 90,
 	types: ["Colorless"],
 
 	description: {
 		ja: "いつも 暴れているので すぐに お腹が 空いてしまうが 食事の ときも じっとして いられない。",
 		'zh-tw': "由於無時無刻都在大鬧， 肚子馬上就會覺得餓， 但牠卻連吃飯時也靜不下來。",
-		'zh-cn': "由於無時無刻都在大鬧， 肚子馬上就會覺得餓， 但牠卻連吃飯時也靜不下來。"
+		'zh-cn': "由於無時無刻都在大鬧， 肚子馬上就會覺得餓， 但牠卻連吃飯時也靜不下來。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "スラッシュクロー",
-			'zh-tw': "利爪揮砍",
-			'zh-cn': "利爪揮砍"
+	attacks: [
+		{
+			name: {
+				ja: "スラッシュクロー",
+				'zh-tw': "利爪揮砍",
+				'zh-cn': "利爪揮砍",
+			},
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		damage: 50
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793517,
+				tcgplayer: 587663,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ナマケロ",
+	},
 
 	retreat: 2,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [288],
+};
 
-	thirdParty: {
-		cardmarket: 793517
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/084.ts
+++ b/data-asia/SV/SV8/084.ts
@@ -1,68 +1,77 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ケッキングex",
 		'zh-tw': "請假王ex",
-		'zh-cn': "請假王ex"
+		'zh-cn': "請假王ex",
 	},
 
 	illustrator: "PLANETA Igarashi",
-	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 340,
 	types: ["Colorless"],
+
 	stage: "Stage2",
-	suffix: "EX",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "さぼりたいしつ",
-			'zh-tw': "懶怠個性",
-			'zh-cn': "懶怠個性"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "さぼりたいしつ",
+				'zh-tw': "懶怠個性",
+				'zh-cn': "懶怠個性",
+			},
+			effect: {
+				ja: "相手の場に「ポケモンex・V」がいないなら、このポケモンはワザが使えない。",
+				'zh-tw': "若對手的場上沒有「寶可夢【ex】・【V】」，則這隻寶可夢無法使用招式。",
+				'zh-cn': "若對手的場上沒有「寶可夢【ex】・【V】」，則這隻寶可夢無法使用招式。",
+			},
 		},
+	],
 
-		effect: {
-			ja: "相手の場に「ポケモンex・V」がいないなら、このポケモンはワザが使えない。",
-			'zh-tw': "若對手的場上沒有「寶可夢【ex】・【V】」，則這隻寶可夢無法使用招式。",
-			'zh-cn': "若對手的場上沒有「寶可夢【ex】・【V】」，則這隻寶可夢無法使用招式。"
-		}
-	}],
-
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "グレートスイング",
-			'zh-tw': "偉大橫掃",
-			'zh-cn': "偉大橫掃"
+	attacks: [
+		{
+			name: {
+				ja: "グレートスイング",
+				'zh-tw': "偉大橫掃",
+				'zh-cn': "偉大橫掃",
+			},
+			damage: 280,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。",
+				'zh-cn': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		damage: 280,
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
-			'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。",
-			'zh-cn': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。"
-		}
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793518,
+				tcgplayer: 587664,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ヤルキモノ",
+	},
 
 	retreat: 4,
 	regulationMark: "H",
+	rarity: "Double rare",
+	dexId: [289],
 
-	thirdParty: {
-		cardmarket: 793518
-	}
-}
+	suffix: "EX",
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/085.ts
+++ b/data-asia/SV/SV8/085.ts
@@ -1,59 +1,61 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ザングース",
 		'zh-tw': "貓鼬斬",
-		'zh-cn': "貓鼬斬"
+		'zh-cn': "貓鼬斬",
 	},
 
 	illustrator: "Ligton",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [335],
 	hp: 90,
 	types: ["Colorless"],
 
 	description: {
 		ja: "ハブネークに 出会うと 体毛が 逆立ち 攻撃態勢になる。 鋭い ツメが 最大の 武器。",
 		'zh-tw': "遇上飯匙蛇就會豎起體毛， 擺出攻擊的架勢。 銳利的爪子是最大的武器。",
-		'zh-cn': "遇上飯匙蛇就會豎起體毛， 擺出攻擊的架勢。 銳利的爪子是最大的武器。"
+		'zh-cn': "遇上飯匙蛇就會豎起體毛， 擺出攻擊的架勢。 銳利的爪子是最大的武器。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "れんぞくぎり",
-			'zh-tw': "連斬",
-			'zh-cn': "連斬"
+	attacks: [
+		{
+			name: {
+				ja: "れんぞくぎり",
+				'zh-tw': "連斬",
+				'zh-cn': "連斬",
+			},
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを3回投げる。オモテが1回なら、20ダメージ追加。オモテが2回なら、50ダメージ追加。すべてオモテなら、80ダメージ追加。",
+				'zh-tw': "擲3次硬幣。若出現1次正面，則增加20點傷害。若出現2次正面，則增加50點傷害。若全部為正面，則增加80點傷害。",
+				'zh-cn': "擲3次硬幣。若出現1次正面，則增加20點傷害。若出現2次正面，則增加50點傷害。若全部為正面，則增加80點傷害。",
+			},
 		},
+	],
 
-		damage: "10+",
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "コインを3回投げる。オモテが1回なら、20ダメージ追加。オモテが2回なら、50ダメージ追加。すべてオモテなら、80ダメージ追加。",
-			'zh-tw': "擲3次硬幣。若出現1次正面，則增加20點傷害。若出現2次正面，則增加50點傷害。若全部為正面，則增加80點傷害。",
-			'zh-cn': "擲3次硬幣。若出現1次正面，則增加20點傷害。若出現2次正面，則增加50點傷害。若全部為正面，則增加80點傷害。"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793519,
+				tcgplayer: 587665,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [335],
+};
 
-	thirdParty: {
-		cardmarket: 793519
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/086.ts
+++ b/data-asia/SV/SV8/086.ts
@@ -1,73 +1,76 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "カクレオン",
 		'zh-tw': "變隱龍",
-		'zh-cn': "變隱龍"
+		'zh-cn': "變隱龍",
 	},
 
 	illustrator: "Shinji Kanda",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [352],
 	hp: 70,
 	types: ["Colorless"],
 
 	description: {
 		ja: "身体の 色を 変えて 景色に 溶け込む。 長く かまわないでいると スネて 姿を 見せなくなる。",
 		'zh-tw': "能改變體色，融入周圍的景色中。 如果長時間不去理會牠， 牠就會鬧彆扭而不肯現身。",
-		'zh-cn': "能改變體色，融入周圍的景色中。 如果長時間不去理會牠， 牠就會鬧彆扭而不肯現身。"
+		'zh-cn': "能改變體色，融入周圍的景色中。 如果長時間不去理會牠， 牠就會鬧彆扭而不肯現身。",
 	},
 
 	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			ja: "かくれじょうず",
-			'zh-tw': "躲藏高手",
-			'zh-cn': "躲藏高手"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "かくれじょうず",
+				'zh-tw': "躲藏高手",
+				'zh-cn': "躲藏高手",
+			},
+			effect: {
+				ja: "このポケモンがワザのダメージを受けるとき、自分はコインを1回投げる。オモテなら、このポケモンはそのダメージを受けない。",
+				'zh-tw': "這隻寶可夢受到招式的傷害時，自己擲1次硬幣。若為正面，則這隻寶可夢不會受到那個傷害。",
+				'zh-cn': "這隻寶可夢受到招式的傷害時，自己擲1次硬幣。若為正面，則這隻寶可夢不會受到那個傷害。",
+			},
 		},
+	],
 
-		effect: {
-			ja: "このポケモンがワザのダメージを受けるとき、自分はコインを1回投げる。オモテなら、このポケモンはそのダメージを受けない。",
-			'zh-tw': "這隻寶可夢受到招式的傷害時，自己擲1次硬幣。若為正面，則這隻寶可夢不會受到那個傷害。",
-			'zh-cn': "這隻寶可夢受到招式的傷害時，自己擲1次硬幣。若為正面，則這隻寶可夢不會受到那個傷害。"
-		}
-	}],
-
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "ベロウィップ",
-			'zh-tw': "舌之鞭打",
-			'zh-cn': "舌之鞭打"
+	attacks: [
+		{
+			name: {
+				ja: "ベロウィップ",
+				'zh-tw': "舌之鞭打",
+				'zh-cn': "舌之鞭打",
+			},
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "對手的1隻寶可夢受到30點傷害。[在備戰區不計算弱點・抵抗力。]",
+				'zh-cn': "對手的1隻寶可夢受到30點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		effect: {
-			ja: "相手のポケモン1匹に、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
-			'zh-tw': "對手的1隻寶可夢受到30點傷害。[在備戰區不計算弱點・抵抗力。]",
-			'zh-cn': "對手的1隻寶可夢受到30點傷害。[在備戰區不計算弱點・抵抗力。]"
-		}
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793520,
+				tcgplayer: 587666,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [352],
+};
 
-	thirdParty: {
-		cardmarket: 793520
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/087.ts
+++ b/data-asia/SV/SV8/087.ts
@@ -1,75 +1,75 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "バッフロン",
 		'zh-tw': "爆炸頭水牛",
-		'zh-cn': "爆炸頭水牛"
+		'zh-cn': "爆炸頭水牛",
 	},
 
 	illustrator: "Anesaki Dynamic",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [626],
 	hp: 130,
 	types: ["Colorless"],
 
 	description: {
 		ja: "頭突きだけで 車を 潰す。 頭の 毛が 大きいほど 群れでの 地位が 上がるのだ。",
 		'zh-tw': "只用頭錘就能壓扁汽車。 頭部的那團毛越大一團， 在群體裡的地位就會越高。",
-		'zh-cn': "只用頭錘就能壓扁汽車。 頭部的那團毛越大一團， 在群體裡的地位就會越高。"
+		'zh-cn': "只用頭錘就能壓扁汽車。 頭部的那團毛越大一團， 在群體裡的地位就會越高。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless", "Colorless"],
-
-		name: {
-			ja: "まちうけホーン",
-			'zh-tw': "等待角擊",
-			'zh-cn': "等待角擊"
+	attacks: [
+		{
+			name: {
+				ja: "まちうけホーン",
+				'zh-tw': "等待角擊",
+				'zh-cn': "等待角擊",
+			},
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンがワザのダメージを受けたとき、ワザを使ったポケモンにダメカンを6個のせる。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害時，在使用招式的寶可夢身上放置6個傷害指示物。",
+				'zh-cn': "在下個對手的回合，這隻寶可夢受到招式的傷害時，在使用招式的寶可夢身上放置6個傷害指示物。",
+			},
 		},
-
-		damage: 40,
-
-		effect: {
-			ja: "次の相手の番、このポケモンがワザのダメージを受けたとき、ワザを使ったポケモンにダメカンを6個のせる。",
-			'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害時，在使用招式的寶可夢身上放置6個傷害指示物。",
-			'zh-cn': "在下個對手的回合，這隻寶可夢受到招式的傷害時，在使用招式的寶可夢身上放置6個傷害指示物。"
-		}
-	}, {
-		cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
-
-		name: {
-			ja: "スマッシュヘッド",
-			'zh-tw': "粉碎頭擊",
-			'zh-cn': "粉碎頭擊"
+		{
+			name: {
+				ja: "スマッシュヘッド",
+				'zh-tw': "粉碎頭擊",
+				'zh-cn': "粉碎頭擊",
+			},
+			damage: 150,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+				'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。",
+				'zh-cn': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		damage: 150,
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
-			'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。",
-			'zh-cn': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793521,
+				tcgplayer: 587667,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [626],
+};
 
-	thirdParty: {
-		cardmarket: 793521
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/088.ts
+++ b/data-asia/SV/SV8/088.ts
@@ -1,69 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "エリキテル",
 		'zh-tw': "傘電蜥",
-		'zh-cn': "傘電蜥"
+		'zh-cn': "傘電蜥",
 	},
 
 	illustrator: "miki kudo",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [694],
 	hp: 70,
 	types: ["Colorless"],
 
 	description: {
 		ja: "頭の ひだを 広げ 太陽の 光で 発電すると パワフルな 電気技を 出せるようになる。",
 		'zh-tw': "當牠張開頭部的褶邊 用太陽光發電，就能使出 威力強大的電屬性招式。",
-		'zh-cn': "當牠張開頭部的褶邊 用太陽光發電，就能使出 威力強大的電屬性招式。"
+		'zh-cn': "當牠張開頭部的褶邊 用太陽光發電，就能使出 威力強大的電屬性招式。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "プチボルト",
-			'zh-tw': "小伏特",
-			'zh-cn': "小伏特"
+	attacks: [
+		{
+			name: {
+				ja: "プチボルト",
+				'zh-tw': "小伏特",
+				'zh-cn': "小伏特",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
-
-		damage: 10
-	}, {
-		cost: ["Colorless", "Colorless", "Colorless"],
-
-		name: {
-			ja: "とつげき",
-			'zh-tw': "突擊",
-			'zh-cn': "突擊"
+		{
+			name: {
+				ja: "とつげき",
+				'zh-tw': "突擊",
+				'zh-cn': "突擊",
+			},
+			damage: 40,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも10ダメージ。",
+				'zh-tw': "這隻寶可夢也受到10點傷害。",
+				'zh-cn': "這隻寶可夢也受到10點傷害。",
+			},
 		},
+	],
 
-		damage: 40,
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "このポケモンにも10ダメージ。",
-			'zh-tw': "這隻寶可夢也受到10點傷害。",
-			'zh-cn': "這隻寶可夢也受到10點傷害。"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793522,
+				tcgplayer: 587668,
+			},
+		},
+	],
 
 	retreat: 1,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [694],
+};
 
-	thirdParty: {
-		cardmarket: 793522
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/089.ts
+++ b/data-asia/SV/SV8/089.ts
@@ -1,67 +1,73 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "エレザード",
 		'zh-tw': "光電傘蜥",
-		'zh-cn': "光電傘蜥"
+		'zh-cn': "光電傘蜥",
 	},
 
 	illustrator: "Ryota Murayama",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [695],
 	hp: 110,
 	types: ["Colorless"],
 
 	description: {
 		ja: "襟巻を 広げて 太陽光を 浴びると 大都会で 使われる 電気を １匹で 発電する。",
 		'zh-tw': "如果展開頸傘沐浴陽光， 單憑１隻光電傘蜥就能 製造出大城市所需的電力。",
-		'zh-cn': "如果展開頸傘沐浴陽光， 單憑１隻光電傘蜥就能 製造出大城市所需的電力。"
+		'zh-cn': "如果展開頸傘沐浴陽光， 單憑１隻光電傘蜥就能 製造出大城市所需的電力。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "パラボラチャージ",
-			'zh-tw': "拋物面充電",
-			'zh-cn': "拋物面充電"
+	attacks: [
+		{
+			name: {
+				ja: "パラボラチャージ",
+				'zh-tw': "拋物面充電",
+				'zh-cn': "拋物面充電",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からエネルギーを4枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多4張能量卡，在給對手看過後加入手牌。並且重洗牌庫。",
+				'zh-cn': "從自己的牌庫選擇最多4張能量卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			ja: "自分の山札からエネルギーを4枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
-			'zh-tw': "從自己的牌庫選擇最多4張能量卡，在給對手看過後加入手牌。並且重洗牌庫。",
-			'zh-cn': "從自己的牌庫選擇最多4張能量卡，在給對手看過後加入手牌。並且重洗牌庫。"
-		}
-	}, {
-		cost: ["Colorless", "Colorless", "Colorless"],
-
-		name: {
-			ja: "エレキスラッグ",
-			'zh-tw': "電氣猛擊",
-			'zh-cn': "電氣猛擊"
+		{
+			name: {
+				ja: "エレキスラッグ",
+				'zh-tw': "電氣猛擊",
+				'zh-cn': "電氣猛擊",
+			},
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 80
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793523,
+				tcgplayer: 587669,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "エリキテル",
+	},
 
 	retreat: 1,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [695],
+};
 
-	thirdParty: {
-		cardmarket: 793523
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/090.ts
+++ b/data-asia/SV/SV8/090.ts
@@ -1,67 +1,69 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ヤレユータン",
 		'zh-tw': "智揮猩",
-		'zh-cn': "智揮猩"
+		'zh-cn': "智揮猩",
 	},
 
 	illustrator: "Saboteri",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [765],
 	hp: 120,
 	types: ["Colorless"],
 
 	description: {
 		ja: "森の奥で 静かに 暮らす。 マントのような 紫の 毛は 歳を 重ねるほどに 長くなる。",
 		'zh-tw': "在森林深處過著安靜的生活。 如同斗蓬般的紫色體毛 會隨著年齡而越變越長。",
-		'zh-cn': "在森林深處過著安靜的生活。 如同斗蓬般的紫色體毛 會隨著年齡而越變越長。"
+		'zh-cn': "在森林深處過著安靜的生活。 如同斗蓬般的紫色體毛 會隨著年齡而越變越長。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "よわみをにぎる",
-			'zh-tw': "掌握弱點",
-			'zh-cn': "掌握弱點"
+	attacks: [
+		{
+			name: {
+				ja: "よわみをにぎる",
+				'zh-tw': "掌握弱點",
+				'zh-cn': "掌握弱點",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の自分の番の終わりまで、このワザを受けたポケモンの弱点は[C]タイプになる。［弱点は「×2」でダメージ計算をする。］",
+				'zh-tw': "在下個自己的回合結束前，受到這個招式的寶可夢弱點改爲【無】屬性。[弱點以「×2」計算傷害。]",
+				'zh-cn': "在下個自己的回合結束前，受到這個招式的寶可夢弱點改爲【無】屬性。[弱點以「×2」計算傷害。]",
+			},
 		},
-
-		effect: {
-			ja: "次の自分の番の終わりまで、このワザを受けたポケモンの弱点はタイプになる。［弱点は「×2」でダメージ計算をする。］",
-			'zh-tw': "在下個自己的回合結束前，受到這個招式的寶可夢弱點改爲【無】屬性。[弱點以「×2」計算傷害。]",
-			'zh-cn': "在下個自己的回合結束前，受到這個招式的寶可夢弱點改爲【無】屬性。[弱點以「×2」計算傷害。]"
-		}
-	}, {
-		cost: ["Colorless", "Colorless", "Colorless"],
-
-		name: {
-			ja: "ひらてうち",
-			'zh-tw': "掌擊",
-			'zh-cn': "掌擊"
+		{
+			name: {
+				ja: "ひらてうち",
+				'zh-tw': "掌擊",
+				'zh-cn': "掌擊",
+			},
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 80
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793524,
+				tcgplayer: 587670,
+			},
+		},
+	],
 
 	retreat: 2,
 	regulationMark: "H",
+	rarity: "Common",
+	dexId: [765],
+};
 
-	thirdParty: {
-		cardmarket: 793524
-	}
-}
-
-export default card
+export default card;

--- a/data-asia/SV/SV8/091.ts
+++ b/data-asia/SV/SV8/091.ts
@@ -1,55 +1,61 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ワッカネズミ",
 		'zh-tw': "一對鼠",
-		'zh-cn': "一對鼠"
+		'zh-cn': "一對鼠",
 	},
 
 	illustrator: "USGMEN",
-	rarity: "Common",
 	category: "Pokemon",
-	dexId: [924],
 	hp: 40,
 	types: ["Colorless"],
 
 	description: {
 		ja: "どんなときでも ２匹は 一緒。 見つけた エサは ぴったりと 半分こして 仲良く 食べる。",
 		'zh-tw': "無論何時２隻都待在一起。 會把尋獲的食物均分成兩半， 親密無間地一同進食。",
-		'zh-cn': "無論何時２隻都待在一起。 會把尋獲的食物均分成兩半， 親密無間地一同進食。"
+		'zh-cn': "無論何時２隻都待在一起。 會把尋獲的食物均分成兩半， 親密無間地一同進食。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "じゃれつく",
-			'zh-tw': "嬉鬧",
-			'zh-cn': "嬉鬧"
+	attacks: [
+		{
+			name: {
+				ja: "じゃれつく",
+				'zh-tw': "嬉鬧",
+				'zh-cn': "嬉鬧",
+			},
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、10ダメージ追加。",
+				'zh-tw': "擲1次硬幣若為正面，則增加10點傷害。",
+				'zh-cn': "擲1次硬幣若為正面，則增加10點傷害。",
+			},
 		},
+	],
 
-		damage: "10+",
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "コインを1回投げオモテなら、10ダメージ追加。",
-			'zh-tw': "擲1次硬幣若為正面，則增加10點傷害。",
-			'zh-cn': "擲1次硬幣若為正面，則增加10點傷害。"
-		}
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793525,
+				tcgplayer: 587671,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Common",
+	dexId: [924],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/092.ts
+++ b/data-asia/SV/SV8/092.ts
@@ -1,69 +1,78 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "イッカネズミ",
 		'zh-tw': "一家鼠",
-		'zh-cn': "一家鼠"
+		'zh-cn': "一家鼠",
 	},
 
 	illustrator: "DOM",
-	rarity: "Uncommon",
 	category: "Pokemon",
-	dexId: [925],
 	hp: 80,
 	types: ["Colorless"],
 
 	description: {
 		ja: "大きな ２匹が 子どもたちを 守りながら 戦う。 強い 相手には 全員で 立ち向かう。",
 		'zh-tw': "身型大的２隻會在戰鬥的 同時保護著孩子。對抗實力 強大的對手時會集體出陣。",
-		'zh-cn': "身型大的２隻會在戰鬥的 同時保護著孩子。對抗實力 強大的對手時會集體出陣。"
+		'zh-cn': "身型大的２隻會在戰鬥的 同時保護著孩子。對抗實力 強大的對手時會集體出陣。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "ファミリーマーチ",
-			'zh-tw': "家族行軍",
-			'zh-cn': "家族行軍"
+	attacks: [
+		{
+			name: {
+				ja: "ファミリーマーチ",
+				'zh-tw': "家族行軍",
+				'zh-cn': "家族行軍",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から「イッカネズミ（『ポケモンex』をふくむ）」を2枚まで選び、ベンチに出す。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多2張「一家鼠（包含『寶可夢【ex】』）」，放置於備戰區。並且重洗牌庫。",
+				'zh-cn': "從自己的牌庫選擇最多2張「一家鼠（包含『寶可夢【ex】』）」，放置於備戰區。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			ja: "自分の山札から「イッカネズミ（『ポケモンex』をふくむ）」を2枚まで選び、ベンチに出す。そして山札を切る。",
-			'zh-tw': "從自己的牌庫選擇最多2張「一家鼠（包含『寶可夢【ex】』）」，放置於備戰區。並且重洗牌庫。",
-			'zh-cn': "從自己的牌庫選擇最多2張「一家鼠（包含『寶可夢【ex】』）」，放置於備戰區。並且重洗牌庫。"
-		}
-	}, {
-		cost: ["Colorless"],
-
-		name: {
-			ja: "れんぞくまえば",
-			'zh-tw': "連續門牙",
-			'zh-cn': "連續門牙"
+		{
+			name: {
+				ja: "れんぞくまえば",
+				'zh-tw': "連續門牙",
+				'zh-cn': "連續門牙",
+			},
+			damage: "30×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを4回投げ、オモテの数×30ダメージ。",
+				'zh-tw': "擲4次硬幣，造成正面出現的次數×30點傷害。",
+				'zh-cn': "擲4次硬幣，造成正面出現的次數×30點傷害。",
+			},
 		},
+	],
 
-		damage: "30×",
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-		effect: {
-			ja: "コインを4回投げ、オモテの数×30ダメージ。",
-			'zh-tw': "擲4次硬幣，造成正面出現的次數×30點傷害。",
-			'zh-cn': "擲4次硬幣，造成正面出現的次數×30點傷害。"
-		}
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793526,
+				tcgplayer: 587672,
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ワッカネズミ",
+	},
 
 	retreat: 1,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Uncommon",
+	dexId: [925],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/093.ts
+++ b/data-asia/SV/SV8/093.ts
@@ -1,63 +1,69 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "テラパゴス",
 		'zh-tw': "太樂巴戈斯",
-		'zh-cn': "太樂巴戈斯"
+		'zh-cn': "太樂巴戈斯",
 	},
 
 	illustrator: "GIDORA",
-	rarity: "Rare",
 	category: "Pokemon",
-	dexId: [1024],
 	hp: 120,
 	types: ["Colorless"],
 
 	description: {
 		ja: "テラスタルの 甲羅は 相手の 技を 受けると そのエネルギーを 吸い取って 自分のものにする。",
 		'zh-tw': "太晶的甲殼若受到對手的 招式攻擊，就會把該招式 的能量吸收來供自己使用。",
-		'zh-cn': "太晶的甲殼若受到對手的 招式攻擊，就會把該招式 的能量吸收來供自己使用。"
+		'zh-cn': "太晶的甲殼若受到對手的 招式攻擊，就會把該招式 的能量吸收來供自己使用。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		cost: ["Colorless"],
-
-		name: {
-			ja: "プリズムチャージ",
-			'zh-tw': "稜鏡充能",
-			'zh-cn': "稜鏡充能"
+	attacks: [
+		{
+			name: {
+				ja: "プリズムチャージ",
+				'zh-tw': "稜鏡充能",
+				'zh-cn': "稜鏡充能",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から、それぞれちがうタイプの基本エネルギーを3枚まで選び、自分の「テラスタル」のポケモンに好きなようにつける。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多3張各不同屬性的基本能量卡，以任意方式附於自己的「太晶」寶可夢身上。並且重洗牌庫。",
+				'zh-cn': "從自己的牌庫選擇最多3張各不同屬性的基本能量卡，以任意方式附於自己的「太晶」寶可夢身上。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			ja: "自分の山札から、それぞれちがうタイプの基本エネルギーを3枚まで選び、自分の「テラスタル」のポケモンに好きなようにつける。そして山札を切る。",
-			'zh-tw': "從自己的牌庫選擇最多3張各不同屬性的基本能量卡，以任意方式附於自己的「太晶」寶可夢身上。並且重洗牌庫。",
-			'zh-cn': "從自己的牌庫選擇最多3張各不同屬性的基本能量卡，以任意方式附於自己的「太晶」寶可夢身上。並且重洗牌庫。"
-		}
-	}, {
-		cost: ["Colorless", "Colorless", "Colorless"],
-
-		name: {
-			ja: "ハードタックル",
-			'zh-tw': "堅硬衝撞",
-			'zh-cn': "堅硬衝撞"
+		{
+			name: {
+				ja: "ハードタックル",
+				'zh-tw': "堅硬衝撞",
+				'zh-cn': "堅硬衝撞",
+			},
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 100
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793527,
+				tcgplayer: 587673,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "H"
-}
+	regulationMark: "H",
+	rarity: "Rare",
+	dexId: [1024],
+};
 
-export default card
+export default card;

--- a/data-asia/SV/SV8/094.ts
+++ b/data-asia/SV/SV8/094.ts
@@ -1,27 +1,36 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "推理セット",
 		'zh-tw': "推理組合",
-		'zh-cn': "推理組合"
+		'zh-cn': "推理組合",
 	},
 
 	illustrator: "AYUMI ODASHIMA",
-	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {
 		ja: "自分の山札を上から3枚見て、好きな順番に入れ替えて、山札の上にもどす。または、そのカードをすべてウラにして切り、山札の下にもどす。",
 		'zh-tw': "查看自己的牌庫上方3張卡，以任意順序排列，放回牌庫上方。或者將那些卡全部翻回反面並重洗，放回牌庫下方。",
-		'zh-cn': "查看自己的牌庫上方3張卡，以任意順序排列，放回牌庫上方。或者將那些卡全部翻回反面並重洗，放回牌庫下方。"
+		'zh-cn': "查看自己的牌庫上方3張卡，以任意順序排列，放回牌庫上方。或者將那些卡全部翻回反面並重洗，放回牌庫下方。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "H"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793528,
+				tcgplayer: 587674,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "H",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SV/SV8/096.ts
+++ b/data-asia/SV/SV8/096.ts
@@ -1,27 +1,36 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "のんびりじゃらし",
 		'zh-tw': "悠哉尾草棒",
-		'zh-cn': "悠哉尾草棒"
+		'zh-cn': "悠哉尾草棒",
 	},
 
 	illustrator: "AYUMI ODASHIMA",
-	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {
-		ja: "このカードは、後攻プレイヤーの最初の番しか使えない。\n\n相手の場のポケモンについているエネルギーを1個選び、相手の手札にもどす。",
+		ja: "このカードは、後攻プレイヤーの最初の番しか使えない。相手の場のポケモンについているエネルギーを1個選び、相手の手札にもどす。",
 		'zh-tw': "這張卡只可在後攻玩家的最初回合使用。 選擇1個對手的場上寶可夢身上附加的能量，放回對手的手牌。",
-		'zh-cn': "這張卡只可在後攻玩家的最初回合使用。 選擇1個對手的場上寶可夢身上附加的能量，放回對手的手牌。"
+		'zh-cn': "這張卡只可在後攻玩家的最初回合使用。 選擇1個對手的場上寶可夢身上附加的能量，放回對手的手牌。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "H"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793530,
+				tcgplayer: 587676,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "H",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SV/SV8/097.ts
+++ b/data-asia/SV/SV8/097.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ミラクルインカム",
 		'zh-tw': "奇跡耳麥",
-		'zh-cn': "奇跡耳麥"
+		'zh-cn': "奇跡耳麥",
 	},
 
 	illustrator: "inose yukie",
@@ -16,12 +15,22 @@ const card: Card = {
 	effect: {
 		ja: "自分のトラッシュからサポートを2枚まで選び、相手に見せて、手札に加える。",
 		'zh-tw': "從自己的棄牌區選擇最多2張支援者卡，在給對手看過後加入手牌。",
-		'zh-cn': "從自己的棄牌區選擇最多2張支援者卡，在給對手看過後加入手牌。"
+		'zh-cn': "從自己的棄牌區選擇最多2張支援者卡，在給對手看過後加入手牌。",
 	},
 
-	trainerType: "Item",
-	rarity: "None",
-	regulationMark: "H"
-}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793531,
+				tcgplayer: 587677,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Item",
+	regulationMark: "H",
+	rarity: "ACE SPEC Rare",
+};
+
+export default card;

--- a/data-asia/SV/SV8/098.ts
+++ b/data-asia/SV/SV8/098.ts
@@ -1,13 +1,12 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "希望のアミュレット",
 		'zh-tw': "希望護身符",
-		'zh-cn': "希望護身符"
+		'zh-cn': "希望護身符",
 	},
 
 	illustrator: "Toyste Beach",
@@ -16,12 +15,22 @@ const card: Card = {
 	effect: {
 		ja: "このカードをつけているポケモンが、相手のポケモンからワザのダメージを受けてきぜつしたとき、自分の山札から好きなカードを3枚まで選び、手札に加える。そして山札を切る。",
 		'zh-tw': "附有這張卡的寶可夢受到對手的寶可夢招式的傷害而【昏厥】時，從自己的牌庫任意選擇最多3張卡加入手牌。並且重洗牌庫。",
-		'zh-cn': "附有這張卡的寶可夢受到對手的寶可夢招式的傷害而【昏厥】時，從自己的牌庫任意選擇最多3張卡加入手牌。並且重洗牌庫。"
+		'zh-cn': "附有這張卡的寶可夢受到對手的寶可夢招式的傷害而【昏厥】時，從自己的牌庫任意選擇最多3張卡加入手牌。並且重洗牌庫。",
 	},
 
-	trainerType: "Tool",
-	rarity: "None",
-	regulationMark: "H"
-}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793532,
+				tcgplayer: 587678,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Tool",
+	regulationMark: "H",
+	rarity: "ACE SPEC Rare",
+};
+
+export default card;

--- a/data-asia/SV/SV8/099.ts
+++ b/data-asia/SV/SV8/099.ts
@@ -1,27 +1,36 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ナモのみ",
 		'zh-tw': "刺耳果",
-		'zh-cn': "刺耳果"
+		'zh-cn': "刺耳果",
 	},
 
 	illustrator: "Studio Bora Inc.",
-	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {
-		ja: "このカードをつけているポケモンが、相手のポケモンからワザのダメージを受けるとき、そのダメージは「-60」され、このカードをトラッシュする。",
+		ja: "このカードをつけているポケモンが、相手の[D]ポケモンからワザのダメージを受けるとき、そのダメージは「-60」され、このカードをトラッシュする。",
 		'zh-tw': "附有這張卡的寶可夢受到對手的【惡】寶可夢招式的傷害時，那個傷害「-60」點，將這張卡丟棄。",
-		'zh-cn': "附有這張卡的寶可夢受到對手的【惡】寶可夢招式的傷害時，那個傷害「-60」點，將這張卡丟棄。"
+		'zh-cn': "附有這張卡的寶可夢受到對手的【惡】寶可夢招式的傷害時，那個傷害「-60」點，將這張卡丟棄。",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "H"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793533,
+				tcgplayer: 587679,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Tool",
+	regulationMark: "H",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SV/SV8/100.ts
+++ b/data-asia/SV/SV8/100.ts
@@ -1,27 +1,36 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "リリバのみ",
 		'zh-tw': "霹霹果",
-		'zh-cn': "霹霹果"
+		'zh-cn': "霹霹果",
 	},
 
 	illustrator: "Studio Bora Inc.",
-	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {
-		ja: "このカードをつけているポケモンが、相手のポケモンからワザのダメージを受けるとき、そのダメージは「-60」され、このカードをトラッシュする。",
+		ja: "このカードをつけているポケモンが、相手の[M]ポケモンからワザのダメージを受けるとき、そのダメージは「-60」され、このカードをトラッシュする。",
 		'zh-tw': "附有這張卡的寶可夢受到對手的【鋼】寶可夢招式的傷害時，那個傷害「-60」點，將這張卡丟棄。",
-		'zh-cn': "附有這張卡的寶可夢受到對手的【鋼】寶可夢招式的傷害時，那個傷害「-60」點，將這張卡丟棄。"
+		'zh-cn': "附有這張卡的寶可夢受到對手的【鋼】寶可夢招式的傷害時，那個傷害「-60」點，將這張卡丟棄。",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "H"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793534,
+				tcgplayer: 587680,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Tool",
+	regulationMark: "H",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SV/SV8/101.ts
+++ b/data-asia/SV/SV8/101.ts
@@ -1,27 +1,46 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ワザマシン フローライト",
 		'zh-tw': "招式學習器 螢石",
-		'zh-cn': "招式學習器 螢石"
+		'zh-cn': "招式學習器 螢石",
 	},
 
 	illustrator: "Studio Bora Inc.",
-	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {
 		ja: "このカードをつけているポケモンは、このカードに書かれているワザを使える。［ワザを使うためのエネルギーは必要。］ ポケモンについているこのカードは、自分の番の終わりにトラッシュする。",
 		'zh-tw': "附有這張卡的寶可夢，可使用這張卡上寫的招式。[需要有足夠使用招式的能量。]將附於寶可夢身上的這張卡，在自己的回合結束時丟棄。",
-		'zh-cn': "附有這張卡的寶可夢，可使用這張卡上寫的招式。[需要有足夠使用招式的能量。]將附於寶可夢身上的這張卡，在自己的回合結束時丟棄。"
+		'zh-cn': "附有這張卡的寶可夢，可使用這張卡上寫的招式。[需要有足夠使用招式的能量。]將附於寶可夢身上的這張卡，在自己的回合結束時丟棄。",
 	},
 
-	trainerType: "Tool",
-	regulationMark: "H"
-}
+	attacks: [
+		{
+			name: { ja: "フローライト" },
+			cost: ["Grass", "Water", "Psychic"],
+			effect: {
+				ja: "このポケモンについているエネルギーをすべてトラッシュし、自分の「テラスタル」のポケモン全員のHPを、すべて回復する。",
+			},
+		},
+	],
 
-export default card
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793535,
+				tcgplayer: 587681,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "H",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SV/SV8/102.ts
+++ b/data-asia/SV/SV8/102.ts
@@ -1,27 +1,36 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "シアノ",
 		'zh-tw': "席藍",
-		'zh-cn': "席藍"
+		'zh-cn': "席藍",
 	},
 
 	illustrator: "Akira Komayama",
-	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {
 		ja: "自分の山札から「ポケモンex」を3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
 		'zh-tw': "從自己的牌庫選擇最多3張「寶可夢【ex】」卡，在給對手看過後加入手牌。並且重洗牌庫。",
-		'zh-cn': "從自己的牌庫選擇最多3張「寶可夢【ex】」卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		'zh-cn': "從自己的牌庫選擇最多3張「寶可夢【ex】」卡，在給對手看過後加入手牌。並且重洗牌庫。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "H"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793536,
+				tcgplayer: 587682,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "H",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SV/SV8/103.ts
+++ b/data-asia/SV/SV8/103.ts
@@ -1,27 +1,36 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "シトロンの機転",
 		'zh-tw': "希特隆的機智",
-		'zh-cn': "希特隆的機智"
+		'zh-cn': "希特隆的機智",
 	},
 
 	illustrator: "Naoki Saito",
-	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {
-		ja: "自分のポケモン全員のHPを、それぞれ「60」回復する。",
+		ja: "自分の[L]ポケモン全員のHPを、それぞれ「60」回復する。",
 		'zh-tw': "將自己的所有【雷】寶可夢各恢復「60」HP。",
-		'zh-cn': "將自己的所有【雷】寶可夢各恢復「60」HP。"
+		'zh-cn': "將自己的所有【雷】寶可夢各恢復「60」HP。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "H"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793537,
+				tcgplayer: 587683,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "H",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SV/SV8/104.ts
+++ b/data-asia/SV/SV8/104.ts
@@ -1,27 +1,36 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ミカンのまなざし",
 		'zh-tw': "阿蜜的目光",
-		'zh-cn': "阿蜜的目光"
+		'zh-cn': "阿蜜的目光",
 	},
 
 	illustrator: "Taira Akitsu",
-	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {
 		ja: "次の相手の番、自分のポケモン全員が、相手のポケモンから受けるワザのダメージは「-30」される。（新しく場に出したポケモンもふくむ。）",
 		'zh-tw': "在下個對手的回合，自己的所有寶可夢受到對手的寶可夢招式的傷害「-30」點。（包含新上場的寶可夢。）",
-		'zh-cn': "在下個對手的回合，自己的所有寶可夢受到對手的寶可夢招式的傷害「-30」點。（包含新上場的寶可夢。）"
+		'zh-cn': "在下個對手的回合，自己的所有寶可夢受到對手的寶可夢招式的傷害「-30」點。（包含新上場的寶可夢。）",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "H"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793538,
+				tcgplayer: 587684,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "H",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SV/SV8/105.ts
+++ b/data-asia/SV/SV8/105.ts
@@ -1,27 +1,36 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "エキサイトスタジアム",
 		'zh-tw': "激動競技場",
-		'zh-cn': "激動競技場"
+		'zh-cn': "激動競技場",
 	},
 
 	illustrator: "imoniii",
-	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {
 		ja: "おたがいの場のたねポケモン全員の最大HPは、それぞれ「＋30」される。",
 		'zh-tw': "雙方場上所有【基礎】寶可夢的最大HP各「+30」。",
-		'zh-cn': "雙方場上所有【基礎】寶可夢的最大HP各「+30」。"
+		'zh-cn': "雙方場上所有【基礎】寶可夢的最大HP各「+30」。",
 	},
 
-	trainerType: "Stadium",
-	regulationMark: "H"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793539,
+				tcgplayer: 587685,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Stadium",
+	regulationMark: "H",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SV/SV8/106.ts
+++ b/data-asia/SV/SV8/106.ts
@@ -1,27 +1,36 @@
-import { Card } from "../../../interfaces"
-import Set from "../SV8"
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "グラビティーマウンテン",
 		'zh-tw': "引力山岳",
-		'zh-cn': "引力山岳"
+		'zh-cn': "引力山岳",
 	},
 
 	illustrator: "AYUMI ODASHIMA",
-	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {
 		ja: "おたがいの場の2進化ポケモン全員の最大HPは、それぞれ「-30」される。",
 		'zh-tw': "雙方場上所有【2階進化】寶可夢的最大HP各「-30」。",
-		'zh-cn': "雙方場上所有【2階進化】寶可夢的最大HP各「-30」。"
+		'zh-cn': "雙方場上所有【2階進化】寶可夢的最大HP各「-30」。",
 	},
 
-	trainerType: "Stadium",
-	regulationMark: "H"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 793540,
+				tcgplayer: 587686,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Stadium",
+	regulationMark: "H",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/SV/SV8/107.ts
+++ b/data-asia/SV/SV8/107.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビビヨン",
+	},
+
+	illustrator: "REND",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Grass"],
+
+	description: {
+		ja: "不思議な 土地で 生まれた。 色鮮やかな 毒の りんぷんを 翅から 散らして 戦う。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "エボルパウダー" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のベンチポケモン全員からそれぞれ進化するカードを、自分の山札から1枚ずつ選び、それぞれにのせて進化させる。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "カッターウインド" },
+			damage: 90,
+			cost: ["Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793571,
+				tcgplayer: 587687,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コフーライ",
+	},
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [666],
+};
+
+export default card;

--- a/data-asia/SV/SV8/108.ts
+++ b/data-asia/SV/SV8/108.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メラルバ",
+	},
+
+	illustrator: "Whisker",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "大昔は 太陽の遣い と 崇められたが しばしば 山火事を 起こすこともあり 煙たがられた。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "ひをはく" },
+			damage: 20,
+			cost: ["Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793572,
+				tcgplayer: 587726,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [636],
+};
+
+export default card;

--- a/data-asia/SV/SV8/109.ts
+++ b/data-asia/SV/SV8/109.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソウブレイズ",
+	},
+
+	illustrator: "Rond",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fire"],
+
+	description: {
+		ja: "怨念の 染みついた 古い 鎧により 進化した 姿。 容赦なく 敵を 切り刻む。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ブレイズカース" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のポケモン全員についている特殊エネルギーを、すべてトラッシュする。",
+			},
+		},
+		{
+			name: { ja: "こくえんぎり" },
+			damage: 160,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793573,
+				tcgplayer: 587688,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カルボウ",
+	},
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [937],
+};
+
+export default card;

--- a/data-asia/SV/SV8/110.ts
+++ b/data-asia/SV/SV8/110.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒンバス",
+	},
+
+	illustrator: "Kuroimori",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Water"],
+
+	description: {
+		ja: "一番 みすぼらしい ポケモン。 水草の 多い 川底で 大勢 集まって 暮らしている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はねにげ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793574,
+				tcgplayer: 587689,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [349],
+};
+
+export default card;

--- a/data-asia/SV/SV8/111.ts
+++ b/data-asia/SV/SV8/111.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タマザラシ",
+	},
+
+	illustrator: "miki kudo",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "ぶ厚い 脂肪に 包まれた 見事に まんまるな 体。 歩くより 転がるほうが 速い。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こなゆき" },
+			damage: 10,
+			cost: ["Water"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793575,
+				tcgplayer: 587690,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [363],
+};
+
+export default card;

--- a/data-asia/SV/SV8/112.ts
+++ b/data-asia/SV/SV8/112.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レアコイル",
+	},
+
+	illustrator: "Shinji Kanda",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Lightning"],
+
+	description: {
+		ja: "連結した タイプの コイルは 太陽の 黒点が 多いとき たくさん 現れると 言われる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かじょうほうでん" },
+			effect: {
+				ja: "自分の番に1回使えて、使ったなら、このポケモンをきぜつさせる。自分のトラッシュから基本エネルギーを3枚まで選び、自分の[L]ポケモンに好きなようにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ライトニングボール" },
+			damage: 40,
+			cost: ["Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793576,
+				tcgplayer: 587725,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コイル",
+	},
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [82],
+};
+
+export default card;

--- a/data-asia/SV/SV8/113.ts
+++ b/data-asia/SV/SV8/113.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マッギョ",
+	},
+
+	illustrator: "N-DESIGN Inc.",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Lightning"],
+
+	description: {
+		ja: "干潟が すみか。 泥に 棲む 細菌に よって 電気を つくる 器官が 発達した。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "バチッとしびれる" },
+			damage: 50,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。さらに、そのポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793577,
+				tcgplayer: 587724,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [618],
+};
+
+export default card;

--- a/data-asia/SV/SV8/114.ts
+++ b/data-asia/SV/SV8/114.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エムリット",
+	},
+
+	illustrator: "HYOGONOSUKE",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "悲しみの 苦しさと 喜びの 尊さを 人々に 教えた。 感情の神と 呼ばれている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こころをみたす" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札から「基本[P]エネルギー」を2枚まで選び、自分のポケモンに好きなようにつける。",
+			},
+		},
+		{
+			name: { ja: "ゴッドバースト" },
+			damage: 160,
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "自分のベンチに「ユクシー」「アグノム」がいないなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793578,
+				tcgplayer: 587691,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [481],
+};
+
+export default card;

--- a/data-asia/SV/SV8/115.ts
+++ b/data-asia/SV/SV8/115.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴマゾウ",
+	},
+
+	illustrator: "Saboteri",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "見た目より ずっと 力持ち。 振りまわす 鼻に ぶつかると 腕の 骨が もっていかれる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ずつき" },
+			damage: 20,
+			cost: ["Fighting"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793579,
+				tcgplayer: 587692,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [231],
+};
+
+export default card;

--- a/data-asia/SV/SV8/116.ts
+++ b/data-asia/SV/SV8/116.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラ ダグトリオ",
+	},
+
+	illustrator: "Yukihiro Tada",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Metal"],
+
+	description: {
+		ja: "金属質の 髭は 重いので 素早さは いまいちだが 硬い 岩盤も 掘りぬくパワーを 持つ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "スリービンゴ" },
+			damage: 120,
+			cost: [],
+			effect: {
+				ja: "自分の手札が3枚でないなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793580,
+				tcgplayer: 587723,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アローラディグダ",
+	},
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [51],
+};
+
+export default card;

--- a/data-asia/SV/SV8/117.ts
+++ b/data-asia/SV/SV8/117.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ナマケロ",
+	},
+
+	illustrator: "Mékayu",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ナマケロの 怠けた 様子は 見ている 人の 怠け心を 存分に 刺激するのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "のんびりする" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「60」回復する。次の自分の番、このポケモンはにげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793581,
+				tcgplayer: 587722,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [287],
+};
+
+export default card;

--- a/data-asia/SV/SV8/118.ts
+++ b/data-asia/SV/SV8/118.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カクレオン",
+	},
+
+	illustrator: "Mori Yuu",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "身体の 色を 変えて 景色に 溶け込む。 長く かまわないでいると スネて 姿を 見せなくなる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かくれじょうず" },
+			effect: {
+				ja: "このポケモンがワザのダメージを受けるとき、自分はコインを1回投げる。オモテなら、このポケモンはそのダメージを受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ベロウィップ" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793582,
+				tcgplayer: 587693,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Illustration rare",
+	dexId: [352],
+};
+
+export default card;

--- a/data-asia/SV/SV8/119.ts
+++ b/data-asia/SV/SV8/119.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アイアントex",
+	},
+
+	illustrator: "PLANETA Tsuji",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "いきなりけずる" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。相手の山札を上から1枚トラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "リベンジクラッシュ" },
+			damage: "120+",
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手がすでにとったサイドの枚数×30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793583,
+				tcgplayer: 587721,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "Ultra Rare",
+	dexId: [632],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV8/120.ts
+++ b/data-asia/SV/SV8/120.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スコヴィランex",
+	},
+
+	illustrator: "PLANETA Igarashi",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Fire"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ダブルタイプ" },
+			effect: {
+				ja: "このポケモンは、場にいるかぎり[G]と[R]の2つのタイプになる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スパイシーレイジ" },
+			damage: "10+",
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数×70ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793584,
+				tcgplayer: 587720,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カプサイジ",
+	},
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "Ultra Rare",
+	dexId: [952],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV8/121.ts
+++ b/data-asia/SV/SV8/121.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミロカロスex",
+	},
+
+	illustrator: "N-DESIGN Inc.",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "きらめくウロコ" },
+			effect: {
+				ja: "このポケモンは、相手の「テラスタル」のポケモンからワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ヒプノスプラッシュ" },
+			damage: 160,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793585,
+				tcgplayer: 587717,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒンバス",
+	},
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "Ultra Rare",
+	dexId: [350],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV8/122.ts
+++ b/data-asia/SV/SV8/122.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウex",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "がんばりハート" },
+			effect: {
+				ja: "このポケモンのHPがまんたんの状態で、このポケモンがワザのダメージを受けてきぜつするとき、きぜつせず、残りHPが「10」の状態で場に残る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "トパーズボルト" },
+			damage: 300,
+			cost: ["Grass", "Lightning", "Metal"],
+			effect: {
+				ja: "このポケモンについているエネルギーを3個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793587,
+				tcgplayer: 587694,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Ultra Rare",
+	dexId: [25],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV8/123.ts
+++ b/data-asia/SV/SV8/123.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シロデスナex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "すなじごく" },
+			damage: 160,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "バライトジェイル" },
+			cost: ["Water", "Psychic", "Fighting"],
+			effect: {
+				ja: "相手のベンチポケモン全員に、それぞれ残りHPが「100」になるように、ダメカンをのせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793588,
+				tcgplayer: 587695,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "スナバァ",
+	},
+
+	retreat: 4,
+	regulationMark: "H",
+	rarity: "Ultra Rare",
+	dexId: [770],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV8/124.ts
+++ b/data-asia/SV/SV8/124.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サザンドラex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Darkness"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "クラッシュヘッズ" },
+			damage: 200,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手の山札を上から3枚トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "オブシディアン" },
+			damage: 130,
+			cost: ["Psychic", "Darkness", "Metal", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン2匹にも、それぞれ130ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793589,
+				tcgplayer: 587716,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジヘッド",
+	},
+
+	retreat: 3,
+	regulationMark: "H",
+	rarity: "Ultra Rare",
+	dexId: [635],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV8/125.ts
+++ b/data-asia/SV/SV8/125.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シャリタツex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふいうちポンプ" },
+			damage: 100,
+			cost: ["Fire", "Water"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+		{
+			name: { ja: "シナバールアー" },
+			cost: ["Fire", "Water", "Darkness"],
+			effect: {
+				ja: "自分の山札を上から10枚見て、その中からポケモンを好きなだけ選び、ベンチに出す。残りのカードは山札にもどして切る。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793590,
+				tcgplayer: 587715,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Ultra Rare",
+	dexId: [978],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV8/126.ts
+++ b/data-asia/SV/SV8/126.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケッキングex",
+	},
+
+	illustrator: "PLANETA Igarashi",
+	category: "Pokemon",
+	hp: 340,
+	types: ["Colorless"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "さぼりたいしつ" },
+			effect: {
+				ja: "相手の場に「ポケモンex・V」がいないなら、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "グレートスイング" },
+			damage: 280,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793591,
+				tcgplayer: 587714,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤルキモノ",
+	},
+
+	retreat: 4,
+	regulationMark: "H",
+	rarity: "Ultra Rare",
+	dexId: [289],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV8/127.ts
+++ b/data-asia/SV/SV8/127.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シアノ",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から「ポケモンex」を3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793592,
+				tcgplayer: 587696,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "H",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SV/SV8/128.ts
+++ b/data-asia/SV/SV8/128.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シトロンの機転",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の[L]ポケモン全員のHPを、それぞれ「60」回復する。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793593,
+				tcgplayer: 587707,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "H",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SV/SV8/129.ts
+++ b/data-asia/SV/SV8/129.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミカンのまなざし",
+	},
+
+	illustrator: "Taira Akitsu",
+	category: "Trainer",
+
+	effect: {
+		ja: "次の相手の番、自分のポケモン全員が、相手のポケモンから受けるワザのダメージは「-30」される。（新しく場に出したポケモンもふくむ。）",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793594,
+				tcgplayer: 587704,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "H",
+	rarity: "Ultra Rare",
+};
+
+export default card;

--- a/data-asia/SV/SV8/130.ts
+++ b/data-asia/SV/SV8/130.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アイアントex",
+	},
+
+	illustrator: "osare",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "いきなりけずる" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。相手の山札を上から1枚トラッシュする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "リベンジクラッシュ" },
+			damage: "120+",
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手がすでにとったサイドの枚数×30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793595,
+				tcgplayer: 587711,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "Special illustration rare",
+	dexId: [632],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV8/131.ts
+++ b/data-asia/SV/SV8/131.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミロカロスex",
+	},
+
+	illustrator: "Kuroimori",
+	category: "Pokemon",
+	hp: 270,
+	types: ["Water"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "きらめくウロコ" },
+			effect: {
+				ja: "このポケモンは、相手の「テラスタル」のポケモンからワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ヒプノスプラッシュ" },
+			damage: 160,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793596,
+				tcgplayer: 587698,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒンバス",
+	},
+
+	retreat: 2,
+	regulationMark: "H",
+	rarity: "Special illustration rare",
+	dexId: [350],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV8/132.ts
+++ b/data-asia/SV/SV8/132.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウex",
+	},
+
+	illustrator: "GIDORA",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "がんばりハート" },
+			effect: {
+				ja: "このポケモンのHPがまんたんの状態で、このポケモンがワザのダメージを受けてきぜつするとき、きぜつせず、残りHPが「10」の状態で場に残る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "トパーズボルト" },
+			damage: 300,
+			cost: ["Grass", "Lightning", "Metal"],
+			effect: {
+				ja: "このポケモンについているエネルギーを3個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793597,
+				tcgplayer: 587699,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Special illustration rare",
+	dexId: [25],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV8/133.ts
+++ b/data-asia/SV/SV8/133.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サザンドラex",
+	},
+
+	illustrator: "AKIRA EGAWA",
+	category: "Pokemon",
+	hp: 330,
+	types: ["Darkness"],
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "クラッシュヘッズ" },
+			damage: 200,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手の山札を上から3枚トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "オブシディアン" },
+			damage: 130,
+			cost: ["Psychic", "Darkness", "Metal", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン2匹にも、それぞれ130ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793598,
+				tcgplayer: 587700,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジヘッド",
+	},
+
+	retreat: 3,
+	regulationMark: "H",
+	rarity: "Special illustration rare",
+	dexId: [635],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV8/134.ts
+++ b/data-asia/SV/SV8/134.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シトロンの機転",
+	},
+
+	illustrator: "Shinya Mizuno",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の[L]ポケモン全員のHPを、それぞれ「60」回復する。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793599,
+				tcgplayer: 587712,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "H",
+	rarity: "Special illustration rare",
+};
+
+export default card;

--- a/data-asia/SV/SV8/135.ts
+++ b/data-asia/SV/SV8/135.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミカンのまなざし",
+	},
+
+	illustrator: "Fujimoto Gold",
+	category: "Trainer",
+
+	effect: {
+		ja: "次の相手の番、自分のポケモン全員が、相手のポケモンから受けるワザのダメージは「-30」される。（新しく場に出したポケモンもふくむ。）",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793600,
+				tcgplayer: 587697,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "H",
+	rarity: "Special illustration rare",
+};
+
+export default card;

--- a/data-asia/SV/SV8/136.ts
+++ b/data-asia/SV/SV8/136.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウex",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "がんばりハート" },
+			effect: {
+				ja: "このポケモンのHPがまんたんの状態で、このポケモンがワザのダメージを受けてきぜつするとき、きぜつせず、残りHPが「10」の状態で場に残る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "トパーズボルト" },
+			damage: 300,
+			cost: ["Grass", "Lightning", "Metal"],
+			effect: {
+				ja: "このポケモンについているエネルギーを3個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793602,
+				tcgplayer: 587703,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "H",
+	rarity: "Mega Hyper Rare",
+	dexId: [25],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/SV/SV8/137.ts
+++ b/data-asia/SV/SV8/137.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "夜のタンカ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュからポケモンまたは基本エネルギーを1枚選び、相手に見せて、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793604,
+				tcgplayer: 587702,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "H",
+	rarity: "Mega Hyper Rare",
+};
+
+export default card;

--- a/data-asia/SV/SV8/138.ts
+++ b/data-asia/SV/SV8/138.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../SV8";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グラビティーマウンテン",
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの場の2進化ポケモン全員の最大HPは、それぞれ「-30」される。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 793605,
+				tcgplayer: 587701,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "H",
+	rarity: "Secret Rare",
+};
+
+export default card;


### PR DESCRIPTION
## What

Refreshes the existing Japanese set **SV8 超電ブレイカー (Super Electric Breaker)** from its primary sources. The curated content stays: every card keeps its `zh-tw`/`zh-cn` texts verbatim.

What changes across the 138 card files:

- `thirdParty.cardmarket` moves onto `variants` objects and 50 missing ids are filled in
- per card where missing: `dexId`, `evolveFrom`, `resistances`, the Japanese flavor text and the Japanese effect/attack texts straight from the official database and limitless

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (793435–793605)
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (587581–587726), keyed by the collection number each product carries in `extendedData`

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- 101 is a Pokémon Tool that grant an attack — modeled as `effect` + `attacks`, like their English prints
- All 138 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
