### PR TITLE
fix: Espeon VMAX malformed abilities

### DIFF
--- a/data/Sword & Shield/Fusion Strike/270.ts
+++ b/data/Sword & Shield/Fusion Strike/270.ts
@@ -49,12 +49,12 @@ const card: Card = {
 		type: "Ability",
 
 		name: {
-			en: "$$$ABILITY.TITLE.MISSING.TOKEN$$$",
-			fr: "$$$ABILITY.TITLE.MISSING.TOKEN$$$",
-			de: "$$$ABILITY.TITLE.MISSING.TOKEN$$$",
-			es: "$$$ABILITY.TITLE.MISSING.TOKEN$$$",
-			pt: "$$$ABILITY.TITLE.MISSING.TOKEN$$$",
-			it: "$$$ABILITY.TITLE.MISSING.TOKEN$$$"
+			en: "Solar Revelation",
+			fr: "Révélation Solaire",
+			de: "Solarschild",
+			es: "Revelación Solar",
+			pt: "Revelação Solar",
+			it: "Rivelasole"
 		},
 
 		effect: {


### PR DESCRIPTION
<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

closes #1812

## Changes

Replaces the malformed abilities for Espeon VMAX in Fusion Strike

