### PR TITLE
Fix variants for me05 047 and 084

### DIFF
--- a/data/Mega Evolution/Pitch Black/047.ts
+++ b/data/Mega Evolution/Pitch Black/047.ts
@@ -82,19 +82,19 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal",
-			thirdParty: {
-				cardmarket: 895833,
-				tcgplayer: 704804
-			}
-		},
-		{
 			type: "reverse",
 			thirdParty: {
 				cardmarket: 895833,
 				tcgplayer: 704804
 			}
 		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 895833,
+				tcgplayer: 704804
+			}
+		}
 	],
 }
 

--- a/data/Mega Evolution/Pitch Black/084.ts
+++ b/data/Mega Evolution/Pitch Black/084.ts
@@ -37,6 +37,13 @@ const card: Card = {
 				tcgplayer: 704841
 			}
 		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 895868,
+				tcgplayer: 704841
+			}
+		}
 	],
 }
 


### PR DESCRIPTION
- Removed normal from `me05-047` (Koraidon)
- Added holo to `me05-047` (Koraidon)
- Added reverse holo to `me05-084` (Voltaic Lightning Energy)