### PR TITLE
(data) Add missing German translations for base2

### DIFF
--- a/data/Base/Jungle/1.ts
+++ b/data/Base/Jungle/1.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Clefairy",
-		fr: "Mélofée"
+		fr: "Mélofée",
+		de: "Piepi"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Choose 1 of the Defending Pokémon's attacks. Metronome copies that attack except for its Energy costs and anything else required in order to use that attack, such as discarding Energy cards. (No matter what type the Defending Pokémon is, Clefable's type is still Colorless.)",
 				fr: "Choisissez 1 des attaques du Pokémon Défenseur. Métronome copie cette attaque à l'exception de son coût d'Énergie et de toute autre action requise pour utiliser cette attaque, comme par exemple, défausser des cartes Énergie. (Quel que soit le type du Pokémon Défenseur, Mélodelfe demeure de type Incolore.)",
-				de: "Wähle einen der Angriffe des verteidigenden Pokémon. Metronom kopiert diesen Angriff, außer seiner Energiekosten und was sonst noch für den Einsatz dieses Angriffs erforderlich ist, wie z.B. das Entfernen von Energiekarten. (Unabhängig vom Typ des verteidigenden Pokémon bleibt Pixi immer noch ein farbloses Pokémon.)"
+				de: "Wähle einen der Angriffe des verteidigenden Pokémon. Metronom kopiert diesen Angriff außer seiner Energiekosten und was sonst noch für den Einsatz dieses Angriffs erforderlich ist wie z.B. das Entfernen von Energiekarten. (Unabhängig vom Typ des verteidigenden Pokémon bleibt Pixi immer noch ein farbloses Pokémon.)"
 			},
 
 		},
@@ -84,7 +85,8 @@ const card: Card = {
 
 	description: {
 		fr: "Une sorte de petite fée très rare. Il se cache en apercevant un être humain.",
-		en: "A timid fairy Pokémon that is rarely seen. It will run and hide the moment it senses people."
+		en: "A timid fairy Pokémon that is rarely seen. It will run and hide the moment it senses people.",
+		de: "Ein furchtsames Feen-Pokémon, das selten zum Vorschein kommt. Sobald es Menschen wittert, läuft es davon und versteckt sich."
 	},
 
 

--- a/data/Base/Jungle/10.ts
+++ b/data/Base/Jungle/10.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "During your next turn, Scyther's Slash attack's base damage is 60 instead of 30.",
 				fr: "Pendant votre prochain tour, l'attaque Tranche d'Insécateur inflige 60 dégâts de base au lieu de 30.",
-				de: "Während deines nächsten Zuges betragen die Basis Schadenspunkte von Sichlors Schlitzer-Angriff 60 anstatt 30."
+				de: "Während deines nächsten Zuges betragen die Basis-Schadenspunkte von Sichlors Schlitzer-Angriff 60 anstatt 30."
 			},
 
 		},
@@ -75,7 +75,8 @@ const card: Card = {
 
 	description: {
 		en: "With ninja-like agility and speed, it can create the illusion that there is more than one of it.",
-		fr: "Rapide et agile comme un ninja, il se déplace si vite qu'il crée l'illusion d'être en groupe."
+		fr: "Rapide et agile comme un ninja, il se déplace si vite qu'il crée l'illusion d'être en groupe.",
+		de: "Mit Ninja-ähnlicher Beweglichkeit und Geschwindigkeit kann es die Illusion erzeugen, daß es sich um mehr als ein Monster handelt."
 	},
 
 

--- a/data/Base/Jungle/11.ts
+++ b/data/Base/Jungle/11.ts
@@ -25,6 +25,7 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Munchlax",
+		de: "Mampfaxo"
 	},
 
 	stage: "Basic",
@@ -40,7 +41,7 @@ const card: Card = {
 			effect: {
 				en: "Snorlax can't become Asleep, Confused, Paralyzed, or Poisoned. This power can't be used if Snorlax is already Asleep, Confused, or Paralyzed.",
 				fr: "Ronflex ne peut pas devenir Endormi, Confus, Paralysé ou Empoisonné. Ce pouvoir ne peut être utilisé si Ronflex est déjà Endormi, Confus ou Paralysé.",
-				de: "Relaxo kann nicht in den Schlaf versetzt, verwirrt, gelähmt oder vergiftet weden. Diese Fähigkeit kann nicht eingesetzt werden, falls Relaxo scchläft, verwirrt oder gelähmt ist."
+				de: "Relaxo kann nicht in den Schlaf versetzt, verwirrt, gelähmt oder vergiftet werden. Diese Fähigkeit kann nicht eingesetzt werden, falls Relaxo schläft, verwirrt oder gelähmt ist."
 			},
 		},
 	],
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei Kopf ist das verteidigende Pokémon jezt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 30,
 
@@ -86,7 +87,8 @@ const card: Card = {
 
 	description: {
 		en: "Very lazy. Just eats and sleeps. As its rotund bulk builds, it becomes steadily more slothful.",
-		fr: "Très paresseux, il ne fait que manger et dormir. Plus il est gros, plus il devient fainéant."
+		fr: "Très paresseux, il ne fait que manger et dormir. Plus il est gros, plus il devient fainéant.",
+		de: "Totaler Faulenzer. Frisst und schläft nur. Je mehr seine rundliche Masse zunimmt, desto träger wird es."
 	},
 
 

--- a/data/Base/Jungle/12.ts
+++ b/data/Base/Jungle/12.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Eevee",
-		fr: "Évoli"
+		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage; if tails, this attack does 10 damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires ; si c'est pile, cette attaque inflige 10 dégâts.",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu; bei \"Zahl\" fügt dieser Angriff 10 Schaden zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu. Bei „Zahl“ fügt dieser Angriff 10 Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -63,7 +64,7 @@ const card: Card = {
 			effect: {
 				en: "Does 30 damage plus 10 more damage for each Energy attached to Vaporeon but not used to pay for this attack's Energy cost. Extra Energy after the 2nd doesn't count.",
 				fr: "Inflige 30 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  attachée à Aquali en plus du coût en Énergie de cette attaque. Les Énergies  supplémentaires après la seconde ne comptent pas.",
-				de: "Fügt 30 Schadenspunkte plus 10 weitere Scadenspunkte für jede auf Aquana abgelegte  Energie zu, die nicht zum Zahler der Energiekosten für diesen Angriff verwendet wurde. Du kannst nicht mehr als 20 Schaenspunkte auf diese Weise hinzufügen."
+				de: "Fügt 30 Schadenspunkte plus 10 weitere Schadenspunkte für jede auf Aquana abgelegte {W}-Energie zu, die nicht zum Zahlen der Energiekosten für diesen Angriff verwendet wurde. Du kannst nicht mehr als 20 Schadenspunkte auf diese Weise hinzufügen."
 			},
 			damage: "30+",
 
@@ -81,7 +82,8 @@ const card: Card = {
 
 	description: {
 		en: "Lives close to water. Its long tail is ridged with a fin that is often mistaken for a mermaid's.",
-		fr: "Il vit au bord de l'eau. Sa queue lui donne l'apparence d'une sirène."
+		fr: "Il vit au bord de l'eau. Sa queue lui donne l'apparence d'une sirène.",
+		de: "Lebt in Ufernähe. Sein langer Schwanz hat eine Flosse, die oft mit der einer Meeresjungfrau verwechselt wird."
 	},
 
 

--- a/data/Base/Jungle/13.ts
+++ b/data/Base/Jungle/13.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Venonat",
-		fr: "Mimitoss"
+		fr: "Mimitoss",
+		de: "Bluzuk"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may change the type of Venomoth to the type of any other Pokémon in play other than Colorless. This power can't be used if Venomoth is Asleep, Confused, or Paralyzed.",
 				fr: "Une fois pendant votre tour (avant votre attaque), vous pouvez changer le type d'Aéromite pour le type de n'importe quel Pokémon en jeu autre qu'Incolore. Ce pouvoir ne peut être utilisé si Aéromite est Endormi, Confus, ou Paralysé.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du den Typ von Omot in den Typ eines im Spiewl befindlichen Pokémon deiuner Wahl (Farblos ausgenommen) umwndeln. Diese Fähigkeit kann nicht eingesetzt werden, falls Omot schläft, verwirrt oder gelähmt ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du den Typ von Omot in den Typ eines im Spiel befindlichen Pokémon deiner Wahl (Farblos ausgenommen) umwandeln. Diese Fähigkeit kann nicht eingesetzt werden, falls Omot schläft, verwirrt oder gelähmt ist."
 			},
 		},
 	],
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused and Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus et Empoisonné.",
-				de: "Wirf eine Münze. Bei Kopf ist das verteidigende Pokémon jetzt verwirrt und vergiftet."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das verteidigende Pokémon jetzt verwirrt und vergiftet."
 			},
 
 			damage: 10
@@ -85,7 +86,8 @@ const card: Card = {
 
 	description: {
 		en: "The dust-like scales covering its wings are color coded to indicate the kinds of poison it has.",
-		fr: "Les motifs ocres de ses ailes changent en fonction de son type de poison."
+		fr: "Les motifs ocres de ses ailes changent en fonction de son type de poison.",
+		de: "Die staubähnlichen Schuppen, die seine Flügel bedecken, sind je nach Art ihres Giftes farbkodiert."
 	},
 
 

--- a/data/Base/Jungle/14.ts
+++ b/data/Base/Jungle/14.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Weepinbell",
-		fr: "Boustiflor"
+		fr: "Boustiflor",
+		de: "Ultrigaria"
 	},
 
 	stage: "Stage2",
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon can't retreat during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur ne peut pas battre en retraite pendant le prochain tour de votre adversaire.",
-				de: "Wirf eine Münze. Bei Kopf kann sich das verteidigende Pokémon während des nächsten Zuges des Gegnersnicht zurückziehen."
+				de: "Wirf eine Münze. Bei „Kopf“ kann das verteidigende Pokémon sich während des nächsten Zuges des Gegners nicht zurückziehen."
 			},
 			damage: 20,
 
@@ -78,7 +79,8 @@ const card: Card = {
 
 	description: {
 		en: "Said to live in huge colonies deep in jungles, although no one has ever returned from there.",
-		fr: "Il vit en colonie dans la jungle mais personne n'en est jamais revenu vivant."
+		fr: "Il vit en colonie dans la jungle mais personne n'en est jamais revenu vivant.",
+		de: "Soll in riesigen Kolonien tief im Dschungel leben, obwohl noch niemand jemals von dort zurückgekehrt ist."
 	},
 
 

--- a/data/Base/Jungle/15.ts
+++ b/data/Base/Jungle/15.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Gloom",
-		fr: "Ortide"
+		fr: "Ortide",
+		de: "Duflor"
 	},
 
 	stage: "Stage2",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may flip a coin. If heads, remove 1 damage counter from 1 of your Pokémon. This power can't be used if Vileplume is Asleep, Confused, or Paralyzed.",
 				fr: "Une fois pendant votre tour (avant votre attaque), vous pouvez lancer une pièce. Si c'est face, retirez 1 marqueur de dégâts d'un de vos Pokémon. Ce pouvoir ne peut être utilisé si Raflésia est Endormi, Confus, ou Paralysé.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du eine Münze werfen. Bei Kopf entferne eine Schadensmarke von einem deiner Pokémon. Diese Fähigkeit kann nicht eigesetzt werden, falls Giflor schlafend, verwirrt oder gelähmt ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du eine Münze werfen. Bei „Kopf“ entferne eine Schadensmarke von einem deiner Pokémon. Diese Fähigkeit kann nicht eingesetzt werden, falls Giflor schlafend, verwirrt oder gelähmt ist."
 			},
 		},
 	],
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 40 damage times the number of heads. Vileplume is now Confused (after doing damage).",
 				fr: "Lancez 3 pièces. Cette attaque inflige 40 dégâts multipliés par le nombre de faces. Raflésia est maintenant Confus (après résolution des dégâts).",
-				de: "Wirf drei Münzen. Dieser Angriff fügt jedesmal, wenn die Münze Kopf zeigt, 40 Schadenspunkte zu. Giflor ist jetzt verwirrt (nach der Schadensverteilung)."
+				de: "Wirf drei Münzen. Dieser Angriff fügt jedesmal, wenn die Münze „Kopf“ zeigt, 40 Schadenspunkte zu. Giflor ist jetzt verwirrt (nach der Schadensverteilung)."
 			},
 			damage: "40x",
 
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "The larger its petals, the more toxic pollen it contains. Its big head is heavy and hard to hold up.",
-		fr: "Plus ses pétales sont grands, plus ils contiennent de pollen toxique."
+		fr: "Plus ses pétales sont grands, plus ils contiennent de pollen toxique.",
+		de: "Je größer die Blütenblätter, desto giftiger ist der Blütenstaub darin. Sein großer Kopf ist schwer und nicht einfach hochzuhalten."
 	},
 
 

--- a/data/Base/Jungle/16.ts
+++ b/data/Base/Jungle/16.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Jigglypuff",
-		fr: "Rondoudou"
+		fr: "Rondoudou",
+		de: "Pummeluff"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
-				de: "Das verteidigende Pokémon ist jetzt schlafend"
+				de: "Das verteidigende Pokémon ist jetzt schlafend."
 			},
 
 		},
@@ -86,7 +87,8 @@ const card: Card = {
 
 	description: {
 		en: "The body is soft and rubbery. When angered, it will suck in air and inflate itself to an enormous size.",
-		fr: "En cas de danger, il gonfle d'air son corps doux et potelé dans des proportions gigantesques."
+		fr: "En cas de danger, il gonfle d'air son corps doux et potelé dans des proportions gigantesques.",
+		de: "Sein Körper ist weich und gummiartig. Wenn es wütend wird, saugt es Luft ein und bläst sich auf eine enorme Größe auf."
 	},
 
 

--- a/data/Base/Jungle/17.ts
+++ b/data/Base/Jungle/17.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Clefairy",
-		fr: "Mélofée"
+		fr: "Mélofée",
+		de: "Piepi"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Choose 1 of the Defending Pokémon's attacks. Metronome copies that attack except for its Energy costs and anything else required in order to use that attack, such as discarding Energy cards. (No matter what type the Defending Pokémon is, Clefable's type is still Colorless.)",
 				fr: "Choisissez 1 des attaques du Pokémon Défenseur. Métronome copie cette attaque à l'exception de son coût d'Énergie et de toute autre action requise pour utiliser cette attaque, comme par exemple, défausser des cartes Énergie. (Quel que soit le type du Pokémon Défenseur, Mélodelfe demeure de type Incolore.)",
-				de: "Wähle einen der Angriffe des verteidigenden Pokémon. Metronom kopiert diesen Angriff, außer seiner Energiekosten und was sonst noch für den Einsatz dieses Angriffs erforderlich ist, wie z.B. das Entfernen von Energiekarten. (Unabhängig vom Typ des verteidigenden Pokémon bleibt Pixi immer noch ein farbloses Pokémon.)"
+				de: "Wähle einen der Angriffe des verteidigenden Pokémon. Metronom kopiert diesen Angriff außer seiner Energiekosten und was sonst noch für den Einsatz dieses Angriffs erforderlich ist wie z.B. das Entfernen von Energiekarten. (Unabhängig vom Typ des verteidigenden Pokémon bleibt Pixi immer noch ein farbloses Pokémon.)"
 			},
 
 		},
@@ -84,7 +85,8 @@ const card: Card = {
 
 	description: {
 		en: "A timid Fairy Pokémon that is rarely seen. It will run and hide the moment it senses people.",
-		fr: "Une sorte de petite fée très rare. Il se cache en apercevant un être humain."
+		fr: "Une sorte de petite fée très rare. Il se cache en apercevant un être humain.",
+		de: "Ein furchtsames Feen-Pokémon, das selten zum Vorschein kommt. Sobald es Menschen wittert, läuft es davon und versteckt sich."
 	},
 
 

--- a/data/Base/Jungle/18.ts
+++ b/data/Base/Jungle/18.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Voltorb",
-		fr: "Voltorbe"
+		fr: "Voltorbe",
+		de: "Voltobal"
 	},
 
 	stage: "Stage1",
@@ -59,7 +60,7 @@ const card: Card = {
 			effect: {
 				en: "If the Defending Pokémon isn't Colorless, this attack does 10 damage to each Benched Pokémon of the same type as the Defending Pokémon (including your own).",
 				fr: "Si le Pokémon Défenseur n'est pas de type Incolore, cette attaque inflige 10 dégâts à chacun des Pokémon du même type que le Pokémon Défenseur qui sont sur un Banc (y compris le vôtre).",
-				de: "Ist das Verteidigende Pokémon nicht farblos, fügt dieser Angriff jedem auf der Bank befindlichen Pokémon (einschließlich deiner eigenen) vom gleichen Typs wie das Verteidigende Pokémon 10 Schadenspunkte zu."
+				de: "Ist das verteidigende Pokémon nicht farblos, fügt dieser Angriff jedem auf der Bank befindlichen Pokémon (einschließlich deiner eigenen) vom gleichen Typs wie das verteidigende Pokémon 10 Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -77,7 +78,8 @@ const card: Card = {
 
 	description: {
 		en: "It stores electrical energy under very high pressure. It often explodes with little or no provocation.",
-		fr: "Il emmagasine des quantités énormes de courant électrique sous pression pouvant exploser."
+		fr: "Il emmagasine des quantités énormes de courant électrique sous pression pouvant exploser.",
+		de: "Es speichert elektrische Energie unter sehr hohem Druck. Es explodiert mit geringer oder sogar keiner Provozierung."
 	},
 
 

--- a/data/Base/Jungle/19.ts
+++ b/data/Base/Jungle/19.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Eevee",
-		fr: "Évoli"
+		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage; if tails, this attack does 10 damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires ; si c'est pile, cette attaque inflige 10 dégâts.",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu; bei \"Zahl\" fügt dieser Angriff 10 Schaden zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu; bei „Zahl“ fügt dieser Angriff 10 Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -64,7 +65,7 @@ const card: Card = {
 			effect: {
 				en: "Discard 1 Energy card attached to Flareon in order to use this attack.",
 				fr: "Défaussez 1 carte Énergie  attachée à Pyroli pour pouvoir utiliser cette attaque.",
-				de: "Entferne eine auf Flamara abgelegte -Energiekarte, um diesen Angriff auszuführen."
+				de: "Entferne eine auf Flamara abgelegte {R}-Energiekarte, um diesen Angriff auszuführen."
 			},
 			damage: 60,
 
@@ -82,7 +83,8 @@ const card: Card = {
 
 	description: {
 		en: "When storing thermal energy in its body, its temperature could soar to over 1600 degrees.",
-		fr: "Il peut accumuler suffisamment de chaleur pour atteindre des températures de 1600 degrés."
+		fr: "Il peut accumuler suffisamment de chaleur pour atteindre des températures de 1600 degrés.",
+		de: "Beim Speichern von Wärmeenergie in seinem Körper erreicht es eine Temperatur von über 900 Grad."
 	},
 
 

--- a/data/Base/Jungle/2.ts
+++ b/data/Base/Jungle/2.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Voltorb",
-		fr: "Voltorbe"
+		fr: "Voltorbe",
+		de: "Voltobal"
 	},
 
 	stage: "Stage1",
@@ -59,7 +60,7 @@ const card: Card = {
 			effect: {
 				en: "If the Defending Pokémon isn't Colorless, this attack does 10 damage to each Benched Pokémon of the same type as the Defending Pokémon (including your own).",
 				fr: "Si le Pokémon Défenseur n'est pas de type Incolore, cette attaque inflige 10 dégâts à chacun des Pokémon du même type que le Pokémon Défenseur qui sont sur un Banc (y compris le vôtre).",
-				de: "Ist das Verteidigende Pokémon nicht farblos, fügt dieser Angriff jedem auf der Bank befindlichen Pokémon (einschließlich deiner eigenen) vom gleichen Typs wie das Verteidigende Pokémon 10 Schadenspunkte zu."
+				de: "Ist das verteidigende Pokémon nicht farblos, fügt dieser Angriff jedem auf der Bank befindlichen Pokémon (einschließlich deiner eigenen) vom gleichen Typs wie das verteidigende Pokémon 10 Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -77,7 +78,8 @@ const card: Card = {
 
 	description: {
 		en: "It stores electrical energy under very high pressure. It often explodes with little or no provocation.",
-		fr: "Il emmagasine des quantités énormes de courant électrique sous pression pouvant exploser."
+		fr: "Il emmagasine des quantités énormes de courant électrique sous pression pouvant exploser.",
+		de: "Es speichert elektrische Energie unter sehr hohem Druck. Es explodiert mit geringer oder sogar keiner Provozierung."
 	},
 
 

--- a/data/Base/Jungle/20.ts
+++ b/data/Base/Jungle/20.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Eevee",
-		fr: "Évoli"
+		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage; if tails, this attack does 10 damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires ; si c'est pile, cette attaque inflige 10 dégâts.",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu; bei \"Zahl\" fügt dieser Angriff 10 Schaden zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu; bei „Zahl“ fügt dieser Angriff 10 Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -63,7 +64,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 4 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 4 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 4 Münzen. Dieser Angriff fügt jedesmal, wenn die Münze \"Kopf\" zeigt, 20 Schadenspunkte zu."
+				de: "Wirf 4 Münzen. Dieser Angriff fügt jedesmal, wenn die Münze „Kopf“ zeigt, 20 Schadenspunkte zu."
 			},
 			damage: "20x",
 
@@ -81,7 +82,8 @@ const card: Card = {
 
 	description: {
 		en: "It accumulates negative ions from the atmosphere to blast out 10,000-volt lightning bolts.",
-		fr: "Il se charge d'électricité statique pour envoyer des décharges de 10000 volts."
+		fr: "Il se charge d'électricité statique pour envoyer des décharges de 10000 volts.",
+		de: "Es sammelt negative Ionen aus der Atmosphäre, um Blitzschläge von 10.000 Volt herauszuschleudern."
 	},
 
 

--- a/data/Base/Jungle/21.ts
+++ b/data/Base/Jungle/21.ts
@@ -57,7 +57,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 4 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 4 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 4 Münzen. Dieser Angriff fügt jedesmal, wenn die Münze \"Kopf\" zeigt, 20 Schadenspunkte zu."
+				de: "Wirf 4 Münzen. Dieser Angriff fügt jedesmal, wenn die Münze „Kopf“ zeigt, 20 Schadenspunkte zu."
 			},
 			damage: "20x",
 
@@ -82,7 +82,8 @@ const card: Card = {
 
 	description: {
 		en: "The infant rarely ventures out of its mother's protective pouch until it is three years old.",
-		fr: "Son enfant ne quitte la poche ventrale protectrice qu'à l'âge de 3 ans."
+		fr: "Son enfant ne quitte la poche ventrale protectrice qu'à l'âge de 3 ans.",
+		de: "Der Nachkömmling verläßt vor dem Alter von drei Jahren nur selten den Beutel der Mutter."
 	},
 
 

--- a/data/Base/Jungle/22.ts
+++ b/data/Base/Jungle/22.ts
@@ -25,6 +25,7 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Mime Jr.",
+		de: "Pantimimi"
 	},
 
 	stage: "Basic",
@@ -40,7 +41,7 @@ const card: Card = {
 			effect: {
 				en: "Whenever an attack (including your own) does 30 or more damage to Mr. Mime (after applying Weakness and Resistance), prevent that damage. (Any other effects of attacks still happen.) This power can't be used if Mr. Mime is Asleep, Confused, or Paralyzed.",
 				fr: "Chaque fois qu'une attaque (y compris les vôtres) inflige 30 dégâts ou plus à M. Mime (après application de la Faiblesse et de la Résistance), prévenez ces dégâts. (Tout autre effet ou attaque subsiste.) Ce pouvoir ne peut être utilisé si M. Mime est Endormi, Confus ou Paralysé.",
-				de: "Immer wenn ein Angriff (auch dein eigener) Pantimos 30 oder mehr Schadenspunkte zufügt (nachdem Schwäche und Resistnz abgerechnet wurden), verhindere diesen Schaden. (Alle anderen Auswirkungen von Agriffen finden immernch statt.) Dies Fähigkeit kann nicht eingesetzt werden, falls Pantimosschlafend, verwirrt oder gelähmt ist."
+				de: "Immer wenn ein Angriff (auch dein eigener) Pantimos 30 oder mehr Schadenspunkte zufügt (nachdem Schwäche und Resistenz abgerechnet wurden), verhindere diesen Schaden. (Alle anderen Auswirkungen von Angriffen finden immer noch statt.) Diese Fähigkeit kann nicht eingesetzt werden, falls Pantimos schlafend, verwirrt oder gelähmt ist."
 			},
 		},
 	],
@@ -59,7 +60,7 @@ const card: Card = {
 			effect: {
 				en: "Does 10 damage plus 10 more damage for each damage counter on the Defending Pokémon.",
 				fr: "Inflige 10 dégâts plus 10 dégâts supplémentaires pour chaque marqueur de dégâts sur le Pokémon Défenseur.",
-				de: "Fügt 10 Schadenspunkte plus 10 weitere Schadenspunkte für jede Schadensmarke auf dem verteidigendem Pokémon zu."
+				de: "Fügt 10 Schadenspunkte plus 10 weitere Schadenspunkte für jede Schadensmarke auf dem verteidigenden Pokémon zu."
 			},
 			damage: "10+",
 
@@ -77,7 +78,8 @@ const card: Card = {
 
 	description: {
 		en: "If interrupted while miming, it will slap around the enemy with its broad hands.",
-		fr: "Dérangez-le pendant qu'il mime et il se battra en distribuant des volées de claques."
+		fr: "Dérangez-le pendant qu'il mime et il se battra en distribuant des volées de claques.",
+		de: "Falls es bei der Pantomime unterbrochen wird, schlägt es den Feind mit seinen breiten Händen."
 	},
 
 

--- a/data/Base/Jungle/23.ts
+++ b/data/Base/Jungle/23.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Nidorina",
-		fr: "Nidorina"
+		fr: "Nidorina",
+		de: "Nidorina"
 	},
 
 	stage: "Stage2",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Does 20 damage plus 20 more damage for each Nidoking you have in play.",
 				fr: "Inflige 20 dégâts plus 20 dégâts supplémentaires pour chaque Nidoking que vous avez en jeu.",
-				de: "Fügt 20 Schadenspunkte plus 20 weitere für jeden Nidoking zu, den du im Spiel hast."
+				de: "Fügt 20 Schadenspunkte plus 20 weitere Schadenspunkte für jeden Nidoking zu, den du im Spiel hast."
 			},
 			damage: "20+",
 
@@ -78,7 +79,8 @@ const card: Card = {
 
 	description: {
 		en: "Its hard scales provide strong protection. It uses its hefty bulk to execute powerful moves.",
-		fr: "Ses écailles très résistantes et son corps massif sont des armes dévastatrices."
+		fr: "Ses écailles très résistantes et son corps massif sont des armes dévastatrices.",
+		de: "Seine harten Schuppen bieten ihm starken Schutz. Es nutzt seine massige Gestalt für kräftige Bewegungen."
 	},
 
 

--- a/data/Base/Jungle/24.ts
+++ b/data/Base/Jungle/24.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pidgeotto",
-		fr: "Roucoups"
+		fr: "Roucoups",
+		de: "Tauboga"
 	},
 
 	stage: "Stage2",
@@ -59,7 +60,7 @@ const card: Card = {
 			effect: {
 				en: "Unless this attack Knocks Out the Defending Pokémon, return the Defending Pokémon and all cards attached to it to your opponent's hand.",
 				fr: "À moins que cette attaque ne mette le Pokémon Défenseur K.O., renvoyez le Pokémon Défenseur et toutes les cartes qui lui sont attachées dans la main de votre adversaire.",
-				de: "Falls dieser Angriff den verteidigenden Pokémon nicht kampfunfähig macht, gib den verteidigenden Pokémon und alle daraufabgelegten Karten deinem Gegner auf die Hand zurück."
+				de: "Falls dieser Angriff den verteidigenden Pokémon nicht kampfunfähig macht, gib den verteidigenden Pokémon und alle darauf abgelegten Karten deinem Gegners auf die Hand zurück."
 			},
 			damage: 30,
 
@@ -82,7 +83,8 @@ const card: Card = {
 
 	description: {
 		en: "When hunting, it skims the surface of water at high speed to pick off unwary prey such as Magikarp.",
-		fr: "Il chasse en surveillant la surface de l'eau et en plongeant pour attraper des proies faciles."
+		fr: "Il chasse en surveillant la surface de l'eau et en plongeant pour attraper des proies faciles.",
+		de: "Auf der Jagd fliegt es mit einer hohen Geschwindigkeit knapp über der Wasseroberfläche, um nichtsahnende Beute wie z.B. Karpador einzufangen."
 	},
 
 

--- a/data/Base/Jungle/25.ts
+++ b/data/Base/Jungle/25.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei Kopf ist das verteidigende Pokémon jetzt gelähmt"
+				de: "Wirf eine Münze. Bei „Kopf“ ist das verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "If it fails to crush the victim in its pincers, it will swing its victim around and toss it hard.",
-		fr: "Quand il ne peut écraser sa proie avec sa pince, il la secoue et l'envoie dans les airs."
+		fr: "Quand il ne peut écraser sa proie avec sa pince, il la secoue et l'envoie dans les airs.",
+		de: "Falls es ihm nicht gelingt, sein Opfer in seinen Kneifzangen zu erdrücken, schwingt es sein Opfer durch die Luft und nimmt es auf die Hörner."
 	},
 
 

--- a/data/Base/Jungle/26.ts
+++ b/data/Base/Jungle/26.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "During your next turn, Scyther's Slash attack's base damage is 60 instead of 30.",
 				fr: "Pendant votre prochain tour, l'attaque Tranche d'Insécateur inflige 60 dégâts de base au lieu de 30.",
-				de: "Während deines nächsten Zuges betragen die Basis Schadenspunkte von Sichlors Schlitzer-Angriff 60 anstatt 30."
+				de: "Während deines nächsten Zuges betragen die Basis-Schadenspunkte von Sichlors Schlitzer-Angriff 60 anstatt 30."
 			},
 
 		},
@@ -75,7 +75,8 @@ const card: Card = {
 
 	description: {
 		en: "With ninja-like agility and speed, it can create the illusion that there is more than one of it.",
-		fr: "Rapide et agile comme un ninja, il se déplace si vite qu'il crée l'illusion d'être en groupe."
+		fr: "Rapide et agile comme un ninja, il se déplace si vite qu'il crée l'illusion d'être en groupe.",
+		de: "Mit Ninja-ähnlicher Beweglichkeit und Geschwindigkeit kann es die Illusion erzeugen, daß es sich um mehr als ein Monster handelt."
 	},
 
 

--- a/data/Base/Jungle/27.ts
+++ b/data/Base/Jungle/27.ts
@@ -25,6 +25,7 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Munchlax",
+		de: "Mampfaxo"
 	},
 
 	stage: "Basic",
@@ -40,7 +41,7 @@ const card: Card = {
 			effect: {
 				en: "Snorlax can't become Asleep, Confused, Paralyzed, or Poisoned. This power can't be used if Snorlax is already Asleep, Confused, or Paralyzed.",
 				fr: "Ronflex ne peut pas devenir Endormi, Confus, Paralysé ou Empoisonné. Ce pouvoir ne peut être utilisé si Ronflex est déjà Endormi, Confus ou Paralysé.",
-				de: "Relaxo kann nicht in den Schlaf versetzt, verwirrt, gelähmt oder vergiftet weden. Diese Fähigkeit kann nicht eingesetzt werden, falls Relaxo scchläft, verwirrt oder gelähmt ist."
+				de: "Relaxo kann nicht in den Schlaf versetzt, verwirrt, gelähmt oder vergiftet werden. Diese Fähigkeit kann nicht eingesetzt werden, falls Relaxo schläft, verwirrt oder gelähmt ist."
 			},
 		},
 	],
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei Kopf ist das verteidigende Pokémon jezt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 30,
 
@@ -86,7 +87,8 @@ const card: Card = {
 
 	description: {
 		en: "Very lazy. Just eats and sleeps. As its rotund bulk builds, it becomes steadily more slothful.",
-		fr: "Très paresseux, il ne fait que manger et dormir. Plus il est gros, plus il devient fainéant."
+		fr: "Très paresseux, il ne fait que manger et dormir. Plus il est gros, plus il devient fainéant.",
+		de: "Totaler Faulenzer. Frisst und schläft nur. Je mehr seine rundliche Masse zunimmt, desto träger wird es."
 	},
 
 

--- a/data/Base/Jungle/28.ts
+++ b/data/Base/Jungle/28.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Eevee",
-		fr: "Évoli"
+		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage; if tails, this attack does 10 damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires ; si c'est pile, cette attaque inflige 10 dégâts.",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu; bei \"Zahl\" fügt dieser Angriff 10 Schaden zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu. Bei „Zahl“ fügt dieser Angriff 10 Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -63,7 +64,7 @@ const card: Card = {
 			effect: {
 				en: "Does 30 damage plus 10 more damage for each Energy attached to Vaporeon but not used to pay for this attack's Energy cost. Extra Energy after the 2nd doesn't count.",
 				fr: "Inflige 30 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  attachée à Aquali en plus du coût en Énergie de cette attaque. Les Énergies  supplémentaires après la seconde ne comptent pas.",
-				de: "Fügt 30 Schadenspunkte plus 10 weitere Scadenspunkte für jede auf Aquana abgelegte  Energie zu, die nicht zum Zahler der Energiekosten für diesen Angriff verwendet wurde. Du kannst nicht mehr als 20 Schaenspunkte auf diese Weise hinzufügen."
+				de: "Fügt 30 Schadenspunkte plus 10 weitere Schadenspunkte für jede auf Aquana abgelegte {W}-Energie zu, die nicht zum Zahlen der Energiekosten für diesen Angriff verwendet wurde. Du kannst nicht mehr als 20 Schadenspunkte auf diese Weise hinzufügen."
 			},
 			damage: "30+",
 
@@ -81,7 +82,8 @@ const card: Card = {
 
 	description: {
 		en: "Lives close to water. Its long tail is ridged with a fin that is often mistaken for a mermaid's.",
-		fr: "Il vit au bord de l'eau. Sa queue lui donne l'apparence d'une sirène."
+		fr: "Il vit au bord de l'eau. Sa queue lui donne l'apparence d'une sirène.",
+		de: "Lebt in Ufernähe. Sein langer Schwanz hat eine Flosse, die oft mit der einer Meeresjungfrau verwechselt wird."
 	},
 
 

--- a/data/Base/Jungle/29.ts
+++ b/data/Base/Jungle/29.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Venonat",
-		fr: "Mimitoss"
+		fr: "Mimitoss",
+		de: "Bluzuk"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may change the type of Venomoth to the type of any other Pokémon in play other than Colorless. This power can't be used if Venomoth is Asleep, Confused, or Paralyzed.",
 				fr: "Une fois pendant votre tour (avant votre attaque), vous pouvez changer le type d'Aéromite pour le type de n'importe quel Pokémon en jeu autre qu'Incolore. Ce pouvoir ne peut être utilisé si Aéromite est Endormi, Confus, ou Paralysé.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du den Typ von Omot in den Typ eines im Spiewl befindlichen Pokémon deiuner Wahl (Farblos ausgenommen) umwndeln. Diese Fähigkeit kann nicht eingesetzt werden, falls Omot schläft, verwirrt oder gelähmt ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du den Typ von Omot in den Typ eines im Spiel befindlichen Pokémon deiner Wahl (Farblos ausgenommen) umwandeln. Diese Fähigkeit kann nicht eingesetzt werden, falls Omot schläft, verwirrt oder gelähmt ist."
 			},
 		},
 	],
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused and Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus et Empoisonné.",
-				de: "Wirf eine Münze. Bei Kopf ist das verteidigende Pokémon jetzt verwirrt und vergiftet."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das verteidigende Pokémon jetzt verwirrt und vergiftet."
 			},
 
 			damage: 10
@@ -85,7 +86,8 @@ const card: Card = {
 
 	description: {
 		en: "The dust-like scales covering its wings are color coded to indicate the kinds of poison it has.",
-		fr: "Les motifs ocres de ses ailes changent en fonction de son type de poison."
+		fr: "Les motifs ocres de ses ailes changent en fonction de son type de poison.",
+		de: "Die staubähnlichen Schuppen, die seine Flügel bedecken, sind je nach Art ihres Giftes farbkodiert."
 	},
 
 

--- a/data/Base/Jungle/3.ts
+++ b/data/Base/Jungle/3.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Eevee",
-		fr: "Évoli"
+		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage; if tails, this attack does 10 damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires ; si c'est pile, cette attaque inflige 10 dégâts.",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu; bei \"Zahl\" fügt dieser Angriff 10 Schaden zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu; bei „Zahl“ fügt dieser Angriff 10 Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -64,7 +65,7 @@ const card: Card = {
 			effect: {
 				en: "Discard 1 Energy card attached to Flareon in order to use this attack.",
 				fr: "Défaussez 1 carte Énergie  attachée à Pyroli pour pouvoir utiliser cette attaque.",
-				de: "Entferne eine auf Flamara abgelegte -Energiekarte, um diesen Angriff auszuführen."
+				de: "Entferne eine auf Flamara abgelegte {R}-Energiekarte, um diesen Angriff auszuführen."
 			},
 			damage: 60,
 
@@ -82,7 +83,8 @@ const card: Card = {
 
 	description: {
 		en: "When storing thermal energy in its body, its temperature could soar to over 1600 degrees.",
-		fr: "Il peut accumuler suffisamment de chaleur pour atteindre des températures de 1600 degrés."
+		fr: "Il peut accumuler suffisamment de chaleur pour atteindre des températures de 1600 degrés.",
+		de: "Beim Speichern von Wärmeenergie in seinem Körper erreicht es eine Temperatur von über 900 Grad."
 	},
 
 

--- a/data/Base/Jungle/30.ts
+++ b/data/Base/Jungle/30.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Weepinbell",
-		fr: "Boustiflor"
+		fr: "Boustiflor",
+		de: "Ultrigaria"
 	},
 
 	stage: "Stage2",
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon can't retreat during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur ne peut pas battre en retraite pendant le prochain tour de votre adversaire.",
-				de: "Wirf eine Münze. Bei Kopf kann sich das verteidigende Pokémon während des nächsten Zuges des Gegnersnicht zurückziehen."
+				de: "Wirf eine Münze. Bei „Kopf“ kann das verteidigende Pokémon sich während des nächsten Zuges des Gegners nicht zurückziehen."
 			},
 			damage: 20,
 
@@ -78,7 +79,8 @@ const card: Card = {
 
 	description: {
 		en: "Said to live in huge colonies deep in jungles, although no one has ever returned from there.",
-		fr: "Il vit en colonie dans la jungle mais personne n'en est jamais revenu vivant."
+		fr: "Il vit en colonie dans la jungle mais personne n'en est jamais revenu vivant.",
+		de: "Soll in riesigen Kolonien tief im Dschungel leben, obwohl noch niemand jemals von dort zurückgekehrt ist."
 	},
 
 

--- a/data/Base/Jungle/31.ts
+++ b/data/Base/Jungle/31.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Gloom",
-		fr: "Ortide"
+		fr: "Ortide",
+		de: "Duflor"
 	},
 
 	stage: "Stage2",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may flip a coin. If heads, remove 1 damage counter from 1 of your Pokémon. This power can't be used if Vileplume is Asleep, Confused, or Paralyzed.",
 				fr: "Une fois pendant votre tour (avant votre attaque), vous pouvez lancer une pièce. Si c'est face, retirez 1 marqueur de dégâts d'un de vos Pokémon. Ce pouvoir ne peut être utilisé si Raflésia est Endormi, Confus, ou Paralysé.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du eine Münze werfen. Bei Kopf entferne eine Schadensmarke von einem deiner Pokémon. Diese Fähigkeit kann nicht eigesetzt werden, falls Giflor schlafend, verwirrt oder gelähmt ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du eine Münze werfen. Bei „Kopf“ entferne eine Schadensmarke von einem deiner Pokémon. Diese Fähigkeit kann nicht eingesetzt werden, falls Giflor schlafend, verwirrt oder gelähmt ist."
 			},
 		},
 	],
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 40 damage times the number of heads. Vileplume is now Confused (after doing damage).",
 				fr: "Lancez 3 pièces. Cette attaque inflige 40 dégâts multipliés par le nombre de faces. Raflésia est maintenant Confus (après résolution des dégâts).",
-				de: "Wirf drei Münzen. Dieser Angriff fügt jedesmal, wenn die Münze Kopf zeigt, 40 Schadenspunkte zu. Giflor ist jetzt verwirrt (nach der Schadensverteilung)."
+				de: "Wirf drei Münzen. Dieser Angriff fügt jedesmal, wenn die Münze „Kopf“ zeigt, 40 Schadenspunkte zu. Giflor ist jetzt verwirrt (nach der Schadensverteilung)."
 			},
 			damage: "40x",
 
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "The larger its petals, the more toxic pollen it contains. Its big head is heavy and hard to hold up.",
-		fr: "Plus ses pétales sont grands, plus ils contiennent de pollen toxique."
+		fr: "Plus ses pétales sont grands, plus ils contiennent de pollen toxique.",
+		de: "Je größer die Blütenblätter, desto giftiger ist der Blütenstaub darin. Sein großer Kopf ist schwer und nicht einfach hochzuhalten."
 	},
 
 

--- a/data/Base/Jungle/32.ts
+++ b/data/Base/Jungle/32.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Jigglypuff",
-		fr: "Rondoudou"
+		fr: "Rondoudou",
+		de: "Pummeluff"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
-				de: "Das verteidigende Pokémon ist jetzt schlafend"
+				de: "Das verteidigende Pokémon ist jetzt schlafend."
 			},
 
 		},
@@ -86,7 +87,8 @@ const card: Card = {
 
 	description: {
 		en: "The body is soft and rubbery. When angered, it will suck in air and inflate itself to an enormous size.",
-		fr: "En cas de danger, il gonfle d'air son corps doux et potelé dans des proportions gigantesques."
+		fr: "En cas de danger, il gonfle d'air son corps doux et potelé dans des proportions gigantesques.",
+		de: "Sein Körper ist weich und gummiartig. Wenn es wütend wird, saugt es Luft ein und bläst sich auf eine enorme Größe auf."
 	},
 
 

--- a/data/Base/Jungle/33.ts
+++ b/data/Base/Jungle/33.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Metapod",
-		fr: "Chrysacier"
+		fr: "Chrysacier",
+		de: "Safcon"
 	},
 
 	stage: "Stage2",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "If your opponent has any Benched Pokémon, he or she chooses 1 of them and switches it with the Defending Pokémon. (Do the damage before switching the Pokémon.)",
 				fr: "Si votre adversaire a au moins 1 Pokémon sur son Banc, il choisit l'un d'eux et l'échange avec son Pokémon Défenseur. (Infligez les dégâts avant de faire l'échange des Pokémon.)",
-				de: "Falls dein gegner irgendwelche Pokémon auf der Bank hat, wählt er eines von ihnen und tauscht es mit dem verteidigenden Pokémonaus. (Füge die Schadenspunkte vor dem Auswechseln des Pokémon zu.)"
+				de: "Falls dein Gegner irgendwelche Pokémon auf der Bank hat, wählt er eines von ihnen und tauscht es mit dem verteidigenden Pokémon aus. (Füge die Schadenspunkte vor dem Auswechseln des Pokémon zu.)"
 			},
 			damage: 20,
 
@@ -87,7 +88,8 @@ const card: Card = {
 
 	description: {
 		en: "In battle, it flaps its wings at high speed to release highly toxic dust into the air.",
-		fr: "En combat, il bat des ailes très rapidement pour projeter des poudres toxiques sur ses ennemis."
+		fr: "En combat, il bat des ailes très rapidement pour projeter des poudres toxiques sur ses ennemis.",
+		de: "In der Schlacht schlägt es seine Flügel mit hoher Geschwindigkeit, um so hochgiftigen Staub in die Luft zu wirbeln."
 	},
 
 

--- a/data/Base/Jungle/34.ts
+++ b/data/Base/Jungle/34.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Doduo",
-		fr: "Doduo"
+		fr: "Doduo",
+		de: "Dodu"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "As long as Dodrio is Benched, pay 1 Colorless less to retreat your Active Pokémon.",
 				fr: "Tant que Dodrio est sur le Banc, payez  en moins pour faire battre en retraite votre Pokémon Actif.",
-				de: "Solange Dodri auf der Bank sitzt, zahle  weniger, im dein aktives Pokémon zurückzuziehen."
+				de: "Solange Dodri auf der Bank sitzt, zahle {C} weniger, um dein aktives Pokémon zurückzuziehen."
 			},
 		},
 	],
@@ -84,7 +85,8 @@ const card: Card = {
 
 	description: {
 		en: "Uses its three brains to execute complex plans. While two heads sleep, one head stays awake.",
-		fr: "Il élabore des plans complexes avec ses trois cerveaux. Une de ses têtes reste toujours éveillée."
+		fr: "Il élabore des plans complexes avec ses trois cerveaux. Une de ses têtes reste toujours éveillée.",
+		de: "Verwendet seine drei Gehirne zum Aushecken von komplizierten Plänen. Während zwei Köpfe schlafen, bleibt einer immer wach."
 	},
 
 

--- a/data/Base/Jungle/35.ts
+++ b/data/Base/Jungle/35.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Exeggcute",
-		fr: "Noeunoeuf"
+		fr: "Noeunoeuf",
+		de: "Owei"
 	},
 
 	stage: "Stage1",
@@ -59,7 +60,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a number of coins equal to the number of Energy attached to Exeggutor. This attack does 20 damage times the number of heads.",
 				fr: "Lancez un nombre de pièces égal au nombre d'Énergies attachées à Noadkoko. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf eine Anzahl Münzen, die der auf Kokowei abgelegten Energiemenge entspricht. Dieser Angriff fügt jedesmal, wenn die Münze 'Kopf' zeigt, 20 Schadenspunkte zu."
+				de: "Wirf eine Anzahl Münzen, die der auf Kokowei abgelegten Energiemenge entspricht. Dieser Angriff fügt jedesmal, wenn die Münze „Kopf“ zeigt, 20 Schadenspunkte zu."
 			},
 			damage: "20x",
 
@@ -77,7 +78,8 @@ const card: Card = {
 
 	description: {
 		en: "Legend has it that on rare occasions, one of its heads will drop off and continue on as an Exeggcute.",
-		fr: "On raconte que si une de ses têtes se détache, elle se transforme en un Nœunœuf."
+		fr: "On raconte que si une de ses têtes se détache, elle se transforme en un Nœunœuf.",
+		de: "Der Legende nach soll in seltenen Fällen eines seiner Köpfe abfallen und als Owei weiterleben."
 	},
 
 

--- a/data/Base/Jungle/36.ts
+++ b/data/Base/Jungle/36.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Spearow",
-		fr: "Piafabec"
+		fr: "Piafabec",
+		de: "Habitak"
 	},
 
 	stage: "Stage1",
@@ -45,7 +46,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Fearow.",
 				fr: "Lancez une pièce. Si c'est face, pendant le prochain tour de votre adversaire, prévenez tous les effets d'attaques, y compris les dégâts, infligés à Rapasdepic.",
-				de: "Wirf eine Münze. Bei 'Kopf' verhindere während des nächsten gegnerischen Zuges alle Auswirkungen von Angriffen auf Ibitak (einschließlich der Schadenspunkte)."
+				de: "Wirf eine Münze. Bei „Kopf“ verhindere während des nächsten gegnerischen Zuges alle Auswirkungen von Angriffen auf Ibitak (einschließlich der Schadenspunkte)."
 			},
 			damage: 20,
 
@@ -84,7 +85,8 @@ const card: Card = {
 
 	description: {
 		en: "With its huge and magnificent wings, it can keep aloft without ever having to land for rest.",
-		fr: "Ses ailes géantes lui permettent de planer si longtemps qu'il ne se pose que très rarement."
+		fr: "Ses ailes géantes lui permettent de planer si longtemps qu'il ne se pose que très rarement.",
+		de: "Mit seinen riesigen und prächtigen Flügeln kann es in der Luft bleiben, ohne jemals zum Ausruhen landen zu müssen."
 	},
 
 

--- a/data/Base/Jungle/37.ts
+++ b/data/Base/Jungle/37.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Oddish",
-		fr: "Mystherbe"
+		fr: "Mystherbe",
+		de: "Myrapla"
 	},
 
 	stage: "Stage1",
@@ -78,7 +79,8 @@ const card: Card = {
 
 	description: {
 		en: "The fluid that oozes from its mouth isn't drool; it is a nectar that is used to attract prey.",
-		fr: "Le liquide qui s'écoule de sa bouche est comestible. Il sert à appâter sa proie."
+		fr: "Le liquide qui s'écoule de sa bouche est comestible. Il sert à appâter sa proie.",
+		de: "Die von seiner Schnauze herunterlaufende Flüssigket ist nicht Geifer, sondern vielmehr Nektar zum Anlocken der Beute."
 	},
 
 

--- a/data/Base/Jungle/38.ts
+++ b/data/Base/Jungle/38.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei 'Kopf' ist das verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 
@@ -56,7 +56,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Wirf eine Münze. Bei 'Kopf' ist das verteidigende Pokémon jetzt verwirrt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das verteidigende Pokémon jetzt verwirrt."
 			},
 
 		},
@@ -80,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "Its tongue can be extended like a chameleon's. It leaves a stinging sensation when it licks enemies.",
-		fr: "Il peut projeter sa langue comme un caméléon. Tout contact avec elle provoque une irritation."
+		fr: "Il peut projeter sa langue comme un caméléon. Tout contact avec elle provoque une irritation.",
+		de: "Seine Zunge lässt sich ausziehen wie die eines Chamäleons. Es hinterläßt ein stechendes Gefühl, wenn es Feinde leckt."
 	},
 
 

--- a/data/Base/Jungle/39.ts
+++ b/data/Base/Jungle/39.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Cubone",
-		fr: "Osselait"
+		fr: "Osselait",
+		de: "Tragosso"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 30 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de faces.",
-				de: "Wirf zwei Münzen. Dieser Angriff fügt jedesmal, wenn die Münze 'Kopf' zeigt, 30 Schadenspunkte zu."
+				de: "Wirf zwei Münzen. Dieser Angriff fügt jedesmal, wenn die Münze „Kopf“ zeigt, 30 Schadenspunkte zu."
 			},
 			damage: "30x",
 
@@ -63,7 +64,7 @@ const card: Card = {
 			effect: {
 				en: "Search your deck for a Fighting Basic Pokémon card and put it onto your Bench. Shuffle your deck afterward. (You can't use this attack if your Bench is full.)",
 				fr: "Cherchez dans votre deck une carte Pokémon  de base et placez-la sur votre Banc. Mélangez ensuite votre deck. (Vous ne pouvez pas utiliser cette attaque si votre Banc est plein.)",
-				de: "Suche in deinem Deck nach einer  Basis-Pokémon-Karte und lege sie auf deine Bank. Mische dein Deck danach. (Du kannst diesen Angriff nicht einsetzen, wenn deine Bank voll ist.)"
+				de: "Suche in deinem Deck nach einer {F} Basis-Pokémon-Karte und lege sie auf deine Bank. Mische dein Deck danach. (Du kannst diesen Angriff nicht einsetzen, wenn deine Bank voll ist.)"
 			},
 
 		},
@@ -87,7 +88,8 @@ const card: Card = {
 
 	description: {
 		en: "The bone it holds is its key weapon. It throws the bone skillfully like a boomerang to K.O. targets.",
-		fr: "L'os qu'il tient dans sa main est une arme. Il peut le lancer avec adresse pour assommer sa proie."
+		fr: "L'os qu'il tient dans sa main est une arme. Il peut le lancer avec adresse pour assommer sa proie.",
+		de: "Seine Schlüsselwaffe ist der Knochen, den es hält. Es wirft den Knochen geschickt wie einen Bumerang, um Feinde kampfunfähig zu machen."
 	},
 
 

--- a/data/Base/Jungle/4.ts
+++ b/data/Base/Jungle/4.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Eevee",
-		fr: "Évoli"
+		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage; if tails, this attack does 10 damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires ; si c'est pile, cette attaque inflige 10 dégâts.",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu; bei \"Zahl\" fügt dieser Angriff 10 Schaden zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu; bei „Zahl“ fügt dieser Angriff 10 Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -63,7 +64,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 4 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 4 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 4 Münzen. Dieser Angriff fügt jedesmal, wenn die Münze \"Kopf\" zeigt, 20 Schadenspunkte zu."
+				de: "Wirf 4 Münzen. Dieser Angriff fügt jedesmal, wenn die Münze „Kopf“ zeigt, 20 Schadenspunkte zu."
 			},
 			damage: "20x",
 
@@ -81,7 +82,8 @@ const card: Card = {
 
 	description: {
 		en: "It accumulates negative ions from the atmosphere to blast out 10,000-volt lightning bolts.",
-		fr: "Il se charge d'électricité statique pour envoyer des décharges de 10000 volts."
+		fr: "Il se charge d'électricité statique pour envoyer des décharges de 10000 volts.",
+		de: "Es sammelt negative Ionen aus der Atmosphäre, um Blitzschläge von 10.000 Volt herauszuschleudern."
 	},
 
 

--- a/data/Base/Jungle/40.ts
+++ b/data/Base/Jungle/40.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Nidoran♀",
-		fr: "Nidoran"
+		fr: "Nidoran",
+		de: "Nidoran♀"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Wirf eine Münze. Bei 'Kopf' ist das verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das verteidigende Pokémon jetzt verwirrt."
 			},
 
 		},
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 30 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de faces.",
-				de: "Wirf zwei Münzen. Dieser Angriff fügt jedesmal, wenn die Münze 'Kopf' zeigt, 30 Schadenspunkte zu."
+				de: "Wirf zwei Münzen. Dieser Angriff fügt jedesmal, wenn die Münze „Kopf“zeigt, 30 Schadenspunkte zu."
 			},
 			damage: "30x",
 
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "The female's horn develops slowly. Prefers physical attacks such as clawing and biting.",
-		fr: "La corne de la femelle grandit lentement. Elle préfère attaquer avec ses griffes et sa gueule."
+		fr: "La corne de la femelle grandit lentement. Elle préfère attaquer avec ses griffes et sa gueule.",
+		de: "Das Horn des Weibchens entwickelt sich nur langsam. Es zieht körperliche Angriffe wie z.B. Kratzen und Beißen vor."
 	},
 
 

--- a/data/Base/Jungle/41.ts
+++ b/data/Base/Jungle/41.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Paras",
-		fr: "Paras"
+		fr: "Paras",
+		de: "Paras"
 	},
 
 	stage: "Stage1",
@@ -76,7 +77,8 @@ const card: Card = {
 
 	description: {
 		en: "A host-parasite pair in which the parasite mushroom has taken over the host bug. Prefers damp places.",
-		fr: "Une symbiose entre un parasite et un insecte. Le champignon a pris le contrôle sur son hôte."
+		fr: "Une symbiose entre un parasite et un insecte. Le champignon a pris le contrôle sur son hôte.",
+		de: "Ein Wirt-Parasitenverhältnis, in dem der Parasitenpilz den Wirtskäfer übernommen hat. Zieht feuchte Orte vor."
 	},
 
 

--- a/data/Base/Jungle/42.ts
+++ b/data/Base/Jungle/42.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Meowth",
-		fr: "Miaouss"
+		fr: "Miaouss",
+		de: "Mauzi"
 	},
 
 	stage: "Stage1",
@@ -82,7 +83,8 @@ const card: Card = {
 
 	description: {
 		en: "Although its fur has many admirers, it is tough to raise as a pet because of its fickle meanness.",
-		fr: "Très apprécié pour sa fourrure, il est difficile à apprivoiser en raison de son caractère rétif."
+		fr: "Très apprécié pour sa fourrure, il est difficile à apprivoiser en raison de son caractère rétif.",
+		de: "Obwohl sein Fell viele Bewunderer findet, ist es wegen seiner launischen Gemeinheit schwer als Haustier zu halten."
 	},
 
 

--- a/data/Base/Jungle/43.ts
+++ b/data/Base/Jungle/43.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Mankey",
-		fr: "Férosinge"
+		fr: "Férosinge",
+		de: "Menki"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf drei Münzen. Dieser Angriff fügt jedesmal, wenn die Münze 'Kopf' zeigt, 20 Schadenspunkte zu."
+				de: "Wirf drei Münzen. Dieser Angriff fügt jedesmal, wenn die Münze „Kopf“ zeigt, 20 Schadenspunkte zu."
 			},
 			damage: "20x",
 
@@ -63,7 +64,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, Primeape is now Confused (after doing damage).",
 				fr: "Lancez une pièce. Si c'est pile, Colossinge est maintenant Confus (après le calcul des dégâts).",
-				de: "Wirf eine Münze. Bei 'Zahl' ist Rasaff jetzt verwirrt (nach der Schadensverteilung)."
+				de: "Wirf eine Münze. Bei „Zahl“ ist Rasaff jetzt verwirrt (nach der Schadensverteilung)."
 			},
 			damage: 50,
 
@@ -81,7 +82,8 @@ const card: Card = {
 
 	description: {
 		en: "Always furious and tenacious to boot. It will not abandon chasing its quarry until its quarry is caught.",
-		fr: "Agressif et teigneux, il poursuit son gibier jusqu'à épuisement complet."
+		fr: "Agressif et teigneux, il poursuit son gibier jusqu'à épuisement complet.",
+		de: "Stets wild und hartnäckig loszuwerden. Es gibt seine Beute nicht auf, bis sie gefangen ist."
 	},
 
 

--- a/data/Base/Jungle/44.ts
+++ b/data/Base/Jungle/44.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Ponyta",
-		fr: "Ponyta"
+		fr: "Ponyta",
+		de: "Ponita"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 10 more damage; if tails, this attack does 20 damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires ; si c'est pile, cette attaque inflige 20 dégâts.",
-				de: "Wirf eine Münze. Bei 'Kopf' fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu; bei 'Zahl' fügt dieser Angriff 20 Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu; bei „Zahl“ fügt dieser Angriff 20 Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -63,7 +64,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Rapidash.",
 				fr: "Lancez une pièce. Si c'est face, pendant le prochain tour de votre adversaire, prévenez tous les effets d'attaques, y compris les dégâts, infligés à Galopa.",
-				de: "Wirf eine Münze. Bei 'Kopf' verhindere während des nächsten gegnerischen Zuges als Auswirkung von Angriffen auf Gallopa (einschließlich der Schadenspunkte)."
+				de: "Wirf eine Münze. Bei „Kopf“ verhindere während des nächsten gegnerischen Zuges alle Auswirkungen von Angriffen auf Gallopa (einschließlich der Schadenspunkte)."
 			},
 			damage: 30,
 
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "Very competitive, this Pokémon will chase anything that moves fast in the hopes of racing it.",
-		fr: "Doté d'un esprit de compétition, il poursuit toute créature rapide pour faire la course."
+		fr: "Doté d'un esprit de compétition, il poursuit toute créature rapide pour faire la course.",
+		de: "Immer konkurrenzbereit jagt dieses Pokémon hinter jedem sich schnell bewegenden Objekt in der Hoffnung auf ein Rennen hinterher."
 	},
 
 

--- a/data/Base/Jungle/45.ts
+++ b/data/Base/Jungle/45.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Rhyhorn",
-		fr: "Rhinocorne"
+		fr: "Rhinocorne",
+		de: "Rihorn"
 	},
 
 	stage: "Stage1",
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Rhydon does 20 damage to itself. If your opponent has any Benched Pokémon, he or she chooses 1 of them and switches it with the Defending Pokémon. (Do the damage before switching the Pokémon. Switch the Pokémon even if Rhydon is knocked out.)",
 				fr: "Rhinoféros s'inflige 20 dégâts. Si votre adversaire a au moins 1 Pokémon sur son Banc, il choisit l'un d'eux et l'échange avec son Pokémon Défenseur. (Infligez les dégâts avant de faire l'échange des Pokémon. Échangez les Pokémon même si Rhinoféros est K.O.)",
-				de: "Rizeros fügt sich selbst 20 Schadenspunkte zu. Falls dein gegner irgendwelche Pokémon auf der Bank hat, wählt er eines von ihnen und tauscht es mit dem verteidigenden Pokémon aus. (Füge die Schadenspunkte vor dem Auswechseln des Pokémon zu. Tausche das Pokémon auch wenn Rizeros kampfunfähig wird.)"
+				de: "Rizeros fügt sich selbst 20 Schadenspunkte zu. Falls dein Gegner irgendwelche Pokémon auf der Bank hat, wählt er eines von ihnen und tauscht es mit dem verteidigenden Pokémon aus. (Füge die Schadenspunkte vor dem Auswechseln des Pokémon zu. Tausche das Pokémon auch wenn Rizeros kampfunfähig wird.)"
 			},
 			damage: 50,
 
@@ -86,7 +87,8 @@ const card: Card = {
 
 	description: {
 		en: "Protected by an armor-like hide, it is capable of living in molten lava of 3600 degrees.",
-		fr: "Son épiderme très épais lui permet de survivre dans un environnement de plus de 3600 degrés."
+		fr: "Son épiderme très épais lui permet de survivre dans un environnement de plus de 3600 degrés.",
+		de: "Unter dem Schutz eines Harnisch gleichenden Fells ist es in der Lage, in geschmolzener Lava von fast 2000 Grad zu leben."
 	},
 
 

--- a/data/Base/Jungle/46.ts
+++ b/data/Base/Jungle/46.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Goldeen",
-		fr: "Poissirène"
+		fr: "Poissirène",
+		de: "Goldini"
 	},
 
 	stage: "Stage1",
@@ -38,7 +39,7 @@ const card: Card = {
 			name: {
 				en: "Horn Attack",
 				fr: "Koud'korne",
-				de: "Kopfnuss"
+				de: "Hornattacke"
 			},
 
 			damage: 10,
@@ -71,7 +72,8 @@ const card: Card = {
 
 	description: {
 		en: "In the autumn spawning season, they can be seen swimming powerfully up rivers and creeks.",
-		fr: "Pendant la saison des amours, on peut le voir nager dans les rivières et les lacs."
+		fr: "Pendant la saison des amours, on peut le voir nager dans les rivières et les lacs.",
+		de: "In der Laichsaison im Herbst sind sie beim kräftigen Stromaufwärts-Schwimmen zu sehen."
 	},
 
 

--- a/data/Base/Jungle/47.ts
+++ b/data/Base/Jungle/47.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 10 more damage; if tails, this attack does 20 damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires ; si c'est pile, cette attaque inflige 20 dégâts.",
-				de: "Wirf eine Münze. Bei 'Kopf' fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu; bei 'Zahl' fügt dieser Angriff 20 Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu; bei „Zahl“ fügt dieser Angriff 20 Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -58,7 +58,7 @@ const card: Card = {
 			effect: {
 				en: "Does 20 damage plus 10 more damage for each damage counter on Tauros. Flip a coin. If tails, Tauros is now Confused (after doing damage).",
 				fr: "Cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires pour chaque marqueur de dégâts sur Tauros. Lancez une pièce. Si c'est pile, Tauros est maintenant Confus (après le calcul des dégâts).",
-				de: "Fügt 20 Schadenspunkte plus 10 weitere Schadenspunkte für jede Schadensmarke auf Tauros zu. Wirf eine Münze. Bei 'Zahl' ist Tauros jetzt verwirrt (nach der Schadensverteilung)."
+				de: "Fügt 20 Schadenspunkte plus 10 weitere Schadenspunkte für jede Schadensmarke auf Tauros zu. Wirf eine Münze. Bei „Zahl“ ist Tauros jetzt verwirrt (nach der Schadensverteilung)."
 			},
 			damage: "20+",
 
@@ -83,7 +83,8 @@ const card: Card = {
 
 	description: {
 		en: "When it targets an enemy, it charges furiously while whipping its body with its long tails.",
-		fr: "Une fois sa cible en vue, il la charge furieusement en fouettant l'air de sa queue."
+		fr: "Une fois sa cible en vue, il la charge furieusement en fouettant l'air de sa queue.",
+		de: "Wenn es einen Feind als Ziel auserkoren hat, startet es mit den heftig wedelnden langen Schwänzen einen Ganzkörperangriff."
 	},
 
 

--- a/data/Base/Jungle/48.ts
+++ b/data/Base/Jungle/48.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Bellsprout",
-		fr: "Chétiflor"
+		fr: "Chétiflor",
+		de: "Knofensa"
 	},
 
 	stage: "Stage1",
@@ -45,7 +46,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Empoisonné.",
-				de: "Wirf eine Münze. Bei 'Kopf' ist das verteidigende Pokémon jetzt vergiftet."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das verteidigende Pokémon jetzt vergiftet."
 			},
 
 			damage: 10
@@ -77,7 +78,8 @@ const card: Card = {
 
 	description: {
 		en: "It spits out poisonpowder to immobilize the enemy, and then finishes the enemy with a spray of acid.",
-		fr: "Il crache de la poudre toxik pour immobiliser sa proie et il l'achève avec de l'acide."
+		fr: "Il crache de la poudre toxik pour immobiliser sa proie et il l'achève avec de l'acide.",
+		de: "Es spuckt Giftpuder, um den Feind bewegungsunfähig zu machen, und erledigt ihn dann ganz mit einem Sprühnebel an Säure."
 	},
 
 

--- a/data/Base/Jungle/49.ts
+++ b/data/Base/Jungle/49.ts
@@ -51,7 +51,7 @@ const card: Card = {
 			effect: {
 				en: "Search your deck for a Basic Pokémon named Bellsprout and put it onto your Bench. Shuffle your deck afterward. (You can't use this attack if your Bench is full.)",
 				fr: "Cherchez dans votre deck un Pokémon de base appelé Chétiflor et placez-le sur votre Banc. Mélangez ensuite votre deck. (Vous ne pouvez pas utiliser cette attaque si votre Banc est plein.)",
-				de: "Suche in deinem Deck nach einer Basis-Pokémon-Karte mit dem namen Knofensa und lege sie auf deine Bank. Mische dein Deck danach. (Du kannst diesen Angriff nicht einsetzen, wenn deine bank voll ist.)"
+				de: "Suche in deinem Deck nach einer Basis-Pokémon-Karte mit dem Namen Knofensa und lege sie auf deine Bank. Mische dein Deck danach. (Du kannst diesen Angriff nicht einsetzen, wenn deine Bank voll ist.)"
 			},
 
 		},
@@ -68,7 +68,8 @@ const card: Card = {
 
 	description: {
 		en: "A carnivorous Pokémon that traps and eats bugs. It uses its root feet to soak up needed moisture.",
-		fr: "Un Pokémon carnivore qui se nourrit de petits insectes. Ses racines servent d'attaches."
+		fr: "Un Pokémon carnivore qui se nourrit de petits insectes. Ses racines servent d'attaches.",
+		de: "Ein fleischfressendes Pokémon, das Käfer in eine Falle lockt und sie dann frißt. Es verwendet seine Wurzelfüße, um notwendige Feuchtigkeit aufzusaugen."
 	},
 
 

--- a/data/Base/Jungle/5.ts
+++ b/data/Base/Jungle/5.ts
@@ -57,7 +57,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 4 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 4 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 4 Münzen. Dieser Angriff fügt jedesmal, wenn die Münze \"Kopf\" zeigt, 20 Schadenspunkte zu."
+				de: "Wirf 4 Münzen. Dieser Angriff fügt jedesmal, wenn die Münze „Kopf“ zeigt, 20 Schadenspunkte zu."
 			},
 			damage: "20x",
 
@@ -82,7 +82,8 @@ const card: Card = {
 
 	description: {
 		en: "The infant rarely ventures out of its mother's protective pouch until it is three years old.",
-		fr: "Son enfant ne quitte la poche ventrale protectrice qu'à l'âge de 3 ans."
+		fr: "Son enfant ne quitte la poche ventrale protectrice qu'à l'âge de 3 ans.",
+		de: "Der Nachkömmling verläßt vor dem Alter von drei Jahren nur selten den Beutel der Mutter."
 	},
 
 

--- a/data/Base/Jungle/50.ts
+++ b/data/Base/Jungle/50.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "If the Defending Pokémon attacks Cubone during your opponent's next turn, any damage done by the attack is reduced by 20 (after applying Weakness and Resistance). (Benching either Pokémon ends this effect.)",
 				fr: "Si le Pokémon Défenseur attaque Osselait pendant le prochain tour de votre adversaire, les dégâts infligés par l'attaque sont réduits de 20 (après application de la Faiblesse et de la Résistance). (Si l'un des Pokémon bat en retraite, cet effet prend fin.)",
-				de: "Greift das verteidigende Pokémon Tragossi während des nächsten gegnerischen Zuges an, wird aller aufgrund dieses Angriffs zugefügte Schaden um 20 Schadenspunkte reduziert (nachdem Schwäche und Resistenz abgerechnet wurden). (Kommt einer der beiden Pokémon auf die Bank, ist diese Wirkung nich weiter gültig.)"
+				de: "Greift das verteidigende Pokémon Tragosso während des nächsten gegnerischen Zuges an, wird aller aufgrund dieses Angriffs zugefügte Schaden um 20 Schadenspunkte reduziert (nachdem Schwäche und Resistenz abgerechnet wurden). (Kommt einer der beiden Pokémon auf die Bank, ist diese Wirkung nicht weiter gültig.)"
 			},
 
 		},
@@ -80,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "Because it never removes its skull helmet, no one has ever seen this Pokémon's real face.",
-		fr: "Il ne retire jamais son casque en os. Personne n'a jamais vu le visage de ce Pokémon."
+		fr: "Il ne retire jamais son casque en os. Personne n'a jamais vu le visage de ce Pokémon.",
+		de: "Da es nie seinen Schädelhelm abnimmt, hat noch nie jemand das wahre Gesicht dieses Pokémon gesehen."
 	},
 
 

--- a/data/Base/Jungle/51.ts
+++ b/data/Base/Jungle/51.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon can't attack Eevee during your opponent's next turn. (Benching either Pokémon ends this effect.)",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur ne peut pas attaquer Évoli pendant le prochain tour de votre adversaire. (Si l'un des deux Pokémon bat en retraite, cet effet prend fin.)",
-				de: "Wirf eine Münze. Bei 'Kopf' kann das verteidigende Pokémon Evoli während des nächsten Zuges des gegners nicht angreifen. (Kommt einer der beiden Pokémon auf die Bank, ist diese Wirkung nicht weiter gültig.)"
+				de: "Wirf eine Münze. Bei „Kopf“ kann das verteidigende Pokémon Evoli während des nächsten Zuges des Gegners nicht angreifen. (Kommt einer der beiden Pokémon auf die Bank, ist diese Wirkung nicht weiter gültig.)"
 			},
 
 		},
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage; if tails, this attack does 10 damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires ; si c'est pile, cette attaque inflige 10 dégâts.",
-				de: "Wirf eine Münze. Bei 'Kopf' fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu. Bei 'Zahl' fügt dieser Angriff 10 Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu; bei „Zahl“ fügt dieser Angriff 10 Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -80,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "Its genetic code is irregular. It may mutate if it is exposed to radiation from elemental stones.",
-		fr: "Il est capable de copier le code génétique d'un ennemi pour se transformer en son double."
+		fr: "Il est capable de copier le code génétique d'un ennemi pour se transformer en son double.",
+		de: "Sein genetischer Code ist unregelmäßig. Es kann mutieren, falls es Strahlung von Elementarsteinen ausgesetzt wird."
 	},
 
 

--- a/data/Base/Jungle/52.ts
+++ b/data/Base/Jungle/52.ts
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "Often mistaken for eggs. When disturbed, they quickly gather and attack in swarms.",
-		fr: "Souvent pris pour des œufs, ils attaquent en groupe comme un essaim."
+		fr: "Souvent pris pour des œufs, ils attaquent en groupe comme un essaim.",
+		de: "Oft mit Eiern verwechselt. Wenn sie gestört werden, sammeln sie sich und greifen in Geschwadern an."
 	},
 
 

--- a/data/Base/Jungle/53.ts
+++ b/data/Base/Jungle/53.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			name: {
 				en: "Horn Attack",
 				fr: "Koud'korne",
-				de: "Kopfnuss"
+				de: "Hornattacke"
 			},
 
 			damage: 10,
@@ -50,7 +50,8 @@ const card: Card = {
 
 	description: {
 		en: "Its tail fin billows like an elegant ballroom dress, giving it the nickname \"Water Queen.\"",
-		fr: "Sa queue ondule gracieusement comme un voile. On l'appelle: \"Reine des Océans\"."
+		fr: "Sa queue ondule gracieusement comme un voile. On l'appelle: \"Reine des Océans\".",
+		de: "Seine Schwanzflosse bauscht sich wie ein elegantes Abendkleid, was ihm den Spitznamen „Wasserkönigin“ verleiht."
 	},
 
 

--- a/data/Base/Jungle/54.ts
+++ b/data/Base/Jungle/54.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
-				de: "das verteidigende Pokémon ist jetzt gelähmt."
+				de: "Das verteidigende Pokémon ist jetzt schlafend."
 			},
 
 		},
@@ -76,7 +76,8 @@ const card: Card = {
 
 	description: {
 		en: "When its huge eyes light up, it sings a mysteriously soothing melody that lulls its enemies to sleep.",
-		fr: "Quand ses yeux s'illuminent, il chante une mystérieuse berceuse."
+		fr: "Quand ses yeux s'illuminent, il chante une mystérieuse berceuse.",
+		de: "Wenn seine riesigen Augen aufleuchten, singt es eine gewaltige Melodei, die seine Feinde auf eine geheimnisvolle sanfte Weise in den Schlaf versetzt."
 	},
 
 

--- a/data/Base/Jungle/55.ts
+++ b/data/Base/Jungle/55.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Peek",
 				fr: "Coup d'œil",
-				de: "Blick"
+				de: "Verstohlener Blick"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may look at one of the following: the top card of either player's deck, a random card from your opponent's hand, or one of either player's Prizes. This power can't be used if Mankey is Asleep, Confused, or Paralyzed.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez regarder au choix: la carte du dessus du deck d'un des joueurs, une carte au hasard de la main de votre adversaire, ou une des Récompenses d'un des joueurs. Ce pouvoir ne peut être utilisé si Férosinge est Endormi, Confus ou Paralysé.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du dir eine der folgenden Karten anschauen: die oberste Karte vom Deck eines Spielers, eine Zufällige Karte von der hand deines Gegners oder einen der Preise eines Spielers. Diese Fähigkeit kann nicht eingesetzt werden, falls Menki schlafend, verwirrt oder gelähmt ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du dir eine der folgenden Karten anschauen: die oberste Karte vom Deck eines Spielers, eine zufällige Karte von der Hand deines Gegners oder einen der Preise eines Spielers. Diese Fähigkeit kann nicht eingesetzt werden, falls Menki schlafend, verwirrt oder gelähmt ist."
 			},
 		},
 	],
@@ -66,7 +66,8 @@ const card: Card = {
 
 	description: {
 		en: "Extremely quick to anger. It could be docile one moment, then thrashing away the next.",
-		fr: "Il se met en colère très vite. Calme ou furieux, son humeur change d'une seconde à l'autre."
+		fr: "Il se met en colère très vite. Calme ou furieux, son humeur change d'une seconde à l'autre.",
+		de: "Sehr jähzornig. Kann einen Augenblick unterwürfig, dann im nächsten Augenblick aufständig sein."
 	},
 
 

--- a/data/Base/Jungle/56.ts
+++ b/data/Base/Jungle/56.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, draw a card.",
 				fr: "Lancez une pièce. Si c'est face, piochez une carte.",
-				de: "Wirf eine Münze. Bei 'Kopf' ziehe eine Karte."
+				de: "Wirf eine Münze. Bei „Kopf“ ziehe eine Karte."
 			},
 			damage: 10,
 
@@ -64,7 +64,8 @@ const card: Card = {
 
 	description: {
 		en: "Adores circular objects. Wanders the streets on a nightly basis to look for dropped loose change.",
-		fr: "Il adore les pièces de monnaie. Il hante les rues à la recherche de pièces oubliées par les passants."
+		fr: "Il adore les pièces de monnaie. Il hante les rues à la recherche de pièces oubliées par les passants.",
+		de: "Bewundert kreisförmige Objekte. Streift nächtlich auf der Suche nach verlorenen Münzen ziellos durch die Straßen."
 	},
 
 

--- a/data/Base/Jungle/57.ts
+++ b/data/Base/Jungle/57.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de faces.",
-				de: "Wirf drei Münzen. Deiser Angriff fügt jedesmal, wenn die Münze 'Kopf' zeigt, 10 Schadenspunkte zu."
+				de: "Wirf drei Münzen. Dieser Angriff fügt jedesmal, wenn die Münze „Kopf“ zeigt, 10 Schadenspunkte zu."
 			},
 			damage: "10x",
 
@@ -56,7 +56,7 @@ const card: Card = {
 			effect: {
 				en: "Search your deck for a Basic Pokémon named Nidoran M or Nidoran F and put it onto your Bench. Shuffle your deck afterward. (You can't use this attack if your Bench is full.)",
 				fr: "Cherchez dans votre deck un Pokémon de base appelé Nidoran ♀ or Nidoran ♂ et placez-le sur votre Banc. Mélangez ensuite votre deck. (Vous ne pouvez pas utiliser cette attaque si votre Banc est plein.)",
-				de: "Suche in deinem Deck nach einer Basis-Pokémon-Karte mit dem Namen Nidoran M oder Nidoran W und lege sie auf deine Bank. Mische dein deck dannach. (Du kannst diesen Angriff nicht einsetzen, wenn deine Bank voll ist.)"
+				de: "Suche in deinem Deck nach einer Basis-Pokémon-Karte mit dem Namen Nidoran♂ oder Nidoran♀ und lege sie auf deine Bank. Mische dein Deck danach. (Du kannst diesen Angriff nicht einsetzen, wenn deine Bank voll ist.)"
 			},
 
 		},
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "Although small, its venomous barbs make this Pokémon dangerous. The female has smaller horns.",
-		fr: "Ce Pokémon est hérissé de dards empoisonnés. Les femelles ont des dards plus petits."
+		fr: "Ce Pokémon est hérissé de dards empoisonnés. Les femelles ont des dards plus petits.",
+		de: "Obwohl es klein ist, machen seine giftigen Widerhaken dieses Pokémon doch gefährlich. Das Weibchen hat kleinere Hörner."
 	},
 
 	variants: [

--- a/data/Base/Jungle/58.ts
+++ b/data/Base/Jungle/58.ts
@@ -33,12 +33,12 @@ const card: Card = {
 			name: {
 				en: "Stun Spore",
 				fr: "Para-spore",
-				de: "Stachelsporen"
+				de: "Stachelspore"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei 'Kopf' ist das verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 
@@ -56,7 +56,7 @@ const card: Card = {
 			effect: {
 				en: "Search your deck for a Basic Pokémon named Oddish and put it onto your Bench. Shuffle your deck afterward. (You can't use this attack if your Bench is full.)",
 				fr: "Cherchez dans votre deck un Pokémon de base appelé Mystherbe et placez-le sur votre Banc. Mélangez ensuite votre deck. (Vous ne pouvez pas utiliser cette attaque si votre Banc est plein.)",
-				de: "Suche in deinem Deck nach einer Basis-Pokémon-Karte mit dem Namen Myrapla und lege sie auf deine Bank. Mische dein Deck danach. (du kannst diesen Angriff nicht einsetzen, wenn deine bank voll ist.)"
+				de: "Suche in deinem Deck nach einer Basis-Pokémon-Karte mit dem Namen Myrapla und lege sie auf deine Bank. Mische dein Deck danach. (du kannst diesen Angriff nicht einsetzen, wenn deine Bank voll ist.)"
 			},
 
 		},
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "During the day, it keeps its face buried in the ground. At night, it wanders around sowing its seeds.",
-		fr: "Pendant la journée il se cache sous terre. Il s'aventure la nuit pour planter des graines."
+		fr: "Pendant la journée il se cache sous terre. Il s'aventure la nuit pour planter des graines.",
+		de: "Tagsüber hält es sein Gesicht im Sand vergraben. Nachts wandert es durch die Gegend und verstreut seinen Samen."
 	},
 
 

--- a/data/Base/Jungle/59.ts
+++ b/data/Base/Jungle/59.ts
@@ -70,7 +70,8 @@ const card: Card = {
 
 	description: {
 		en: "Burrows to suck tree roots. The mushrooms on its back grow by drawing nutrients from the bug host.",
-		fr: "Les champignons sur son dos se nourrissent des nutriments de leur hôte insectoïde."
+		fr: "Les champignons sur son dos se nourrissent des nutriments de leur hôte insectoïde.",
+		de: "Buddelt sich ein, um an Baumwurzeln zu saugen. Die Pilze auf seinem Rücken wachsen, weil sie dem Käferwirt Nährstoffe entziehen."
 	},
 
 

--- a/data/Base/Jungle/6.ts
+++ b/data/Base/Jungle/6.ts
@@ -25,6 +25,7 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Mime Jr.",
+		de: "Pantimimi"
 	},
 
 	stage: "Basic",
@@ -40,7 +41,7 @@ const card: Card = {
 			effect: {
 				en: "Whenever an attack (including your own) does 30 or more damage to Mr. Mime (after applying Weakness and Resistance), prevent that damage. (Any other effects of attacks still happen.) This power can't be used if Mr. Mime is Asleep, Confused, or Paralyzed.",
 				fr: "Chaque fois qu'une attaque (y compris les vôtres) inflige 30 dégâts ou plus à M. Mime (après application de la Faiblesse et de la Résistance), prévenez ces dégâts. (Tout autre effet ou attaque subsiste.) Ce pouvoir ne peut être utilisé si M. Mime est Endormi, Confus ou Paralysé.",
-				de: "Immer wenn ein Angriff (auch dein eigener) Pantimos 30 oder mehr Schadenspunkte zufügt (nachdem Schwäche und Resistnz abgerechnet wurden), verhindere diesen Schaden. (Alle anderen Auswirkungen von Agriffen finden immernch statt.) Dies Fähigkeit kann nicht eingesetzt werden, falls Pantimosschlafend, verwirrt oder gelähmt ist."
+				de: "Immer wenn ein Angriff (auch dein eigener) Pantimos 30 oder mehr Schadenspunkte zufügt (nachdem Schwäche und Resistenz abgerechnet wurden), verhindere diesen Schaden. (Alle anderen Auswirkungen von Angriffen finden immer noch statt.) Diese Fähigkeit kann nicht eingesetzt werden, falls Pantimos schlafend, verwirrt oder gelähmt ist."
 			},
 		},
 	],
@@ -59,7 +60,7 @@ const card: Card = {
 			effect: {
 				en: "Does 10 damage plus 10 more damage for each damage counter on the Defending Pokémon.",
 				fr: "Inflige 10 dégâts plus 10 dégâts supplémentaires pour chaque marqueur de dégâts sur le Pokémon Défenseur.",
-				de: "Fügt 10 Schadenspunkte plus 10 weitere Schadenspunkte für jede Schadensmarke auf dem verteidigendem Pokémon zu."
+				de: "Fügt 10 Schadenspunkte plus 10 weitere Schadenspunkte für jede Schadensmarke auf dem verteidigenden Pokémon zu."
 			},
 			damage: "10+",
 
@@ -77,7 +78,8 @@ const card: Card = {
 
 	description: {
 		en: "If interrupted while miming, it will slap around the enemy with its broad hands.",
-		fr: "Dérangez-le pendant qu'il mime et il se battra en distribuant des volées de claques."
+		fr: "Dérangez-le pendant qu'il mime et il se battra en distribuant des volées de claques.",
+		de: "Falls es bei der Pantomime unterbrochen wird, schlägt es den Feind mit seinen breiten Händen."
 	},
 
 

--- a/data/Base/Jungle/60.ts
+++ b/data/Base/Jungle/60.ts
@@ -25,6 +25,7 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pichu",
+		de: "Pichu"
 	},
 
 	stage: "Basic",
@@ -38,7 +39,7 @@ const card: Card = {
 			name: {
 				en: "Spark",
 				fr: "Étincelle",
-				de: "Funkensprung"
+				de: "Funkenregen"
 			},
 			effect: {
 				en: "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)",
@@ -61,7 +62,8 @@ const card: Card = {
 
 	description: {
 		en: "When several of these Pokémon gather, their electricity can build and cause lightning storms.",
-		fr: "Quand plusieurs de ces Pokémon se réunissent, ils provoquent de gigantesques orages."
+		fr: "Quand plusieurs de ces Pokémon se réunissent, ils provoquent de gigantesques orages.",
+		de: "Wenn mehrere dieser Pokémon sich versammeln, kann ihre Elektrizität Gewitter verursachen."
 	},
 
 

--- a/data/Base/Jungle/61.ts
+++ b/data/Base/Jungle/61.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon can't attack Rhyhorn during your opponent's next turn. (Benching either Pokémon ends this effect.)",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur ne peut pas attaquer Rhinocorne pendant le prochain tour de votre adversaire. (Si l'un des deux Pokémon bat en retraite, cet effet prend fin.)",
-				de: "Wirf eine Münze. Bei 'Kopf' kann das verteidigende Pokémon Rihorn während des nächsten gegnerischen Zuges nicht angreifen. (Kommt einer der beiden Pokémon auf der Bank, ist diese Wirkung nicht weiter gültig.)"
+				de: "Wirf eine Münze. Bei „Kopf“ kann das verteidigende Pokémon Rihorn während des nächsten gegnerischen Zuges nicht angreifen. (Kommt einer der beiden Pokémon auf die Bank, ist diese Wirkung nicht weiter gültig.)"
 			},
 
 		},
@@ -77,7 +77,8 @@ const card: Card = {
 
 	description: {
 		en: "Its massive bones are 1,000 times harder than human bones. It can easily knock a trailer flying.",
-		fr: "Avec une ossature 1000 fois plus résistante que celle de l'homme, ses charges sont dévastatrices."
+		fr: "Avec une ossature 1000 fois plus résistante que celle de l'homme, ses charges sont dévastatrices.",
+		de: "Seine massiven Knochen sind tausendmal härter als menschliche Knochen. Es kann problemlos einen Wohnwagen umwerfen."
 	},
 
 

--- a/data/Base/Jungle/62.ts
+++ b/data/Base/Jungle/62.ts
@@ -53,7 +53,7 @@ const card: Card = {
 			effect: {
 				en: "If Spearow was attacked last turn, do the final result of that attack on Spearow to the Defending Pokémon.",
 				fr: "Si Piafabec a été attaqué durant le tour précédent, infligez le résultat final de cette attaque sur Piafabec au Pokémon Défenseur.",
-				de: "Falls Habitak im letzten Zug angegriffen wurde, füge dem verteidigenden Pokémon Schadenspunkte in Höhe der Endstärke dieses Angriffs und ausserdem alle Auswirkungen, die dieser Angriff auf habitak hatte, zu."
+				de: "Falls Habitak im letzten Zug angegriffen wurde, füge dem verteidigenden Pokémon Schadenspunkte in Höhe der Endstärke dieses Angriffs und ausserdem alle Auswirkungen, die dieser Angriff auf Habitak hatte, zu."
 			},
 
 		},
@@ -75,7 +75,8 @@ const card: Card = {
 
 	description: {
 		en: "Eats bugs in grassy areas. It has to flap its short wings at high speeds to stay airborne.",
-		fr: "Il chasse les insectes dans les hautes herbes. Ses petites ailes lui permettent de voler très vite."
+		fr: "Il chasse les insectes dans les hautes herbes. Ses petites ailes lui permettent de voler très vite.",
+		de: "Frißt in grasbedeckten Gegenden Käfer. Es muß seine kurzen Flügel schnell schlagen, um in der Luft zu bleiben."
 	},
 
 

--- a/data/Base/Jungle/63.ts
+++ b/data/Base/Jungle/63.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei 'Kopf' ist das verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 
@@ -56,7 +56,7 @@ const card: Card = {
 			effect: {
 				en: "Remove a number of damage counters from Venonat equal to the damage done to the Defending Pokémon (after applying Weakness and Resistance).",
 				fr: "Retirez de Mimitoss un nombre de marqueurs de dégâts égal aux dégâts infligés au Pokémon Défenseur (après application de la Faiblesse et de la Résistance). Si Mimitoss a moins de marqueurs de 10 dégâts, retirez-les tous.",
-				de: "Entferne von Bluzuk Schadensmarken in Höhe des Schadens, der dem verteidigenden Pokémon durch diesen Angriff zugefügt wurden (nachdem Schwäche und Reistenz abgerechnet wurden). Falls Bluzuk weniger Schadensmarken als diese Anzahl hat, entferne sie alle."
+				de: "Entferne von Bluzuk Schadensmarken in Höhe des Schadens, der dem verteidigenden Pokémon durch diesen Angriff zugefügt wurden (nachdem Schwäche und Resistenz abgerechnet wurden). Falls Bluzuk weniger Schadensmarken als diese Anzahl hat, entferne sie alle."
 			},
 			damage: 10,
 
@@ -74,7 +74,8 @@ const card: Card = {
 
 	description: {
 		en: "Lives in the shadows of tall trees where it eats insects. It is attracted by light at night.",
-		fr: "Il vit à l'ombre des grands arbres où il mange des insectes. Il est attiré par la lumière."
+		fr: "Il vit à l'ombre des grands arbres où il mange des insectes. Il est attiré par la lumière.",
+		de: "Lebt im Schatten hoher Bäume, wo es Insekten frißt. Es wird nachts von Licht angezogen."
 	},
 
 

--- a/data/Base/Jungle/64.ts
+++ b/data/Base/Jungle/64.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Flip a coin. If heads, you may search your deck for any Basic Pokémon or Evolution card. Show that card to your opponent, then put it into your hand. Shuffle your deck afterward.",
 		fr: "Lancez une pièce. Si c'est face, vous pouvez chercher n'importe quelle carte Pokémon de base ou Évolution dans votre deck. Montrez cette carte à votre adversaire, puis placez-la dans votre main. Mélangez ensuite votre deck.",
-		de: "Wirf eine Münze. Bei 'Kopf' darfst du dein Deck nach einer beliebigen Basis-Pokémon- oder Evolutionskarte durchsuchen. Zeige diese karte deinem gegner und nimm sie auf deine Hand. Mische dein Deck dannach,"
+		de: "Wirf eine Münze. Bei „Kopf“ darfst du dein Deck nach einer beliebigen Basis-Pokémon- oder Evolutionskarte durchsuchen. Zeige diese Karte deinem Gegner und nimm sie auf deine Hand. Mische dein Deck danach."
 	},
 
 

--- a/data/Base/Jungle/7.ts
+++ b/data/Base/Jungle/7.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Nidorina",
-		fr: "Nidorina"
+		fr: "Nidorina",
+		de: "Nidorina"
 	},
 
 	stage: "Stage2",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Does 20 damage plus 20 more damage for each Nidoking you have in play.",
 				fr: "Inflige 20 dégâts plus 20 dégâts supplémentaires pour chaque Nidoking que vous avez en jeu.",
-				de: "Fügt 20 Schadenspunkte plus 20 weitere für jeden Nidoking zu, den du im Spiel hast."
+				de: "Fügt 20 Schadenspunkte plus 20 weitere Schadenspunkte für jeden Nidoking zu, den du im Spiel hast."
 			},
 			damage: "20+",
 
@@ -78,7 +79,8 @@ const card: Card = {
 
 	description: {
 		en: "Its hard scales provide strong protection. It uses its hefty bulk to execute powerful moves.",
-		fr: "Ses écailles très résistantes et son corps massif sont des armes dévastatrices."
+		fr: "Ses écailles très résistantes et son corps massif sont des armes dévastatrices.",
+		de: "Seine harten Schuppen bieten ihm starken Schutz. Es nutzt seine massige Gestalt für kräftige Bewegungen."
 	},
 
 

--- a/data/Base/Jungle/8.ts
+++ b/data/Base/Jungle/8.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pidgeotto",
-		fr: "Roucoups"
+		fr: "Roucoups",
+		de: "Tauboga"
 	},
 
 	stage: "Stage2",
@@ -59,7 +60,7 @@ const card: Card = {
 			effect: {
 				en: "Unless this attack Knocks Out the Defending Pokémon, return the Defending Pokémon and all cards attached to it to your opponent's hand.",
 				fr: "À moins que cette attaque ne mette le Pokémon Défenseur K.O., renvoyez le Pokémon Défenseur et toutes les cartes qui lui sont attachées dans la main de votre adversaire.",
-				de: "Falls dieser Angriff den verteidigenden Pokémon nicht kampfunfähig macht, gib den verteidigenden Pokémon und alle daraufabgelegten Karten deinem Gegner auf die Hand zurück."
+				de: "Falls dieser Angriff den verteidigenden Pokémon nicht kampfunfähig macht, gib den verteidigenden Pokémon und alle darauf abgelegten Karten deinem Gegners auf die Hand zurück."
 			},
 			damage: 30,
 
@@ -82,7 +83,8 @@ const card: Card = {
 
 	description: {
 		en: "When hunting, it skims the surface of water at high speed to pick off unwary prey such as Magikarp.",
-		fr: "Il chasse en surveillant la surface de l'eau et en plongeant pour attraper des proies faciles."
+		fr: "Il chasse en surveillant la surface de l'eau et en plongeant pour attraper des proies faciles.",
+		de: "Auf der Jagd fliegt es mit einer hohen Geschwindigkeit knapp über der Wasseroberfläche, um nichtsahnende Beute wie z.B. Karpador einzufangen."
 	},
 
 

--- a/data/Base/Jungle/9.ts
+++ b/data/Base/Jungle/9.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei Kopf ist das verteidigende Pokémon jetzt gelähmt"
+				de: "Wirf eine Münze. Bei „Kopf“ ist das verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "If it fails to crush the victim in its pincers, it will swing its victim around and toss it hard.",
-		fr: "Quand il ne peut écraser sa proie avec sa pince, il la secoue et l'envoie dans les airs."
+		fr: "Quand il ne peut écraser sa proie avec sa pince, il la secoue et l'envoie dans les airs.",
+		de: "Falls es ihm nicht gelingt, sein Opfer in seinen Kneifzangen zu erdrücken, schwingt es sein Opfer durch die Luft und nimmt es auf die Hörner."
 	},
 
 


### PR DESCRIPTION
## Add missing German translations for base2

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my german cards due to lacking docs or because there was english text in the german card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up with actual authentic card data. To make sure this data is accurate I'm using PokéWiki (large german card database) + OCR on card screenshots + the `NSSpellChecker` with the German dictionary to make sure no mistakes from the wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far from complete. If you have any question let me know. Where changes come from etc. is fully logged on my device and I can tell you where which text comes from.

### Validation

Validated locally with `bun run validate` (tsc), and the data compiles via `server: bun run compile` with the German strings present in `generated/de/cards.json`.
