### PR TITLE
(fix) wrong evolveFrom on Base Set Raticate and Neo Discovery Espeon

### DIFF
--- a/data/Base/Base Set/40.ts
+++ b/data/Base/Base Set/40.ts
@@ -25,7 +25,7 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Poochyena",
+		en: "Rattata",
 		fr: "Rattata",
 		it: "Rattata"
 	},

--- a/data/Neo/Neo Discovery/1.ts
+++ b/data/Neo/Neo Discovery/1.ts
@@ -24,7 +24,7 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Dodrio",
+		en: "Eevee",
 		fr: "Évoli"
 	},
 


### PR DESCRIPTION
While automatically adding all DE-Translations I stumbled across these.
