### PR TITLE
(data) Add Japanese XY set CP2 Legendary Holo Collection

### DIFF
--- a/data-asia/XY/CP2/001.ts
+++ b/data-asia/XY/CP2/001.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハリマロン",
+	},
+
+	illustrator: "Atsuko Nishida",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Grass"],
+
+	description: {
+		ja: "頭と 背中を 硬い 樹木の 殻で 覆われているため トラックが ぶつかってきても 平気なのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つるのムチ" },
+			damage: 30,
+			cost: ["Grass", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563482,
+				tcgplayer: 605332,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [650],
+};
+
+export default card;

--- a/data-asia/XY/CP2/002.ts
+++ b/data-asia/XY/CP2/002.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レシラム",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きりさく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "かえんれんだん" },
+			damage: "90+",
+			cost: ["Fire", "Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数x20ダメージを追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 563483,
+				tcgplayer: 605350,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [643],
+};
+
+export default card;

--- a/data-asia/XY/CP2/003.ts
+++ b/data-asia/XY/CP2/003.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フォッコ",
+	},
+
+	illustrator: "Kanako Eo",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Fire"],
+
+	description: {
+		ja: "小枝を 持ち歩き おやつがわりに ポリポリ 食べる。 耳から 熱気を 噴き出して 相手を 威嚇する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひをふく" },
+			damage: "10+",
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、30ダメージを追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563484,
+				tcgplayer: 605335,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [653],
+};
+
+export default card;

--- a/data-asia/XY/CP2/004.ts
+++ b/data-asia/XY/CP2/004.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "テールナー",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "木の枝を 尻尾から 引き抜くとき 摩擦で 着火。 枝の 炎を 振って 仲間に 合図を 送る。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "かえんほうしゃ" },
+			damage: 70,
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563485,
+				tcgplayer: 605330,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "フォッコ",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [654],
+};
+
+export default card;

--- a/data-asia/XY/CP2/005.ts
+++ b/data-asia/XY/CP2/005.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "パルキア",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "スプラッシュ" },
+			damage: 30,
+			cost: ["Water", "Colorless"],
+		},
+		{
+			name: { ja: "クロススライサー" },
+			damage: 80,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、手札からエネルギーを出してつけられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 563486,
+				tcgplayer: 605346,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [484],
+};
+
+export default card;

--- a/data-asia/XY/CP2/006.ts
+++ b/data-asia/XY/CP2/006.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ケロマツ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Water"],
+
+	description: {
+		ja: "繊細な 泡で 体を 包み 肌を 守る。 のんきに 見せかけて 抜け目なく 周囲を うかがう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はたく" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563487,
+				tcgplayer: 605336,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [656],
+};
+
+export default card;

--- a/data-asia/XY/CP2/007.ts
+++ b/data-asia/XY/CP2/007.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゲコガシラ",
+	},
+
+	illustrator: "Masakazu Fukuda",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Water"],
+
+	description: {
+		ja: "身軽さは だれにも 負けない。 ６００メートルを 超える タワーの 天辺まで １分で 登りきる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "いあいぎり" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563488,
+				tcgplayer: 605337,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ケロマツ",
+	},
+
+	retreat: 1,
+	rarity: "Uncommon",
+	dexId: [657],
+};
+
+export default card;

--- a/data-asia/XY/CP2/008.ts
+++ b/data-asia/XY/CP2/008.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ピカチュウEX",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "アイアンテール" },
+			damage: "30×",
+			cost: ["Colorless"],
+			effect: {
+				ja: "ウラが出るまでコインを投げ、オモテの数x30ダメージ。",
+			},
+		},
+		{
+			name: { ja: "オーバースパーク" },
+			damage: "50×",
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている[雷]エネルギーをすべてトラッシュし、トラッシュした枚数x50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 563489,
+				tcgplayer: 605348,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Double rare",
+	dexId: [25],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/XY/CP2/009.ts
+++ b/data-asia/XY/CP2/009.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゼクロム",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "きりさく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ボルテージストーム" },
+			damage: 90,
+			cost: ["Lightning", "Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン全員にも、それぞれ10ダメージ。［ベンチは弱点・抵抗力の計算をしない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 563490,
+				tcgplayer: 605354,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [644],
+};
+
+export default card;

--- a/data-asia/XY/CP2/010.ts
+++ b/data-asia/XY/CP2/010.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "デデンネ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "尻尾で 発電所や 民家の コンセントから 電気を 吸い取り ヒゲから 電撃を 撃ち出す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "でんきショック" },
+			damage: 10,
+			cost: ["Lightning"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Metal", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563491,
+				tcgplayer: 605333,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [702],
+};
+
+export default card;

--- a/data-asia/XY/CP2/011.ts
+++ b/data-asia/XY/CP2/011.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ソーナンス",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Psychic"],
+
+	description: {
+		ja: "真っ黒な 尻尾を 隠すため 暗闇で ひっそりと 生きている。 自分からは 攻撃しない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ミラーバリア" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージを受けない。",
+			},
+		},
+		{
+			name: { ja: "ころがりタックル" },
+			damage: 50,
+			cost: ["Psychic", "Psychic", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563492,
+				tcgplayer: 605353,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [202],
+};
+
+export default card;

--- a/data-asia/XY/CP2/012.ts
+++ b/data-asia/XY/CP2/012.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フーパEX",
+	},
+
+	illustrator: "Hitoshi Ariga",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "いじげんリング" },
+			cost: ["Psychic"],
+			effect: {
+				ja: "自分の山札からグッズを2枚まで選び、相手に見せてから、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ワンダートリック" },
+			damage: 100,
+			cost: ["Psychic", "Psychic", "Psychic"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 563493,
+				tcgplayer: 605340,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Double rare",
+	dexId: [720],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/XY/CP2/013.ts
+++ b/data-asia/XY/CP2/013.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒポポタス",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "全身に 砂を まとうことで ばい菌から 体を 守る。 水に ぬれることが 苦手。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はなふんしゃ" },
+			damage: 30,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンがワザを使うとき、相手はコインを1回投げる。ウラならそのワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563494,
+				tcgplayer: 605339,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Common",
+	dexId: [449],
+};
+
+export default card;

--- a/data-asia/XY/CP2/014.ts
+++ b/data-asia/XY/CP2/014.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤンチャム",
+	},
+
+	illustrator: "Mizue",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fighting"],
+
+	description: {
+		ja: "一生懸命 怖い 顔で 相手を にらみつけるが 頭を なでられると つい にやけてしまう。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "えらぶる" },
+			damage: 10,
+			cost: ["Fighting", "Colorless"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Psychic", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563495,
+				tcgplayer: 605347,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Common",
+	dexId: [674],
+};
+
+export default card;

--- a/data-asia/XY/CP2/015.ts
+++ b/data-asia/XY/CP2/015.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルチャブル",
+	},
+
+	illustrator: "match",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fighting"],
+
+	description: {
+		ja: "翼を 使い 空中で 姿勢を コントロール。 防ぎにくい 頭上から 攻撃を 仕掛ける。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "とびひざげり" },
+			damage: 20,
+			cost: ["Fighting"],
+		},
+		{
+			name: { ja: "スカイキック" },
+			damage: 40,
+			cost: ["Fighting", "Fighting"],
+			effect: {
+				ja: "このワザのダメージは抵抗力の計算をしない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563496,
+				tcgplayer: 605338,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [701],
+};
+
+export default card;

--- a/data-asia/XY/CP2/016.ts
+++ b/data-asia/XY/CP2/016.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーイーカ",
+	},
+
+	illustrator: "Kouki Saitou",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Darkness"],
+
+	description: {
+		ja: "光の 点滅で 襲ってきた 敵の 戦意を なくしてしまう。 その すきに 姿を くらますのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "みだれかいてん" },
+			damage: "10×",
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "コインを4回投げ、オモテの数x10ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563497,
+				tcgplayer: 605341,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [686],
+};
+
+export default card;

--- a/data-asia/XY/CP2/017.ts
+++ b/data-asia/XY/CP2/017.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ディアルガ",
+	},
+
+	illustrator: "TOKIYA",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Metal"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "メタルクロー" },
+			damage: 30,
+			cost: ["Metal", "Colorless"],
+		},
+		{
+			name: { ja: "じかんとうけつ" },
+			damage: 80,
+			cost: ["Metal", "Metal", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、手札からポケモンを出して進化できない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [{ type: "Psychic", value: "-20" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 563498,
+				tcgplayer: 605334,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [483],
+};
+
+export default card;

--- a/data-asia/XY/CP2/018.ts
+++ b/data-asia/XY/CP2/018.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラティアス",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "むげんのおもい" },
+			cost: ["Fire"],
+			effect: {
+				ja: "自分の山札を1枚引く。自分のベンチに「ラティオス」がいるなら、さらに1枚引く。",
+			},
+		},
+		{
+			name: { ja: "スピードウイング" },
+			damage: 60,
+			cost: ["Psychic", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 563499,
+				tcgplayer: 605342,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [380],
+};
+
+export default card;

--- a/data-asia/XY/CP2/019.ts
+++ b/data-asia/XY/CP2/019.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラティオス",
+	},
+
+	illustrator: "Naoki Saito",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かっくう" },
+			damage: 20,
+			cost: ["Colorless"],
+		},
+		{
+			name: { ja: "スカイブレード" },
+			damage: "70+",
+			cost: ["Water", "Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分のベンチに「ラティアス」がいるなら、50ダメージを追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 563500,
+				tcgplayer: 605343,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Rare",
+	dexId: [381],
+};
+
+export default card;

--- a/data-asia/XY/CP2/020.ts
+++ b/data-asia/XY/CP2/020.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブラックキュレム",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "サンダーネイル" },
+			damage: 40,
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "ひょうけつざん" },
+			damage: 120,
+			cost: ["Water", "Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "このポケモンにも20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 563501,
+				tcgplayer: 605329,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [646],
+};
+
+export default card;

--- a/data-asia/XY/CP2/021.ts
+++ b/data-asia/XY/CP2/021.ts
@@ -1,0 +1,54 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ホワイトキュレム",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Dragon"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はかいこうせん" },
+			damage: 40,
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+		{
+			name: { ja: "フレアブリザード" },
+			damage: 120,
+			cost: ["Fire", "Fire", "Water", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「フレアブリザード」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fairy", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 563502,
+				tcgplayer: 605352,
+			},
+		},
+	],
+
+	retreat: 3,
+	rarity: "Rare",
+	dexId: [646],
+};
+
+export default card;

--- a/data-asia/XY/CP2/022.ts
+++ b/data-asia/XY/CP2/022.ts
@@ -1,0 +1,49 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニャース",
+	},
+
+	illustrator: "kirisAki",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "まるいものが 大好き。 夜な夜な 出かけては 落ちている コインを 拾い 集めて 帰ってくる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "へとへとタックル" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンに30ダメージ。ウラなら、このポケモンに30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563503,
+				tcgplayer: 605344,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [52],
+};
+
+export default card;

--- a/data-asia/XY/CP2/023.ts
+++ b/data-asia/XY/CP2/023.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "レジギガス",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "だいちのめざめ" },
+			effect: {
+				ja: "自分の手札からこのポケモンにエネルギーをつけるたび、このポケモンのHPを「20」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ギガスパンチ" },
+			damage: 100,
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、すべてウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 563504,
+				tcgplayer: 605349,
+			},
+		},
+	],
+
+	retreat: 4,
+	rarity: "Rare",
+	dexId: [486],
+};
+
+export default card;

--- a/data-asia/XY/CP2/024.ts
+++ b/data-asia/XY/CP2/024.ts
@@ -1,0 +1,53 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アルセウス",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひかりをあつめる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分のベンチポケモンについているエネルギーを好きなだけ選び、このポケモンにつけ替える。",
+			},
+		},
+		{
+			name: { ja: "ジャッジメントバースト" },
+			damage: "10+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている基本エネルギーのタイプの数x30ダメージを追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 563505,
+				tcgplayer: 605328,
+			},
+		},
+	],
+
+	retreat: 2,
+	rarity: "Rare",
+	dexId: [493],
+};
+
+export default card;

--- a/data-asia/XY/CP2/025.ts
+++ b/data-asia/XY/CP2/025.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ワシボン",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Colorless"],
+
+	description: {
+		ja: "強い 相手にも 見境なく 戦いを 挑む。 戦いを 繰り返す ことで 強くなるのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "つつく" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563506,
+				tcgplayer: 605351,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [627],
+};
+
+export default card;

--- a/data-asia/XY/CP2/026.ts
+++ b/data-asia/XY/CP2/026.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウォーグル",
+	},
+
+	illustrator: "match",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Colorless"],
+
+	description: {
+		ja: "仲間のため 危険を かえりみず 戦う。 自動車を つかんだまま 大空を 舞う ことが できる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "つばさでうつ" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "デュアルカッター" },
+			damage: "80×",
+			cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数x80ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563507,
+				tcgplayer: 605331,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ワシボン",
+	},
+
+	retreat: 2,
+	rarity: "Uncommon",
+	dexId: [628],
+};
+
+export default card;

--- a/data-asia/XY/CP2/027.ts
+++ b/data-asia/XY/CP2/027.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../CP2";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "オンバット",
+	},
+
+	illustrator: "sui",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Colorless"],
+
+	description: {
+		ja: "２０万ヘルツの 超音波を 浴びると 屈強な レスラーも 目が 回り 立っていられないのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちょっとすいとる" },
+			damage: 10,
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「10」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-20" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 563508,
+				tcgplayer: 605345,
+			},
+		},
+	],
+
+	retreat: 1,
+	rarity: "Common",
+	dexId: [714],
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **CP2 伝説キラコレクション (Legendary Holo Collection)**, released 2015-07-18:

- `data-asia/XY/CP2/001.ts` … `027.ts` — all 27 cards (27 Pokémon (2 of them ex))
- the set definition `data-asia/XY/CP2.ts` already existed and is untouched

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (563482–563508)
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (605328–605354), keyed by the collection number each product carries in `extendedData`

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- No `regulationMark` (the set predates regulation marks); resistances are `-20` per the era
- All 27 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
