### PR TITLE
(data) en ex6 FireRed LeafGreen - added card variants 

### DIFF
--- a/data/EX/FireRed & LeafGreen/1.ts
+++ b/data/EX/FireRed & LeafGreen/1.ts
@@ -76,21 +76,30 @@ const card: Card = {
 		},
 	],
 
-	
 	retreat: 0,
-
-	thirdParty: {
-		cardmarket: 276177,
-		tcgplayer: 83769
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276177,
+				tcgplayer: 83769
+			},
 		},
 		{
 			type: "holo",
-			foil: "energy"
+			thirdParty: {
+				cardmarket: 276177,
+				tcgplayer: 83769
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276177,
+				tcgplayer: 83769
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/1.ts
+++ b/data/EX/FireRed & LeafGreen/1.ts
@@ -80,13 +80,6 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal",
-			thirdParty: {
-				cardmarket: 276177,
-				tcgplayer: 83769
-			},
-		},
-		{
 			type: "holo",
 			thirdParty: {
 				cardmarket: 276177,

--- a/data/EX/FireRed & LeafGreen/10.ts
+++ b/data/EX/FireRed & LeafGreen/10.ts
@@ -81,37 +81,57 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 0,
 
-	thirdParty: {
-		cardmarket: 276186,
-		tcgplayer: 88031
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276186,
+				tcgplayer: 88031
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276186,
+				tcgplayer: 88031
+			},
 		},
 		{
 			type: "holo",
-			foil: "energy"
+			stamp: ["takashi-yoneda"],
+			thirdParty: {
+				cardmarket: 871522,
+				tcgplayer: 477560
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["takashi-yoneda"]
+			stamp: ["jeremy-maron"],
+			thirdParty: {
+				cardmarket: 871521,
+				tcgplayer: 477561
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["jeremy-maron"]
+			stamp: ["hiroki-yano"],
+			thirdParty: {
+				cardmarket: 869519,
+				tcgplayer: 477881
+			}
 		},
 		{
 			type: "holo",
-			stamp: ["hiroki-yano"]
-		},
-		{
-			type: "holo",
-			stamp: ["jimmy-ballard"]
+			stamp: ["jimmy-ballard"],
+			thirdParty: {
+				cardmarket: 869520,
+				tcgplayer: 477882
+			}
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/100.ts
+++ b/data/EX/FireRed & LeafGreen/100.ts
@@ -20,20 +20,24 @@ const card: Card = {
 		de: "Search your dicard pile for a Supporter card, show it to your opponent, and put it into your hand."
 	},
 
-	thirdParty: {
-		cardmarket: 276276,
-		tcgplayer: 90426
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276276,
+				tcgplayer: 90426
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276276,
+				tcgplayer: 90426
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/101.ts
+++ b/data/EX/FireRed & LeafGreen/101.ts
@@ -20,20 +20,24 @@ const card: Card = {
 		de: "Entferne 2 Schadensmarken von 1 deiner Pokémon (1 falls dieses nur 1 hat).",
 	},
 
-	thirdParty: {
-		cardmarket: 276277,
-		tcgplayer: 88334
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276277,
+				tcgplayer: 88334
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276277,
+				tcgplayer: 88334
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/102.ts
+++ b/data/EX/FireRed & LeafGreen/102.ts
@@ -20,20 +20,24 @@ const card: Card = {
 		de: "Switch 1 of your Active Pokémon with 1 of your Benched Pokémon."
 	},
 
-	thirdParty: {
-		cardmarket: 276278,
-		tcgplayer: 89712
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276278,
+				tcgplayer: 89712
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276278,
+				tcgplayer: 89712
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/103.ts
+++ b/data/EX/FireRed & LeafGreen/103.ts
@@ -20,20 +20,24 @@ const card: Card = {
 		fr: "Attachez Énergies multiples à un de vos Pokémon. Lorsqu'elle est en jeu, Énergies multiples fournit tous les types d'énergie (un seul à la fois). (Elle ne compte pas comme carte Énergie de base lorsqu'elle n'est pas en jeu). Énergies multiples fournit une énergie Incolore lorsqu'elle est attachée à un Pokémon qui possède déjà des cartes Énergie Spéciales.",
 	},
 
-	thirdParty: {
-		cardmarket: 276279,
-		tcgplayer: 87630
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276279,
+				tcgplayer: 87630
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276279,
+				tcgplayer: 87630
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/104.ts
+++ b/data/EX/FireRed & LeafGreen/104.ts
@@ -76,23 +76,26 @@ const card: Card = {
 		},
 	],
 
-	
 	retreat: 3,
 
-	thirdParty: {
-		cardmarket: 276280,
-		tcgplayer: 83900
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276280,
+				tcgplayer: 83900
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["hiroki-yano"]
+			stamp: ["hiroki-yano"],
+			thirdParty: {
+				cardmarket: 869512,
+				tcgplayer: 477601
+			},
 		},
-	]
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/105.ts
+++ b/data/EX/FireRed & LeafGreen/105.ts
@@ -96,17 +96,16 @@ const card: Card = {
 		},
 	],
 
-	
-	retreat: 2,
 
-	thirdParty: {
-		cardmarket: 276281,
-		tcgplayer: 84199
-	},
+	retreat: 2,
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276281,
+				tcgplayer: 84199
+			},
 		},
 	]
 }

--- a/data/EX/FireRed & LeafGreen/106.ts
+++ b/data/EX/FireRed & LeafGreen/106.ts
@@ -71,17 +71,16 @@ const card: Card = {
 		},
 	],
 
-	
-	retreat: 2,
 
-	thirdParty: {
-		cardmarket: 276282,
-		tcgplayer: 84350
-	},
+	retreat: 2,
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276282,
+				tcgplayer: 84350
+			},
 		},
 	]
 }

--- a/data/EX/FireRed & LeafGreen/107.ts
+++ b/data/EX/FireRed & LeafGreen/107.ts
@@ -74,17 +74,16 @@ const card: Card = {
 		},
 	],
 
-	
-	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276283,
-		tcgplayer: 85165
-	},
+	retreat: 1,
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276283,
+				tcgplayer: 85165
+			},
 		},
 	]
 }

--- a/data/EX/FireRed & LeafGreen/108.ts
+++ b/data/EX/FireRed & LeafGreen/108.ts
@@ -92,17 +92,15 @@ const card: Card = {
 		},
 	],
 
-	
 	retreat: 2,
-
-	thirdParty: {
-		cardmarket: 276284,
-		tcgplayer: 85680
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276284,
+				tcgplayer: 85680
+			},
 		},
 	]
 }

--- a/data/EX/FireRed & LeafGreen/109.ts
+++ b/data/EX/FireRed & LeafGreen/109.ts
@@ -75,17 +75,17 @@ const card: Card = {
 		},
 	],
 
-	
-	retreat: 3,
 
-	thirdParty: {
-		cardmarket: 276285,
-		tcgplayer: 86004
-	},
+	retreat: 3,
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276285,
+				tcgplayer: 86004
+			},
+
 		},
 	]
 }

--- a/data/EX/FireRed & LeafGreen/11.ts
+++ b/data/EX/FireRed & LeafGreen/11.ts
@@ -93,21 +93,24 @@ const card: Card = {
 		},
 	],
 
-	
-	retreat: 2,
 
-	thirdParty: {
-		cardmarket: 276187,
-		tcgplayer: 88276
-	},
+	retreat: 2,
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276187,
+				tcgplayer: 88276
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276187,
+				tcgplayer: 88276
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/110.ts
+++ b/data/EX/FireRed & LeafGreen/110.ts
@@ -61,17 +61,16 @@ const card: Card = {
 		},
 	],
 
-	
-	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276286,
-		tcgplayer: 87598
-	},
+	retreat: 1,
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276286,
+				tcgplayer: 87598
+			},
 		},
 	]
 }

--- a/data/EX/FireRed & LeafGreen/111.ts
+++ b/data/EX/FireRed & LeafGreen/111.ts
@@ -61,17 +61,16 @@ const card: Card = {
 		},
 	],
 
-	
-	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276287,
-		tcgplayer: 87599
-	},
+	retreat: 1,
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276287,
+				tcgplayer: 87599
+			},
 		},
 	]
 }

--- a/data/EX/FireRed & LeafGreen/112.ts
+++ b/data/EX/FireRed & LeafGreen/112.ts
@@ -96,17 +96,17 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 3,
 
-	thirdParty: {
-		cardmarket: 276288,
-		tcgplayer: 90323
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276288,
+				tcgplayer: 90323
+			},
 		},
 	]
 }

--- a/data/EX/FireRed & LeafGreen/113.ts
+++ b/data/EX/FireRed & LeafGreen/113.ts
@@ -66,17 +66,16 @@ const card: Card = {
 		},
 	],
 
-	
-	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276289,
-		tcgplayer: 84211
-	},
+	retreat: 1,
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276289,
+				tcgplayer: 84211
+			},
 		},
 	]
 }

--- a/data/EX/FireRed & LeafGreen/114.ts
+++ b/data/EX/FireRed & LeafGreen/114.ts
@@ -69,17 +69,16 @@ const card: Card = {
 		type: "Poke-POWER"
 	}],
 
-	
-	retreat: 2,
 
-	thirdParty: {
-		cardmarket: 276290,
-		tcgplayer: 83654
-	},
+	retreat: 2,
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276290,
+				tcgplayer: 83654
+			},
 		},
 	]
 }

--- a/data/EX/FireRed & LeafGreen/115.ts
+++ b/data/EX/FireRed & LeafGreen/115.ts
@@ -69,17 +69,16 @@ const card: Card = {
 		type: "Poke-POWER"
 	}],
 
-	
-	retreat: 2,
 
-	thirdParty: {
-		cardmarket: 276291,
-		tcgplayer: 87566
-	},
+	retreat: 2,
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276291,
+				tcgplayer: 87566
+			},
 		},
 	]
 }

--- a/data/EX/FireRed & LeafGreen/116.ts
+++ b/data/EX/FireRed & LeafGreen/116.ts
@@ -69,17 +69,16 @@ const card: Card = {
 		type: "Poke-POWER"
 	}],
 
-	
-	retreat: 2,
 
-	thirdParty: {
-		cardmarket: 276292,
-		tcgplayer: 90723
-	},
+	retreat: 2,
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276292,
+				tcgplayer: 90723
+			},
 		},
 	]
 }

--- a/data/EX/FireRed & LeafGreen/12.ts
+++ b/data/EX/FireRed & LeafGreen/12.ts
@@ -75,21 +75,25 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276188,
-		tcgplayer: 88507
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276188,
+				tcgplayer: 88507
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276188,
+				tcgplayer: 88507
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/13.ts
+++ b/data/EX/FireRed & LeafGreen/13.ts
@@ -89,21 +89,25 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276189,
-		tcgplayer: 88581
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276189,
+				tcgplayer: 88581
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276189,
+				tcgplayer: 88581
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/14.ts
+++ b/data/EX/FireRed & LeafGreen/14.ts
@@ -74,21 +74,25 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276190,
-		tcgplayer: 89304
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276190,
+				tcgplayer: 89304
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276190,
+				tcgplayer: 89304
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/15.ts
+++ b/data/EX/FireRed & LeafGreen/15.ts
@@ -87,21 +87,25 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 3,
 
-	thirdParty: {
-		cardmarket: 276191,
-		tcgplayer: 89388
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276191,
+				tcgplayer: 89388
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276191,
+				tcgplayer: 89388
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/16.ts
+++ b/data/EX/FireRed & LeafGreen/16.ts
@@ -71,21 +71,25 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276192,
-		tcgplayer: 89761
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276192,
+				tcgplayer: 89761
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276192,
+				tcgplayer: 89761
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/17.ts
+++ b/data/EX/FireRed & LeafGreen/17.ts
@@ -75,21 +75,25 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 2,
 
-	thirdParty: {
-		cardmarket: 276193,
-		tcgplayer: 90362
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276193,
+				tcgplayer: 90362
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276193,
+				tcgplayer: 90362
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/18.ts
+++ b/data/EX/FireRed & LeafGreen/18.ts
@@ -73,21 +73,25 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 2,
 
-	thirdParty: {
-		cardmarket: 276194,
-		tcgplayer: 83582
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276194,
+				tcgplayer: 83582
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276194,
+				tcgplayer: 83582
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/19.ts
+++ b/data/EX/FireRed & LeafGreen/19.ts
@@ -69,21 +69,25 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 2,
 
-	thirdParty: {
-		cardmarket: 276195,
-		tcgplayer: 84173
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276195,
+				tcgplayer: 84173
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276195,
+				tcgplayer: 84173
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/2.ts
+++ b/data/EX/FireRed & LeafGreen/2.ts
@@ -96,21 +96,24 @@ const card: Card = {
 		},
 	],
 
-	
-	retreat: 0,
 
-	thirdParty: {
-		cardmarket: 276178,
-		tcgplayer: 84065
-	},
+	retreat: 0,
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276178,
+				tcgplayer: 84065
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276178,
+				tcgplayer: 84065
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/20.ts
+++ b/data/EX/FireRed & LeafGreen/20.ts
@@ -89,21 +89,25 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276196,
-		tcgplayer: 84373
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276196,
+				tcgplayer: 84373
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276196,
+				tcgplayer: 84373
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/21.ts
+++ b/data/EX/FireRed & LeafGreen/21.ts
@@ -81,21 +81,25 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276197,
-		tcgplayer: 84850
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276197,
+				tcgplayer: 84850
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276197,
+				tcgplayer: 84850
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/22.ts
+++ b/data/EX/FireRed & LeafGreen/22.ts
@@ -77,21 +77,25 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276198,
-		tcgplayer: 85000
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276198,
+				tcgplayer: 85000
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276198,
+				tcgplayer: 85000
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/23.ts
+++ b/data/EX/FireRed & LeafGreen/23.ts
@@ -75,21 +75,24 @@ const card: Card = {
 		},
 	],
 
-	
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276199,
-		tcgplayer: 85384
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276199,
+				tcgplayer: 85384
+			},˝
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276199,
+				tcgplayer: 85384
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/23.ts
+++ b/data/EX/FireRed & LeafGreen/23.ts
@@ -84,7 +84,7 @@ const card: Card = {
 			thirdParty: {
 				cardmarket: 276199,
 				tcgplayer: 85384
-			},˝
+			},
 		},
 		{
 			type: "reverse",

--- a/data/EX/FireRed & LeafGreen/24.ts
+++ b/data/EX/FireRed & LeafGreen/24.ts
@@ -96,21 +96,24 @@ const card: Card = {
 		},
 	],
 
-	
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276200,
-		tcgplayer: 85397
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276200,
+				tcgplayer: 85397
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276200,
+				tcgplayer: 85397
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/25.ts
+++ b/data/EX/FireRed & LeafGreen/25.ts
@@ -74,21 +74,24 @@ const card: Card = {
 		},
 	],
 
-	
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276201,
-		tcgplayer: 86252
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276201,
+				tcgplayer: 86252
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276201,
+				tcgplayer: 86252
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/26.ts
+++ b/data/EX/FireRed & LeafGreen/26.ts
@@ -74,21 +74,24 @@ const card: Card = {
 		},
 	],
 
-	
-	retreat: 2,
 
-	thirdParty: {
-		cardmarket: 276202,
-		tcgplayer: 86456
-	},
+	retreat: 2,
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276202,
+				tcgplayer: 86456
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276202,
+				tcgplayer: 86456
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/27.ts
+++ b/data/EX/FireRed & LeafGreen/27.ts
@@ -83,21 +83,25 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276203,
-		tcgplayer: 87102
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276203,
+				tcgplayer: 87102
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276203,
+				tcgplayer: 87102
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/28.ts
+++ b/data/EX/FireRed & LeafGreen/28.ts
@@ -72,21 +72,24 @@ const card: Card = {
 		},
 	],
 
-	
-	retreat: 0,
 
-	thirdParty: {
-		cardmarket: 276204,
-		tcgplayer: 88362
-	},
+	retreat: 0,
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276204,
+				tcgplayer: 88362
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276204,
+				tcgplayer: 88362
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/29.ts
+++ b/data/EX/FireRed & LeafGreen/29.ts
@@ -69,21 +69,25 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276205,
-		tcgplayer: 88998
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276205,
+				tcgplayer: 88998
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276205,
+				tcgplayer: 88998
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/3.ts
+++ b/data/EX/FireRed & LeafGreen/3.ts
@@ -88,21 +88,24 @@ const card: Card = {
 		},
 	],
 
-	
-	retreat: 2,
 
-	thirdParty: {
-		cardmarket: 276179,
-		tcgplayer: 84789
-	},
+	retreat: 2,
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276179,
+				tcgplayer: 84789
+			},
 		},
 		{
 			type: "holo",
-			foil: "energy"
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276179,
+				tcgplayer: 84789
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/30.ts
+++ b/data/EX/FireRed & LeafGreen/30.ts
@@ -73,21 +73,25 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276206,
-		tcgplayer: 89742
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276206,
+				tcgplayer: 89742
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276206,
+				tcgplayer: 89742
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/31.ts
+++ b/data/EX/FireRed & LeafGreen/31.ts
@@ -73,21 +73,24 @@ const card: Card = {
 		},
 	],
 
-	
-	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276207,
-		tcgplayer: 84226
-	},
+	retreat: 1,
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276207,
+				tcgplayer: 84226
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276207,
+				tcgplayer: 84226
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/32.ts
+++ b/data/EX/FireRed & LeafGreen/32.ts
@@ -68,20 +68,24 @@ const card: Card = {
 		},
 	],
 
-	
-	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276208
-	},
+	retreat: 1,
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276208,
+				tcgplayer: 84973,
+			},
 		},
 		{
 			type: "holo",
-			foil: "energy"
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276208,
+				tcgplayer: 84973,
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/33.ts
+++ b/data/EX/FireRed & LeafGreen/33.ts
@@ -70,21 +70,25 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276209,
-		tcgplayer: 85346
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276209,
+				tcgplayer: 85346
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276209,
+				tcgplayer: 85346
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/34.ts
+++ b/data/EX/FireRed & LeafGreen/34.ts
@@ -81,21 +81,25 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276210,
-		tcgplayer: 86025
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276210,
+				tcgplayer: 86025
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276210,
+				tcgplayer: 86025
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/35.ts
+++ b/data/EX/FireRed & LeafGreen/35.ts
@@ -84,9 +84,13 @@ const card: Card = {
 		},
 		{
 			type: "reverse",
-			foil: "energy"
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276211,
+				tcgplayer: 86297
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/35.ts
+++ b/data/EX/FireRed & LeafGreen/35.ts
@@ -71,20 +71,19 @@ const card: Card = {
 		},
 	],
 
-	
-	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276211,
-		tcgplayer: 86297
-	},
+	retreat: 1,
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276211,
+				tcgplayer: 86297
+			},
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			foil: "energy"
 		}
 	]

--- a/data/EX/FireRed & LeafGreen/36.ts
+++ b/data/EX/FireRed & LeafGreen/36.ts
@@ -69,23 +69,26 @@ const card: Card = {
 		},
 	],
 
-	
 	retreat: 2,
 
-	thirdParty: {
-		cardmarket: 276212,
-		tcgplayer: 86411
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276212,
+				tcgplayer: 86411
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276212,
+				tcgplayer: 86411
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/37.ts
+++ b/data/EX/FireRed & LeafGreen/37.ts
@@ -69,23 +69,26 @@ const card: Card = {
 		},
 	],
 
-	
-	retreat: 2,
 
-	thirdParty: {
-		cardmarket: 276213,
-		tcgplayer: 86719
-	},
+	retreat: 2,
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276213,
+				tcgplayer: 86719
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276213,
+				tcgplayer: 86719
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/38.ts
+++ b/data/EX/FireRed & LeafGreen/38.ts
@@ -65,23 +65,26 @@ const card: Card = {
 		},
 	],
 
-	
-	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276214,
-		tcgplayer: 87173
-	},
+	retreat: 1,
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276214,
+				tcgplayer: 87173
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276214,
+				tcgplayer: 87173
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/39.ts
+++ b/data/EX/FireRed & LeafGreen/39.ts
@@ -70,23 +70,26 @@ const card: Card = {
 		},
 	],
 
-	
-	retreat: 2,
 
-	thirdParty: {
-		cardmarket: 276215,
-		tcgplayer: 87389
-	},
+	retreat: 2,
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276215,
+				tcgplayer: 87389
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276215,
+				tcgplayer: 87389
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/4.ts
+++ b/data/EX/FireRed & LeafGreen/4.ts
@@ -68,21 +68,24 @@ const card: Card = {
 		},
 	],
 
-	
-	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276180,
-		tcgplayer: 84831
-	},
+	retreat: 1,
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276180,
+				tcgplayer: 84831
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276180,
+				tcgplayer: 84831
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/40.ts
+++ b/data/EX/FireRed & LeafGreen/40.ts
@@ -70,27 +70,34 @@ const card: Card = {
 		},
 	],
 
-	
-	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276216,
-		tcgplayer: 87735
-	},
+	retreat: 1,
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276216,
+				tcgplayer: 87735
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276216,
+				tcgplayer: 87735
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["jeremy-maron"]
-		}
-	]
+			stamp: ["jeremy-maron"],
+			thirdParty: {
+				cardmarket: 871515,
+				tcgplayer: 477559
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/41.ts
+++ b/data/EX/FireRed & LeafGreen/41.ts
@@ -76,23 +76,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276217,
-		tcgplayer: 87744
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276217,
+				tcgplayer: 87744
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276217,
+				tcgplayer: 87744
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/42.ts
+++ b/data/EX/FireRed & LeafGreen/42.ts
@@ -65,23 +65,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 3,
 
-	thirdParty: {
-		cardmarket: 276218,
-		tcgplayer: 87879
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276218,
+				tcgplayer: 87879
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276218,
+				tcgplayer: 87879
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/43.ts
+++ b/data/EX/FireRed & LeafGreen/43.ts
@@ -74,23 +74,25 @@ const card: Card = {
 		},
 	],
 
-	
 	retreat: 1,
-
-	thirdParty: {
-		cardmarket: 276219,
-		tcgplayer: 87957
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276219,
+				tcgplayer: 87957
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276219,
+				tcgplayer: 87957
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/44.ts
+++ b/data/EX/FireRed & LeafGreen/44.ts
@@ -90,23 +90,25 @@ const card: Card = {
 		},
 	],
 
-	
 	retreat: 1,
-
-	thirdParty: {
-		cardmarket: 276220,
-		tcgplayer: 87984
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276220,
+				tcgplayer: 87984
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276220,
+				tcgplayer: 87984
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/45.ts
+++ b/data/EX/FireRed & LeafGreen/45.ts
@@ -78,39 +78,59 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 0,
 
-	thirdParty: {
-		cardmarket: 276221,
-		tcgplayer: 88040
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276221,
+				tcgplayer: 88040
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276221,
+				tcgplayer: 88040
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["takashi-yoneda"]
+			stamp: ["takashi-yoneda"],
+			thirdParty: {
+				cardmarket: 871520,
+				tcgplayer: 477562
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["jeremy-maron"]
+			stamp: ["jeremy-maron"],
+			thirdParty: {
+				cardmarket: 871519,
+				tcgplayer: 477563
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["hiroki-yano"]
+			stamp: ["hiroki-yano"],
+			thirdParty: {
+				cardmarket: 869521,
+				tcgplayer: 477884
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["jimmy-ballard"]
-		}
-	]
+			stamp: ["jimmy-ballard"],
+			thirdParty: {
+				cardmarket: 869522,
+				tcgplayer: 477886
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/46.ts
+++ b/data/EX/FireRed & LeafGreen/46.ts
@@ -75,23 +75,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276222,
-		tcgplayer: 88265
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276222,
+				tcgplayer: 88265
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276222,
+				tcgplayer: 88265
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/47.ts
+++ b/data/EX/FireRed & LeafGreen/47.ts
@@ -69,23 +69,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276223,
-		tcgplayer: 88308
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276223,
+				tcgplayer: 88308
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276223,
+				tcgplayer: 88308
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/48.ts
+++ b/data/EX/FireRed & LeafGreen/48.ts
@@ -89,23 +89,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 0,
 
-	thirdParty: {
-		cardmarket: 276224,
-		tcgplayer: 88603
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276224,
+				tcgplayer: 88603
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276224,
+				tcgplayer: 88603
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/49.ts
+++ b/data/EX/FireRed & LeafGreen/49.ts
@@ -90,23 +90,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 0,
 
-	thirdParty: {
-		cardmarket: 276225,
-		tcgplayer: 90301
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276225,
+				tcgplayer: 90301
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276225,
+				tcgplayer: 90301
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/5.ts
+++ b/data/EX/FireRed & LeafGreen/5.ts
@@ -74,21 +74,24 @@ const card: Card = {
 		},
 	],
 
-	
-	retreat: 2,
 
-	thirdParty: {
-		cardmarket: 276181,
-		tcgplayer: 85359
-	},
+	retreat: 2,
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276181,
+				tcgplayer: 85359
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276181,
+				tcgplayer: 85359
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/50.ts
+++ b/data/EX/FireRed & LeafGreen/50.ts
@@ -76,31 +76,43 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 2,
 
-	thirdParty: {
-		cardmarket: 276226,
-		tcgplayer: 90486
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276226,
+				tcgplayer: 90486
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276226,
+				tcgplayer: 90486
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["pre-release"]
+			stamp: ["pre-release"],
+			thirdParty: {
+				cardmarket: 881786,
+				tcgplayer: 285695
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["hiroki-yano"]
-		}
-	]
+			stamp: ["hiroki-yano"],
+			thirdParty: {
+				cardmarket: 869514,
+				tcgplayer: 477978
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/51.ts
+++ b/data/EX/FireRed & LeafGreen/51.ts
@@ -71,23 +71,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276227,
-		tcgplayer: 90552
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276227,
+				tcgplayer: 90552
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276227,
+				tcgplayer: 90552
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/52.ts
+++ b/data/EX/FireRed & LeafGreen/52.ts
@@ -74,23 +74,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276228,
-		tcgplayer: 90596
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276228,
+				tcgplayer: 90596
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276228,
+				tcgplayer: 90596
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/53.ts
+++ b/data/EX/FireRed & LeafGreen/53.ts
@@ -48,23 +48,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276229,
-		tcgplayer: 83807
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276229,
+				tcgplayer: 83807
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276229,
+				tcgplayer: 83807
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/54.ts
+++ b/data/EX/FireRed & LeafGreen/54.ts
@@ -65,23 +65,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276230,
-		tcgplayer: 84029
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276230,
+				tcgplayer: 84029
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276230,
+				tcgplayer: 84029
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/55.ts
+++ b/data/EX/FireRed & LeafGreen/55.ts
@@ -66,23 +66,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276231,
-		tcgplayer: 84030
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276231,
+				tcgplayer: 84030
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276231,
+				tcgplayer: 84030
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/56.ts
+++ b/data/EX/FireRed & LeafGreen/56.ts
@@ -68,23 +68,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276232,
-		tcgplayer: 84136
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276232,
+				tcgplayer: 84136
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276232,
+				tcgplayer: 84136
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/57.ts
+++ b/data/EX/FireRed & LeafGreen/57.ts
@@ -51,23 +51,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276233,
-		tcgplayer: 84209
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276233,
+				tcgplayer: 84209
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276233,
+				tcgplayer: 84209
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/58.ts
+++ b/data/EX/FireRed & LeafGreen/58.ts
@@ -62,23 +62,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276234,
-		tcgplayer: 84210
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276234,
+				tcgplayer: 84210
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276234,
+				tcgplayer: 84210
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/59.ts
+++ b/data/EX/FireRed & LeafGreen/59.ts
@@ -65,23 +65,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276235,
-		tcgplayer: 84354
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276235,
+				tcgplayer: 84354
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276235,
+				tcgplayer: 84354
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/6.ts
+++ b/data/EX/FireRed & LeafGreen/6.ts
@@ -84,21 +84,23 @@ const card: Card = {
 		},
 	],
 
-	
 	retreat: 2,
-
-	thirdParty: {
-		cardmarket: 276182,
-		tcgplayer: 86421
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276182,
+				tcgplayer: 86421
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276182,
+				tcgplayer: 86421
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/60.ts
+++ b/data/EX/FireRed & LeafGreen/60.ts
@@ -65,23 +65,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276236,
-		tcgplayer: 84531
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276236,
+				tcgplayer: 84531
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276236,
+				tcgplayer: 84531
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/61.ts
+++ b/data/EX/FireRed & LeafGreen/61.ts
@@ -51,23 +51,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276237,
-		tcgplayer: 84821
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276237,
+				tcgplayer: 84821
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276237,
+				tcgplayer: 84821
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/62.ts
+++ b/data/EX/FireRed & LeafGreen/62.ts
@@ -76,23 +76,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276238,
-		tcgplayer: 84861
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276238,
+				tcgplayer: 84861
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276238,
+				tcgplayer: 84861
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/63.ts
+++ b/data/EX/FireRed & LeafGreen/63.ts
@@ -58,23 +58,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276239,
-		tcgplayer: 85650
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276239,
+				tcgplayer: 85650
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276239,
+				tcgplayer: 85650
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/64.ts
+++ b/data/EX/FireRed & LeafGreen/64.ts
@@ -63,23 +63,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 2,
 
-	thirdParty: {
-		cardmarket: 276240,
-		tcgplayer: 85954
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276240,
+				tcgplayer: 85954
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276240,
+				tcgplayer: 85954
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/65.ts
+++ b/data/EX/FireRed & LeafGreen/65.ts
@@ -69,23 +69,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276241,
-		tcgplayer: 86316
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276241,
+				tcgplayer: 86316
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276241,
+				tcgplayer: 86316
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/66.ts
+++ b/data/EX/FireRed & LeafGreen/66.ts
@@ -64,23 +64,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 2,
 
-	thirdParty: {
-		cardmarket: 276242,
-		tcgplayer: 86524
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276242,
+				tcgplayer: 86524
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276242,
+				tcgplayer: 86524
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/67.ts
+++ b/data/EX/FireRed & LeafGreen/67.ts
@@ -69,32 +69,44 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276243,
-		tcgplayer: 87026
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276243,
+				tcgplayer: 87026
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276243,
+				tcgplayer: 87026
+			},
 		},
 		{
 			type: "normal",
-			subtype: "rarity-error"
+			subtype: "rarity-error",
+			thirdParty: {
+				cardmarket: 276243,
+				tcgplayer: 87026
+			},
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			foil: "energy",
-			subtype: "rarity-error"
+			subtype: "rarity-error",
+			thirdParty: {
+				cardmarket: 276243,
+				tcgplayer: 87026
+			},
 		},
-	]
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/68.ts
+++ b/data/EX/FireRed & LeafGreen/68.ts
@@ -72,23 +72,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276244,
-		tcgplayer: 87075
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276244,
+				tcgplayer: 87075
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276244,
+				tcgplayer: 87075
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/69.ts
+++ b/data/EX/FireRed & LeafGreen/69.ts
@@ -65,23 +65,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276245,
-		tcgplayer: 87317
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276245,
+				tcgplayer: 87317
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276245,
+				tcgplayer: 87317
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/7.ts
+++ b/data/EX/FireRed & LeafGreen/7.ts
@@ -76,21 +76,25 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276183,
-		tcgplayer: 87226
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276183,
+				tcgplayer: 87226
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276183,
+				tcgplayer: 87226
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/70.ts
+++ b/data/EX/FireRed & LeafGreen/70.ts
@@ -23,7 +23,6 @@ const card: Card = {
 	stage: "Basic",
 
 
-	
 
 	retreat: 1,
 
@@ -69,15 +68,27 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276246,
+				tcgplayer: 87717,
+			}
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276246,
+				tcgplayer: 87717,
+			}
 		},
 		{
 			type: "normal",
-			stamp: ["jeremy-maron"]
+			stamp: ["jeremy-maron"],
+			thirdParty: {
+				cardmarket: 871514,
+				tcgplayer: 477558,
+			}
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/71.ts
+++ b/data/EX/FireRed & LeafGreen/71.ts
@@ -23,7 +23,7 @@ const card: Card = {
 	stage: "Basic",
 
 
-	
+
 
 	retreat: 1,
 
@@ -72,11 +72,19 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276247,
+				tcgplayer: 87726,
+			}
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276247,
+				tcgplayer: 87726,
+			}
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/72.ts
+++ b/data/EX/FireRed & LeafGreen/72.ts
@@ -68,23 +68,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276248,
-		tcgplayer: 87950
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276248,
+				tcgplayer: 87950
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276248,
+				tcgplayer: 87950
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/73.ts
+++ b/data/EX/FireRed & LeafGreen/73.ts
@@ -72,39 +72,59 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276249,
-		tcgplayer: 88048
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276249,
+				tcgplayer: 88048
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276249,
+				tcgplayer: 88048
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["takashi-yoneda"]
+			stamp: ["takashi-yoneda"],
+			thirdParty: {
+				cardmarket: 871518,
+				tcgplayer: 477564
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["jeremy-maron"]
+			stamp: ["jeremy-maron"],
+			thirdParty: {
+				cardmarket: 871517,
+				tcgplayer: 477565
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["hiroki-yano"]
+			stamp: ["hiroki-yano"],
+			thirdParty: {
+				cardmarket: 869523,
+				tcgplayer: 477889
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["jimmy-ballard"]
-		}
-	]
+			stamp: ["jimmy-ballard"],
+			thirdParty: {
+				cardmarket: 869524,
+				tcgplayer: 477890
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/74.ts
+++ b/data/EX/FireRed & LeafGreen/74.ts
@@ -52,23 +52,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276250,
-		tcgplayer: 88078
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276250,
+				tcgplayer: 88078
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276250,
+				tcgplayer: 88078
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/75.ts
+++ b/data/EX/FireRed & LeafGreen/75.ts
@@ -65,23 +65,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276251,
-		tcgplayer: 88257
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276251,
+				tcgplayer: 88257
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276251,
+				tcgplayer: 88257
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/76.ts
+++ b/data/EX/FireRed & LeafGreen/76.ts
@@ -53,23 +53,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276252,
-		tcgplayer: 88285
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276252,
+				tcgplayer: 88285
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276252,
+				tcgplayer: 88285
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/77.ts
+++ b/data/EX/FireRed & LeafGreen/77.ts
@@ -64,23 +64,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276253,
-		tcgplayer: 88615
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276253,
+				tcgplayer: 88615
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276253,
+				tcgplayer: 88615
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/78.ts
+++ b/data/EX/FireRed & LeafGreen/78.ts
@@ -52,23 +52,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276254,
-		tcgplayer: 89052
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276254,
+				tcgplayer: 89052
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276254,
+				tcgplayer: 89052
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/79.ts
+++ b/data/EX/FireRed & LeafGreen/79.ts
@@ -64,23 +64,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276255,
-		tcgplayer: 89137
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276255,
+				tcgplayer: 89137
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276255,
+				tcgplayer: 89137
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/8.ts
+++ b/data/EX/FireRed & LeafGreen/8.ts
@@ -93,21 +93,23 @@ const card: Card = {
 		},
 	],
 
-	
 	retreat: 3,
-
-	thirdParty: {
-		cardmarket: 276184,
-		tcgplayer: 87696
-	},
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276184,
+				tcgplayer: 87696
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276184,
+				tcgplayer: 87696
+			},
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/80.ts
+++ b/data/EX/FireRed & LeafGreen/80.ts
@@ -51,23 +51,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276256,
-		tcgplayer: 89327
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276256,
+				tcgplayer: 89327
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276256,
+				tcgplayer: 89327
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/81.ts
+++ b/data/EX/FireRed & LeafGreen/81.ts
@@ -73,23 +73,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276257,
-		tcgplayer: 89439
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276257,
+				tcgplayer: 89439
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276257,
+				tcgplayer: 89439
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/82.ts
+++ b/data/EX/FireRed & LeafGreen/82.ts
@@ -52,23 +52,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276258,
-		tcgplayer: 89489
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276258,
+				tcgplayer: 89489
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276258,
+				tcgplayer: 89489
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/83.ts
+++ b/data/EX/FireRed & LeafGreen/83.ts
@@ -69,27 +69,35 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276259,
-		tcgplayer: 89490
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276259,
+				tcgplayer: 89490
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276259,
+				tcgplayer: 89490
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["hiroki-yano"]
-		}
-	]
+			stamp: ["hiroki-yano"],
+			thirdParty: {
+				cardmarket: 869515,
+				tcgplayer: 477964
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/84.ts
+++ b/data/EX/FireRed & LeafGreen/84.ts
@@ -64,23 +64,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276260,
-		tcgplayer: 90307
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276260,
+				tcgplayer: 90307
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276260,
+				tcgplayer: 90307
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/85.ts
+++ b/data/EX/FireRed & LeafGreen/85.ts
@@ -69,23 +69,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276261,
-		tcgplayer: 90414
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276261,
+				tcgplayer: 90414
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276261,
+				tcgplayer: 90414
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/86.ts
+++ b/data/EX/FireRed & LeafGreen/86.ts
@@ -67,23 +67,27 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 1,
 
-	thirdParty: {
-		cardmarket: 276262,
-		tcgplayer: 90542
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276262,
+				tcgplayer: 90542
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276262,
+				tcgplayer: 90542
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/87.ts
+++ b/data/EX/FireRed & LeafGreen/87.ts
@@ -20,28 +20,40 @@ const card: Card = {
 		de: "If you have any cards in your hand, shuffel 1 of them into your deck, then draw 3 cards.",
 	},
 
-	thirdParty: {
-		cardmarket: 276263,
-		tcgplayer: 83838
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276263,
+				tcgplayer: 83838
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276263,
+				tcgplayer: 83838
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["takashi-yoneda"]
+			stamp: ["takashi-yoneda"],
+			thirdParty: {
+				cardmarket: 871579,
+				tcgplayer: 477499
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["jimmy-ballard"]
-		}
-	]
+			stamp: ["jimmy-ballard"],
+			thirdParty: {
+				cardmarket: 869583,
+				tcgplayer: 477600
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/88.ts
+++ b/data/EX/FireRed & LeafGreen/88.ts
@@ -20,36 +20,64 @@ const card: Card = {
 		de: "Search your deck for a Basic Pokémon or Evolution card (excluding Pokémon-ex ), show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
 	},
 
-	thirdParty: {
-		cardmarket: 276264,
-		tcgplayer: 84154
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276264,
+				tcgplayer: 84154
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276264,
+				tcgplayer: 84154
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["takashi-yoneda"]
+			stamp: ["takashi-yoneda"],
+			thirdParty: {
+				cardmarket: 871562,
+				tcgplayer: 477500
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["jeremy-maron"]
+			stamp: ["jeremy-maron"],
+			thirdParty: {
+				cardmarket: 871560,
+				tcgplayer: 477502
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["hiroki-yano"]
+			stamp: ["hiroki-yano"],
+			thirdParty: {
+				cardmarket: 869550,
+				tcgplayer: 477602
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["jimmy-ballard"]
+			stamp: ["jimmy-ballard"],
+			thirdParty: {
+				cardmarket: 869551,
+				tcgplayer: 477603
+			},
+		},
+		{
+			type: 'normal',
+			stamp: ['michael-gonzalez'],
+			thirdParty: {
+				cardmarket: 871561,
+				tcgplayer: 477501,
+			}
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/89.ts
+++ b/data/EX/FireRed & LeafGreen/89.ts
@@ -20,24 +20,32 @@ const card: Card = {
 		de: "Flip a coin. If heads, choose 1 Energy card attached to 1 of your opponent's Pokémon and discard it."
 	},
 
-	thirdParty: {
-		cardmarket: 276265,
-		tcgplayer: 85222
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276265,
+				tcgplayer: 85222
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276265,
+				tcgplayer: 85222
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["curran-hill"]
-		}
-	]
+			stamp: ["curran-hill"],
+			thirdParty: {
+				cardmarket: 871540,
+				tcgplayer: 477519
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/9.ts
+++ b/data/EX/FireRed & LeafGreen/9.ts
@@ -91,25 +91,32 @@ const card: Card = {
 		},
 	],
 
-	
-	retreat: 2,
 
-	thirdParty: {
-		cardmarket: 276185,
-		tcgplayer: 87707
-	},
+	retreat: 2,
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 276185,
+				tcgplayer: 87707
+			},
+		},
+		{
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276185,
+				tcgplayer: 87707
+			},
 		},
 		{
 			type: "holo",
-			foil: "energy"
-		},
-		{
-			type: "holo",
-			stamp: ["jeremy-maron"]
+			stamp: ["jeremy-maron"],
+			thirdParty: {
+				cardmarket: 871516,
+				tcgplayer: 477557
+			}
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/90.ts
+++ b/data/EX/FireRed & LeafGreen/90.ts
@@ -20,20 +20,24 @@ const card: Card = {
 		de: "Move a basic Energy card attached to 1 of your Pokémon to another of your Pokémon."
 	},
 
-	thirdParty: {
-		cardmarket: 276266,
-		tcgplayer: 85254
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276266,
+				tcgplayer: 85254
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276266,
+				tcgplayer: 85254
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/91.ts
+++ b/data/EX/FireRed & LeafGreen/91.ts
@@ -20,19 +20,24 @@ const card: Card = {
 		de: "Wenn im Zug deines Gegners 1 deiner Aktiven Pokémon durch den Anrgiff deines Gegners kampfunfähig wird, kannst du 1 Basis-Energiekarte, die an dem angegriffenen Aktiven Pokémon angelegt ist, an das Pokémon anlegen, an dem EP-Teiler angelegt ist. Wenn du das machst, lege EP-Teiler auf deinen Ablagestapel."
 	},
 
-	thirdParty: {
-		cardmarket: 276267
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276267,
+				tcgplayer: 85368,
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276267,
+				tcgplayer: 85368,
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/92.ts
+++ b/data/EX/FireRed & LeafGreen/92.ts
@@ -20,24 +20,32 @@ const card: Card = {
 		de: "Durchsuche dein Deck nach einem Basis-Pokémon (kein Pokémon-ex) und lege es auf deine Bank. Mische dein Deck danach."
 	},
 
-	thirdParty: {
-		cardmarket: 276268,
-		tcgplayer: 85895
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276268,
+				tcgplayer: 85895
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276268,
+				tcgplayer: 85895
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["jeremy-maron"]
+			stamp: ["jeremy-maron"],
+			thirdParty: {
+				cardmarket: 276268,
+				tcgplayer: 85895
+			},
 		},
-	]
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/93.ts
+++ b/data/EX/FireRed & LeafGreen/93.ts
@@ -20,20 +20,24 @@ const card: Card = {
 		de: "Flip a coin. If heads, choose 1 of your Pokémon (excluding Pokémon-ex) , and remove all Spezial Conditions and 6 damage counters from thad Pokémon (all if there are less than 6)."
 	},
 
-	thirdParty: {
-		cardmarket: 276269,
-		tcgplayer: 86731
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276269,
+				tcgplayer: 86731
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276269,
+				tcgplayer: 86731
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/94.ts
+++ b/data/EX/FireRed & LeafGreen/94.ts
@@ -20,20 +20,24 @@ const card: Card = {
 		de: "Any Pokémon (both yours and your opponent's) with maximum HP less than 70 can't use any Poke-Power",
 	},
 
-	thirdParty: {
-		cardmarket: 276270,
-		tcgplayer: 87603
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276270,
+				tcgplayer: 87603
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276270,
+				tcgplayer: 87603
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/95.ts
+++ b/data/EX/FireRed & LeafGreen/95.ts
@@ -20,19 +20,24 @@ const card: Card = {
 		de: "Wirf 1 Münze. Bei \"Kopf\" durchsuche dein Deck nach einem basis-Pokémon pder einer Evolutionskarte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 	},
 
-	thirdParty: {
-		cardmarket: 276271
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276271,
+				tcgplayer: 88183,
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276271,
+				tcgplayer: 88183,
+			},
+		},
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/96.ts
+++ b/data/EX/FireRed & LeafGreen/96.ts
@@ -22,11 +22,19 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276272,
+				tcgplayer: 88201
+			}
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276272,
+				tcgplayer: 88201
+			}
 		}
 	]
 }

--- a/data/EX/FireRed & LeafGreen/97.ts
+++ b/data/EX/FireRed & LeafGreen/97.ts
@@ -20,27 +20,40 @@ const card: Card = {
 		de: "Wirf 1 Münze. Bei \"Kopf\" tausche 1 Verteidigendes Pokémon gegen 1 der Pokémon auf der Bank deines Gegners aus. Dein Gegner wählt aus, welches Verteidigende Pokémon getauscht wird."
 	},
 
-	thirdParty: {
-		cardmarket: 276273
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276273,
+				tcgplayer: 88239,
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276273,
+				tcgplayer: 88239,
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["curran-hill"]
+			stamp: ["curran-hill"],
+			thirdParty: {
+				cardmarket: 871542,
+				tcgplayer: 477567,
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["michael-gonzalez"]
+			stamp: ["michael-gonzalez"],
+			thirdParty: {
+				cardmarket: 871543,
+				tcgplayer: 477568,
+			},
 		},
-	]
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/98.ts
+++ b/data/EX/FireRed & LeafGreen/98.ts
@@ -20,23 +20,31 @@ const card: Card = {
 		de: "Mische deine Hand in dein Deck, und ziehe dann 5 Karten.",
 	},
 
-	thirdParty: {
-		tcgplayer: 88403
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276274,
+				tcgplayer: 88403
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276274,
+				tcgplayer: 88403
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["professor-program"]
+			stamp: ["professor-program"],
+			thirdParty: {
+				tcgplayer: 176629
+			},
 		},
-	]
+	],
 }
 
 export default card

--- a/data/EX/FireRed & LeafGreen/99.ts
+++ b/data/EX/FireRed & LeafGreen/99.ts
@@ -20,20 +20,24 @@ const card: Card = {
 		de: "Wirf 1 Münze. Nimm bei \"Kopf\" 1 deiner Pokémon und alle daran angelegten Karten zurück auf die Hand."
 	},
 
-	thirdParty: {
-		cardmarket: 276275,
-		tcgplayer: 89636
-	},
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 276275,
+				tcgplayer: 89636
+			},
 		},
 		{
-			type: "holo",
-			foil: "energy"
-		}
-	]
+			type: "reverse",
+			foil: "energy",
+			thirdParty: {
+				cardmarket: 276275,
+				tcgplayer: 89636
+			},
+		},
+	],
 }
 
 export default card


### PR DESCRIPTION
closes #N/A

## Changes

- corrected reverse holos (some cards were `holo` with foil `energy`. But EX error cards sould be `reverse holo` with foil energy
- added tcgplayer and cardmarket ids

## Details

- removed thirdparty root object
- moved thirdparty to normal, reverse or holo

