### PR TITLE
(data) en tk-sm-r SM Trainer Kit Alolan Raichu - added card variants 

### DIFF
--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/1.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/1.ts
@@ -1,0 +1,28 @@
+import { Card } from '../../../interfaces'
+import Set from '../SM trainer Kit (Alolan Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Lightning Energy",
+	},
+
+	rarity: "None",
+	category: "Energy",
+	set: Set,
+	retreat: 0,
+
+	thirdParty: {
+		tcgplayer: 152850,
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152850,
+			},
+		},
+	],
+}
+
+export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/1.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/1.ts
@@ -3,7 +3,7 @@ import Set from '../SM trainer Kit (Alolan Raichu)'
 
 const card: Card = {
 	name: {
-		en: "Lightning Energy",
+		en: "Lightning Energy"
 	},
 
 	rarity: "None",
@@ -11,18 +11,15 @@ const card: Card = {
 	set: Set,
 	retreat: 0,
 
-	thirdParty: {
-		tcgplayer: 152850,
-	},
-
 	variants: [
 		{
 			type: "normal",
 			thirdParty: {
-				tcgplayer: 152850,
-			},
+				tcgplayer: 152850
+			}
 		},
 	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/1.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/1.ts
@@ -15,6 +15,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297232,
 				tcgplayer: 152850
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/10.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/10.ts
@@ -15,6 +15,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297240,
 				tcgplayer: 152857
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/10.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/10.ts
@@ -3,7 +3,7 @@ import Set from '../SM trainer Kit (Alolan Raichu)'
 
 const card: Card = {
 	name: {
-		en: "Lightning Energy",
+		en: "Lightning Energy"
 	},
 
 	rarity: "None",
@@ -11,18 +11,15 @@ const card: Card = {
 	set: Set,
 	retreat: 0,
 
-	thirdParty: {
-		tcgplayer: 152857,
-	},
-
 	variants: [
 		{
 			type: "normal",
 			thirdParty: {
-				tcgplayer: 152857,
-			},
+				tcgplayer: 152857
+			}
 		},
 	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/10.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/10.ts
@@ -1,0 +1,28 @@
+import { Card } from '../../../interfaces'
+import Set from '../SM trainer Kit (Alolan Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Lightning Energy",
+	},
+
+	rarity: "None",
+	category: "Energy",
+	set: Set,
+	retreat: 0,
+
+	thirdParty: {
+		tcgplayer: 152857,
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152857,
+			},
+		},
+	],
+}
+
+export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/11.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/11.ts
@@ -51,6 +51,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297242,
 				tcgplayer: 152864
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/11.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/11.ts
@@ -14,10 +14,26 @@ const card: Card = {
 		de: "Zubat"
 	},
 
+	illustrator: "Satoshi Shirai",
 	rarity: "Common",
 	category: "Pokemon",
 	hp: 50,
-	types: ["Psychic"],
+	types: [
+		"Psychic"
+	],
+	attacks: [
+		{
+			cost: [
+				"Psychic",
+			],
+			name: {
+				en: "Astonish"
+			},
+			effect: {
+				en: "Choose a random card from your opponent's hand. Your opponent reveals that card and shuffles it into their deck."
+			}
+		},
+	],
 	stage: "Basic",
 	retreat: 1,
 
@@ -31,9 +47,15 @@ const card: Card = {
 		value: "-20"
 	}],
 
-	thirdParty: {
-		tcgplayer: 152864
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152864
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/12.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/12.ts
@@ -3,7 +3,7 @@ import Set from '../SM trainer Kit (Alolan Raichu)'
 
 const card: Card = {
 	name: {
-		en: "Lightning Energy",
+		en: "Lightning Energy"
 	},
 
 	rarity: "None",
@@ -11,18 +11,15 @@ const card: Card = {
 	set: Set,
 	retreat: 0,
 
-	thirdParty: {
-		tcgplayer: 192937,
-	},
-
 	variants: [
 		{
 			type: "normal",
 			thirdParty: {
-				tcgplayer: 192937,
-			},
+				tcgplayer: 192937
+			}
 		},
 	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/12.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/12.ts
@@ -15,6 +15,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297243,
 				tcgplayer: 192937
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/12.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/12.ts
@@ -1,0 +1,28 @@
+import { Card } from '../../../interfaces'
+import Set from '../SM trainer Kit (Alolan Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Lightning Energy",
+	},
+
+	rarity: "None",
+	category: "Energy",
+	set: Set,
+	retreat: 0,
+
+	thirdParty: {
+		tcgplayer: 192937,
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 192937,
+			},
+		},
+	],
+}
+
+export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/13.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/13.ts
@@ -52,6 +52,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297244,
 				tcgplayer: 152865
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/13.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/13.ts
@@ -14,10 +14,27 @@ const card: Card = {
 		de: "Habitak"
 	},
 
+	illustrator: "Yukiko Baba",
 	rarity: "Common",
 	category: "Pokemon",
 	hp: 60,
-	types: ["Colorless"],
+	types: [
+		"Colorless"
+	],
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				en: "Peck Bugs"
+			},
+			effect: {
+				en: "If your opponent's Active Pokémon is a Grass Pokémon, this attack does 30 more damage."
+			},
+			damage: "10+"
+		},
+	],
 	stage: "Basic",
 	retreat: 1,
 
@@ -31,9 +48,15 @@ const card: Card = {
 		value: "-20"
 	}],
 
-	thirdParty: {
-		tcgplayer: 152865
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152865
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/14.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/14.ts
@@ -63,6 +63,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297245,
 				tcgplayer: 152868
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/14.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/14.ts
@@ -17,7 +17,9 @@ const card: Card = {
 	rarity: "None",
 	category: "Pokemon",
 	hp: 60,
-	types: ["Lightning"],
+	types: [
+		"Lightning"
+	],
 	stage: "Basic",
 	retreat: 1,
 	illustrator: "kodama",
@@ -57,9 +59,15 @@ const card: Card = {
 		value: "-20"
 	}],
 
-	thirdParty: {
-		tcgplayer: 152868
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152868
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/15.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/15.ts
@@ -32,6 +32,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297246,
 				tcgplayer: 152870
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/15.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/15.ts
@@ -13,6 +13,7 @@ const card: Card = {
 		de: "Trank"
 	},
 
+	illustrator: "Toyste Beach",
 	rarity: "Uncommon",
 	category: "Trainer",
 
@@ -27,9 +28,15 @@ const card: Card = {
 
 	trainerType: "Item",
 
-	thirdParty: {
-		tcgplayer: 152870
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152870
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/16.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/16.ts
@@ -14,10 +14,25 @@ const card: Card = {
 		de: "Mabula"
 	},
 
+	illustrator: "Akira Komayama",
 	rarity: "Common",
 	category: "Pokemon",
 	hp: 70,
-	types: ["Grass"],
+	types: [
+		"Grass"
+	],
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				en: "Vice Grip"
+			},
+			damage: 20
+		},
+	],
 	stage: "Basic",
 	retreat: 2,
 
@@ -26,9 +41,15 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	thirdParty: {
-		tcgplayer: 152871
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152871
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/16.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/16.ts
@@ -45,6 +45,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297247,
 				tcgplayer: 152871
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/17.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/17.ts
@@ -73,6 +73,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297248,
 				tcgplayer: 152872
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/17.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/17.ts
@@ -17,7 +17,9 @@ const card: Card = {
 	rarity: "None",
 	category: "Pokemon",
 	hp: 110,
-	types: ["Lightning"],
+	types: [
+		"Lightning"
+	],
 
 	evolveFrom: {
 		en: "Pikachu",
@@ -67,9 +69,15 @@ const card: Card = {
 		value: "-20"
 	}],
 
-	thirdParty: {
-		tcgplayer: 152872
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152872
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/18.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/18.ts
@@ -14,10 +14,13 @@ const card: Card = {
 		de: "Kosturso"
 	},
 
+	illustrator: "kirisAki",
 	rarity: "Rare",
 	category: "Pokemon",
 	hp: 130,
-	types: ["Colorless"],
+	types: [
+		"Colorless"
+	],
 
 	evolveFrom: {
 		en: "Stufful",
@@ -28,6 +31,35 @@ const card: Card = {
 		de: "Velursi"
 	},
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				en: "Bear Hug"
+			},
+			effect: {
+				en: "The Defending Pokémon can't retreat during your opponent's next turn."
+			},
+			damage: 40
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				en: "Superpower"
+			},
+			effect: {
+				en: "You may do 40 more damage. If you do, this Pokémon does 20 damage to itself."
+			},
+			damage: "80+"
+		},
+	],
 	stage: "Stage1",
 	retreat: 3,
 
@@ -36,9 +68,15 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	thirdParty: {
-		tcgplayer: 152874
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152874
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/18.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/18.ts
@@ -72,6 +72,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297253,
 				tcgplayer: 152874
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/19.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/19.ts
@@ -13,6 +13,7 @@ const card: Card = {
 		de: "Tali"
 	},
 
+	illustrator: "Ken Sugimori",
 	rarity: "Uncommon",
 	category: "Trainer",
 
@@ -27,9 +28,15 @@ const card: Card = {
 
 	trainerType: "Supporter",
 
-	thirdParty: {
-		tcgplayer: 152840
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152842
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/19.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/19.ts
@@ -32,6 +32,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297254,
 				tcgplayer: 152842
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/2.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/2.ts
@@ -17,9 +17,15 @@ const card: Card = {
 	category: "Energy",
 	energyType: "Normal",
 
-	thirdParty: {
-		tcgplayer: 152851
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152852
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/2.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/2.ts
@@ -21,6 +21,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297233,
 				tcgplayer: 152852
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/20.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/20.ts
@@ -17,9 +17,15 @@ const card: Card = {
 	category: "Energy",
 	energyType: "Normal",
 
-	thirdParty: {
-		tcgplayer: 152858
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152858
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/20.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/20.ts
@@ -21,6 +21,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297249,
 				tcgplayer: 152858
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/21.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/21.ts
@@ -32,6 +32,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297255,
 				tcgplayer: 152846
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/21.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/21.ts
@@ -13,6 +13,7 @@ const card: Card = {
 		de: "Superball"
 	},
 
+	illustrator: "Ryo Ueda",
 	rarity: "Uncommon",
 	category: "Trainer",
 
@@ -27,9 +28,15 @@ const card: Card = {
 
 	trainerType: "Item",
 
-	thirdParty: {
-		tcgplayer: 152844
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152846
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/22.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/22.ts
@@ -57,6 +57,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297256,
 				tcgplayer: 152875
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/22.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/22.ts
@@ -14,10 +14,37 @@ const card: Card = {
 		de: "Traumato"
 	},
 
+	illustrator: "Suwama Chiaki",
 	rarity: "Common",
 	category: "Pokemon",
 	hp: 70,
-	types: ["Psychic"],
+	types: [
+		"Psychic"
+	],
+	attacks: [
+		{
+			cost: [
+				"Psychic",
+			],
+			name: {
+				en: "Psychic Boom"
+			},
+			effect: {
+				en: "This attack does 10 damage times the amount of Energy attached to your opponent's Active Pokémon."
+			},
+			damage: "10×"
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				en: "Headbutt"
+			},
+			damage: 20
+		},
+	],
 	stage: "Basic",
 	retreat: 2,
 
@@ -26,9 +53,15 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	thirdParty: {
-		tcgplayer: 152875
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152875
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/23.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/23.ts
@@ -32,6 +32,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297257,
 				tcgplayer: 152843
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/23.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/23.ts
@@ -13,6 +13,7 @@ const card: Card = {
 		de: "Tali"
 	},
 
+	illustrator: "Ken Sugimori",
 	rarity: "Uncommon",
 	category: "Trainer",
 
@@ -27,9 +28,15 @@ const card: Card = {
 
 	trainerType: "Supporter",
 
-	thirdParty: {
-		tcgplayer: 152841
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152843
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/24.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/24.ts
@@ -1,0 +1,31 @@
+import { Card } from '../../../interfaces'
+import Set from '../SM trainer Kit (Alolan Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Psychic Energy",
+	},
+
+	rarity: "None",
+	category: "Energy",
+	set: Set,
+	types: [
+		"Psychic",
+	],
+	retreat: 0,
+
+	thirdParty: {
+		tcgplayer: 152859,
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152859,
+			},
+		},
+	],
+}
+
+export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/24.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/24.ts
@@ -3,7 +3,7 @@ import Set from '../SM trainer Kit (Alolan Raichu)'
 
 const card: Card = {
 	name: {
-		en: "Psychic Energy",
+		en: "Psychic Energy"
 	},
 
 	rarity: "None",
@@ -14,18 +14,15 @@ const card: Card = {
 	],
 	retreat: 0,
 
-	thirdParty: {
-		tcgplayer: 152859,
-	},
-
 	variants: [
 		{
 			type: "normal",
 			thirdParty: {
-				tcgplayer: 152859,
-			},
+				tcgplayer: 152859
+			}
 		},
 	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/24.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/24.ts
@@ -18,6 +18,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297250,
 				tcgplayer: 152859
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/25.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/25.ts
@@ -13,6 +13,7 @@ const card: Card = {
 		de: "Superball"
 	},
 
+	illustrator: "Ryo Ueda",
 	rarity: "Uncommon",
 	category: "Trainer",
 
@@ -27,9 +28,15 @@ const card: Card = {
 
 	trainerType: "Item",
 
-	thirdParty: {
-		tcgplayer: 152845
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152847
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/25.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/25.ts
@@ -32,6 +32,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297258,
 				tcgplayer: 152847
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/26.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/26.ts
@@ -63,6 +63,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297251,
 				tcgplayer: 152877
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/26.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/26.ts
@@ -14,10 +14,38 @@ const card: Card = {
 		de: "Togedemaru"
 	},
 
+	illustrator: "Megumi Mizutani",
 	rarity: "Common",
 	category: "Pokemon",
 	hp: 70,
-	types: ["Lightning"],
+	types: [
+		"Lightning"
+	],
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				en: "Defense Curl"
+			},
+			effect: {
+				en: "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent's next turn."
+			}
+		},
+		{
+			cost: [
+				"Lightning",
+			],
+			name: {
+				en: "Discharge"
+			},
+			effect: {
+				en: "Discard all Lightning Energy from this Pokémon. This attack does 30 damage for each card you discarded in this way."
+			},
+			damage: "30×"
+		},
+	],
 	stage: "Basic",
 	retreat: 1,
 
@@ -31,9 +59,15 @@ const card: Card = {
 		value: "-20"
 	}],
 
-	thirdParty: {
-		tcgplayer: 152877
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152877
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/27.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/27.ts
@@ -18,6 +18,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297259,
 				tcgplayer: 152860
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/27.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/27.ts
@@ -3,7 +3,7 @@ import Set from '../SM trainer Kit (Alolan Raichu)'
 
 const card: Card = {
 	name: {
-		en: "Psychic Energy",
+		en: "Psychic Energy"
 	},
 
 	rarity: "None",
@@ -14,18 +14,15 @@ const card: Card = {
 	],
 	retreat: 0,
 
-	thirdParty: {
-		tcgplayer: 152860,
-	},
-
 	variants: [
 		{
 			type: "normal",
 			thirdParty: {
-				tcgplayer: 152860,
-			},
+				tcgplayer: 152860
+			}
 		},
 	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/27.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/27.ts
@@ -1,0 +1,31 @@
+import { Card } from '../../../interfaces'
+import Set from '../SM trainer Kit (Alolan Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Psychic Energy",
+	},
+
+	rarity: "None",
+	category: "Energy",
+	set: Set,
+	types: [
+		"Psychic",
+	],
+	retreat: 0,
+
+	thirdParty: {
+		tcgplayer: 152860,
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152860,
+			},
+		},
+	],
+}
+
+export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/28.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/28.ts
@@ -18,6 +18,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297252,
 				tcgplayer: 152861
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/28.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/28.ts
@@ -3,7 +3,7 @@ import Set from '../SM trainer Kit (Alolan Raichu)'
 
 const card: Card = {
 	name: {
-		en: "Psychic Energy",
+		en: "Psychic Energy"
 	},
 
 	rarity: "None",
@@ -14,18 +14,15 @@ const card: Card = {
 	],
 	retreat: 0,
 
-	thirdParty: {
-		tcgplayer: 152861,
-	},
-
 	variants: [
 		{
 			type: "normal",
 			thirdParty: {
-				tcgplayer: 152861,
-			},
+				tcgplayer: 152861
+			}
 		},
 	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/28.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/28.ts
@@ -1,0 +1,31 @@
+import { Card } from '../../../interfaces'
+import Set from '../SM trainer Kit (Alolan Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Psychic Energy",
+	},
+
+	rarity: "None",
+	category: "Energy",
+	set: Set,
+	types: [
+		"Psychic",
+	],
+	retreat: 0,
+
+	thirdParty: {
+		tcgplayer: 152861,
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152861,
+			},
+		},
+	],
+}
+
+export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/29.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/29.ts
@@ -63,6 +63,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297260,
 				tcgplayer: 152869
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/29.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/29.ts
@@ -17,7 +17,9 @@ const card: Card = {
 	rarity: "None",
 	category: "Pokemon",
 	hp: 60,
-	types: ["Lightning"],
+	types: [
+		"Lightning"
+	],
 	stage: "Basic",
 	retreat: 1,
 	illustrator: "kodama",
@@ -57,9 +59,15 @@ const card: Card = {
 		value: "-20"
 	}],
 
-	thirdParty: {
-		tcgplayer: 152869
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152869
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/3.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/3.ts
@@ -1,0 +1,29 @@
+import { Card } from '../../../interfaces'
+import Set from '../SM trainer Kit (Alolan Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Lightning Energy",
+	},
+
+	illustrator: "N/A",
+	rarity: "None",
+	category: "Energy",
+	set: Set,
+	retreat: 0,
+
+	thirdParty: {
+		tcgplayer: 152852,
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152852,
+			},
+		},
+	],
+}
+
+export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/3.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/3.ts
@@ -16,6 +16,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297234,
 				tcgplayer: 152852
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/3.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/3.ts
@@ -3,7 +3,7 @@ import Set from '../SM trainer Kit (Alolan Raichu)'
 
 const card: Card = {
 	name: {
-		en: "Lightning Energy",
+		en: "Lightning Energy"
 	},
 
 	illustrator: "N/A",
@@ -12,18 +12,15 @@ const card: Card = {
 	set: Set,
 	retreat: 0,
 
-	thirdParty: {
-		tcgplayer: 152852,
-	},
-
 	variants: [
 		{
 			type: "normal",
 			thirdParty: {
-				tcgplayer: 152852,
-			},
+				tcgplayer: 152852
+			}
 		},
 	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/30.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/30.ts
@@ -73,6 +73,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
+				cardmarket: 297261,
 				tcgplayer: 152873
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/30.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/30.ts
@@ -17,7 +17,9 @@ const card: Card = {
 	rarity: "None",
 	category: "Pokemon",
 	hp: 110,
-	types: ["Lightning"],
+	types: [
+		"Lightning"
+	],
 
 	evolveFrom: {
 		en: "Pikachu",
@@ -67,9 +69,15 @@ const card: Card = {
 		value: "-20"
 	}],
 
-	thirdParty: {
-		tcgplayer: 152873
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				tcgplayer: 152873
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/4.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/4.ts
@@ -45,6 +45,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297241,
 				tcgplayer: 152862
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/4.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/4.ts
@@ -14,10 +14,25 @@ const card: Card = {
 		de: "Velursi"
 	},
 
+	illustrator: "Sanosuke Sakuma",
 	rarity: "Common",
 	category: "Pokemon",
 	hp: 70,
-	types: ["Colorless"],
+	types: [
+		"Colorless"
+	],
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				en: "Tackle"
+			},
+			damage: 30
+		},
+	],
 	stage: "Basic",
 	retreat: 2,
 
@@ -26,9 +41,15 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	thirdParty: {
-		tcgplayer: 152862
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152862
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/5.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/5.ts
@@ -15,6 +15,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297235,
 				tcgplayer: 152853
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/5.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/5.ts
@@ -3,7 +3,7 @@ import Set from '../SM trainer Kit (Alolan Raichu)'
 
 const card: Card = {
 	name: {
-		en: "Lightning Energy",
+		en: "Lightning Energy"
 	},
 
 	rarity: "None",
@@ -11,18 +11,15 @@ const card: Card = {
 	set: Set,
 	retreat: 0,
 
-	thirdParty: {
-		tcgplayer: 152853,
-	},
-
 	variants: [
 		{
 			type: "normal",
 			thirdParty: {
-				tcgplayer: 152853,
-			},
+				tcgplayer: 152853
+			}
 		},
 	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/5.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/5.ts
@@ -1,0 +1,28 @@
+import { Card } from '../../../interfaces'
+import Set from '../SM trainer Kit (Alolan Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Lightning Energy",
+	},
+
+	rarity: "None",
+	category: "Energy",
+	set: Set,
+	retreat: 0,
+
+	thirdParty: {
+		tcgplayer: 152853,
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152853,
+			},
+		},
+	],
+}
+
+export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/6.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/6.ts
@@ -14,10 +14,13 @@ const card: Card = {
 		de: "Golbat"
 	},
 
+	illustrator: "Masakazu Fukuda",
 	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 80,
-	types: ["Psychic"],
+	types: [
+		"Psychic"
+	],
 
 	evolveFrom: {
 		en: "Zubat",
@@ -28,6 +31,32 @@ const card: Card = {
 		de: "Zubat"
 	},
 
+	attacks: [
+		{
+			cost: [
+				"Psychic",
+			],
+			name: {
+				en: "Super Poison Breath"
+			},
+			effect: {
+				en: "Your opponent's Active Pokémon is now Poisoned."
+			}
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				en: "Acrobatics"
+			},
+			effect: {
+				en: "Flip 2 coins. This attack does 20 more damage for each heads."
+			},
+			damage: "10+"
+		},
+	],
 	stage: "Stage1",
 	retreat: 0,
 
@@ -41,9 +70,15 @@ const card: Card = {
 		value: "-20"
 	}],
 
-	thirdParty: {
-		tcgplayer: 152863
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152863
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/6.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/6.ts
@@ -74,6 +74,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297236,
 				tcgplayer: 152863
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/7.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/7.ts
@@ -15,6 +15,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297237,
 				tcgplayer: 152854
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/7.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/7.ts
@@ -1,0 +1,28 @@
+import { Card } from '../../../interfaces'
+import Set from '../SM trainer Kit (Alolan Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Lightning Energy",
+	},
+
+	rarity: "None",
+	category: "Energy",
+	set: Set,
+	retreat: 0,
+
+	thirdParty: {
+		tcgplayer: 152854,
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152854,
+			},
+		},
+	],
+}
+
+export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/7.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/7.ts
@@ -3,7 +3,7 @@ import Set from '../SM trainer Kit (Alolan Raichu)'
 
 const card: Card = {
 	name: {
-		en: "Lightning Energy",
+		en: "Lightning Energy"
 	},
 
 	rarity: "None",
@@ -11,18 +11,15 @@ const card: Card = {
 	set: Set,
 	retreat: 0,
 
-	thirdParty: {
-		tcgplayer: 152854,
-	},
-
 	variants: [
 		{
 			type: "normal",
 			thirdParty: {
-				tcgplayer: 152854,
-			},
+				tcgplayer: 152854
+			}
 		},
 	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/8.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/8.ts
@@ -1,0 +1,28 @@
+import { Card } from '../../../interfaces'
+import Set from '../SM trainer Kit (Alolan Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Lightning Energy",
+	},
+
+	rarity: "None",
+	category: "Energy",
+	set: Set,
+	retreat: 0,
+
+	thirdParty: {
+		tcgplayer: 152855,
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152855,
+			},
+		},
+	],
+}
+
+export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/8.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/8.ts
@@ -15,6 +15,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297238,
 				tcgplayer: 152855
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/8.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/8.ts
@@ -3,7 +3,7 @@ import Set from '../SM trainer Kit (Alolan Raichu)'
 
 const card: Card = {
 	name: {
-		en: "Lightning Energy",
+		en: "Lightning Energy"
 	},
 
 	rarity: "None",
@@ -11,18 +11,15 @@ const card: Card = {
 	set: Set,
 	retreat: 0,
 
-	thirdParty: {
-		tcgplayer: 152855,
-	},
-
 	variants: [
 		{
 			type: "normal",
 			thirdParty: {
-				tcgplayer: 152855,
-			},
+				tcgplayer: 152855
+			}
 		},
 	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/9.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/9.ts
@@ -3,7 +3,7 @@ import Set from '../SM trainer Kit (Alolan Raichu)'
 
 const card: Card = {
 	name: {
-		en: "Lightning Energy",
+		en: "Lightning Energy"
 	},
 
 	rarity: "None",
@@ -11,18 +11,15 @@ const card: Card = {
 	set: Set,
 	retreat: 0,
 
-	thirdParty: {
-		tcgplayer: 152856,
-	},
-
 	variants: [
 		{
 			type: "normal",
 			thirdParty: {
-				tcgplayer: 152856,
-			},
+				tcgplayer: 152856
+			}
 		},
 	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/9.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/9.ts
@@ -1,0 +1,28 @@
+import { Card } from '../../../interfaces'
+import Set from '../SM trainer Kit (Alolan Raichu)'
+
+const card: Card = {
+	name: {
+		en: "Lightning Energy",
+	},
+
+	rarity: "None",
+	category: "Energy",
+	set: Set,
+	retreat: 0,
+
+	thirdParty: {
+		tcgplayer: 152856,
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152856,
+			},
+		},
+	],
+}
+
+export default card

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/9.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/9.ts
@@ -15,6 +15,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297239,
 				tcgplayer: 152856
 			}
 		},


### PR DESCRIPTION
closes #N/A

## Changes

- added cardmarket ids
- added tcgplayerids

## Details

- used tcgplayer source from https://www.pkmn.gg/series/sun-moon/sun-moon-trainer-kit-alolan-raichu
- used cardmarketsource from card market using json script

