### PR TITLE
(data) en swsh10.5 Pokemon Go - added card variants

### DIFF
--- a/data/Sword & Shield/Pokémon GO/006.ts
+++ b/data/Sword & Shield/Pokémon GO/006.ts
@@ -59,7 +59,7 @@ const card: Card = {
 		en: "Although the poison from its fangs isn't that strong, it's potent enough to weaken prey that gets caught in its web.",
 	},
 
-	
+
 
 	variants: [
 		{
@@ -74,6 +74,13 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 665655,
 				tcgplayer: 276944
+			}
+		},
+		{
+			type: 'reverse',
+			subtype: 'peelable-ditto',
+			thirdParty: {
+				tcgplayer: 277793
 			}
 		},
 	],

--- a/data/Sword & Shield/Pokémon GO/013.ts
+++ b/data/Sword & Shield/Pokémon GO/013.ts
@@ -72,7 +72,7 @@ const card: Card = {
 		en: "The magma in its body reaches 2,200 degrees Fahrenheit. Its hump gets smaller when it uses Fire-type moves.",
 	},
 
-	
+
 
 	variants: [
 		{
@@ -87,6 +87,13 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 665657,
 				tcgplayer: 276947
+			}
+		},
+		{
+			type: 'reverse',
+			subtype: 'peelable-ditto',
+			thirdParty: {
+				tcgplayer: 277791
 			}
 		},
 	],

--- a/data/Sword & Shield/Pokémon GO/027.ts
+++ b/data/Sword & Shield/Pokémon GO/027.ts
@@ -59,7 +59,7 @@ const card: Card = {
 		en: "Pikachu that can generate powerful electricity have cheek sacs that are extra soft and super stretchy.",
 	},
 
-	
+
 
 	variants: [
 		{
@@ -74,6 +74,14 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 665260,
 				tcgplayer: 276946
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 669496,
+				tcgplayer: 279927
 			}
 		},
 	],

--- a/data/Sword & Shield/Pokémon GO/029.ts
+++ b/data/Sword & Shield/Pokémon GO/029.ts
@@ -72,7 +72,7 @@ const card: Card = {
 		en: "This Pokémon has complete control over electricity. There are tales of Zapdos nesting in the dark depths of pitch-black thunderclouds.",
 	},
 
-	
+
 
 	variants: [
 		{
@@ -87,6 +87,14 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 665264,
 				tcgplayer: 276954
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['jesse-parker'],
+			thirdParty: {
+				cardmarket: 815464,
+				tcgplayer: 637603
 			}
 		},
 	],

--- a/data/Sword & Shield/Pokémon GO/030.ts
+++ b/data/Sword & Shield/Pokémon GO/030.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	regulationMark: "F",
 
 
-	
+
 
 	variants: [
 		{
@@ -83,6 +83,14 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 665266,
 				tcgplayer: 276960
+			}
+		},
+		{
+			type: 'holo',
+			stamp: ['player-rewards-program'],
+			thirdParty: {
+				cardmarket: 728200,
+				tcgplayer: 513796
 			}
 		},
 	],

--- a/data/Sword & Shield/Pokémon GO/052.ts
+++ b/data/Sword & Shield/Pokémon GO/052.ts
@@ -80,7 +80,7 @@ const card: Card = {
 		en: "Whenever a Blissey finds a weakened Pokémon, it will share its egg and offer its care until the other Pokémon is all better.",
 	},
 
-	
+
 
 	variants: [
 		{
@@ -95,6 +95,14 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 665274,
 				tcgplayer: 276967
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 669498,
+				tcgplayer: 279929
 			}
 		},
 	],

--- a/data/Sword & Shield/Pokémon GO/058.ts
+++ b/data/Sword & Shield/Pokémon GO/058.ts
@@ -69,7 +69,7 @@ const card: Card = {
 	regulationMark: "F",
 
 
-	
+
 
 	variants: [
 		{
@@ -77,6 +77,14 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 665677,
 				tcgplayer: 276980
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['gabriel-fernandez'],
+			thirdParty: {
+				cardmarket: 833048,
+				tcgplayer: 541774
 			}
 		},
 	],

--- a/data/Sword & Shield/Pokémon GO/059.ts
+++ b/data/Sword & Shield/Pokémon GO/059.ts
@@ -59,7 +59,7 @@ const card: Card = {
 		en: "It constantly gnaws on logs and rocks to whittle down its front teeth. It nests alongside water.",
 	},
 
-	
+
 
 	variants: [
 		{
@@ -74,6 +74,13 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 665282,
 				tcgplayer: 276982
+			}
+		},
+		{
+			type: 'reverse',
+			subtype: 'peelable-ditto',
+			thirdParty: {
+				tcgplayer: 277788
 			}
 		},
 	],

--- a/data/Sword & Shield/Pokémon GO/068.ts
+++ b/data/Sword & Shield/Pokémon GO/068.ts
@@ -30,7 +30,7 @@ const card: Card = {
 	regulationMark: "F",
 
 
-	
+
 
 	variants: [
 		{
@@ -45,6 +45,21 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 665288,
 				tcgplayer: 276996
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['shao-tong-yen'],
+			thirdParty: {
+				cardmarket: 833226,
+				tcgplayer: 542083
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['sakuya-ota'],
+			thirdParty: {
+				cardmarket: 815426
 			}
 		},
 	],

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -36,6 +36,7 @@ export type VariantStamps = '1st-edition' | 'w-promo' | 'pre-release' | 'pokemon
 	| "international-championship-europe" | "international-championship-latin-america" | "international-championship-north-america" | 'ace-trainer'
 	| 'pikachu' | 'bulbasaur' | 'squirtle' | 'charmander' | 'pokeball' | '30th-pokeday' | 'mcdonalds' | 'pokemon-together' | 'rain-city' | 'tournament-collection'
 	| 'worlds-2024' | 'worlds-2023' | 'asia-2023-24' | 'thank-you' | 'jr-stamp-rally' | 'grey-star' | 'pop-tournament' | 'chase-moloney' | 'chicago-2009'
+	| 'jesse-parker' | 'gabriel-fernandez' | 'sakuya-ota' | 'shao-tong-yen'
 
 export interface variant_detailed {
 	/**
@@ -55,7 +56,7 @@ export interface variant_detailed {
 		| 'missing-hp' | 'aoki-error' | '1999-copyright' | 'evolution-box-error' | 'no-holo-error' | 'd-ink-dot-error'
 		| 'energy-symbol-error' | 'text-error' | 'shifted-energy-cost' | 'japanese-back' | 'no-e-reader' | 'rarity-error'
 		| 'cosmos' | 'blue-border' | 'glossy' | 'shadowless-red-cheek' | '2019-copyright' | '2020-copyright' | 'nintedo-error' 
-		| '1995-1998-copyright' | 'no-rarity' | 'phanphy-error'
+		| '1995-1998-copyright' | 'no-rarity' | 'phanphy-error' | 'peelable-ditto'
 
 	/**
 	 * define the size of the card

--- a/meta/translations/de.json
+++ b/meta/translations/de.json
@@ -298,8 +298,8 @@
 		"nintedo-error": "Nintedo-Fehler",
 		"1995-1998-copyright": "Copyright 1995-1998",
 		"no-rarity": "Ohne Seltenheit",
-		"phanphy-error" : "phanphy-fehler",
-		"peelable-ditto": "Abziehbares Ditto"
-		"missing-retreat-cost": "Fehlende Rückzugskosten",
+		"phanphy-error": "phanphy-fehler",
+		"peelable-ditto": "Abziehbares Ditto",
+		"missing-retreat-cost": "Fehlende Rückzugskosten"
 	}
 }

--- a/meta/translations/de.json
+++ b/meta/translations/de.json
@@ -292,6 +292,7 @@
 		"nintedo-error": "Nintedo-Fehler",
 		"1995-1998-copyright": "Copyright 1995-1998",
 		"no-rarity": "Ohne Seltenheit",
-		"phanphy-error" : "phanphy-fehler"
+		"phanphy-error" : "phanphy-fehler",
+		"peelable-ditto": "Abziehbares Ditto"
 	}
 }

--- a/meta/translations/de.json
+++ b/meta/translations/de.json
@@ -264,7 +264,11 @@
 		"grey-star": "grauer stern",
 		"pop-tournament": "pop-tournament",
 		"chicago-2009": "chicago-2009",
-		"chase-moloney": "chase-moloney"
+		"chase-moloney": "chase-moloney",
+		"jesse-parker": "jesse-parker",
+		"gabriel-fernandez": "gabriel-fernandez",
+		"shao-tong-yen": "shao-tong-yen",
+		"sakuya-ota": "sakuya-ota"
 	},
 	"variantSubtype": {
 		"shadowless": "schattenlos",

--- a/meta/translations/es.json
+++ b/meta/translations/es.json
@@ -264,7 +264,11 @@
 		"grey-star": "estrella gris",
 		"pop-tournament": "pop-tournament",
 		"chicago-2009": "chicago-2009",
-		"chase-moloney": "chase-moloney"
+		"chase-moloney": "chase-moloney",
+		"jesse-parker": "jesse-parker",
+		"gabriel-fernandez": "gabriel-fernandez",
+		"shao-tong-yen": "shao-tong-yen",
+		"sakuya-ota": "sakuya-ota"
 	},
 	"variantSubtype": {
 		"shadowless": "sin sombra",

--- a/meta/translations/es.json
+++ b/meta/translations/es.json
@@ -298,8 +298,8 @@
 		"nintedo-error": "Error Nintedo",
 		"1995-1998-copyright": "Copyright 1995-1998",
 		"no-rarity": "Sin rareza",
-		"phanphy-error" : "Error de phanphy",
-		"peelable-ditto": "Ditto despegable"
-		"missing-retreat-cost": "Coste de retirada ausente",
+		"phanphy-error": "Error de phanphy",
+		"peelable-ditto": "Ditto despegable",
+		"missing-retreat-cost": "Coste de retirada ausente"
 	}
 }

--- a/meta/translations/es.json
+++ b/meta/translations/es.json
@@ -292,6 +292,7 @@
 		"nintedo-error": "Error Nintedo",
 		"1995-1998-copyright": "Copyright 1995-1998",
 		"no-rarity": "Sin rareza",
-		"phanphy-error" : "Error de phanphy"
+		"phanphy-error" : "Error de phanphy",
+		"peelable-ditto": "Ditto despegable"
 	}
 }

--- a/meta/translations/fr.json
+++ b/meta/translations/fr.json
@@ -298,8 +298,8 @@
 		"nintedo-error": "Erreur Nintedo",
 		"1995-1998-copyright": "Copyright 1995-1998",
 		"no-rarity": "Sans rareté",
-		"phanphy-error" : "Erreur de phanphy",
-		"peelable-ditto": "Ditto décollable"
-		"missing-retreat-cost": "Coût de retraite manquant",
+		"phanphy-error": "Erreur de phanphy",
+		"peelable-ditto": "Ditto décollable",
+		"missing-retreat-cost": "Coût de retraite manquant"
 	}
 }

--- a/meta/translations/fr.json
+++ b/meta/translations/fr.json
@@ -292,6 +292,7 @@
 		"nintedo-error": "Erreur Nintedo",
 		"1995-1998-copyright": "Copyright 1995-1998",
 		"no-rarity": "Sans rareté",
-		"phanphy-error" : "Erreur de phanphy"
+		"phanphy-error" : "Erreur de phanphy",
+		"peelable-ditto": "Ditto décollable"
 	}
 }

--- a/meta/translations/fr.json
+++ b/meta/translations/fr.json
@@ -263,7 +263,11 @@
 		"grey-star": "étoile grise",
 		"pop-tournament": "pop-tournament",
 		"chicago-2009": "chicago-2009",
-		"chase-moloney": "chase-moloney"
+		"chase-moloney": "chase-moloney",
+		"jesse-parker": "jesse-parker",
+		"gabriel-fernandez": "gabriel-fernandez",
+		"shao-tong-yen": "shao-tong-yen",
+		"sakuya-ota": "sakuya-ota"
 	},
 	"variantSubtype": {
 		"shadowless": "sans ombre",

--- a/meta/translations/it.json
+++ b/meta/translations/it.json
@@ -292,6 +292,7 @@
 		"1995-1998-copyright": "Copyright 1995-1998",
 		"shadowless-red-cheek": "guancia rossa senza ombre",
 		"no-rarity": "Senza rarità",
-		"phanphy-error" : "Errore di phanphy"
+		"phanphy-error" : "Errore di phanphy",
+		"peelable-ditto": "Ditto rimovibile"
 	}
 }

--- a/meta/translations/it.json
+++ b/meta/translations/it.json
@@ -298,8 +298,8 @@
 		"1995-1998-copyright": "Copyright 1995-1998",
 		"shadowless-red-cheek": "guancia rossa senza ombre",
 		"no-rarity": "Senza rarità",
-		"phanphy-error" : "Errore di phanphy",
-		"peelable-ditto": "Ditto rimovibile"
-		"missing-retreat-cost": "Costo di ritirata mancante",
+		"phanphy-error": "Errore di phanphy",
+		"peelable-ditto": "Ditto rimovibile",
+		"missing-retreat-cost": "Costo di ritirata mancante"
 	}
 }

--- a/meta/translations/it.json
+++ b/meta/translations/it.json
@@ -264,7 +264,11 @@
 		"grey-star": "grey-star",
 		"pop-tournament": "pop-tournament",
 		"chicago-2009": "chicago-2009",
-		"chase-moloney": "chase-moloney"
+		"chase-moloney": "chase-moloney",
+		"jesse-parker": "jesse-parker",
+		"gabriel-fernandez": "gabriel-fernandez",
+		"shao-tong-yen": "shao-tong-yen",
+		"sakuya-ota": "sakuya-ota"
 	},
 	"variantSubtype": {
 		"shadowless": "senza ombra",

--- a/meta/translations/pt.json
+++ b/meta/translations/pt.json
@@ -297,8 +297,8 @@
 		"nintedo-error": "Erro de Nintedo",
 		"1995-1998-copyright": "Copyright 1995-1998",
 		"no-rarity": "Sem raridade",
-		"phanphy-error" : "error de phanphy",
-		"peelable-ditto": "Ditto destacável"
-		"misisng-retreat-cost" : "Custo de recuo ausente",
+		"phanphy-error": "error de phanphy",
+		"peelable-ditto": "Ditto destacável",
+		"misisng-retreat-cost": "Custo de recuo ausente"
 	}
 }

--- a/meta/translations/pt.json
+++ b/meta/translations/pt.json
@@ -291,6 +291,7 @@
 		"nintedo-error": "Erro de Nintedo",
 		"1995-1998-copyright": "Copyright 1995-1998",
 		"no-rarity": "Sem raridade",
-		"phanphy-error" : "error de phanphy"
+		"phanphy-error" : "error de phanphy",
+		"peelable-ditto": "Ditto destacável"
 	}
 }

--- a/meta/translations/pt.json
+++ b/meta/translations/pt.json
@@ -263,7 +263,11 @@
 		"grey-star": "estrela cinza",
 		"pop-tournament": "pop-tournament",
 		"chicago-2009": "chicago-2009",
-		"chase-moloney": "chase-moloney"
+		"chase-moloney": "chase-moloney",
+		"jesse-parker": "jesse-parker",
+		"gabriel-fernandez": "gabriel-fernandez",
+		"shao-tong-yen": "shao-tong-yen",
+		"sakuya-ota": "sakuya-ota"
 	},
 	"variantSubtype": {
 		"shadowless": "sem sombra",


### PR DESCRIPTION
closes #N/A

## Changes
- added new subtype `peelable-ditto`
- added peelable ditto cards (spinarak, numel, bidoof)
- added championship cards
- added cosmo holo tin exclusive variants (pikachu and blissey)

## Details
| Name | Variant | Image |
|---|------|------|
| 6 |  Spinarak (Ditto) | <img width="200" height="280" alt="image" src="https://github.com/user-attachments/assets/d266d9b8-9e1f-4e98-8534-94a548bc18d8" />|
| 13 |  Numel (Ditto) | <img width="200" height="280" alt="image" src="https://github.com/user-attachments/assets/f70fab72-68f0-4e08-a88f-a96598cc65d7" />|
| 27 |  Pikachu (Cosmo Holo) | 
| 29 |  Zapdos (Jesse Parker) |  <img width="200" height="280" alt="image" src="https://github.com/user-attachments/assets/04751737-2fa9-432f-bbe2-ed6b79c218aa" />|
| 30 |  Mewtwo (Player Rewards Program) |  <img width="200" height="280" alt="image" src="https://github.com/user-attachments/assets/0fe8f068-5db2-490a-b200-973527b6c39e" />|
| 52 |  Blissey (Cosmo Holo) | 
| 58 |  Slaking V (Gabriel Fernandez) | <img width="200" height="280" alt="image" src="https://github.com/user-attachments/assets/222f63f6-6ee0-42b4-8dda-c6903470b906" />|
| 59 |  Bidoof (Ditto) | <img width="200" height="280" alt="image" src="https://github.com/user-attachments/assets/e3b55e9a-028b-47ea-81da-af2ec3eae672" />|
| 68 | Pokestop (shao tong yen) and (sakuya ota)| <img width="200" height="280" alt="image" src="https://github.com/user-attachments/assets/92865021-9b87-4401-adf1-c18133ece905" /><img width="200" height="280" alt="image" src="https://github.com/user-attachments/assets/3a359c4f-7274-4afc-bed9-8678611cb5b8" />|