### PR TITLE
Add missing variants to me05: 028, 035, 056, 062, 070 and 083

### DIFF
--- a/data/Mega Evolution/Pitch Black/028.ts
+++ b/data/Mega Evolution/Pitch Black/028.ts
@@ -95,6 +95,13 @@ const card: Card = {
 				tcgplayer: 704785
 			}
 		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895815,
+				tcgplayer: 704785
+			}
+		}
 	],
 }
 

--- a/data/Mega Evolution/Pitch Black/035.ts
+++ b/data/Mega Evolution/Pitch Black/035.ts
@@ -73,6 +73,13 @@ const card: Card = {
 				tcgplayer: 704792
 			}
 		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895822,
+				tcgplayer: 704792
+			}
+		}
 	],
 }
 

--- a/data/Mega Evolution/Pitch Black/056.ts
+++ b/data/Mega Evolution/Pitch Black/056.ts
@@ -95,6 +95,13 @@ const card: Card = {
 				tcgplayer: 704813
 			}
 		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895841,
+				tcgplayer: 704813
+			}
+		}
 	],
 }
 

--- a/data/Mega Evolution/Pitch Black/062.ts
+++ b/data/Mega Evolution/Pitch Black/062.ts
@@ -87,6 +87,13 @@ const card: Card = {
 				tcgplayer: 704819
 			}
 		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895847,
+				tcgplayer: 704819
+			}
+		}
 	],
 }
 

--- a/data/Mega Evolution/Pitch Black/070.ts
+++ b/data/Mega Evolution/Pitch Black/070.ts
@@ -93,6 +93,13 @@ const card: Card = {
 				tcgplayer: 704827
 			}
 		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895854,
+				tcgplayer: 704827
+			}
+		}
 	],
 }
 

--- a/data/Mega Evolution/Pitch Black/083.ts
+++ b/data/Mega Evolution/Pitch Black/083.ts
@@ -41,7 +41,7 @@ const card: Card = {
 			type: "reverse",
 			thirdParty: {
 				cardmarket: 895847,
-				tcgplayer: 704840,
+				tcgplayer: 704840
 			}
 		}
 	],

--- a/data/Mega Evolution/Pitch Black/083.ts
+++ b/data/Mega Evolution/Pitch Black/083.ts
@@ -37,6 +37,13 @@ const card: Card = {
 				tcgplayer: 704840
 			}
 		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895847,
+				tcgplayer: 704840,
+			}
+		}
 	],
 }
 


### PR DESCRIPTION
## Changes

- Add missing holo variant to 028 - Miraidon
- Add missing holo variant to 035 - Spiritbomb
- Add missing holo variant to 056 - Zarude
- Add missing reverse variant to 062 - Bastiodon
- Add missing reverse variant to 070 - Silvally
- Add missing reverse variant to 083 - Shadowy Darkness Energy