### PR TITLE
(data) Add Japanese S set S-P Sword & Shield Promotional Cards

### DIFF
--- a/data-asia/S/S-P/001.ts
+++ b/data-asia/S/S-P/001.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウ",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "つくる 電気が 強力な ピカチュウほど ほっぺの 袋は 軟らかく よく 伸びるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アイアンテール" },
+			damage: "30×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数×30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "エレキボール" },
+			damage: 60,
+			cost: ["Lightning", "Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 462904,
+				tcgplayer: 597228,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/S/S-P/002.ts
+++ b/data-asia/S/S-P/002.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シブヤのピカチュウ",
+	},
+
+	illustrator: "",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "つくる 電気が 強力な ピカチュウほど ほっぺの 袋は 軟らかく よく 伸びるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ニューオープン" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "おたがいのプレイヤーは、それぞれ自分の山札を上から1枚オモテにして、相手に見せて、手札に加える。",
+			},
+		},
+		{
+			name: { ja: "かみなり" },
+			damage: 80,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このポケモンにも20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 462909,
+				tcgplayer: 597229,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/S/S-P/003.ts
+++ b/data-asia/S/S-P/003.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レックウザ",
+	},
+
+	illustrator: "so-taro",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "はるか 上空の オゾン層の 中を 飛んでいるため 最近まで 姿を 見た 者は いなかった。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "くらいつく" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "パワーブラスト" },
+			damage: 120,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 462914,
+				tcgplayer: 597230,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [384],
+};
+
+export default card;

--- a/data-asia/S/S-P/004.ts
+++ b/data-asia/S/S-P/004.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウールー",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "パーマの かかった 体毛は 高い クッション性が ある。 崖から 落ちても へっちゃら。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "まるくなる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージを受けない。",
+			},
+		},
+		{
+			name: { ja: "ずつき" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 462919,
+				tcgplayer: 597231,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [831],
+};
+
+export default card;

--- a/data-asia/S/S-P/005.ts
+++ b/data-asia/S/S-P/005.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホップ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597232,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/006.ts
+++ b/data-asia/S/S-P/006.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒバニー",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fire"],
+
+	description: {
+		ja: "走りまわって 体温を 上げると 炎エネルギーが 体を 巡り 本来の 力を 発揮できる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "さきどり" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
+		},
+		{
+			name: { ja: "ひだね" },
+			damage: 20,
+			cost: ["Fire", "Fire"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597233,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [813],
+};
+
+export default card;

--- a/data-asia/S/S-P/007.ts
+++ b/data-asia/S/S-P/007.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サルノリ",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "特別な スティックで リズムを 刻むと 草花を 元気にする パワーが 音波になって 広がる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "まっしぐら" },
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 462934,
+				tcgplayer: 597234,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [810],
+};
+
+export default card;

--- a/data-asia/S/S-P/008.ts
+++ b/data-asia/S/S-P/008.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メッソン",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "怯えると 玉ねぎ１００個分の 催涙成分を もつ 涙を 流して もらい泣き させる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なきごえ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-20」される。",
+			},
+		},
+		{
+			name: { ja: "みずかけ" },
+			damage: 10,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 462939,
+				tcgplayer: 597235,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [816],
+};
+
+export default card;

--- a/data-asia/S/S-P/009.ts
+++ b/data-asia/S/S-P/009.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本草エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 649919,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/010.ts
+++ b/data-asia/S/S-P/010.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本炎エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 462949,
+				tcgplayer: 649758,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/011.ts
+++ b/data-asia/S/S-P/011.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本水エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 649786,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/012.ts
+++ b/data-asia/S/S-P/012.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本雷エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 649911,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/013.ts
+++ b/data-asia/S/S-P/013.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本超エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 649805,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/014.ts
+++ b/data-asia/S/S-P/014.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本闘エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 649802,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/015.ts
+++ b/data-asia/S/S-P/015.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本悪エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 649780,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/016.ts
+++ b/data-asia/S/S-P/016.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本鋼エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 649775,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/017.ts
+++ b/data-asia/S/S-P/017.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "きずぐすり",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のポケモン1匹のHPを「30」回復する。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 462984,
+				tcgplayer: 597237,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "D",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/018.ts
+++ b/data-asia/S/S-P/018.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "なんでもなおし",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンの特殊状態を、すべて回復する。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 462989,
+				tcgplayer: 597238,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "D",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/019.ts
+++ b/data-asia/S/S-P/019.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モンスターボール",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "コインを1回投げオモテなら、自分の山札からポケモンを1枚選び、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 462994,
+				tcgplayer: 597239,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "D",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/020.ts
+++ b/data-asia/S/S-P/020.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コオリッポV",
+	},
+
+	illustrator: "PLANETA Tsuji",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "れいききゅうしゅう" },
+			effect: {
+				ja: "自分の番に、自分の手札から[水]エネルギーをこのポケモンにつけるたび、このポケモンのHPを「30」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ふぶき" },
+			damage: 120,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン全員にも、それぞれ10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 462999,
+				tcgplayer: 597240,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [875],
+};
+
+export default card;

--- a/data-asia/S/S-P/021.ts
+++ b/data-asia/S/S-P/021.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒメンカ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Grass"],
+
+	description: {
+		ja: "一本足を 地面に 刺して 陽の光を たっぷり 浴びると 花びらが 鮮やかに 色づく。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "うたう" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463004,
+				tcgplayer: 597241,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [829],
+};
+
+export default card;

--- a/data-asia/S/S-P/022.ts
+++ b/data-asia/S/S-P/022.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エースバーン",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Fire"],
+
+	description: {
+		ja: "小石を リフティングして 炎の サッカーボールを つくる。 するどい シュートで 相手を 燃やす。",
+	},
+
+	stage: "Stage2",
+
+	attacks: [
+		{
+			name: { ja: "ほのおをまとう" },
+			damage: 40,
+			cost: ["Fire"],
+			effect: {
+				ja: "自分のトラッシュから[炎]エネルギーを1枚選び、このポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "ぐれんのほのお" },
+			damage: 160,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このポケモンについているエネルギーを2個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463009,
+				tcgplayer: 597242,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ラビフット",
+	},
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [815],
+};
+
+export default card;

--- a/data-asia/S/S-P/023.ts
+++ b/data-asia/S/S-P/023.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マンタイン",
+	},
+
+	illustrator: "0313",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Water"],
+
+	description: {
+		ja: "泳いで スピードが のってくると 波の上に 飛びだし そのまま １００メートルも 滑空 する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みずため" },
+			cost: ["Water"],
+			effect: {
+				ja: "自分の山札から[水]エネルギーを3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "スプラッシュ" },
+			damage: 60,
+			cost: ["Water", "Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463014,
+				tcgplayer: 597243,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [226],
+};
+
+export default card;

--- a/data-asia/S/S-P/024.ts
+++ b/data-asia/S/S-P/024.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウ",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "つくる 電気が 強力な ピカチュウほど ほっぺの 袋は 軟らかく よく 伸びるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "しっぽをふる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このワザを受けたポケモンは、ワザが使えない。",
+			},
+		},
+		{
+			name: { ja: "ピカボルト" },
+			damage: 50,
+			cost: ["Lightning", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463019,
+				tcgplayer: 597244,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/S/S-P/025.ts
+++ b/data-asia/S/S-P/025.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガラル ポニータ",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "小さな ツノに 癒しの 力を 秘めている。 ちょっとした 傷なら ツノを すり寄せ 治して くれる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "いやしのはどう" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のポケモンを1匹選び、HPを「30」回復する。",
+			},
+		},
+		{
+			name: { ja: "はねまわる" },
+			damage: 20,
+			cost: ["Psychic", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463024,
+				tcgplayer: 597245,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [77],
+};
+
+export default card;

--- a/data-asia/S/S-P/026.ts
+++ b/data-asia/S/S-P/026.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨルノズク",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Colorless"],
+
+	description: {
+		ja: "ものごとを 考えだすと 首を １８０度 回転 させて 頭の 働きを 高める。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "つばさでうつ" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "やまにつれさる" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンと、相手のベンチポケモンを1匹選び、それぞれのポケモンと、ついているすべてのカードを、山札にもどして切る。相手のベンチポケモンがいないなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463029,
+				tcgplayer: 597246,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ホーホー",
+	},
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [164],
+};
+
+export default card;

--- a/data-asia/S/S-P/027.ts
+++ b/data-asia/S/S-P/027.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビート",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札から基本エネルギーを1枚選び、ベンチポケモンにつける。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597247,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/028.ts
+++ b/data-asia/S/S-P/028.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャースV",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ネコにこばん" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
+		},
+		{
+			name: { ja: "スラッシュクロー" },
+			damage: 130,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463039,
+				tcgplayer: 597248,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [52],
+};
+
+export default card;

--- a/data-asia/S/S-P/029.ts
+++ b/data-asia/S/S-P/029.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャースVMAX",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 300,
+	types: ["Colorless"],
+
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: { ja: "キョダイコバン" },
+			damage: 200,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札を3枚引く。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463044,
+				tcgplayer: 597249,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニャースV",
+	},
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [52],
+};
+
+export default card;

--- a/data-asia/S/S-P/030.ts
+++ b/data-asia/S/S-P/030.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジュラルドン",
+	},
+
+	illustrator: "Ryuta Fuse",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Metal"],
+
+	description: {
+		ja: "磨きあげた 金属の ような 体は 軽いうえに 硬いが 錆びやすいのが 欠点なのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "メタルクロー" },
+			damage: 70,
+			cost: ["Metal", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "てっていこうせん" },
+			damage: 150,
+			cost: ["Metal", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも40ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463049,
+				tcgplayer: 597250,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [884],
+};
+
+export default card;

--- a/data-asia/S/S-P/031.ts
+++ b/data-asia/S/S-P/031.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ともだちてちょう",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュからサポートを2枚選び、相手に見せてから、山札にもどす。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597251,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "D",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/032.ts
+++ b/data-asia/S/S-P/032.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モルペコ",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Lightning"],
+
+	description: {
+		ja: "いつも お腹を すかせている。 ポケットの ような 袋に 入れた タネを 食べて 電気を つくる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きずにうちこむ" },
+			damage: "10+",
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手のバトルポケモンにダメカンがのっているなら、50ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463059,
+				tcgplayer: 597252,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [877],
+};
+
+export default card;

--- a/data-asia/S/S-P/033.ts
+++ b/data-asia/S/S-P/033.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バチンウニV",
+	},
+
+	illustrator: "PLANETA Igarashi",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Lightning"],
+
+	description: {
+		ja: "棘の 先から 電気を 放つ。 鋭い 歯で 岩に ついた 海藻を こそいで 食べる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はんげきバリバリ" },
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、自分はコインを3回投げ、オモテの数×3個のダメカンを、ワザを使ったポケモンにのせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スパーキングアタック" },
+			damage: 120,
+			cost: ["Lightning", "Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463064,
+				tcgplayer: 597253,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [871],
+};
+
+export default card;

--- a/data-asia/S/S-P/034.ts
+++ b/data-asia/S/S-P/034.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒバニー",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fire"],
+
+	description: {
+		ja: "走りまわって 体温を 上げると 炎エネルギーが 体を 巡り 本来の 力を 発揮できる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ほのおでこがす" },
+			damage: 10,
+			cost: ["Fire"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをやけどにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463084,
+				tcgplayer: 597254,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [813],
+};
+
+export default card;

--- a/data-asia/S/S-P/035.ts
+++ b/data-asia/S/S-P/035.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モルペコ",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Lightning"],
+
+	description: {
+		ja: "いつも お腹を すかせている。 ポケットの ような 袋に 入れた タネを 食べて 電気を つくる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ペコペコ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
+		},
+		{
+			name: { ja: "でんきショック" },
+			damage: 40,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463089,
+				tcgplayer: 597255,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Promo",
+	dexId: [877],
+};
+
+export default card;

--- a/data-asia/S/S-P/036.ts
+++ b/data-asia/S/S-P/036.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "救助隊DXのピカチュウ",
+	},
+
+	illustrator: "Spike Chunsoft.",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "ある日 目が 覚めたら ピカチュウに なっちゃった！ 困った ポケモンを 助けるため 救助隊を 結成したぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ともだちきゅうじょ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュからポケモンを1枚選び、相手に見せて、手札に加える。",
+			},
+		},
+		{
+			name: { ja: "エレキボール" },
+			damage: 50,
+			cost: ["Lightning", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463094,
+				tcgplayer: 597256,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/S/S-P/037.ts
+++ b/data-asia/S/S-P/037.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダイオウドウV",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こんごうプレス" },
+			damage: 90,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+		{
+			name: { ja: "たたきつぶす" },
+			damage: 180,
+			cost: ["Metal", "Metal", "Metal", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463099,
+				tcgplayer: 597257,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [879],
+};
+
+export default card;

--- a/data-asia/S/S-P/038.ts
+++ b/data-asia/S/S-P/038.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブースター",
+	},
+
+	illustrator: "You Iribi",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fire"],
+
+	description: {
+		ja: "体内に 炎が 溜まると ブースターの 体温も 最高 ９００度 まで 上がっていく。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "こがす" },
+			cost: ["Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+		{
+			name: { ja: "メラメラ" },
+			damage: 120,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。その後、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463104,
+				tcgplayer: 597258,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [136],
+};
+
+export default card;

--- a/data-asia/S/S-P/039.ts
+++ b/data-asia/S/S-P/039.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルクシオ",
+	},
+
+	illustrator: "NC Empire",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Lightning"],
+
+	description: {
+		ja: "鋭い ツメの 先には 強い 電気が 流れており ほんの少し かするだけで 相手を気絶させる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "トップエントリー" },
+			effect: {
+				ja: "自分の番のはじめに、山札からこのカードを引いたとき、自分のベンチに空きがあるなら、手札に加える前に1回使える。このカードを自分のベンチに出す。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "エレキック" },
+			damage: 30,
+			cost: ["Lightning"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463109,
+				tcgplayer: 597259,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コリンク",
+	},
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [404],
+};
+
+export default card;

--- a/data-asia/S/S-P/040.ts
+++ b/data-asia/S/S-P/040.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポットデスV",
+	},
+
+	illustrator: "PLANETA Igarashi",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "びっくりポット" },
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、相手の手札からオモテを見ないで1枚選び、そのカードのオモテを見てから、相手の山札の下にもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "サイコトリップ" },
+			damage: 100,
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463114,
+				tcgplayer: 597260,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [855],
+};
+
+export default card;

--- a/data-asia/S/S-P/041.ts
+++ b/data-asia/S/S-P/041.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミブリム",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Psychic"],
+
+	description: {
+		ja: "頭の 突起で 生物の 気持ちを 感じとる。 穏やかな ものにしか 心を 開かない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ともだちをさがす" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からポケモンを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "サイコショット" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463119,
+				tcgplayer: 597261,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [856],
+};
+
+export default card;

--- a/data-asia/S/S-P/042.ts
+++ b/data-asia/S/S-P/042.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タンドン",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "およそ４００年前に 炭鉱で 見つかった。 体の ほとんどが 石炭と 同じ 成分。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463124,
+				tcgplayer: 597262,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [837],
+};
+
+export default card;

--- a/data-asia/S/S-P/043.ts
+++ b/data-asia/S/S-P/043.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤブクロン",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "不衛生な 場所が 好き。 ゴミで 汚したまま 放っておくと 部屋にも 現れて 棲みつく。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ベノムショック" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンがどくなら、50ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463129,
+				tcgplayer: 597263,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [568],
+};
+
+export default card;

--- a/data-asia/S/S-P/044.ts
+++ b/data-asia/S/S-P/044.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イーブイ",
+	},
+
+	illustrator: "You Iribi",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "まわりの 環境に 合わせて 体の つくりを 変えていく 能力の 持ち主。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "しんかのきざし" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "「イーブイ」から進化するカードを、自分の山札から1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "けりつける" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463134,
+				tcgplayer: 597264,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [133],
+};
+
+export default card;

--- a/data-asia/S/S-P/045.ts
+++ b/data-asia/S/S-P/045.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "逆境グローブ",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンの弱点のタイプと、相手のバトルポケモンのタイプが同じなら、このカードをつけているポケモンが使うワザの、相手のバトルポケモンへのダメージは「+30」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463139,
+				tcgplayer: 597265,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "D",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/046.ts
+++ b/data-asia/S/S-P/046.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソニア",
+	},
+
+	illustrator: "Yusuke Ohmura",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札からたねポケモンを2枚まで、または基本エネルギーを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525020,
+				tcgplayer: 597266,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/047.ts
+++ b/data-asia/S/S-P/047.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バチンウニ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Lightning"],
+
+	description: {
+		ja: "棘の 先から 電気を 放つ。 鋭い 歯で 岩に ついた 海藻を こそいで 食べる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ダブルドロー" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分の山札を2枚引く。",
+			},
+		},
+		{
+			name: { ja: "びりびりちくちく" },
+			damage: 50,
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463144,
+				tcgplayer: 597267,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [871],
+};
+
+export default card;

--- a/data-asia/S/S-P/048.ts
+++ b/data-asia/S/S-P/048.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ストリンダーV",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たいでん" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュから[雷]エネルギーを1枚選び、このポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "ベノムスラップ" },
+			damage: 120,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463149,
+				tcgplayer: 597268,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [849],
+};
+
+export default card;

--- a/data-asia/S/S-P/049.ts
+++ b/data-asia/S/S-P/049.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スピード雷エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、ポケモンについているかぎり、[雷]エネルギー1個ぶんとしてはたらく。このカードを手札から[雷]ポケモンにつけたとき、自分の山札を2枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597269,
+			},
+		},
+	],
+
+	regulationMark: "D",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/050.ts
+++ b/data-asia/S/S-P/050.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メッソン",
+	},
+
+	illustrator: "Megumi Mizutani",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "怯えると 玉ねぎ１００個分の 催涙成分を もつ 涙を 流して もらい泣き させる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みずでっぽう" },
+			damage: 20,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463159,
+				tcgplayer: 597270,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [816],
+};
+
+export default card;

--- a/data-asia/S/S-P/051.ts
+++ b/data-asia/S/S-P/051.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "きずぐすり",
+	},
+
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のポケモン1匹のHPを「30」回復する。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463164,
+				tcgplayer: 597271,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "D",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/052.ts
+++ b/data-asia/S/S-P/052.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ふしぎなアメ",
+	},
+
+	illustrator: "Yoshinobu Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のたねポケモン1匹から進化する1進化の上の2進化ポケモンを、手札から1枚選び、そのたねポケモンにのせて進化させる。[最初の自分の番と、この番出したばかりのたねポケモンには使えない。]",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463169,
+				tcgplayer: 597272,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "D",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/053.ts
+++ b/data-asia/S/S-P/053.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモンいれかえ",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463174,
+				tcgplayer: 649941,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "D",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/054.ts
+++ b/data-asia/S/S-P/054.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モンスターボール",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "コインを1回投げオモテなら、自分の山札からポケモンを1枚選び、相手に見せてから、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463179,
+				tcgplayer: 597273,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "D",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/055.ts
+++ b/data-asia/S/S-P/055.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "げんきのハチマキ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンが使うワザの、相手のバトルポケモンへのダメージは「＋10」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463184,
+				tcgplayer: 597274,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "D",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/056.ts
+++ b/data-asia/S/S-P/056.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビート",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札から基本エネルギーを1枚選び、ベンチポケモンにつける。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597275,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/057.ts
+++ b/data-asia/S/S-P/057.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモンごっこ",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札からポケモンを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463194,
+				tcgplayer: 597276,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/058.ts
+++ b/data-asia/S/S-P/058.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホップ",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597277,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/059.ts
+++ b/data-asia/S/S-P/059.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イエッサンV",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "こころくばり" },
+			effect: {
+				ja: "自分の番に1回使える。自分のバトルポケモンのHPを「20」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "サイコキネシス" },
+			damage: "10+",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数×60ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597278,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [876],
+};
+
+export default card;

--- a/data-asia/S/S-P/068.ts
+++ b/data-asia/S/S-P/068.ts
@@ -1,47 +1,66 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "暖暖豬"
+		ja: "モルペコ",
+		'zh-tw': "暖暖豬",
 	},
 
-	illustrator: "Eri Yamaki",
+	illustrator: "Hideki Ishikawa",
 	category: "Pokemon",
 	hp: 80,
-	types: ["Fire"],
+	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "最喜歡吃烤過的樹果，但有時候會因為興奮過頭，把樹果烤得焦黑。"
+		ja: "いつも お腹を すかせている。 ポケットの ような 袋に 入れた タネを 食べて 電気を つくる。",
+		'zh-tw': "最喜歡吃烤過的樹果，但有時候會因為興奮過頭，把樹果烤得焦黑。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "衝撞"
+	attacks: [
+		{
+			name: {
+				ja: "ペコペコ",
+				'zh-tw': "衝撞",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
 		},
-
-		damage: 20,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "烈焰"
+		{
+			name: {
+				ja: "でんきショック",
+				'zh-tw': "烈焰",
+			},
+			damage: 40,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
 		},
+	],
 
-		damage: 50,
-		cost: ["Fire", "Fire", "Colorless"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525070,
+				tcgplayer: 597279,
+			},
+		},
+	],
 
-	retreat: 2,
-	regulationMark: "E"
-}
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [877],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/069.ts
+++ b/data-asia/S/S-P/069.ts
@@ -1,50 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伽勒爾 魔牆人偶"
+		ja: "ポケモンセンターのお姉さん",
+		'zh-tw': "伽勒爾 魔牆人偶",
 	},
 
-	illustrator: "Shigenori Negishi",
-	category: "Pokemon",
-	hp: 80,
-	types: ["Water"],
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "會從腳底釋放出冷氣。一整天都會在自己凍住的地板上努力練習踢踏舞。"
+	effect: {
+		ja: "自分のポケモンを1匹選び、そのポケモンのHPを「60」回復し、特殊状態もすべて回復する。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "拍擊"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525075,
+				tcgplayer: 597280,
+			},
 		},
+	],
 
-		damage: 10,
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "找到"
-		},
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Promo",
+};
 
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張物品卡，在給對手看過後加入手牌。並且重洗牌庫。"
-		},
-
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "E"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/070.ts
+++ b/data-asia/S/S-P/070.ts
@@ -1,54 +1,57 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "月亮伊布"
+		ja: "フクスロー",
+		'zh-tw': "月亮伊布",
 	},
 
-	illustrator: "Souichirou Gunjima",
+	illustrator: "AKIRA EGAWA",
 	category: "Pokemon",
-	hp: 110,
-	types: ["Darkness"],
+	hp: 80,
+	types: ["Grass"],
 
 	description: {
-		'zh-tw': "在滿月之夜或是興奮的時候，牠身上圈圈一樣的花紋就會發出金黃色的光。"
+		ja: "刃羽根 と 呼ばれる ナイフのような 羽根を 立て続けに 投げて 敵の 急所を 確実に つらぬく。",
+		'zh-tw': "在滿月之夜或是興奮的時候，牠身上圈圈一樣的花紋就會發出金黃色的光。",
 	},
 
 	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "暗中奇襲"
+	attacks: [
+		{
+			name: {
+				ja: "はっぱカッター",
+				'zh-tw': "暗中奇襲",
+			},
+			damage: 40,
+			cost: ["Grass"],
 		},
+	],
 
-		effect: {
-			'zh-tw': "對手的身上放置有傷害指示物的1隻寶可夢受到60點傷害。[在備戰區不計算弱點・抵抗力。]"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525080,
+				tcgplayer: 597281,
+			},
 		},
+	],
 
-		cost: ["Darkness"]
-	}, {
-		name: {
-			'zh-tw': "月亮幻想"
-		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【混亂】。"
-		},
-
-		damage: 80,
-		cost: ["Darkness", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "モクロー",
+	},
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [723],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/071.ts
+++ b/data-asia/S/S-P/071.ts
@@ -1,56 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "嘟嘟利V"
+		ja: "シャワーズ",
+		'zh-tw': "嘟嘟利V",
 	},
 
-	illustrator: "5ban Graphics",
+	illustrator: "so-taro",
 	category: "Pokemon",
-	hp: 200,
-	types: ["Colorless"],
-	stage: "Basic",
-	suffix: "V",
+	hp: 110,
+	types: ["Water"],
 
-	attacks: [{
-		name: {
-			'zh-tw': "接二連三"
+	description: {
+		ja: "シャワーズの 全身の ひれが 小刻みに 震えはじめるのは 数時間後に 雨が降る しるし。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "みずがくれ" },
+			effect: {
+				ja: "このポケモンは、ベンチにいるかぎり、ワザのダメージを受けない。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+80」點。"
+	attacks: [
+		{
+			name: {
+				ja: "ハイドロポンプ",
+				'zh-tw': "接二連三",
+			},
+			damage: "60+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーの数×20ダメージ追加。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+80」點。",
+			},
 		},
+	],
 
-		damage: 20,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "爆走鑽"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525085,
+				tcgplayer: 597282,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢也受到30點傷害。"
-		},
+	evolveFrom: {
+		ja: "イーブイ",
+	},
 
-		damage: 160,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [134],
+};
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
-
-	retreat: 1,
-	regulationMark: "E"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/072.ts
+++ b/data-asia/S/S-P/072.ts
@@ -1,50 +1,57 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伊布"
+		ja: "ナックラー",
+		'zh-tw': "伊布",
 	},
 
-	illustrator: "Souichirou Gunjima",
+	illustrator: "MAHOU",
 	category: "Pokemon",
 	hp: 60,
-	types: ["Colorless"],
+	types: ["Fighting"],
 
 	description: {
-		'zh-tw': "由於不穩定的基因，蘊含著各式各樣進化可能性的特殊寶可夢。"
+		ja: "砂漠に つくられた 巣穴は すり鉢の 形を しているので 落ちてしまうと 脱出不可能。",
+		'zh-tw': "由於不穩定的基因，蘊含著各式各樣進化可能性的特殊寶可夢。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "準備"
+	attacks: [
+		{
+			name: {
+				ja: "だいちのこどう",
+				'zh-tw': "準備",
+			},
+			damage: "10+",
+			cost: ["Fighting"],
+			effect: {
+				ja: "場にスタジアムが出ているなら、10ダメージ追加。",
+				'zh-tw': "從自己的手牌選擇1張基本能量卡，附於這隻寶可夢身上。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的手牌選擇1張基本能量卡，附於這隻寶可夢身上。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525090,
+				tcgplayer: 597283,
+			},
 		},
-
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "咬住"
-		},
-
-		damage: 30,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [328],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/073.ts
+++ b/data-asia/S/S-P/073.ts
@@ -1,22 +1,54 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "蜜葉"
+		ja: "イトマル",
+		'zh-tw': "蜜葉",
 	},
 
-	illustrator: "Ryuta Fuse",
-	category: "Trainer",
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
 
-	effect: {
-		'zh-tw': "從自己的牌庫抽出與對手的備戰區的「寶可夢【V】」數量相同數量的卡。"
+	description: {
+		ja: "キバの 毒は さほど 強くないが 巣に かかって 動けない 獲物を 弱らせるには 充分。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "E"
-}
+	stage: "Basic",
 
-export default card
+	attacks: [
+		{
+			name: { ja: "ぶらさがる" },
+			damage: 10,
+			cost: ["Darkness"],
+		},
+		{
+			name: { ja: "チクチクさす" },
+			damage: 20,
+			cost: ["Darkness", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525095,
+				tcgplayer: 597284,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [167],
+};
+
+export default card;

--- a/data-asia/S/S-P/074.ts
+++ b/data-asia/S/S-P/074.ts
@@ -1,56 +1,52 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "噴火龍GX"
+		ja: "ゾウドウ",
+		'zh-tw': "噴火龍GX",
 	},
 
-	illustrator: "5ban Graphics",
+	illustrator: "0313",
 	category: "Pokemon",
-	hp: 250,
-	types: ["Fire"],
-	stage: "Stage2",
+	hp: 100,
+	types: ["Metal"],
 
-	attacks: [{
-		name: {
-			'zh-tw': "翅膀攻擊"
+	description: {
+		ja: "５トンの 荷物を もっても 平気な 力持ち ポケモン。 鼻を 使って 土を 掘る。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: {
+				ja: "かいりき",
+				'zh-tw': "翅膀攻擊",
+			},
+			damage: 60,
+			cost: ["Metal", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 70,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "紅蓮風暴"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525100,
+				tcgplayer: 597285,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將這隻寶可夢身上所附加的3個【火】能量丟到棄牌區。"
-		},
+	retreat: 3,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [878],
+};
 
-		damage: 300,
-		cost: ["Fire", "Fire", "Fire", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "怒火中燒GX"
-		},
-
-		effect: {
-			'zh-tw': "將對手的牌庫上方的10張丟到棄牌區。［對戰中，己方只可使用1次GX招式。］"
-		},
-
-		cost: ["Fire", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "A"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/075.ts
+++ b/data-asia/S/S-P/075.ts
@@ -1,47 +1,66 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "噴火龍V"
+		ja: "イーブイ",
+		'zh-tw': "噴火龍V",
 	},
 
-	illustrator: "5ban Graphics",
+	illustrator: "so-taro",
 	category: "Pokemon",
-	hp: 220,
-	types: ["Fire"],
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "まわりの 環境に 合わせて 体の つくりを 変えていく 能力の 持ち主。",
+	},
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "利爪劈擊"
+	attacks: [
+		{
+			name: {
+				ja: "しんかのきざし",
+				'zh-tw': "利爪劈擊",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "「イーブイ」から進化するカードを、自分の山札から1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
 		},
-
-		damage: 80,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "火焰旋渦"
+		{
+			name: {
+				ja: "けりつける",
+				'zh-tw': "火焰旋渦",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+				'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525105,
+				tcgplayer: 597286,
+			},
 		},
+	],
 
-		damage: 220,
-		cost: ["Fire", "Fire", "Colorless", "Colorless"]
-	}],
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [133],
+};
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
-
-	retreat: 3,
-	regulationMark: "D"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/076.ts
+++ b/data-asia/S/S-P/076.ts
@@ -1,56 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "噴火龍"
+		ja: "ヨクバリスV",
+		'zh-tw': "噴火龍",
 	},
 
-	illustrator: "Ryuta Fuse",
+	illustrator: "PLANETA Igarashi",
 	category: "Pokemon",
-	hp: 170,
-	types: ["Fire"],
+	hp: 200,
+	types: ["Colorless"],
 
-	description: {
-		'zh-tw': "會噴出彷彿連岩石都能燒焦的灼熱火焰。有時會引發森林火災。"
-	},
+	stage: "Basic",
 
-	stage: "Stage2",
-
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "戰鬥意識"
+	attacks: [
+		{
+			name: {
+				ja: "かみくだく",
+				'zh-tw': "王者火焰",
+			},
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "增加自己的棄牌區的「丹帝」的張數×50點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在自己的回合時，可使用1次。查看自己的牌庫上方3張卡，選擇其中1張卡加入手牌。將剩餘卡丟棄。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "王者火焰"
+		{
+			name: { ja: "でんぐりプレス" },
+			damage: 180,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加自己的棄牌區的「丹帝」的張數×50點傷害。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525110,
+				tcgplayer: 597287,
+			},
 		},
+	],
 
-		damage: "100+",
-		cost: ["Fire", "Fire"]
-	}],
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [820],
+};
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
-
-	retreat: 3,
-	regulationMark: "D"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/077.ts
+++ b/data-asia/S/S-P/077.ts
@@ -1,52 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "皮卡丘"
+		ja: "ウカッツ",
+		'zh-tw': "皮卡丘",
 	},
 
-	illustrator: "Kagemaru Himeno",
-	category: "Pokemon",
-	hp: 70,
-	types: ["Lightning"],
+	illustrator: "Hitoshi Ariga",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "最近發表了聚集大量皮卡丘來建造發電廠的計畫。"
+	effect: {
+		ja: "自分の山札から「めずらしい化石」を2枚まで選び、ベンチに出す。そして山札を切る。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "電光一閃"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525115,
+				tcgplayer: 597288,
+			},
 		},
+	],
 
-		damage: 10,
-		cost: ["Lightning"]
-	}, {
-		name: {
-			'zh-tw': "電球"
-		},
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Promo",
+};
 
-		damage: 60,
-		cost: ["Lightning", "Lightning", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Metal",
-		value: "-20"
-	}],
-
-	retreat: 1,
-	regulationMark: "C"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/078.ts
+++ b/data-asia/S/S-P/078.ts
@@ -1,59 +1,32 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "皮卡丘"
+		ja: "ヤロー",
+		'zh-tw': "皮卡丘",
 	},
 
-	illustrator: "Naoyo Kimura",
-	category: "Pokemon",
-	hp: 70,
-	types: ["Lightning"],
+	illustrator: "take",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "最近發表了聚集大量皮卡丘來建造發電廠的計畫。"
+	effect: {
+		ja: "自分の手札を2枚までトラッシュし、その枚数×2枚、自分の山札を引く。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "蹭蹭臉頰"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597289,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。"
-		},
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Promo",
+};
 
-		cost: ["Lightning"]
-	}, {
-		name: {
-			'zh-tw': "伏特攻擊"
-		},
-
-		effect: {
-			'zh-tw': "這隻寶可夢也受到10點傷害。"
-		},
-
-		damage: 70,
-		cost: ["Lightning", "Lightning", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Metal",
-		value: "-20"
-	}],
-
-	retreat: 1,
-	regulationMark: "C"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/079.ts
+++ b/data-asia/S/S-P/079.ts
@@ -1,50 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "皮卡丘"
+		ja: "ムゲンダイナV",
+		'zh-tw': "皮卡丘",
 	},
 
-	illustrator: "Ryuta Fuse",
+	illustrator: "5ban Graphics",
 	category: "Pokemon",
-	hp: 60,
-	types: ["Lightning"],
-
-	description: {
-		'zh-tw': "最近發表了聚集大量皮卡丘來建造發電廠的計畫。"
-	},
+	hp: 220,
+	types: ["Darkness"],
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "充電"
+	attacks: [
+		{
+			name: {
+				ja: "パワーアクセル",
+				'zh-tw': "充電",
+			},
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "のぞむなら、自分の手札から[悪]エネルギーを1枚選び、ベンチポケモンにつける。",
+				'zh-tw': "從自己的牌庫選擇1張【雷】能量卡，附於這隻寶可夢身上。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張【雷】能量卡，附於這隻寶可夢身上。並且重洗牌庫。"
+		{
+			name: {
+				ja: "ダイマックスほう",
+				'zh-tw': "電球",
+			},
+			damage: "120+",
+			cost: ["Darkness", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが「ポケモンVMAX」なら、120ダメージ追加。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "電球"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 468279,
+				tcgplayer: 597290,
+			},
 		},
+	],
 
-		damage: 20,
-		cost: ["Lightning", "Colorless"]
-	}],
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [890],
+};
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "D"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/080.ts
+++ b/data-asia/S/S-P/080.ts
@@ -1,50 +1,66 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "皮卡丘"
+		ja: "ムゲンダイナVMAX",
+		'zh-tw': "皮卡丘",
 	},
 
-	illustrator: "Hitoshi Ariga",
+	illustrator: "5ban Graphics",
 	category: "Pokemon",
-	hp: 60,
-	types: ["Lightning"],
+	hp: 340,
+	types: ["Darkness"],
 
-	description: {
-		'zh-tw': "最近發表了聚集大量皮卡丘來建造發電廠的計畫。"
+	stage: "VMAX",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ムゲンゾーン" },
+			effect: {
+				ja: "自分の場のポケモン全員が[悪]タイプならはたらく。自分のベンチに出せる[悪]ポケモンの数は8匹になり、別のタイプは場に出せない。（この特性がはたらかなくなったとき、ベンチが5匹になるまでトラッシュする。）",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: {
+				ja: "ドレッドエンド",
+				'zh-tw': "搖尾巴",
+			},
+			damage: "30×",
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "自分の場の[悪]ポケモンの数×30ダメージ。",
+				'zh-tw': "擲1次硬幣若為正面，則在下個對手的回合，受到這個招式的寶可夢無法使用招式。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 468284,
+				tcgplayer: 597291,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ムゲンダイナV",
 	},
 
-	stage: "Basic",
+	retreat: 3,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [890],
+};
 
-	attacks: [{
-		name: {
-			'zh-tw': "搖尾巴"
-		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則在下個對手的回合，受到這個招式的寶可夢無法使用招式。"
-		},
-
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "皮卡伏特"
-		},
-
-		damage: 50,
-		cost: ["Lightning", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "D"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/081.ts
+++ b/data-asia/S/S-P/081.ts
@@ -1,44 +1,57 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "皮卡丘"
+		ja: "フーパ",
+		'zh-tw': "皮卡丘",
 	},
 
-	illustrator: "sowsow",
+	illustrator: "so-taro",
 	category: "Pokemon",
-	hp: 60,
-	types: ["Lightning"],
+	hp: 120,
+	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "最近發表了聚集大量皮卡丘來建造發電廠的計畫。"
+		ja: "気に入った ものを リングを 使い 秘密の 住処へ 集めている。 リングを 潜って テレポートする。",
+		'zh-tw': "最近發表了聚集大量皮卡丘來建造發電廠的計畫。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "電擊"
+	attacks: [
+		{
+			name: {
+				ja: "アサルトゲート",
+				'zh-tw': "電擊",
+			},
+			damage: 90,
+			cost: ["Darkness"],
+			effect: {
+				ja: "この番、このポケモンがベンチからバトル場に出ていないなら、このワザは失敗。このワザのダメージは弱点を計算しない。",
+				'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 468289,
+				tcgplayer: 597292,
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Lightning", "Lightning"]
-	}],
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [720],
+};
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "D"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/082.ts
+++ b/data-asia/S/S-P/082.ts
@@ -1,50 +1,70 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "皮卡丘V"
+		ja: "ガラル タチフサグマ",
+		'zh-tw': "皮卡丘V",
 	},
 
-	illustrator: "PLANETA Tsuji",
+	illustrator: "Shin Nagasawa",
 	category: "Pokemon",
-	hp: 190,
-	types: ["Lightning"],
-	stage: "Basic",
-	suffix: "V",
+	hp: 170,
+	types: ["Darkness"],
 
-	attacks: [{
-		name: {
-			'zh-tw': "充電"
+	description: {
+		ja: "凄まじい 声量を もつ。 シャウトとともに 威嚇するさまは ブロッキングと 呼ばれている。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "バッドルーラー" },
+			effect: {
+				ja: "自分の番に1回使える。相手は相手自身の手札を、4枚になるようにトラッシュする。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多2張【雷】能量卡，附於這隻寶可夢身上。並且重洗牌庫。"
+	attacks: [
+		{
+			name: {
+				ja: "ナックルインパクト",
+				'zh-tw': "充電",
+			},
+			damage: 180,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+				'zh-tw': "從自己的牌庫選擇最多2張【雷】能量卡，附於這隻寶可夢身上。並且重洗牌庫。",
+			},
 		},
+	],
 
-		cost: ["Lightning"]
-	}, {
-		name: {
-			'zh-tw': "十萬伏特"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 468294,
+				tcgplayer: 597293,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將這隻寶可夢身上附加的能量全部丟棄。"
-		},
+	evolveFrom: {
+		ja: "ガラル マッスグマ",
+	},
 
-		damage: 200,
-		cost: ["Lightning", "Lightning", "Colorless"]
-	}],
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [862],
+};
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "D"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/083.ts
+++ b/data-asia/S/S-P/083.ts
@@ -1,55 +1,32 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "皮卡丘&捷克羅姆GX"
+		ja: "基本悪エネルギー",
+		'zh-tw': "皮卡丘&捷克羅姆GX",
 	},
 
-	illustrator: "5ban Graphics",
-	category: "Pokemon",
-	hp: 240,
-	types: ["Lightning"],
-	stage: "Basic",
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
 
-	attacks: [{
-		name: {
-			'zh-tw': "滿溢驅動"
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 468299,
+				tcgplayer: 649784,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的牌庫抽出最多3張【雷】能量卡，附於自己的1隻寶可夢身上。並且重洗牌庫。"
-		},
+	rarity: "Promo",
+};
 
-		damage: 150,
-		cost: ["Lightning", "Lightning", "Lightning"]
-	}, {
-		name: {
-			'zh-tw': "聯手伏特GX"
-		},
-
-		effect: {
-			'zh-tw': "若額外附有3個【雷】能量，則對手的1隻備戰寶可夢也受到170點傷害。[在備戰區不計算弱點・抵抗力。][對戰中，己方只可使用1次GX招式。]"
-		},
-
-		damage: 200,
-		cost: ["Lightning", "Lightning", "Lightning"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Metal",
-		value: "-20"
-	}],
-
-	retreat: 3,
-	regulationMark: "C"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/084.ts
+++ b/data-asia/S/S-P/084.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フォクスライ",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Darkness"],
+
+	description: {
+		ja: "狙った 獲物は こっそり マーキング。 においを 辿って 油断 したころ 盗みに 来るぞ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "てしたをよぶ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からたねポケモンを3枚まで選び、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "おいつめる" },
+			damage: 80,
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525125,
+				tcgplayer: 597294,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "クスネ",
+	},
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [828],
+};
+
+export default card;

--- a/data-asia/S/S-P/085.ts
+++ b/data-asia/S/S-P/085.ts
@@ -1,61 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "萊希拉姆&噴火龍GX"
+		ja: "エール団のしたっぱ",
+		'zh-tw': "萊希拉姆&噴火龍GX",
 	},
 
-	illustrator: "aky CG Works",
-	category: "Pokemon",
-	hp: 270,
-	types: ["Fire"],
-	stage: "Basic",
+	illustrator: "nagimiso",
+	category: "Trainer",
 
-	attacks: [{
-		name: {
-			'zh-tw': "逆鱗"
+	effect: {
+		ja: "相手の場のポケモンについているエネルギーを1個選び、相手の手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463204,
+				tcgplayer: 597295,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加這隻寶可夢身上所放置的傷害指示物的數量×10點傷害。"
-		},
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Promo",
+};
 
-		damage: "30+",
-		cost: ["Fire", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "閃焰強襲"
-		},
-
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「閃焰強襲」。"
-		},
-
-		damage: 230,
-		cost: ["Fire", "Fire", "Fire", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "雙重火焰GX"
-		},
-
-		effect: {
-			'zh-tw': "若額外附有3個【火】能量，則增加100點傷害。這個情況下，這個招式的傷害不計算對手的戰鬥寶可夢身上的附加效果。[對戰中，己方只可使用1次GX招式。]"
-		},
-
-		damage: "200+",
-		cost: ["Fire", "Fire", "Fire"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
-
-	retreat: 3,
-	regulationMark: "C"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/086.ts
+++ b/data-asia/S/S-P/086.ts
@@ -1,56 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "噴火龍GX"
+		ja: "マリィ",
+		'zh-tw': "噴火龍GX",
 	},
 
-	illustrator: "5ban Graphics",
-	category: "Pokemon",
-	hp: 250,
-	types: ["Fire"],
-	stage: "Stage2",
+	illustrator: "kirisAki",
+	category: "Trainer",
 
-	attacks: [{
-		name: {
-			'zh-tw': "翅膀攻擊"
+	effect: {
+		ja: "おたがいのプレイヤーは、それぞれ自分の手札をすべてウラにして切り、山札の下にもどす。その後、自分は5枚、相手は4枚、山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525130,
+				tcgplayer: 597296,
+			},
 		},
+	],
 
-		damage: 70,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "紅蓮風暴"
-		},
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Promo",
+};
 
-		effect: {
-			'zh-tw': "將這隻寶可夢身上所附加的3個【火】能量丟到棄牌區。"
-		},
-
-		damage: 300,
-		cost: ["Fire", "Fire", "Fire", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "怒火中燒GX"
-		},
-
-		effect: {
-			'zh-tw': "將對手的牌庫上方的10張丟到棄牌區。［對戰中，己方只可使用1次GX招式。］"
-		},
-
-		cost: ["Fire", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "A"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/087.ts
+++ b/data-asia/S/S-P/087.ts
@@ -1,46 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "噴火龍VMAX"
+		ja: "グズマ&ハラ",
+		'zh-tw': "噴火龍VMAX",
 	},
 
-	illustrator: "aky CG Works",
-	category: "Pokemon",
-	hp: 330,
-	types: ["Fire"],
-	stage: "VMAX",
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
 
-	attacks: [{
-		name: {
-			'zh-tw': "利爪劈擊"
+	effect: {
+		ja: "自分の山札にある「スタジアム」を1枚、相手に見せてから、手札に加える。そして山札を切る。追加で、このカードを使うときに、自分の手札を2枚トラッシュしてよい。その場合、「ポケモンのどうぐ」と「特殊エネルギー」も1枚ずつ手札に加えられる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463209,
+				tcgplayer: 597297,
+			},
 		},
+	],
 
-		damage: 100,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "超極巨地獄滅焰"
-		},
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Promo",
+};
 
-		effect: {
-			'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。"
-		},
-
-		damage: 300,
-		cost: ["Fire", "Fire", "Fire", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
-
-	retreat: 3,
-	regulationMark: "D"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/088.ts
+++ b/data-asia/S/S-P/088.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "丹帝"
+		ja: "シロナ&カトレア",
+		'zh-tw': "丹帝",
 	},
 
 	illustrator: "Ken Sugimori",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "在這個回合，自己的寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+30」點。"
+		ja: "自分のトラッシュにあるサポート（「シロナ&カトレア」とこのカードの効果でトラッシュされたカードをのぞく）を1枚、相手に見せてから、手札に加える。追加で、このカードを使うときに、自分の手札を1枚トラッシュしてよい。その場合、自分の山札を3枚引く。",
+		'zh-tw': "在這個回合，自己的寶可夢使用的招式，對對手的戰鬥寶可夢造成的傷害「+30」點。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "D"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463214,
+				tcgplayer: 597298,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/089.ts
+++ b/data-asia/S/S-P/089.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "竹蘭"
+		ja: "マオ&スイレン",
+		'zh-tw': "竹蘭",
 	},
 
 	illustrator: "Ken Sugimori",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "將自己的手牌全部放回牌庫並重洗。然後，從牌庫抽出6張。"
+		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。追加で、このカードを使うときに、自分の手札を2枚トラッシュしてよい。その場合、ベンチに入れ替えたポケモンのHPを「120」回復する。",
+		'zh-tw': "將自己的手牌全部放回牌庫並重洗。然後，從牌庫抽出6張。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "B"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 463219,
+				tcgplayer: 597299,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/090.ts
+++ b/data-asia/S/S-P/090.ts
@@ -1,22 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "莉莉艾"
+		ja: "基本草エネルギー",
+		'zh-tw': "莉莉艾",
 	},
 
-	illustrator: "Megumi Mizutani",
-	category: "Trainer",
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
 
 	effect: {
-		'zh-tw': "從牌庫抽卡直到自己的手牌滿6張為止。若在自己的最初回合使用，則抽卡直到滿8張為止。"
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+		'zh-tw': "從牌庫抽卡直到自己的手牌滿6張為止。若在自己的最初回合使用，則抽卡直到滿8張為止。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "A"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525135,
+				tcgplayer: 649918,
+			},
+		},
+	],
 
-export default card
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/091.ts
+++ b/data-asia/S/S-P/091.ts
@@ -1,22 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "古茲馬"
+		ja: "基本炎エネルギー",
+		'zh-tw': "古茲馬",
 	},
 
-	illustrator: "Masakazu Fukuda",
-	category: "Trainer",
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
 
 	effect: {
-		'zh-tw': "選擇對手的1隻備戰寶可夢，與戰鬥寶可夢互換。然後，將自己的戰鬥寶可夢與備戰寶可夢互換。"
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+		'zh-tw': "選擇對手的1隻備戰寶可夢，與戰鬥寶可夢互換。然後，將自己的戰鬥寶可夢與備戰寶可夢互換。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "A"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525140,
+				tcgplayer: 649756,
+			},
+		},
+	],
 
-export default card
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/092.ts
+++ b/data-asia/S/S-P/092.ts
@@ -1,22 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "竹蘭"
+		ja: "基本水エネルギー",
+		'zh-tw': "竹蘭",
 	},
 
-	illustrator: "nagimiso",
-	category: "Trainer",
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
 
 	effect: {
-		'zh-tw': "將自己的手牌全部放回牌庫並重洗。然後，從牌庫抽出6張。"
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+		'zh-tw': "將自己的手牌全部放回牌庫並重洗。然後，從牌庫抽出6張。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "B"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525145,
+				tcgplayer: 649795,
+			},
+		},
+	],
 
-export default card
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/093.ts
+++ b/data-asia/S/S-P/093.ts
@@ -1,47 +1,32 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "斗笠菇V"
+		ja: "基本雷エネルギー",
+		'zh-tw': "斗笠菇V",
 	},
 
-	illustrator: "PLANETA Mochizuki",
-	category: "Pokemon",
-	hp: 210,
-	types: ["Grass"],
-	stage: "Basic",
-	suffix: "V",
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
 
-	attacks: [{
-		name: {
-			'zh-tw': "雙倍奉還"
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525150,
+				tcgplayer: 649912,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "增加與在上個對手的回合這隻寶可夢受到的招式的傷害點相同數量的傷害。"
-		},
+	rarity: "Promo",
+};
 
-		damage: "20+",
-		cost: ["Grass", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "音速直擊"
-		},
-
-		damage: 140,
-		cost: ["Grass", "Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "E"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/094.ts
+++ b/data-asia/S/S-P/094.ts
@@ -1,40 +1,31 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雪童子"
+		ja: "基本超エネルギー",
+		'zh-tw': "雪童子",
 	},
 
-	illustrator: "otumami",
-	category: "Pokemon",
-	hp: 60,
-	types: ["Water"],
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
 
-	description: {
-		'zh-tw': "只能在寒冷的土地上生存。即使在零下１００度的環境下也能充滿活力地到處蹦蹦跳跳。"
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "頭錘"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 649806,
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Water", "Colorless"]
-	}],
+	rarity: "Promo",
+};
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "E"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/095.ts
+++ b/data-asia/S/S-P/095.ts
@@ -1,43 +1,32 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "斑斑馬"
+		ja: "基本闘エネルギー",
+		'zh-tw': "斑斑馬",
 	},
 
-	illustrator: "Oswaldo KATO",
-	category: "Pokemon",
-	hp: 60,
-	types: ["Lightning"],
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
 
-	description: {
-		'zh-tw': "放電時鬃毛會發光。利用鬃毛閃爍的次數及 節奏與夥伴交談。"
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "雷電箭"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525160,
+				tcgplayer: 649798,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "對手的1隻寶可夢受到10點傷害。[在備戰區不計算弱點・抵抗力。]"
-		},
+	rarity: "Promo",
+};
 
-		cost: ["Lightning"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "E"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/096.ts
+++ b/data-asia/S/S-P/096.ts
@@ -1,60 +1,31 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "太陽伊布"
+		ja: "基本悪エネルギー",
+		'zh-tw': "太陽伊布",
 	},
 
-	illustrator: "Tika Matsuno",
-	category: "Pokemon",
-	hp: 110,
-	types: ["Psychic"],
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
 
-	description: {
-		'zh-tw': "從額頭的珠子放射出精神力量進行戰鬥。當力量用盡時，珠子的顏色也會褪去。"
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
 	},
 
-	stage: "Stage1",
-
-	attacks: [{
-		name: {
-			'zh-tw': "念力"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 649787,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。"
-		},
+	rarity: "Promo",
+};
 
-		damage: 20,
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "精神強念"
-		},
-
-		effect: {
-			'zh-tw': "增加對手的戰鬥寶可夢身上附加的能量的數量×40點傷害。"
-		},
-
-		damage: "10+",
-		cost: ["Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
-
-	retreat: 1,
-	regulationMark: "E"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/097.ts
+++ b/data-asia/S/S-P/097.ts
@@ -1,44 +1,31 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "瓦斯彈"
+		ja: "基本鋼エネルギー",
+		'zh-tw': "瓦斯彈",
 	},
 
-	illustrator: "miki kudo",
-	category: "Pokemon",
-	hp: 70,
-	types: ["Darkness"],
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
 
-	description: {
-		'zh-tw': "污濁的空氣是牠的美味大餐。據說在昔日的伽勒爾地區曾經存在著更多的瓦斯彈。"
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "濁霧"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 649777,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。"
-		},
+	rarity: "Promo",
+};
 
-		damage: 20,
-		cost: ["Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "E"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/098.ts
+++ b/data-asia/S/S-P/098.ts
@@ -1,50 +1,32 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伊布"
+		ja: "基本フェアリーエネルギー",
+		'zh-tw': "伊布",
 	},
 
-	illustrator: "Tika Matsuno",
-	category: "Pokemon",
-	hp: 60,
-	types: ["Colorless"],
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
 
-	description: {
-		'zh-tw': "由於不穩定的基因，蘊含著各式各樣進化可能性的特殊寶可夢。"
+	effect: {
+		ja: "エネルギーカード付き カードボックス メガミュウツーX・メガミュウツーY",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "準備"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525175,
+				tcgplayer: 649920,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的手牌選擇1張基本能量卡，附於這隻寶可夢身上。"
-		},
+	rarity: "Promo",
+};
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "咬住"
-		},
-
-		damage: 30,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "E"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/099.ts
+++ b/data-asia/S/S-P/099.ts
@@ -1,22 +1,56 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "機器鶘"
+		ja: "名探偵ピカチュウ",
+		'zh-tw': "機器鶘",
 	},
 
-	illustrator: "Ryo Ueda",
-	category: "Trainer",
+	illustrator: "",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Lightning"],
 
-	effect: {
-		'zh-tw': "這張卡必須從自己的手牌將1張物品卡丟棄才可使用。擲1次硬幣若為正面，則從自己的牌庫任意選擇1張卡加入手牌。並且重洗牌庫。"
+	description: {
+		ja: "ウンチクを 語るのが 好き。 表情 豊かで おっさん みたいな ピカチュウ。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "E"
-}
+	stage: "Basic",
 
-export default card
+	attacks: [
+		{
+			name: { ja: "とぼとぼかえる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "しっぽではたく" },
+			damage: 50,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525180,
+				tcgplayer: 597300,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/S/S-P/100.ts
+++ b/data-asia/S/S-P/100.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イーブイ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "まわりの 環境に 合わせて 体の つくりを 変えていく 能力の 持ち主。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はじめのいっぽ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+			},
+		},
+		{
+			name: { ja: "しっぽではたく" },
+			damage: 30,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597301,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [133],
+};
+
+export default card;

--- a/data-asia/S/S-P/101.ts
+++ b/data-asia/S/S-P/101.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イーブイVMAX",
+	},
+
+	illustrator: "PLANETA Mochizuki",
+	category: "Pokemon",
+	hp: 300,
+	types: ["Colorless"],
+
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: { ja: "キョダイホーヨー" },
+			damage: 150,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンがワザを使うとき、相手はコインを1回投げる。ウラならそのワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525190,
+				tcgplayer: 597302,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイV",
+	},
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [133],
+};
+
+export default card;

--- a/data-asia/S/S-P/102.ts
+++ b/data-asia/S/S-P/102.ts
@@ -1,55 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "葉伊布"
+		ja: "ジムトレーナー",
+		'zh-tw': "葉伊布",
 	},
 
-	illustrator: "OKACHEKE",
-	category: "Pokemon",
-	hp: 110,
-	types: ["Grass"],
+	illustrator: "Ryuta Fuse",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "尾巴如同銳利的刀刃，鋒利得無與倫比，連大樹都能一刀兩斷。"
+	effect: {
+		ja: "自分の山札を2枚引く。前の相手の番に、自分のポケモンがきぜつしていたなら、さらに2枚引く。",
 	},
 
-	stage: "Stage1",
-
-	attacks: [{
-		name: {
-			'zh-tw': "葉子防守"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525195,
+				tcgplayer: 597303,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-30」點。"
-		},
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Promo",
+};
 
-		damage: 30,
-		cost: ["Grass"]
-	}, {
-		name: {
-			'zh-tw': "打草結"
-		},
-
-		effect: {
-			'zh-tw': "增加對手的戰鬥寶可夢【撤退】所需的能量的數量×30點傷害。"
-		},
-
-		damage: "50+",
-		cost: ["Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "E"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/103.ts
+++ b/data-asia/S/S-P/103.ts
@@ -1,54 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "冰伊布"
+		ja: "リザードンV",
+		'zh-tw': "冰伊布",
 	},
 
-	illustrator: "OKACHEKE",
+	illustrator: "5ban Graphics",
 	category: "Pokemon",
-	hp: 110,
-	types: ["Water"],
+	hp: 220,
+	types: ["Fire"],
 
-	description: {
-		'zh-tw': "冰伊布釋放出的冷氣能製造出粉狀的雪。這使牠受到各個滑雪場的熱烈歡迎。"
-	},
+	stage: "Basic",
 
-	stage: "Stage1",
-
-	attacks: [{
-		name: {
-			'zh-tw': "冰雹"
+	attacks: [
+		{
+			name: {
+				ja: "ツメできりさく",
+				'zh-tw': "冰雹",
+			},
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
-
-		effect: {
-			'zh-tw': "對手的所有寶可夢各受到20點傷害。[在備戰區不計算弱點・抵抗力。]"
+		{
+			name: {
+				ja: "ほのおのうず",
+				'zh-tw': "冰霜颱風",
+			},
+			damage: 220,
+			cost: ["Fire", "Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「冰霜颱風」。",
+			},
 		},
+	],
 
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "冰霜颱風"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525200,
+				tcgplayer: 597304,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「冰霜颱風」。"
-		},
+	retreat: 3,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [6],
+};
 
-		damage: 120,
-		cost: ["Water", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "E"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/104.ts
+++ b/data-asia/S/S-P/104.ts
@@ -1,40 +1,59 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "天秤偶"
+		ja: "リザードンVMAX",
+		'zh-tw': "天秤偶",
 	},
 
-	illustrator: "Nagomi Nijo",
+	illustrator: "aky CG Works",
 	category: "Pokemon",
-	hp: 60,
-	types: ["Fighting"],
+	hp: 330,
+	types: ["Fire"],
 
-	description: {
-		'zh-tw': "在古代遺跡被發現。會一邊旋轉一邊移動。晚上睡覺的時候也是單腳站著。"
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: {
+				ja: "ツメできりさく",
+				'zh-tw': "掌擊",
+			},
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "キョダイゴクエン" },
+			damage: 300,
+			cost: ["Fire", "Fire", "Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597305,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "リザードンV",
 	},
 
-	stage: "Basic",
+	retreat: 3,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [6],
+};
 
-	attacks: [{
-		name: {
-			'zh-tw': "掌擊"
-		},
-
-		damage: 20,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "E"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/105.ts
+++ b/data-asia/S/S-P/105.ts
@@ -1,40 +1,61 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "不良蛙"
+		ja: "まるのみされたピカチュウ",
+		'zh-tw': "不良蛙",
 	},
 
-	illustrator: "Yuya Oka",
+	illustrator: "2020 Pikachu Project",
 	category: "Pokemon",
 	hp: 60,
-	types: ["Darkness"],
+	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "毒素在稀釋後能製成藥品。牠是製藥公司的吉祥物，廣受眾人的歡迎。"
+		ja: "オコヤの森で 出会った ピカチュウと ウッウ。 すっかり ウッウに 気に入られてしまい 困っている。",
+		'zh-tw': "毒素在稀釋後能製成藥品。牠是製藥公司的吉祥物，廣受眾人的歡迎。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "推擊"
+	attacks: [
+		{
+			name: {
+				ja: "もがく",
+				'zh-tw': "推擊",
+			},
+			damage: 10,
+			cost: ["Colorless"],
 		},
+		{
+			name: { ja: "10まんボルト" },
+			damage: 70,
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、すべてトラッシュする。",
+			},
+		},
+	],
 
-		damage: 20,
-		cost: ["Darkness"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525215,
+				tcgplayer: 597306,
+			},
+		},
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [25],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/106.ts
+++ b/data-asia/S/S-P/106.ts
@@ -1,46 +1,65 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "鰓魚龍V"
+		ja: "ココ",
+		'zh-tw': "鰓魚龍V",
 	},
 
-	illustrator: "Satoshi Shirai",
+	illustrator: "Tetsuo Yajima",
 	category: "Pokemon",
-	hp: 220,
-	types: ["Dragon"],
+	hp: 90,
+	types: ["Grass"],
+
+	description: {
+		ja: "ザルードに 育てられた 少年。 ジャングルの ポケモン達から 慕われている。",
+	},
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "咬咬粉碎"
+	attacks: [
+		{
+			name: {
+				ja: "もりのよびごえ",
+				'zh-tw': "咬咬粉碎",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から[草]ポケモンを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "在造成傷害前，將對手的戰鬥寶可夢身上附加的「寶可夢道具」丟棄。有丟棄的情況下，增加120點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在造成傷害前，將對手的戰鬥寶可夢身上附加的「寶可夢道具」丟棄。有丟棄的情況下，增加120點傷害。"
+		{
+			name: {
+				ja: "ターザンキック",
+				'zh-tw': "龍之強襲",
+			},
+			damage: 120,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "コインを1回投げ、ウラなら失敗。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「龍之強襲」。",
+			},
 		},
+	],
 
-		damage: "60+",
-		cost: ["Grass", "Water"]
-	}, {
-		name: {
-			'zh-tw': "龍之強襲"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597307,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「龍之強襲」。"
-		},
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+};
 
-		damage: 210,
-		cost: ["Grass", "Water", "Water"]
-	}],
-
-	retreat: 3,
-	regulationMark: "E"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/107.ts
+++ b/data-asia/S/S-P/107.ts
@@ -1,50 +1,67 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伊布"
+		ja: "モルペコ",
+		'zh-tw': "伊布",
 	},
 
-	illustrator: "OKACHEKE",
+	illustrator: "Saya Tsuruta",
 	category: "Pokemon",
-	hp: 60,
-	types: ["Colorless"],
+	hp: 80,
+	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "由於不穩定的基因，蘊含著各式各樣進化可能性的特殊寶可夢。"
+		ja: "いつも お腹を すかせている。 ポケットの ような 袋に 入れた タネを 食べて 電気を つくる。",
+		'zh-tw': "由於不穩定的基因，蘊含著各式各樣進化可能性的特殊寶可夢。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "準備"
+	attacks: [
+		{
+			name: {
+				ja: "ペコペコ",
+				'zh-tw': "準備",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+				'zh-tw': "從自己的手牌選擇1張基本能量卡，附於這隻寶可夢身上。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的手牌選擇1張基本能量卡，附於這隻寶可夢身上。"
+		{
+			name: {
+				ja: "でんきショック",
+				'zh-tw': "咬住",
+			},
+			damage: 40,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "咬住"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525210,
+				tcgplayer: 597308,
+			},
 		},
-
-		damage: 30,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [877],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/108.ts
+++ b/data-asia/S/S-P/108.ts
@@ -1,22 +1,55 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "打空保險"
+		ja: "ザルードV",
+		'zh-tw': "打空保險",
 	},
 
-	illustrator: "Ayaka Yoshida",
-	category: "Trainer",
+	illustrator: "PLANETA Igarashi",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Grass"],
 
-	effect: {
-		'zh-tw': "寶可夢道具卡，附於自己的寶可夢使用。1隻寶可夢只可附上1張寶可夢道具卡，並且保持附加狀態。"
-	},
+	stage: "Basic",
 
-	trainerType: "Tool",
-	regulationMark: "E"
-}
+	attacks: [
+		{
+			name: { ja: "しばりつける" },
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "ジャングルライズ" },
+			damage: 100,
+			cost: ["Grass", "Grass"],
+			effect: {
+				ja: "のぞむなら、自分の手札から基本エネルギーを2枚まで選び、ベンチポケモンに好きなようにつける。その後、つけたポケモンのHPをすべて回復する。",
+			},
+		},
+	],
 
-export default card
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597309,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [893],
+};
+
+export default card;

--- a/data-asia/S/S-P/109.ts
+++ b/data-asia/S/S-P/109.ts
@@ -1,22 +1,59 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "博士的研究（維羅博士）"
+		ja: "イエッサン",
+		'zh-tw': "博士的研究（維羅博士）",
 	},
 
-	illustrator: "Yusuke Kozaki",
-	category: "Trainer",
+	illustrator: "Souichirou Gunjima",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Colorless"],
 
-	effect: {
-		'zh-tw': "將自己的手牌全部丟棄，從牌庫抽出7張卡。"
+	description: {
+		ja: "頭の ツノで 相手の 気持ちを 感じとる。 オスは 従者の ように 主のそばで 世話を焼く。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "D"
-}
+	stage: "Basic",
 
-export default card
+	attacks: [
+		{
+			name: { ja: "てだすけ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から基本エネルギーを1枚選び、ベンチポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "サイコキネシス" },
+			damage: "20+",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数×20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525230,
+				tcgplayer: 597310,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [876],
+};
+
+export default card;

--- a/data-asia/S/S-P/110.ts
+++ b/data-asia/S/S-P/110.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イオルブV",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひるがえす" },
+			damage: 20,
+			cost: ["Grass"],
+			effect: {
+				ja: "のぞむなら、このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "ミステリーウェーブ" },
+			damage: "50+",
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数×30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525235,
+				tcgplayer: 597311,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [826],
+};
+
+export default card;

--- a/data-asia/S/S-P/111.ts
+++ b/data-asia/S/S-P/111.ts
@@ -1,39 +1,59 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "火伊布VMAX"
+		ja: "ブリムオンV",
+		'zh-tw': "火伊布VMAX",
 	},
 
-	illustrator: "OKACHEKE",
+	illustrator: "PLANETA Igarashi",
 	category: "Pokemon",
-	hp: 320,
-	types: ["Fire"],
-	stage: "VMAX",
+	hp: 200,
+	types: ["Psychic"],
 
-	attacks: [{
-		name: {
-			'zh-tw': "極巨爆裂"
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: {
+				ja: "まよいのはどう",
+				'zh-tw': "極巨爆裂",
+			},
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、新しく出てきたポケモンをこんらんにする。",
+				'zh-tw': "將自己的牌庫上方5張卡丟棄，造成其中的能量卡的張數×100點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將自己的牌庫上方5張卡丟棄，造成其中的能量卡的張數×100點傷害。"
+		{
+			name: { ja: "メンタルクラッシュ" },
+			damage: "90+",
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンがこんらんなら、90ダメージ追加。",
+			},
 		},
+	],
 
-		damage: "100×",
-		cost: ["Fire", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525240,
+				tcgplayer: 597312,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [858],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/112.ts
+++ b/data-asia/S/S-P/112.ts
@@ -1,49 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "水伊布VMAX"
+		ja: "ヒトカゲ",
+		'zh-tw': "水伊布VMAX",
 	},
 
-	illustrator: "Atsushi Furusawa",
+	illustrator: "Uta",
 	category: "Pokemon",
-	hp: 320,
-	types: ["Water"],
-	stage: "VMAX",
+	hp: 70,
+	types: ["Fire"],
 
-	attacks: [{
-		name: {
-			'zh-tw': "泡沫艙"
+	description: {
+		ja: "熱いものを 好む 性格。 雨に濡れると しっぽの 先から 煙が 出るという。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: {
+				ja: "もってくる",
+				'zh-tw': "泡沫艙",
+			},
+			cost: ["Fire"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+				'zh-tw': "從自己的棄牌區選擇1張【水】寶可夢卡，放置於備戰區。然後，從自己的棄牌區選擇最多3張【水】能量卡，附於剛放置的寶可夢身上。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的棄牌區選擇1張【水】寶可夢卡，放置於備戰區。然後，從自己的棄牌區選擇最多3張【水】能量卡，附於剛放置的寶可夢身上。"
+		{
+			name: {
+				ja: "ほのお",
+				'zh-tw': "極巨激流",
+			},
+			damage: 30,
+			cost: ["Fire", "Fire"],
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "極巨激流"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525245,
+				tcgplayer: 597313,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若對手的戰鬥寶可夢身上放置有傷害指示物，則增加100點傷害。"
-		},
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [4],
+};
 
-		damage: "100+",
-		cost: ["Water", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "E"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/113.ts
+++ b/data-asia/S/S-P/113.ts
@@ -1,39 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雷伊布VMAX"
+		ja: "サシカマス",
+		'zh-tw': "雷伊布VMAX",
 	},
 
-	illustrator: "Hasuno",
+	illustrator: "tetsuya koizumi",
 	category: "Pokemon",
-	hp: 300,
-	types: ["Lightning"],
-	stage: "VMAX",
+	hp: 60,
+	types: ["Water"],
 
-	attacks: [{
-		name: {
-			'zh-tw': "極巨迅雷"
+	description: {
+		ja: "鋭く 尖った 顎が 自慢。 少しでも 動くものを 見つけると 一直線に 突撃する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: {
+				ja: "むれる",
+				'zh-tw': "極巨迅雷",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から「サシカマス」を2枚まで選び、ベンチに出す。そして山札を切る。",
+				'zh-tw': "對手的身上放置有傷害指示物的1隻備戰寶可夢也受到100點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
-
-		effect: {
-			'zh-tw': "對手的身上放置有傷害指示物的1隻備戰寶可夢也受到100點傷害。[在備戰區不計算弱點・抵抗力。]"
+		{
+			name: { ja: "つつく" },
+			damage: 20,
+			cost: ["Water", "Colorless"],
 		},
+	],
 
-		damage: 100,
-		cost: ["Lightning", "Colorless"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525250,
+				tcgplayer: 597314,
+			},
+		},
+	],
 
-	retreat: 0,
-	regulationMark: "E"
-}
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [846],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/114.ts
+++ b/data-asia/S/S-P/114.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サンダース",
+	},
+
+	illustrator: "Yuu Nishida",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Lightning"],
+
+	description: {
+		ja: "怒ったり 驚いたりすると 全身の 毛が 針の ように 逆立って 相手を つらぬく。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "たいでん" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分のトラッシュから[雷]エネルギーを1枚選び、このポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "かみなり" },
+			damage: 160,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525255,
+				tcgplayer: 597315,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 0,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [135],
+};
+
+export default card;

--- a/data-asia/S/S-P/115.ts
+++ b/data-asia/S/S-P/115.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴマゾウ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "体は 小さいが 力持ち。 大人の 人を 軽々と 背中に 乗せて 歩いてしまう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふむ" },
+			damage: 10,
+			cost: ["Fighting"],
+		},
+		{
+			name: { ja: "おかえしアタック" },
+			damage: "30×",
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数×30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525260,
+				tcgplayer: 597316,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [231],
+};
+
+export default card;

--- a/data-asia/S/S-P/116.ts
+++ b/data-asia/S/S-P/116.ts
@@ -1,49 +1,67 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "強顎雞母蟲"
+		ja: "ワルビル",
+		'zh-tw': "強顎雞母蟲",
 	},
 
-	illustrator: "Atsuko Nishida",
+	illustrator: "Shin Nagasawa",
 	category: "Pokemon",
-	hp: 70,
-	types: ["Grass"],
-	stage: "Basic",
+	hp: 90,
+	types: ["Darkness"],
 
-	attacks: [{
-		name: {
-			'zh-tw': "帶電"
+	description: {
+		ja: "獲物の １部は 砂の中に 埋めて 狩りが 失敗したときの 非常食に するのだ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: {
+				ja: "かみつく",
+				'zh-tw': "帶電",
+			},
+			damage: 20,
+			cost: ["Darkness"],
 		},
-
-		effect: {
-			'zh-tw': "從自己的棄牌區選擇1張【雷】能量卡，附於這隻寶可夢身上。"
+		{
+			name: {
+				ja: "ほりあらす",
+				'zh-tw': "偷襲",
+			},
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の山札を上から3枚トラッシュする。",
+				'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "偷襲"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525265,
+				tcgplayer: 597317,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。"
-		},
-
-		damage: 50,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "メグロコ",
+	},
 
 	retreat: 2,
-	regulationMark: "E"
-}
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [552],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/117.ts
+++ b/data-asia/S/S-P/117.ts
@@ -1,50 +1,66 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伽勒爾 踏冰人偶V"
+		ja: "イーブイ",
+		'zh-tw': "伽勒爾 踏冰人偶V",
 	},
 
-	illustrator: "5ban Graphics",
+	illustrator: "Yuu Nishida",
 	category: "Pokemon",
-	hp: 210,
-	types: ["Water"],
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "まわりの 環境に 合わせて 体の つくりを 変えていく 能力の 持ち主。",
+	},
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "驚嚇之手"
+	attacks: [
+		{
+			name: {
+				ja: "しんかのきざし",
+				'zh-tw': "驚嚇之手",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "「イーブイ」から進化するカードを、自分の山札から1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+				'zh-tw': "從自己的牌庫選擇最多3張物品卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多3張物品卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		{
+			name: {
+				ja: "けりつける",
+				'zh-tw': "特製拐杖",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+				'zh-tw': "若這隻寶可夢身上附有「寶可夢道具」，則增加90點傷害。",
+			},
 		},
+	],
 
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "特製拐杖"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597318,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若這隻寶可夢身上附有「寶可夢道具」，則增加90點傷害。"
-		},
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [133],
+};
 
-		damage: "90+",
-		cost: ["Water", "Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "E"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/118.ts
+++ b/data-asia/S/S-P/118.ts
@@ -1,50 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "毒電嬰"
+		ja: "ソッドとシルディ",
+		'zh-tw': "毒電嬰",
 	},
 
-	illustrator: "Souichirou Gunjima",
-	category: "Pokemon",
-	hp: 70,
-	types: ["Lightning"],
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "透過讓自身的毒素產生化學反應來發電。電力雖然弱，卻能造成麻痺。"
+	effect: {
+		ja: "自分のトラッシュからトレーナーズを1枚選び、相手に見せて、手札に加えて良いかを相手にたずねる。相手が良いなら、選んだカードを手札に加える。良くないなら、選んだカードをトラッシュにもどし、自分の山札を3枚引く。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "叫聲"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525275,
+				tcgplayer: 597319,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢使用招式的傷害「-30」點。"
-		},
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Promo",
+};
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "小伏特"
-		},
-
-		damage: 10,
-		cost: ["Lightning"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "E"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/119.ts
+++ b/data-asia/S/S-P/119.ts
@@ -1,55 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "仙子伊布"
+		ja: "ふくよかミュージシャン",
+		'zh-tw': "仙子伊布",
 	},
 
-	illustrator: "Mizue",
-	category: "Pokemon",
-	hp: 110,
-	types: ["Psychic"],
+	illustrator: "Hirotaka Marufuji",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "伽勒爾地區的童話中有著美麗的仙子伊布擊退了可怕的龍寶可夢的故事。"
+	effect: {
+		ja: "好きな歌を歌いながら、自分の山札を3枚引く。相手は、その歌が上手だと思ったら、はくしゅをしてもよい。",
 	},
 
-	stage: "Stage1",
-
-	attacks: [{
-		name: {
-			'zh-tw': "延後踢"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525280,
+				tcgplayer: 597320,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若希望，選擇1個對手的戰鬥寶可夢身上附加的能量，放回對手的手牌。"
-		},
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Promo",
+};
 
-		damage: 30,
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "諧和鞭打"
-		},
-
-		effect: {
-			'zh-tw': "在這個回合，若從手牌使出了支援者卡，則增加70點傷害。"
-		},
-
-		damage: "70+",
-		cost: ["Psychic", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "E"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/120.ts
+++ b/data-asia/S/S-P/120.ts
@@ -1,47 +1,32 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "隆隆石"
+		ja: "ローズ",
+		'zh-tw': "隆隆石",
 	},
 
-	illustrator: "AKIRA EGAWA",
-	category: "Pokemon",
-	hp: 110,
-	types: ["Fighting"],
+	illustrator: "Yusuke Ohmura",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "藉著從山崖上滾落來移動。如果不小心掉進河裡，就會在最後掙扎時來個大爆炸。"
+	effect: {
+		ja: "自分のトラッシュから基本エネルギーを2枚まで選び、自分の「ポケモンVMAX」1匹につける。その後、自分の手札をすべてトラッシュする。",
 	},
 
-	stage: "Stage1",
-
-	attacks: [{
-		name: {
-			'zh-tw': "撞擊"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597321,
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "岩石粉碎"
-		},
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Promo",
+};
 
-		damage: 70,
-		cost: ["Fighting", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
-
-	retreat: 4,
-	regulationMark: "E"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/121.ts
+++ b/data-asia/S/S-P/121.ts
@@ -1,50 +1,59 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伊布"
+		ja: "ピカチュウV",
+		'zh-tw': "伊布",
 	},
 
-	illustrator: "Mizue",
+	illustrator: "Ryota Murayama",
 	category: "Pokemon",
-	hp: 60,
-	types: ["Colorless"],
-
-	description: {
-		'zh-tw': "由於不穩定的基因，蘊含著各式各樣進化可能性的特殊寶可夢。"
-	},
+	hp: 190,
+	types: ["Lightning"],
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "準備"
+	attacks: [
+		{
+			name: {
+				ja: "ピカボール",
+				'zh-tw': "準備",
+			},
+			damage: 30,
+			cost: ["Lightning"],
 		},
-
-		effect: {
-			'zh-tw': "從自己的手牌選擇1張基本能量卡，附於這隻寶可夢身上。"
+		{
+			name: {
+				ja: "エレキサークル",
+				'zh-tw': "咬住",
+			},
+			damage: "30×",
+			cost: ["Lightning", "Lightning"],
+			effect: {
+				ja: "自分のベンチポケモンの数×30ダメージ。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "咬住"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525290,
+				tcgplayer: 597322,
+			},
 		},
-
-		damage: 30,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [25],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/122.ts
+++ b/data-asia/S/S-P/122.ts
@@ -1,22 +1,55 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "辣味香料咖哩"
+		ja: "ピカチュウV",
+		'zh-tw': "辣味香料咖哩",
 	},
 
-	illustrator: "AYUMI ODASHIMA",
-	category: "Trainer",
+	illustrator: "PLANETA Tsuji",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Lightning"],
 
-	effect: {
-		'zh-tw': "將自己的戰鬥寶可夢【灼傷】。將自己的戰鬥寶可夢恢復「40」HP。"
-	},
+	stage: "Basic",
 
-	trainerType: "Item",
-	regulationMark: "E"
-}
+	attacks: [
+		{
+			name: { ja: "じゅうでん" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分の山札から[雷]エネルギーを2枚まで選び、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "10まんボルト" },
+			damage: 200,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを、すべてトラッシュする。",
+			},
+		},
+	],
 
-export default card
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525295,
+				tcgplayer: 597323,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/S/S-P/123.ts
+++ b/data-asia/S/S-P/123.ts
@@ -1,40 +1,56 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "阿渡的噴火龍V"
+		ja: "ピカチュウVMAX",
+		'zh-tw': "阿渡的噴火龍V",
 	},
 
-	illustrator: "Hideki Ishikawa",
+	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
-	hp: 220,
-	types: ["Fire"],
-	stage: "Basic",
-	suffix: "V",
+	hp: 310,
+	types: ["Lightning"],
 
-	attacks: [{
-		name: {
-			'zh-tw': "噴射火焰"
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: {
+				ja: "キョダイボルテッカー",
+				'zh-tw': "噴射火焰",
+			},
+			damage: "120+",
+			cost: ["Lightning", "Lightning", "Lightning"],
+			effect: {
+				ja: "のぞむなら、このポケモンについているエネルギーを、すべてトラッシュする。その場合、150ダメージ追加。",
+				'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525300,
+				tcgplayer: 597324,
+			},
 		},
+	],
 
-		damage: 200,
-		cost: ["Fire", "Fire", "Colorless"]
-	}],
+	evolveFrom: {
+		ja: "ピカチュウV",
+	},
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [25],
+};
 
-	retreat: 3,
-	regulationMark: "E"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/124.ts
+++ b/data-asia/S/S-P/124.ts
@@ -1,51 +1,56 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "邪惡仙子伊布V"
+		ja: "ピカチュウ",
+		'zh-tw': "邪惡仙子伊布V",
 	},
 
-	illustrator: "Ryuta Fuse",
+	illustrator: "sowsow",
 	category: "Pokemon",
-	hp: 180,
-	types: ["Psychic"],
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "つくる 電気が 強力な ピカチュウほど ほっぺの 袋は 軟らかく よく 伸びるぞ。",
+	},
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "魅惑之聲"
+	attacks: [
+		{
+			name: {
+				ja: "でんきショック",
+				'zh-tw': "魅惑之聲",
+			},
+			damage: 30,
+			cost: ["Lightning", "Lightning"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【混亂】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【混亂】。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525305,
+				tcgplayer: 597325,
+			},
 		},
-
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "捉弄蝴蝶結"
-		},
-
-		effect: {
-			'zh-tw': "在不看正面的情況下，從對手的手牌選擇1張，在看過那張卡正面後放回對手的牌庫並重洗。"
-		},
-
-		damage: 100,
-		cost: ["Psychic", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [25],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/125.ts
+++ b/data-asia/S/S-P/125.ts
@@ -1,50 +1,52 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "阿爾宙斯V"
+		ja: "ピカチュウ",
+		'zh-tw': "阿爾宙斯V",
 	},
 
-	illustrator: "Atsushi Furusawa",
+	illustrator: "nagimiso",
 	category: "Pokemon",
-	hp: 220,
-	types: ["Colorless"],
+	hp: 70,
+	types: ["Lightning"],
+
+	description: {
+		ja: "電気を ため込む 性質。 ピカチュウが 群れて 暮らす 森は 落雷が 絶えず 危険だ。",
+	},
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "三重蓄能"
+	attacks: [
+		{
+			name: {
+				ja: "ピカボール",
+				'zh-tw': "三重蓄能",
+			},
+			damage: 30,
+			cost: ["Lightning", "Colorless"],
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多3張基本能量卡，以任意方式附於自己的「寶可夢【V】」身上。並且重洗牌庫。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525310,
+				tcgplayer: 597326,
+			},
 		},
+	],
 
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "力量刀鋒"
-		},
+	retreat: 1,
+	regulationMark: "C",
+	rarity: "Promo",
+	dexId: [25],
+};
 
-		damage: 130,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Colorless"
-	}],
-
-	retreat: 2,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/126.ts
+++ b/data-asia/S/S-P/126.ts
@@ -1,54 +1,68 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "可可"
+		ja: "ピカチュウ",
+		'zh-tw': "可可",
 	},
 
-	illustrator: "Tetsuo Yajima",
+	illustrator: "Naoyo Kimura",
 	category: "Pokemon",
-	hp: 90,
-	types: ["Grass"],
+	hp: 70,
+	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "薩戮德養育的少年，叢林寶可夢們的憧憬。"
+		ja: "電気を ため込む 性質。 ピカチュウが 群れて 暮らす 森は 落雷が 絶えず 危険だ。",
+		'zh-tw': "薩戮德養育的少年，叢林寶可夢們的憧憬。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "森林呼聲"
+	attacks: [
+		{
+			name: {
+				ja: "ほっぺすりすり",
+				'zh-tw': "森林呼聲",
+			},
+			cost: ["Lightning"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+				'zh-tw': "從自己的牌庫選擇1張【草】寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張【草】寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		{
+			name: {
+				ja: "ボルテッカー",
+				'zh-tw': "泰山踢",
+			},
+			damage: 70,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンにも10ダメージ。",
+				'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "泰山踢"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525315,
+				tcgplayer: 597327,
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。"
-		},
-
-		damage: 120,
-		cost: ["Grass", "Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "D"
-}
+	regulationMark: "C",
+	rarity: "Promo",
+	dexId: [25],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/127.ts
+++ b/data-asia/S/S-P/127.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プレイヤーズセレモニー",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分の山札を2枚引いてよい。その場合、自分の番は終わる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525320,
+				tcgplayer: 597328,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "D",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/128.ts
+++ b/data-asia/S/S-P/128.ts
@@ -1,51 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "葉伊布V"
+		ja: "博士の研究",
+		'zh-tw': "葉伊布V",
 	},
 
-	illustrator: "PLANETA Yamashita",
-	category: "Pokemon",
-	hp: 210,
-	types: ["Grass"],
-	stage: "Basic",
-	suffix: "V",
+	illustrator: "Yusuke Ohmura",
+	category: "Trainer",
 
-	attacks: [{
-		name: {
-			'zh-tw': "葉子防守"
+	effect: {
+		ja: "自分の手札をすべてトラッシュし、山札を7枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525325,
+				tcgplayer: 597329,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-30」點。"
-		},
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Promo",
+};
 
-		damage: 30,
-		cost: ["Grass"]
-	}, {
-		name: {
-			'zh-tw': "猛擊在地"
-		},
-
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「猛擊在地」。"
-		},
-
-		damage: 180,
-		cost: ["Grass", "Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/129.ts
+++ b/data-asia/S/S-P/129.ts
@@ -1,47 +1,52 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "冰伊布V"
+		ja: "メッソン",
+		'zh-tw': "冰伊布V",
 	},
 
-	illustrator: "PLANETA Yamashita",
+	illustrator: "Megumi Mizutani",
 	category: "Pokemon",
-	hp: 210,
+	hp: 60,
 	types: ["Water"],
+
+	description: {
+		ja: "怯えると 玉ねぎ１００個分の 催涙成分を もつ 涙を 流して もらい泣き させる。",
+	},
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "冰霜充能"
+	attacks: [
+		{
+			name: {
+				ja: "みずでっぽう",
+				'zh-tw': "冰霜充能",
+			},
+			damage: 20,
+			cost: ["Water"],
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張【水】能量卡，附於這隻寶可夢身上。並且重洗牌庫。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525330,
+				tcgplayer: 597330,
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "凍凝之風"
-		},
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [816],
+};
 
-		damage: 130,
-		cost: ["Water", "Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/130.ts
+++ b/data-asia/S/S-P/130.ts
@@ -1,47 +1,56 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "草苗龜"
+		ja: "ヒバニー",
+		'zh-tw': "草苗龜",
 	},
 
-	illustrator: "Narumi Sato",
+	illustrator: "kirisAki",
 	category: "Pokemon",
-	hp: 80,
-	types: ["Grass"],
+	hp: 60,
+	types: ["Fire"],
 
 	description: {
-		'zh-tw': "用全身進行光合作用，製造氧氣。當口渴的時候，頭上的葉子就會枯萎。"
+		ja: "戦う 準備が 整うと 鼻の 頭と 足の 裏の 肉球が 高熱を 発する。",
+		'zh-tw': "用全身進行光合作用，製造氧氣。當口渴的時候，頭上的葉子就會枯萎。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "咬住"
+	attacks: [
+		{
+			name: {
+				ja: "ひのこ",
+				'zh-tw': "咬住",
+			},
+			damage: 30,
+			cost: ["Fire"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
 		},
+	],
 
-		damage: 10,
-		cost: ["Grass"]
-	}, {
-		name: {
-			'zh-tw': "魯莽頭擊"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525335,
+				tcgplayer: 597331,
+			},
 		},
+	],
 
-		damage: 20,
-		cost: ["Grass", "Colorless"]
-	}],
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [813],
+};
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/131.ts
+++ b/data-asia/S/S-P/131.ts
@@ -1,44 +1,53 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "敲音猴"
+		ja: "メッソン",
+		'zh-tw': "敲音猴",
 	},
 
-	illustrator: "Akira Komayama",
+	illustrator: "Megumi Mizutani",
 	category: "Pokemon",
 	hp: 60,
-	types: ["Grass"],
+	types: ["Water"],
 
 	description: {
-		'zh-tw': "當牠用特別的木棒敲奏時，能夠給予花草活力的力量就會變成音波擴散開來。"
+		ja: "怯えると 玉ねぎ１００個分の 催涙成分を もつ 涙を 流して もらい泣き させる。",
+		'zh-tw': "當牠用特別的木棒敲奏時，能夠給予花草活力的力量就會變成音波擴散開來。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "直奔"
+	attacks: [
+		{
+			name: {
+				ja: "みずでっぽう",
+				'zh-tw': "直奔",
+			},
+			damage: 20,
+			cost: ["Water"],
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525340,
+				tcgplayer: 597332,
+			},
 		},
-
-		damage: 30,
-		cost: ["Grass"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [816],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/132.ts
+++ b/data-asia/S/S-P/132.ts
@@ -1,47 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "噴火龍V"
+		ja: "ピカチュウ",
+		'zh-tw': "噴火龍V",
 	},
 
-	illustrator: "N-DESIGN Inc.",
+	illustrator: "Hitoshi Ariga",
 	category: "Pokemon",
-	hp: 220,
-	types: ["Fire"],
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "つくる 電気が 強力な ピカチュウほど ほっぺの 袋は 軟らかく よく 伸びるぞ。",
+	},
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "燒盡"
+	attacks: [
+		{
+			name: {
+				ja: "しっぽをふる",
+				'zh-tw': "燒盡",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このワザを受けたポケモンは、ワザが使えない。",
+				'zh-tw': "在造成傷害前，將對手的戰鬥寶可夢身上附加的「寶可夢道具」丟棄。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在造成傷害前，將對手的戰鬥寶可夢身上附加的「寶可夢道具」丟棄。"
+		{
+			name: {
+				ja: "ピカボルト",
+				'zh-tw': "高溫爆破",
+			},
+			damage: 50,
+			cost: ["Lightning", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 90,
-		cost: ["Fire", "Fire", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "高溫爆破"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525345,
+				tcgplayer: 597333,
+			},
 		},
+	],
 
-		damage: 180,
-		cost: ["Fire", "Fire", "Fire", "Colorless"]
-	}],
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [25],
+};
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/133.ts
+++ b/data-asia/S/S-P/133.ts
@@ -1,44 +1,32 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "小火焰猴"
+		ja: "基本水エネルギー",
+		'zh-tw': "小火焰猴",
 	},
 
-	illustrator: "Shin Nagasawa",
-	category: "Pokemon",
-	hp: 50,
-	types: ["Fire"],
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
 
-	description: {
-		'zh-tw': "肚子產生的瓦斯在屁股上燃燒。如果身體狀況不好的話，火焰就會變弱。"
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "火花"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525350,
+				tcgplayer: 649791,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。"
-		},
+	rarity: "Promo",
+};
 
-		damage: 30,
-		cost: ["Fire"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/135.ts
+++ b/data-asia/S/S-P/135.ts
@@ -1,50 +1,67 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "炎兔兒"
+		ja: "ガラル ジグザグマ",
+		'zh-tw': "炎兔兒",
 	},
 
-	illustrator: "Akira Komayama",
+	illustrator: "kirisAki",
 	category: "Pokemon",
-	hp: 60,
-	types: ["Fire"],
+	hp: 70,
+	types: ["Darkness"],
 
 	description: {
-		'zh-tw': "不斷奔跑使體溫升高後，火之能量會在牠體內循環，促使牠發揮出真正的力量。"
+		ja: "この姿が いちばん 古い ジグザグマの 姿 らしい。 ジグザグ動いて あたりを 荒らす。",
+		'zh-tw': "不斷奔跑使體溫升高後，火之能量會在牠體內循環，促使牠發揮出真正的力量。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "搶先一步"
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "かんしゃくヘッド" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。相手のポケモン1匹に、ダメカンを1個のせる。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的牌庫抽出1張卡。"
+	attacks: [
+		{
+			name: {
+				ja: "ふいをつく",
+				'zh-tw': "搶先一步",
+			},
+			damage: 30,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+				'zh-tw': "從自己的牌庫抽出1張卡。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "火種"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525355,
+				tcgplayer: 597334,
+			},
 		},
-
-		damage: 20,
-		cost: ["Fire", "Fire"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [263],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/136.ts
+++ b/data-asia/S/S-P/136.ts
@@ -1,44 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "波加曼"
+		ja: "げんきのハチマキ",
+		'zh-tw': "波加曼",
 	},
 
-	illustrator: "Atsushi Furusawa",
-	category: "Pokemon",
-	hp: 60,
-	types: ["Water"],
+	illustrator: "Toyste Beach",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "自尊心很強，討厭從人那裡接受食物。長長的絨毛能抵禦寒冷。"
+	effect: {
+		ja: "このカードをつけているポケモンが使うワザの、相手のバトルポケモンへのダメージは「＋10」される。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "泡沫"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525360,
+				tcgplayer: 597335,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。"
-		},
+	trainerType: "Tool",
+	regulationMark: "D",
+	rarity: "Promo",
+};
 
-		damage: 10,
-		cost: ["Water"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/137.ts
+++ b/data-asia/S/S-P/137.ts
@@ -1,50 +1,67 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "淚眼蜥"
+		ja: "モルペコ",
+		'zh-tw': "淚眼蜥",
 	},
 
-	illustrator: "Akira Komayama",
+	illustrator: "Atsushi Furusawa",
 	category: "Pokemon",
-	hp: 60,
-	types: ["Water"],
+	hp: 80,
+	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "害怕時流下的淚水中含有相當於１００顆洋蔥的催淚成分，能讓對手淚流不止。"
+		ja: "いつも お腹を すかせている。 ポケットの ような 袋に 入れた タネを 食べて 電気を つくる。",
+		'zh-tw': "害怕時流下的淚水中含有相當於１００顆洋蔥的催淚成分，能讓對手淚流不止。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "叫聲"
+	attacks: [
+		{
+			name: {
+				ja: "ペコペコ",
+				'zh-tw': "叫聲",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を1枚引く。",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢使用招式的傷害「-20」點。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢使用招式的傷害「-20」點。"
+		{
+			name: {
+				ja: "でんきショック",
+				'zh-tw': "潑水",
+			},
+			damage: 40,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "潑水"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525365,
+				tcgplayer: 597336,
+			},
 		},
-
-		damage: 10,
-		cost: ["Water"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "D"
-}
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [877],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/138.ts
+++ b/data-asia/S/S-P/138.ts
@@ -1,50 +1,32 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "皮卡丘"
+		ja: "ビート",
+		'zh-tw': "皮卡丘",
 	},
 
-	illustrator: "chibi",
-	category: "Pokemon",
-	hp: 60,
-	types: ["Lightning"],
+	illustrator: "You Iribi",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "皮卡丘們把尾巴貼在一起交換電流，其實是在互相打招呼。"
+	effect: {
+		ja: "自分の手札から基本エネルギーを1枚選び、ベンチポケモンにつける。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "帶電"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597337,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的棄牌區選擇1張【雷】能量卡，附於這隻寶可夢身上。"
-		},
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Promo",
+};
 
-		cost: ["Lightning"]
-	}, {
-		name: {
-			'zh-tw': "電球"
-		},
-
-		damage: 30,
-		cost: ["Lightning", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "E"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/139.ts
+++ b/data-asia/S/S-P/139.ts
@@ -1,50 +1,32 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雷丘V"
+		ja: "ホップ",
+		'zh-tw': "雷丘V",
 	},
 
-	illustrator: "MUGENUP",
-	category: "Pokemon",
-	hp: 200,
-	types: ["Lightning"],
-	stage: "Basic",
-	suffix: "V",
+	illustrator: "Taira Akitsu",
+	category: "Trainer",
 
-	attacks: [{
-		name: {
-			'zh-tw': "急速蓄電"
+	effect: {
+		ja: "自分の山札を3枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597338,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這個招式在先攻玩家的最初回合也可使用。從自己的牌庫選擇1張【雷】能量卡，附於這隻寶可夢身上。並且重洗牌庫。"
-		},
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Promo",
+};
 
-		cost: ["Lightning"]
-	}, {
-		name: {
-			'zh-tw': "極限電光"
-		},
-
-		effect: {
-			'zh-tw': "將自己的場上寶可夢身上附加的任意數量的【雷】能量卡丟棄，造成其張數×60點傷害。"
-		},
-
-		damage: "60×",
-		cost: ["Lightning", "Lightning"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/140.ts
+++ b/data-asia/S/S-P/140.ts
@@ -1,54 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "莫魯貝可"
+		ja: "マリィ",
+		'zh-tw': "莫魯貝可",
 	},
 
-	illustrator: "Atsushi Furusawa",
-	category: "Pokemon",
-	hp: 80,
-	types: ["Lightning"],
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "總是餓著肚子。會吃掉裝在像口袋一樣的袋子裡的種子來發電。"
+	effect: {
+		ja: "おたがいのプレイヤーは、それぞれ自分の手札をすべてウラにして切り、山札の下にもどす。その後、自分は5枚、相手は4枚、山札を引く。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "貝可餓餓"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525380,
+				tcgplayer: 597339,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的牌庫抽出1張卡。"
-		},
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Promo",
+};
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "電擊"
-		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。"
-		},
-
-		damage: 40,
-		cost: ["Lightning", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "D"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/141.ts
+++ b/data-asia/S/S-P/141.ts
@@ -1,51 +1,71 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "莫魯貝可V"
+		ja: "ムウマージ",
+		'zh-tw': "莫魯貝可V",
 	},
 
-	illustrator: "5ban Graphics",
+	illustrator: "NC Empire",
 	category: "Pokemon",
-	hp: 170,
-	types: ["Lightning"],
-	stage: "Basic",
-	suffix: "V",
+	hp: 90,
+	types: ["Psychic"],
 
-	attacks: [{
-		name: {
-			'zh-tw': "電光"
+	description: {
+		ja: "祟りや 呪いを 振りまくとして 恐れられて きた。 気まぐれに 人を助ける 呪文も 使う。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: {
+				ja: "サイケこうせん",
+				'zh-tw': "電光",
+			},
+			damage: 20,
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+				'zh-tw': "對手的1隻備戰寶可夢也受到20點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
-
-		effect: {
-			'zh-tw': "對手的1隻備戰寶可夢也受到20點傷害。[在備戰區不計算弱點・抵抗力。]"
+		{
+			name: {
+				ja: "くなんのたたり",
+				'zh-tw': "電輪",
+			},
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにのっているダメカンが9個なら、そのポケモンをきぜつさせる。",
+				'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。然後，將這隻寶可夢與備戰寶可夢互換。",
+			},
 		},
+	],
 
-		damage: 20,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "電輪"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525385,
+				tcgplayer: 597340,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。然後，將這隻寶可夢與備戰寶可夢互換。"
-		},
+	evolveFrom: {
+		ja: "ムウマ",
+	},
 
-		damage: 150,
-		cost: ["Lightning", "Lightning", "Colorless"]
-	}],
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [429],
+};
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "D"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/142.ts
+++ b/data-asia/S/S-P/142.ts
@@ -1,52 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "叉字蝠V"
+		ja: "ナツメ＆ハチク",
+		'zh-tw': "叉字蝠V",
 	},
 
-	illustrator: "PLANETA Mochizuki",
-	category: "Pokemon",
-	hp: 180,
-	types: ["Darkness"],
-	stage: "Basic",
-	suffix: "V",
+	illustrator: "Ryuta Fuse",
+	category: "Trainer",
 
-	abilities: [{
-		type: "Ability",
+	effect: {
+		ja: "自分の山札から基本エネルギーを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。 追加で、このカードを使うときに、自分の手札を5枚トラッシュしてよい。その場合、それぞれちがうタイプのポケモンも3枚まで選び、手札に加えられる。",
+	},
 
-		name: {
-			'zh-tw': "暗夜能源"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525390,
+				tcgplayer: 597341,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，當從手牌將這張卡放置於備戰區時，可使用1次。從牌庫抽卡直到自己的手牌滿6張為止。在這個回合，若已經使出了其他的「暗夜能源」，則這個特性無法使用。"
-		}
-	}],
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Promo",
+};
 
-	attacks: [{
-		name: {
-			'zh-tw': "毒牙"
-		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【中毒】。"
-		},
-
-		damage: 70,
-		cost: ["Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "D"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/143.ts
+++ b/data-asia/S/S-P/143.ts
@@ -1,51 +1,61 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "袋獸"
+		ja: "リザードン",
+		'zh-tw': "袋獸",
 	},
 
-	illustrator: "HYOGONOSUKE",
+	illustrator: "Jiro Sasumo",
 	category: "Pokemon",
-	hp: 130,
-	types: ["Colorless"],
+	hp: 170,
+	types: ["Fire"],
 
 	description: {
-		'zh-tw': "袋獸的母愛很深。如果是為了守護自己的孩子，據說連死都毫不畏懼。"
+		ja: "岩石も 焼けるような 灼熱の 炎を 吐いて 山火事を 起こすことが ある。",
+		'zh-tw': "袋獸的母愛很深。如果是為了守護自己的孩子，據說連死都毫不畏懼。",
 	},
 
-	stage: "Basic",
+	stage: "Stage2",
 
-	attacks: [{
-		name: {
-			'zh-tw': "捲土重來"
+	attacks: [
+		{
+			name: {
+				ja: "ブレイブフレイム",
+				'zh-tw': "捲土重來",
+			},
+			damage: 180,
+			cost: ["Fire", "Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+				'zh-tw': "若在上個對手的回合，自己的寶可夢因招式的傷害而【氣絕】了，則增加90點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若在上個對手的回合，自己的寶可夢因招式的傷害而【氣絕】了，則增加90點傷害。"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525395,
+				tcgplayer: 597342,
+			},
 		},
+	],
 
-		damage: "30+",
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "頭突"
-		},
+	evolveFrom: {
+		ja: "リザード",
+	},
 
-		damage: 100,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
+	retreat: 3,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [6],
+};
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "D"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/144.ts
+++ b/data-asia/S/S-P/144.ts
@@ -1,50 +1,67 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伊布"
+		ja: "カナザワのピカチュウ",
+		'zh-tw': "伊布",
 	},
 
-	illustrator: "Atsushi Furusawa",
+	illustrator: "Fuzichoco",
 	category: "Pokemon",
-	hp: 70,
-	types: ["Colorless"],
+	hp: 60,
+	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "由於不穩定的基因，蘊含著各式各樣進化可能性的特殊寶可夢。"
+		ja: "つくる 電気が 強力な ピカチュウほど ほっぺの 袋は 軟らかく よく 伸びるぞ。",
+		'zh-tw': "由於不穩定的基因，蘊含著各式各樣進化可能性的特殊寶可夢。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "布搜索"
+	attacks: [
+		{
+			name: {
+				ja: "ニューオープン",
+				'zh-tw': "布搜索",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "おたがいのプレイヤーは、それぞれ自分の山札を上から1枚オモテにして、相手に見せて、手札に加える。",
+				'zh-tw': "從自己的牌庫選擇最多3張「寶可夢【V】」卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多3張「寶可夢【V】」卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		{
+			name: {
+				ja: "ピカさんぽ",
+				'zh-tw': "踩",
+			},
+			damage: "30+",
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、30ダメージ追加。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "踩"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525400,
+				tcgplayer: 597343,
+			},
 		},
-
-		damage: 20,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "E"
-}
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [25],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/145.ts
+++ b/data-asia/S/S-P/145.ts
@@ -1,47 +1,67 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "卡比獸"
+		ja: "ミロカロス",
+		'zh-tw': "卡比獸",
 	},
 
-	illustrator: "Tika Matsuno",
+	illustrator: "Fuzichoco",
 	category: "Pokemon",
-	hp: 150,
-	types: ["Colorless"],
+	hp: 120,
+	types: ["Water"],
 
 	description: {
-		'zh-tw': "每天不吃下４００公斤的食物絕不會善罷甘休。吃飽了就會開始睡覺。"
+		ja: "もっとも 美しい ポケモンとも 呼ばれ 多くの 芸術家に インスピレーションを 与えてきた。",
+		'zh-tw': "每天不吃下４００公斤的食物絕不會善罷甘休。吃飽了就會開始睡覺。",
 	},
 
-	stage: "Basic",
+	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "滾動衝撞"
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ブライトヒール" },
+			effect: {
+				ja: "自分の番に1回使える。自分のポケモン全員のHPを、それぞれ「20」回復する。",
+			},
 		},
+	],
 
-		damage: 80,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "重磅衝擊"
+	attacks: [
+		{
+			name: {
+				ja: "なみのり",
+				'zh-tw': "滾動衝撞",
+			},
+			damage: 80,
+			cost: ["Water", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: 130,
-		cost: ["Colorless", "Colorless", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525405,
+				tcgplayer: 597344,
+			},
+		},
+	],
 
-	retreat: 4,
-	regulationMark: "D"
-}
+	evolveFrom: {
+		ja: "ヒンバス",
+	},
 
-export default card
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [350],
+};
+
+export default card;

--- a/data-asia/S/S-P/146.ts
+++ b/data-asia/S/S-P/146.ts
@@ -1,50 +1,52 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "阿爾宙斯V"
+		ja: "メッソン",
+		'zh-tw': "阿爾宙斯V",
 	},
 
-	illustrator: "N-DESIGN Inc.",
+	illustrator: "Fuzichoco",
 	category: "Pokemon",
-	hp: 220,
-	types: ["Colorless"],
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "怯えると 玉ねぎ１００個分の 催涙成分を もつ 涙を 流して もらい泣き させる。",
+	},
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "三重蓄能"
+	attacks: [
+		{
+			name: {
+				ja: "みずでっぽう",
+				'zh-tw': "三重蓄能",
+			},
+			damage: 20,
+			cost: ["Water"],
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的牌庫選擇最多3張基本能量卡，以任意方式附於自己的「寶可夢【V】」身上。並且重洗牌庫。"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525410,
+				tcgplayer: 597345,
+			},
 		},
+	],
 
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "力量刀鋒"
-		},
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [816],
+};
 
-		damage: 130,
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Colorless"
-	}],
-
-	retreat: 2,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/147.ts
+++ b/data-asia/S/S-P/147.ts
@@ -1,22 +1,59 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "先機球"
+		ja: "カナザワのピカチュウ",
+		'zh-tw': "先機球",
 	},
 
-	illustrator: "Ryo Ueda",
-	category: "Trainer",
+	illustrator: "Fuzichoco",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
 
-	effect: {
-		'zh-tw': "這張卡必須將自己的1張手牌丟棄才可使用。 從自己的牌庫選擇1張【基礎】寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。"
+	description: {
+		ja: "つくる 電気が 強力な ピカチュウほど ほっぺの 袋は 軟らかく よく 伸びるぞ。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "D"
-}
+	stage: "Basic",
 
-export default card
+	attacks: [
+		{
+			name: { ja: "ニューオープン" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "おたがいのプレイヤーは、それぞれ自分の山札を上から1枚オモテにして、相手に見せて、手札に加える。",
+			},
+		},
+		{
+			name: { ja: "ピカさんぽ" },
+			damage: "30+",
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525415,
+				tcgplayer: 597346,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/S/S-P/148.ts
+++ b/data-asia/S/S-P/148.ts
@@ -1,22 +1,59 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "高級球"
+		ja: "ゲノセクト",
+		'zh-tw': "高級球",
 	},
 
-	illustrator: "sadaji",
-	category: "Trainer",
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Grass"],
 
-	effect: {
-		'zh-tw': "這張卡必須將自己的2張手牌丟棄才可使用。 從自己的牌庫選擇1張寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。"
+	description: {
+		ja: "３億年前に いた ポケモン。 プラズマ団に 改造 され 背中に 砲台を つけられた。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "F"
-}
+	stage: "Basic",
 
-export default card
+	attacks: [
+		{
+			name: { ja: "ちょくげきだん" },
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "テクノバスター" },
+			damage: 120,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525420,
+				tcgplayer: 597347,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [649],
+};
+
+export default card;

--- a/data-asia/S/S-P/149.ts
+++ b/data-asia/S/S-P/149.ts
@@ -1,22 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "精靈球"
+		ja: "ヒードラン",
+		'zh-tw': "精靈球",
 	},
 
-	illustrator: "Studio Bora Inc.",
-	category: "Trainer",
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fire"],
 
-	effect: {
-		'zh-tw': "擲1次硬幣若為正面，則從自己的牌庫選擇1張寶可夢卡，在給對手看過後加入手牌。並且重洗牌庫。"
+	description: {
+		ja: "マグマのように 燃えたぎる 血液が 体を 流れている。 火山の 洞穴に 生息する。",
 	},
 
-	trainerType: "Item",
-	regulationMark: "D"
-}
+	stage: "Basic",
 
-export default card
+	attacks: [
+		{
+			name: { ja: "ほのおのキバ" },
+			damage: 30,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+		{
+			name: { ja: "レイジングフレア" },
+			damage: "80+",
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数×10ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525425,
+				tcgplayer: 597348,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [485],
+};
+
+export default card;

--- a/data-asia/S/S-P/150.ts
+++ b/data-asia/S/S-P/150.ts
@@ -1,51 +1,64 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "烈焰猴V"
+		ja: "スイクン",
+		'zh-tw': "烈焰猴V",
 	},
 
-	illustrator: "Ayaka Yoshida",
+	illustrator: "so-taro",
 	category: "Pokemon",
-	hp: 200,
-	types: ["Fire"],
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "一瞬で 汚く 濁った 水も 清める 力を 持つ。 北風の 生まれ変わり という。",
+	},
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "流星拳"
+	attacks: [
+		{
+			name: {
+				ja: "スプラッシュ",
+				'zh-tw': "流星拳",
+			},
+			damage: 20,
+			cost: ["Water"],
 		},
-
-		effect: {
-			'zh-tw': "擲硬幣直到出現反面，造成正面出現的次數×30點傷害。"
+		{
+			name: {
+				ja: "オーロラループ",
+				'zh-tw': "紅蓮火焰",
+			},
+			damage: 130,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[水]エネルギーを2個選び、手札にもどす。",
+				'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
+	],
 
-		damage: "30×",
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "紅蓮火焰"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525430,
+				tcgplayer: 597349,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇2個這隻寶可夢身上附加的能量，將其丟棄。"
-		},
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [245],
+};
 
-		damage: 200,
-		cost: ["Fire", "Fire", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
-
-	retreat: 0,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/151.ts
+++ b/data-asia/S/S-P/151.ts
@@ -1,47 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "龍蝦小兵"
+		ja: "ルギア",
+		'zh-tw': "龍蝦小兵",
 	},
 
-	illustrator: "0313",
+	illustrator: "kodama",
 	category: "Pokemon",
-	hp: 70,
-	types: ["Water"],
+	hp: 130,
+	types: ["Colorless"],
 
 	description: {
-		'zh-tw': "有著頑強生命力的寶可夢。不論河裡的水有多髒都能適應並繁衍後代。"
+		ja: "海の神様と 伝えられる ポケモン。 嵐の 夜 姿を 見たという 話が 伝えられる。",
+		'zh-tw': "有著頑強生命力的寶可夢。不論河裡的水有多髒都能適應並繁衍後代。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "水槍"
+	attacks: [
+		{
+			name: {
+				ja: "かぜおこし",
+				'zh-tw': "水槍",
+			},
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
 		},
-
-		damage: 10,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "蟹鉗錘"
+		{
+			name: {
+				ja: "ウインドプレッシャー",
+				'zh-tw': "蟹鉗錘",
+			},
+			damage: 250,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の手札が5枚以下なら、このワザは失敗。",
+			},
 		},
+	],
 
-		damage: 50,
-		cost: ["Water", "Colorless", "Colorless"]
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597350,
+			},
+		},
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [249],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/152.ts
+++ b/data-asia/S/S-P/152.ts
@@ -1,49 +1,62 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "彷徨夜靈"
+		ja: "クロバットV",
+		'zh-tw': "彷徨夜靈",
 	},
 
-	illustrator: "DOM",
+	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
-	hp: 90,
-	types: ["Psychic"],
+	hp: 180,
+	types: ["Darkness"],
 
-	description: {
-		'zh-tw': "身體內部是空的。只要一張開嘴就會像黑洞一樣吸入所有東西。"
-	},
+	stage: "Basic",
 
-	stage: "Stage1",
-
-	attacks: [{
-		name: {
-			'zh-tw': "漆黑"
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ナイトアセット" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の手札が6枚になるように、山札を引く。この番、すでに別の「ナイトアセット」を使っていたなら、この特性は使えない。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【混亂】。"
+	attacks: [
+		{
+			name: {
+				ja: "どくのキバ",
+				'zh-tw': "漆黑",
+			},
+			damage: 70,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+				'zh-tw': "將對手的戰鬥寶可夢【混亂】。",
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Psychic"]
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525440,
+				tcgplayer: 597351,
+			},
+		},
+	],
 
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [169],
+};
 
-	retreat: 2,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/153.ts
+++ b/data-asia/S/S-P/153.ts
@@ -1,40 +1,32 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "利歐路"
+		ja: "基本悪エネルギー",
+		'zh-tw': "利歐路",
 	},
 
-	illustrator: "Taira Akitsu",
-	category: "Pokemon",
-	hp: 60,
-	types: ["Fighting"],
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
 
-	description: {
-		'zh-tw': "精力充沛，可以奔跑一整夜。由於牠十分活潑，帶牠散步的人非常辛苦。"
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "踢倒"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525445,
+				tcgplayer: 649783,
+			},
 		},
+	],
 
-		damage: 50,
-		cost: ["Fighting", "Fighting"]
-	}],
+	rarity: "Promo",
+};
 
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/154.ts
+++ b/data-asia/S/S-P/154.ts
@@ -1,50 +1,32 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "瑪狃拉"
+		ja: "ハイド悪エネルギー",
+		'zh-tw': "瑪狃拉",
 	},
 
-	illustrator: "Shin Nagasawa",
-	category: "Pokemon",
-	hp: 110,
-	types: ["Darkness"],
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
 
-	description: {
-		'zh-tw': "成群結隊襲擊獵物。透過團隊合作，連象牙豬那樣強大的對手也能輕鬆解決。"
+	effect: {
+		ja: "このカードは、ポケモンについているかぎり、[悪]エネルギー1個ぶんとしてはたらく。このカードをつけている[悪]ポケモンのにげるためのエネルギーは、すべてなくなる。",
 	},
 
-	stage: "Stage1",
-
-	attacks: [{
-		name: {
-			'zh-tw': "追打爪"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597352,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "對手的1隻備戰寶可夢，受到那隻寶可夢身上放置的傷害指示物的數量×20點傷害。[在備戰區不計算弱點・抵抗力。]"
-		},
+	regulationMark: "D",
+	rarity: "Promo",
+};
 
-		cost: ["Darkness"]
-	}, {
-		name: {
-			'zh-tw': "利爪劈擊"
-		},
-
-		damage: 110,
-		cost: ["Darkness", "Darkness", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/155.ts
+++ b/data-asia/S/S-P/155.ts
@@ -1,49 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "姆克兒"
+		ja: "シロナ",
+		'zh-tw': "姆克兒",
 	},
 
-	illustrator: "Ligton",
-	category: "Pokemon",
-	hp: 60,
-	types: ["Colorless"],
+	illustrator: "Atsushi Furusawa",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "為了獵捕蟲寶可夢，以龐大的群體在山野間飛來飛去。叫聲非常吵鬧。"
+	effect: {
+		ja: "自分の手札をすべて山札にもどして切る。その後、山札を6枚引く。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "鉤爪"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 534092,
+				tcgplayer: 597353,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為反面，則這個招式失敗。"
-		},
+	trainerType: "Supporter",
+	regulationMark: "B",
+	rarity: "Promo",
+};
 
-		damage: 30,
-		cost: ["Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
-
-	retreat: 1,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/156.ts
+++ b/data-asia/S/S-P/156.ts
@@ -1,22 +1,57 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "亞玄"
+		ja: "カビゴン",
+		'zh-tw': "亞玄",
 	},
 
-	illustrator: "AYUMI ODASHIMA",
-	category: "Trainer",
+	illustrator: "Yuya Oka",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Colorless"],
 
-	effect: {
-		'zh-tw': "將自己的牌庫上方5張卡翻到正面，請對手從其中選擇2張卡。自己將被選擇的卡丟棄，將剩餘卡加入手牌。"
+	description: {
+		ja: "頑丈な 胃袋は カビの 生えたものや 腐ったものを 食べても 壊れることはない。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "F"
-}
+	stage: "Basic",
 
-export default card
+	attacks: [
+		{
+			name: { ja: "はりて" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "いちげきタックル" },
+			damage: 120,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 534097,
+				tcgplayer: 597354,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [143],
+};
+
+export default card;

--- a/data-asia/S/S-P/157.ts
+++ b/data-asia/S/S-P/157.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミツバ",
+	},
+
+	illustrator: "Ryuta Fuse",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のベンチの「ポケモンV」の数ぶん、自分の山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597355,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/158.ts
+++ b/data-asia/S/S-P/158.ts
@@ -1,51 +1,52 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "葉伊布V"
+		ja: "チェリンボ",
+		'zh-tw': "葉伊布V",
 	},
 
-	illustrator: "PLANETA Mochizuki",
+	illustrator: "Lee HyunJung",
 	category: "Pokemon",
-	hp: 210,
+	hp: 50,
 	types: ["Grass"],
+
+	description: {
+		ja: "体が 赤い チェリンボほど 栄養が 多く 玉の 味も 甘くて おいしいよ。",
+	},
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "葉子防守"
+	attacks: [
+		{
+			name: {
+				ja: "このは",
+				'zh-tw': "葉子防守",
+			},
+			damage: 10,
+			cost: ["Grass"],
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-30」點。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561773,
+				tcgplayer: 597356,
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Grass"]
-	}, {
-		name: {
-			'zh-tw': "猛擊在地"
-		},
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [420],
+};
 
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「猛擊在地」。"
-		},
-
-		damage: 180,
-		cost: ["Grass", "Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/159.ts
+++ b/data-asia/S/S-P/159.ts
@@ -1,51 +1,56 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "葉伊布VSTAR"
+		ja: "ポカブ",
+		'zh-tw': "葉伊布VSTAR",
 	},
 
-	illustrator: "5ban Graphics",
+	illustrator: "Eri Yamaki",
 	category: "Pokemon",
-	hp: 260,
-	types: ["Grass"],
-	stage: "VMAX",
+	hp: 80,
+	types: ["Fire"],
 
-	abilities: [{
-		type: "Ability",
+	description: {
+		ja: "焼いた 木の実を 食べるのが 大好きだが 興奮しすぎて ときどき 真っ黒焦げに しちゃう。",
+	},
 
-		name: {
-			'zh-tw': "常春藤星星"
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: {
+				ja: "ぶつかる",
+				'zh-tw': "葉子防守",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
-
-		effect: {
-			'zh-tw': "在自己的回合時可使用。選擇對手的1隻備戰寶可夢，與戰鬥寶可夢互換。[對戰中，己方只可使用1次【VSTAR】力量。]"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "葉子防守"
+		{
+			name: { ja: "かえん" },
+			damage: 50,
+			cost: ["Fire", "Fire", "Colorless"],
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-30」點。"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597357,
+			},
 		},
-
-		damage: 180,
-		cost: ["Grass", "Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [498],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/160.ts
+++ b/data-asia/S/S-P/160.ts
@@ -1,47 +1,62 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "冰伊布V"
+		ja: "ガラル バリヤード",
+		'zh-tw': "冰伊布V",
 	},
 
-	illustrator: "PLANETA Mochizuki",
+	illustrator: "Shigenori Negishi",
 	category: "Pokemon",
-	hp: 210,
+	hp: 80,
 	types: ["Water"],
+
+	description: {
+		ja: "足の 裏から 冷気を 出す。 凍らせた 床の 上で １日 タップダンスに 励んでいる。",
+	},
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "冰霜充能"
+	attacks: [
+		{
+			name: {
+				ja: "はたく",
+				'zh-tw': "冰霜充能",
+			},
+			damage: 10,
+			cost: ["Water"],
 		},
-
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張【水】能量卡，附於這隻寶可夢身上。並且重洗牌庫。"
+		{
+			name: {
+				ja: "さぐりあてる",
+				'zh-tw': "凍凝之風",
+			},
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札からグッズを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "凍凝之風"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561775,
+				tcgplayer: 597358,
+			},
 		},
+	],
 
-		damage: 130,
-		cost: ["Water", "Water", "Colorless"]
-	}],
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [122],
+};
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/161.ts
+++ b/data-asia/S/S-P/161.ts
@@ -1,50 +1,71 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "冰伊布VSTAR"
+		ja: "ブラッキー",
+		'zh-tw': "冰伊布VSTAR",
 	},
 
-	illustrator: "5ban Graphics",
+	illustrator: "Souichirou Gunjima",
 	category: "Pokemon",
-	hp: 260,
-	types: ["Water"],
-	stage: "VMAX",
+	hp: 110,
+	types: ["Darkness"],
 
-	attacks: [{
-		name: {
-			'zh-tw': "冰柱射擊"
+	description: {
+		ja: "満月の 夜や 興奮 したとき 全身の 輪っか模様は 黄色く 光る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: {
+				ja: "やみうち",
+				'zh-tw': "冰柱射擊",
+			},
+			cost: ["Darkness"],
+			effect: {
+				ja: "ダメカンがのっている相手のポケモン1匹に、60ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。"
+		{
+			name: {
+				ja: "ムーンミラージュ",
+				'zh-tw': "[VSTAR力量]水晶星星",
+			},
+			damage: 80,
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢不會受到招式的傷害與效果的影響。[對戰中，己方只可使用1次【VSTAR】力量。]",
+			},
 		},
+	],
 
-		damage: 180,
-		cost: ["Water", "Water", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "[VSTAR力量]水晶星星"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561776,
+				tcgplayer: 597359,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，這隻寶可夢不會受到招式的傷害與效果的影響。[對戰中，己方只可使用1次【VSTAR】力量。]"
-		},
+	evolveFrom: {
+		ja: "イーブイ",
+	},
 
-		damage: 220,
-		cost: ["Water", "Water", "Colorless"]
-	}],
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [197],
+};
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/162.ts
+++ b/data-asia/S/S-P/162.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ドードリオV",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たたみかける" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンが使うワザの、相手のバトルポケモンへのダメージは「+80」される。",
+			},
+		},
+		{
+			name: { ja: "ばくそうドリル" },
+			damage: 160,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561777,
+				tcgplayer: 597360,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [85],
+};
+
+export default card;

--- a/data-asia/S/S-P/163.ts
+++ b/data-asia/S/S-P/163.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イーブイ",
+	},
+
+	illustrator: "Souichirou Gunjima",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "不安定な 遺伝子の おかげで さまざまな 進化の 可能性を 秘めている 特殊な ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "じゅんびする" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札から基本エネルギーを1枚選び、このポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "かみつく" },
+			damage: 30,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597361,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [133],
+};
+
+export default card;

--- a/data-asia/S/S-P/164.ts
+++ b/data-asia/S/S-P/164.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミツバ",
+	},
+
+	illustrator: "Ryuta Fuse",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のベンチの「ポケモンV」の数ぶん、自分の山札を引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597362,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/166.ts
+++ b/data-asia/S/S-P/166.ts
@@ -1,44 +1,61 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "圓法師"
+		ja: "アルセウス&ディアルガ&パルキアGX",
+		'zh-tw': "圓法師",
 	},
 
-	illustrator: "Shigenori Negishi",
+	illustrator: "Mitsuhiro Arita",
 	category: "Pokemon",
-	hp: 60,
-	types: ["Grass"],
-
-	description: {
-		'zh-tw': "觸角之間互相碰撞時，會叮叮咚咚地奏出 如同木琴一般的音色。"
-	},
+	hp: 280,
+	types: ["Dragon"],
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "打滾"
+	attacks: [
+		{
+			name: {
+				ja: "アルティメットレイ",
+				'zh-tw': "打滾",
+			},
+			damage: 150,
+			cost: ["Water", "Metal", "Colorless"],
+			effect: {
+				ja: "自分の山札にある基本エネルギーを3枚まで、自分のポケモンに好きなようにつける。そして山札を切る。",
+				'zh-tw': "擲1次硬幣若為正面，則增加20點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則增加20點傷害。"
+		{
+			name: { ja: "オルタージェネシスGX" },
+			cost: ["Metal"],
+			effect: {
+				ja: "この対戦が終わるまで、自分のポケモン全員が使うワザの、相手のバトルポケモンへのダメージはすべて「+30」される。追加で[水]エネルギーが1個ついているなら、そのワザのダメージで相手のバトルポケモンをきぜつさせた場合、サイドを1枚多くとる。［対戦中、自分はGXワザを1回しか使えない。］",
+			},
 		},
+	],
 
-		damage: "10+",
-		cost: ["Grass"]
-	}],
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525455,
+				tcgplayer: 597364,
+			},
+		},
+	],
 
-	retreat: 1,
-	regulationMark: "F"
-}
+	retreat: 3,
+	regulationMark: "C",
+	rarity: "Promo",
+	dexId: [493, 483, 484],
 
-export default card
+	suffix: "TAG TEAM-GX",
+};
+
+export default card;

--- a/data-asia/S/S-P/167.ts
+++ b/data-asia/S/S-P/167.ts
@@ -1,50 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洗翠 野蠻鱸魚"
+		ja: "プレシャスボール",
+		'zh-tw': "洗翠 野蠻鱸魚",
 	},
 
-	illustrator: "Shin Nagasawa",
-	category: "Pokemon",
-	hp: 50,
-	types: ["Water"],
+	illustrator: "5ban Graphics",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "此寶可夢具有多項野蠻鱸魚的特徵， 雖然有性情溫馴等不同點存在， 吾人仍將其定義為野蠻鱸魚的地區形態。"
+	effect: {
+		ja: "自分の山札にある「ポケモンGX」を1枚、相手に見せてから、手札に加える。そして山札を切る。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "無聲下潛"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 525460,
+				tcgplayer: 597365,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這個招式只可在後攻玩家的最初回合使用。在下個對手的回合，這隻寶可夢不會受到招式的傷害。"
-		},
+	trainerType: "Item",
+	regulationMark: "C",
+	rarity: "Promo",
+};
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "咬住"
-		},
-
-		damage: 20,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/168.ts
+++ b/data-asia/S/S-P/168.ts
@@ -1,52 +1,56 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "波克基古"
+		ja: "エースバーンV",
+		'zh-tw': "波克基古",
 	},
 
-	illustrator: "Narumi Sato",
+	illustrator: "aky CG Works",
 	category: "Pokemon",
-	hp: 80,
-	types: ["Psychic"],
+	hp: 210,
+	types: ["Fire"],
 
-	description: {
-		'zh-tw': "據說牠會為了將幸福帶給心地善良的人而現身。"
-	},
+	stage: "Basic",
 
-	stage: "Stage1",
-
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "幸福之聲"
+	attacks: [
+		{
+			name: {
+				ja: "ほのお",
+				'zh-tw': "妖精之風",
+			},
+			damage: 50,
+			cost: ["Colorless", "Colorless"],
 		},
-
-		effect: {
-			'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。將自己的戰鬥寶可夢恢復「30」HP。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "妖精之風"
+		{
+			name: { ja: "ぜんりょくシュート" },
+			damage: 210,
+			cost: ["Fire", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Psychic", "Colorless"]
-	}],
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 534107,
+				tcgplayer: 597366,
+			},
+		},
+	],
 
-	retreat: 1,
-	regulationMark: "F"
-}
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [815],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/169.ts
+++ b/data-asia/S/S-P/169.ts
@@ -1,51 +1,55 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "頭蓋龍"
+		ja: "エースバーンVMAX",
+		'zh-tw': "頭蓋龍",
 	},
 
-	illustrator: "GIDORA",
+	illustrator: "5ban Graphics",
 	category: "Pokemon",
-	hp: 90,
-	types: ["Fighting"],
+	hp: 320,
+	types: ["Fire"],
 
-	description: {
-		'zh-tw': "特徵是堅硬的頭蓋骨。會用頭錘撞斷樹木， 吃樹上長的樹果。"
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: {
+				ja: "キョダイカキュウ",
+				'zh-tw': "衝撞",
+			},
+			damage: 230,
+			cost: ["Fire", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 540531,
+				tcgplayer: 597367,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "エースバーンV",
 	},
-
-	stage: "Stage1",
-
-	attacks: [{
-		name: {
-			'zh-tw': "衝撞"
-		},
-
-		damage: 20,
-		cost: ["Fighting"]
-	}, {
-		name: {
-			'zh-tw': "尖石攻擊"
-		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則增加40點傷害。"
-		},
-
-		damage: "40+",
-		cost: ["Fighting", "Fighting"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [815],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/170.ts
+++ b/data-asia/S/S-P/170.ts
@@ -1,52 +1,57 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "月月熊V"
+		ja: "ゴリランダーV",
+		'zh-tw': "月月熊V",
 	},
 
 	illustrator: "5ban Graphics",
 	category: "Pokemon",
-	hp: 230,
-	types: ["Fighting"],
+	hp: 220,
+	types: ["Grass"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "堅硬膜"
+	attacks: [
+		{
+			name: {
+				ja: "ドレインパンチ",
+				'zh-tw': "泥炭肩膀",
+			},
+			damage: 60,
+			cost: ["Grass", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+				'zh-tw': "減少這隻寶可夢身上放置的傷害指示物的數量×10點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "這隻寶可夢受到招式的傷害「-30」點。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "泥炭肩膀"
+		{
+			name: { ja: "ドラムラッシュ" },
+			damage: 160,
+			cost: ["Grass", "Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		effect: {
-			'zh-tw': "減少這隻寶可夢身上放置的傷害指示物的數量×10點傷害。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 534112,
+				tcgplayer: 597368,
+			},
 		},
+	],
 
-		damage: "220-",
-		cost: ["Fighting", "Fighting", "Fighting"]
-	}],
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [812],
+};
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
-
-	retreat: 4,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/171.ts
+++ b/data-asia/S/S-P/171.ts
@@ -1,49 +1,56 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "駒刀小兵"
+		ja: "ゴリランダーVMAX",
+		'zh-tw': "駒刀小兵",
 	},
 
-	illustrator: "Yuya Oka",
+	illustrator: "5ban Graphics",
 	category: "Pokemon",
-	hp: 60,
-	types: ["Metal"],
+	hp: 330,
+	types: ["Grass"],
 
-	description: {
-		'zh-tw': "揮舞銳利的刀刃將敵人逼向絕境。會用河灘的 石頭來精心保養刀刃。"
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: {
+				ja: "キョダイコランダ",
+				'zh-tw': "突擊",
+			},
+			damage: 180,
+			cost: ["Grass", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン2匹にも、それぞれ40ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "這隻寶可夢也受到10點傷害。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 540526,
+				tcgplayer: 597369,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴリランダーV",
 	},
 
-	stage: "Basic",
+	retreat: 3,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [812],
+};
 
-	attacks: [{
-		name: {
-			'zh-tw': "突擊"
-		},
-
-		effect: {
-			'zh-tw': "這隻寶可夢也受到10點傷害。"
-		},
-
-		damage: 30,
-		cost: ["Metal"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
-
-	retreat: 1,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/172.ts
+++ b/data-asia/S/S-P/172.ts
@@ -1,22 +1,56 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "拉苯博士"
+		ja: "ガラル ヤドン",
+		'zh-tw': "拉苯博士",
 	},
 
-	illustrator: "Ken Sugimori",
-	category: "Trainer",
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
 
-	effect: {
-		'zh-tw': "從自己的棄牌區選擇最多3張名稱中有「洗翠」的寶可夢卡，在給對手看過後加入手牌。"
+	description: {
+		ja: "ガラル地方にだけ 生息する 植物の タネを 食べているため しっぽは スパイシーな 味わいだ。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "F"
-}
+	stage: "Basic",
 
-export default card
+	attacks: [
+		{
+			name: { ja: "みんなでねそべる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のポケモン全員のHPを、それぞれ「10」回復する。",
+			},
+		},
+		{
+			name: { ja: "しっぽではたく" },
+			damage: 30,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561781,
+				tcgplayer: 597370,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [79],
+};
+
+export default card;

--- a/data-asia/S/S-P/173.ts
+++ b/data-asia/S/S-P/173.ts
@@ -1,55 +1,64 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雷吉奇卡斯"
+		ja: "コオリッポ",
+		'zh-tw': "雷吉奇卡斯",
 	},
 
-	illustrator: "GOSSAN",
+	illustrator: "kirisAki",
 	category: "Pokemon",
-	hp: 150,
-	types: ["Colorless"],
+	hp: 120,
+	types: ["Water"],
 
 	description: {
-		'zh-tw': "在世上流傳著的傳說中，牠拉動了被繩子所綑綁的大地。"
+		ja: "暑さに 弱い 顔を いつも 氷で 冷やしている。 頭の 毛を 海に たらして 餌を釣る。",
+		'zh-tw': "在世上流傳著的傳說中，牠拉動了被繩子所綑綁的大地。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "暖身"
+	attacks: [
+		{
+			name: {
+				ja: "アイスボーナス",
+				'zh-tw': "暖身",
+			},
+			cost: ["Water"],
+			effect: {
+				ja: "自分の手札から[水]エネルギーを1枚選び、トラッシュする。その後、自分の山札を3枚引く。",
+				'zh-tw': "從自己的棄牌區選擇1張基本能量卡，附於這隻寶可夢身上。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "從自己的棄牌區選擇1張基本能量卡，附於這隻寶可夢身上。"
+		{
+			name: {
+				ja: "とびだしヘッド",
+				'zh-tw': "雙重衝擊",
+			},
+			damage: 100,
+			cost: ["Water", "Water", "Colorless"],
 		},
+	],
 
-		damage: 20,
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "雙重衝擊"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561782,
+				tcgplayer: 597371,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲2次硬幣，造成正面出現的次數×120點傷害。"
-		},
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [875],
+};
 
-		damage: "120×",
-		cost: ["Colorless", "Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	retreat: 4,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/174.ts
+++ b/data-asia/S/S-P/174.ts
@@ -1,49 +1,58 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "阿羅拉 椰蛋樹V"
+		ja: "サダイジャV",
+		'zh-tw': "阿羅拉 椰蛋樹V",
 	},
 
-	illustrator: "MUGENUP",
+	illustrator: "Narumi Sato",
 	category: "Pokemon",
-	hp: 240,
-	types: ["Grass"],
+	hp: 220,
+	types: ["Fighting"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "悠悠成長"
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "すなのぼうへき" },
+			effect: {
+				ja: "このポケモンが受けるワザのダメージは「-30」される。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則從自己的牌庫選擇最多5張【草】能量卡，以任意方式附於自己的寶可夢身上。並且重洗牌庫。"
+	attacks: [
+		{
+			name: {
+				ja: "ランドクラッシュ",
+				'zh-tw': "悠悠成長",
+			},
+			damage: 140,
+			cost: ["Fighting", "Fighting", "Colorless"],
 		},
+	],
 
-		cost: ["Grass"]
-	}, {
-		name: {
-			'zh-tw': "嗡嗡頭擊"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561783,
+				tcgplayer: 597372,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "對手的1隻寶可夢，受到這隻寶可夢身上附加的【草】能量的數量×30點傷害。[在備戰區不計算弱點・抵抗力。]"
-		},
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [844],
+};
 
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	retreat: 3,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/175.ts
+++ b/data-asia/S/S-P/175.ts
@@ -1,50 +1,62 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "皮卡丘"
+		ja: "セレビィV",
+		'zh-tw': "皮卡丘",
 	},
 
-	illustrator: "Ryota Murayama",
+	illustrator: "Teeziro",
 	category: "Pokemon",
-	hp: 60,
-	types: ["Lightning"],
-
-	description: {
-		'zh-tw': "越是能製造出強大電流的皮卡丘，臉頰上的囊就越 柔軟，同時也越有伸展性。"
-	},
+	hp: 190,
+	types: ["Grass"],
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "親送之禮"
+	attacks: [
+		{
+			name: {
+				ja: "わかばのまい",
+				'zh-tw': "親送之禮",
+			},
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の手札から[草]エネルギーを好きなだけ選び、自分のポケモンに好きなようにつける。",
+				'zh-tw': "擲1次硬幣若為正面，則從自己的牌庫選擇1張物品卡，在給對手看過後加入手牌。並且重洗牌庫。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則從自己的牌庫選擇1張物品卡，在給對手看過後加入手牌。並且重洗牌庫。"
+		{
+			name: {
+				ja: "スラッシュバック",
+				'zh-tw': "皮卡球",
+			},
+			damage: 60,
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "皮卡球"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561784,
+				tcgplayer: 597373,
+			},
 		},
-
-		damage: 50,
-		cost: ["Lightning", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [251],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/176.ts
+++ b/data-asia/S/S-P/176.ts
@@ -1,52 +1,59 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "超夢V"
+		ja: "キノガッサV",
+		'zh-tw': "超夢V",
 	},
 
 	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
-	hp: 220,
-	types: ["Psychic"],
+	hp: 210,
+	types: ["Grass"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "超念力"
+	attacks: [
+		{
+			name: {
+				ja: "カウンター",
+				'zh-tw': "超念力",
+			},
+			damage: "20+",
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "前の相手の番に、このポケモンが受けたワザのダメージと同じダメージ追加。",
+			},
 		},
-
-		damage: 50,
-		cost: ["Psychic", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "轉移破壞"
+		{
+			name: {
+				ja: "マッハストレート",
+				'zh-tw': "轉移破壞",
+			},
+			damage: 140,
+			cost: ["Grass", "Grass", "Colorless"],
 		},
+	],
 
-		effect: {
-			'zh-tw': "選擇1個這隻寶可夢身上附加的能量，改附於備戰寶可夢身上。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 570871,
+				tcgplayer: 597374,
+			},
 		},
-
-		damage: 160,
-		cost: ["Psychic", "Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [286],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/177.ts
+++ b/data-asia/S/S-P/177.ts
@@ -1,52 +1,52 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "美錄梅塔V"
+		ja: "ユキワラシ",
+		'zh-tw': "美錄梅塔V",
 	},
 
-	illustrator: "sadaji",
+	illustrator: "otumami",
 	category: "Pokemon",
-	hp: 220,
-	types: ["Metal"],
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "寒い 土地でしか 生きられない。 マイナス １００度の 環境でも 元気に 跳ねまわっているよ。",
+	},
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "臂充能"
+	attacks: [
+		{
+			name: {
+				ja: "ずつき",
+				'zh-tw': "臂充能",
+			},
+			damage: 30,
+			cost: ["Water", "Colorless"],
 		},
+	],
 
-		effect: {
-			'zh-tw': "若希望，從自己的手牌選擇1張【鋼】能量卡，附於這隻寶可夢身上。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 570873,
+				tcgplayer: 597375,
+			},
 		},
+	],
 
-		damage: 50,
-		cost: ["Metal", "Metal"]
-	}, {
-		name: {
-			'zh-tw': "百萬噸重拳"
-		},
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [361],
+};
 
-		damage: 140,
-		cost: ["Metal", "Metal", "Metal"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
-
-	retreat: 3,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/178.ts
+++ b/data-asia/S/S-P/178.ts
@@ -1,52 +1,55 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "章魚桶"
+		ja: "シママ",
+		'zh-tw': "章魚桶",
 	},
 
-	illustrator: "KIYOTAKA OSHIYAMA",
+	illustrator: "Oswaldo KATO",
 	category: "Pokemon",
-	hp: 110,
-	types: ["Water"],
+	hp: 60,
+	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "有著堅硬結實的腦袋。會用帶有吸盤的腳纏住對手， 然後不停地用頭猛撞。"
+		ja: "放電すると たてがみが 光る。 たてがみが 輝く 回数や リズムで 仲間と 会話している。",
+		'zh-tw': "有著堅硬結實的腦袋。會用帶有吸盤的腳纏住對手， 然後不停地用頭猛撞。",
 	},
 
-	stage: "Stage1",
+	stage: "Basic",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "連擊搜索"
+	attacks: [
+		{
+			name: {
+				ja: "サンダーアロー",
+				'zh-tw': "攀瀑",
+			},
+			cost: ["Lightning"],
+			effect: {
+				ja: "相手のポケモン1匹に、10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合時，可使用1次。從自己的牌庫選擇1張「連擊」卡，在給對手看過後加入手牌。並且重洗牌庫。在這個回合，若已經使出了其他的「連擊搜索」，則這個特性無法使用。"
-		}
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	attacks: [{
-		name: {
-			'zh-tw': "攀瀑"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 570874,
+				tcgplayer: 597376,
+			},
 		},
+	],
 
-		damage: 50,
-		cost: ["Water", "Colorless", "Colorless"]
-	}],
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [522],
+};
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "E"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/179.ts
+++ b/data-asia/S/S-P/179.ts
@@ -1,52 +1,68 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "黑魯加"
+		ja: "エーフィ",
+		'zh-tw': "黑魯加",
 	},
 
-	illustrator: "Uta",
+	illustrator: "Tika Matsuno",
 	category: "Pokemon",
-	hp: 130,
-	types: ["Darkness"],
+	hp: 110,
+	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "特徵是令人不寒而慄的長嚎。過去人們認為牠是來自 地獄的使者，對牠十分畏懼。"
+		ja: "額の 珠から サイコパワーを 放射して 戦う。 パワーが つきると 珠の 色が くすむ。",
+		'zh-tw': "特徵是令人不寒而慄的長嚎。過去人們認為牠是來自 地獄的使者，對牠十分畏懼。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "一擊咆哮"
+	attacks: [
+		{
+			name: {
+				ja: "ねんりき",
+				'zh-tw': "暗之牙",
+			},
+			damage: 20,
+			cost: ["Psychic"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在自己的回合時，可使用1次。從自己的牌庫選擇1張「一擊能量」卡，附於自己的「一擊」寶可夢身上。並且重洗牌庫。然後，在附上那張卡的寶可夢身上放置2個傷害指示物。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "暗之牙"
+		{
+			name: { ja: "サイコキネシス" },
+			damage: "10+",
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーの数×40ダメージ追加。",
+			},
 		},
+	],
 
-		damage: 50,
-		cost: ["Darkness", "Colorless"]
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 570872,
+				tcgplayer: 597377,
+			},
+		},
+	],
 
-	retreat: 2,
-	regulationMark: "E"
-}
+	evolveFrom: {
+		ja: "イーブイ",
+	},
 
-export default card
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [196],
+};
+
+export default card;

--- a/data-asia/S/S-P/180.ts
+++ b/data-asia/S/S-P/180.ts
@@ -1,51 +1,56 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "千面避役VMAX"
+		ja: "ドガース",
+		'zh-tw': "千面避役VMAX",
 	},
 
-	illustrator: "Kazuma Koda",
+	illustrator: "miki kudo",
 	category: "Pokemon",
-	hp: 320,
-	types: ["Water"],
-	stage: "VMAX",
+	hp: 70,
+	types: ["Darkness"],
 
-	abilities: [{
-		type: "Ability",
+	description: {
+		ja: "汚い 空気が ごちそう。 むかしの ガラル地方には いまより たくさんの ドガースが いたという。",
+	},
 
-		name: {
-			'zh-tw': "雙重射擊手"
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: {
+				ja: "スモッグ",
+				'zh-tw': "超極巨漩澴盤渦",
+			},
+			damage: 20,
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+				'zh-tw': "若希望，選擇1個這隻寶可夢身上附加的能量，放回手牌。這個情況下，增加70點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，若從自己的手牌將1張【水】能量卡丟棄，則可使用1次。在對手的2隻備戰寶可夢身上，各放置2個傷害指示物。"
-		}
-	}],
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
 
-	attacks: [{
-		name: {
-			'zh-tw': "超極巨漩澴盤渦"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 570875,
+				tcgplayer: 597378,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若希望，選擇1個這隻寶可夢身上附加的能量，放回手牌。這個情況下，增加70點傷害。"
-		},
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [109],
+};
 
-		damage: "70+",
-		cost: ["Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "E"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/181.ts
+++ b/data-asia/S/S-P/181.ts
@@ -1,50 +1,62 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "耿鬼VMAX"
+		ja: "イーブイ",
+		'zh-tw': "耿鬼VMAX",
 	},
 
-	illustrator: "sowsow",
+	illustrator: "Tika Matsuno",
 	category: "Pokemon",
-	hp: 320,
-	types: ["Darkness"],
-	stage: "VMAX",
+	hp: 60,
+	types: ["Colorless"],
 
-	attacks: [{
-		name: {
-			'zh-tw': "恐慌恐懼"
+	description: {
+		ja: "不安定な 遺伝子の おかげで さまざまな 進化の 可能性を 秘めている 特殊な ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: {
+				ja: "じゅんびする",
+				'zh-tw': "恐慌恐懼",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札から基本エネルギーを1枚選び、このポケモンにつける。",
+				'zh-tw': "造成對手的場上的「寶可夢【V】・【GX】」的數量×60點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "造成對手的場上的「寶可夢【V】・【GX】」的數量×60點傷害。"
+		{
+			name: {
+				ja: "かみつく",
+				'zh-tw': "超極巨大口吞噬",
+			},
+			damage: 30,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		damage: "60×",
-		cost: ["Darkness", "Darkness"]
-	}, {
-		name: {
-			'zh-tw': "超極巨大口吞噬"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597379,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。"
-		},
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [133],
+};
 
-		damage: 250,
-		cost: ["Darkness", "Darkness", "Darkness"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
-
-	retreat: 3,
-	regulationMark: "E"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/182.ts
+++ b/data-asia/S/S-P/182.ts
@@ -1,47 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "妙蛙種子"
+		ja: "ウッウロボ",
+		'zh-tw': "妙蛙種子",
 	},
 
-	illustrator: "Shibuzoh.",
-	category: "Pokemon",
-	hp: 70,
-	types: ["Grass"],
+	illustrator: "Ryo Ueda",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "從出生的時候開始背上就有一顆植物種子。 這顆種子會漸漸地長大。"
+	effect: {
+		ja: "このカードは、自分の手札からグッズを1枚トラッシュしなければ使えない。コインを1回投げオモテなら、自分の山札から好きなカードを1枚選び、手札に加える。そして山札を切る。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "藤鞭"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 570877,
+				tcgplayer: 597380,
+			},
 		},
+	],
 
-		damage: 10,
-		cost: ["Grass"]
-	}, {
-		name: {
-			'zh-tw': "飛葉快刀"
-		},
+	trainerType: "Item",
+	regulationMark: "E",
+	rarity: "Promo",
+};
 
-		damage: 20,
-		cost: ["Grass", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/183.ts
+++ b/data-asia/S/S-P/183.ts
@@ -1,44 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "小火龍"
+		ja: "モミ",
+		'zh-tw': "小火龍",
 	},
 
-	illustrator: "Saya Tsuruta",
-	category: "Pokemon",
-	hp: 60,
-	types: ["Fire"],
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "天生喜歡熱熱的東西。據說當牠被雨淋濕的時候， 尾巴的末端會冒出煙來。"
+	effect: {
+		ja: "自分の進化ポケモン全員のHPを、すべて回復する。その後、回復したポケモンについているエネルギーを、すべてトラッシュする。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "燃燒之尾"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 570878,
+				tcgplayer: 597381,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "從自己的牌庫選擇1張【火】能量卡，附於這隻寶可夢身上。並且重洗牌庫。"
-		},
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Promo",
+};
 
-		damage: 10,
-		cost: ["Fire"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/184.ts
+++ b/data-asia/S/S-P/184.ts
@@ -1,40 +1,61 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "傑尼龜"
+		ja: "エンペルトV",
+		'zh-tw': "傑尼龜",
 	},
 
-	illustrator: "kurumitsu",
+	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
-	hp: 70,
+	hp: 210,
 	types: ["Water"],
-
-	description: {
-		'zh-tw': "當牠把長長的脖子縮回殼裡時，會順勢發射 力道強勁的水槍。"
-	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "水槍"
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エンペラーアイ" },
+			effect: {
+				ja: "このポケモンがバトル場にいるかぎり、相手の場のたねポケモン（「ルールを持つポケモン」をのぞく）の特性は、すべてなくなる。",
+			},
 		},
+	],
 
-		damage: 20,
-		cost: ["Water"]
-	}],
+	attacks: [
+		{
+			name: {
+				ja: "らせんぎり",
+				'zh-tw': "水槍",
+			},
+			damage: 130,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、ベンチポケモンにつけ替える。",
+			},
+		},
+	],
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-	retreat: 1,
-	regulationMark: "F"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 564162,
+				tcgplayer: 597382,
+			},
+		},
+	],
 
-export default card
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [395],
+};
+
+export default card;

--- a/data-asia/S/S-P/185.ts
+++ b/data-asia/S/S-P/185.ts
@@ -1,42 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "快龍V"
+		ja: "バンギラスV",
+		'zh-tw': "快龍V",
 	},
 
-	illustrator: "kawayoo",
+	illustrator: "PLANETA Tsuji",
 	category: "Pokemon",
 	hp: 230,
-	types: ["Dragon"],
+	types: ["Darkness"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "破壞光線"
+	attacks: [
+		{
+			name: {
+				ja: "やまなだれ",
+				'zh-tw': "破壞光線",
+			},
+			damage: 60,
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の山札を上から2枚トラッシュする。",
+				'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的能量，將其丟棄。"
+		{
+			name: {
+				ja: "いちげきクラッシュ",
+				'zh-tw': "光炮尾",
+			},
+			damage: 240,
+			cost: ["Darkness", "Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札を上から4枚トラッシュする。",
+			},
 		},
+	],
 
-		damage: 60,
-		cost: ["Water", "Lightning"]
-	}, {
-		name: {
-			'zh-tw': "光炮尾"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 564163,
+				tcgplayer: 597383,
+			},
 		},
+	],
 
-		damage: 160,
-		cost: ["Water", "Lightning", "Colorless"]
-	}],
+	retreat: 3,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [248],
+};
 
-	retreat: 2,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/186.ts
+++ b/data-asia/S/S-P/186.ts
@@ -1,44 +1,56 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "快龍VSTAR"
+		ja: "ブースターVMAX",
+		'zh-tw': "快龍VSTAR",
 	},
 
-	illustrator: "PLANETA Mochizuki",
+	illustrator: "OKACHEKE",
 	category: "Pokemon",
-	hp: 280,
-	types: ["Dragon"],
+	hp: 320,
+	types: ["Fire"],
+
 	stage: "VMAX",
 
-	attacks: [{
-		name: {
-			'zh-tw': "終極衝擊"
+	attacks: [
+		{
+			name: {
+				ja: "ダイバクレツ",
+				'zh-tw': "終極衝擊",
+			},
+			damage: "100×",
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札を上から5枚トラッシュし、その中にあるエネルギーの枚数×100ダメージ。",
+				'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用招式。"
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571389,
+				tcgplayer: 597384,
+			},
 		},
+	],
 
-		damage: 250,
-		cost: ["Water", "Lightning", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "[VSTAR力量]龍之星星"
-		},
-
-		effect: {
-			'zh-tw': "查看自己的牌庫上方12張卡，從其中選擇任意數量的【水】或者【雷】能量卡，以任意方式附於自己的寶可夢身上。將剩餘卡放回牌庫並重洗。[對戰中，己方只可使用1次【VSTAR】力量。]"
-		},
-
-		cost: ["Colorless"]
-	}],
+	evolveFrom: {
+		ja: "ブースターV",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [136],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/187.ts
+++ b/data-asia/S/S-P/187.ts
@@ -1,40 +1,62 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "向日種子"
+		ja: "シャワーズVMAX",
+		'zh-tw': "向日種子",
 	},
 
-	illustrator: "ryoma uratsuka",
+	illustrator: "Atsushi Furusawa",
 	category: "Pokemon",
-	hp: 40,
-	types: ["Grass"],
+	hp: 320,
+	types: ["Water"],
 
-	description: {
-		'zh-tw': "只飲用積在葉子背面的朝露來過活。據說除此之外什麼都不吃。"
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: {
+				ja: "バブルポッド",
+				'zh-tw': "種子炸彈",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュから[水]ポケモンを1枚選び、ベンチに出す。その後、自分のトラッシュから[水]エネルギーを3枚まで選び、出したポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "ダイゲキリュウ" },
+			damage: "100+",
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンにダメカンがのっているなら、100ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571390,
+				tcgplayer: 597385,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シャワーズV",
 	},
 
-	stage: "Basic",
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [134],
+};
 
-	attacks: [{
-		name: {
-			'zh-tw': "種子炸彈"
-		},
-
-		damage: 20,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/188.ts
+++ b/data-asia/S/S-P/188.ts
@@ -1,47 +1,55 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "小海獅"
+		ja: "サンダースVMAX",
+		'zh-tw': "小海獅",
 	},
 
-	illustrator: "Kagemaru Himeno",
+	illustrator: "Hasuno",
 	category: "Pokemon",
-	hp: 70,
-	types: ["Water"],
+	hp: 300,
+	types: ["Lightning"],
 
-	description: {
-		'zh-tw': "因為有著厚厚的脂肪，所以完全不怕寒冷的海域， 但在溫暖的海裡就有點容易中暑。"
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: {
+				ja: "ダイジンライ",
+				'zh-tw': "頭錘",
+			},
+			damage: 100,
+			cost: ["Lightning", "Colorless"],
+			effect: {
+				ja: "ダメカンがのっている相手のベンチポケモン1匹にも、100ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 571391,
+				tcgplayer: 597386,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "サンダースV",
 	},
 
-	stage: "Basic",
+	retreat: 0,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [135],
+};
 
-	attacks: [{
-		name: {
-			'zh-tw': "頭錘"
-		},
-
-		damage: 10,
-		cost: ["Water"]
-	}, {
-		name: {
-			'zh-tw': "潑水"
-		},
-
-		damage: 20,
-		cost: ["Water", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/189.ts
+++ b/data-asia/S/S-P/189.ts
@@ -1,50 +1,66 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "蓋歐卡V"
+		ja: "エーフィVMAX",
+		'zh-tw': "蓋歐卡V",
 	},
 
-	illustrator: "PLANETA Tsuji",
+	illustrator: "Kouki Saitou",
 	category: "Pokemon",
-	hp: 230,
-	types: ["Water"],
-	stage: "Basic",
-	suffix: "V",
+	hp: 310,
+	types: ["Psychic"],
 
-	attacks: [{
-		name: {
-			'zh-tw': "二重飛濺"
+	stage: "VMAX",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "たいようのけいじ" },
+			effect: {
+				ja: "このポケモンがいるかぎり、エネルギーがついている自分のポケモン全員は、相手のポケモンが使うワザの効果を受けない。（すでに受けている効果は、なくならない。）",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "對手的2隻寶可夢各受到50點傷害。[在備戰區不計算弱點・抵抗力。]"
+	attacks: [
+		{
+			name: {
+				ja: "ダイサイコ",
+				'zh-tw': "二重飛濺",
+			},
+			damage: "60×",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の場のポケモンについているエネルギーの数×60ダメージ。",
+				'zh-tw': "對手的2隻寶可夢各受到50點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		cost: ["Water", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "水之颱風"
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 564161,
+				tcgplayer: 597387,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個自己的回合，這隻寶可夢無法使用「水之颱風」。"
-		},
+	evolveFrom: {
+		ja: "エーフィV",
+	},
 
-		damage: 210,
-		cost: ["Water", "Colorless", "Colorless", "Colorless"]
-	}],
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [196],
+};
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	retreat: 3,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/190.ts
+++ b/data-asia/S/S-P/190.ts
@@ -1,52 +1,74 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "麻麻鰻"
+		ja: "ポットデス",
+		'zh-tw': "麻麻鰻",
 	},
 
-	illustrator: "NC Empire",
+	illustrator: "Misa Tsutsui",
 	category: "Pokemon",
-	hp: 80,
-	types: ["Lightning"],
+	hp: 60,
+	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "食慾旺盛的寶可夢。一發現獵物就會發動襲擊， 用電流使其麻痺後大快朵頤。"
+		ja: "アンティークの ポットに 棲みつく。 ほとんどが 贋作だが ごくまれに 真作が 見つかる ことも。",
+		'zh-tw': "食慾旺盛的寶可夢。一發現獵物就會發動襲擊， 用電流使其麻痺後大快朵頤。",
 	},
 
 	stage: "Stage1",
 
-	abilities: [{
-		type: "Ability",
-
-		name: {
-			'zh-tw': "臨場衝擊"
+	abilities: [
+		{
+			type: "Ability",
+			name: {
+				ja: "ティーブレイク",
+				'zh-tw': "臨場衝擊",
+			},
+			effect: {
+				ja: "自分の番に、自分の手札からワザ「マッドパーティ」を持つポケモンを1枚トラッシュするなら、1回使える。自分の山札を2枚引く。",
+				'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在自己的回合，當從手牌使出這張卡並完成進化時，可使用1次。擲1次硬幣若為正面，則將對手的戰鬥寶可夢【麻痺】。"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "劈哩啪啦"
+	attacks: [
+		{
+			name: {
+				ja: "マッドパーティ",
+				'zh-tw': "劈哩啪啦",
+			},
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある、ワザ「マッドパーティ」を持つポケモンの数×20ダメージ。",
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Lightning"]
-	}],
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561785,
+				tcgplayer: 597388,
+			},
+		},
+	],
 
-	retreat: 2,
-	regulationMark: "F"
-}
+	evolveFrom: {
+		ja: "ヤバチャ",
+	},
 
-export default card
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [855],
+};
+
+export default card;

--- a/data-asia/S/S-P/191.ts
+++ b/data-asia/S/S-P/191.ts
@@ -1,55 +1,71 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "眷戀雲"
+		ja: "ガラル バリコオル",
+		'zh-tw': "眷戀雲",
 	},
 
-	illustrator: "Jiro Sasumo",
+	illustrator: "KEIICHIRO ITO",
 	category: "Pokemon",
 	hp: 120,
-	types: ["Psychic"],
+	types: ["Water"],
 
 	description: {
-		'zh-tw': "當牠越過大海飛來，便代表嚴寒的 冬季即將終結。傳說中其慈愛將使 新的生命在洗翠大地上萌芽。"
+		ja: "タップダンスの 達人。 氷で できた ステッキを 振り 軽やかな ステップを 披露する。",
+		'zh-tw': "當牠越過大海飛來，便代表嚴寒的 冬季即將終結。傳說中其慈愛將使 新的生命在洗翠大地上萌芽。",
 	},
 
-	stage: "Basic",
+	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "吸取之吻"
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "シャッフルダンス" },
+			effect: {
+				ja: "自分の番に1回使える。ウラになっている相手のサイドを1枚選び、相手の山札の一番上のカードと、ウラのまま入れ替える。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "將這隻寶可夢恢復「20」HP。"
+	attacks: [
+		{
+			name: {
+				ja: "マッドパーティ",
+				'zh-tw': "吸取之吻",
+			},
+			damage: "20×",
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある、ワザ「マッドパーティ」を持つポケモンの数×20ダメージ。",
+				'zh-tw': "將這隻寶可夢恢復「20」HP。",
+			},
 		},
+	],
 
-		damage: 20,
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "愛之共感"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561786,
+				tcgplayer: 597389,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若自己的手牌的張數與對手的手牌的張數相同，則增加70點傷害。"
-		},
-
-		damage: "70+",
-		cost: ["Psychic", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Metal",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "ガラル バリヤード",
+	},
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [866],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/192.ts
+++ b/data-asia/S/S-P/192.ts
@@ -1,49 +1,57 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "金屬怪"
+		ja: "デデンネ",
+		'zh-tw': "金屬怪",
 	},
 
-	illustrator: "Nisota Niso",
+	illustrator: "Yuu Nishida",
 	category: "Pokemon",
-	hp: 100,
-	types: ["Metal"],
+	hp: 70,
+	types: ["Psychic"],
 
 	description: {
-		'zh-tw': "由２隻鐵啞鈴以磁力結合而成。因為有２個大腦， 精神力量也強化成２倍了。"
+		ja: "上の ヒゲは 辺りを 探る センサーで 下に 生えた ヒゲは 電気を 放つ 器官 なのだ。",
+		'zh-tw': "由２隻鐵啞鈴以磁力結合而成。因為有２個大腦， 精神力量也強化成２倍了。",
 	},
 
-	stage: "Stage1",
+	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "子彈拳"
+	attacks: [
+		{
+			name: {
+				ja: "マッドパーティ",
+				'zh-tw': "子彈拳",
+			},
+			damage: "20×",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある、ワザ「マッドパーティ」を持つポケモンの数×20ダメージ。",
+				'zh-tw': "擲2次硬幣，增加正面出現的次數×30點傷害。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "擲2次硬幣，增加正面出現的次數×30點傷害。"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561787,
+				tcgplayer: 597390,
+			},
 		},
+	],
 
-		damage: "30+",
-		cost: ["Metal", "Colorless"]
-	}],
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [702],
+};
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
-
-	retreat: 2,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/193.ts
+++ b/data-asia/S/S-P/193.ts
@@ -1,22 +1,52 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "挖洞兄弟"
+		ja: "ホルビー",
+		'zh-tw': "挖洞兄弟",
 	},
 
-	illustrator: "Yuu Nishida",
-	category: "Trainer",
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Colorless"],
 
-	effect: {
-		'zh-tw': "擲1次硬幣。若為正面，則查看自己的牌庫下方8張卡，若為反面，則查看自己的牌庫下方3張卡，選擇其中1張卡加入手牌。將剩餘卡放回牌庫並重洗。"
+	description: {
+		ja: "耳で 穴を 掘るのが 得意。 地下１０メートルに とどく 巣穴を 一晩で つくってしまう。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "F"
-}
+	stage: "Basic",
 
-export default card
+	attacks: [
+		{
+			name: { ja: "マッドパーティ" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある、ワザ「マッドパーティ」を持つポケモンの数×20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 561788,
+				tcgplayer: 597391,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [659],
+};
+
+export default card;

--- a/data-asia/S/S-P/208.ts
+++ b/data-asia/S/S-P/208.ts
@@ -1,22 +1,52 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "瑪俐"
+		ja: "ピカチュウ",
+		'zh-tw': "瑪俐",
 	},
 
-	illustrator: "kirisAki",
-	category: "Trainer",
+	illustrator: "YU NAGABA",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
 
-	effect: {
-		'zh-tw': "雙方玩家各將自己的手牌全部翻回反面並重洗，放回牌庫下方。然後，從牌庫抽卡，自己抽出5張，對手抽出4張。"
+	description: {
+		ja: "おたがいの しっぽを くっつけて 電気を 流しあうのが ピカチュウ 同士の 挨拶だ。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "D"
-}
+	stage: "Basic",
 
-export default card
+	attacks: [
+		{
+			name: { ja: "いっぱつしょうぶ" },
+			damage: 70,
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 568802,
+				tcgplayer: 597392,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/S/S-P/209.ts
+++ b/data-asia/S/S-P/209.ts
@@ -1,22 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "露璃娜"
+		ja: "チルタリス",
+		'zh-tw': "露璃娜",
 	},
 
-	illustrator: "take",
-	category: "Trainer",
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Dragon"],
 
-	effect: {
-		'zh-tw': "從自己的棄牌區選擇【水】寶可夢卡與【水】能量卡合計最多4張，在給對手看過後加入手牌。"
+	description: {
+		ja: "晴れた日 綿雲に まぎれながら 大空を 自由に 飛び回り 美しい ソプラノで 歌う。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "D"
-}
+	stage: "Stage1",
 
-export default card
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "いざなうしらべ" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札からサポートを1枚選び、相手に見せる。残りの山札を切り、選んだカードを山札の上にもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かっくう" },
+			damage: 60,
+			cost: ["Water", "Metal"],
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 568803,
+				tcgplayer: 597393,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チルット",
+	},
+
+	retreat: 0,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [334],
+};
+
+export default card;

--- a/data-asia/S/S-P/210.ts
+++ b/data-asia/S/S-P/210.ts
@@ -1,44 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "皮卡丘"
+		ja: "レックウザV",
+		'zh-tw': "皮卡丘",
 	},
 
-	illustrator: "You Iribi",
+	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
-	hp: 70,
-	types: ["Lightning"],
-
-	description: {
-		'zh-tw': "皮卡丘們把尾巴貼在一起交換電流，其實是在互相打招呼。"
-	},
+	hp: 210,
+	types: ["Dragon"],
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "瘋狂伏特"
+	attacks: [
+		{
+			name: {
+				ja: "りゅうのはどう",
+				'zh-tw': "瘋狂伏特",
+			},
+			damage: 40,
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分の山札を上から2枚トラッシュする。",
+				'zh-tw': "這隻寶可夢也受到30點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "這隻寶可夢也受到30點傷害。"
+		{
+			name: { ja: "スパイラルバースト" },
+			damage: "20+",
+			cost: ["Fire", "Lightning"],
+			effect: {
+				ja: "のぞむなら、このポケモンについている[炎]または[雷]タイプのどちらかの基本エネルギーを2枚までトラッシュし、その枚数×80ダメージ追加。",
+			},
 		},
+	],
 
-		damage: 90,
-		cost: ["Lightning", "Lightning", "Colorless"]
-	}],
+	weaknesses: [],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 568804,
+				tcgplayer: 597394,
+			},
+		},
+	],
 
-	retreat: 1,
-	regulationMark: "F"
-}
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [384],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/211.ts
+++ b/data-asia/S/S-P/211.ts
@@ -1,22 +1,57 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "阿馴"
+		ja: "バクガメス",
+		'zh-tw': "阿馴",
 	},
 
-	illustrator: "Ken Sugimori",
-	category: "Trainer",
+	illustrator: "Ryuta Fuse",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Dragon"],
 
-	effect: {
-		'zh-tw': "從自己的牌庫抽出3張卡。"
+	description: {
+		ja: "火山で 暮らし 食べた 硫黄が 甲羅の 爆薬の もとになる。 フンも 爆発する 危険物。",
 	},
 
-	trainerType: "Supporter",
-	regulationMark: "F"
-}
+	stage: "Basic",
 
-export default card
+	attacks: [
+		{
+			name: { ja: "トラップシェル" },
+			damage: 30,
+			cost: ["Fire", "Fighting"],
+			effect: {
+				ja: "次の相手の番、このポケモンがワザのダメージを受けたとき、ワザを使ったポケモンにダメカンを8個のせる。",
+			},
+		},
+		{
+			name: { ja: "ヒートスタンプ" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 568805,
+				tcgplayer: 597395,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [776],
+};
+
+export default card;

--- a/data-asia/S/S-P/212.ts
+++ b/data-asia/S/S-P/212.ts
@@ -1,47 +1,63 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "路卡利歐V"
+		ja: "ジジーロン",
+		'zh-tw': "路卡利歐V",
 	},
 
-	illustrator: "takuyoa",
+	illustrator: "Tomokazu Komiya",
 	category: "Pokemon",
-	hp: 210,
-	types: ["Fighting"],
+	hp: 120,
+	types: ["Dragon"],
+
+	description: {
+		ja: "人懐っこく 心優しいが ひとたび 怒ると 強風を 巻き起こし すべてを なぎ倒す。",
+	},
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "粉碎拳"
+	attacks: [
+		{
+			name: {
+				ja: "どつく",
+				'zh-tw': "粉碎拳",
+			},
+			damage: 30,
+			cost: ["Colorless"],
 		},
-
-		effect: {
-			'zh-tw': "選擇1個對手的戰鬥寶可夢身上附加的特殊能量，將其丟棄。"
+		{
+			name: {
+				ja: "ぎゃくじょう",
+				'zh-tw': "旋風踢",
+			},
+			damage: "70+",
+			cost: ["Water", "Fighting"],
+			effect: {
+				ja: "自分のベンチポケモンにダメカンがのっているなら、90ダメージ追加。",
+			},
 		},
+	],
 
-		damage: 50,
-		cost: ["Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "旋風踢"
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 568806,
+				tcgplayer: 597396,
+			},
 		},
-
-		damage: 120,
-		cost: ["Fighting", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [780],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/213.ts
+++ b/data-asia/S/S-P/213.ts
@@ -1,50 +1,60 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "路卡利歐VSTAR"
+		ja: "ジュラルドンV",
+		'zh-tw': "路卡利歐VSTAR",
 	},
 
-	illustrator: "aky CG Works",
+	illustrator: "PLANETA Mochizuki",
 	category: "Pokemon",
-	hp: 270,
-	types: ["Fighting"],
-	stage: "VMAX",
+	hp: 220,
+	types: ["Dragon"],
 
-	attacks: [{
-		name: {
-			'zh-tw': "搏鬥肘擊"
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: {
+				ja: "メタルクロー",
+				'zh-tw': "搏鬥肘擊",
+			},
+			damage: 70,
+			cost: ["Fighting", "Metal"],
 		},
-
-		effect: {
-			'zh-tw': "若對手的戰鬥寶可夢為「寶可夢【V】」，則增加120點傷害。"
+		{
+			name: {
+				ja: "ワイドブレイカー",
+				'zh-tw': "[VSTAR力量] 波導星星",
+			},
+			damage: 140,
+			cost: ["Fighting", "Metal", "Metal"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-30」される。",
+				'zh-tw': "造成對手的場上寶可夢身上附加的能量的數量×70點傷害。[對戰中，己方只可使用1次【VSTAR】力量。]",
+			},
 		},
+	],
 
-		damage: "120+",
-		cost: ["Fighting", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "[VSTAR力量] 波導星星"
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 568807,
+				tcgplayer: 597397,
+			},
 		},
-
-		effect: {
-			'zh-tw': "造成對手的場上寶可夢身上附加的能量的數量×70點傷害。[對戰中，己方只可使用1次【VSTAR】力量。]"
-		},
-
-		damage: "70×",
-		cost: ["Fighting", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
+	],
 
 	retreat: 2,
-	regulationMark: "F"
-}
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [884],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/214.ts
+++ b/data-asia/S/S-P/214.ts
@@ -1,69 +1,55 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "阿勃梭魯"
+		ja: "いたずら好きのピチュー",
+		'zh-tw': "阿勃梭魯",
 	},
 
-	illustrator: "Shiburingaru",
+	illustrator: "Akira Komayama",
 	category: "Pokemon",
-	hp: 100,
-	types: ["Darkness"],
+	hp: 30,
+	types: ["Lightning"],
 
 	description: {
-		'zh-tw': "如風般地奔馳在山野中。形狀如弓的角能夠敏銳 感應到自然災害的預兆。"
+		ja: "遊ぶときは いつだって 全力だ！ でも お片付けも 忘れずに！",
+		'zh-tw': "如風般地奔馳在山野中。形狀如弓的角能夠敏銳 感應到自然災害的預兆。",
 	},
 
 	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "劈開"
+	attacks: [
+		{
+			name: {
+				ja: "どたばたパーティ",
+				'zh-tw': "劈開",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のポケモン全員に、それぞれ10ダメージ。ウラなら、自分のポケモン全員に、それぞれ10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Darkness"]
-	}, {
-		name: {
-			'zh-tw': "放逐爪"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 660428,
+				tcgplayer: 597398,
+			},
 		},
-
-		effect: {
-			'zh-tw': "在不看正面的情況下，選擇1張對手的手牌，放置於放逐區。"
-		},
-
-		damage: 70,
-		cost: ["Darkness", "Colorless", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "劈開"
-		},
-
-		damage: 30,
-		cost: ["Darkness"]
-	}, {
-		name: {
-			'zh-tw': "放逐爪"
-		},
-
-		effect: {
-			'zh-tw': "在不看正面的情況下，選擇1張對手的手牌，放置於放逐區。"
-		},
-
-		damage: 70,
-		cost: ["Darkness", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Grass",
-		value: "×2"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [172],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/215.ts
+++ b/data-asia/S/S-P/215.ts
@@ -1,72 +1,72 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洗翠 火爆獸V"
+		ja: "リーフィア",
+		'zh-tw': "洗翠 火爆獸V",
 	},
 
-	illustrator: "5ban Graphics",
+	illustrator: "OKACHEKE",
 	category: "Pokemon",
-	hp: 210,
-	types: ["Psychic"],
-	stage: "Basic",
-	suffix: "V",
+	hp: 110,
+	types: ["Grass"],
 
-	attacks: [{
-		name: {
-			'zh-tw': "灼熱"
+	description: {
+		ja: "しっぽは 鋭く 刃のよう。 大木も 真っ二つに する 抜群の 切れ味を 誇る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: {
+				ja: "リーフガード",
+				'zh-tw': "灼熱",
+			},
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+				'zh-tw': "將對手的戰鬥寶可夢【灼傷】。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【灼傷】。"
-		}
-	}, {
-		name: {
-			'zh-tw': "戰慄火焰"
+		{
+			name: {
+				ja: "くさむすび",
+				'zh-tw': "戰慄火焰",
+			},
+			damage: "50+",
+			cost: ["Grass", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンのにげるためのエネルギーの数×30ダメージ追加。",
+				'zh-tw': "在不看正面的情況下，從對手的手牌選擇1張，在看過那張卡正面後放回對手的牌庫並重洗。",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在不看正面的情況下，從對手的手牌選擇1張，在看過那張卡正面後放回對手的牌庫並重洗。"
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 574583,
+				tcgplayer: 597399,
+			},
 		},
+	],
 
-		damage: 120,
-		cost: ["Psychic", "Psychic", "Colorless"]
-	}, {
-		name: {
-			'zh-tw': "灼熱"
-		},
+	evolveFrom: {
+		ja: "イーブイ",
+	},
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【灼傷】。"
-		}
-	}, {
-		name: {
-			'zh-tw': "戰慄火焰"
-		},
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [470],
+};
 
-		effect: {
-			'zh-tw': "在不看正面的情況下，從對手的手牌選擇1張，在看過那張卡正面後放回對手的牌庫並重洗。"
-		},
-
-		damage: 120,
-		cost: ["Psychic", "Psychic", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
-
-	retreat: 2,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/216.ts
+++ b/data-asia/S/S-P/216.ts
@@ -1,51 +1,71 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雷吉艾勒奇V"
+		ja: "グレイシア",
+		'zh-tw': "雷吉艾勒奇V",
 	},
 
-	illustrator: "Eske Yoshinob",
+	illustrator: "OKACHEKE",
 	category: "Pokemon",
-	hp: 200,
-	types: ["Lightning"],
-	stage: "Basic",
-	suffix: "V",
+	hp: 110,
+	types: ["Water"],
 
-	attacks: [{
-		name: {
-			'zh-tw': "切換伏特"
+	description: {
+		ja: "グレイシアが 放つ 冷気は パウダースノーを つくりだし スキー場に ひっぱりだこ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: {
+				ja: "あられ",
+				'zh-tw': "切換伏特",
+			},
+			cost: ["Water"],
+			effect: {
+				ja: "相手のポケモン全員に、それぞれ20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+				'zh-tw': "將這隻寶可夢與備戰寶可夢互換。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將這隻寶可夢與備戰寶可夢互換。"
+		{
+			name: {
+				ja: "フロストタイフーン",
+				'zh-tw': "雷電堡壘",
+			},
+			damage: 120,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「フロストタイフーン」が使えない。",
+				'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-100」點。",
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Lightning"]
-	}, {
-		name: {
-			'zh-tw': "雷電堡壘"
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 574584,
+				tcgplayer: 597400,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，這隻寶可夢受到招式的傷害「-100」點。"
-		},
-
-		damage: 100,
-		cost: ["Lightning", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	evolveFrom: {
+		ja: "イーブイ",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [471],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/217.ts
+++ b/data-asia/S/S-P/217.ts
@@ -1,55 +1,52 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "未知圖騰V"
+		ja: "ヤジロン",
+		'zh-tw': "未知圖騰V",
 	},
 
-	illustrator: "PLANETA Mochizuki",
+	illustrator: "Nagomi Nijo",
 	category: "Pokemon",
-	hp: 180,
-	types: ["Psychic"],
+	hp: 60,
+	types: ["Fighting"],
+
+	description: {
+		ja: "古代 遺跡で 発見された。 回転 しながら 移動。 夜 眠る ときも 一本足だ。",
+	},
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "奇異刻印"
+	attacks: [
+		{
+			name: {
+				ja: "ひらてうち",
+				'zh-tw': "奇異刻印",
+			},
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
 		},
+	],
 
-		effect: {
-			'zh-tw': "將對手的戰鬥寶可夢【混亂】。"
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 574585,
+				tcgplayer: 597401,
+			},
 		},
-
-		damage: 30,
-		cost: ["Psychic"]
-	}, {
-		name: {
-			'zh-tw': "勝利象徵"
-		},
-
-		effect: {
-			'zh-tw': "使用這個招式時，若自己剩餘獎賞卡的張數為1張，則這場對戰己方獲勝。"
-		},
-
-		cost: ["Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [343],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/218.ts
+++ b/data-asia/S/S-P/218.ts
@@ -1,45 +1,52 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雷吉鐸拉戈V"
+		ja: "グレッグル",
+		'zh-tw': "雷吉鐸拉戈V",
 	},
 
-	illustrator: "PLANETA Hiiragi",
+	illustrator: "Yuya Oka",
 	category: "Pokemon",
-	hp: 220,
-	types: ["Dragon"],
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "毒を 薄めると 薬に なる。 薬品会社の マスコットに なって 人気者に なった。",
+	},
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "天之吶喊"
+	attacks: [
+		{
+			name: {
+				ja: "どつく",
+				'zh-tw': "天之吶喊",
+			},
+			damage: 20,
+			cost: ["Darkness"],
 		},
+	],
 
-		effect: {
-			'zh-tw': "將自己的牌庫上方3張卡丟棄，將其中的能量卡全部附於這隻寶可夢身上。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 574586,
+				tcgplayer: 597402,
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "龍之鐳射"
-		},
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [453],
+};
 
-		effect: {
-			'zh-tw': "對手的1隻備戰寶可夢也受到30點傷害。[在備戰區不計算弱點・抵抗力。]"
-		},
-
-		damage: 130,
-		cost: ["Grass", "Grass", "Fire"]
-	}],
-
-	retreat: 3,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/219.ts
+++ b/data-asia/S/S-P/219.ts
@@ -1,55 +1,64 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洛奇亞V"
+		ja: "ウオノラゴンV",
+		'zh-tw': "洛奇亞V",
 	},
 
-	illustrator: "PLANETA Mochizuki",
+	illustrator: "Satoshi Shirai",
 	category: "Pokemon",
 	hp: 220,
-	types: ["Colorless"],
+	types: ["Dragon"],
+
 	stage: "Basic",
-	suffix: "V",
 
-	attacks: [{
-		name: {
-			'zh-tw': "讀風"
+	attacks: [
+		{
+			name: {
+				ja: "ガブガブクラッシュ",
+				'zh-tw': "讀風",
+			},
+			damage: "60+",
+			cost: ["Grass", "Water"],
+			effect: {
+				ja: "ダメージを与える前に、相手のバトルポケモンについている「ポケモンのどうぐ」をトラッシュする。トラッシュした場合、120ダメージ追加。",
+				'zh-tw': "將自己的1張手牌丟棄。然後，從自己的牌庫抽出3張卡。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "將自己的1張手牌丟棄。然後，從自己的牌庫抽出3張卡。"
+		{
+			name: {
+				ja: "ドラゴンストライク",
+				'zh-tw': "氣旋俯衝",
+			},
+			damage: 210,
+			cost: ["Grass", "Water", "Water"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「ドラゴンストライク」が使えない。",
+				'zh-tw': "若希望，將場上的競技場卡丟棄。",
+			},
 		},
+	],
 
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "氣旋俯衝"
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 574587,
+				tcgplayer: 597403,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "若希望，將場上的競技場卡丟棄。"
-		},
+	retreat: 3,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [882],
+};
 
-		damage: 130,
-		cost: ["Colorless", "Colorless", "Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
-
-	retreat: 2,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/220.ts
+++ b/data-asia/S/S-P/220.ts
@@ -1,56 +1,59 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洛奇亞VSTAR"
+		ja: "イーブイ",
+		'zh-tw': "洛奇亞VSTAR",
 	},
 
-	illustrator: "PLANETA Igarashi",
+	illustrator: "OKACHEKE",
 	category: "Pokemon",
-	hp: 280,
+	hp: 60,
 	types: ["Colorless"],
-	stage: "VMAX",
 
-	abilities: [{
-		type: "Ability",
+	description: {
+		ja: "不安定な 遺伝子の おかげで さまざまな 進化の 可能性を 秘めている 特殊な ポケモン。",
+	},
 
-		name: {
-			'zh-tw': "聚合星星"
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: {
+				ja: "じゅんびする",
+				'zh-tw': "風暴俯衝",
+			},
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札から基本エネルギーを1枚選び、このポケモンにつける。",
+				'zh-tw': "若希望，將場上的競技場卡丟棄。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "在自己的回合時可使用。從自己的棄牌區選擇最多2張【無】寶可夢卡（「擁有規則的寶可夢」除外），放置於備戰區。[對戰中，己方只可使用1次【VSTAR】力量。]"
-		}
-	}],
-
-	attacks: [{
-		name: {
-			'zh-tw': "風暴俯衝"
+		{
+			name: { ja: "かみつく" },
+			damage: 30,
+			cost: ["Colorless", "Colorless", "Colorless"],
 		},
+	],
 
-		effect: {
-			'zh-tw': "若希望，將場上的競技場卡丟棄。"
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597404,
+			},
 		},
+	],
 
-		damage: 220,
-		cost: ["Colorless", "Colorless", "Colorless", "Colorless"]
-	}],
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [133],
+};
 
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
-
-	retreat: 2,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/221.ts
+++ b/data-asia/S/S-P/221.ts
@@ -1,44 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "小火馬"
+		ja: "からぶりほけん",
+		'zh-tw': "小火馬",
 	},
 
-	illustrator: "Eri Yamaki",
-	category: "Pokemon",
-	hp: 70,
-	types: ["Fire"],
+	illustrator: "Ayaka Yoshida",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "剛出生的時候不擅長奔跑，但隨著和夥伴們不斷地賽跑， 會逐漸鍛鍊出強健的腳力。"
+	effect: {
+		ja: "このカードをつけているポケモンがワザを使ったとき、ワザのダメージや効果で自分がコインを投げてウラが出たなら、自分の番の終わりに、自分の山札を3枚引く。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "猛撞"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 574589,
+				tcgplayer: 597405,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "這隻寶可夢也受到10點傷害。"
-		},
+	trainerType: "Tool",
+	regulationMark: "E",
+	rarity: "Promo",
+};
 
-		damage: 50,
-		cost: ["Fire", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
-
-	retreat: 1,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/223.ts
+++ b/data-asia/S/S-P/223.ts
@@ -1,49 +1,32 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "雙卵細胞球"
+		ja: "クララ",
+		'zh-tw': "雙卵細胞球",
 	},
 
-	illustrator: "Nelnal",
-	category: "Pokemon",
-	hp: 70,
-	types: ["Psychic"],
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "據說當牠的２個大腦意見一致時，發出的念力 可以覆蓋方圓１公里的範圍。"
+	effect: {
+		ja: "自分のトラッシュからポケモンを2枚までと、基本エネルギーを2枚まで選び、相手に見せて、手札に加える。（ポケモンまたは基本エネルギーのどちらかだけでもよい。）",
 	},
 
-	stage: "Stage1",
-
-	attacks: [{
-		name: {
-			'zh-tw': "細胞尖槍"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597406,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在對手的1隻備戰寶可夢身上放置2個傷害指示物。"
-		},
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Promo",
+};
 
-		damage: 20,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Darkness",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
-
-	retreat: 2,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/224.ts
+++ b/data-asia/S/S-P/224.ts
@@ -1,40 +1,33 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "頑皮熊貓"
+		ja: "博士の研究",
+		'zh-tw': "頑皮熊貓",
 	},
 
-	illustrator: "Misa Tsutsui",
-	category: "Pokemon",
-	hp: 70,
-	types: ["Fighting"],
+	illustrator: "Yusuke Kozaki",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "會模仿自己敬為頭領的流氓熊貓，向牠學習戰鬥 及捕捉獵物的方法。"
+	effect: {
+		ja: "自分の手札をすべてトラッシュし、山札を7枚引く。",
 	},
 
-	stage: "Basic",
-
-	attacks: [{
-		name: {
-			'zh-tw': "劈打"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 569232,
+				tcgplayer: 597407,
+			},
 		},
+	],
 
-		damage: 30,
-		cost: ["Colorless", "Colorless"]
-	}],
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Promo",
+};
 
-	weaknesses: [{
-		type: "Psychic",
-		value: "×2"
-	}],
-
-	retreat: 2,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/225.ts
+++ b/data-asia/S/S-P/225.ts
@@ -1,49 +1,68 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "伽勒爾 喵喵"
+		ja: "アップリュー",
+		'zh-tw': "伽勒爾 喵喵",
 	},
 
-	illustrator: "aoki",
+	illustrator: "nagimiso",
 	category: "Pokemon",
-	hp: 70,
-	types: ["Metal"],
+	hp: 80,
+	types: ["Dragon"],
 
 	description: {
-		'zh-tw': "和好戰的海洋民族一起生活，久而久之身體的各個地方 就都變成了黑鐵。"
+		ja: "りんごの 皮の 翼で 飛んで 強酸性の 唾液を 飛ばす。 りんごの 形に 変形する。",
+		'zh-tw': "和好戰的海洋民族一起生活，久而久之身體的各個地方 就都變成了黑鐵。",
 	},
 
-	stage: "Basic",
+	stage: "Stage1",
 
-	attacks: [{
-		name: {
-			'zh-tw': "出爪"
+	attacks: [
+		{
+			name: {
+				ja: "フライトアップ",
+				'zh-tw': "出爪",
+			},
+			cost: ["Fire"],
+			effect: {
+				ja: "自分のトラッシュから基本エネルギーを3枚まで選び、ベンチポケモン1匹につける。",
+				'zh-tw': "擲1次硬幣若為正面，則增加20點傷害。",
+			},
 		},
-
-		effect: {
-			'zh-tw': "擲1次硬幣若為正面，則增加20點傷害。"
+		{
+			name: { ja: "さんでとかす" },
+			damage: 70,
+			cost: ["Grass", "Fire"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
 		},
+	],
 
-		damage: "10+",
-		cost: ["Metal"]
-	}],
+	weaknesses: [],
+	resistances: [],
 
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 573770,
+				tcgplayer: 597408,
+			},
+		},
+	],
 
-	resistances: [{
-		type: "Grass",
-		value: "-30"
-	}],
+	evolveFrom: {
+		ja: "カジッチュ",
+	},
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [841],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/226.ts
+++ b/data-asia/S/S-P/226.ts
@@ -1,59 +1,57 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "化石翼龍"
+		ja: "ウッウ",
+		'zh-tw': "化石翼龍",
 	},
 
-	illustrator: "Uta",
+	illustrator: "Mitsuhiro Arita",
 	category: "Pokemon",
-	hp: 130,
-	types: ["Colorless"],
+	hp: 90,
+	types: ["Water"],
 
 	description: {
-		'zh-tw': "古代的凶猛寶可夢。據說即使是當今的科學， 也無法將牠完美地復原。"
+		ja: "食いしん坊で エサの サシカマスを 丸飲みするが たまに 間違えて ほかの ポケモンに 食らいつく。",
+		'zh-tw': "古代的凶猛寶可夢。據說即使是當今的科學， 也無法將牠完美地復原。",
 	},
 
-	stage: "Stage1",
+	stage: "Basic",
 
-	attacks: [{
-		name: {
-			'zh-tw': "直擊彈"
+	attacks: [
+		{
+			name: {
+				ja: "さんれんづき",
+				'zh-tw': "直擊彈",
+			},
+			damage: "60×",
+			cost: ["Water", "Water", "Water"],
+			effect: {
+				ja: "コインを3回投げ、オモテの数×60ダメージ。",
+				'zh-tw': "對手的1隻寶可夢受到50點傷害。[在備戰區不計算弱點・抵抗力。]",
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "對手的1隻寶可夢受到50點傷害。[在備戰區不計算弱點・抵抗力。]"
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 573771,
+				tcgplayer: 597409,
+			},
 		},
-
-		cost: ["Colorless"]
-	}, {
-		name: {
-			'zh-tw': "噴射俯衝"
-		},
-
-		effect: {
-			'zh-tw': "選擇1個這隻寶可夢身上附加的能量，將其丟棄。"
-		},
-
-		damage: 120,
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
+	],
 
 	retreat: 1,
-	regulationMark: "F"
-}
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [845],
+};
 
-export default card
+export default card;

--- a/data-asia/S/S-P/227.ts
+++ b/data-asia/S/S-P/227.ts
@@ -1,22 +1,51 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "平和公園"
+		ja: "ピカチュウ",
+		'zh-tw': "平和公園",
 	},
 
-	illustrator: "AYUMI ODASHIMA",
-	category: "Trainer",
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
 
-	effect: {
-		'zh-tw': "雙方的所有寶可夢不會【混亂】，受到的【混亂】全部恢復。"
+	description: {
+		ja: "おたがいの しっぽを くっつけて 電気を 流しあうのが ピカチュウ 同士の 挨拶だ。",
 	},
 
-	trainerType: "Stadium",
-	regulationMark: "F"
-}
+	stage: "Basic",
 
-export default card
+	attacks: [
+		{
+			name: { ja: "いれかわる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 573772,
+				tcgplayer: 597410,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/S/S-P/228.ts
+++ b/data-asia/S/S-P/228.ts
@@ -1,22 +1,34 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "慶祝開場樂"
+		ja: "キバナ",
+		'zh-tw': "慶祝開場樂",
 	},
 
-	illustrator: "Kagemaru Himeno",
+	illustrator: "Hideki Ishikawa",
 	category: "Trainer",
 
 	effect: {
-		'zh-tw': "雙方玩家在每個自己的回合時，可使用1次，可將自己的所有寶可夢各恢復「10」HP。這個情況下，自己的回合結束。"
+		ja: "このカードは、前の相手の番に、自分のポケモンがきぜつしていなければ使えない。自分のトラッシュから基本エネルギーを1枚選び、自分のポケモンにつける。その後、自分の山札から好きなカードを1枚選び、手札に加える。そして山札を切る。",
+		'zh-tw': "雙方玩家在每個自己的回合時，可使用1次，可將自己的所有寶可夢各恢復「10」HP。這個情況下，自己的回合結束。",
 	},
 
-	trainerType: "Stadium",
-	regulationMark: "E"
-}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 573773,
+				tcgplayer: 597411,
+			},
+		},
+	],
 
-export default card
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/229.ts
+++ b/data-asia/S/S-P/229.ts
@@ -1,59 +1,32 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
-		'zh-tw': "洗翠 勇士雄鷹"
+		ja: "サイトウ",
+		'zh-tw': "洗翠 勇士雄鷹",
 	},
 
-	illustrator: "Yuu Nishida",
-	category: "Pokemon",
-	hp: 130,
-	types: ["Colorless"],
+	illustrator: "Atsushi Furusawa",
+	category: "Trainer",
 
-	description: {
-		'zh-tw': "勇猛的大鳥。狩獵時會發出 氣勢駭人的戰吼，朝湖水發出 衝擊波，捕捉浮出水面的獵物。"
+	effect: {
+		ja: "自分の山札を上から5枚トラッシュし、その中にあるエネルギーをすべて、ベンチの[闘]ポケモンに好きなようにつける。",
 	},
 
-	stage: "Stage1",
-
-	attacks: [{
-		name: {
-			'zh-tw': "戰慄怒吼"
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597412,
+			},
 		},
+	],
 
-		effect: {
-			'zh-tw': "在下個對手的回合，受到這個招式的寶可夢無法撤退。"
-		},
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Promo",
+};
 
-		damage: 40
-	}, {
-		name: {
-			'zh-tw': "二重利刃"
-		},
-
-		effect: {
-			'zh-tw': "擲2次硬幣，造成正面出現的次數×70點傷害。"
-		},
-
-		damage: "70×",
-		cost: ["Colorless", "Colorless"]
-	}],
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	resistances: [{
-		type: "Fighting",
-		value: "-30"
-	}],
-
-	retreat: 1,
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/230.ts
+++ b/data-asia/S/S-P/230.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダンデ",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Trainer",
+
+	effect: {
+		ja: "この番、自分のポケモンが使うワザの、相手のバトルポケモンへのダメージは「+30」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597413,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/231.ts
+++ b/data-asia/S/S-P/231.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルリナ",
+	},
+
+	illustrator: "Souichirou Gunjima",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュから[水]ポケモンと[水]エネルギーを合計4枚まで選び、相手に見せて、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597414,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "D",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/232.ts
+++ b/data-asia/S/S-P/232.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポッチャマ",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Water"],
+
+	description: {
+		ja: "プライドが 高く 人から 食べ物を もらう ことを 嫌う。 長い 産毛が 寒さを 防ぐ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "がんばりジャンプ" },
+			damage: "30+",
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 575115,
+				tcgplayer: 597415,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [393],
+};
+
+export default card;

--- a/data-asia/S/S-P/234.ts
+++ b/data-asia/S/S-P/234.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アゴジムシ",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "大きな 顎で 森の 地面を 掘って 巣穴を つくる。 甘い 樹液が 大好物。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たいでん" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュから[雷]エネルギーを1枚選び、このポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "ふいをつく" },
+			damage: 50,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 606603,
+				tcgplayer: 597416,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [736],
+};
+
+export default card;

--- a/data-asia/S/S-P/235.ts
+++ b/data-asia/S/S-P/235.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガラル バリコオルV",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "びっくりハンド" },
+			cost: ["Water"],
+			effect: {
+				ja: "自分の山札からグッズを3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "カスタムステッキ" },
+			damage: "90+",
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンに「ポケモンのどうぐ」がついているなら、90ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 606604,
+				tcgplayer: 597417,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [866],
+};
+
+export default card;

--- a/data-asia/S/S-P/236.ts
+++ b/data-asia/S/S-P/236.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エレズン",
+	},
+
+	illustrator: "Souichirou Gunjima",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "毒素を 化学変化 させて 電気を 出す。 電力は 弱いが ビリビリと 痺れる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なきごえ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンが使うワザのダメージは「-30」される。",
+			},
+		},
+		{
+			name: { ja: "プチボルト" },
+			damage: 10,
+			cost: ["Lightning"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597418,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [848],
+};
+
+export default card;

--- a/data-asia/S/S-P/237.ts
+++ b/data-asia/S/S-P/237.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニンフィア",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Psychic"],
+
+	description: {
+		ja: "恐ろしい ドラゴンポケモンを 美しい ニンフィアが 退治する 童話が ガラル地方に 残る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "おあずけキック" },
+			damage: 30,
+			cost: ["Psychic"],
+			effect: {
+				ja: "のぞむなら、相手のバトルポケモンについているエネルギーを1個選び、相手の手札にもどす。",
+			},
+		},
+		{
+			name: { ja: "シンフォニーウィップ" },
+			damage: "70+",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "この番、手札からサポートを出して使っていたなら、70ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 606606,
+				tcgplayer: 597419,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イーブイ",
+	},
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [700],
+};
+
+export default card;

--- a/data-asia/S/S-P/238.ts
+++ b/data-asia/S/S-P/238.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴローン",
+	},
+
+	illustrator: "AKIRA EGAWA",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "崖を 転がり 移動する。 間違えて 川に 落ちると 最期の あがきで 大爆発。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 30,
+			cost: ["Fighting"],
+		},
+		{
+			name: { ja: "ロックスマッシュ" },
+			damage: 70,
+			cost: ["Fighting", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 606607,
+				tcgplayer: 597420,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イシツブテ",
+	},
+
+	retreat: 4,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [75],
+};
+
+export default card;

--- a/data-asia/S/S-P/239.ts
+++ b/data-asia/S/S-P/239.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イーブイ",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "不安定な 遺伝子の おかげで さまざまな 進化の 可能性を 秘めている 特殊な ポケモン。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "じゅんびする" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札から基本エネルギーを1枚選び、このポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "かみつく" },
+			damage: 30,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597421,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [133],
+};
+
+export default card;

--- a/data-asia/S/S-P/240.ts
+++ b/data-asia/S/S-P/240.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "からくちスパイシーカレー",
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンをやけどにする。自分のバトルポケモンのHPを「40」回復する。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 606609,
+				tcgplayer: 597422,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "E",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/241.ts
+++ b/data-asia/S/S-P/241.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピオニー",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の手札をすべてトラッシュし、自分の山札からトレーナーズを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 606610,
+				tcgplayer: 597423,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/242.ts
+++ b/data-asia/S/S-P/242.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オドリドリ",
+	},
+
+	illustrator: "Ryuta Fuse",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "むらさきのミツを 吸った オドリドリ。 しなやかで 艶やかな 踊りを 参考にする ダンサーも いる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ミックスコール" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からポケモンとサポートを1枚ずつ選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "するどいはね" },
+			damage: 80,
+			cost: ["Psychic", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 576797,
+				tcgplayer: 597424,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [741],
+};
+
+export default card;

--- a/data-asia/S/S-P/243.ts
+++ b/data-asia/S/S-P/243.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビクティニV",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひろがるほのお" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュから[炎]エネルギーを3枚まで選び、自分のポケモンに好きなようにつける。",
+			},
+		},
+		{
+			name: { ja: "エネバースト" },
+			damage: "30×",
+			cost: ["Fire", "Fire"],
+			effect: {
+				ja: "おたがいのバトルポケモンについているエネルギーの数×30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 585973,
+				tcgplayer: 597236,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "D",
+	rarity: "Promo",
+	dexId: [494],
+};
+
+export default card;

--- a/data-asia/S/S-P/244.ts
+++ b/data-asia/S/S-P/244.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ワンパチ",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "おやつに 釣られて 人の 仕事を 手伝う 食いしん坊。 パチパチと 電気を まとって ひた走る。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ボールさがし" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分のトラッシュから「モンスターボール」と「スーパーボール」をそれぞれ1枚まで選び、相手に見せて、手札に加える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "はねまわる" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 585974,
+				tcgplayer: 597425,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [835],
+};
+
+export default card;

--- a/data-asia/S/S-P/245.ts
+++ b/data-asia/S/S-P/245.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "あなぬけのヒモ",
+	},
+
+	illustrator: "sadaji",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、それぞれ、自分のバトルポケモンをベンチポケモンと入れ替える。（入れ替えは相手からおこない、ベンチがいないプレイヤーは、入れ替えをしない。）",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597426,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "E",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/246.ts
+++ b/data-asia/S/S-P/246.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本草エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 649917,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/247.ts
+++ b/data-asia/S/S-P/247.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本炎エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605825,
+				tcgplayer: 649759,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/248.ts
+++ b/data-asia/S/S-P/248.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本水エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 649792,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/249.ts
+++ b/data-asia/S/S-P/249.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本雷エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 649808,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/250.ts
+++ b/data-asia/S/S-P/250.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本超エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605828,
+				tcgplayer: 649803,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/251.ts
+++ b/data-asia/S/S-P/251.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本闘エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 649801,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/252.ts
+++ b/data-asia/S/S-P/252.ts
@@ -1,0 +1,30 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本悪エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 649785,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/253.ts
+++ b/data-asia/S/S-P/253.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "基本鋼エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Normal",
+
+	effect: {
+		ja: "&copy;Pokémon/Nintendo/Creatures/GAME FREAK ポケットモンスター・ポケモン・Pokémonは任天堂・クリーチャーズ・ゲームフリークの商標です。 このホームページに掲載された画像その他の内容の無断転載はお断りします。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605831,
+				tcgplayer: 649776,
+			},
+		},
+	],
+
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/254.ts
+++ b/data-asia/S/S-P/254.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "おいわいファンファーレ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのプレイヤーは、自分の番ごとに1回、自分のポケモン全員のHPを、それぞれ「10」回復してよい。その場合、自分の番は終わる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 573615,
+				tcgplayer: 597427,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "E",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/255.ts
+++ b/data-asia/S/S-P/255.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒバニー",
+	},
+
+	illustrator: "Taira Akitsu",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fire"],
+
+	description: {
+		ja: "戦う 準備が 整うと 鼻の 頭と 足の 裏の 肉球が 高熱を 発する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "メラメラダッシュ" },
+			cost: ["Fire"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数ぶん、自分の山札を引く。",
+			},
+		},
+		{
+			name: { ja: "ほのお" },
+			damage: 30,
+			cost: ["Fire", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 585975,
+				tcgplayer: 597428,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "E",
+	rarity: "Promo",
+	dexId: [813],
+};
+
+export default card;

--- a/data-asia/S/S-P/256.ts
+++ b/data-asia/S/S-P/256.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マオ&スイレン",
+	},
+
+	illustrator: "aoki",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。追加で、このカードを使うときに、自分の手札を2枚トラッシュしてよい。その場合、ベンチに入れ替えたポケモンのHPを「120」回復する。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 608122,
+				tcgplayer: 597429,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "C",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/257.ts
+++ b/data-asia/S/S-P/257.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴウカザルV",
+	},
+
+	illustrator: "Ayaka Yoshida",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "りゅうせいパンチ" },
+			damage: "30×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数×30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ぐれんのほのお" },
+			damage: 200,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605832,
+				tcgplayer: 597430,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [392],
+};
+
+export default card;

--- a/data-asia/S/S-P/258.ts
+++ b/data-asia/S/S-P/258.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヘイガニ",
+	},
+
+	illustrator: "0313",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "どんなに 水が 汚れた 川でも 適応して 増えていく タフな 生命力の 持ち主。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みずでっぽう" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "クラブハンマー" },
+			damage: 50,
+			cost: ["Water", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605833,
+				tcgplayer: 597431,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [341],
+};
+
+export default card;

--- a/data-asia/S/S-P/259.ts
+++ b/data-asia/S/S-P/259.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サマヨール",
+	},
+
+	illustrator: "DOM",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "体の 中は 空っぽ。 口を 開けると ブラックホールの ように なんでも 吸いこんでしまう。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "あんこく" },
+			damage: 30,
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605834,
+				tcgplayer: 597432,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヨマワル",
+	},
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [356],
+};
+
+export default card;

--- a/data-asia/S/S-P/260.ts
+++ b/data-asia/S/S-P/260.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リオル",
+	},
+
+	illustrator: "Taira Akitsu",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fighting"],
+
+	description: {
+		ja: "一晩中 走っていられる スタミナを もつ。 活発で 散歩の 相手は たいへん。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "けたぐり" },
+			damage: 50,
+			cost: ["Fighting", "Fighting"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597433,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [447],
+};
+
+export default card;

--- a/data-asia/S/S-P/261.ts
+++ b/data-asia/S/S-P/261.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マニューラ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Darkness"],
+
+	description: {
+		ja: "群れを 成し 獲物を 襲う。 チームプレーで マンムーなどの 大物も たやすく しとめる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "おいうちクロー" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のベンチポケモン1匹に、そのポケモンにのっているダメカンの数×20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ツメできりさく" },
+			damage: 110,
+			cost: ["Darkness", "Darkness", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605836,
+				tcgplayer: 597434,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニューラ",
+	},
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [461],
+};
+
+export default card;

--- a/data-asia/S/S-P/262.ts
+++ b/data-asia/S/S-P/262.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ムックル",
+	},
+
+	illustrator: "Ligton",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "むしポケモンを ねらって 野山を 大勢の 群れで 飛び回る。 鳴き声が とても やかましい。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かぎづめ" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605837,
+				tcgplayer: 597435,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [396],
+};
+
+export default card;

--- a/data-asia/S/S-P/263.ts
+++ b/data-asia/S/S-P/263.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲン",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を上から5枚オモテにして、相手にその中からカードを2枚選んでもらう。自分は選ばれたカードをトラッシュし、残りのカードは手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597436,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/264.ts
+++ b/data-asia/S/S-P/264.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "キバナ",
+	},
+
+	illustrator: "take",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードは、前の相手の番に、自分のポケモンがきぜつしていなければ使えない。自分のトラッシュから基本エネルギーを1枚選び、自分のポケモンにつける。その後、自分の山札から好きなカードを1枚選び、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605839,
+				tcgplayer: 597437,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "E",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/265.ts
+++ b/data-asia/S/S-P/265.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウVMAX",
+	},
+
+	illustrator: "AKIRA EGAWA",
+	category: "Pokemon",
+	hp: 310,
+	types: ["Lightning"],
+
+	stage: "VMAX",
+
+	attacks: [
+		{
+			name: { ja: "じゅうでんテール" },
+			damage: 30,
+			cost: ["Lightning"],
+			effect: {
+				ja: "自分のトラッシュから[L]エネルギーを3枚まで選び、自分のポケモン1匹につける。",
+			},
+		},
+		{
+			name: { ja: "キョダイカミナリ" },
+			damage: 250,
+			cost: ["Lightning", "Lightning", "Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 605000,
+				tcgplayer: 597438,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ピカチュウV",
+	},
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/S/S-P/266.ts
+++ b/data-asia/S/S-P/266.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レジギガス",
+	},
+
+	illustrator: "GOSSAN",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Colorless"],
+
+	description: {
+		ja: "縄で 縛った 大陸を 引っ張って 動かしたという 伝説が 残されている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かたならし" },
+			damage: 20,
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュから基本エネルギーを1枚選び、このポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "ダブルインパクト" },
+			damage: "120×",
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×120ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 606611,
+				tcgplayer: 597439,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [486],
+};
+
+export default card;

--- a/data-asia/S/S-P/267.ts
+++ b/data-asia/S/S-P/267.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アルセウスV",
+	},
+
+	illustrator: "Atsushi Furusawa",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "トリニティチャージ" },
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札から基本エネルギーを3枚まで選び、自分の「ポケモンV」に好きなようにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "パワーエッジ" },
+			damage: 130,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 574302,
+				tcgplayer: 597440,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [493],
+};
+
+export default card;

--- a/data-asia/S/S-P/268.ts
+++ b/data-asia/S/S-P/268.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リーフィアV",
+	},
+
+	illustrator: "PLANETA Yamashita",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "リーフガード" },
+			damage: 30,
+			cost: ["Grass"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+		{
+			name: { ja: "スラッシュダウン" },
+			damage: 180,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「スラッシュダウン」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 604992,
+				tcgplayer: 597441,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [470],
+};
+
+export default card;

--- a/data-asia/S/S-P/269.ts
+++ b/data-asia/S/S-P/269.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "リーフィアVSTAR",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Grass"],
+
+	stage: "VSTAR",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "アイビースター" },
+			effect: {
+				ja: "自分の番に使える。相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。［対戦中、自分はVSTARパワーを1回しか使えない。］",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "リーフガード" },
+			damage: 180,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 604993,
+				tcgplayer: 597442,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "リーフィアV",
+	},
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [470],
+};
+
+export default card;

--- a/data-asia/S/S-P/270.ts
+++ b/data-asia/S/S-P/270.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グレイシアV",
+	},
+
+	illustrator: "PLANETA Yamashita",
+	category: "Pokemon",
+	hp: 210,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "フロストチャージ" },
+			damage: 30,
+			cost: ["Water"],
+			effect: {
+				ja: "自分の山札から[W]エネルギーを1枚選び、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "フリーズウインド" },
+			damage: 130,
+			cost: ["Water", "Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 604994,
+				tcgplayer: 597443,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [471],
+};
+
+export default card;

--- a/data-asia/S/S-P/271.ts
+++ b/data-asia/S/S-P/271.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グレイシアVSTAR",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Water"],
+
+	stage: "VSTAR",
+
+	attacks: [
+		{
+			name: { ja: "つららショット" },
+			damage: 180,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "クリスタルスター" },
+			damage: 220,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンはワザのダメージや効果を受けない。［対戦中、自分はVSTARパワーを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 604995,
+				tcgplayer: 597444,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "グレイシアV",
+	},
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [471],
+};
+
+export default card;

--- a/data-asia/S/S-P/272.ts
+++ b/data-asia/S/S-P/272.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウ",
+	},
+
+	illustrator: "Ryota Murayama",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "つくる 電気が 強力な ピカチュウほど ほっぺの 袋は 軟らかく よく 伸びるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "おとどけギフト" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、自分の山札からグッズを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ピカボール" },
+			damage: 50,
+			cost: ["Lightning", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 653675,
+				tcgplayer: 597445,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [25],
+};
+
+export default card;

--- a/data-asia/S/S-P/273.ts
+++ b/data-asia/S/S-P/273.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミュウツーV",
+	},
+
+	illustrator: "PLANETA Mochizuki",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちょうねんりき" },
+			damage: 50,
+			cost: ["Psychic", "Colorless"],
+		},
+		{
+			name: { ja: "トランスブレイク" },
+			damage: 160,
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、ベンチポケモンにつけ替える。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 653676,
+				tcgplayer: 597446,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [150],
+};
+
+export default card;

--- a/data-asia/S/S-P/274.ts
+++ b/data-asia/S/S-P/274.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モクロー",
+	},
+
+	illustrator: "sowsow",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "狭くて 暗い場所が 落ち着く。 トレーナーの ふところや バッグを 巣の 代わりに することも あるぞ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とびつく" },
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、10ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 606612,
+				tcgplayer: 597447,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [722],
+};
+
+export default card;

--- a/data-asia/S/S-P/275.ts
+++ b/data-asia/S/S-P/275.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒノアラシ",
+	},
+
+	illustrator: "Teeziro",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fire"],
+
+	description: {
+		ja: "臆病な 性格。 驚くと 背中の 炎が 一段と 強く 燃え上がる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "エネチャージ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から基本エネルギーを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ひだね" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 606613,
+				tcgplayer: 597448,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [155],
+};
+
+export default card;

--- a/data-asia/S/S-P/276.ts
+++ b/data-asia/S/S-P/276.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミジュマル",
+	},
+
+	illustrator: "kurumitsu",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "お腹の ホタチで 戦う。 攻撃を 受け止めてから すかさず 切りつけて 反撃するのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たたく" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 606614,
+				tcgplayer: 597449,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [501],
+};
+
+export default card;

--- a/data-asia/S/S-P/278.ts
+++ b/data-asia/S/S-P/278.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コロボーシ",
+	},
+
+	illustrator: "Shigenori Negishi",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "触角 同士が ぶつかると コロン コロンと 木琴に 似た 音色を 奏でる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ころばす" },
+			damage: "10+",
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 650950,
+				tcgplayer: 597451,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Promo",
+	dexId: [401],
+};
+
+export default card;

--- a/data-asia/S/S-P/279.ts
+++ b/data-asia/S/S-P/279.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒスイ バスラオ",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Water"],
+
+	description: {
+		ja: "温厚な 気質など 相違点 あれども バスラオの 特徴を 多く 有すゆえ そのリージョンフォームと 定義す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっそりもぐる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このワザは、後攻プレイヤーの最初の番にだけ使える。次の相手の番、このポケモンはワザのダメージを受けない。",
+			},
+		},
+		{
+			name: { ja: "かみつく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 650951,
+				tcgplayer: 597452,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Promo",
+	dexId: [550],
+};
+
+export default card;

--- a/data-asia/S/S-P/280.ts
+++ b/data-asia/S/S-P/280.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トゲチック",
+	},
+
+	illustrator: "Narumi Sato",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Psychic"],
+
+	description: {
+		ja: "心優しい 人の 前に 幸せを もたらすため 姿を 現すと 言われている。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しあわせボイス" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。自分のバトルポケモンのHPを「30」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ようせいのかぜ" },
+			damage: 30,
+			cost: ["Psychic", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 650952,
+				tcgplayer: 597453,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "トゲピー",
+	},
+
+	retreat: 1,
+	rarity: "Promo",
+	dexId: [176],
+};
+
+export default card;

--- a/data-asia/S/S-P/281.ts
+++ b/data-asia/S/S-P/281.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ズガイドス",
+	},
+
+	illustrator: "GIDORA",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fighting"],
+
+	description: {
+		ja: "硬い 頭蓋骨が 特徴。 頭突きで 樹木を へし折って 実った きのみを 食っていた。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 20,
+			cost: ["Fighting"],
+		},
+		{
+			name: { ja: "ストーンエッジ" },
+			damage: "40+",
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "コインを1回投げオモテなら、40ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 650953,
+				tcgplayer: 597454,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Promo",
+	dexId: [408],
+};
+
+export default card;

--- a/data-asia/S/S-P/282.ts
+++ b/data-asia/S/S-P/282.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガチグマV",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ハードコート" },
+			effect: {
+				ja: "このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ピートショルダー 220-" },
+			cost: ["Fighting", "Fighting", "Fighting"],
+			effect: {
+				ja: "このポケモンにのっているダメカンの数×10ダメージぶん、このワザのダメージは小さくなる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 650954,
+				tcgplayer: 597455,
+			},
+		},
+	],
+
+	retreat: 4,
+	rarity: "Promo",
+	dexId: [901],
+};
+
+export default card;

--- a/data-asia/S/S-P/283.ts
+++ b/data-asia/S/S-P/283.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コマタナ",
+	},
+
+	illustrator: "Yuya Oka",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Metal"],
+
+	description: {
+		ja: "鋭い 刃を 操り 敵を 追い詰める。 河原の 石で 体の 刃を 手入れする。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とつげき" },
+			damage: 30,
+			cost: ["Metal"],
+			effect: {
+				ja: "このポケモンにも10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 650955,
+				tcgplayer: 597456,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Promo",
+	dexId: [624],
+};
+
+export default card;

--- a/data-asia/S/S-P/284.ts
+++ b/data-asia/S/S-P/284.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラベン博士",
+	},
+
+	illustrator: "Ken Sugimori",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュから、名前に「ヒスイ」とつくポケモンを3枚まで選び、相手に見せて、手札に加える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 650956,
+				tcgplayer: 597457,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/285.ts
+++ b/data-asia/S/S-P/285.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハマナのバックアップ",
+	},
+
+	illustrator: "Nagomi Nijo",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュから「ポケモン」と「ポケモンのどうぐ」と「スタジアム」と「エネルギー」を、それぞれ1枚まで選び、相手に見せて、山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 654761,
+				tcgplayer: 597458,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/286.ts
+++ b/data-asia/S/S-P/286.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マナフィ",
+	},
+
+	illustrator: "NC Empire",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "どんな ポケモンとでも 心を 通い合わせる ことが できる 不思議な 能力を 持っている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひきこむかいりゅう" },
+			cost: ["Water"],
+			effect: {
+				ja: "相手の手札を見て、その中からたねポケモンを2枚まで選び、相手のベンチに出す。",
+			},
+		},
+		{
+			name: { ja: "アクアバレット" },
+			damage: 40,
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、20ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 650565,
+				tcgplayer: 597459,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [490],
+};
+
+export default card;

--- a/data-asia/S/S-P/287.ts
+++ b/data-asia/S/S-P/287.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フシギダネ",
+	},
+
+	illustrator: "Shibuzoh.",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "生まれたときから 背中に 植物の タネが あって 少しずつ 大きく 育つ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つるのムチ" },
+			damage: 10,
+			cost: ["Grass"],
+		},
+		{
+			name: { ja: "はっぱカッター" },
+			damage: 20,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 664342,
+				tcgplayer: 597460,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [1],
+};
+
+export default card;

--- a/data-asia/S/S-P/288.ts
+++ b/data-asia/S/S-P/288.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アローラナッシーV",
+	},
+
+	illustrator: "MUGENUP",
+	category: "Pokemon",
+	hp: 240,
+	types: ["Grass"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "のびのびそだつ" },
+			cost: ["Grass"],
+			effect: {
+				ja: "コインを1回投げオモテなら、自分の山札から[G]エネルギーを5枚まで選び、自分のポケモンに好きなようにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ブンブンヘッド" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、このポケモンについている[G]エネルギーの数×30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 664343,
+				tcgplayer: 597461,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [103],
+};
+
+export default card;

--- a/data-asia/S/S-P/289.ts
+++ b/data-asia/S/S-P/289.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒトカゲ",
+	},
+
+	illustrator: "Saya Tsuruta",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fire"],
+
+	description: {
+		ja: "熱いものを 好む 性格。 雨に濡れると しっぽの 先から 煙が 出るという。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "もえるしっぽ" },
+			damage: 10,
+			cost: ["Fire"],
+			effect: {
+				ja: "自分の山札から[R]エネルギーを1枚選び、このポケモンにつける。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 664344,
+				tcgplayer: 597462,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [4],
+};
+
+export default card;

--- a/data-asia/S/S-P/290.ts
+++ b/data-asia/S/S-P/290.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼニガメ",
+	},
+
+	illustrator: "kurumitsu",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "長い 首を 甲羅のなかに 引っこめるとき 勢いよく 水鉄砲を 発射する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みずでっぽう" },
+			damage: 20,
+			cost: ["Water"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 664345,
+				tcgplayer: 597463,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [7],
+};
+
+export default card;

--- a/data-asia/S/S-P/291.ts
+++ b/data-asia/S/S-P/291.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メルメタルV",
+	},
+
+	illustrator: "sadaji",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アームチャージ" },
+			damage: 50,
+			cost: ["Metal", "Metal"],
+			effect: {
+				ja: "のぞむなら、自分の手札から[M]エネルギーを1枚選び、このポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "メガトンパンチ" },
+			damage: 140,
+			cost: ["Metal", "Metal", "Metal"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 664346,
+				tcgplayer: 597464,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [809],
+};
+
+export default card;

--- a/data-asia/S/S-P/292.ts
+++ b/data-asia/S/S-P/292.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カイリューV",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はかいこうせん" },
+			damage: 60,
+			cost: ["Water", "Lightning"],
+			effect: {
+				ja: "相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "バスターテール" },
+			damage: 160,
+			cost: ["Water", "Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 664347,
+				tcgplayer: 597465,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [149],
+};
+
+export default card;

--- a/data-asia/S/S-P/293.ts
+++ b/data-asia/S/S-P/293.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カイリューVSTAR",
+	},
+
+	illustrator: "PLANETA Mochizuki",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Dragon"],
+
+	stage: "VSTAR",
+
+	attacks: [
+		{
+			name: { ja: "ギガインパクト" },
+			damage: 250,
+			cost: ["Water", "Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+		{
+			name: { ja: "ドラゴニックスター" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を上から12枚見て、その中から[W]または[L]エネルギーを好きなだけ選び、自分のポケモンに好きなようにつける。残りのカードは山札にもどして切る。［対戦中、自分はVSTARパワーを1回しか使えない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 664348,
+				tcgplayer: 597466,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カイリューV",
+	},
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [149],
+};
+
+export default card;

--- a/data-asia/S/S-P/294.ts
+++ b/data-asia/S/S-P/294.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒマナッツ",
+	},
+
+	illustrator: "ryoma uratsuka",
+	category: "Pokemon",
+	hp: 40,
+	types: ["Grass"],
+
+	description: {
+		ja: "葉っぱの 裏側に たまった 朝露だけを 飲んで 暮らす。 他には なにも 食べないという。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "タネばくだん" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 666783,
+				tcgplayer: 597467,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [191],
+};
+
+export default card;

--- a/data-asia/S/S-P/295.ts
+++ b/data-asia/S/S-P/295.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パウワウ",
+	},
+
+	illustrator: "Kagemaru Himeno",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "分厚い 脂肪の おかげで 寒い 海も へっちゃらだけど 暖かい 海では ちょっと バテやすいのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ずつき" },
+			damage: 10,
+			cost: ["Water"],
+		},
+		{
+			name: { ja: "みずかけ" },
+			damage: 20,
+			cost: ["Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597468,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [86],
+};
+
+export default card;

--- a/data-asia/S/S-P/296.ts
+++ b/data-asia/S/S-P/296.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カイオーガV",
+	},
+
+	illustrator: "PLANETA Tsuji",
+	category: "Pokemon",
+	hp: 230,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "デュアルスプラッシュ" },
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン2匹に、それぞれ50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "アクアタイフーン" },
+			damage: 210,
+			cost: ["Water", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「アクアタイフーン」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 666785,
+				tcgplayer: 597469,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [382],
+};
+
+export default card;

--- a/data-asia/S/S-P/297.ts
+++ b/data-asia/S/S-P/297.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シビビール",
+	},
+
+	illustrator: "NC Empire",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Lightning"],
+
+	description: {
+		ja: "食欲 旺盛な ポケモン。 獲物を 見つけると 襲いかかり 電気で しびれさせてから 食べる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "でたとこショック" },
+			effect: {
+				ja: "自分の番に、このカードを手札から出して進化させたとき、1回使える。コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "バチバチ" },
+			damage: 30,
+			cost: ["Lightning"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 666786,
+				tcgplayer: 597470,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "シビシラス",
+	},
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [603],
+};
+
+export default card;

--- a/data-asia/S/S-P/298.ts
+++ b/data-asia/S/S-P/298.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラブトロス",
+	},
+
+	illustrator: "Jiro Sasumo",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "海を越えて 飛来したらば 厳しき冬の 終わりを知る。 慈愛が ヒスイの地に 新しき命 芽吹かせるとの 伝承あり。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ドレインキッス" },
+			damage: 20,
+			cost: ["Psychic"],
+			effect: {
+				ja: "このポケモンのHPを「20」回復する。",
+			},
+		},
+		{
+			name: { ja: "ラブシンパシー" },
+			damage: "70+",
+			cost: ["Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の手札と相手の手札が同じ枚数なら、70ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 666787,
+				tcgplayer: 597471,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [905],
+};
+
+export default card;

--- a/data-asia/S/S-P/299.ts
+++ b/data-asia/S/S-P/299.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メタング",
+	},
+
+	illustrator: "Nisota Niso",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Metal"],
+
+	description: {
+		ja: "２匹の ダンバルが 磁力で くっついた。 ２つの 脳みそにより サイコパワーは ２倍に 強化。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "バレットパンチ" },
+			damage: "30+",
+			cost: ["Metal", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×30ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 666788,
+				tcgplayer: 597472,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ダンバル",
+	},
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [375],
+};
+
+export default card;

--- a/data-asia/S/S-P/300.ts
+++ b/data-asia/S/S-P/300.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "穴掘り兄弟",
+	},
+
+	illustrator: "Yuu Nishida",
+	category: "Trainer",
+
+	effect: {
+		ja: "コインを1回投げる。オモテなら8枚、ウラなら3枚、自分の山札を下から見て、その中からカードを1枚選び、手札に加える。残りのカードは山札にもどして切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 666789,
+				tcgplayer: 597473,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/301.ts
+++ b/data-asia/S/S-P/301.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シマボシ",
+	},
+
+	illustrator: "nagimiso",
+	category: "Trainer",
+
+	effect: {
+		ja: "コインを2回投げ、オモテの数ぶんまで、自分のトラッシュから好きなカードを選び、相手に見せて、好きな順番に入れ替えて、山札の上にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 666790,
+				tcgplayer: 597474,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/302.ts
+++ b/data-asia/S/S-P/302.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アブソル",
+	},
+
+	illustrator: "Shiburingaru",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Darkness"],
+
+	description: {
+		ja: "風のように 野山を 駆けぬける。 弓なりの ツノは 自然災害の 予兆を 敏感に 感じとる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きりさく" },
+			damage: 30,
+			cost: ["Darkness"],
+		},
+		{
+			name: { ja: "ロストクロー" },
+			damage: 70,
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、ロストゾーンに置く。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 597475,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [359],
+};
+
+export default card;

--- a/data-asia/S/S-P/310.ts
+++ b/data-asia/S/S-P/310.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポニータ",
+	},
+
+	illustrator: "Eri Yamaki",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fire"],
+
+	description: {
+		ja: "生まれたばかりは 走るのが へた。 仲間と かけっこを するうちに 足腰が 強く 育っていく。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とっしん" },
+			damage: 50,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンにも10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 678807,
+				tcgplayer: 597483,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [77],
+};
+
+export default card;

--- a/data-asia/S/S-P/311.ts
+++ b/data-asia/S/S-P/311.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヌオーV",
+	},
+
+	illustrator: "PLANETA Igarashi",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "てんねん" },
+			effect: {
+				ja: "このポケモンは、相手のポケモンが使うワザの効果を受けない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "どろんこヘッド" },
+			damage: "100+",
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "このポケモンに[F]エネルギーがついているなら、120ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 678809,
+				tcgplayer: 597484,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [195],
+};
+
+export default card;

--- a/data-asia/S/S-P/312.ts
+++ b/data-asia/S/S-P/312.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダブラン",
+	},
+
+	illustrator: "Nelnal",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Psychic"],
+
+	description: {
+		ja: "２つの 脳みその 意見が 一致したときの 念力は 周囲１キロに およぶと いう。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "セルスピア" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹に、ダメカンを2個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 678813,
+				tcgplayer: 597485,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ユニラン",
+	},
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [578],
+};
+
+export default card;

--- a/data-asia/S/S-P/313.ts
+++ b/data-asia/S/S-P/313.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤンチャム",
+	},
+
+	illustrator: "Misa Tsutsui",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Fighting"],
+
+	description: {
+		ja: "親分と 慕う ゴロンダの 真似を する ことで 戦い方や 獲物の 捕まえ方を 学ぶ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "チョップ" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 678816,
+				tcgplayer: 597486,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [674],
+};
+
+export default card;

--- a/data-asia/S/S-P/314.ts
+++ b/data-asia/S/S-P/314.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガラル ニャース",
+	},
+
+	illustrator: "aoki",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Metal"],
+
+	description: {
+		ja: "戦闘的な 海洋民族と 暮らすうちに 鍛えられ 体の あちこちが 黒鉄に 変化した。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ツメをだす" },
+			damage: "10+",
+			cost: ["Metal"],
+			effect: {
+				ja: "コインを1回投げオモテなら、20ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Grass", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 678822,
+				tcgplayer: 597487,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [52],
+};
+
+export default card;

--- a/data-asia/S/S-P/315.ts
+++ b/data-asia/S/S-P/315.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プテラ",
+	},
+
+	illustrator: "Uta",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "古代の 獰猛な ポケモン。 完璧な 復元は いまの 科学でも 不可能らしい。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ちょくげきだん" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "ジェットダイブ" },
+			damage: 120,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 678823,
+				tcgplayer: 597488,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [142],
+};
+
+export default card;

--- a/data-asia/S/S-P/316.ts
+++ b/data-asia/S/S-P/316.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "やすらぎの公園",
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのポケモン全員は、こんらんにならず、受けているこんらんは、すべて回復する。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 678824,
+				tcgplayer: 597489,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "F",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/317.ts
+++ b/data-asia/S/S-P/317.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ネジキ",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のトラッシュからたねポケモンを1枚選び、自分の場のたねポケモン1匹と入れ替える（ついているカード・ダメカン・特殊状態・効果などは、すべて引きつぐ）。入れ替えたポケモンはトラッシュする。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 678825,
+				tcgplayer: 597490,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "F",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/318.ts
+++ b/data-asia/S/S-P/318.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒスイ ウォーグル",
+	},
+
+	illustrator: "Yuu Nishida",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	description: {
+		ja: "鬼気迫る 鬨の声を 上げ 狩りをする 猛き 大鳥。 湖水に 衝撃波を 放ち 水面に 浮かびし 獲物を 捕る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "せんりつのおたけび" },
+			damage: 40,
+			cost: [],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+		{
+			name: { ja: "デュアルカッター" },
+			damage: "70×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×70ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 681215,
+				tcgplayer: 597491,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ワシボン",
+	},
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [628],
+};
+
+export default card;

--- a/data-asia/S/S-P/319.ts
+++ b/data-asia/S/S-P/319.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レジエレキV",
+	},
+
+	illustrator: "Eske Yoshinob",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "スイッチボルト" },
+			damage: 30,
+			cost: ["Lightning"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "ライトニングウォール" },
+			damage: 100,
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-100」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 681789,
+				tcgplayer: 597492,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [894],
+};
+
+export default card;

--- a/data-asia/S/S-P/320.ts
+++ b/data-asia/S/S-P/320.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アンノーンV",
+	},
+
+	illustrator: "PLANETA Mochizuki",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "あやしいこくいん" },
+			damage: 30,
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+		{
+			name: { ja: "ビクトリーシンボル" },
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザを使ったとき、自分のサイドの残り枚数が1枚なら、この対戦は自分の勝ちになる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 681790,
+				tcgplayer: 597493,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [201],
+};
+
+export default card;

--- a/data-asia/S/S-P/321.ts
+++ b/data-asia/S/S-P/321.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レジドラゴV",
+	},
+
+	illustrator: "PLANETA Hiiragi",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "てんのさけび" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札を上から3枚トラッシュし、その中にあるエネルギーをすべて、このポケモンにつける。",
+			},
+		},
+		{
+			name: { ja: "ドラゴンレーザー" },
+			damage: 130,
+			cost: ["Grass", "Grass", "Fire"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 681791,
+				tcgplayer: 597494,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [895],
+};
+
+export default card;

--- a/data-asia/S/S-P/322.ts
+++ b/data-asia/S/S-P/322.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルギアV",
+	},
+
+	illustrator: "PLANETA Mochizuki",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かぜよみ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札を1枚トラッシュする。その後、自分の山札を3枚引く。",
+			},
+		},
+		{
+			name: { ja: "エアロダイブ" },
+			damage: 130,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、場に出ているスタジアムをトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 681792,
+				tcgplayer: 597495,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [249],
+};
+
+export default card;

--- a/data-asia/S/S-P/324.ts
+++ b/data-asia/S/S-P/324.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルギアV",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 220,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かぜよみ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の手札を1枚トラッシュする。その後、自分の山札を3枚引く。",
+			},
+		},
+		{
+			name: { ja: "エアロダイブ" },
+			damage: 130,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、場に出ているスタジアムをトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 675887,
+				tcgplayer: 597497,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [249],
+};
+
+export default card;

--- a/data-asia/S/S-P/325.ts
+++ b/data-asia/S/S-P/325.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルギアVSTAR",
+	},
+
+	illustrator: "PLANETA Igarashi",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Colorless"],
+
+	stage: "VSTAR",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "アッセンブルスター" },
+			effect: {
+				ja: "自分の番に使える。自分のトラッシュから[C]ポケモン（「ルールを持つポケモン」をのぞく）を2枚まで選び、ベンチに出す。［対戦中、自分はVSTARパワーを1回しか使えない。］",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ストームダイブ" },
+			damage: 220,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、場に出ているスタジアムをトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 675886,
+				tcgplayer: 597498,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ルギアV",
+	},
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [249],
+};
+
+export default card;

--- a/data-asia/S/S-P/326.ts
+++ b/data-asia/S/S-P/326.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "シェイミ",
+	},
+
+	illustrator: "Yukiko Baba",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Colorless"],
+
+	description: {
+		ja: "グラシデアの花が 咲く 季節 感謝の 心を 届けるために 飛び立つと 言われている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はなひろい" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のトラッシュからエネルギーを2枚まで選び、相手に見せて、山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "うしろげり" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 675888,
+				tcgplayer: 597499,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [492],
+};
+
+export default card;

--- a/data-asia/S/S-P/327.ts
+++ b/data-asia/S/S-P/327.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アーケオス",
+	},
+
+	illustrator: "Nisota Niso",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Colorless"],
+
+	description: {
+		ja: "飛び立つために 助走する。 その 距離は およそ ４キロ。 走る速さは 時速４０キロ。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "プライマルターボ" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札から特殊エネルギーを2枚まで選び、自分のポケモン1匹につける。そして山札を切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スピードウイング" },
+			damage: 120,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 675889,
+				tcgplayer: 597500,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アーケン",
+	},
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [567],
+};
+
+export default card;

--- a/data-asia/S/S-P/328.ts
+++ b/data-asia/S/S-P/328.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ダブルターボエネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、ポケモンについているかぎり、[C]エネルギー2個ぶんとしてはたらく。このカードをつけているポケモンが使うワザの、相手のポケモンへのダメージは「-20」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 675890,
+				tcgplayer: 597501,
+			},
+		},
+	],
+
+	regulationMark: "F",
+	rarity: "Promo",
+};
+
+export default card;

--- a/data-asia/S/S-P/337.ts
+++ b/data-asia/S/S-P/337.ts
@@ -1,56 +1,51 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "フシギダネ",
 	},
 
 	illustrator: "Julie Hang",
-	rarity: "Promo",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Grass"],
-	stage: "Basic",
-	dexId: [1],
-
-	attacks: [{
-		cost: ["Grass"],
-
-		name: {
-			ja: "ゆすってあつめる",
-		},
-
-		effect: {
-			en: "ウラが出るまでコインを投げ、オモテの数ぶん、自分の山札を引く。",
-		},
-
-	}],
-
-	weaknesses: [{
-		type: "Fire",
-		value: "×2"
-	}],
-
-	retreat: 2,
 
 	description: {
-		ja: "生まれたときから背中に植物のタネがあって少しずつ大きく育つ。.",
+		ja: "生まれたときから 背中に 植物の タネが あって 少しずつ 大きく 育つ。",
 	},
 
-	variants: [
+	stage: "Basic",
+
+	attacks: [
 		{
-			type: "normal",
-			stamp: ["illustration-contest-2022"],
-			thirdParty: {
-				tcgplayer: 485843
+			name: { ja: "ゆすってあつめる" },
+			cost: ["Grass"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数ぶん、自分の山札を引く。",
+				en: "ウラが出るまでコインを投げ、オモテの数ぶん、自分の山札を引く。",
 			},
 		},
 	],
 
-	regulationMark: "F"
-}
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
 
-export default card
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 681793,
+				tcgplayer: 597502,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [1],
+};
+
+export default card;

--- a/data-asia/S/S-P/338.ts
+++ b/data-asia/S/S-P/338.ts
@@ -1,61 +1,55 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ウインディ",
 	},
 
 	illustrator: "REND",
-	rarity: "Promo",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Fire"],
+
+	description: {
+		ja: "一昼夜で １００００キロの 距離を 駆けぬける 姿は 多くの 人を 魅了してきた。",
+	},
+
 	stage: "Stage1",
-	dexId: [59],
 
-	attacks: [{
-		cost: ["Fire", "Fire", "Colorless"],
-
-		name: {
-			ja: "ひだまりタックル",
+	attacks: [
+		{
+			name: { ja: "ひだまりタックル" },
+			damage: 160,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
 		},
+	],
 
-		effect: {
-			ja: "次の自分の番、このポケモンはワザが使えない。",
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 681794,
+				tcgplayer: 597503,
+			},
 		},
-
-		damage: 160
-	}],
+	],
 
 	evolveFrom: {
 		ja: "ガーディ",
 	},
 
-	weaknesses: [{
-		type: "Water",
-		value: "×2"
-	}],
-
 	retreat: 3,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [59],
+};
 
-	description: {
-		ja: "一昼夜で10000キロもの距離を走りひろる。炎を吹くと岩も粉々になる。",
-	},
-
-	variants: [
-		{
-			type: "normal",
-			stamp: ["illustration-contest-2022"],
-			thirdParty: {
-				tcgplayer: 597503
-			},
-		},
-	],
-
-	regulationMark: "F"
-}
-
-export default card
+export default card;

--- a/data-asia/S/S-P/339.ts
+++ b/data-asia/S/S-P/339.ts
@@ -1,61 +1,55 @@
-import { Card } from "../../../interfaces"
-import Set from "../S-P"
+import { Card } from "../../../interfaces";
+import Set from "../S-P";
 
 const card: Card = {
 	set: Set,
-
 	name: {
 		ja: "ゲッコウガ",
 	},
 
 	illustrator: "Taiga Kasai",
-	rarity: "Promo",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Water"],
-	stage: "Stage2",
-	dexId: [658],
-
-	attacks: [{
-		cost: ["Water", "Colorless", "Colorless"],
-
-		name: {
-			ja: "れんけいしゅりけん",
-		},
-
-		effect: {
-			ja: "相手のベンチポケモン3匹にも、それぞれ10ダメージ。「ベンチは弱点・抵抗力を計算しない。」",
-		},
-
-		damage: 120
-	}],
-
-	evolveFrom: {
-		ja: "ゲコガシ",
-	},
-
-	weaknesses: [{
-		type: "Lightning",
-		value: "×2"
-	}],
-
-	retreat: 1,
 
 	description: {
-		ja: "水を圧縮して手裏剣を作り出す。高速回転させて飛ばすと金属も真っ二つ。"
+		ja: "水を 圧縮して 手裏剣を 作り出す。 高速回転させて 飛ばすと 金属も 真っ二つ。",
 	},
 
-	variants: [
+	stage: "Stage2",
+
+	attacks: [
 		{
-			type: "normal",
-			stamp: ["illustration-contest-2022"],
-			thirdParty: {
-				tcgplayer: 597504
+			name: { ja: "れんけいしゅりけん" },
+			damage: 120,
+			cost: ["Water", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン3匹にも、それぞれ10ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
 			},
 		},
 	],
 
-	regulationMark: "F"
-}
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
 
-export default card
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 681795,
+				tcgplayer: 597504,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゲコガシラ",
+	},
+
+	retreat: 1,
+	regulationMark: "F",
+	rarity: "Promo",
+	dexId: [658],
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **S-P ソード&シールド プロモカード (Sword & Shield Promotional Cards)**, released 2020-05-25:

- `data-asia/S/S-P/001.ts` … `350.ts` — the 296 promos published so far (numbering has gaps)
- the set definition `data-asia/S/S-P.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (462904–738964)
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (597228–649941), keyed by the collection number each product carries in `extendedData`

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- `tsc --noEmit` reports the same 17 pre-existing errors as upstream/master — this change adds none. They are `rarity` being required by `interfaces.d.ts` while these older hand-written files omit it, which is out of scope here.
