### PR TITLE
(data) en tk-bw-z BW Trainer Kit Zoroark - added card variants 

### DIFF
--- a/data/Trainer kits/BW trainer Kit (Zoroark)/1.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/1.ts
@@ -18,7 +18,9 @@ const card: Card = {
 	rarity: "None",
 	category: "Pokemon",
 	hp: 60,
-	types: ["Darkness"],
+	types: [
+		"Darkness"
+	],
 	stage: "Basic",
 
 	attacks: [{
@@ -57,6 +59,15 @@ const card: Card = {
 	},
 
 	retreat: 1,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98703
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/1.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/1.ts
@@ -63,6 +63,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280093,
 				tcgplayer: 98703
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/10.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/10.ts
@@ -24,6 +24,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280073,
 				tcgplayer: 98724
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/10.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/10.ts
@@ -15,7 +15,20 @@ const card: Card = {
 
 	rarity: "None",
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+	types: [
+		"Darkness"
+	],
+	retreat: 0,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98724
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/11.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/11.ts
@@ -32,6 +32,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280072,
 				tcgplayer: 98694
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/11.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/11.ts
@@ -26,7 +26,17 @@ const card: Card = {
 		de: "Während dieses Zuges fügen alle Angriffe deines Pokémon den Aktiven Pokémon 10 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 	},
 
-	trainerType: "Item"
+	trainerType: "Item",
+	retreat: 0,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98694
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/12.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/12.ts
@@ -18,40 +18,56 @@ const card: Card = {
 	rarity: "None",
 	category: "Pokemon",
 	hp: 50,
-	types: ["Colorless"],
+	types: [
+		"Colorless"
+	],
 	stage: "Basic",
 
-	attacks: [{
-		cost: [
-			"Colorless",
+	attacks:
+		[
+			{
+				cost: [
+					"Colorless",
+				],
+				name: {
+					en: "Tackle",
+					fr: "Charge"
+				},
+				damage: 10
+			}, {
+				cost: [
+					"Colorless",
+					"Colorless"
+				],
+				name: {
+					en: "Bite",
+					fr: "Morsure"
+				},
+				damage: 20
+			}
 		],
-		name: {
-			en: "Tackle",
-			fr: "Charge"
-		},
-		damage: 10
-	}, {
-		cost: [
-			"Colorless",
-			"Colorless"
-		],
-		name: {
-			en: "Bite",
-			fr: "Morsure"
-		},
-		damage: 20
-	}],
 
-	weaknesses: [{
-		type: "Fighting",
-		value: "×2"
-	}],
+	weaknesses: [
+		{
+			type: "Fighting",
+			value: "×2"
+		}
+	],
 
 	description: {
 		en: "Using food stored in cheek pouches, they can keep watch for days. They use their tails to communicate with others."
 	},
 
 	retreat: 1,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98708
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/12.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/12.ts
@@ -63,6 +63,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280074,
 				tcgplayer: 98708
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/13.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/13.ts
@@ -18,7 +18,9 @@ const card: Card = {
 	rarity: "None",
 	category: "Pokemon",
 	hp: 60,
-	types: ["Darkness"],
+	types: [
+		"Darkness"
+	],
 	stage: "Basic",
 
 	attacks: [{
@@ -52,6 +54,15 @@ const card: Card = {
 	},
 
 	retreat: 1,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98710
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/13.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/13.ts
@@ -58,6 +58,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280075,
 				tcgplayer: 98710
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/14.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/14.ts
@@ -57,6 +57,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280077,
 				tcgplayer: 98712
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/14.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/14.ts
@@ -18,7 +18,9 @@ const card: Card = {
 	rarity: "None",
 	category: "Pokemon",
 	hp: 50,
-	types: ["Colorless"],
+	types: [
+		"Colorless"
+	],
 	stage: "Basic",
 
 	attacks: [{
@@ -51,6 +53,15 @@ const card: Card = {
 	},
 
 	retreat: 1,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98712
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/15.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/15.ts
@@ -76,6 +76,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280076,
 				tcgplayer: 98714
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/15.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/15.ts
@@ -18,7 +18,9 @@ const card: Card = {
 	rarity: "None",
 	category: "Pokemon",
 	hp: 70,
-	types: ["Colorless"],
+	types: [
+		"Colorless"
+	],
 
 	evolveFrom: {
 		en: "Pidove",
@@ -28,7 +30,6 @@ const card: Card = {
 		pt: "Pidove",
 		de: "Dusselgurr"
 	},
-
 	stage: "Stage1",
 
 	attacks: [{
@@ -71,6 +72,15 @@ const card: Card = {
 	},
 
 	retreat: 1,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98714
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/16.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/16.ts
@@ -32,6 +32,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280071,
 				tcgplayer: 98717
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/16.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/16.ts
@@ -26,7 +26,17 @@ const card: Card = {
 		de: "Nimm 2 Basis-Energiekarten von deinem Ablagestapel auf deine Hand."
 	},
 
-	trainerType: "Item"
+	trainerType: "Item",
+	retreat: 0,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98717
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/17.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/17.ts
@@ -79,6 +79,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280070,
 				tcgplayer: 98715
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/17.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/17.ts
@@ -21,7 +21,9 @@ const card: Card = {
 	stage: "Stage1",
 
 	hp: 100,
-	types: ["Darkness"],
+	types: [
+		"Darkness"
+	],
 
 	evolveFrom: {
 		en: "Zorua",
@@ -44,7 +46,7 @@ const card: Card = {
 			en: "Flip 3 coins. This attack does 20 damage times the number of heads.",
 			fr: "Lancez 3 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face."
 		},
-		damage: "20×",
+		damage: "20×"
 	}, {
 		cost: [
 			"Darkness",
@@ -73,6 +75,15 @@ const card: Card = {
 	},
 
 	retreat: 2,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98715
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/18.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/18.ts
@@ -32,6 +32,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280065,
 				tcgplayer: 98700
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/18.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/18.ts
@@ -26,7 +26,17 @@ const card: Card = {
 		de: "Nimm 1 Pokémon von deiner Hand, zeige es deinem Gegner und lege es auf dein Deck. Wenn du das machst, durchsuche dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck."
 	},
 
-	trainerType: "Item"
+	trainerType: "Item",
+	retreat: 0,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98700
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/19.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/19.ts
@@ -52,6 +52,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280064,
 				tcgplayer: 98707
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/19.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/19.ts
@@ -18,7 +18,9 @@ const card: Card = {
 	rarity: "None",
 	category: "Pokemon",
 	hp: 60,
-	types: ["Colorless"],
+	types: [
+		"Colorless"
+	],
 	stage: "Basic",
 
 	attacks: [{
@@ -46,6 +48,15 @@ const card: Card = {
 	},
 
 	retreat: 1,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98707
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/2.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/2.ts
@@ -76,6 +76,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280066,
 				tcgplayer: 98705
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/2.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/2.ts
@@ -18,7 +18,9 @@ const card: Card = {
 	rarity: "None",
 	category: "Pokemon",
 	hp: 90,
-	types: ["Colorless"],
+	types: [
+		"Colorless"
+	],
 
 	evolveFrom: {
 		en: "Patrat",
@@ -43,7 +45,7 @@ const card: Card = {
 		effect: {
 			en: "The Defending Pokémon is now Confused.",
 			fr: "Le Pokémon Défenseur est maintenant Confus."
-		},
+		}
 	}, {
 		cost: [
 			"Colorless",
@@ -70,6 +72,15 @@ const card: Card = {
 	},
 
 	retreat: 1,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98705
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/20.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/20.ts
@@ -24,6 +24,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280067,
 				tcgplayer: 98725
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/20.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/20.ts
@@ -15,7 +15,20 @@ const card: Card = {
 
 	rarity: "None",
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+	types: [
+		"Darkness"
+	],
+	retreat: 0,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98725
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/21.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/21.ts
@@ -18,7 +18,9 @@ const card: Card = {
 	rarity: "None",
 	category: "Pokemon",
 	hp: 50,
-	types: ["Colorless"],
+	types: [
+		"Colorless"
+	],
 	stage: "Basic",
 
 	attacks: [{
@@ -51,6 +53,15 @@ const card: Card = {
 	},
 
 	retreat: 1,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98713
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/21.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/21.ts
@@ -57,6 +57,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280069,
 				tcgplayer: 98713
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/22.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/22.ts
@@ -15,7 +15,20 @@ const card: Card = {
 
 	rarity: "None",
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+	types: [
+		"Darkness"
+	],
+	retreat: 0,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98726
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/22.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/22.ts
@@ -24,6 +24,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280068,
 				tcgplayer: 98726
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/23.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/23.ts
@@ -58,6 +58,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280078,
 				tcgplayer: 98711
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/23.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/23.ts
@@ -18,7 +18,9 @@ const card: Card = {
 	rarity: "None",
 	category: "Pokemon",
 	hp: 60,
-	types: ["Darkness"],
+	types: [
+		"Darkness"
+	],
 	stage: "Basic",
 
 	attacks: [{
@@ -52,6 +54,15 @@ const card: Card = {
 	},
 
 	retreat: 1,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98711
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/24.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/24.ts
@@ -24,6 +24,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280079,
 				tcgplayer: 98727
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/24.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/24.ts
@@ -15,7 +15,20 @@ const card: Card = {
 
 	rarity: "None",
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+	types: [
+		"Darkness"
+	],
+	retreat: 0,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98727
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/25.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/25.ts
@@ -63,6 +63,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280089,
 				tcgplayer: 98704
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/25.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/25.ts
@@ -18,7 +18,9 @@ const card: Card = {
 	rarity: "None",
 	category: "Pokemon",
 	hp: 60,
-	types: ["Darkness"],
+	types: [
+		"Darkness"
+	],
 	stage: "Basic",
 
 	attacks: [{
@@ -57,6 +59,15 @@ const card: Card = {
 	},
 
 	retreat: 1,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98704
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/26.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/26.ts
@@ -15,7 +15,20 @@ const card: Card = {
 
 	rarity: "None",
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+	types: [
+		"Darkness"
+	],
+	retreat: 0,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98728
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/26.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/26.ts
@@ -24,6 +24,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280088,
 				tcgplayer: 98728
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/27.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/27.ts
@@ -26,7 +26,17 @@ const card: Card = {
 		de: "Durchsuche dein Deck nach 1 Basis-Energiekarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
 	},
 
-	trainerType: "Item"
+	trainerType: "Item",
+	retreat: 0,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98698
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/27.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/27.ts
@@ -32,6 +32,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280090,
 				tcgplayer: 98698
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/28.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/28.ts
@@ -15,7 +15,20 @@ const card: Card = {
 
 	rarity: "None",
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+	types: [
+		"Darkness"
+	],
+	retreat: 0,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98729
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/28.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/28.ts
@@ -24,6 +24,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280091,
 				tcgplayer: 98729
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/29.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/29.ts
@@ -58,6 +58,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280092,
 				tcgplayer: 98709
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/29.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/29.ts
@@ -18,7 +18,9 @@ const card: Card = {
 	rarity: "None",
 	category: "Pokemon",
 	hp: 50,
-	types: ["Colorless"],
+	types: [
+		"Colorless"
+	],
 	stage: "Basic",
 
 	attacks: [{
@@ -52,6 +54,15 @@ const card: Card = {
 	},
 
 	retreat: 1,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98709
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/3.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/3.ts
@@ -24,6 +24,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280087,
 				tcgplayer: 98718
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/3.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/3.ts
@@ -15,7 +15,20 @@ const card: Card = {
 
 	rarity: "None",
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+	types: [
+		"Darkness"
+	],
+	retreat: 0,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98718
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/30.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/30.ts
@@ -21,7 +21,9 @@ const card: Card = {
 	stage: "Stage1",
 
 	hp: 100,
-	types: ["Darkness"],
+	types: [
+		"Darkness"
+	],
 
 	evolveFrom: {
 		en: "Zorua",
@@ -44,7 +46,7 @@ const card: Card = {
 			en: "Flip 3 coins. This attack does 20 damage times the number of heads.",
 			fr: "Lancez 3 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face."
 		},
-		damage: "20×",
+		damage: "20×"
 	}, {
 		cost: [
 			"Darkness",
@@ -73,6 +75,15 @@ const card: Card = {
 	},
 
 	retreat: 2,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				tcgplayer: 98716
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/30.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/30.ts
@@ -79,6 +79,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
+				cardmarket: 280086,
 				tcgplayer: 98716
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/4.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/4.ts
@@ -18,7 +18,9 @@ const card: Card = {
 	rarity: "None",
 	category: "Pokemon",
 	hp: 60,
-	types: ["Colorless"],
+	types: [
+		"Colorless"
+	],
 	stage: "Basic",
 
 	attacks: [{
@@ -46,6 +48,15 @@ const card: Card = {
 	},
 
 	retreat: 1,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98706
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/4.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/4.ts
@@ -52,6 +52,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280081,
 				tcgplayer: 98706
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/5.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/5.ts
@@ -24,6 +24,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280080,
 				tcgplayer: 98719
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/5.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/5.ts
@@ -15,7 +15,20 @@ const card: Card = {
 
 	rarity: "None",
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+	types: [
+		"Darkness"
+	],
+	retreat: 0,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98719
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/6.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/6.ts
@@ -24,6 +24,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280082,
 				tcgplayer: 98720
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/6.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/6.ts
@@ -15,7 +15,20 @@ const card: Card = {
 
 	rarity: "None",
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+	types: [
+		"Darkness"
+	],
+	retreat: 0,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98720
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/7.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/7.ts
@@ -15,7 +15,20 @@ const card: Card = {
 
 	rarity: "None",
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+	types: [
+		"Darkness"
+	],
+	retreat: 0,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98721
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/7.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/7.ts
@@ -24,6 +24,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280083,
 				tcgplayer: 98721
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/8.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/8.ts
@@ -15,7 +15,20 @@ const card: Card = {
 
 	rarity: "None",
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+	types: [
+		"Darkness"
+	],
+	retreat: 0,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98722
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/8.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/8.ts
@@ -24,6 +24,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280085,
 				tcgplayer: 98722
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/9.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/9.ts
@@ -15,7 +15,20 @@ const card: Card = {
 
 	rarity: "None",
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+	types: [
+		"Darkness"
+	],
+	retreat: 0,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98723
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/9.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/9.ts
@@ -24,6 +24,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280084,
 				tcgplayer: 98723
 			}
 		},


### PR DESCRIPTION
closes #N/A

## Changes

- added cardmarket ids
- added tcgplayerids

## Details

- used tcgplayer source from https://www.pkmn.gg/series/black-white/black-white-trainer-kit-zoroark
- used cardmarketsource from card market using json script

