### PR TITLE
(data) en hgss2 Unleashed - added card variants 

### DIFF
--- a/data/HeartGold & SoulSilver/Unleashed/1.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/1.ts
@@ -9,18 +9,16 @@ const card: Card = {
 	},
 
 	illustrator: "Wataru Kawahara",
-	rarity: "Rare Holo",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		385,
-	],
+	dexId: [385],
 
 	hp: 60,
 
 	types: [
-		"Psychic",
+		"Psychic"
 	],
 
 	stage: "Basic",
@@ -37,7 +35,7 @@ const card: Card = {
 				en: "Once during your turn, when you put Jirachi from your hand onto your Bench, you may flip 3 coins. For each heads, search your discard pile for a Psychic Energy card and attach it to Jirachi.",
 				fr: "Une seule fois pendant votre tour, lorsque vous placez Jirachi de votre main sur votre Banc, vous pouvez lancer 3 pièces. Pour chaque côté face, récupérez une carte Énergie Psychic dans votre pile de défausse et attachez-la à Jirachi.",
 				de: "Einmal während deines Zuges kannst du, wenn du Jirachi von deiner Hand auf deine Bank legst, 3 Münzen werfen. Durchsuche pro \"Kopf\" deinen Ablagestapel nach einer -Energiekarte und lege sie an Jirachi an."
-			},
+			}
 		},
 	],
 
@@ -52,7 +50,7 @@ const card: Card = {
 				de: "Zeitumkehrung"
 			},
 			effect: {
-				en: "Choose a number of your opponent’s Stage 1 or Stage 2 Evolved Pokémon up to the amount of Energy attached to Jirachi. Remove the highest Stage Evolution card from each of those Pokémon and put those cards back into your opponent’s hand.",
+				en: "Choose a number of your opponent's Stage 1 or Stage 2 Evolved Pokémon up to the amount of Energy attached to Jirachi. Remove the highest Stage Evolution card from each of those Pokémon and put those cards back into your opponent's hand.",
 				fr: "Choisissez au maximum autant de cartes Pokémon Évolution de votre adversaire (niveau 1 ou 2) qu’il y a de cartes Énergie attachées à Jirachi. Retirez les cartes Évolution de niveau le plus élevé de ces Pokémon et remettez-les dans la main de votre adversaire.",
 				de: "Wähle maximal so viele entwickelte Phase-1- oder Phase -2 Pokémon deines Gegners, wie Energien an Jirachi angelegt sind. Entferne die höchste Evolutionskarte von jedem der gewählten Pokémon. Dein Gegner nimmt diese Karten auf seine Hand zurück."
 			},
@@ -75,15 +73,19 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
-		},
-		{
-			type: "reverse"
-		},
-		{
 			type: "holo",
-			foil: "cracked-ice"
-		}
+			thirdParty: {
+				tcgplayer: 86330,
+				cardmarket: 279157
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 86330,
+				cardmarket: 279157
+			}
+		},
 	],
 
 	thirdParty: {

--- a/data/HeartGold & SoulSilver/Unleashed/1.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/1.ts
@@ -88,10 +88,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279157,
-		tcgplayer: 86330
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/10.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/10.ts
@@ -9,23 +9,21 @@ const card: Card = {
 	},
 
 	illustrator: "match",
-	rarity: "Rare Holo",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		389,
-	],
+	dexId: [389],
 
 	hp: 140,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	evolveFrom: {
 		en: "Grotle",
-		fr: "Boskara",
+		fr: "Boskara"
 	},
 
 	stage: "Stage2",
@@ -83,14 +81,25 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				tcgplayer: 89987,
+				cardmarket: 279166
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 89987,
+				cardmarket: 279166
+			}
 		},
 		{
 			type: "holo",
-			foil: "cracked-ice"
+			foil: "cracked-ice",
+			thirdParty: {
+				tcgplayer: 153265
+			}
 		}
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/10.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/10.ts
@@ -103,10 +103,6 @@ const card: Card = {
 		}
 	],
 
-	thirdParty: {
-		cardmarket: 279166,
-		tcgplayer: 89987
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/11.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/11.ts
@@ -108,10 +108,6 @@ const card: Card = {
 		}
 	],
 
-	thirdParty: {
-		cardmarket: 279167,
-		tcgplayer: 90666
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/11.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/11.ts
@@ -9,23 +9,21 @@ const card: Card = {
 	},
 
 	illustrator: "sui",
-	rarity: "Rare Holo",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		178,
-	],
+	dexId: [178],
 
 	hp: 90,
 
 	types: [
-		"Psychic",
+		"Psychic"
 	],
 
 	evolveFrom: {
 		en: "Natu",
-		fr: "Natu",
+		fr: "Natu"
 	},
 
 	stage: "Stage1",
@@ -45,7 +43,7 @@ const card: Card = {
 				fr: "Inflige 20 dégâts multipliés par le nombre de cartes Énergie attachées au Pokémon Défenseur.",
 				de: "Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl der an das Verteidigende Pokémon angelegten Energien zu."
 			},
-			damage: "20x",
+			damage: "20×",
 
 		},
 		{
@@ -91,14 +89,22 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				tcgplayer: 90666,
+				cardmarket: 279167
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 90666,
+				cardmarket: 279167
+			}
 		},
 		{
 			type: "holo",
-			foil: "cracked-ice"
+			foil: "cracked-ice",
 		}
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/12.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/12.ts
@@ -96,10 +96,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279168,
-		tcgplayer: 83772
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/12.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/12.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		15,
-	],
+	dexId: [15],
 
 	hp: 110,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	evolveFrom: {
 		en: "Kakuna",
-		fr: "Coconfort",
+		fr: "Coconfort"
 	},
 
 	stage: "Stage2",
@@ -45,7 +43,7 @@ const card: Card = {
 				fr: "Lancez 2 pièces. Cette attaque inflige 50 dégâts multipliés par le nombre de côtés face.",
 				de: "Wirf 2 Münzen. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl \"Kopf\" zu."
 			},
-			damage: "50x",
+			damage: "50×",
 
 		},
 		{
@@ -83,10 +81,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 83772,
+				cardmarket: 279168
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 83772,
+				cardmarket: 279168
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/13.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/13.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		9,
-	],
+	dexId: [9],
 
 	hp: 130,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	evolveFrom: {
 		en: "Wartortle",
-		fr: "Carabaffe",
+		fr: "Carabaffe"
 	},
 
 	stage: "Stage2",
@@ -39,10 +37,10 @@ const card: Card = {
 				de: "Wegspülen"
 			},
 			effect: {
-				en: "As often as you like during your turn (before your attack), you may move a Water Energy attached to 1 of your Benched Pokémon to your Active Pokémon. This power can’t be used if Blastoise is affected by a Special Condition.",
+				en: "As often as you like during your turn (before your attack), you may move a Water Energy attached to 1 of your Benched Pokémon to your Active Pokémon. This power can't be used if Blastoise is affected by a Special Condition.",
 				fr: "Autant de fois que vous le souhaitez pendant votre tour (avant votre attaque), vous pouvez prendre une carte Énergie Water attachée à l’un des Pokémon de votre Banc et l’attacher à votre Pokémon Actif. Ce pouvoir ne peut pas être utilisé si Tortank est affecté par un État Spécial.",
 				de: "Beliebig oft während deines Zuges (vor deinen Angriff) kannst du 1 -Energie, die an 1 Pokémon auf deiner Bank angelegt ist, an dein Aktives Pokémon anlegen. Diese Poké-Power kann nicht benutzt werden, wenn Turtok von einem Speziellen Zustand betroffen ist."
-			},
+			}
 		},
 	],
 
@@ -60,7 +58,7 @@ const card: Card = {
 				de: "Wasserwerfer"
 			},
 			effect: {
-				en: "Return 2 Water Energy attached to Blastoise to your hand. Choose 1 of your opponent’s Pokémon. This attack does 100 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)",
+				en: "Return 2 Water Energy attached to Blastoise to your hand. Choose 1 of your opponent's Pokémon. This attack does 100 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Récupérez dans votre main 2 cartes Énergie Water attachées à Tortank. Choisissez l’un des Pokémon de votre adversaire. Cette attaque inflige 100 dégâts à ce Pokémon. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
 				de: "Nimm 2 -Energie, die an Turtok angelegt sind, zurück auf deine Hand und wähle dann 1 Pokémon deines Gegners. Dieser Angfriff fügt dem ausgewählten Pokémon 100 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
@@ -83,22 +81,40 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 83895,
+				cardmarket: 279169
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 83895,
+				cardmarket: 279169
+			}
 		},
 		{
 			type: "holo",
-			foil: "cracked-ice"
+			foil: "cracked-ice",
+			thirdParty: {
+				tcgplayer: 145612
+			}
 		},
 		{
 			type: "normal",
 			stamp: ["pre-release","staff"],
+			thirdParty: {
+				tcgplayer: 211518
+			}
 		},
 		{
 			type: "normal",
 			stamp: ["pre-release"],
+			thirdParty: {
+				cardmarket: 882913,
+				tcgplayer: 211517
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/13.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/13.ts
@@ -118,10 +118,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279169,
-		tcgplayer: 83895
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/14.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/14.ts
@@ -112,10 +112,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279170,
-		tcgplayer: 84488
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/14.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/14.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		169,
-	],
+	dexId: [169],
 
 	hp: 110,
 
 	types: [
-		"Psychic",
+		"Psychic"
 	],
 
 	evolveFrom: {
 		en: "Golbat",
-		fr: "Nosferalto",
+		fr: "Nosferalto"
 	},
 
 	stage: "Stage2",
@@ -64,7 +62,7 @@ const card: Card = {
 				fr: "Lancez 4 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
 				de: "Wirf 4 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl \"Kopf\" zu."
 			},
-			damage: "30x",
+			damage: "30×",
 
 		},
 	],
@@ -91,14 +89,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
-		},
-		{
-			type: "reverse"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 84488,
+				cardmarket: 279170
+			}
 		},
 		{
 			type: "reverse",
-			foil: "league"
+			thirdParty: {
+				tcgplayer: 84488,
+				cardmarket: 279170
+			}
+		},
+		{
+			type: "reverse",
+			foil: "league",
+			thirdParty: {
+				cardmarket: 371561,
+				tcgplayer: 153256
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/15.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/15.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		22,
-	],
+	dexId: [22],
 
 	hp: 80,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	evolveFrom: {
 		en: "Spearow",
-		fr: "Piafabec",
+		fr: "Piafabec"
 	},
 
 	stage: "Stage1",
@@ -61,7 +59,7 @@ const card: Card = {
 				fr: "Lancez 5 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
 				de: "Wirf 5 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
 			},
-			damage: "20x",
+			damage: "20×",
 
 		},
 	],
@@ -88,10 +86,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 85399,
+				cardmarket: 279171
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 85399,
+				cardmarket: 279171
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/15.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/15.ts
@@ -101,10 +101,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279171,
-		tcgplayer: 85399
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/16.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/16.ts
@@ -91,10 +91,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279172,
-		tcgplayer: 85515
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/16.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/16.ts
@@ -13,18 +13,16 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		419,
-	],
+	dexId: [419],
 
 	hp: 80,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	evolveFrom: {
-		fr: "Mustébouée",
+		fr: "Mustébouée"
 	},
 
 	stage: "Stage1",
@@ -38,10 +36,10 @@ const card: Card = {
 				de: "Wasser marsch!"
 			},
 			effect: {
-				en: "Once during your turn (before your attack), you may attach a Water Energy card from your hand to Floatzel. This power can’t be used if Floatzel is affected by a Special Condition.",
+				en: "Once during your turn (before your attack), you may attach a Water Energy card from your hand to Floatzel. This power can't be used if Floatzel is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez attacher une carte Énergie Water de votre main à Mustéflott. Ce pouvoir ne peut pas être utilisé si Mustéflott est affecté par un État Spécial.",
 				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 -Energiekarte aus deiner Hand an Bojelin anlegen. Diese Poké-Power kann nicht benutzt werden, wenn Bojelin von einem Speziellen Zustand betroffen ist."
-			},
+			}
 		},
 	],
 
@@ -78,10 +76,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 85515,
+				cardmarket: 279172
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 85515,
+				cardmarket: 279172
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/17.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/17.ts
@@ -96,10 +96,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279173,
-		tcgplayer: 86447
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/17.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/17.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		230,
-	],
+	dexId: [230],
 
 	hp: 130,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	evolveFrom: {
 		en: "Seadra",
-		fr: "Hypocean",
+		fr: "Hypocean"
 	},
 
 	stage: "Stage2",
@@ -41,7 +39,7 @@ const card: Card = {
 				de: "Wasserpfeil"
 			},
 			effect: {
-				en: "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)",
+				en: "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Choisissez l’un des Pokémon de votre adversaire. Cette attaque inflige 30 dégâts à ce Pokémon. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
 				de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
@@ -83,10 +81,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 86447,
+				cardmarket: 279173
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 86447,
+				cardmarket: 279173
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/18.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/18.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		171,
-	],
+	dexId: [171],
 
 	hp: 90,
 
 	types: [
-		"Lightning",
+		"Lightning"
 	],
 
 	evolveFrom: {
 		en: "Chinchou",
-		fr: "Loupio",
+		fr: "Loupio"
 	},
 
 	stage: "Stage1",
@@ -84,10 +82,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 86610,
+				cardmarket: 279174
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 86610,
+				cardmarket: 279174
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/18.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/18.ts
@@ -97,10 +97,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279174,
-		tcgplayer: 86610
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/19.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/19.ts
@@ -92,10 +92,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279175,
-		tcgplayer: 86880
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/19.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/19.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		448,
-	],
+	dexId: [448],
 
 	hp: 90,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	evolveFrom: {
 		en: "Riolu",
-		fr: "Riolu",
+		fr: "Riolu"
 	},
 
 	stage: "Stage1",
@@ -41,7 +39,7 @@ const card: Card = {
 				de: "Protzer"
 			},
 			effect: {
-				en: "During your next turn, each of Lucario’s attacks does 30 more damage to the Defending Pokémon (before applying Weakness and Resistance).",
+				en: "During your next turn, each of Lucario's attacks does 30 more damage to the Defending Pokémon (before applying Weakness and Resistance).",
 				fr: "Lors de votre prochain tour, chaque attaque de Lucario inflige 30 dégâts supplémentaires au Pokémon Défenseur (avant application de la Faiblesse et de la Résistance).",
 				de: "In deinem nächsten Zug fügen Lucarios Angriffe dem Verteidigenden Pokémon 30 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 			},
@@ -79,10 +77,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 86880,
+				cardmarket: 279175
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 86880,
+				cardmarket: 279175
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/2.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/2.ts
@@ -107,10 +107,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279158,
-		tcgplayer: 87059
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/2.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/2.ts
@@ -9,23 +9,21 @@ const card: Card = {
 	},
 
 	illustrator: "Hajime Kusajima",
-	rarity: "Rare Holo",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		467,
-	],
+	dexId: [467],
 
 	hp: 110,
 
 	types: [
-		"Fire",
+		"Fire"
 	],
 
 	evolveFrom: {
 		en: "Magmar",
-		fr: "Magmar",
+		fr: "Magmar"
 	},
 
 	stage: "Stage1",
@@ -47,7 +45,7 @@ const card: Card = {
 				fr: "Défaussez les 3 cartes du dessus de votre deck. Cette attaque inflige 50 dégâts multipliés par le nombre de cartes Énergie que vous avez défaussées.",
 				de: "Lege die obersten 3 Karten deines Decks auf deinen Ablagestapel. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl abgelegter Energiekarten zu."
 			},
-			damage: "50x",
+			damage: "50×",
 
 		},
 		{
@@ -87,10 +85,25 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				tcgplayer: 87059,
+				cardmarket: 279158
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 87059,
+				cardmarket: 279158
+			}
+		},
+		{
+			type: "holo",
+			foil: 'cracked-ice',
+			thirdParty: {
+				tcgplayer: 226911
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/20.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/20.ts
@@ -95,10 +95,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279176,
-		tcgplayer: 87776
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/20.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/20.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		38,
-	],
+	dexId: [38],
 
 	hp: 90,
 
 	types: [
-		"Fire",
+		"Fire"
 	],
 
 	evolveFrom: {
 		en: "Vulpix",
-		fr: "Goupix",
+		fr: "Goupix"
 	},
 
 	stage: "Stage1",
@@ -82,12 +80,21 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 87776,
+				cardmarket: 279176
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 87776,
+				cardmarket: 279176
+			}
 		},
 	],
+
 	thirdParty: {
 		cardmarket: 279176,
 		tcgplayer: 87776

--- a/data/HeartGold & SoulSilver/Unleashed/21.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/21.ts
@@ -113,10 +113,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279177,
-		tcgplayer: 88279
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/21.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/21.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		62,
-	],
+	dexId: [62],
 
 	hp: 130,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	evolveFrom: {
 		en: "Poliwhirl",
-		fr: "Tetarte",
+		fr: "Tetarte"
 	},
 
 	stage: "Stage2",
@@ -42,7 +40,7 @@ const card: Card = {
 				de: "Überrollen"
 			},
 			effect: {
-				en: "Does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)",
+				en: "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 20 dégâts à l’un des Pokémon se trouvant sur le Banc de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
 				de: "Dieser Angriff fügt 1 Pokémon auf der Bank deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
@@ -85,19 +83,33 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
-		},
-		{
-			type: "reverse"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 88279,
+				cardmarket: 279177
+			}
 		},
 		{
 			type: "reverse",
-			foil: "league"
+			thirdParty: {
+				tcgplayer: 88279,
+				cardmarket: 279177
+			}
+		},
+		{
+			type: "reverse",
+			foil: "league",
+			thirdParty: {
+				tcgplayer: 220667
+			}
 		},
 		{
 			type: "reverse",
 			foil: "league",
 			stamp: ["staff"],
+			thirdParty: {
+				tcgplayer: 220668
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/22.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/22.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		57,
-	],
+	dexId: [57],
 
 	hp: 90,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	evolveFrom: {
 		en: "Mankey",
-		fr: "Férosinge",
+		fr: "Férosinge"
 	},
 
 	stage: "Stage1",
@@ -56,7 +54,7 @@ const card: Card = {
 				de: "Bebop-Hieb"
 			},
 			effect: {
-				en: "Choose 1 of your opponent’s Pokémon. Flip a coin until you get tails. This attack does 50 damage times the number of heads to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)",
+				en: "Choose 1 of your opponent's Pokémon. Flip a coin until you get tails. This attack does 50 damage times the number of heads to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Choisissez l’un des Pokémon de votre adversaire. Lancez une pièce jusqu’à ce qu’elle tombe sur pile. Cette attaque inflige à ce Pokémon 50 dégâts multipliés par le nombre de côtés face. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
 				de: "Wähle 1 Pokémon deines Gegners. Wirf so lange 1 Münze, bis zum ersten Mal das Ergebnis \"Zahl\" kommt. Dieser Angriff fügt dem gewählten Pokémon 50 Schadenspunkte mal der Anzahl \"Kopf\" zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an)."
 			},
@@ -79,10 +77,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 88365,
+				cardmarket: 279178
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 88365,
+				cardmarket: 279178
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/22.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/22.ts
@@ -92,10 +92,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279178,
-		tcgplayer: 88365
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/23.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/23.ts
@@ -95,10 +95,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279179,
-		tcgplayer: 88830
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/23.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/23.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		407,
-	],
+	dexId: [407],
 
 	hp: 90,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	evolveFrom: {
 		en: "Roselia",
-		fr: "Roselia",
+		fr: "Roselia"
 	},
 
 	stage: "Stage1",
@@ -39,10 +37,10 @@ const card: Card = {
 				de: "Energiesignal"
 			},
 			effect: {
-				en: "When you attach a Grass Energy card or Psychic Energy card from your hand to Roserade during your turn, you may use this power. If you attach a Grass Energy card, the Defending Pokémon is now Confused. If you attach a Psychic Energy card, the Defending Pokémon is now Poisoned. This power can’t be used if Roserade is affected by a Special Condition.",
+				en: "When you attach a Grass Energy card or Psychic Energy card from your hand to Roserade during your turn, you may use this power. If you attach a Grass Energy card, the Defending Pokémon is now Confused. If you attach a Psychic Energy card, the Defending Pokémon is now Poisoned. This power can't be used if Roserade is affected by a Special Condition.",
 				fr: "Lorsque vous attachez une carte Énergie Grass ou Énergie Psychic de votre main à Roserade, vous pouvez utiliser ce pouvoir. Si vous attachez une carte Énergie Grass, le Pokémon Défenseur est maintenant Confus. Si vous attachez une carte Énergie Psychic, le Pokémon Défenseur est maintenant Empoisonné. Ce pouvoir ne peut pas être utilisé si Roserade est affecté par un État Spécial.",
 				de: "Wenn du in deinem Zug 1 -Energiekarte oder 1 -Energiekarte aus deiner Hand an Roserade anlegst, kannst du diese Poké-Power verwenden. Wenn du 1 -Energiekarte anlegst, ist das Verteidigende Pokémon jetzt verwirrt. Wenn du 1 -Energiekarte anlegst, ist das Verteidigende Pokémon jetzt vergifet. Diese Poké-Power kann nicht benutzt werden, wenn Roserade von einem Speziellen Zustand betroffen ist."
-			},
+			}
 		},
 	],
 
@@ -62,7 +60,7 @@ const card: Card = {
 				fr: "Inflige 20 dégâts multipliés par le nombre de cartes Énergie attachées à Roserade.",
 				de: "Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl der an Roserade angelegten Energien zu."
 			},
-			damage: "20x",
+			damage: "20×",
 
 		},
 	],
@@ -82,10 +80,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 88830,
+				cardmarket: 279179
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 88830,
+				cardmarket: 279179
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/24.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/24.ts
@@ -121,10 +121,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279180,
-		tcgplayer: 89563
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/24.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/24.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		208,
-	],
+	dexId: [208],
 
 	hp: 120,
 
 	types: [
-		"Metal",
+		"Metal"
 	],
 
 	evolveFrom: {
 		en: "Onix",
-		fr: "Onix",
+		fr: "Onix"
 	},
 
 	stage: "Stage1",
@@ -43,7 +41,7 @@ const card: Card = {
 				de: "Schutzdruck"
 			},
 			effect: {
-				en: "During your opponent’s next turn, any damage done to Steelix by attacks is reduced by 20 (after applying Weakness and Resistance).",
+				en: "During your opponent's next turn, any damage done to Steelix by attacks is reduced by 20 (after applying Weakness and Resistance).",
 				fr: "Tous les dégâts infligés à Steelix par des attaques pendant le prochain tour de votre adversaire sont réduits de 20 (après application de la Faiblesse et de la Résistance).",
 				de: "Während des nächsten Zuges deines Gegners wird Schaden, der Stahlos durch Angriffe zugefügt wird, um 20 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
@@ -67,7 +65,7 @@ const card: Card = {
 				fr: "Lancez 2 pièces. Cette attaque inflige 80 dégâts multipliés par le nombre de côtés face.",
 				de: "Wirf 2 Münzen. Dieser Angriff fügt 80 Schadenspunkte mal der Anzahl \"Kopf\" zu."
 			},
-			damage: "80x",
+			damage: "80×",
 
 		},
 	],
@@ -94,18 +92,32 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
-		},
-		{
-			type: "reverse"
-		},
-		{
-			type: "holo",
-			foil: "cosmos"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 89563,
+				cardmarket: 279180
+			}
 		},
 		{
 			type: "reverse",
-			foil: "league"
+			thirdParty: {
+				tcgplayer: 89563,
+				cardmarket: 279180
+			}
+		},
+		{
+			type: "reverse",
+			foil: 'league',
+			thirdParty: {
+				tcgplayer: 164283,
+				cardmarket: 371565
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				tcgplayer: 125050
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/25.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/25.ts
@@ -86,10 +86,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279181,
-		tcgplayer: 89972
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/25.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/25.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		324,
-	],
+	dexId: [324],
 
 	hp: 80,
 
 	types: [
-		"Fire",
+		"Fire"
 	],
 
 	stage: "Basic",
@@ -34,10 +32,10 @@ const card: Card = {
 				de: "Hitzeschnauber"
 			},
 			effect: {
-				en: "Once during your turn when you put Torkoal from your hand onto your Bench, you may flip a coin. If heads, the Defending Pokémon is now Burned.",
+				en: "Once during your turn, when you put Torkoal from your hand onto your Bench, you may flip a coin. If heads, the Defending Pokémon is now Burned.",
 				fr: "Une seule fois pendant votre tour, lorsque vous placez Chartor de votre main sur votre Banc, vous pouvez lancer une pièce. Si c’est face, le Pokémon Défenseur est maintenant Brûlé.",
 				de: "Einmal während deines Zuges kannst du, wenn du Qurtel von deiner Hand auf deine Bank legst, 1 Münze werfen. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt verbrannt."
-			},
+			}
 		},
 	],
 
@@ -73,10 +71,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 89972,
+				cardmarket: 279181
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 89972,
+				cardmarket: 279181
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/26.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/26.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		248,
-	],
+	dexId: [248],
 
 	hp: 140,
 
 	types: [
-		"Darkness",
+		"Darkness"
 	],
 
 	evolveFrom: {
 		en: "Pupitar",
-		fr: "Ymphect",
+		fr: "Ymphect"
 	},
 
 	stage: "Stage2",
@@ -94,14 +92,25 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				tcgplayer: 90121,
+				cardmarket: 279182
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 90121,
+				cardmarket: 279182
+			}
 		},
 		{
 			type: "holo",
-			foil: "cosmos"
+			foil: "cosmos",
+			thirdParty: {
+				tcgplayer: 125049
+			}
 		}
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/26.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/26.ts
@@ -114,10 +114,6 @@ const card: Card = {
 		}
 	],
 
-	thirdParty: {
-		cardmarket: 279182,
-		tcgplayer: 90121
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/27.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/27.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		217,
-	],
+	dexId: [217],
 
 	hp: 100,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	evolveFrom: {
 		en: "Teddiursa",
-		fr: "Teddiursa",
+		fr: "Teddiursa"
 	},
 
 	stage: "Stage1",
@@ -80,10 +78,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 90254,
+				cardmarket: 279183
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 90254,
+				cardmarket: 279183
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/27.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/27.ts
@@ -93,10 +93,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279183,
-		tcgplayer: 90254
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/28.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/28.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		421,
-	],
+	dexId: [421],
 
 	hp: 80,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	evolveFrom: {
 		en: "Cherubi",
-		fr: "Ceribou",
+		fr: "Ceribou"
 	},
 
 	stage: "Stage1",
@@ -39,10 +37,10 @@ const card: Card = {
 				de: "Sonnenheilung"
 			},
 			effect: {
-				en: "Once during your turn (before your attack), you may remove 1 damage counter from your Active Pokémon. This power can’t be used if Cherrim is affected by a Special Condition.",
+				en: "Once during your turn (before your attack), you may remove 1 damage counter from your Active Pokémon. This power can't be used if Cherrim is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez retirer un marqueur de dégât de votre Pokémon Actif. Ce pouvoir ne peut pas être utilisé si Ceriflor est affecté par un État Spécial.",
 				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 Schadensmarke von deinem Aktiven Pokémon entfernen. Diese Poké-Power kann nicht benutzt werden, wenn Kinoso von einem Speziellen Zustand betroffen ist."
-			},
+			}
 		},
 	],
 
@@ -84,10 +82,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 84257,
+				cardmarket: 279184
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 84257,
+				cardmarket: 279184
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/28.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/28.ts
@@ -97,10 +97,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279184,
-		tcgplayer: 84257
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/29.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/29.ts
@@ -73,10 +73,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279185,
-		tcgplayer: 85013
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/29.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/29.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		206,
-	],
+	dexId: [206],
 
 	hp: 60,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	stage: "Basic",
@@ -60,10 +58,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 85013,
+				cardmarket: 279185
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 85013,
+				cardmarket: 279185
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/3.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/3.ts
@@ -85,10 +85,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279159,
-		tcgplayer: 87148
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/3.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/3.ts
@@ -9,18 +9,16 @@ const card: Card = {
 	},
 
 	illustrator: "Masakazu Fukuda",
-	rarity: "Rare Holo",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		490,
-	],
+	dexId: [490],
 
 	hp: 60,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	stage: "Basic",
@@ -72,10 +70,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				tcgplayer: 87148,
+				cardmarket: 279159
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 87148,
+				cardmarket: 279159
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/30.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/30.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		42,
-	],
+	dexId: [42],
 
 	hp: 80,
 
 	types: [
-		"Psychic",
+		"Psychic"
 	],
 
 	evolveFrom: {
 		en: "Zubat",
-		fr: "Nosferapti",
+		fr: "Nosferapti"
 	},
 
 	stage: "Stage1",
@@ -41,7 +39,7 @@ const card: Card = {
 				de: "Horrorblick"
 			},
 			effect: {
-				en: "The Defending Pokémon can’t retreat during your opponent’s next turn.",
+				en: "The Defending Pokémon can't retreat during your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas battre en retraite durant le prochain tour de votre adversaire.",
 				de: "Das Verteidigende Pokémon kann sich im nächsten Zug deines Gegners nicht zurückziehen."
 			},
@@ -72,10 +70,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 85797,
+				cardmarket: 279186
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 85797,
+				cardmarket: 279186
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/30.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/30.ts
@@ -85,10 +85,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279186,
-		tcgplayer: 85797
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/31.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/31.ts
@@ -101,10 +101,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279187,
-		tcgplayer: 85919
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/31.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/31.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		388,
-	],
+	dexId: [388],
 
 	hp: 90,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	evolveFrom: {
 		en: "Turtwig",
-		fr: "Tortipouss",
+		fr: "Tortipouss"
 	},
 
 	stage: "Stage1",
@@ -88,10 +86,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 85919,
+				cardmarket: 279187
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 85919,
+				cardmarket: 279187
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/32.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/32.ts
@@ -93,10 +93,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279188,
-		tcgplayer: 86415
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/32.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/32.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		14,
-	],
+	dexId: [14],
 
 	hp: 80,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	evolveFrom: {
 		en: "Weedle",
-		fr: "Aspicot",
+		fr: "Aspicot"
 	},
 
 	stage: "Stage1",
@@ -80,10 +78,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 86415,
+				cardmarket: 279188
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 86415,
+				cardmarket: 279188
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/33.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/33.ts
@@ -92,10 +92,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279189,
-		tcgplayer: 87381
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/33.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/33.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		375,
-	],
+	dexId: [375],
 
 	hp: 80,
 
 	types: [
-		"Psychic",
+		"Psychic"
 	],
 
 	evolveFrom: {
 		en: "Beldum",
-		fr: "Terhal",
+		fr: "Terhal"
 	},
 
 	stage: "Stage1",
@@ -79,10 +77,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 87381,
+				cardmarket: 279189
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 87381,
+				cardmarket: 279189
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/34.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/34.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		312,
-	],
+	dexId: [312],
 
 	hp: 60,
 
 	types: [
-		"Lightning",
+		"Lightning"
 	],
 
 	stage: "Basic",
@@ -83,10 +81,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 87491,
+				cardmarket: 279190
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 87491,
+				cardmarket: 279190
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/34.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/34.ts
@@ -96,10 +96,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279190,
-		tcgplayer: 87491
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/35.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/35.ts
@@ -87,10 +87,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279191,
-		tcgplayer: 87816
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/35.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/35.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		322,
-	],
+	dexId: [322],
 
 	hp: 60,
 
 	types: [
-		"Fire",
+		"Fire"
 	],
 
 	stage: "Basic",
@@ -74,10 +72,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 87816,
+				cardmarket: 279191
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 87816,
+				cardmarket: 279191
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/36.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/36.ts
@@ -96,10 +96,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279192,
-		tcgplayer: 88171
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/36.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/36.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		311,
-	],
+	dexId: [311],
 
 	hp: 60,
 
 	types: [
-		"Lightning",
+		"Lightning"
 	],
 
 	stage: "Basic",
@@ -83,10 +81,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 88171,
+				cardmarket: 279192
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 88171,
+				cardmarket: 279192
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/37.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/37.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		61,
-	],
+	dexId: [61],
 
 	hp: 80,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	evolveFrom: {
 		en: "Poliwag",
-		fr: "Ptitard",
+		fr: "Ptitard"
 	},
 
 	stage: "Stage1",
@@ -79,19 +77,34 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
-		},
-		{
-			type: "reverse"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 88268,
+				cardmarket: 279193
+			}
 		},
 		{
 			type: "reverse",
-			foil: "league"
+			thirdParty: {
+				tcgplayer: 88268,
+				cardmarket: 279193
+			}
+		},
+		{
+			type: "reverse",
+			foil: "league",
+			thirdParty: {
+				cardmarket: 450133,
+				tcgplayer: 231416
+			}
 		},
 		{
 			type: "reverse",
 			foil: "league",
 			stamp: ["staff"],
+			thirdParty: {
+				tcgplayer: 231417
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/37.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/37.ts
@@ -108,10 +108,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279193,
-		tcgplayer: 88268
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/38.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/38.ts
@@ -102,10 +102,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279194,
-		tcgplayer: 88453
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/38.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/38.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		247,
-	],
+	dexId: [247],
 
 	hp: 70,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	evolveFrom: {
 		en: "Larvitar",
-		fr: "Embrylex",
+		fr: "Embrylex"
 	},
 
 	stage: "Stage1",
@@ -39,10 +37,10 @@ const card: Card = {
 				de: "Antriebsgas"
 			},
 			effect: {
-				en: "If Pupitar has any Energy attached to it, the Retreat Cost for Pupitar is 0.",
+				en: "If Pupitar has any Energy attached to it, the Retreat Cost of Pupitar is 0.",
 				fr: "Si une ou plusieurs cartes Énergie sont attachées à Ymphect, le Coût de retraite de ce dernier est de 0.",
 				de: "Wenn an Pupitar mindestens 1 Energie angelegt ist, hat Pupitar Rückzugskosten von 0."
-			},
+			}
 		},
 	],
 
@@ -89,10 +87,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 88453,
+				cardmarket: 279194
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 88453,
+				cardmarket: 279194
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/39.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/39.ts
@@ -97,10 +97,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279194,
-		tcgplayer: 88454
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/39.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/39.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		247,
-	],
+	dexId: [247],
 
 	hp: 80,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	evolveFrom: {
 		en: "Larvitar",
-		fr: "Embrylex",
+		fr: "Embrylex"
 	},
 
 	stage: "Stage1",
@@ -84,10 +82,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 88454,
+				cardmarket: 279195
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 88454,
+				cardmarket: 279195
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/4.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/4.ts
@@ -108,10 +108,6 @@ const card: Card = {
 		}
 	],
 
-	thirdParty: {
-		cardmarket: 279160,
-		tcgplayer: 87340
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/4.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/4.ts
@@ -9,23 +9,21 @@ const card: Card = {
 	},
 
 	illustrator: "Wataru Kawahara",
-	rarity: "Rare Holo",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		376,
-	],
+	dexId: [376],
 
 	hp: 130,
 
 	types: [
-		"Psychic",
+		"Psychic"
 	],
 
 	evolveFrom: {
 		en: "Metang",
-		fr: "Metang",
+		fr: "Metang"
 	},
 
 	stage: "Stage2",
@@ -42,7 +40,7 @@ const card: Card = {
 				en: "If you have any Psychic Energy attached to your Active Pokémon, the Retreat Cost for that Pokémon is 0.",
 				fr: "Si une ou plusieurs cartes Énergie Psychic sont attachées à votre Pokémon Actif, le Coût de retraite de ce dernier est de 0.",
 				de: "Wenn an dein Aktives Pokémon mindestens 1 -Energie angelegt ist, hat dieses Pokémon Rückzugskosten von 0."
-			},
+			}
 		},
 	],
 
@@ -73,7 +71,7 @@ const card: Card = {
 				de: "Doppelter Beinhammer"
 			},
 			effect: {
-				en: "Choose 2 of your opponent’s Benched Pokémon. This attack does 40 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)",
+				en: "Choose 2 of your opponent's Benched Pokémon. This attack does 40 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Choisissez 2 des Pokémon se trouvant sur le Banc de votre adversaire. Cette attaque inflige 40 dégâts à chacun d’entre eux. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
 				de: "Wähle 2 Pokémon auf der Bank deines Gegners. Dieser Angriff fügt jedem der gewählten Pokémon 40 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
@@ -93,13 +91,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo"
-		},
+				},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 87340,
+				cardmarket: 279160
+			}
 		},
 		{
 			type: "holo",
-			foil: "cracked-ice"
+			foil: "cracked-ice",
+			thirdParty: {
+				tcgplayer: 227095
+			}
 		}
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/40.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/40.ts
@@ -101,10 +101,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279196,
-		tcgplayer: 89016
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/40.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/40.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		117,
-	],
+	dexId: [117],
 
 	hp: 80,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	evolveFrom: {
 		en: "Horsea",
-		fr: "Hypotrempe",
+		fr: "Hypotrempe"
 	},
 
 	stage: "Stage1",
@@ -41,7 +39,7 @@ const card: Card = {
 				de: "Lehmbrühe"
 			},
 			effect: {
-				en: "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)",
+				en: "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à l’un des Pokémon se trouvant sur le Banc de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
 				de: "Dieser Angriff fügt 1 Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistzenz bei Pokémon auf der Bank nicht an.)"
 			},
@@ -80,14 +78,26 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 89016,
+				cardmarket: 279196
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 89016,
+				cardmarket: 279196
+			}
 		},
 		{
 			type: "normal",
 			stamp: ["gustavo-wada"],
+			thirdParty: {
+				cardmarket: 868151,
+				tcgplayer: 480490
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/41.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/41.ts
@@ -88,10 +88,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279197,
-		tcgplayer: 89766
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/41.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/41.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		128,
-	],
+	dexId: [128],
 
 	hp: 90,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	stage: "Basic",
@@ -55,7 +53,7 @@ const card: Card = {
 				fr: "Lancez 3 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face. Tauros est maintenant Confus.",
 				de: "Wirf 3 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl \"Kopf\" zu."
 			},
-			damage: "30x",
+			damage: "30×",
 
 		},
 	],
@@ -75,10 +73,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 89766,
+				cardmarket: 279197
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 89766,
+				cardmarket: 279197
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/42.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/42.ts
@@ -92,10 +92,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279198,
-		tcgplayer: 90491
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/42.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/42.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		8,
-	],
+	dexId: [8],
 
 	hp: 80,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	evolveFrom: {
 		en: "Squirtle",
-		fr: "Carapuce",
+		fr: "Carapuce"
 	},
 
 	stage: "Stage1",
@@ -41,7 +39,7 @@ const card: Card = {
 				de: "Wasserpfeil"
 			},
 			effect: {
-				en: "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)",
+				en: "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Choisissez l’un des Pokémon de votre adversaire. Cette attaque inflige 20 dégâts à ce Pokémon. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
 				de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
@@ -79,10 +77,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 90491,
+				cardmarket: 279198
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 90491,
+				cardmarket: 279198
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/43.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/43.ts
@@ -99,10 +99,6 @@ const card: Card = {
 		}
 	],
 
-	thirdParty: {
-		cardmarket: 279199,
-		tcgplayer: 83492
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/43.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/43.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		190,
-	],
+	dexId: [190],
 
 	hp: 50,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	stage: "Basic",
@@ -36,7 +34,7 @@ const card: Card = {
 				de: "Schweifcode"
 			},
 			effect: {
-				en: "Move an Energy card attached to the Defending Pokémon to another of your opponent’s Pokémon.",
+				en: "Move an Energy card attached to the Defending Pokémon to another of your opponent's Pokémon.",
 				fr: "Prenez une carte Énergie attachée au Pokémon Défenseur et attachez-la à un autre des Pokémon de votre adversaire.",
 				de: "Lege eine an das Verteidigende Pokémon angelegte Energiekarte an 1 anderes Pokémon deines Gegners an."
 			},
@@ -77,10 +75,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 83492,
+				cardmarket: 279199
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 83492,
+				cardmarket: 279199
+			}
 		},
 		{
 			type: "normal",

--- a/data/HeartGold & SoulSilver/Unleashed/44.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/44.ts
@@ -73,10 +73,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279200,
-		tcgplayer: 83791
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/44.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/44.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		374,
-	],
+	dexId: [374],
 
 	hp: 60,
 
 	types: [
-		"Psychic",
+		"Psychic"
 	],
 
 	stage: "Basic",
@@ -60,10 +58,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 83791,
+				cardmarket: 279200
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 83791,
+				cardmarket: 279200
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/45.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/45.ts
@@ -73,10 +73,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279201,
-		tcgplayer: 84022
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/45.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/45.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		418,
-	],
+	dexId: [418],
 
 	hp: 60,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	stage: "Basic",
@@ -36,7 +34,7 @@ const card: Card = {
 				de: "Lehmbrühe"
 			},
 			effect: {
-				en: "Does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)",
+				en: "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à l’un des Pokémon se trouvant sur le Banc de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
 				de: "Dieser Angriff fügt 1 Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
@@ -60,10 +58,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 84022,
+				cardmarket: 279201
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 84022,
+				cardmarket: 279201
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/46.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/46.ts
@@ -92,10 +92,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279202,
-		tcgplayer: 84104
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/46.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/46.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		455,
-	],
+	dexId: [455],
 
 	hp: 80,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	stage: "Basic",
@@ -79,10 +77,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 84104,
+				cardmarket: 279202
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 84104,
+				cardmarket: 279202
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/47.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/47.ts
@@ -76,10 +76,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279203,
-		tcgplayer: 84264
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/47.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/47.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		420,
-	],
+	dexId: [420],
 
 	hp: 50,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	stage: "Basic",
@@ -63,10 +61,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 84264,
+				cardmarket: 279203
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 84264,
+				cardmarket: 279203
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/48.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/48.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		170,
-	],
+	dexId: [170],
 
 	hp: 60,
 
 	types: [
-		"Lightning",
+		"Lightning"
 	],
 
 	stage: "Basic",
@@ -70,15 +68,23 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 84310,
+				cardmarket: 279204
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 84310,
+				cardmarket: 279204
+			}
 		},
 		{
 			type: "normal",
 			stamp: ["snowflake"],
-			languages: ["de"]
+			languages: ["de"],
 		}
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/48.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/48.ts
@@ -88,10 +88,6 @@ const card: Card = {
 		}
 	],
 
-	thirdParty: {
-		cardmarket: 279204,
-		tcgplayer: 84310
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/49.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/49.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		116,
-	],
+	dexId: [116],
 
 	hp: 50,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	stage: "Basic",
@@ -54,7 +52,7 @@ const card: Card = {
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
 				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
 			},
-			damage: "20x",
+			damage: "20×",
 
 		},
 	],
@@ -74,19 +72,31 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 86192,
+				cardmarket: 279205
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 86192,
+				cardmarket: 279205
+			}
 		},
 		{
 			type: "normal",
 			stamp: ["gustavo-wada"],
+			thirdParty: {
+				cardmarket: 868152,
+				tcgplayer: 480408
+			}
 		},
 		{
 			type: "normal",
 			stamp: ["snowflake"],
-			languages: ["de"]
+			languages: ["de"],
 		}
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/49.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/49.ts
@@ -100,10 +100,6 @@ const card: Card = {
 		}
 	],
 
-	thirdParty: {
-		cardmarket: 279205,
-		tcgplayer: 86192
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/5.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/5.ts
@@ -107,10 +107,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279161,
-		tcgplayer: 87517
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/5.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/5.ts
@@ -9,23 +9,21 @@ const card: Card = {
 	},
 
 	illustrator: "Hideaki Hakozaki",
-	rarity: "Rare Holo",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		429,
-	],
+	dexId: [429],
 
 	hp: 90,
 
 	types: [
-		"Psychic",
+		"Psychic"
 	],
 
 	evolveFrom: {
 		en: "Misdreavus",
-		fr: "Feuforêve",
+		fr: "Feuforêve"
 	},
 
 	stage: "Stage1",
@@ -39,10 +37,10 @@ const card: Card = {
 				de: "Magischer Transfer"
 			},
 			effect: {
-				en: "Once during your turn (before your attack), you may move a Psychic Energy attached to 1 of your Pokémon to another of your Pokémon. This power can’t be used if Mismagius is affected by a Special Condition.",
+				en: "Once during your turn (before your attack), you may move a Psychic Energy attached to 1 of your Pokémon to another of your Pokémon. This power can't be used if Mismagius is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez prendre une carte Énergie Psychic attachée à l’un de vos Pokémon et l’attacher à un autre Pokémon. Ce pouvoir ne peut pas être utilisé si Magirêve est affecté par un État Spécial.",
 				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 -Energie, die an 1 deiner Pokémon angelegt ist, an 1 anderes deiner Pokémon anlegen. Diese Poké-Power kann nicht benutzt werden, wenn Traunmagil von einem Speziellen Zustand betroffen ist."
-			},
+			}
 		},
 	],
 
@@ -57,7 +55,7 @@ const card: Card = {
 				de: "Psychopuls"
 			},
 			effect: {
-				en: "Does 10 damage to each of your opponent’s Benched Pokémon that has any damage counters on it. (Don’t apply Weakness and Resistance for Benched Pokémon.)",
+				en: "Does 10 damage to each of your opponent's Benched Pokémon that has any damage counters on it. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à chacun des Pokémon se trouvant sur le Banc de votre adversaire et ayant des marqueurs de dégât. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
 				de: "Dieser Angriff fügt jedem Pokémon auf der Bank deines Gegners, auf dem bereits mindestens 1 Schadensmarke liegt, 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
@@ -88,19 +86,24 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
-		},
-		{
-			type: "reverse"
-		},
-		{
-			type: "reverse",
-			foil: "league"
+			type: "holo",
+			thirdParty: {
+				tcgplayer: 87517,
+				cardmarket: 279161
+			}
 		},
 		{
 			type: "reverse",
-			foil: "league",
-			stamp: ["staff"]
+			thirdParty: {
+				tcgplayer: 87517,
+				cardmarket: 279161
+			}
+		},
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 125048
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/50.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/50.ts
@@ -96,10 +96,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279206,
-		tcgplayer: 86644
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/50.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/50.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		246,
-	],
+	dexId: [246],
 
 	hp: 50,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	stage: "Basic",
@@ -36,7 +34,7 @@ const card: Card = {
 				de: "Bergfresser"
 			},
 			effect: {
-				en: "Discard the top card of your opponent’s deck. Then, remove 2 damage counters from Larvitar.",
+				en: "Discard the top card of your opponent's deck. Then, remove 2 damage counters from Larvitar.",
 				fr: "Défaussez la carte du dessus du deck de votre adversaire. Ensuite, retirez 2 marqueurs de dégât à Embrylex.",
 				de: "Lege die oberste Karte vom Deck deines Gegners auf seinen Ablagestapel. Entferne dann 2 Schadensmarken von Larvitar."
 			},
@@ -83,10 +81,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 86644,
+				cardmarket: 279206
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 86644,
+				cardmarket: 279206
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/51.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/51.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		246,
-	],
+	dexId: [246],
 
 	hp: 60,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	stage: "Basic",
@@ -77,15 +75,23 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 86645,
+				cardmarket: 279207
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 86645,
+				cardmarket: 279207
+			}
 		},
 		{
 			type: "normal",
 			stamp: ["snowflake"],
-			languages: ["de"]
+			languages: ["de"],
 		}
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/51.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/51.ts
@@ -95,10 +95,6 @@ const card: Card = {
 		}
 	],
 
-	thirdParty: {
-		cardmarket: 279206,
-		tcgplayer: 86645
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/52.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/52.ts
@@ -83,10 +83,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279208,
-		tcgplayer: 87050
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/52.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/52.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		126,
-	],
+	dexId: [126],
 
 	hp: 70,
 
 	types: [
-		"Fire",
+		"Fire"
 	],
 
 	stage: "Basic",
@@ -70,10 +68,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 87050,
+				cardmarket: 279208
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 87050,
+				cardmarket: 279208
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/53.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/53.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		56,
-	],
+	dexId: [56],
 
 	hp: 50,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	stage: "Basic",
@@ -74,10 +72,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 87176,
+				cardmarket: 279209
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 87176,
+				cardmarket: 279209
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/53.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/53.ts
@@ -87,10 +87,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279209,
-		tcgplayer: 87176
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/54.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/54.ts
@@ -79,10 +79,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279210,
-		tcgplayer: 87510
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/54.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/54.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		200,
-	],
+	dexId: [200],
 
 	hp: 50,
 
 	types: [
-		"Psychic",
+		"Psychic"
 	],
 
 	stage: "Basic",
@@ -36,7 +34,7 @@ const card: Card = {
 				de: "Scharfschuss"
 			},
 			effect: {
-				en: "Choose 1 of your opponent’s Pokémon. This attack does 10 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)",
+				en: "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Choisissez l’un des Pokémon de votre adversaire. Cette attaque inflige 10 dégâts à ce Pokémon. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
 				de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
@@ -66,10 +64,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 87510,
+				cardmarket: 279210
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 87510,
+				cardmarket: 279210
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/55.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/55.ts
@@ -97,10 +97,6 @@ const card: Card = {
 		}
 	],
 
-	thirdParty: {
-		cardmarket: 279211,
-		tcgplayer: 87687
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/55.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/55.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		177,
-	],
+	dexId: [177],
 
 	hp: 50,
 
 	types: [
-		"Psychic",
+		"Psychic"
 	],
 
 	stage: "Basic",
@@ -79,15 +77,23 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 87687,
+				cardmarket: 279211
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 87687,
+				cardmarket: 279211
+			}
 		},
 		{
 			type: "normal",
 			stamp: ["snowflake"],
-			languages: ["de"]
+			languages: ["de"],
 		}
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/56.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/56.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		95,
-	],
+	dexId: [95],
 
 	hp: 90,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	stage: "Basic",
@@ -34,10 +32,10 @@ const card: Card = {
 				de: "Energie-Heiler"
 			},
 			effect: {
-				en: "Whenever you attach an Energy card from you hand to 1 of your Pokémon, remove 1 damage counter from that Pokémon.",
+				en: "Whenever you attach an Energy card from your hand to Onix, remove a damage counter from Onix.",
 				fr: "Lorsque vous attachez une carte Énergie de votre main à Onix, retirez-lui 1 marqueur de dégât.",
 				de: "Wenn du 1 Energiekarte von deiner Hand an Onix anlegst, entferne 1 Schadensmarke von Onix."
-			},
+			}
 		},
 	],
 
@@ -55,7 +53,7 @@ const card: Card = {
 				de: "Unbegrenzte Kraft"
 			},
 			effect: {
-				en: "Onix can’t attack during your next turn.",
+				en: "Onix can't attack during your next turn.",
 				fr: "Pendant votre prochain tour, Onix ne peut pas attaquer.",
 				de: "Onix kann in deinem nächsten Zug nicht angreifen."
 			},
@@ -79,15 +77,23 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 87884,
+				cardmarket: 279212
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 87884,
+				cardmarket: 279212
+			}
 		},
 		{
 			type: "normal",
 			stamp: ["snowflake"],
-			languages: ["de"]
+			languages: ["de"],
 		}
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/56.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/56.ts
@@ -97,10 +97,6 @@ const card: Card = {
 		}
 	],
 
-	thirdParty: {
-		cardmarket: 279212,
-		tcgplayer: 87884
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/57.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/57.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		95,
-	],
+	dexId: [95],
 
 	hp: 90,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	stage: "Basic",
@@ -62,10 +60,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 87885,
+				cardmarket: 279213
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 87885,
+				cardmarket: 279213
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/57.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/57.ts
@@ -75,10 +75,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279212,
-		tcgplayer: 87885
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/58.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/58.ts
@@ -102,10 +102,6 @@ const card: Card = {
 		}
 	],
 
-	thirdParty: {
-		cardmarket: 279214,
-		tcgplayer: 88260
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/58.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/58.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		60,
-	],
+	dexId: [60],
 
 	hp: 50,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	stage: "Basic",
@@ -73,19 +71,34 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
-		},
-		{
-			type: "reverse"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 88260,
+				cardmarket: 279214
+			}
 		},
 		{
 			type: "reverse",
-			foil: "league"
+			thirdParty: {
+				tcgplayer: 88260,
+				cardmarket: 279214
+			}
 		},
 		{
 			type: "reverse",
 			foil: "league",
-			stamp: ["staff"]
+			thirdParty: {
+				cardmarket: 450128,
+				tcgplayer: 164216
+			}
+		},
+		{
+			type: "reverse",
+			foil: "league",
+			stamp: ["staff"],
+			thirdParty: {
+				tcgplayer: 164217
+			}
 		}
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/59.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/59.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		223,
-	],
+	dexId: [223],
 
 	hp: 50,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	stage: "Basic",
@@ -50,7 +48,7 @@ const card: Card = {
 				de: "Wasserpfeil"
 			},
 			effect: {
-				en: "Choose 1 of your opponent’s Pokémon. This attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)",
+				en: "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Choisissez l’un des Pokémon de votre adversaire. Cette attaque inflige 20 dégâts à ce Pokémon. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
 				de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
@@ -73,10 +71,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 88699,
+				cardmarket: 279215
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 88699,
+				cardmarket: 279215
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/59.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/59.ts
@@ -86,10 +86,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279215,
-		tcgplayer: 88699
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/6.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/6.ts
@@ -9,23 +9,21 @@ const card: Card = {
 	},
 
 	illustrator: "Ken Sugimori",
-	rarity: "Rare Holo",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		224,
-	],
+	dexId: [224],
 
 	hp: 80,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	evolveFrom: {
 		en: "Remoraid",
-		fr: "Remoraid",
+		fr: "Remoraid"
 	},
 
 	stage: "Stage1",
@@ -41,7 +39,7 @@ const card: Card = {
 				de: "Tauschkanone"
 			},
 			effect: {
-				en: "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) Switch Octillery with 1 of your Benched Pokémon.",
+				en: "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Switch Octillery with 1 of your Benched Pokémon.",
 				fr: "Choisissez l’un des Pokémon de votre adversaire. Cette attaque inflige 30 dégâts à ce Pokémon. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.) Échangez Octillery avec l’un des Pokémon de votre Banc.",
 				de: "Wähle 1 Pokémon deines Gegners. Diesen Angriff fügt dem Gewählten Pokémon 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.) Tausche Octillery gegen 1 Pokémon auf deiner Bank aus."
 			},
@@ -59,7 +57,7 @@ const card: Card = {
 				de: "Tintenbombe"
 			},
 			effect: {
-				en: "If the Defending Pokémon tries to attack during your opponent’s next turn, your opponent flips a coin. If tails, that attack does nothing.",
+				en: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
 				fr: "Si le Pokémon Défenseur essaie d’attaquer pendant le prochain tour de votre adversaire, ce dernier lance une pièce. Si c’est pile, cette attaque ne fait rien.",
 				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
 			},
@@ -83,10 +81,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				tcgplayer: 87834,
+				cardmarket: 279162
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 87834,
+				cardmarket: 279162
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/6.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/6.ts
@@ -96,10 +96,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279162,
-		tcgplayer: 87834
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/60.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/60.ts
@@ -92,10 +92,6 @@ const card: Card = {
 		}
 	],
 
-	thirdParty: {
-		cardmarket: 279216,
-		tcgplayer: 88757
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/60.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/60.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		447,
-	],
+	dexId: [447],
 
 	hp: 60,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	stage: "Basic",
@@ -54,7 +52,7 @@ const card: Card = {
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
 				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
 			},
-			damage: "20x",
+			damage: "20×",
 
 		},
 	],
@@ -74,15 +72,23 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 88757,
+				cardmarket: 279216
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 88757,
+				cardmarket: 279216
+			}
 		},
 		{
 			type: "normal",
 			stamp: ["snowflake"],
-			languages: ["de"]
+			languages: ["de"],
 		}
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/61.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/61.ts
@@ -73,10 +73,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279217,
-		tcgplayer: 88823
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/61.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/61.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		315,
-	],
+	dexId: [315],
 
 	hp: 60,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	stage: "Basic",
@@ -40,7 +38,7 @@ const card: Card = {
 				fr: "Lancez 3 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face. Roselia est maintenant Confus.",
 				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu. Roselia ist jetzt verwirrt."
 			},
-			damage: "20x",
+			damage: "20×",
 
 		},
 	],
@@ -60,10 +58,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 88823,
+				cardmarket: 279217
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 88823,
+				cardmarket: 279217
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/62.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/62.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		21,
-	],
+	dexId: [21],
 
 	hp: 50,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	stage: "Basic",
@@ -36,7 +34,7 @@ const card: Card = {
 				de: "Ruheort"
 			},
 			effect: {
-				en: "Remove 4 damage counters from Spearow. Spearow can’t retreat during your next turn.",
+				en: "Remove 4 damage counters from Spearow. Spearow can't retreat during your next turn.",
 				fr: "Retirez 4 marqueurs de dégât à Piafabec. Piafabec ne peut pas battre en retraite pendant votre prochain tour.",
 				de: "Entferne 4 Schadensmarken von Habitak. Habitak kann sich in deinem nächsten Zug nicht zurückziehen."
 			},
@@ -79,10 +77,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 89442,
+				cardmarket: 279218
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 89442,
+				cardmarket: 279218
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/62.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/62.ts
@@ -92,10 +92,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279218,
-		tcgplayer: 89442
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/63.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/63.ts
@@ -84,10 +84,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279219,
-		tcgplayer: 89496
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/63.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/63.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		7,
-	],
+	dexId: [7],
 
 	hp: 60,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	stage: "Basic",
@@ -71,10 +69,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 89496,
+				cardmarket: 279219
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 89496,
+				cardmarket: 279219
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/64.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/64.ts
@@ -91,10 +91,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279220,
-		tcgplayer: 89506
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/64.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/64.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		234,
-	],
+	dexId: [234],
 
 	hp: 70,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	stage: "Basic",
@@ -78,10 +76,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 89506,
+				cardmarket: 279220
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 89506,
+				cardmarket: 279220
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/65.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/65.ts
@@ -73,10 +73,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279221,
-		tcgplayer: 89859
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/65.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/65.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		216,
-	],
+	dexId: [216],
 
 	hp: 60,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	stage: "Basic",
@@ -60,10 +58,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 89859,
+				cardmarket: 279221
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 89859,
+				cardmarket: 279221
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/66.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/66.ts
@@ -93,10 +93,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279222,
-		tcgplayer: 90061
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/66.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/66.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		357,
-	],
+	dexId: [357],
 
 	hp: 80,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	stage: "Basic",
@@ -80,10 +78,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 90061,
+				cardmarket: 279222
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 90061,
+				cardmarket: 279222
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/67.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/67.ts
@@ -94,10 +94,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279223,
-		tcgplayer: 90080
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/67.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/67.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		387,
-	],
+	dexId: [387],
 
 	hp: 50,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	stage: "Basic",
@@ -81,10 +79,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 90080,
+				cardmarket: 279223
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 90080,
+				cardmarket: 279223
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/68.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/68.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		37,
-	],
+	dexId: [37],
 
 	hp: 60,
 
 	types: [
-		"Fire",
+		"Fire"
 	],
 
 	stage: "Basic",
@@ -60,10 +58,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 90445,
+				cardmarket: 279224
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 90445,
+				cardmarket: 279224
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/68.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/68.ts
@@ -73,10 +73,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279224,
-		tcgplayer: 90445
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/69.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/69.ts
@@ -85,10 +85,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279225,
-		tcgplayer: 90546
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/69.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/69.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		13,
-	],
+	dexId: [13],
 
 	hp: 40,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	stage: "Basic",
@@ -72,10 +70,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 90546,
+				cardmarket: 279225
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 90546,
+				cardmarket: 279225
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/7.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/7.ts
@@ -9,23 +9,21 @@ const card: Card = {
 	},
 
 	illustrator: "Naoyo Kimura",
-	rarity: "Rare Holo",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		186,
-	],
+	dexId: [186],
 
 	hp: 120,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	evolveFrom: {
 		en: "Poliwhirl",
-		fr: "Tetarte",
+		fr: "Tetarte"
 	},
 
 	stage: "Stage2",
@@ -39,10 +37,10 @@ const card: Card = {
 				de: "Bocksprung"
 			},
 			effect: {
-				en: "Once during your turn (before your attack), you may choose a Water Pokémon on your Bench and switch it with your Active Pokémon. This power can’t be used if Politoed is affected by a Special Condition.",
+				en: "Once during your turn (before your attack), you may choose a Water Pokémon on your Bench and switch it with your Active Pokémon. This power can't be used if Politoed is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez choisir un Pokémon Water de votre Banc et l’échanger avec votre Pokémon Actif. Ce pouvoir ne peut pas être utilisé si Tarpaud est affecté par un État Spécial.",
 				de: "Einmal während deises Zuges (vor deinem Angriff) kannst du ein -Pokémon auf deiner Bank wählen und es gegen dein Aktives Pokémon austauschen. Diese Poké-Power kann nicht benutzt werden, wenn Quaxo von einem Speziellen Zustand betroffen ist."
-			},
+			}
 		},
 	],
 
@@ -63,7 +61,7 @@ const card: Card = {
 				fr: "Lancez une pièce pour chacun de vos Pokémon Water en jeu. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
 				de: "Wirf eine Münze für jedes deiner -Pokémon im Spiel. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl \"Kopf\" zu."
 			},
-			damage: "30x",
+			damage: "30×",
 
 		},
 	],
@@ -83,13 +81,35 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				tcgplayer: 88251,
+				cardmarket: 279163
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 88251,
+				cardmarket: 279163
+			}
+		},
+		{
+			type: "reverse",
+			foil: 'league',
+			thirdParty: {
+				cardmarket: 450113,
+				tcgplayer: 220667,
+			}
+		},
+		{
+			type: "reverse",
+			stamp: ["staff"],
+			thirdParty: {
+				tcgplayer: 220668
+			}
 		},
 	],
-
 	thirdParty: {
 		cardmarket: 279163,
 		tcgplayer: 88251

--- a/data/HeartGold & SoulSilver/Unleashed/7.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/7.ts
@@ -110,10 +110,6 @@ const card: Card = {
 			}
 		},
 	],
-	thirdParty: {
-		cardmarket: 279163,
-		tcgplayer: 88251
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/70.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/70.ts
@@ -92,10 +92,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279226,
-		tcgplayer: 90776
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/70.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/70.ts
@@ -13,14 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		41,
-	],
+	dexId: [41],
 
 	hp: 50,
 
 	types: [
-		"Psychic",
+		"Psychic"
 	],
 
 	stage: "Basic",
@@ -49,7 +47,7 @@ const card: Card = {
 				de: "Doppelter Angriff"
 			},
 			effect: {
-				en: "Choose 2 of your opponent’s Benched Pokémon. This attack does 10 damage to each of them. (Don’t apply Weakness and Resistance for Benched Pokémon.)",
+				en: "Choose 2 of your opponent's Benched Pokémon. This attack does 10 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Choisissez 2 des Pokémon se trouvant sur le Banc de votre adversaire. Cette attaque inflige 10 dégâts à chacun de ces Pokémon. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
 				de: "Wähle 2 Pokémon auf der Bank deines Gegners. Dieser Angriff fügt jedem der gewählten Pokémon 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
@@ -79,10 +77,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 90776,
+				cardmarket: 279226
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 90776,
+				cardmarket: 279226
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/71.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/71.ts
@@ -3,7 +3,7 @@ import Set from '../Unleashed'
 
 const card: Card = {
 	name: {
-		en: "Cheerleader’s Cheer",
+		en: "Cheerleader's Cheer",
 		fr: "Encouragements hystériques",
 		de: "Cheerleader-Jubel"
 	},
@@ -15,7 +15,7 @@ const card: Card = {
 
 	effect: {
 		fr: "Piochez 3 cartes. Votre adversaire peut piocher une carte.",
-		en: "Draw 3 cards. Your opponent may draw a card.",
+		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Draw 3 cards. Your opponent may draw a card.",
 		de: "Ziehe 3 Karten. Dein Gegner kann 1 Karte ziehen."
 	},
 
@@ -23,14 +23,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279227,
+				tcgplayer: 84246
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 279227,
+				tcgplayer: 84246
+			}
 		},
 	],
-
-	hp: 0
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/72.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/72.ts
@@ -23,14 +23,25 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 84988,
+				cardmarket: 279228
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 84988,
+				cardmarket: 279228
+			}
 		},
 		{
 			type: "normal",
 			stamp: ["igor-costa"],
+			thirdParty: {
+				cardmarket: 868033
+			}
 		}
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/72.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/72.ts
@@ -45,10 +45,6 @@ const card: Card = {
 		}
 	],
 
-	thirdParty: {
-		cardmarket: 279228,
-		tcgplayer: 84988
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/73.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/73.ts
@@ -3,7 +3,7 @@ import Set from '../Unleashed'
 
 const card: Card = {
 	name: {
-		en: "Emcee’s Chatter",
+		en: "Emcee's Chatter",
 		fr: "Bavardage du maître",
 		de: "MCs Geschwätz"
 	},
@@ -15,7 +15,7 @@ const card: Card = {
 
 	effect: {
 		fr: "Lancez une pièce. Si c’est face, piochez 3 cartes. Si c’est pile, piochez 2 cartes.",
-		en: "Flip a coin. If heads, draw 3 cards. If tails, draw 2 cards.",
+		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Flip a coin. If heads, draw 3 cards. If tails, draw 2 cards.",
 		de: "Wirf eine Münze. Ziehe bei \"Kopf\" 3 Karten. Ziehe bei \"Zahl\" 2 Karten."
 	},
 
@@ -23,14 +23,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279229,
+				tcgplayer: 85187
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 279229,
+				tcgplayer: 85187
+			}
 		},
 	],
-
-	hp: 0
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/74.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/74.ts
@@ -23,14 +23,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 85234,
+				cardmarket: 279230
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 85234,
+				cardmarket: 279230
+			}
 		},
 	],
-
-	hp: 0,
 
 	thirdParty: {
 		cardmarket: 279230,

--- a/data/HeartGold & SoulSilver/Unleashed/74.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/74.ts
@@ -38,10 +38,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279230,
-		tcgplayer: 85234
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/75.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/75.ts
@@ -3,7 +3,7 @@ import Set from '../Unleashed'
 
 const card: Card = {
 	name: {
-		en: "Engineer’s Adjustments",
+		en: "Engineer's Adjustments",
 		fr: "Réglages techniques",
 		de: "Ingenieurkniffe"
 	},
@@ -15,7 +15,7 @@ const card: Card = {
 
 	effect: {
 		fr: "Défaussez une carte Énergie de votre main. Piochez 4 cartes dans votre deck.",
-		en: "Discard an Energy card from your hand. Then. draw 4 cards.",
+		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Discard an Energy card from your hand. Then, draw 4 cards.",
 		de: "Lege 1 Energiekarte von deiner Hand auf deinen Ablagestapel. Ziehe 4 Karten."
 	},
 
@@ -23,18 +23,27 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279231,
+				tcgplayer: 85264
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 85264
+			}
 		},
 		{
 			type: "normal",
 			stamp: ["christopher-kan"],
+			thirdParty: {
+				cardmarket: 868178,
+				tcgplayer: 480393
+			}
 		}
 	],
-
-	hp: 0
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/76.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/76.ts
@@ -23,10 +23,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 85840,
+				cardmarket: 279232
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 85840,
+				cardmarket: 279232
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/76.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/76.ts
@@ -40,10 +40,6 @@ const card: Card = {
 
 	hp: 0,
 
-	thirdParty: {
-		cardmarket: 279232,
-		tcgplayer: 85840
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/77.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/77.ts
@@ -3,7 +3,7 @@ import Set from '../Unleashed'
 
 const card: Card = {
 	name: {
-		en: "Interviewer’s Questions",
+		en: "Interviewer's Questions",
 		fr: "Questionnaire d’interview",
 		de: "Befragung"
 	},
@@ -15,7 +15,7 @@ const card: Card = {
 
 	effect: {
 		fr: "Regardez les 8 cartes du dessus de votre deck. Choisissez autant de cartes Énergie que vous le souhaitez, montrez-les à votre adversaire et ajoutez-les à votre main. Mélangez les autres cartes avec votre deck.",
-		en: "Look at the top 8 cards of your deck. Choose as many Energy cards as you like, show them to your opponent, and put them into your hand. Shuffle the other cards back into your deck.",
+		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Look at the top 8 cards of your deck. Choose as many Energy cards as you like, show them to your opponent, and put them into your hand. Shuffle the other cards back into your deck.",
 		de: "Schau dir die obersten 8 Karten deines Decks an. Wähle beliebig viele Energiekarten, zeige sie deinem Gegner und nimm sie auf die Hand. Mische die anderen Karten anschließend in dein Deck."
 	},
 
@@ -23,14 +23,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279233,
+				tcgplayer: 86286
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 279233,
+				tcgplayer: 86286
+			}
 		},
 	],
-
-	hp: 0
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/78.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/78.ts
@@ -72,10 +72,6 @@ const card: Card = {
 
 	hp: 0,
 
-	thirdParty: {
-		cardmarket: 279234,
-		tcgplayer: 86359
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/78.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/78.ts
@@ -15,7 +15,7 @@ const card: Card = {
 
 	effect: {
 		fr: "Chaque joueur mélange sa main avec son deck, puis pioche 4 cartes (c’est vous qui piochez en premier).",
-		en: "Each player shuffles his or her hand into his or her deck and draws 4 cards.",
+		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Each player shuffles his or her hand into his or her deck and draws 4 cards.",
 		de: "Jeder Spieler mischt seine Handkarten in sein Deck und zieht 4 Karten."
 	},
 
@@ -23,22 +23,50 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 86359,
+				cardmarket: 279234
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 86359,
+				cardmarket: 279234
+			}
+		},
+		{
+			type: 'reverse',
+			foil: 'league',
+			thirdParty: {
+				cardmarket: 449093,
+				tcgplayer: 123183,
+			}
 		},
 		{
 			type: "normal",
 			stamp: ["michael-pramawat"],
+			thirdParty: {
+				cardmarket: 868764,
+				tcgplayer: 480056
+			}
 		},
 		{
 			type: "normal",
 			stamp: ["yuka-furusawa"],
+			thirdParty: {
+				cardmarket: 868765,
+				tcgplayer: 480057
+			}
 		},
 		{
 			type: "normal",
 			stamp: ["gustavo-wada"],
+			thirdParty: {
+				cardmarket: 868208,
+				tcgplayer: 480410
+			}
 		}
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/79.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/79.ts
@@ -23,10 +23,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 86733,
+				cardmarket: 279235
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 86733,
+				cardmarket: 279235
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/79.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/79.ts
@@ -40,10 +40,6 @@ const card: Card = {
 
 	hp: 0,
 
-	thirdParty: {
-		cardmarket: 279235,
-		tcgplayer: 86733
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/8.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/8.ts
@@ -9,18 +9,16 @@ const card: Card = {
 	},
 
 	illustrator: "Hideaki Hakozaki",
-	rarity: "Rare Holo",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		492,
-	],
+	dexId: [492],
 
 	hp: 70,
 
 	types: [
-		"Grass",
+		"Grass"
 	],
 
 	stage: "Basic",
@@ -37,7 +35,7 @@ const card: Card = {
 				en: "Once during your turn, when you put Shaymin from your hand onto your Bench, you may move as many Energy cards attached to your Pokémon as you like to any of your other Pokémon.",
 				fr: "Une seule fois pendant votre tour, lorsque vous placez Shaymin de votre main sur votre Banc, vous pouvez prendre une ou plusieurs cartes Énergie attachées à l’un de vos Pokémon et les attacher à un autre Pokémon.",
 				de: "Einmal während deines Zuges, wenn du Shaymin von deiner Hand auf deine Bank legst, kannst du beliebig viele Energiekarten, die an deine Pokémon angelegt sind, in beliebiger Verteilung an deine anderen Pokémon anlegen."
-			},
+			}
 		},
 	],
 
@@ -84,18 +82,34 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				tcgplayer: 89109,
+				cardmarket: 279164
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 89109,
+				cardmarket: 279164
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["zachary-bokhari"]
+			stamp: ["zachary-bokhari"],
+			thirdParty: {
+				cardmarket: 867994,
+				tcgplayer: 480625,
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["igor-costa"]
+			stamp: ["igor-costa"],
+			thirdParty: {
+				cardmarket: 867990,
+				tcgplayer: 480626
+			}
 		}
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/8.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/8.ts
@@ -113,10 +113,6 @@ const card: Card = {
 		}
 	],
 
-	thirdParty: {
-		cardmarket: 279164,
-		tcgplayer: 89109
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/80.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/80.ts
@@ -15,7 +15,7 @@ const card: Card = {
 
 	effect: {
 		fr: "Attachez PlusPower à l’un de vos Pokémon. Une fois votre tour terminé, défaussez cette carte. Si la carte PlusPower est attachée à un Pokémon effectuant une attaque, cette dernière inflige 10 dégâts supplémentaires au Pokémon Actif (avant application de la Faiblesse et de la Résistance).",
-		en: "Attach PlusPower to 1 of your Pokémon. Discard this card at the end of your turn. \nIf the Pokémon PlusPower is attached to attacks, the attack does 10 more damage to the Defending Pokémon (before applying Weakness and Resistance).",
+		en: "Attach PlusPower to 1 of your Pokémon. Discard this card at the end of your turn. If the Pokémon PlusPower is attached to attacks, the attack does 10 more damage to the Defending Pokémon (before applying Weakness and Resistance).",
 		de: "Während dieses Zuges fügen alle Angriffe deines Pokémon den Aktiven Pokémon 10 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden.)"
 	},
 
@@ -23,18 +23,28 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 88179,
+				cardmarket: 279236
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 88179,
+				cardmarket: 279236
+			}
 		},
 		{
 			type: "normal",
 			stamp: ["yuka-furusawa"],
+			thirdParty: {
+				cardmarket: 868809,
+				tcgplayer: 480092
+			}
 		}
 	],
-
-	hp: 0,
 
 	thirdParty: {
 		cardmarket: 279236,

--- a/data/HeartGold & SoulSilver/Unleashed/80.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/80.ts
@@ -46,10 +46,6 @@ const card: Card = {
 		}
 	],
 
-	thirdParty: {
-		cardmarket: 279236,
-		tcgplayer: 88179
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/81.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/81.ts
@@ -23,18 +23,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
-		},
-		{
-			type: "reverse"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279237,
+				tcgplayer: 88216
+			}
 		},
 	],
-
-	hp: 0,
-
-	thirdParty: {
-		cardmarket: 279237
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/82.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/82.ts
@@ -15,7 +15,7 @@ const card: Card = {
 
 	effect: {
 		fr: "Choisissez l’un de vos Pokémon de base en jeu. Si vous avez dans votre main une carte Évolution de niveau 1 ou 2 correspondant à ce Pokémon, placez-la sur ce dernier (cela équivaut à faire évoluer ce Pokémon). (Si vous choisissez dans votre main une carte Évolution de niveau 2, placez-la sur le Pokémon de base correspondant au lieu d’un Pokémon de niveau 1.)",
-		en: "Choose 1 of your Basic Pokémon in play. If you have a Stage 1 or Stage 2 card that evolves from that Pokémon in your hand, put that card on the Basic Pokémon. (This counts as evolving that Pokémon.) (If you choose a Stage 2 Pokémon in your hand, put that Pokémon on the Basic Pokémon instead of on a Stage 1 Pokémon.)",
+		en: "Choose 1 of your Basic Pokémon in play. If you have a Stage 1 or Stage 2 card that evolves from that Pokémon in your hand, put that card on the Basic Pokémon. (This counts as evolving that Pokémon.) If you choose a Stage 2 Pokémon in your hand, put that Pokémon on the Basic Pokémon instead of on a Stage 1 Pokémon.",
 		de: "Wähle 1 deiner Basis-Pokémon im Spiel. Wenn du eine Phase-2-Karte, auf der Hand hast, die sich aus diesem Pokémon entwickelt, lege sie auf das Basis-Pokémon. (Das zählt als Entwickeln des gewählten Pokémon.) Du kannst diese Karte nicht während deines ersten Zuges oder für ein Basis-Pokémon, das in diesem Zug ins Spiel gebracht wurde, verwenden."
 	},
 
@@ -23,47 +23,83 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
-		},
-		{
-			type: "reverse"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 88595,
+				cardmarket: 279238
+			}
 		},
 		{
 			type: "reverse",
-			foil: "league"
+			thirdParty: {
+				tcgplayer: 88595,
+				cardmarket: 279238
+			}
+		},
+		{
+			type: "reverse",
+			foil: "league",
+			thirdParty: {
+				cardmarket: 450263,
+				tcgplayer: 221298
+			}
 		},
 		{
 			type: "normal",
 			stamp: ["michael-pramawat"],
+			thirdParty: {
+				cardmarket: 868771,
+				tcgplayer: 480105
+			}
 		},
 		{
 			type: "normal",
 			stamp: ["yuka-furusawa"],
+			thirdParty: {
+				cardmarket: 868773,
+				tcgplayer: 480106
+			}
 		},
 		{
 			type: "normal",
 			stamp: ["gustavo-wada"],
+			thirdParty: {
+				cardmarket: 868186,
+				tcgplayer: 480468
+			}
 		},
 		{
 			type: "normal",
 			stamp: ["christopher-kan"],
+			thirdParty: {
+				cardmarket: 868184,
+				tcgplayer: 480470
+			}
 		},
 		{
 			type: "normal",
 			stamp: ["ross-cawthorn"],
+			thirdParty: {
+				tcgplayer: 480471
+			}
 		},
 		{
 			type: "normal",
 			stamp: ["david-cohen"],
-		}
+			thirdParty: {
+				cardmarket: 868185,
+				tcgplayer: 480472
+			}
+		},
+		{
+			type: "normal",
+			stamp: ["ross-cawthorn"],
+			thirdParty: {
+				cardmarket: 868187,
+				tcgplayer: 480471
+			}
+		},
 	],
-
-	hp: 0,
-
-	thirdParty: {
-		cardmarket: 279238,
-		tcgplayer: 88595
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/83.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/83.ts
@@ -56,10 +56,6 @@ const card: Card = {
 
 	hp: 0,
 
-	thirdParty: {
-		cardmarket: 279239,
-		tcgplayer: 89640
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/83.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/83.ts
@@ -23,18 +23,34 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
-		},
-		{
-			type: "reverse"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 89640,
+				cardmarket: 279239
+			}
 		},
 		{
 			type: "reverse",
-			foil: "league"
+			thirdParty: {
+				tcgplayer: 89640,
+				cardmarket: 279239
+			}
+		},
+		{
+			type: "reverse",
+			foil: "league",
+			thirdParty: {
+				cardmarket: 450423,
+				tcgplayer: 261732
+			}
 		},
 		{
 			type: "normal",
 			stamp: ["mychael-bryan"],
+			thirdParty: {
+				cardmarket: 868798,
+				tcgplayer: 480113
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/84.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/84.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		169,
-	],
+	dexId: [169],
 
 	hp: 130,
 
 	types: [
-		"Psychic",
+		"Psychic"
 	],
 
 	evolveFrom: {
 		en: "Golbat",
-		fr: "Nosferalto",
+		fr: "Nosferalto"
 	},
 
 	stage: "Stage2",
@@ -57,7 +55,7 @@ const card: Card = {
 				de: "Geübter Sturzflug"
 			},
 			effect: {
-				en: "Choose 1 of your opponent’s Pokémon. This attack does 30 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)",
+				en: "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Choisissez l’un des Pokémon de votre adversaire. Cette attaque inflige 30 dégâts à ce Pokémon. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
 				de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
@@ -84,14 +82,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 279170,
+				tcgplayer: 84489
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 279170,
-		tcgplayer: 84489
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/85.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/85.ts
@@ -91,10 +91,6 @@ const card: Card = {
 			}
 		},
 	],
-	thirdParty: {
-		cardmarket: 279173,
-		tcgplayer: 86448
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/85.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/85.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		230,
-	],
+	dexId: [230],
 
 	hp: 130,
 
 	types: [
-		"Water",
+		"Water"
 	],
 
 	evolveFrom: {
 		en: "Seadra",
-		fr: "Hypocean",
+		fr: "Hypocean"
 	},
 
 	stage: "Stage2",
@@ -39,10 +37,10 @@ const card: Card = {
 				de: "Fontänenspritzer"
 			},
 			effect: {
-				en: "Once during your turn (before your attack), you may put 1 damage counter on 1 of your opponent’s Pokémon. This power can’t be used if Kingdra is affected by a Special Condition.",
+				en: "Once during your turn (before your attack), you may put 1 damage counter on 1 of your opponent's Pokémon. This power can't be used if Kingdra is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez placer un marqueur de dégât sur l’un des Pokémon de votre adversaire. Ce pouvoir ne peut pas être utilisé si Hyporoi est affecté par un État Spécial.",
 				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 Schadensmarke auf 1 Pokémon deines Gegners legen. Diese Poké-Power kann nicht benutzt werden, wenn Seedraking von einem Speziellen Zustand betroffen ist."
-			},
+			}
 		},
 	],
 
@@ -57,7 +55,7 @@ const card: Card = {
 				de: "Drachendampf"
 			},
 			effect: {
-				en: "If your opponent has any Fire Pokémon in play, this attack’s base damage is 20 instead of 60.",
+				en: "If your opponent has any Fire Pokémon in play, this attack's base damage is 20 instead of 60.",
 				fr: "Si votre adversaire dispose de n’importe quel Pokémon Fire en jeu, cette attaque inflige 20 dégâts de base au lieu de 60.",
 				de: "Wenn dein Gegner mindestens 1 -Pokémon im Spiel hat, beträgt der Grundschaden dieses Angriffs 20 Schadenspunkte anstelle von 60 Schadenspunkten."
 			},
@@ -78,14 +76,21 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 279241,
+				tcgplayer: 86448
+			}
 		},
 		{
-			type: "holo",
+			type: "normal",
 			stamp: ["gustavo-wada"],
+			thirdParty: {
+				cardmarket: 868150,
+				tcgplayer: 480416
+			}
 		},
 	],
-
 	thirdParty: {
 		cardmarket: 279173,
 		tcgplayer: 86448

--- a/data/HeartGold & SoulSilver/Unleashed/86.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/86.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		171,
-	],
+	dexId: [171],
 
 	hp: 110,
 
 	types: [
-		"Lightning",
+		"Lightning"
 	],
 
 	evolveFrom: {
 		en: "Chinchou",
-		fr: "Loupio",
+		fr: "Loupio"
 	},
 
 	stage: "Stage1",
@@ -34,15 +32,15 @@ const card: Card = {
 		{
 			type: "Poke-POWER",
 			name: {
-				en: "Submerge",
+				en: "Underwater Dive",
 				fr: "Submerger",
 				de: "Tauchgang"
 			},
 			effect: {
-				en: "Once during your turn (before your attack), you may use this power. Lanturn’s type is Water until the end of your turn. This power can’t be used if Lanturn is affected by a Special Condition.",
+				en: "Once during your turn (before your attack), you may use this power. Lanturn's type is Water until the end of your turn. This power can't be used if Lanturn is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez utiliser ce pouvoir. Lanturn devient un Pokémon de type Water jusqu’à la fin de votre tour. Ce pouvoir ne peut pas être utilisé si Lanturn est affecté par un État Spécial.",
 				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du diese Poké-Power verwenden. Lanturns Type ist  biz zum Ende des Zuges. Diese Poké-Power kann nicht benutzt werden, wenn Lanturn von einem Speziellen Zustand betroffen ist."
-			},
+			}
 		},
 	],
 
@@ -80,14 +78,14 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 279174,
+				tcgplayer: 86611
+			}
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279174,
-		tcgplayer: 86611
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/87.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/87.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		208,
-	],
+	dexId: [208],
 
 	hp: 140,
 
 	types: [
-		"Metal",
+		"Metal"
 	],
 
 	evolveFrom: {
 		en: "Onix",
-		fr: "Onix",
+		fr: "Onix"
 	},
 
 	stage: "Stage1",
@@ -39,10 +37,10 @@ const card: Card = {
 				de: "Perfektes Metall"
 			},
 			effect: {
-				en: "Steelix can’t be affected by any Special Conditions.",
+				en: "Steelix can't be affected by any Special Conditions",
 				fr: "Steelix ne peut pas être affecté par les États Spéciaux.",
 				de: "Stahlos kann nicht von Speziellen Zuständen betroffen werden."
-			},
+			}
 		},
 	],
 
@@ -107,14 +105,14 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 279180,
+				tcgplayer: 89564
+			}
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279180,
-		tcgplayer: 89564
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/88.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/88.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		248,
-	],
+	dexId: [248],
 
 	hp: 160,
 
 	types: [
-		"Darkness",
+		"Darkness"
 	],
 
 	evolveFrom: {
 		en: "Pupitar",
-		fr: "Ymphect",
+		fr: "Ymphect"
 	},
 
 	stage: "Stage2",
@@ -41,7 +39,7 @@ const card: Card = {
 				de: "Finsternisjauler"
 			},
 			effect: {
-				en: "This attack does 20 damage to each Pokémon in play (both yours and your opponent’s) (excluding any Darkness Pokémon). (Don’t apply Weakness and Resistance for Benched Pokémon.)",
+				en: "This attack does 20 damage to each Pokémon in play (both yours and your opponent's) (excluding any Darkness Pokémon). (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige 20 dégâts à chaque Pokémon en jeu (les vôtres et ceux de votre adversaire), à l’exception des Pokémon Darkness. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
 				de: "Dieser Angriff fügt jedem Pokémon im Spiel (deinen und denen deines Gegners) 10 Schadenspunkte zu. (-Pokémon sind hiervon ausgenommen.) (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
@@ -59,7 +57,7 @@ const card: Card = {
 				de: "Kraftklaue"
 			},
 			effect: {
-				en: "This attack’s damage isn’t affected by Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon.",
+				en: "This attack's damage isn't affected by Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par les Poké-Powers, les Poké-Bodies ou tout autre effet actif sur le Pokémon Défenseur.",
 				de: "Poké-Power, Poké-Body und alle anderen Effekte auf dem Verteidigenden Pokémon haben keine Auswirkungen auf die Schadenspunkte dieses Angriffs."
 			},
@@ -107,14 +105,14 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 279182,
+				tcgplayer: 90122
+			}
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279182,
-		tcgplayer: 90122
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/89.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/89.ts
@@ -13,19 +13,17 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		217,
-	],
+	dexId: [217],
 
 	hp: 110,
 
 	types: [
-		"Colorless",
+		"Colorless"
 	],
 
 	evolveFrom: {
 		en: "Teddiursa",
-		fr: "Teddiursa",
+		fr: "Teddiursa"
 	},
 
 	stage: "Stage1",
@@ -39,10 +37,10 @@ const card: Card = {
 				de: "Berserker"
 			},
 			effect: {
-				en: "If Ursaring has any damage counters on it, each of Ursaring’s attacks does 60 more damage (before applying Weakness and Resistance).",
+				en: "If Ursaring has any damage counters on it, each of Ursaring's attacks does 60 more damage (before applying Weakness and Resistance).",
 				fr: "Si Ursaring a des marqueurs de dégât, chacune de ses attaques inflige 60 dégâts supplémentaires (avant application de la Faiblesse et de la Résistance).",
 				de: "Wenn auf Ursaring mindestens 1 Schadensmarke liegt, fügen sämtliche Angriffe Ursarings 60 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
-			},
+			}
 		},
 	],
 
@@ -59,7 +57,7 @@ const card: Card = {
 				de: "Hammerarm"
 			},
 			effect: {
-				en: "Discard the top card from your opponent’s deck.",
+				en: "Discard the top card from your opponent's deck.",
 				fr: "Défaussez la première carte du dessus du deck de votre adversaire.",
 				de: "Lege die oberste Karte vom Deck deines Gegners auf seinen Ablagestapel."
 			},
@@ -96,14 +94,14 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 279183,
+				tcgplayer: 90255
+			}
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279183,
-		tcgplayer: 90255
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/9.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/9.ts
@@ -9,18 +9,16 @@ const card: Card = {
 	},
 
 	illustrator: "Sachiko Adachi",
-	rarity: "Rare Holo",
+	rarity: "Holo Rare",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [
-		185,
-	],
+	dexId: [185],
 
 	hp: 90,
 
 	types: [
-		"Fighting",
+		"Fighting"
 	],
 
 	stage: "Basic",
@@ -40,7 +38,7 @@ const card: Card = {
 				fr: "Inflige 20 dégâts multipliés par le nombre de cartes Énergie Fighting attachées à Simularbre.",
 				de: "Dieser Angriff fügt 20 Schadenspunkte mal der Anzhal der an Mogelbaum angelegten -Energien zu."
 			},
-			damage: "20x",
+			damage: "20×",
 
 		},
 		{
@@ -55,7 +53,7 @@ const card: Card = {
 				de: "Grollen"
 			},
 			effect: {
-				en: "The Defending Pokémon can’t retreat during your opponent’s next turn.",
+				en: "The Defending Pokémon can't retreat during your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas battre en retraite durant le prochain tour de votre adversaire.",
 				de: "Das Verteidigende Pokémon kann sich im nächsten Zug deines Gegners nicht zurückziehen."
 			},
@@ -79,10 +77,18 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				tcgplayer: 89596,
+				cardmarket: 279165
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				tcgplayer: 89596,
+				cardmarket: 279165
+			}
 		},
 	],
 

--- a/data/HeartGold & SoulSilver/Unleashed/9.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/9.ts
@@ -92,10 +92,6 @@ const card: Card = {
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279165,
-		tcgplayer: 89596
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/90.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/90.ts
@@ -8,17 +8,17 @@ const card: Card = {
 		de: "Entei & Raikou LEGENDE"
 	},
 
-	illustrator: "Shinji Higuchi + Sachiko Eba 樋口 真嗣 + 江場 左知子",
+	illustrator: "Shinji Higuchi + Sachiko Eba",
 	rarity: "LEGEND",
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [244, 243],
+	dexId: [243],
 	hp: 140,
 
 	types: [
 		"Fire",
-		"Lightning",
+		"Lightning"
 	],
 
 	suffix: "Legend",
@@ -26,16 +26,10 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Water",
-			value: "×2",
+			value: "×2"
 		},
 	],
 	retreat: 0,
-
-	variants: [
-		{
-			type: "holo"
-		},
-	],
 
 	attacks: [{
 		name: {
@@ -65,9 +59,15 @@ const card: Card = {
 		cost: ["Lightning", "Colorless"]
 	}],
 
-	thirdParty: {
-		cardmarket: 279246
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 279246,
+				tcgplayer: 85277,
+			}
+		},
+	],
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/91.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/91.ts
@@ -13,12 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [244, 243],
+	dexId: [243],
 	hp: 140,
 
 	types: [
 		"Fire",
-		"Lightning",
+		"Lightning"
 	],
 
 	suffix: "Legend",
@@ -53,7 +53,7 @@ const card: Card = {
 				de: "Donnerfall"
 			},
 			effect: {
-				en: "Discard all Energy attached to Entei & Raikou LEGEND. This attack does 80 damage to each Pokémon that has any Poké-Powers (both yours and your opponent’s). This attack’s damage isn’t affected by Weakness or Resistance.",
+				en: "Discard all Energy attached to Entei & Raikou LEGEND. This attack does 80 damage to each Pokémon that has any Poké-Powers (both yours and your opponent's). This attack's damage isn't affected by Weakness or Resistance.",
 				fr: "Défaussez toutes les cartes Énergie attachées à Entei & Raikou LÉGENDE. Cette attaque inflige 80 dégâts à chaque Pokémon ayant des Poké-Powers (les vôtres et ceux de votre adversaire). Les dégâts infligés par cette attaque ne sont pas affectés par la Faiblesse ou la Résistance.",
 				de: "Lege alle an Entei & Raikou-LEGENDE angelegte Energien auf deinen Ablagestapel. Dieser Angriff fügt jedem Pokémon (deinen und denen deines Gegners), das NICHT über Poké-Power verfügt, 80 Schadenspunkte zu. Der Schaden dieses Angriffs wird durch Schwäche und Resistenz nicht verändert."
 			},
@@ -77,13 +77,14 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				tcgplayer: 85276,
+				cardmarket: 279246
+			}
 		},
 	],
 
-	thirdParty: {
-		cardmarket: 279246
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/92.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/92.ts
@@ -13,12 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [243, 245],
+	dexId: [243],
 	hp: 160,
 
 	types: [
 		"Lightning",
-		"Water",
+		"Water"
 	],
 
 	suffix: "Legend",
@@ -26,21 +26,24 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "×2",
+			value: "×2"
 		},
 		{
 			type: "Lightning",
-			value: "×2",
+			value: "×2"
 		},
 	],
-	retreat: 0,
+	retreat: 1,
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				tcgplayer: 88539,
+				cardmarket: 279248
+			}
 		},
 	],
-
 	attacks: [{
 		name: {
 			en: "Thunderbolt Spear",
@@ -70,10 +73,6 @@ const card: Card = {
 
 		cost: ["Water", "Colorless", "Colorless"]
 	}],
-
-	thirdParty: {
-		cardmarket: 279248
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/93.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/93.ts
@@ -13,12 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [243, 245],
+	dexId: [243],
 	hp: 160,
 
 	types: [
 		"Lightning",
-		"Water",
+		"Water"
 	],
 
 	suffix: "Legend",
@@ -36,7 +36,7 @@ const card: Card = {
 				de: "Blitzspeer"
 			},
 			effect: {
-				en: "Raikou & Suicune LEGEND does 50 damage to itself, and don’t apply Weakness to this damage.",
+				en: "Raikou & Suicune LEGEND does 50 damage to itself and don't apply Weakness to this damage.",
 				fr: "Raikou & Suicune LÉGENDE s'infligent 50 dégâts. N'appliquez pas la Faiblesse à ces dégâts.",
 				de: "Raikou & Suicune-LEGENDE fügt sich selbst 50 Schadenspunkte zu; wende dabei Schwäche nicht an."
 			},
@@ -80,13 +80,13 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 279248,
+				tcgplayer: 88538,
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 279248
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/94.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/94.ts
@@ -13,12 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [245, 244],
+	dexId: [244],
 	hp: 160,
 
 	types: [
 		"Water",
-		"Fire",
+		"Fire"
 	],
 
 	suffix: "Legend",
@@ -26,23 +26,30 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Lightning",
-			value: "×2",
+			value: "×2"
 		},
 		{
 			type: "Water",
-			value: "×2",
+			value: "×2"
 		},
 	],
-	retreat: 0,
-
+	retreat: 1,
 	variants: [
 		{
-			type: "holo"
+			type: 'holo',
+			thirdParty: {
+				cardmarket: 279250,
+				tcgplayer: 89610
+			}
 		},
 		{
-			type: "holo",
+			type: 'holo',
 			stamp: ["ross-cawthorn"],
-		},
+			thirdParty: {
+				cardmarket: 868168,
+				tcgplayer: 480498
+			}
+		}
 	],
 
 	attacks: [{
@@ -72,10 +79,6 @@ const card: Card = {
 
 		cost: ["Fire", "Colorless", "Colorless"]
 	}],
-
-	thirdParty: {
-		cardmarket: 279250
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/95.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/95.ts
@@ -13,12 +13,12 @@ const card: Card = {
 	category: "Pokemon",
 	set: Set,
 
-	dexId: [245, 244],
+	dexId: [244],
 	hp: 160,
 
 	types: [
 		"Water",
-		"Fire",
+		"Fire"
 	],
 
 	suffix: "Legend",
@@ -36,7 +36,7 @@ const card: Card = {
 				de: "Schwallfang"
 			},
 			effect: {
-				en: "Return 2 Water Energy attached to Suicune & Entei LEGEND to your hand. Choose one of your opponent’s Benched Pokémon. This attack does 100 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)",
+				en: "Return 2 Water Energy attached to Suicune & Entei LEGEND to your hand. Choose 1 of your opponent's Benched Pokémon. This attack does 100 damage to that Pokémon. (Don't apply Weakness or Resistance for Benched Pokémon.)",
 				fr: "Reprenez dans votre main 2 cartes Énergie Water attachées à Suicune & Entei LÉGENDE. Cette attaque inflige 100 dégâts à l'un des Pokémon se trouvant sur le Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
 				de: "Nimm 2 -Energiekarten, die an Suicune & Entei-LEGENDE angelegt sind, zurück auf deine Hand. Dieser Angriff fügt 1 Pokémon auf der Bank deines Gegners 100 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
@@ -79,17 +79,21 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 279251,
+				tcgplayer: 89609
+			}
 		},
 		{
-			type: "holo",
+			type: "normal",
 			stamp: ["ross-cawthorn"],
+			thirdParty: {
+				cardmarket: 868169,
+				tcgplayer: 480500
+			}
 		},
 	],
-
-	thirdParty: {
-		cardmarket: 279250
-	}
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Unleashed/TWO.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/TWO.ts
@@ -23,15 +23,15 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
-		},
+			type: "normal",
+			thirdParty: {
+				cardmarket: 279156,
+				tcgplayer: 83510
+			}
+				},
 	],
-
 	hp: 0,
-
-	thirdParty: {
-		cardmarket: 279156
-	}
+	retreat: 0
 }
 
 export default card


### PR DESCRIPTION
closes #N/A

## Changes
- moved thirdparty to root
- added cardmarket/tcgplayer id for holo/normal/reverse variants and sigs

## Details

- tcgplayerid source from https://www.pkmn.gg/series/heartgold-soulsilver/hs-unleashed 
- cardmarketid source from json script

