### PR TITLE
(Fix) FR Name change on DP Promo 50 (From Dialga to Arceus)

### DIFF
--- a/data/Diamond & Pearl/DP Black Star Promos/DP50.ts
+++ b/data/Diamond & Pearl/DP Black Star Promos/DP50.ts
@@ -4,7 +4,7 @@ import Set from '../DP Black Star Promos'
 const card: Card = {
 	name: {
 		en: "Arceus",
-		fr: "Dialga",
+		fr: "Arceus",
 		de: "Arceus"
 	},
 


### PR DESCRIPTION
<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

closes # <!-- Indicate the issue number here -->

## Changes

Changed french translation from "Dialga" to "Arceus" to be correct.

## Details

Source taken from the following website : https://www.pokepedia.fr/Promo_DP

