### PR TITLE
Add missing German translations for basep

### DIFF
--- a/data/Base/Wizards Black Star Promos/1.ts
+++ b/data/Base/Wizards Black Star Promos/1.ts
@@ -4,6 +4,7 @@ import Set from '../Wizards Black Star Promos'
 const card: Card = {
 	name: {
 		en: "Pikachu",
+		de: "Pikachu"
 	},
 	illustrator: "Keiji Kinebuchi",
 	rarity: "Common",
@@ -28,9 +29,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Growl",
+				de: "Heuler"
 			},
 			effect: {
 				en: "If the Defending Pokémon attacks Pikachu during your opponent's next turn, any damage done by the attack is reduced by 10 (after applying Weakness and Resistance). (Benching either Pokémon ends this effect.)",
+				de: "Falls das verteidigende Pokémon Pikachu während des nächsten gegnerischen Zuges angreift, werden die Schadenspunkte dieses Angriffs um 10 Schadenspunkte reduziert (nachdem Schwäche und Resistenz abgerechnet wurden). (Wenn einer der beiden Pokémon auf die Bank geht, ist dieser Effekt somit beendet.)"
 			},
 
 		},
@@ -41,9 +44,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Thundershock",
+				de: "Donnerschock"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
+				de: "Wirf eine Münze. Bei „Kopf“ ist das verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -59,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "When several of these Pokémon gather, their electricity could build and cause lightning storms.",
+		de: "Wenn mehrere dieser Pokémon sich versammeln, kann ihre gesammelte Elektrizität sogar Gewitter verursachen."
 	},
 
 	variants: [

--- a/data/Base/Wizards Black Star Promos/14.ts
+++ b/data/Base/Wizards Black Star Promos/14.ts
@@ -4,7 +4,8 @@ import Set from '../Wizards Black Star Promos'
 const card: Card = {
 	name: {
 		en: "Mewtwo",
-		fr: "Mewtwo"
+		fr: "Mewtwo",
+		de: "Mewtu"
 	},
 
 	illustrator: "Benimaru Itoh",
@@ -31,11 +32,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Energy Absorption",
-				fr: "Absorption d'Énergie"
+				fr: "Absorption d'Énergie",
+				de: "Energieaufnahme"
 			},
 			effect: {
 				en: "Choose up to 2 Energy cards from your discard pile and attach them to Mewtwo.",
-				fr: "Choisissez jusqu'à 2 cartes Énergie de votre pile de défausse et attachez-les à Mewtwo."
+				fr: "Choisissez jusqu'à 2 cartes Énergie de votre pile de défausse et attachez-les à Mewtwo.",
+				de: "Wähle bis zu 2 Energiekarten aus deinem Ablagestapel, und lege sie auf Mewtu ab."
 			},
 
 		},
@@ -47,7 +50,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Psyburn",
-				fr: "Brûlepsy"
+				fr: "Brûlepsy",
+				de: "Psychoverbrennung"
 			},
 
 			damage: 40,
@@ -66,7 +70,8 @@ const card: Card = {
 
 	description: {
 		en: "Years of genetic experiments resulted in the creation of this never-before-seen violent Pokémon.",
-		fr: "Ce Pokémon violent, jamais vu auparavant, est le fruit de nombreuses années d'expériences génétiques."
+		fr: "Ce Pokémon violent, jamais vu auparavant, est le fruit de nombreuses années d'expériences génétiques.",
+		de: "In langjährigen genetischen Experimenten wurde dieses einzigartige und gewalttätige Pokémon erschaffen."
 	},
 
 	variants: [

--- a/data/Base/Wizards Black Star Promos/2.ts
+++ b/data/Base/Wizards Black Star Promos/2.ts
@@ -4,7 +4,8 @@ import Set from '../Wizards Black Star Promos'
 const card: Card = {
 	name: {
 		en: "Electabuzz",
-		fr: "Electabuzz"
+		fr: "Electabuzz",
+		de: "Elektek"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -31,11 +32,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Light Screen",
-				fr: "Écran de lumière"
+				fr: "Écran de lumière",
+				de: "Lichtschirm"
 			},
 			effect: {
 				en: "Whenever an attack does damage to Electabuzz (after applying Weakness and Resistance) during your opponent's next turn, that attack only does half the damage to Electabuzz (rounded down to the nearest 10). (Any other effects still happen.)",
-				fr: "Dès qu'une attaque provoque des dégâts à Electabuzz (après application de la faiblesse et de la résistance), pendant le prochain tour de votre adversaire, cette attaque ne produit que la moitié des dégâts à Electabuzz (arrondis à la dizaine la plus proche). (Tout autre effet ou attaque est toujours valide.)"
+				fr: "Dès qu'une attaque provoque des dégâts à Electabuzz (après application de la faiblesse et de la résistance), pendant le prochain tour de votre adversaire, cette attaque ne produit que la moitié des dégâts à Electabuzz (arrondis à la dizaine la plus proche). (Tout autre effet ou attaque est toujours valide.)",
+				de: "Immer dann, wenn Elektek Schaden zugefügt wird, während Dein Mitspieler am Zug ist, (nach Anwendung von Schwäche und Widerstand), richtet dieser Angriff bei Elektek nur den halben Schaden an (auf die nächste 10 abrunden). (Andere Auswirkungen von Angriffen treten weiter ein.)"
 			},
 
 		},
@@ -46,11 +49,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Quick Attack",
-				fr: "Attaque rapide"
+				fr: "Attaque rapide",
+				de: "Schnellangriff"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage; if tails, this attack does 10 damage.",
-				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires ; si c'est pile, cette attaque inflige 10 dégâts."
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires ; si c'est pile, cette attaque inflige 10 dégâts.",
+				de: "Wirf eine Münze. Bei Kopf erhältst Du 10 Schadenspunkte plus 20 weitere; bei Zahl verursacht der Angriff 10 Schadenspunkte."
 			},
 			damage: "10+",
 
@@ -68,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "A wild Pokémon with a short temper. It is able to distinguish colors, and likes the color red.",
-		fr: "Un Pokémon sauvage au mauvais caractère. Capable de reconnaître les couleurs et apprécie la couleur rouge."
+		fr: "Un Pokémon sauvage au mauvais caractère. Capable de reconnaître les couleurs et apprécie la couleur rouge.",
+		de: "Ein wildes, hitzköpfiges Pokémon. Es kann Farben unterscheiden und ihm gefällt die Farbe Rot."
 	},
 
 	variants: [

--- a/data/Base/Wizards Black Star Promos/21.ts
+++ b/data/Base/Wizards Black Star Promos/21.ts
@@ -4,7 +4,8 @@ import Set from '../Wizards Black Star Promos'
 const card: Card = {
 	name: {
 		en: "Moltres",
-		fr: "Sulfura"
+		fr: "Sulfura",
+		de: "Lavados"
 	},
 
 	illustrator: "Naoyo Kimura",
@@ -33,11 +34,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Hyper Flame",
-				fr: "Super flamme"
+				fr: "Super flamme",
+				de: "Hyperflamme"
 			},
 			effect: {
 				en: "Flip a coin. If heads, discard 1 Energy card attached to Moltres. If tails, discard all Energy cards attached to Moltres. If you can't discard Energy cards, this attack does nothing.",
-				fr: "Lancez une pièce. Si c'est face, défaussez une carte Énergie  attachée à Sulfura. Si c'est pile, défaussez toutes les cartes Énergies attachées à Sulfura. Vous ne pouvez utiliser cette attaque que si vous pouvez défausser des cartes Énergies attachées à Sulfura."
+				fr: "Lancez une pièce. Si c'est face, défaussez une carte Énergie  attachée à Sulfura. Si c'est pile, défaussez toutes les cartes Énergies attachées à Sulfura. Vous ne pouvez utiliser cette attaque que si vous pouvez défausser des cartes Énergies attachées à Sulfura.",
+				de: "Wirf eine Münze. Bei „Kopf“ entferne eine auf lavados abgelegte {R}-Energiekarte. Bei „Zahl“ entferne alle auf Lavados abgelegte Energiekarten. Du kannst diesen Angriff nur dann einsetzen, wenn du Energiekarten von Lavados entfernen kannst."
 			},
 			damage: 60,
 
@@ -55,7 +58,8 @@ const card: Card = {
 
 	description: {
 		en: "The flames on this legendary Pokémon's wings burn so brightly that they can make night seem like day.",
-		fr: "Les flammes des ailes de ce Pokémon légendaire brûlent d'un feu si ardent qu'elles permettent de voir la nuit comme en plein jour."
+		fr: "Les flammes des ailes de ce Pokémon légendaire brûlent d'un feu si ardent qu'elles permettent de voir la nuit comme en plein jour.",
+		de: "Die Flammen auf den Flügeln dieses legendären Pokémon brennen so lichterloh, dass sie die Nacht scheinbar zum Tag machen."
 	},
 
 	variants: [

--- a/data/Base/Wizards Black Star Promos/22.ts
+++ b/data/Base/Wizards Black Star Promos/22.ts
@@ -4,7 +4,8 @@ import Set from '../Wizards Black Star Promos'
 const card: Card = {
 	name: {
 		en: "Articuno",
-		fr: "Artikodin"
+		fr: "Artikodin",
+		de: "Arktos"
 	},
 
 	illustrator: "Naoyo Kimura",
@@ -33,11 +34,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Diamond Dust",
-				fr: "Poussière de diamant"
+				fr: "Poussière de diamant",
+				de: "Diamantenstaub"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed, and this attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé et cette attaque inflige 10 dégâts à chacun des Pokémon du Banc de votre adversaire. (Ne pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc.)"
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé et cette attaque inflige 10 dégâts à chacun des Pokémon du Banc de votre adversaire. (Ne pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc.)",
+				de: "Wirf eine Münze. Bei „Kopf“ ist das verteidigende Pokémon jetzt gelähmt und dieser Angriff fügt jedem Pokémon auf der Bank des Gegners 10 Schadenspunkte zu. (Schwäche und Resistenz für Pokémon auf der Bank nicht anwenden.)"
 			},
 			damage: 20,
 
@@ -55,7 +58,8 @@ const card: Card = {
 
 	description: {
 		en: "This legendary Pokémon is said to freeze the water in the air during winter, causing snow.",
-		fr: "On prétend que ce Pokémon légendaire refroidit l'eau contenue dans l'air en hiver, au point de provoquer des chutes de neige."
+		fr: "On prétend que ce Pokémon légendaire refroidit l'eau contenue dans l'air en hiver, au point de provoquer des chutes de neige.",
+		de: "Diesem legendären Pokémon wird nachgesagt, dass es das Wasser im Winter in der Luft zu Schnee gefrieren lässt."
 	},
 
 	variants: [

--- a/data/Base/Wizards Black Star Promos/23.ts
+++ b/data/Base/Wizards Black Star Promos/23.ts
@@ -4,7 +4,8 @@ import Set from '../Wizards Black Star Promos'
 const card: Card = {
 	name: {
 		en: "Zapdos",
-		fr: "Électhor"
+		fr: "Électhor",
+		de: "Zapdos"
 	},
 
 	illustrator: "Naoyo Kimura",
@@ -33,11 +34,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Lightning Burn",
-				fr: "Brûlure éclair"
+				fr: "Brûlure éclair",
+				de: "Blitzbrand"
 			},
 			effect: {
 				en: "Flip a coin. If heads, and if your opponent has any Benched Pokémon, choose 1 of them. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) If tails, Zapdos does 30 damage to itself.",
-				fr: "Lancez une pièce. Si c'est face, choisissez un des Pokémon du Banc de votre adversaire. Cette attaque inflige 30 dégâts à ce Pokémon. (Ne pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc.) Si c'est pile, Électhor s'inflige 30 dégâts."
+				fr: "Lancez une pièce. Si c'est face, choisissez un des Pokémon du Banc de votre adversaire. Cette attaque inflige 30 dégâts à ce Pokémon. (Ne pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc.) Si c'est pile, Électhor s'inflige 30 dégâts.",
+				de: "Wirf eine Münze. Wähle bei „Kopf“ ein Pokémon auf der Bank deines Gegners. Dieser Angriff fügt diesem Pokémon 30 Schadenspunkte zu. (Schwäche und Resistenz für Pokémon auf der Bank nicht anwenden.) Bei „Zahl“ fügt sich Zapdos selbst 30 Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -55,7 +58,8 @@ const card: Card = {
 
 	description: {
 		en: "This legendary Pokémon is said to be present wherever there is a lightning storm.",
-		fr: "Ce Pokémon légendaire est connu pour se montrer partout où il y a un orage."
+		fr: "Ce Pokémon légendaire est connu pour se montrer partout où il y a un orage.",
+		de: "Diesem legendäres Pokémon wird nachgesagt, dass es immer bei Gewittern erscheint."
 	},
 
 	variants: [

--- a/data/Base/Wizards Black Star Promos/24.ts
+++ b/data/Base/Wizards Black Star Promos/24.ts
@@ -4,7 +4,8 @@ import Set from '../Wizards Black Star Promos'
 const card: Card = {
 	name: {
 		en: "___________'s Pikachu",
-		fr: "Pikachu de ________"
+		fr: "Pikachu de ________",
+		de: "S Pikachu"
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -32,11 +33,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Birthday Surprise",
-				fr: "Surprise d'anniversaire"
+				fr: "Surprise d'anniversaire",
+				de: "Geburtstagsüberraschung"
 			},
 			effect: {
 				en: "If it's not your birthday, this attack does 30 damage. If it is your birthday, flip a coin. If heads, this attack does 30 damage plus 50 more damage; if tails, this attack does 30 damage.",
-				fr: "Si ce n'est pas votre anniversaire, cette attaque inflige 30 dégâts. Si c'est votre anniversaire, lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts plus 50 dégâts supplémentaires ; si c'est pile, cette attaque inflige 30 dégâts."
+				fr: "Si ce n'est pas votre anniversaire, cette attaque inflige 30 dégâts. Si c'est votre anniversaire, lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts plus 50 dégâts supplémentaires ; si c'est pile, cette attaque inflige 30 dégâts.",
+				de: "Wenn heute nicht dein Geburtstag ist, fügt dieser Angriff 30 Schadenspunkte zu. Wenn du heute Geburtstag hast, wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 30 Schadenspunkte plus 50 weitere Schadenspunkte zu; bei „Zahl“ fügt dieser Angriff 30 Schadenspunkte zu."
 			},
 			damage: "30+",
 
@@ -53,7 +56,8 @@ const card: Card = {
 
 	description: {
 		en: "Your Birthdate: ______________________________",
-		fr: "Votre anniversaire : _________________________________________"
+		fr: "Votre anniversaire : _________________________________________",
+		de: "Dein Geburtstag: ______________________________________"
 	},
 
 	variants: [

--- a/data/Base/Wizards Black Star Promos/25.ts
+++ b/data/Base/Wizards Black Star Promos/25.ts
@@ -4,7 +4,8 @@ import Set from '../Wizards Black Star Promos'
 const card: Card = {
 	name: {
 		en: "Flying Pikachu",
-		fr: "Pikachu volant"
+		fr: "Pikachu volant",
+		de: "Fliegendes Pikachu"
 	},
 
 	illustrator: "Toshinao Aoki",
@@ -31,11 +32,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Thundershock",
-				fr: "Éclair"
+				fr: "Éclair",
+				de: "Donnerschock"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
-				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé."
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf eine Münze. Bei „Kopf“ ist das verteidigende Pokémon gelähmt."
 			},
 			damage: 10,
 
@@ -48,11 +51,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Fly",
-				fr: "Vol"
+				fr: "Vol",
+				de: "Fliegen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Flying Pikachu; if tails, this attack does nothing (not even damage).",
-				fr: "Lancez une pièce. Si c'est face, pendant le prochain tour de votre adversaire, prévenez tous les effets d'attaques, y compris les dégâts, infligés à Pikachu volant ; si c'est pile, cette attaque ne fait rien (pas même de dégâts)."
+				fr: "Lancez une pièce. Si c'est face, pendant le prochain tour de votre adversaire, prévenez tous les effets d'attaques, y compris les dégâts, infligés à Pikachu volant ; si c'est pile, cette attaque ne fait rien (pas même de dégâts).",
+				de: "Wirf eine Münze. Bei „Kopf“ verhindere während des nächsten gegnerischen Zuges alle Auswirkungen von Angriffen auf Fliegendes Pikachu (einschließlich der Schadenspunkte); bei „Zahl“ richtet dieser Angriff nichts aus (nicht einmal Schadenspunkte)."
 			},
 			damage: 30,
 
@@ -70,7 +75,8 @@ const card: Card = {
 
 	description: {
 		en: "By learning how to fly, Pikachu overcame its weakness to Fighting Pokémon.",
-		fr: "En apprenant à voler, Pikachu a surpassé sa faiblesse contre le Pokémon Combat."
+		fr: "En apprenant à voler, Pikachu a surpassé sa faiblesse contre le Pokémon Combat.",
+		de: "Indem es das Fliegen erlernte, bezwang Pikachu seine Schwäche gegenüber den Kampf-Pokémon."
 	},
 
 	variants: [

--- a/data/Base/Wizards Black Star Promos/26.ts
+++ b/data/Base/Wizards Black Star Promos/26.ts
@@ -4,7 +4,8 @@ import Set from '../Wizards Black Star Promos'
 const card: Card = {
 	name: {
 		en: "Pikachu",
-		fr: "Pikachu"
+		fr: "Pikachu",
+		de: "Pikachu"
 	},
 
 	illustrator: "Gakuji Nomoto",
@@ -31,7 +32,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Scratch",
-				fr: "Griffe"
+				fr: "Griffe",
+				de: "Kratzer"
 			},
 
 			damage: 10,
@@ -44,11 +46,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Thunderbolt",
-				fr: "Tonnerre"
+				fr: "Tonnerre",
+				de: "Donnerblitz"
 			},
 			effect: {
 				en: "Discard all Energy cards attached to Pikachu in order to use this attack.",
-				fr: "Défaussez toutes les cartes Énergie attachées à Pikachu."
+				fr: "Défaussez toutes les cartes Énergie attachées à Pikachu.",
+				de: "Lege alle Energiekarten, die an Pikachu angelegt sind, ab."
 			},
 			damage: 40,
 
@@ -66,7 +70,8 @@ const card: Card = {
 
 	description: {
 		en: "It uses its sensitive tail to sense its environment and has been known to react violently if its tail is grabbed.",
-		fr: "Il utilise sa queue sensible pour explorer son environnement et réagit violemment si on l'attrape par la queue."
+		fr: "Il utilise sa queue sensible pour explorer son environnement et réagit violemment si on l'attrape par la queue.",
+		de: "Es benutzt seinen empfindlichen Schwanz, um seine Umwelt wahrzunehmen, und reagiert äußerst gereizt, wenn man es am Schwanz packt."
 	},
 
 	variants: [

--- a/data/Base/Wizards Black Star Promos/29.ts
+++ b/data/Base/Wizards Black Star Promos/29.ts
@@ -4,7 +4,8 @@ import Set from '../Wizards Black Star Promos'
 const card: Card = {
 	name: {
 		en: "Marill",
-		fr: "Marill"
+		fr: "Marill",
+		de: "Marill"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -32,11 +33,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Water Gun",
-				fr: "Pistolet à O"
+				fr: "Pistolet à O",
+				de: "Aquaknarre"
 			},
 			effect: {
 				en: "Does 20 damage plus 10 more damage for each Energy attached to Marill but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way.",
-				fr: "Inflige 20 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  attachée à Marill mais non utilisée pour payer le coût en Énergie de cette attaque. Vous ne pouvez pas ajouter plus de 20 dégâts de cette façon."
+				fr: "Inflige 20 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  attachée à Marill mais non utilisée pour payer le coût en Énergie de cette attaque. Vous ne pouvez pas ajouter plus de 20 dégâts de cette façon.",
+				de: "Fügt 20 Schadenspunkte plus 10 Schadenspunkte für jede an Marill angelegte {W} Energie zu, die nicht zum Zahlen der Energiekosten für diesen Angriff verrechnet wurde. Du kannst nicht mehr als 20 Schadenspunkte auf diese Weise hinzufügen."
 			},
 			damage: "20+",
 
@@ -54,7 +57,8 @@ const card: Card = {
 
 	description: {
 		en: "The tip of its tail, which contains oil that is lighter than water, lets it swim without drowning.",
-		fr: "L'extrémité de sa queue, qui contient une huile plus légère que l'eau, lui permet de nager sans couler."
+		fr: "L'extrémité de sa queue, qui contient une huile plus légère que l'eau, lui permet de nager sans couler.",
+		de: "Dank seiner Schwanzspitze, in der sich Öl befindet, das leichter als Wasser ist, kann es schwimmen, ohne unterzugehen."
 	},
 
 	variants: [

--- a/data/Base/Wizards Black Star Promos/3.ts
+++ b/data/Base/Wizards Black Star Promos/3.ts
@@ -4,7 +4,8 @@ import Set from '../Wizards Black Star Promos'
 const card: Card = {
 	name: {
 		en: "Mewtwo",
-		fr: "Deuxmiaou"
+		fr: "Deuxmiaou",
+		de: "Mewtu"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -31,11 +32,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Energy Absorption",
-				fr: "Absorption d'énergie"
+				fr: "Absorption d'énergie",
+				de: "Energieaufnahme"
 			},
 			effect: {
 				en: "Choose up to 2 Energy cards from your discard pile and attach them to Mewtwo.",
-				fr: "Choisissez jusqu'à 2 cartes Énergie de votre pile de défausse et attachez-les à Deuxmiaou."
+				fr: "Choisissez jusqu'à 2 cartes Énergie de votre pile de défausse et attachez-les à Deuxmiaou.",
+				de: "Wähle bis zu 2 Energiekarten aus Deinem Ablagestapel, und füge sie an Mewtu."
 			},
 
 		},
@@ -47,7 +50,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Psyburn",
-				fr: "Brûlepsy"
+				fr: "Brûlepsy",
+				de: "Psyburn"
 			},
 
 			damage: 40,
@@ -66,7 +70,8 @@ const card: Card = {
 
 	description: {
 		en: "Years of genetic experiments resulted in the creation of this never-before-seen violent Pokémon.",
-		fr: "Ce Pokémon violent, jamais vu auparavant, est le fruit de nombreuses années d'expériences génétiques."
+		fr: "Ce Pokémon violent, jamais vu auparavant, est le fruit de nombreuses années d'expériences génétiques.",
+		de: "In langjährigen genetischen Experimenten wurde dieses einzigartige und gewalttätige Pokémon erschaffen."
 	},
 
 	variants: [

--- a/data/Base/Wizards Black Star Promos/30.ts
+++ b/data/Base/Wizards Black Star Promos/30.ts
@@ -4,7 +4,8 @@ import Set from '../Wizards Black Star Promos'
 const card: Card = {
 	name: {
 		en: "Togepi",
-		fr: "Togepi"
+		fr: "Togepi",
+		de: "Togepi"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -31,11 +32,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Snivel",
-				fr: "Pleurnicherie"
+				fr: "Pleurnicherie",
+				de: "Geschniefe"
 			},
 			effect: {
 				en: "If the Defending Pokémon attacks Togepi during your opponent's next turn, any damage done to Togepi is reduced by 20 (before applying Weakness and Resistance). (Benching either Pokémon ends this effect.)",
-				fr: "Si le Pokémon Défenseur attaque Togepi durant le prochain tour de votre adversaire, tous les dégâts infligés à Togepi sont réduits de 20 (après avoir appliqué Faiblesse et Résistance). (Mettre l'un des deux Pokémon sur le Banc met fin à cet effet.)"
+				fr: "Si le Pokémon Défenseur attaque Togepi durant le prochain tour de votre adversaire, tous les dégâts infligés à Togepi sont réduits de 20 (après avoir appliqué Faiblesse et Résistance). (Mettre l'un des deux Pokémon sur le Banc met fin à cet effet.)",
+				de: "Wenn das verteidigende Pokémon Togepi während des nächsten Zugs deines Gegner angreift, reduziere allen Schaden, der Togepi zugefügt wird, um 20 (nachdem Schwäche und Resistenz verrechnet wurden). (Kommt eines der beiden Pokémon auf die Bank, endet diese Wirkung.)"
 			},
 
 		},
@@ -46,11 +49,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Mini-Metronome",
-				fr: "Mini-Métronome"
+				fr: "Mini-Métronome",
+				de: "Mini-Metronom"
 			},
 			effect: {
 				en: "Flip a coin. If heads, choose 1 of the Defending Pokémon's attacks. Mini-Metronome copies that attack except for its Energy cost. (You must still do anything else in order to use that attack.) (No matter what type the Defending Pokémon is, Togepi's type is still .) Togepi performs that attack.",
-				fr: "Lancez une pièce. Si c'est face, choisissez 1 des attaques du Pokémon Défenseur. Mini-Métronome copie cette attaque en tous points, excepté son coût en Énergie. (Vous devez cependant faire tout ce qui est autrement requis pour utiliser cette attaque). (Quel que soit le type du Pokémon Défenseur, Togepi reste .) Togepi effectue cette attaque."
+				fr: "Lancez une pièce. Si c'est face, choisissez 1 des attaques du Pokémon Défenseur. Mini-Métronome copie cette attaque en tous points, excepté son coût en Énergie. (Vous devez cependant faire tout ce qui est autrement requis pour utiliser cette attaque). (Quel que soit le type du Pokémon Défenseur, Togepi reste .) Togepi effectue cette attaque.",
+				de: "Wirf eine Münze.Wähle bei „Kopf“ einen der Angriffe des verteidigenden Pokémon. Mini-Metronom kopiert diesen Angriff außer seinen Energiekosten. (Du musst allerdings alles andere tun, um diesen Angriff zu verwenden.) (Unabhängig vom Typ des verteidigenden Pokémon ist Togepis Typ weiterhin {C}.) Togepi führt diesen Angriff aus."
 			},
 
 		},
@@ -67,7 +72,8 @@ const card: Card = {
 
 	description: {
 		en: "Still only a hatchling, it uses poison to chase off its enemies when threatened.",
-		fr: "Même si ce n'est qu'un poussin, il utilise un poison pour repousser ses ennemis quand il se sent menacé."
+		fr: "Même si ce n'est qu'un poussin, il utilise un poison pour repousser ses ennemis quand il se sent menacé.",
+		de: "Obwohl es gerade erst geschlüpft ist, kann es schon mit seinem Gift seine Feinde vertreiben."
 	},
 
 	variants: [

--- a/data/Base/Wizards Black Star Promos/31.ts
+++ b/data/Base/Wizards Black Star Promos/31.ts
@@ -4,7 +4,8 @@ import Set from '../Wizards Black Star Promos'
 const card: Card = {
 	name: {
 		en: "Cleffa",
-		fr: "Mélo"
+		fr: "Mélo",
+		de: "Pii"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -31,11 +32,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Eek",
-				fr: "Hi !"
+				fr: "Hi !",
+				de: "Pieps"
 			},
 			effect: {
 				en: "Draw 2 cards",
-				fr: "Piochez 2 cartes."
+				fr: "Piochez 2 cartes.",
+				de: "Ziehe 2 Karten."
 			},
 
 		},
@@ -43,7 +46,8 @@ const card: Card = {
 
 	description: {
 		en: "Because of its unusual, star-like silhouette, people believe that it came here on a meteor.",
-		fr: "À cause de son étrange forme en étoile, les gens pensent qu'il est arrivé ici sur un météore."
+		fr: "À cause de son étrange forme en étoile, les gens pensent qu'il est arrivé ici sur un météore.",
+		de: "Wegen seiner ungewöhnlichen sternenartigen Silhouette denken viele, dass es auf einer Sternschnuppe hergekommen ist."
 	},
 
 	variants: [

--- a/data/Base/Wizards Black Star Promos/32.ts
+++ b/data/Base/Wizards Black Star Promos/32.ts
@@ -4,7 +4,8 @@ import Set from '../Wizards Black Star Promos'
 const card: Card = {
 	name: {
 		en: "Smeargle",
-		fr: "Queulorior"
+		fr: "Queulorior",
+		de: "Farbeagle"
 	},
 
 	illustrator: "Tomokazu Komiya",
@@ -31,11 +32,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Paint",
-				fr: "Peinture"
+				fr: "Peinture",
+				de: "Anmalen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, choose a type (other than colorless) and put a Coloring counter on the Defending Pokémon. That Pokémon is now the type you choose. If it already had a Coloring counter, remove the old one. If tails, this attack does nothing.",
-				fr: "Lancez une pièce. Si c'est face, choisissez un type (autre qu'Incolore) et placez un marqueur Colorant sur le Pokémon Défenseur. Ce Pokémon est maintenant du type que vous avez choisi. S'il a déjà un marqueur Colorant, retirez l'ancien. Si c'est pile, cette attaque ne fait rien."
+				fr: "Lancez une pièce. Si c'est face, choisissez un type (autre qu'Incolore) et placez un marqueur Colorant sur le Pokémon Défenseur. Ce Pokémon est maintenant du type que vous avez choisi. S'il a déjà un marqueur Colorant, retirez l'ancien. Si c'est pile, cette attaque ne fait rien.",
+				de: "Wirf eine Münze. Wähle bei „Kopf“ einen Typ (außer Farblos) und lege eine Farbe-marke auf das verteidigende Pokémon. Dieses Pokémon hat nun den Typ, den du gewählt hast. Wenn es schon eine Farbe-marke hat, entferne die alte. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 
 		},
@@ -59,7 +62,8 @@ const card: Card = {
 
 	description: {
 		en: "Once it becomes an adult, it has a tendency to let its comrades plant footprints on its back.",
-		fr: "À l'âge adulte, il a tendance à laisser ses camarades imprimer leurs empreintes sur son dos."
+		fr: "À l'âge adulte, il a tendance à laisser ses camarades imprimer leurs empreintes sur son dos.",
+		de: "Wenn es ausgewachsen ist, lässt es sich oft mit Fussabdrücken seiner Kumpel verzieren."
 	},
 
 	variants: [

--- a/data/Base/Wizards Black Star Promos/33.ts
+++ b/data/Base/Wizards Black Star Promos/33.ts
@@ -4,7 +4,8 @@ import Set from '../Wizards Black Star Promos'
 const card: Card = {
 	name: {
 		en: "Scizor",
-		fr: "Cizayox"
+		fr: "Cizayox",
+		de: "Scherox"
 	},
 
 	illustrator: "Hironobu Yoshida",
@@ -24,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Scyther",
-		fr: "Insécateur"
+		fr: "Insécateur",
+		de: "Sichlor"
 	},
 
 	stage: "Stage1",
@@ -36,11 +38,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Leer",
-				fr: "Groz'yeux"
+				fr: "Groz'yeux",
+				de: "Silberblick"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon can't attack Scizor during your opponent's next turn. (Benching either Pokémon ends this effect.)",
-				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur ne peut pas attaquer Cizayox pendant le prochain tour de votre adversaire. (Mettre l'un des deux Pokémon sur le Banc met fin à cet effet.)"
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur ne peut pas attaquer Cizayox pendant le prochain tour de votre adversaire. (Mettre l'un des deux Pokémon sur le Banc met fin à cet effet.)",
+				de: "Wirf eine Münze. Bei „Kopf“ kann das verteidigende Pokémon Scherox während des nächsten Zugs deines Gegners nicht angreifen. (Kommt eins der beiden Pokémon auf die Bank, endet diese Wirkung.)"
 			},
 
 		},
@@ -52,11 +56,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Metal Pincer",
-				fr: "Pinces de Métal"
+				fr: "Pinces de Métal",
+				de: "Metallschneider"
 			},
 			effect: {
 				en: "Flip a coin until you get tails. This attack does 30 damage plus 10 more damage for each heads.",
-				fr: "Lancez une pièce jusqu'à ce que ce soit pile. Cette attaque inflige 30 dégâts plus 10 fois le nombre de faces."
+				fr: "Lancez une pièce jusqu'à ce que ce soit pile. Cette attaque inflige 30 dégâts plus 10 fois le nombre de faces.",
+				de: "Wirf eine Münze, bis „Zahl“ kommt. Dieser Angriff fügt 30 Schadenspunkte plus 10 weitere Schadenspunkte pro geworfenem „Kopf“ zu."
 			},
 			damage: "30+",
 
@@ -81,7 +87,8 @@ const card: Card = {
 
 	description: {
 		en: "Its wings are not used for flying. They are flapped at high speed to adjust its body temperature.",
-		fr: "Il n'utilise pas ses ailes pour voler. Elles lui servent à ajuster la température de son corps en les faisant battre rapidement."
+		fr: "Il n'utilise pas ses ailes pour voler. Elles lui servent à ajuster la température de son corps en les faisant battre rapidement.",
+		de: "Seine Flügel sind nicht zum Fliegen gedacht. Das schnelle Flattern hilft dabei, die Körpertemperatur auszugleichen."
 	},
 
 	variants: [

--- a/data/Base/Wizards Black Star Promos/35.ts
+++ b/data/Base/Wizards Black Star Promos/35.ts
@@ -4,7 +4,8 @@ import Set from '../Wizards Black Star Promos'
 const card: Card = {
 	name: {
 		en: "Pichu",
-		fr: "Pichu"
+		fr: "Pichu",
+		de: "Pichu"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -31,11 +32,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Let's Play!",
-				fr: "On joue ?"
+				fr: "On joue ?",
+				de: "Lass uns spielen!"
 			},
 			effect: {
 				en: "Search your deck for a Baby Pokémon card and put it onto your Bench. Shuffle your deck afterward. (You can't use this attack if your Bench is full.)",
-				fr: "Cherchez une carte Bébé Pokémon dans votre deck et placez-le sur votre Banc. Mélangez ensuite votre deck. (Vous ne pouvez pas utiliser cette attaque si votre Banc est plein.)"
+				fr: "Cherchez une carte Bébé Pokémon dans votre deck et placez-le sur votre Banc. Mélangez ensuite votre deck. (Vous ne pouvez pas utiliser cette attaque si votre Banc est plein.)",
+				de: "Durchsuche dein Deck nach einer Baby-Pokémon-Karte und lege sie auf deine Bank. Mische dein Deck danach. (Du kannst diesen Angriff nicht verwenden, wenn deine Bank voll ist.)"
 			},
 
 		},
@@ -43,7 +46,8 @@ const card: Card = {
 
 	description: {
 		en: "It is not yet skilled at storing electricity. It may send out a jolt if amused or startled.",
-		fr: "Bien qu'il ne soit pas encore très doué pour stocker l'électricité, il peut tout de même envoyer de petites secousses s'il est amusé ou surpris."
+		fr: "Bien qu'il ne soit pas encore très doué pour stocker l'électricité, il peut tout de même envoyer de petites secousses s'il est amusé ou surpris.",
+		de: "Es muss noch trainieren, wie man Energie speichert. Manchmal gibt es einen Stromschlag, wenn es lacht oder sich erschreckt."
 	},
 
 	variants: [

--- a/data/Base/Wizards Black Star Promos/36.ts
+++ b/data/Base/Wizards Black Star Promos/36.ts
@@ -4,7 +4,8 @@ import Set from '../Wizards Black Star Promos'
 const card: Card = {
 	name: {
 		en: "Igglybuff",
-		fr: "Toudoudou"
+		fr: "Toudoudou",
+		de: "Fluffeluff"
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -31,11 +32,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Good Night Song",
-				fr: "Chanson du Marchand de sable"
+				fr: "Chanson du Marchand de sable",
+				de: "Gute-Nacht-Lied"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
-				fr: "Le Pokémon Défenseur est maintenant Endormi."
+				fr: "Le Pokémon Défenseur est maintenant Endormi.",
+				de: "Das verteidigende Pokémon schläft jetzt."
 			},
 
 		},
@@ -43,7 +46,8 @@ const card: Card = {
 
 	description: {
 		en: "Its extremely flexible and elastic body makes it bounce continuously—anytime, anywhere.",
-		fr: "Son corps extrêmement flexible et élastique le fait rebondir continuellement ─ tout le temps, et dans toutes les directions."
+		fr: "Son corps extrêmement flexible et élastique le fait rebondir continuellement ─ tout le temps, et dans toutes les directions.",
+		de: "Sein extrem flexibler und elastischer Körper sorgt dafür, dass es durchgehend herumhüpft – immer und überall."
 	},
 
 	variants: [

--- a/data/Base/Wizards Black Star Promos/37.ts
+++ b/data/Base/Wizards Black Star Promos/37.ts
@@ -4,7 +4,8 @@ import Set from '../Wizards Black Star Promos'
 const card: Card = {
 	name: {
 		en: "Hitmontop",
-		fr: "Kapoera"
+		fr: "Kapoera",
+		de: "Kapoera"
 	},
 
 	illustrator: "Atsuko Nishida",
@@ -32,11 +33,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Repeating Kick",
-				fr: "Coup de pied rafale"
+				fr: "Coup de pied rafale",
+				de: "Dauertritte"
 			},
 			effect: {
 				en: "Flip a coin until you get tails. This attack does 20 damage times the number of heads.",
-				fr: "Lancez une pièce jusqu'à obtenir pile. Cette attaque inflige 20 dégâts multipliés par le nombre de faces."
+				fr: "Lancez une pièce jusqu'à obtenir pile. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
+				de: "Wirf eine Münze, bis „Zahl“ kommt. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 
@@ -49,11 +52,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Rapid Spin",
-				fr: "Tour Rapide"
+				fr: "Tour Rapide",
+				de: "Turbodreher"
 			},
 			effect: {
 				en: "If your opponent has any Benched Pokémon, he or she chooses 1 of them and switches it with his or her Active Pokémon, then, if you have any Benched Pokémon, you switch 1 of them with your Active Pokémon. (Do the damage before switching the Pokémon.)",
-				fr: "Si votre adversaire a des Pokémon sur son Banc, il choisit l'un d'eux et l'échange avec son Pokémon Actif, ensuite, si vous avez des Pokémon sur votre banc, vous choisissez l'un d'eux et vous l'échangez avec votre Pokémon Actif. (Infligez les dégâts avant d'échanger les Pokémon)."
+				fr: "Si votre adversaire a des Pokémon sur son Banc, il choisit l'un d'eux et l'échange avec son Pokémon Actif, ensuite, si vous avez des Pokémon sur votre banc, vous choisissez l'un d'eux et vous l'échangez avec votre Pokémon Actif. (Infligez les dégâts avant d'échanger les Pokémon).",
+				de: "Wenn dein Gegner mindestens ein Pokémon auf seiner Bank hat, wählt er eines davon und tauscht es mit seinem aktiven Pokémon aus. (Füge die Schadenspunkte vor dem Austauschen der Pokémon zu.)"
 			},
 			damage: 30,
 
@@ -71,7 +76,8 @@ const card: Card = {
 
 	description: {
 		en: "It launches kicks while spinning. If it spins at high speed, it may bore its way into the ground.",
-		fr: "Il lance des coups de pieds tournant. S'il tournoie assez vite, il peut s'enfoncer dans le sol."
+		fr: "Il lance des coups de pieds tournant. S'il tournoie assez vite, il peut s'enfoncer dans le sol.",
+		de: "Es verteilt Tritte, während es sich dreht. Wenn es sich zu schnell dreht, kann es passieren, dass es sich in den Boden hineinschraubt."
 	},
 
 	variants: [

--- a/data/Base/Wizards Black Star Promos/38.ts
+++ b/data/Base/Wizards Black Star Promos/38.ts
@@ -4,7 +4,8 @@ import Set from '../Wizards Black Star Promos'
 const card: Card = {
 	name: {
 		en: "Unown [J]",
-		fr: "Zarbi J"
+		fr: "Zarbi J",
+		de: "Icognito [J]"
 	},
 
 	illustrator: "Hideki Kazama",
@@ -29,11 +30,13 @@ const card: Card = {
 			type: "Pokemon Power",
 			name: {
 				en: "[Join]",
-				fr: "JOIN"
+				fr: "JOIN",
+				de: "Join"
 			},
 			effect: {
 				en: "Once during your turn (before you attack), if you have Unown J, Unown O, Unown I, and Unown N on your Bench, you may search your deck for a Basic Pokémon or Evolution Pokémon card. Show that card to your opponent, then put it into your hand. Shuffle your deck afterward.",
-				fr: "Une fois durant votre tour (avant votre attaque), si vous avez Zarbi [J], Zarbi [O], Zarbi [I] et Zarbi [N] sur votre Banc, vous pouvez chercher une carte Pokémon de base ou Évolution dans votre deck. Montrez cette carte à votre adversaire, puis placez-la dans votre main. Mélangez ensuite votre deck."
+				fr: "Une fois durant votre tour (avant votre attaque), si vous avez Zarbi [J], Zarbi [O], Zarbi [I] et Zarbi [N] sur votre Banc, vous pouvez chercher une carte Pokémon de base ou Évolution dans votre deck. Montrez cette carte à votre adversaire, puis placez-la dans votre main. Mélangez ensuite votre deck.",
+				de: "Du kannst einmal während deines Zuges (vor deinem Angriff) dein Deck nach einem Basis-Pokémon oder einer Evolutionskarte durchsuchen, wenn Icognito [J], Icognito [O], Icognito [I] und Icognito [N] auf deiner Bank sind. Zeige diese Karte deinem Gegner und nimm sie auf deine Hand. Mische danach dein Deck."
 			},
 		},
 	],
@@ -45,7 +48,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Hidden Power",
-				fr: "Puis Cachee"
+				fr: "Puis Cachee",
+				de: "Kraftreserve"
 			},
 
 			damage: 10,
@@ -64,7 +68,8 @@ const card: Card = {
 
 	description: {
 		en: "Their shapes look like hieroglyphs on ancient tablets. It is said that the two are somehow related.",
-		fr: "Ils ressemblent à des hiéroglyphes inscrits sur d'antiques tablettes. Certains croient qu'il existe un lien entre les hiéroglyphes et eux."
+		fr: "Ils ressemblent à des hiéroglyphes inscrits sur d'antiques tablettes. Certains croient qu'il existe un lien entre les hiéroglyphes et eux.",
+		de: "Ihre Gestalt erinnert an Hieroglyphen auf alten Steinplatten. Ob ein Zusammenhang besteht, ist unklar."
 	},
 
 	variants: [

--- a/data/Base/Wizards Black Star Promos/39.ts
+++ b/data/Base/Wizards Black Star Promos/39.ts
@@ -4,7 +4,8 @@ import Set from '../Wizards Black Star Promos'
 const card: Card = {
 	name: {
 		en: "Misdreavus",
-		fr: "Feuforêve"
+		fr: "Feuforêve",
+		de: "Traunfugil"
 	},
 
 	illustrator: "Shin-ichi Yoshida",
@@ -31,11 +32,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Pain Split",
-				fr: "Balance"
+				fr: "Balance",
+				de: "Leidteiler"
 			},
 			effect: {
 				en: "Put 1 damage counter on the Defending Pokémon for each damage counter on Misdreavus.",
-				fr: "Placez un marqueur de dégâts sur le Pokémon Défenseur pour chaque marqueur de dégâts sur Feuforêve."
+				fr: "Placez un marqueur de dégâts sur le Pokémon Défenseur pour chaque marqueur de dégâts sur Feuforêve.",
+				de: "Lege für jede Schadensmarke auf Traunfugil eine Schadensmarke auf das verteidigende Pokémon."
 			},
 
 		},
@@ -46,11 +49,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Confuse Ray",
-				fr: "Onde folie"
+				fr: "Onde folie",
+				de: "Konfustrahl"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
-				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus."
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
+				de: "Wirf eine Münze. Bei Kopf ist das verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: 10,
 
@@ -68,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "It loves to bite and yank people's hair from behind without warning, just to see their shocked reactions.",
-		fr: "Il adore mordre et tirer les cheveux des gens par surprise, rien que pour voir leur expression horrifiée."
+		fr: "Il adore mordre et tirer les cheveux des gens par surprise, rien que pour voir leur expression horrifiée.",
+		de: "Es beißt gerne Leute von hinten oder zieht sie ohne Vorwarnung an den Haaren, nur um ihre schockierte Reaktion zu sehen."
 	},
 
 	variants: [

--- a/data/Base/Wizards Black Star Promos/4.ts
+++ b/data/Base/Wizards Black Star Promos/4.ts
@@ -4,7 +4,8 @@ import Set from '../Wizards Black Star Promos'
 const card: Card = {
 	name: {
 		en: "Pikachu",
-		fr: "Pikachu"
+		fr: "Pikachu",
+		de: "Pikachu"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -31,11 +32,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Recharge",
-				fr: "Recharge"
+				fr: "Recharge",
+				de: "Wieder aufladen"
 			},
 			effect: {
 				en: "Search your deck for a Energy card and attach it to Pikachu. Shuffle your deck afterward.",
-				fr: "Dans votre deck, cherchez une carte  Energie et attachez-la à Pikachu. Ensuite, mélangez votre deck."
+				fr: "Dans votre deck, cherchez une carte  Energie et attachez-la à Pikachu. Ensuite, mélangez votre deck.",
+				de: "Suche in Deinem Kartenstapel nach einer {L} Energiekarte und füge sie an Pikachu. Danach mische Deine Spielkarten."
 			},
 
 		},
@@ -47,11 +50,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Thunderbolt",
-				fr: "Éclair"
+				fr: "Éclair",
+				de: "Donnerblitz"
 			},
 			effect: {
 				en: "Discard all Energy cards attached to Pikachu in order to use this attack.",
-				fr: "Défaussez toutes les cartes Énergie attachées à Pikachu pour utiliser cette attaque."
+				fr: "Défaussez toutes les cartes Énergie attachées à Pikachu pour utiliser cette attaque.",
+				de: "Lege alle Pikachu zugeteilten Energiekarten ab, um diesen Angriff durchzuführen."
 			},
 			damage: 50,
 
@@ -68,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "When several of these Pokémon gather, they attract so much electricity that they can cause lightning to strike.",
-		fr: "Quand plusieurs de ces Pokémon se réunissent, ils attirent tellement d'électricité qu'ils peuvent provoquer des coups de foudre."
+		fr: "Quand plusieurs de ces Pokémon se réunissent, ils attirent tellement d'électricité qu'ils peuvent provoquer des coups de foudre.",
+		de: "Wenn sich mehrere dieser Pokémon versammeln, ziehen sie so viel Elektrizität an, dass dadurch ein Blitzeinschlag verursacht wird."
 	},
 
 	variants: [

--- a/data/Base/Wizards Black Star Promos/5.ts
+++ b/data/Base/Wizards Black Star Promos/5.ts
@@ -4,7 +4,8 @@ import Set from '../Wizards Black Star Promos'
 const card: Card = {
 	name: {
 		en: "Dragonite",
-		fr: "Dragonite"
+		fr: "Dragonite",
+		de: "Dragoran (Dragonit)"
 	},
 
 	illustrator: "Toshinao Aoki",
@@ -24,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Dragonair",
-		fr: "Draco"
+		fr: "Draco",
+		de: "Dragonir"
 	},
 
 	stage: "Stage2",
@@ -34,11 +36,13 @@ const card: Card = {
 			type: "Pokemon Power",
 			name: {
 				en: "Special Delivery",
-				fr: "Livraison spéciale"
+				fr: "Livraison spéciale",
+				de: "Spezialattacke"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may draw a card. If you do, choose a card from your hand and put it on top of your deck. This power can't be used if Dragonite is Asleep, Confused, or Paralyzed.",
-				fr: "Une fois durant votre tour (avant votre attaque), vous pouvez tirer une carte. Si vous tirez une carte, choisissez-en une de votre main et placez-la sur le dessus de votre deck. Ce pouvoir ne peut être utilisé si Dragonite est Endormi, Confus ou Paralysé."
+				fr: "Une fois durant votre tour (avant votre attaque), vous pouvez tirer une carte. Si vous tirez une carte, choisissez-en une de votre main et placez-la sur le dessus de votre deck. Ce pouvoir ne peut être utilisé si Dragonite est Endormi, Confus ou Paralysé.",
+				de: "Wenn du an der Reihe bist (bevor du angreifst), kannst du einmal eine Karte ziehen. Wenn du eine gezogen hast, lege eine Karte aus Deiner Hand auf Deinen Kartenstapel. Diese Power kann nicht eingesetzt werden, wenn Dragonit schläft, verwirrt oder gelähmt ist."
 			},
 		},
 	],
@@ -53,12 +57,14 @@ const card: Card = {
 
 			name: {
 				en: "Supersonic Flight",
-				fr: "Vol supersonique"
+				fr: "Vol supersonique",
+				de: "Überschallflug"
 			},
 
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
-				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien."
+				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+				de: "Wirf eine Münze. Bei Zahl, hat dieser Angriff keine Auswirkungen."
 			},
 
 			damage: 60
@@ -76,7 +82,8 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon can fly is spite of its large bulk. It is said to be able to circumnavigate the earth in just 16 hours.",
-		fr: "Ce Pokémon peut voler malgré sa taille imposante. On le dit capable de faire le tour de la Terre en 16 heures à peine."
+		fr: "Ce Pokémon peut voler malgré sa taille imposante. On le dit capable de faire le tour de la Terre en 16 heures à peine.",
+		de: "Dieses Pokémon kann trotz seiner großen Gestalt fliegen. Es heißt, es kann die Erde in nur 16 Stunden umfliegen."
 	},
 
 	variants: [

--- a/data/Base/Wizards Black Star Promos/6.ts
+++ b/data/Base/Wizards Black Star Promos/6.ts
@@ -4,7 +4,8 @@ import Set from '../Wizards Black Star Promos'
 const card: Card = {
 	name: {
 		en: "Arcanine",
-		fr: "Arcanin"
+		fr: "Arcanin",
+		de: "Arkani"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -24,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Growlithe",
-		fr: "Caninos"
+		fr: "Caninos",
+		de: "Fukano"
 	},
 
 	stage: "Stage1",
@@ -37,11 +39,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Quick Attack",
-				fr: "Vive-attaque"
+				fr: "Vive-attaque",
+				de: "Ruckzuckhieb"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage; if tails, this attack does 10 damage.",
-				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires ; si c'est pile, cette attaque inflige 10 dégâts."
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires ; si c'est pile, cette attaque inflige 10 dégâts.",
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu; bei „Zahl“ fügt dieser Angriff 10 Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -53,11 +57,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Flames of Rage",
-				fr: "Flammes de rage"
+				fr: "Flammes de rage",
+				de: "Wutflammen"
 			},
 			effect: {
 				en: "Discard 2 Energy cards attached to Arcanine in order to use this attack. This attack does 40 damage plus 10 more damage for each damage counter on Arcanine.",
-				fr: "Défaussez 2 cartes Énergie  attachées à Arcanin pour pouvoir utiliser cette attaque. Cette attaque inflige 40 dégâts plus 10 dégâts supplémentaires pour chaque marqueur de dégâts sur Arcanin."
+				fr: "Défaussez 2 cartes Énergie  attachées à Arcanin pour pouvoir utiliser cette attaque. Cette attaque inflige 40 dégâts plus 10 dégâts supplémentaires pour chaque marqueur de dégâts sur Arcanin.",
+				de: "Lege 2 {R} Energiekarten auf Arkani zum Einsetzen dieses Angriffs ab. Dieser Angriff fügt 40 Schadenspunkte plus 10 weitere Schadenspunkte für jede Schadensmarke auf Arkani zu."
 			},
 			damage: "40+",
 
@@ -75,7 +81,8 @@ const card: Card = {
 
 	description: {
 		en: "A legendary Pokémon famous for its beauty. It looks almost as if it flies when it runs.",
-		fr: "Un Pokémon légendaire réputé pour sa beauté. Il galope si vite qu'il semble voler."
+		fr: "Un Pokémon légendaire réputé pour sa beauté. Il galope si vite qu'il semble voler.",
+		de: "Ein für seine Schönheit berühmtes Pokémon. Wenn es rennt, sieht es beinahe so aus, als ob es fliegen würde."
 	},
 
 	variants: [

--- a/data/Base/Wizards Black Star Promos/9.ts
+++ b/data/Base/Wizards Black Star Promos/9.ts
@@ -4,7 +4,8 @@ import Set from '../Wizards Black Star Promos'
 const card: Card = {
 	name: {
 		en: "Mew",
-		fr: "Mew"
+		fr: "Mew",
+		de: "Mew"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -31,11 +32,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Psywave",
-				fr: "Vague psy"
+				fr: "Vague psy",
+				de: "Psywelle"
 			},
 			effect: {
 				en: "Does 10 damage times the number of Energy cards attached to the Defending Pokémon.",
-				fr: "Inflige 10 dégâts multipliés par le nombre de cartes Énergie attachés au Pokémon Défenseur."
+				fr: "Inflige 10 dégâts multipliés par le nombre de cartes Énergie attachés au Pokémon Défenseur.",
+				de: "Fügt 10 Schadenspunkte mal der Anzahl der Energiekarten auf dem verteidigenden Pokémon zu."
 			},
 			damage: "10×",
 
@@ -47,11 +50,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Devolution Beam",
-				fr: "Rayon rétrograde"
+				fr: "Rayon rétrograde",
+				de: "Devolutionsstrahl"
 			},
 			effect: {
 				en: "Choose an Evolved Pokémon (your own or your opponent's). Return the highest Stage Evolution card on that Pokémon to its player's hand. That Pokémon is no longer Asleep, Confused, Paralyzed, Poisoned, or anything else that might be the result of an attack (just as if you had evolved it).",
-				fr: "Choisissez un Pokémon évolué (l'un des vôtres ou l'un de ceux de votre adversaire). Retournez la plus haute carte Évolution sur ce Pokémon dans la main de son propriétaire. Ce Pokémon n'est plus Endormi, Confus, Paralysé, Empoisonné ou tout autre effet résultant d'une attaque (comme s'il venait juste d'évoluer)."
+				fr: "Choisissez un Pokémon évolué (l'un des vôtres ou l'un de ceux de votre adversaire). Retournez la plus haute carte Évolution sur ce Pokémon dans la main de son propriétaire. Ce Pokémon n'est plus Endormi, Confus, Paralysé, Empoisonné ou tout autre effet résultant d'une attaque (comme s'il venait juste d'évoluer).",
+				de: "Wähle ein entwickeltes Pokémon (dein eigenes oder ein gegnerisches). Nimm die höchste Evolutionsphasenkarte auf diesem Pokémon zurück auf die Hand des Spielers. Dieses Pokémon ist nicht mehr im Schlaf, verwirrt, gelähmt, vergiftet oder sonst in einem aus einem Angriff resultierenden Zustand (wie wenn du es entwickelt hättest)."
 			},
 
 		},
@@ -68,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "So rare that it is still said to be a mirage by many experts. Only a few people have seen it worldwide.",
-		fr: "Unique et rare, son existence est remise en cause par les experts. Peu nombreux sont ceux qui l'ont vu."
+		fr: "Unique et rare, son existence est remise en cause par les experts. Peu nombreux sont ceux qui l'ont vu.",
+		de: "So selten, dass es von viele Experten noch immer für eine Fata Morgana gehalten wird. Nur wenige Menschen weltweit haben es je erblickt."
 	},
 
 	variants: [


### PR DESCRIPTION
## Add missing German translations for basep

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
