### PR TITLE
(data) en tk-sm-l SM Trainer Kit Lycanroc - added card variants 

### DIFF
--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/1.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/1.ts
@@ -14,10 +14,36 @@ const card: Card = {
 		de: "Raupy"
 	},
 
+	illustrator: "Kanako Eo",
 	rarity: "Common",
 	category: "Pokemon",
 	hp: 50,
-	types: ["Grass"],
+	types: [
+		"Grass"
+	],
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				en: "Nap"
+			},
+			effect: {
+				en: "Heal 20 damage from this Pokémon."
+			}
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				en: "Gnaw"
+			},
+			damage: 20
+		},
+	],
 	stage: "Basic",
 	retreat: 1,
 
@@ -26,9 +52,15 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	thirdParty: {
-		tcgplayer: 152816
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152816
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/1.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/1.ts
@@ -56,6 +56,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297232,
 				tcgplayer: 152816
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/11.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/11.ts
@@ -61,6 +61,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297242,
 				tcgplayer: 152831
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/11.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/11.ts
@@ -14,10 +14,36 @@ const card: Card = {
 		de: "Dartiri"
 	},
 
+	illustrator: "You Iribi",
 	rarity: "Common",
 	category: "Pokemon",
 	hp: 50,
-	types: ["Colorless"],
+	types: [
+		"Colorless"
+	],
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				en: "Growl"
+			},
+			effect: {
+				en: "During your opponent's next turn, the Defending Pokémon's attacks do 20 less damage (before applying Weakness and Resistance)."
+			}
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				en: "Flap"
+			},
+			damage: 20
+		},
+	],
 	stage: "Basic",
 	retreat: 1,
 
@@ -31,9 +57,15 @@ const card: Card = {
 		value: "-20"
 	}],
 
-	thirdParty: {
-		tcgplayer: 152831
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152831
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/12.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/12.ts
@@ -14,10 +14,34 @@ const card: Card = {
 		de: "Mangunior"
 	},
 
+	illustrator: "match",
 	rarity: "Common",
 	category: "Pokemon",
 	hp: 70,
-	types: ["Colorless"],
+	types: [
+		"Colorless"
+	],
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				en: "Tackle"
+			},
+			damage: 10
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				en: "Bite"
+			},
+			damage: 20
+		},
+	],
 	stage: "Basic",
 	retreat: 1,
 
@@ -26,9 +50,15 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	thirdParty: {
-		tcgplayer: 152832
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152832
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/12.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/12.ts
@@ -54,6 +54,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297243,
 				tcgplayer: 152832
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/13.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/13.ts
@@ -14,10 +14,13 @@ const card: Card = {
 		de: "Dartignis"
 	},
 
+	illustrator: "kawayoo",
 	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 70,
-	types: ["Colorless"],
+	types: [
+		"Colorless"
+	],
 
 	evolveFrom: {
 		en: "Fletchling",
@@ -28,6 +31,30 @@ const card: Card = {
 		de: "Dartiri"
 	},
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				en: "Flap"
+			},
+			damage: 20
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				en: "Razor Wind"
+			},
+			effect: {
+				en: "Flip a coin. If tails, this attack does nothing."
+			},
+			damage: 40
+		},
+	],
 	stage: "Stage1",
 	retreat: 1,
 
@@ -41,9 +68,15 @@ const card: Card = {
 		value: "-20"
 	}],
 
-	thirdParty: {
-		tcgplayer: 152833
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152833
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/13.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/13.ts
@@ -72,6 +72,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297244,
 				tcgplayer: 152833
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/14.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/14.ts
@@ -14,10 +14,34 @@ const card: Card = {
 		de: "Wuffels"
 	},
 
+	illustrator: "match",
 	rarity: "Common",
 	category: "Pokemon",
 	hp: 60,
-	types: ["Fighting"],
+	types: [
+		"Fighting"
+	],
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				en: "Tackle"
+			},
+			damage: 10
+		},
+		{
+			cost: [
+				"Fighting",
+				"Colorless",
+			],
+			name: {
+				en: "Rock Throw"
+			},
+			damage: 20
+		},
+	],
 	stage: "Basic",
 	retreat: 1,
 
@@ -26,9 +50,15 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	thirdParty: {
-		tcgplayer: 152834
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152834
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/14.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/14.ts
@@ -54,6 +54,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297245,
 				tcgplayer: 152834
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/15.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/15.ts
@@ -14,10 +14,27 @@ const card: Card = {
 		de: "Peppeck"
 	},
 
+	illustrator: "Shin Nagasawa",
 	rarity: "Common",
 	category: "Pokemon",
 	hp: 50,
-	types: ["Colorless"],
+	types: [
+		"Colorless"
+	],
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				en: "Rock Smash"
+			},
+			effect: {
+				en: "Flip a coin. If heads, this attack does 10 more damage."
+			},
+			damage: "10+"
+		},
+	],
 	stage: "Basic",
 	retreat: 1,
 
@@ -31,9 +48,15 @@ const card: Card = {
 		value: "-20"
 	}],
 
-	thirdParty: {
-		tcgplayer: 152836
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152836
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/15.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/15.ts
@@ -52,6 +52,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297246,
 				tcgplayer: 152836
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/16.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/16.ts
@@ -17,7 +17,9 @@ const card: Card = {
 	rarity: "None",
 	category: "Pokemon",
 	hp: 110,
-	types: ["Fighting"],
+	types: [
+		"Fighting"
+	],
 
 	evolveFrom: {
 		en: "Rockruff",
@@ -57,9 +59,15 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	thirdParty: {
-		tcgplayer: 152837
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152837
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/16.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/16.ts
@@ -63,6 +63,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297247,
 				tcgplayer: 152837
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/18.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/18.ts
@@ -57,6 +57,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297253,
 				tcgplayer: 152839
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/18.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/18.ts
@@ -14,10 +14,37 @@ const card: Card = {
 		de: "Makuhita"
 	},
 
+	illustrator: "Mina Nakai",
 	rarity: "Common",
 	category: "Pokemon",
 	hp: 80,
-	types: ["Fighting"],
+	types: [
+		"Fighting"
+	],
+	attacks: [
+		{
+			cost: [
+				"Fighting",
+			],
+			name: {
+				en: "Surprise Attack"
+			},
+			effect: {
+				en: "Flip a coin. If tails, this attack does nothing."
+			},
+			damage: 20
+		},
+		{
+			cost: [
+				"Fighting",
+				"Colorless",
+			],
+			name: {
+				en: "Strength"
+			},
+			damage: 40
+		},
+	],
 	stage: "Basic",
 	retreat: 2,
 
@@ -26,9 +53,15 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	thirdParty: {
-		tcgplayer: 152839
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152839
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/19.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/19.ts
@@ -13,6 +13,7 @@ const card: Card = {
 		de: "Tali"
 	},
 
+	illustrator: "Ken Sugimori",
 	rarity: "Uncommon",
 	category: "Trainer",
 
@@ -27,9 +28,15 @@ const card: Card = {
 
 	trainerType: "Supporter",
 
-	thirdParty: {
-		tcgplayer: 152840
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152842
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/19.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/19.ts
@@ -32,6 +32,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297254,
 				tcgplayer: 152842
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/21.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/21.ts
@@ -32,6 +32,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297255,
 				tcgplayer: 152846
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/21.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/21.ts
@@ -13,6 +13,7 @@ const card: Card = {
 		de: "Superball"
 	},
 
+	illustrator: "Ryo Ueda",
 	rarity: "Uncommon",
 	category: "Trainer",
 
@@ -27,9 +28,15 @@ const card: Card = {
 
 	trainerType: "Item",
 
-	thirdParty: {
-		tcgplayer: 152844
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152846
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/22.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/22.ts
@@ -14,10 +14,13 @@ const card: Card = {
 		de: "Tukanon"
 	},
 
+	illustrator: "Megumi Mizutani",
 	rarity: "Rare",
 	category: "Pokemon",
 	hp: 140,
-	types: ["Colorless"],
+	types: [
+		"Colorless"
+	],
 
 	evolveFrom: {
 		en: "Trumbeak",
@@ -28,6 +31,35 @@ const card: Card = {
 		de: "Trompeck"
 	},
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				en: "Echoed Voice"
+			},
+			effect: {
+				en: "During your next turn, this Pokémon's Echoed Voice attack does 60 more damage (before applying Weakness and Resistance)."
+			},
+			damage: 60
+		},
+		{
+			cost: [
+				"Colorless",
+				"Colorless",
+				"Colorless",
+			],
+			name: {
+				en: "Beak Blast"
+			},
+			effect: {
+				en: "Flip a coin. If heads, your opponent's Active Pokémon is now Burned."
+			},
+			damage: 100
+		},
+	],
 	stage: "Stage2",
 	retreat: 2,
 
@@ -41,9 +73,15 @@ const card: Card = {
 		value: "-20"
 	}],
 
-	thirdParty: {
-		tcgplayer: 152848
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152848
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/22.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/22.ts
@@ -77,6 +77,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297256,
 				tcgplayer: 152848
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/23.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/23.ts
@@ -32,6 +32,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297257,
 				tcgplayer: 152843
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/23.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/23.ts
@@ -13,6 +13,7 @@ const card: Card = {
 		de: "Tali"
 	},
 
+	illustrator: "Ken Sugimori",
 	rarity: "Uncommon",
 	category: "Trainer",
 
@@ -27,9 +28,15 @@ const card: Card = {
 
 	trainerType: "Supporter",
 
-	thirdParty: {
-		tcgplayer: 152841
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152843
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/25.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/25.ts
@@ -13,6 +13,7 @@ const card: Card = {
 		de: "Superball"
 	},
 
+	illustrator: "Ryo Ueda",
 	rarity: "Uncommon",
 	category: "Trainer",
 
@@ -27,9 +28,15 @@ const card: Card = {
 
 	trainerType: "Item",
 
-	thirdParty: {
-		tcgplayer: 152845
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152847
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/25.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/25.ts
@@ -32,6 +32,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297258,
 				tcgplayer: 152847
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/27.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/27.ts
@@ -32,6 +32,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297259,
 				tcgplayer: 152849
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/27.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/27.ts
@@ -13,6 +13,7 @@ const card: Card = {
 		de: "Maxi-Malasada"
 	},
 
+	illustrator: "5ban Graphics",
 	rarity: "Uncommon",
 	category: "Trainer",
 
@@ -27,9 +28,15 @@ const card: Card = {
 
 	trainerType: "Item",
 
-	thirdParty: {
-		tcgplayer: 152849
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152849
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/29.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/29.ts
@@ -14,10 +14,34 @@ const card: Card = {
 		de: "Wuffels"
 	},
 
+	illustrator: "match",
 	rarity: "Common",
 	category: "Pokemon",
 	hp: 60,
-	types: ["Fighting"],
+	types: [
+		"Fighting"
+	],
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				en: "Tackle"
+			},
+			damage: 10
+		},
+		{
+			cost: [
+				"Fighting",
+				"Colorless",
+			],
+			name: {
+				en: "Rock Throw"
+			},
+			damage: 20
+		},
+	],
 	stage: "Basic",
 	retreat: 1,
 
@@ -26,9 +50,15 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	thirdParty: {
-		tcgplayer: 152835
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152835
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/29.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/29.ts
@@ -54,6 +54,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297260,
 				tcgplayer: 152835
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/30.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/30.ts
@@ -63,6 +63,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
+				cardmarket: 297261,
 				tcgplayer: 152838
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/30.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/30.ts
@@ -17,7 +17,9 @@ const card: Card = {
 	rarity: "None",
 	category: "Pokemon",
 	hp: 110,
-	types: ["Fighting"],
+	types: [
+		"Fighting"
+	],
 
 	evolveFrom: {
 		en: "Rockruff",
@@ -57,9 +59,15 @@ const card: Card = {
 		value: "×2"
 	}],
 
-	thirdParty: {
-		tcgplayer: 152838
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				tcgplayer: 152838
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/4.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/4.ts
@@ -62,6 +62,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297241,
 				tcgplayer: 152830
 			}
 		},

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/4.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/4.ts
@@ -14,10 +14,13 @@ const card: Card = {
 		de: "Trompeck"
 	},
 
+	illustrator: "Kouki Saitou",
 	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 80,
-	types: ["Colorless"],
+	types: [
+		"Colorless"
+	],
 
 	evolveFrom: {
 		en: "Pikipek",
@@ -28,6 +31,20 @@ const card: Card = {
 		de: "Peppeck"
 	},
 
+	attacks: [
+		{
+			cost: [
+				"Colorless",
+			],
+			name: {
+				en: "Bullet Seed"
+			},
+			effect: {
+				en: "Flip 4 coins. This attack does 20 damage for each heads."
+			},
+			damage: "20×"
+		},
+	],
 	stage: "Stage1",
 	retreat: 1,
 
@@ -41,9 +58,15 @@ const card: Card = {
 		value: "-20"
 	}],
 
-	thirdParty: {
-		tcgplayer: 152830
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152830
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/5.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/5.ts
@@ -17,9 +17,15 @@ const card: Card = {
 	category: "Energy",
 	energyType: "Normal",
 
-	thirdParty: {
-		tcgplayer: 152819
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 152819
+			}
+		},
+	],
+
 }
 
 export default card

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/5.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/5.ts
@@ -21,6 +21,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
+				cardmarket: 297235,
 				tcgplayer: 152819
 			}
 		},


### PR DESCRIPTION
closes #N/A

## Changes

- added cardmarket ids
- added tcgplayerids

## Details

- used tcgplayer source from https://www.pkmn.gg/series/sun-moon/sun-moon-trainer-kit-lycanroc
- used cardmarketsource from card market using json script

