### PR TITLE
(data) add Black Bolt Antique Cover Fossil HP

### DIFF
--- a/data/Scarlet & Violet/Black Bolt/080.ts
+++ b/data/Scarlet & Violet/Black Bolt/080.ts
@@ -17,6 +17,7 @@ const card: Card = {
 	illustrator: "AYUMI ODASHIMA",
 	rarity: "Common",
 	category: "Trainer",
+	hp: 60,
 
 	abilities: [{
 		type: "Ability",


### PR DESCRIPTION
## Summary

- add the printed 60 HP to Black Bolt Antique Cover Fossil (`sv10.5b-080`)
- align this reprint with the equivalent Stellar Crown print and every other current Antique Fossil

## Validation

- full 41,195-file multilingual database compilation
- root data TypeScript validation
- server TypeScript validation
- same-pattern scan confirmed no other English 60-HP played-as-Pokémon Fossil is missing `hp: 60`

The same commit has been merged into the downstream fork in whosthatbloke/cards-database#1.