### PR TITLE
(data) en tk-bw-e BW Trainer Kit Exadrill - added card variants 

### DIFF
--- a/data/Trainer kits/BW trainer Kit (Excadrill)/1.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/1.ts
@@ -63,6 +63,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280093,
 				tcgplayer: 98671
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/1.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/1.ts
@@ -59,6 +59,15 @@ const card: Card = {
 
 	retreat: 1,
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98671
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/10.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/10.ts
@@ -20,6 +20,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280073,
 				tcgplayer: 98679
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/10.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/10.ts
@@ -15,7 +15,16 @@ const card: Card = {
 
 	rarity: "None",
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98679
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/11.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/11.ts
@@ -18,7 +18,9 @@ const card: Card = {
 	rarity: "None",
 	category: "Pokemon",
 	hp: 60,
-	types: ["Fighting"],
+	types: [
+		"Fighting"
+	],
 	stage: "Basic",
 
 	attacks: [{
@@ -36,15 +38,25 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "2x"
+			value: "×2"
 		},
 	],
+
 
 	description: {
 		en: "It fights by swinging a piece of lumber around. It is close to evolving when it can handle the lumber without difficulty."
 	},
 
 	retreat: 1,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98685
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/11.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/11.ts
@@ -52,6 +52,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280072,
 				tcgplayer: 98685
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/12.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/12.ts
@@ -18,7 +18,9 @@ const card: Card = {
 	rarity: "None",
 	category: "Pokemon",
 	hp: 80,
-	types: ["Colorless"],
+	types: [
+		"Colorless"
+	],
 	stage: "Basic",
 
 	attacks: [{
@@ -40,15 +42,25 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "2x"
+			value: "×2"
 		},
 	],
+
 
 	description: {
 		en: "It touches others with the feelers on its ears, using the sound of their heartbeats to tell how they are feeling."
 	},
 
 	retreat: 2,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98687
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/12.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/12.ts
@@ -56,6 +56,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280074,
 				tcgplayer: 98687
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/13.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/13.ts
@@ -68,6 +68,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280075,
 				tcgplayer: 98689
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/13.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/13.ts
@@ -14,10 +14,13 @@ const card: Card = {
 		de: "Rotomurf"
 	},
 
+	illustrator: "match",
 	rarity: "None",
 	category: "Pokemon",
 	hp: 70,
-	types: ["Fighting"],
+	types: [
+		"Fighting"
+	],
 	stage: "Basic",
 
 	attacks: [{
@@ -46,9 +49,10 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Water",
-			value: "2x"
+			value: "×2"
 		},
 	],
+
 
 	resistances: [{
 		type: "Lightning",
@@ -60,6 +64,15 @@ const card: Card = {
 	},
 
 	retreat: 2,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98689
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/14.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/14.ts
@@ -14,10 +14,13 @@ const card: Card = {
 		de: "Strepoli"
 	},
 
+	illustrator: "Naoki Saito",
 	rarity: "None",
 	category: "Pokemon",
 	hp: 80,
-	types: ["Fighting"],
+	types: [
+		"Fighting"
+	],
 
 	evolveFrom: {
 		en: "Timburr",
@@ -65,6 +68,15 @@ const card: Card = {
 	},
 
 	retreat: 2,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98691
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/14.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/14.ts
@@ -72,6 +72,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280077,
 				tcgplayer: 98691
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/15.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/15.ts
@@ -31,6 +31,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280076,
 				tcgplayer: 98692
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/15.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/15.ts
@@ -26,7 +26,16 @@ const card: Card = {
 		de: "Heile 30 Schadenspunkte bei 1 deiner Pokémon."
 	},
 
-	trainerType: "Item"
+	trainerType: "Item",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98692
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/16.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/16.ts
@@ -31,6 +31,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280071,
 				tcgplayer: 98693
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/16.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/16.ts
@@ -26,7 +26,16 @@ const card: Card = {
 		de: "Während dieses Zuges fügen alle Angriffe deines Pokémon den Aktiven Pokémon 10 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 	},
 
-	trainerType: "Item"
+	trainerType: "Item",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98693
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/17.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/17.ts
@@ -80,6 +80,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280070,
 				tcgplayer: 98695
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/17.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/17.ts
@@ -58,7 +58,7 @@ const card: Card = {
 			en: "Discard an Energy attached to the Defending Pokémon.",
 			fr: "Défaussez une Énergie attachée au Pokémon Défenseur."
 		},
-		damage: 80,
+		damage: 80
 	}],
 
 	weaknesses: [{
@@ -76,6 +76,15 @@ const card: Card = {
 	},
 
 	retreat: 2,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98695
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/18.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/18.ts
@@ -56,6 +56,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280065,
 				tcgplayer: 98688
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/18.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/18.ts
@@ -18,7 +18,9 @@ const card: Card = {
 	rarity: "None",
 	category: "Pokemon",
 	hp: 80,
-	types: ["Colorless"],
+	types: [
+		"Colorless"
+	],
 	stage: "Basic",
 
 	attacks: [{
@@ -40,15 +42,25 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Fighting",
-			value: "2x"
+			value: "×2"
 		},
 	],
+
 
 	description: {
 		en: "It touches others with the feelers on its ears, using the sound of their heartbeats to tell how they are feeling."
 	},
 
 	retreat: 2,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98688
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/19.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/19.ts
@@ -18,7 +18,9 @@ const card: Card = {
 	rarity: "None",
 	category: "Pokemon",
 	hp: 80,
-	types: ["Colorless"],
+	types: [
+		"Colorless"
+	],
 
 	evolveFrom: {
 		en: "Lillipup",
@@ -67,6 +69,15 @@ const card: Card = {
 	},
 
 	retreat: 1,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98701
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/19.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/19.ts
@@ -73,6 +73,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280064,
 				tcgplayer: 98701
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/2.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/2.ts
@@ -15,7 +15,16 @@ const card: Card = {
 
 	rarity: "None",
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98672
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/2.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/2.ts
@@ -20,6 +20,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280066,
 				tcgplayer: 98672
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/20.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/20.ts
@@ -15,7 +15,16 @@ const card: Card = {
 
 	rarity: "None",
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98680
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/20.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/20.ts
@@ -20,6 +20,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280067,
 				tcgplayer: 98680
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/21.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/21.ts
@@ -26,7 +26,16 @@ const card: Card = {
 		de: "Durchsuche dein Deck nach 1 Basis-Energiekarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
 	},
 
-	trainerType: "Item"
+	trainerType: "Item",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98697
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/21.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/21.ts
@@ -31,6 +31,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280069,
 				tcgplayer: 98697
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/22.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/22.ts
@@ -20,6 +20,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280068,
 				tcgplayer: 98681
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/22.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/22.ts
@@ -15,7 +15,16 @@ const card: Card = {
 
 	rarity: "None",
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98681
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/23.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/23.ts
@@ -26,7 +26,16 @@ const card: Card = {
 		de: "Heile 30 Schadenspunkte bei 1 deiner Pokémon."
 	},
 
-	trainerType: "Item"
+	trainerType: "Item",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98730
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/23.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/23.ts
@@ -31,6 +31,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280078,
 				tcgplayer: 98730
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/24.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/24.ts
@@ -31,6 +31,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280079,
 				tcgplayer: 98699
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/24.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/24.ts
@@ -26,7 +26,16 @@ const card: Card = {
 		de: "Nimm 1 Pokémon von deiner Hand, zeige es deinem Gegner und lege es auf dein Deck. Wenn du das machst, durchsuche dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck."
 	},
 
-	trainerType: "Item"
+	trainerType: "Item",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98699
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/25.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/25.ts
@@ -65,6 +65,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280089,
 				tcgplayer: 98690
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/25.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/25.ts
@@ -14,10 +14,13 @@ const card: Card = {
 		de: "Rotomurf"
 	},
 
+	illustrator: "match",
 	rarity: "None",
 	category: "Pokemon",
 	hp: 70,
-	types: ["Fighting"],
+	types: [
+		"Fighting"
+	],
 	stage: "Basic",
 
 	attacks: [{
@@ -58,6 +61,15 @@ const card: Card = {
 	},
 
 	retreat: 2,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98690
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/26.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/26.ts
@@ -20,6 +20,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280088,
 				tcgplayer: 98682
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/26.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/26.ts
@@ -15,7 +15,16 @@ const card: Card = {
 
 	rarity: "None",
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98682
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/27.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/27.ts
@@ -63,6 +63,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280090,
 				tcgplayer: 98702
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/27.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/27.ts
@@ -59,6 +59,15 @@ const card: Card = {
 
 	retreat: 1,
 
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98702
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/28.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/28.ts
@@ -15,7 +15,16 @@ const card: Card = {
 
 	rarity: "None",
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98683
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/28.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/28.ts
@@ -20,6 +20,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280091,
 				tcgplayer: 98683
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/29.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/29.ts
@@ -52,6 +52,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280092,
 				tcgplayer: 98686
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/29.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/29.ts
@@ -18,7 +18,9 @@ const card: Card = {
 	rarity: "None",
 	category: "Pokemon",
 	hp: 60,
-	types: ["Fighting"],
+	types: [
+		"Fighting"
+	],
 	stage: "Basic",
 
 	attacks: [{
@@ -36,15 +38,25 @@ const card: Card = {
 	weaknesses: [
 		{
 			type: "Psychic",
-			value: "2x"
+			value: "×2"
 		},
 	],
+
 
 	description: {
 		en: "It fights by swinging a piece of lumber around. It is close to evolving when it can handle the lumber without difficulty."
 	},
 
 	retreat: 1,
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98686
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/3.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/3.ts
@@ -15,7 +15,16 @@ const card: Card = {
 
 	rarity: "None",
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98673
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/3.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/3.ts
@@ -20,6 +20,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280087,
 				tcgplayer: 98673
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/30.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/30.ts
@@ -80,6 +80,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
+				cardmarket: 280086,
 				tcgplayer: 98696
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/30.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/30.ts
@@ -58,7 +58,7 @@ const card: Card = {
 			en: "Discard an Energy attached to the Defending Pokémon.",
 			fr: "Défaussez une Énergie attachée au Pokémon Défenseur."
 		},
-		damage: 80,
+		damage: 80
 	}],
 
 	weaknesses: [{
@@ -76,6 +76,15 @@ const card: Card = {
 	},
 
 	retreat: 2,
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				tcgplayer: 98696
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/4.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/4.ts
@@ -26,7 +26,16 @@ const card: Card = {
 		de: "Verschiebe 1 an 1 deiner Pokémon angelegte Basis-Energie auf ein anderes deiner Pokémon."
 	},
 
-	trainerType: "Item"
+	trainerType: "Item",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98684
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/4.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/4.ts
@@ -31,6 +31,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280081,
 				tcgplayer: 98684
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/5.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/5.ts
@@ -15,7 +15,16 @@ const card: Card = {
 
 	rarity: "None",
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98674
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/5.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/5.ts
@@ -20,6 +20,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280080,
 				tcgplayer: 98674
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/6.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/6.ts
@@ -20,6 +20,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280082,
 				tcgplayer: 98675
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/6.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/6.ts
@@ -15,7 +15,16 @@ const card: Card = {
 
 	rarity: "None",
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98675
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/7.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/7.ts
@@ -20,6 +20,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280083,
 				tcgplayer: 98676
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/7.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/7.ts
@@ -15,7 +15,16 @@ const card: Card = {
 
 	rarity: "None",
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98676
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/8.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/8.ts
@@ -15,7 +15,16 @@ const card: Card = {
 
 	rarity: "None",
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98677
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/8.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/8.ts
@@ -20,6 +20,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280085,
 				tcgplayer: 98677
 			}
 		},

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/9.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/9.ts
@@ -15,7 +15,16 @@ const card: Card = {
 
 	rarity: "None",
 	category: "Energy",
-	energyType: "Normal"
+	energyType: "Normal",
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 98678
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/9.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/9.ts
@@ -20,6 +20,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 280084,
 				tcgplayer: 98678
 			}
 		},


### PR DESCRIPTION
closes #N/A

## Changes

- added cardmarket ids
- added tcgplayerids

## Details

- used tcgplayer source from https://www.pkmn.gg/series/black-white/black-white-trainer-kit-excadrill
- used cardmarketsource from card market using json script

