### PR TITLE
(data) en ex9 Emerald - added card variants 

### DIFF
--- a/data/EX/Emerald/1.ts
+++ b/data/EX/Emerald/1.ts
@@ -100,15 +100,26 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 83906,
+				cardmarket: 276512
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 83906,
+				cardmarket: 276512
+			},
 		},
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 97710,
+			},
 		},
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/1.ts
+++ b/data/EX/Emerald/1.ts
@@ -102,7 +102,7 @@ const card: Card = {
 			type: "holo",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		},
 		{

--- a/data/EX/Emerald/10.ts
+++ b/data/EX/Emerald/10.ts
@@ -97,7 +97,7 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 2,
 
 	thirdParty: {
@@ -108,15 +108,26 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 97730,
+				cardmarket: 276521
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 97730,
+				cardmarket: 276521
+			},
 		},
 		{
-			type: "normal"
-		},
-	]
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 88947,
+			},
+		}
+	],
 }
 
 export default card

--- a/data/EX/Emerald/10.ts
+++ b/data/EX/Emerald/10.ts
@@ -110,7 +110,7 @@ const card: Card = {
 			type: "holo",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		},
 		{

--- a/data/EX/Emerald/100.ts
+++ b/data/EX/Emerald/100.ts
@@ -81,8 +81,12 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 88680,
+				cardmarket: 276611
+			},
 		},
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/101.ts
+++ b/data/EX/Emerald/101.ts
@@ -23,8 +23,12 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 85875,
+				cardmarket: 276612
+			},
 		},
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/102.ts
+++ b/data/EX/Emerald/102.ts
@@ -23,8 +23,12 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 85459,
+				cardmarket: 276613
+			},
 		},
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/103.ts
+++ b/data/EX/Emerald/103.ts
@@ -23,8 +23,12 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 90507,
+				cardmarket: 276614
+			},
 		},
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/104.ts
+++ b/data/EX/Emerald/104.ts
@@ -23,8 +23,12 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 86762,
+				cardmarket: 276615
+			},
 		},
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/105.ts
+++ b/data/EX/Emerald/105.ts
@@ -23,8 +23,12 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 88419,
+				cardmarket: 276616
+			},
 		},
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/106.ts
+++ b/data/EX/Emerald/106.ts
@@ -23,8 +23,12 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 85439,
+				cardmarket: 276617
+			},
 		},
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/107.ts
+++ b/data/EX/Emerald/107.ts
@@ -87,8 +87,12 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 85385,
+				cardmarket: 276618
+			},
 		},
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/11.ts
+++ b/data/EX/Emerald/11.ts
@@ -104,7 +104,7 @@ const card: Card = {
 			type: "holo",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		},
 		{

--- a/data/EX/Emerald/11.ts
+++ b/data/EX/Emerald/11.ts
@@ -91,7 +91,7 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 2,
 
 	thirdParty: {
@@ -102,15 +102,26 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 97731,
+				cardmarket: 276522
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 97731,
+				cardmarket: 276522
+			},
 		},
 		{
-			type: "normal"
-		},
-	]
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 89678,
+			},
+		}
+	],
 }
 
 export default card

--- a/data/EX/Emerald/12.ts
+++ b/data/EX/Emerald/12.ts
@@ -82,7 +82,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/12.ts
+++ b/data/EX/Emerald/12.ts
@@ -80,12 +80,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 84294,
+				cardmarket: 276523
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 84294,
+				cardmarket: 276523
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/13.ts
+++ b/data/EX/Emerald/13.ts
@@ -88,7 +88,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/13.ts
+++ b/data/EX/Emerald/13.ts
@@ -86,12 +86,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 85753,
+				cardmarket: 276524
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 85753,
+				cardmarket: 276524
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/14.ts
+++ b/data/EX/Emerald/14.ts
@@ -79,7 +79,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/14.ts
+++ b/data/EX/Emerald/14.ts
@@ -77,12 +77,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 85923,
+				cardmarket: 276525
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 85923,
+				cardmarket: 276525
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/15.ts
+++ b/data/EX/Emerald/15.ts
@@ -81,12 +81,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 86548,
+				cardmarket: 276526
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 86548,
+				cardmarket: 276526
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/15.ts
+++ b/data/EX/Emerald/15.ts
@@ -83,7 +83,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/16.ts
+++ b/data/EX/Emerald/16.ts
@@ -89,12 +89,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 87157,
+				cardmarket: 276527
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 87157,
+				cardmarket: 276527
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/16.ts
+++ b/data/EX/Emerald/16.ts
@@ -91,7 +91,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/17.ts
+++ b/data/EX/Emerald/17.ts
@@ -79,12 +79,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 87799,
+				cardmarket: 276528
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 87799,
+				cardmarket: 276528
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/17.ts
+++ b/data/EX/Emerald/17.ts
@@ -81,7 +81,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/18.ts
+++ b/data/EX/Emerald/18.ts
@@ -79,7 +79,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/18.ts
+++ b/data/EX/Emerald/18.ts
@@ -77,12 +77,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 88685,
+				cardmarket: 276529
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 88685,
+				cardmarket: 276529
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/19.ts
+++ b/data/EX/Emerald/19.ts
@@ -82,7 +82,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/19.ts
+++ b/data/EX/Emerald/19.ts
@@ -80,12 +80,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 88733,
+				cardmarket: 276530
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 88733,
+				cardmarket: 276530
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/2.ts
+++ b/data/EX/Emerald/2.ts
@@ -80,12 +80,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 84766,
+				cardmarket: 276513
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 84766,
+				cardmarket: 276513
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/2.ts
+++ b/data/EX/Emerald/2.ts
@@ -82,7 +82,7 @@ const card: Card = {
 			type: "holo",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/20.ts
+++ b/data/EX/Emerald/20.ts
@@ -80,7 +80,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/20.ts
+++ b/data/EX/Emerald/20.ts
@@ -78,12 +78,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 89083,
+				cardmarket: 276531
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 89083,
+				cardmarket: 276531
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/21.ts
+++ b/data/EX/Emerald/21.ts
@@ -81,12 +81,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 90703,
+				cardmarket: 276532
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 90703,
+				cardmarket: 276532
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/21.ts
+++ b/data/EX/Emerald/21.ts
@@ -83,7 +83,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/22.ts
+++ b/data/EX/Emerald/22.ts
@@ -87,12 +87,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 83956,
+				cardmarket: 276533
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 83956,
+				cardmarket: 276533
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/22.ts
+++ b/data/EX/Emerald/22.ts
@@ -89,7 +89,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/23.ts
+++ b/data/EX/Emerald/23.ts
@@ -90,7 +90,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/23.ts
+++ b/data/EX/Emerald/23.ts
@@ -88,12 +88,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 84090,
+				cardmarket: 276534
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 84090,
+				cardmarket: 276534
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/24.ts
+++ b/data/EX/Emerald/24.ts
@@ -87,7 +87,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/24.ts
+++ b/data/EX/Emerald/24.ts
@@ -85,12 +85,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 84335,
+				cardmarket: 276535
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 84335,
+				cardmarket: 276535
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/25.ts
+++ b/data/EX/Emerald/25.ts
@@ -90,7 +90,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/25.ts
+++ b/data/EX/Emerald/25.ts
@@ -88,12 +88,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 84404,
+				cardmarket: 276536
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 84404,
+				cardmarket: 276536
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/26.ts
+++ b/data/EX/Emerald/26.ts
@@ -91,12 +91,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 84851,
+				cardmarket: 276537
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 84851,
+				cardmarket: 276537
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/26.ts
+++ b/data/EX/Emerald/26.ts
@@ -93,7 +93,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/27.ts
+++ b/data/EX/Emerald/27.ts
@@ -85,7 +85,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/27.ts
+++ b/data/EX/Emerald/27.ts
@@ -83,12 +83,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 85154,
+				cardmarket: 276538
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 85154,
+				cardmarket: 276538
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/28.ts
+++ b/data/EX/Emerald/28.ts
@@ -92,7 +92,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/28.ts
+++ b/data/EX/Emerald/28.ts
@@ -90,12 +90,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 85938,
+				cardmarket: 276539
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 85938,
+				cardmarket: 276539
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/29.ts
+++ b/data/EX/Emerald/29.ts
@@ -89,7 +89,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		},
 		{

--- a/data/EX/Emerald/29.ts
+++ b/data/EX/Emerald/29.ts
@@ -87,16 +87,28 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 85966,
+				cardmarket: 276540
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 85966,
+				cardmarket: 276540
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["pre-release"]
+			stamp: ["pre-release"],
+			thirdParty: {
+				tcgplayer: 85966,
+				cardmarket: 276540
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/3.ts
+++ b/data/EX/Emerald/3.ts
@@ -123,7 +123,7 @@ const card: Card = {
 			type: "holo",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		},
 		{

--- a/data/EX/Emerald/3.ts
+++ b/data/EX/Emerald/3.ts
@@ -121,20 +121,32 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 85371,
+				cardmarket: 276514
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 85371,
+				cardmarket: 276514
+			},
 		},
 		{
 			type: "holo",
-			stamp: ["national-championships"]
+			stamp: ["national-championships"],
+			thirdParty: {
+				tcgplayer: 251243,
+				cardmarket: 449503
+			},
 		},
 		{
 			type: "holo",
-			stamp: ["national-championships", "staff"]
+			stamp: ["national-championships", "staff"],
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/30.ts
+++ b/data/EX/Emerald/30.ts
@@ -81,12 +81,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 85967,
+				cardmarket: 276541
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 85967,
+				cardmarket: 276541
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/30.ts
+++ b/data/EX/Emerald/30.ts
@@ -83,7 +83,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/31.ts
+++ b/data/EX/Emerald/31.ts
@@ -90,7 +90,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/31.ts
+++ b/data/EX/Emerald/31.ts
@@ -88,12 +88,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 86012,
+				cardmarket: 276542
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 86012,
+				cardmarket: 276542
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/32.ts
+++ b/data/EX/Emerald/32.ts
@@ -78,7 +78,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/32.ts
+++ b/data/EX/Emerald/32.ts
@@ -76,12 +76,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 86265,
+				cardmarket: 276543
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 86265,
+				cardmarket: 276543
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/33.ts
+++ b/data/EX/Emerald/33.ts
@@ -84,12 +84,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 86462,
+				cardmarket: 276544
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 86462,
+				cardmarket: 276544
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/33.ts
+++ b/data/EX/Emerald/33.ts
@@ -86,7 +86,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/34.ts
+++ b/data/EX/Emerald/34.ts
@@ -82,12 +82,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 86806,
+				cardmarket: 276545
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 86806,
+				cardmarket: 276545
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/34.ts
+++ b/data/EX/Emerald/34.ts
@@ -84,7 +84,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/35.ts
+++ b/data/EX/Emerald/35.ts
@@ -89,7 +89,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		},
 		{

--- a/data/EX/Emerald/35.ts
+++ b/data/EX/Emerald/35.ts
@@ -87,20 +87,35 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 86841,
+				cardmarket: 276546
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 86841,
+				cardmarket: 276546
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["regional-championships"]
+			stamp: ["regional-championships"],
+			thirdParty: {
+				cardmarket: 449698
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["state-championships"]
+			stamp: ["state-championships"],
+			thirdParty: {
+				tcgplayer: 247287,
+				cardmarket: 449703
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/36.ts
+++ b/data/EX/Emerald/36.ts
@@ -83,12 +83,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 87235,
+				cardmarket: 276547
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 87235,
+				cardmarket: 276547
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/36.ts
+++ b/data/EX/Emerald/36.ts
@@ -85,7 +85,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/37.ts
+++ b/data/EX/Emerald/37.ts
@@ -87,12 +87,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 87485,
+				cardmarket: 276548
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 87485,
+				cardmarket: 276548
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/37.ts
+++ b/data/EX/Emerald/37.ts
@@ -89,7 +89,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/38.ts
+++ b/data/EX/Emerald/38.ts
@@ -87,12 +87,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 87770,
+				cardmarket: 276549
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 87770,
+				cardmarket: 276549
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/38.ts
+++ b/data/EX/Emerald/38.ts
@@ -89,7 +89,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/39.ts
+++ b/data/EX/Emerald/39.ts
@@ -87,12 +87,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 88165,
+				cardmarket: 276550
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 88165,
+				cardmarket: 276550
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/39.ts
+++ b/data/EX/Emerald/39.ts
@@ -89,7 +89,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/4.ts
+++ b/data/EX/Emerald/4.ts
@@ -101,12 +101,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 85633,
+				cardmarket: 276515
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 85633,
+				cardmarket: 276515
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/4.ts
+++ b/data/EX/Emerald/4.ts
@@ -103,7 +103,7 @@ const card: Card = {
 			type: "holo",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/40.ts
+++ b/data/EX/Emerald/40.ts
@@ -90,7 +90,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/40.ts
+++ b/data/EX/Emerald/40.ts
@@ -88,12 +88,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 89671,
+				cardmarket: 276551
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 89671,
+				cardmarket: 276551
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/41.ts
+++ b/data/EX/Emerald/41.ts
@@ -91,7 +91,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/41.ts
+++ b/data/EX/Emerald/41.ts
@@ -89,12 +89,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 89692,
+				cardmarket: 276552
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 89692,
+				cardmarket: 276552
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/42.ts
+++ b/data/EX/Emerald/42.ts
@@ -80,12 +80,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 90397,
+				cardmarket: 276553
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 90397,
+				cardmarket: 276553
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/42.ts
+++ b/data/EX/Emerald/42.ts
@@ -82,7 +82,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/43.ts
+++ b/data/EX/Emerald/43.ts
@@ -74,12 +74,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 83713,
+				cardmarket: 276554
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 83713,
+				cardmarket: 276554
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/43.ts
+++ b/data/EX/Emerald/43.ts
@@ -76,7 +76,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/44.ts
+++ b/data/EX/Emerald/44.ts
@@ -65,7 +65,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/44.ts
+++ b/data/EX/Emerald/44.ts
@@ -63,12 +63,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 84071,
+				cardmarket: 276555
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 84071,
+				cardmarket: 276555
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/45.ts
+++ b/data/EX/Emerald/45.ts
@@ -71,7 +71,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/45.ts
+++ b/data/EX/Emerald/45.ts
@@ -69,12 +69,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 84862,
+				cardmarket: 276556
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 84862,
+				cardmarket: 276556
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/46.ts
+++ b/data/EX/Emerald/46.ts
@@ -66,12 +66,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 85047,
+				cardmarket: 276557
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 85047,
+				cardmarket: 276557
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/46.ts
+++ b/data/EX/Emerald/46.ts
@@ -68,7 +68,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/47.ts
+++ b/data/EX/Emerald/47.ts
@@ -72,7 +72,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/47.ts
+++ b/data/EX/Emerald/47.ts
@@ -70,12 +70,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 85134,
+				cardmarket: 276558
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 85134,
+				cardmarket: 276558
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/48.ts
+++ b/data/EX/Emerald/48.ts
@@ -82,7 +82,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/48.ts
+++ b/data/EX/Emerald/48.ts
@@ -80,12 +80,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 85135,
+				cardmarket: 276559
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 85135,
+				cardmarket: 276559
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/49.ts
+++ b/data/EX/Emerald/49.ts
@@ -82,7 +82,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/49.ts
+++ b/data/EX/Emerald/49.ts
@@ -80,12 +80,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 85402,
+				cardmarket: 276560
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 85402,
+				cardmarket: 276560
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/5.ts
+++ b/data/EX/Emerald/5.ts
@@ -80,7 +80,7 @@ const card: Card = {
 			type: "holo",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/5.ts
+++ b/data/EX/Emerald/5.ts
@@ -78,12 +78,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 85922,
+				cardmarket: 276516
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 85922,
+				cardmarket: 276516
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/50.ts
+++ b/data/EX/Emerald/50.ts
@@ -62,12 +62,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 85403,
+				cardmarket: 276561
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 85403,
+				cardmarket: 276561
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/50.ts
+++ b/data/EX/Emerald/50.ts
@@ -64,7 +64,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/51.ts
+++ b/data/EX/Emerald/51.ts
@@ -73,12 +73,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 85975,
+				cardmarket: 276562
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 85975,
+				cardmarket: 276562
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/51.ts
+++ b/data/EX/Emerald/51.ts
@@ -75,7 +75,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/52.ts
+++ b/data/EX/Emerald/52.ts
@@ -65,7 +65,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/52.ts
+++ b/data/EX/Emerald/52.ts
@@ -63,12 +63,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 86639,
+				cardmarket: 276563
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 86639,
+				cardmarket: 276563
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/53.ts
+++ b/data/EX/Emerald/53.ts
@@ -82,7 +82,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/53.ts
+++ b/data/EX/Emerald/53.ts
@@ -80,12 +80,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 86933,
+				cardmarket: 276564
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 86933,
+				cardmarket: 276564
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/54.ts
+++ b/data/EX/Emerald/54.ts
@@ -65,7 +65,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/54.ts
+++ b/data/EX/Emerald/54.ts
@@ -63,12 +63,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 87129,
+				cardmarket: 276565
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 87129,
+				cardmarket: 276565
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/55.ts
+++ b/data/EX/Emerald/55.ts
@@ -79,7 +79,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		},
 		{

--- a/data/EX/Emerald/55.ts
+++ b/data/EX/Emerald/55.ts
@@ -77,16 +77,28 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 87281,
+				cardmarket: 276566
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 87281,
+				cardmarket: 276566
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["curran-hill"]
+			stamp: ["curran-hill"],
+			thirdParty: {
+				tcgplayer: 477552,
+				cardmarket: 871509
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/56.ts
+++ b/data/EX/Emerald/56.ts
@@ -63,16 +63,24 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 87610,
+				cardmarket: 276567
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 87610,
+				cardmarket: 276567
+			},
 		},
 		{
 			type: "holo",
-			stamp: ["wizard-world-philadelphia"]
+			stamp: ["wizard-world-philadelphia"],
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/56.ts
+++ b/data/EX/Emerald/56.ts
@@ -65,7 +65,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		},
 		{

--- a/data/EX/Emerald/57.ts
+++ b/data/EX/Emerald/57.ts
@@ -79,12 +79,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 87810,
+				cardmarket: 276568
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 87810,
+				cardmarket: 276568
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/57.ts
+++ b/data/EX/Emerald/57.ts
@@ -81,7 +81,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/58.ts
+++ b/data/EX/Emerald/58.ts
@@ -73,12 +73,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 87811,
+				cardmarket: 276569
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 87811,
+				cardmarket: 276569
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/58.ts
+++ b/data/EX/Emerald/58.ts
@@ -75,7 +75,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/59.ts
+++ b/data/EX/Emerald/59.ts
@@ -78,16 +78,24 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 88016,
+				cardmarket: 276570
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 88016,
+				cardmarket: 276570
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["nintendo-world"]
+			stamp: ["nintendo-world"],
 		},
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/59.ts
+++ b/data/EX/Emerald/59.ts
@@ -80,7 +80,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		},
 		{

--- a/data/EX/Emerald/6.ts
+++ b/data/EX/Emerald/6.ts
@@ -80,7 +80,7 @@ const card: Card = {
 			type: "holo",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/6.ts
+++ b/data/EX/Emerald/6.ts
@@ -78,12 +78,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 86547,
+				cardmarket: 276517
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 86547,
+				cardmarket: 276517
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/60.ts
+++ b/data/EX/Emerald/60.ts
@@ -79,7 +79,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		},
 		{

--- a/data/EX/Emerald/60.ts
+++ b/data/EX/Emerald/60.ts
@@ -77,16 +77,27 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 88080,
+				cardmarket: 276571
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 88080,
+				cardmarket: 276571
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["comic-con"]
+			stamp: ["comic-con"],
+			thirdParty: {
+				tcgplayer: 187217,
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/61.ts
+++ b/data/EX/Emerald/61.ts
@@ -64,7 +64,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/61.ts
+++ b/data/EX/Emerald/61.ts
@@ -62,12 +62,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 88557,
+				cardmarket: 276572
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 88557,
+				cardmarket: 276572
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/62.ts
+++ b/data/EX/Emerald/62.ts
@@ -73,12 +73,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 88741,
+				cardmarket: 276573
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 88741,
+				cardmarket: 276573
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/62.ts
+++ b/data/EX/Emerald/62.ts
@@ -75,7 +75,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/63.ts
+++ b/data/EX/Emerald/63.ts
@@ -80,12 +80,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 89184,
+				cardmarket: 276574
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 89184,
+				cardmarket: 276574
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/63.ts
+++ b/data/EX/Emerald/63.ts
@@ -82,7 +82,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/64.ts
+++ b/data/EX/Emerald/64.ts
@@ -61,7 +61,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/64.ts
+++ b/data/EX/Emerald/64.ts
@@ -59,12 +59,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 89400,
+				cardmarket: 276575
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 89400,
+				cardmarket: 276575
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/65.ts
+++ b/data/EX/Emerald/65.ts
@@ -65,7 +65,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/65.ts
+++ b/data/EX/Emerald/65.ts
@@ -63,12 +63,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 89473,
+				cardmarket: 276576
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 89473,
+				cardmarket: 276576
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/66.ts
+++ b/data/EX/Emerald/66.ts
@@ -65,7 +65,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/66.ts
+++ b/data/EX/Emerald/66.ts
@@ -63,12 +63,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 89474,
+				cardmarket: 276577
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 89474,
+				cardmarket: 276577
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/67.ts
+++ b/data/EX/Emerald/67.ts
@@ -88,7 +88,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/67.ts
+++ b/data/EX/Emerald/67.ts
@@ -86,12 +86,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 89655,
+				cardmarket: 276578
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 89655,
+				cardmarket: 276578
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/68.ts
+++ b/data/EX/Emerald/68.ts
@@ -70,12 +70,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 89733,
+				cardmarket: 276579
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 89733,
+				cardmarket: 276579
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/68.ts
+++ b/data/EX/Emerald/68.ts
@@ -72,7 +72,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/69.ts
+++ b/data/EX/Emerald/69.ts
@@ -62,16 +62,24 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 89955,
+				cardmarket: 276580
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 89955,
+				cardmarket: 276580
+			},
 		},
 		{
 			type: "holo",
-			stamp: ["wizard-world-chicago"]
+			stamp: ["wizard-world-chicago"],
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/69.ts
+++ b/data/EX/Emerald/69.ts
@@ -64,7 +64,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		},
 		{

--- a/data/EX/Emerald/7.ts
+++ b/data/EX/Emerald/7.ts
@@ -97,7 +97,7 @@ const card: Card = {
 			type: "holo",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		},
 		{

--- a/data/EX/Emerald/7.ts
+++ b/data/EX/Emerald/7.ts
@@ -95,15 +95,26 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 87156,
+				cardmarket: 276518
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 87156,
+				cardmarket: 276518
+			},
 		},
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				tcgplayer: 97711,
+			},
 		},
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/70.ts
+++ b/data/EX/Emerald/70.ts
@@ -70,16 +70,27 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 90037,
+				cardmarket: 276581
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 90037,
+				cardmarket: 276581
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["gen-con"]
+			stamp: ["gen-con"],
+			thirdParty: {
+				tcgplayer: 213010,
+			},
 		},
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/70.ts
+++ b/data/EX/Emerald/70.ts
@@ -72,7 +72,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		},
 		{

--- a/data/EX/Emerald/71.ts
+++ b/data/EX/Emerald/71.ts
@@ -76,7 +76,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/71.ts
+++ b/data/EX/Emerald/71.ts
@@ -74,12 +74,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 90416,
+				cardmarket: 276582
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 90416,
+				cardmarket: 276582
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/72.ts
+++ b/data/EX/Emerald/72.ts
@@ -77,12 +77,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 90438,
+				cardmarket: 276583
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 90438,
+				cardmarket: 276583
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/72.ts
+++ b/data/EX/Emerald/72.ts
@@ -79,7 +79,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/73.ts
+++ b/data/EX/Emerald/73.ts
@@ -75,7 +75,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		},
 		{

--- a/data/EX/Emerald/73.ts
+++ b/data/EX/Emerald/73.ts
@@ -73,16 +73,28 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 90581,
+				cardmarket: 276584
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 90581,
+				cardmarket: 276584
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["city-championships"]
+			stamp: ["city-championships"],
+			thirdParty: {
+				tcgplayer: 232877,
+				cardmarket: 450533
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/74.ts
+++ b/data/EX/Emerald/74.ts
@@ -77,12 +77,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 90747,
+				cardmarket: 276585
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 90747,
+				cardmarket: 276585
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/74.ts
+++ b/data/EX/Emerald/74.ts
@@ -79,7 +79,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/75.ts
+++ b/data/EX/Emerald/75.ts
@@ -30,7 +30,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		},
 		{

--- a/data/EX/Emerald/75.ts
+++ b/data/EX/Emerald/75.ts
@@ -28,16 +28,28 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 83740,
+				cardmarket: 276586
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 83740,
+				cardmarket: 276586
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["jason-klaczynski"]
+			stamp: ["jason-klaczynski"],
+			thirdParty: {
+				tcgplayer: 477599,
+				cardmarket: 869581
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/76.ts
+++ b/data/EX/Emerald/76.ts
@@ -28,12 +28,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 84888,
+				cardmarket: 276587
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 84888,
+				cardmarket: 276587
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/76.ts
+++ b/data/EX/Emerald/76.ts
@@ -30,7 +30,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/77.ts
+++ b/data/EX/Emerald/77.ts
@@ -30,7 +30,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/77.ts
+++ b/data/EX/Emerald/77.ts
@@ -28,12 +28,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 86598,
+				cardmarket: 276588
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 86598,
+				cardmarket: 276588
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/78.ts
+++ b/data/EX/Emerald/78.ts
@@ -30,7 +30,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/78.ts
+++ b/data/EX/Emerald/78.ts
@@ -28,12 +28,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 86920,
+				cardmarket: 276589
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 86920,
+				cardmarket: 276589
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/79.ts
+++ b/data/EX/Emerald/79.ts
@@ -30,7 +30,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/79.ts
+++ b/data/EX/Emerald/79.ts
@@ -28,12 +28,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 87600,
+				cardmarket: 276590
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 87600,
+				cardmarket: 276590
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/8.ts
+++ b/data/EX/Emerald/8.ts
@@ -85,7 +85,7 @@ const card: Card = {
 			type: "holo",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/8.ts
+++ b/data/EX/Emerald/8.ts
@@ -72,7 +72,7 @@ const card: Card = {
 		},
 	],
 
-	
+
 	retreat: 2,
 
 	thirdParty: {
@@ -83,12 +83,21 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 87453,
+				cardmarket: 276519
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
-		}
-	]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 87453,
+				cardmarket: 276519
+			},
+		},
+		
+	],
 }
 
 export default card

--- a/data/EX/Emerald/80.ts
+++ b/data/EX/Emerald/80.ts
@@ -30,7 +30,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/80.ts
+++ b/data/EX/Emerald/80.ts
@@ -28,12 +28,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 87889,
+				cardmarket: 276591
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 87889,
+				cardmarket: 276591
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/81.ts
+++ b/data/EX/Emerald/81.ts
@@ -27,12 +27,18 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				cardmarket: 276592
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 276592
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/81.ts
+++ b/data/EX/Emerald/81.ts
@@ -29,7 +29,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/82.ts
+++ b/data/EX/Emerald/82.ts
@@ -30,7 +30,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		},
 		{

--- a/data/EX/Emerald/82.ts
+++ b/data/EX/Emerald/82.ts
@@ -28,16 +28,27 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 88382,
+				cardmarket: 276593
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 88382,
+				cardmarket: 276593
+			},
 		},
 		{
-			type: "normal",
-			stamp: ["professor-program"]
+			type: "holo",
+			stamp: ["professor-program"],
+			thirdParty: {
+				tcgplayer: 176630,
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/83.ts
+++ b/data/EX/Emerald/83.ts
@@ -30,7 +30,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		},
 		{

--- a/data/EX/Emerald/83.ts
+++ b/data/EX/Emerald/83.ts
@@ -28,24 +28,44 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 88590,
+				cardmarket: 276594
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 88590,
+				cardmarket: 276594
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["takashi-yoneda"]
+			stamp: ["takashi-yoneda"],
+			thirdParty: {
+				tcgplayer: 477572,
+				cardmarket: 871573
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["michael-gonzalez"]
+			stamp: ["michael-gonzalez"],
+			thirdParty: {
+				tcgplayer: 88590,
+				cardmarket: 871572
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["jeremy-maron"]
+			stamp: ["jeremy-maron"],
+			thirdParty: {
+				tcgplayer: 477574,
+				cardmarket: 871571
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/84.ts
+++ b/data/EX/Emerald/84.ts
@@ -30,7 +30,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		},
 		{

--- a/data/EX/Emerald/84.ts
+++ b/data/EX/Emerald/84.ts
@@ -28,24 +28,44 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 88975,
+				cardmarket: 276595
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 88975,
+				cardmarket: 276595
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["curran-hill"]
+			stamp: ["curran-hill"],
+			thirdParty: {
+				tcgplayer: 477581,
+				cardmarket: 871549
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["takashi-yoneda"]
+			stamp: ["takashi-yoneda"],
+			thirdParty: {
+				tcgplayer: 477582,
+				cardmarket: 871550
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["jason-klaczynski"]
+			stamp: ["jason-klaczynski"],
+			thirdParty: {
+				tcgplayer: 477943,
+				cardmarket: 869574
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/85.ts
+++ b/data/EX/Emerald/85.ts
@@ -30,7 +30,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		},
 		{

--- a/data/EX/Emerald/85.ts
+++ b/data/EX/Emerald/85.ts
@@ -28,16 +28,28 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 90465,
+				cardmarket: 276596
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 90465,
+				cardmarket: 276596
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["curran-hill"]
+			stamp: ["curran-hill"],
+			thirdParty: {
+				tcgplayer: 477595,
+				cardmarket: 871559
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/86.ts
+++ b/data/EX/Emerald/86.ts
@@ -30,7 +30,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		},
 		{

--- a/data/EX/Emerald/86.ts
+++ b/data/EX/Emerald/86.ts
@@ -28,16 +28,28 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 84684,
+				cardmarket: 276597
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 84684,
+				cardmarket: 276597
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["takashi-yoneda"]
+			stamp: ["takashi-yoneda"],
+			thirdParty: {
+				tcgplayer: 477510,
+				cardmarket: 871590
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/87.ts
+++ b/data/EX/Emerald/87.ts
@@ -27,20 +27,36 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 84892,
+				cardmarket: 276598
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 84892,
+				cardmarket: 276598
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["michael-gonzalez"]
+			stamp: ["michael-gonzalez"],
+			thirdParty: {
+				tcgplayer: 477514,
+				cardmarket: 871587
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["jeremy-maron"]
+			stamp: ["jeremy-maron"],
+			thirdParty: {
+				tcgplayer: 477515,
+				cardmarket: 871586
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/87.ts
+++ b/data/EX/Emerald/87.ts
@@ -29,7 +29,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		},
 		{

--- a/data/EX/Emerald/88.ts
+++ b/data/EX/Emerald/88.ts
@@ -30,7 +30,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		},
 		{

--- a/data/EX/Emerald/88.ts
+++ b/data/EX/Emerald/88.ts
@@ -28,20 +28,36 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 87357,
+				cardmarket: 276599
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 87357,
+				cardmarket: 276599
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["curran-hill"]
+			stamp: ["curran-hill"],
+			thirdParty: {
+				tcgplayer: 477553,
+				cardmarket: 871581
+			},
 		},
 		{
 			type: "normal",
-			stamp: ["takashi-yoneda"]
+			stamp: ["takashi-yoneda"],
+			thirdParty: {
+				tcgplayer: 477554,
+				cardmarket: 871582
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/89.ts
+++ b/data/EX/Emerald/89.ts
@@ -28,12 +28,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "normal",
+			thirdParty: {
+				tcgplayer: 87631,
+				cardmarket: 276600
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 87631,
+				cardmarket: 276600
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/89.ts
+++ b/data/EX/Emerald/89.ts
@@ -30,7 +30,7 @@ const card: Card = {
 			type: "normal",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/9.ts
+++ b/data/EX/Emerald/9.ts
@@ -80,7 +80,7 @@ const card: Card = {
 			type: "holo",
 		},
 		{
-			type: "holo",
+			type: "reverse",
 			stamp: ["set-logo"]
 		}
 	]

--- a/data/EX/Emerald/9.ts
+++ b/data/EX/Emerald/9.ts
@@ -78,12 +78,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 88626,
+				cardmarket: 276520
+			},
 		},
 		{
 			type: "reverse",
-			stamp: ["set-logo"]
+			stamp: ["set-logo"],
+			thirdParty: {
+				tcgplayer: 88626,
+				cardmarket: 276520
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/90.ts
+++ b/data/EX/Emerald/90.ts
@@ -92,8 +92,12 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 83524,
+				cardmarket: 276601
+			},
 		},
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/91.ts
+++ b/data/EX/Emerald/91.ts
@@ -103,8 +103,12 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 84084,
+				cardmarket: 276602
+			},
 		},
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/92.ts
+++ b/data/EX/Emerald/92.ts
@@ -104,8 +104,12 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 84096,
+				cardmarket: 276603
+			},
 		},
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/93.ts
+++ b/data/EX/Emerald/93.ts
@@ -81,12 +81,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 84773,
+				cardmarket: 276604
+			},
 		},
 		{
 			type: "holo",
-			stamp: ["jason-klaczynski"]
+			stamp: ["jason-klaczynski"],
+			thirdParty: {
+				tcgplayer: 477608,
+				cardmarket: 869537
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/94.ts
+++ b/data/EX/Emerald/94.ts
@@ -94,8 +94,12 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 85032,
+				cardmarket: 276605
+			},
 		},
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/95.ts
+++ b/data/EX/Emerald/95.ts
@@ -103,12 +103,20 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 87277,
+				cardmarket: 276606
+			},
 		},
 		{
 			type: "holo",
-			stamp: ["curran-hill"]
+			stamp: ["curran-hill"],
+			thirdParty: {
+				tcgplayer: 477551,
+				cardmarket: 871510
+			},
 		}
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/96.ts
+++ b/data/EX/Emerald/96.ts
@@ -103,8 +103,12 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 87460,
+				cardmarket: 276607
+			},
 		},
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/97.ts
+++ b/data/EX/Emerald/97.ts
@@ -100,8 +100,12 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 88526,
+				cardmarket: 276608
+			},
 		},
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/98.ts
+++ b/data/EX/Emerald/98.ts
@@ -82,8 +82,12 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 88660,
+				cardmarket: 276609
+			},
 		},
-	]
+	],
 }
 
 export default card

--- a/data/EX/Emerald/99.ts
+++ b/data/EX/Emerald/99.ts
@@ -81,8 +81,12 @@ const card: Card = {
 	variants: [
 		{
 			type: "holo",
+			thirdParty: {
+				tcgplayer: 88675,
+				cardmarket: 276610
+			},
 		},
-	]
+	],
 }
 
 export default card


### PR DESCRIPTION
closes #N/A

## Changes

- move thidparty from root to variant object
- add missing variants
- add missing cardmarketids and tcgplayerids

## Details

- added deck exclusives
- changed all holo to reverse holo to match official pokmn docks

