### PR TITLE
feat: Add VariantLine type to card variant_detailed

### DIFF
--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -16,6 +16,7 @@ export interface Serie {
 	energies?: Array<Types>
 }
 
+export type VariantLine = 'main' | 'parallel' | 'restricted' | 'exclusive'
 export type VariantType =  'normal' | 'holo' | 'reverse' | 'metal' | 'lenticular'
 export type VariantStamps = '1st-edition' | 'w-promo' | 'pre-release' | 'pokemon-center' | 'set-logo' | 'staff' | 'pikachu-tail'
 	| 'wotc' | 'd-edition-error' | '1st-edition-scratch-error' | "1st-edition-error" | '1st-movie' | '1st-movie-inverted'
@@ -96,6 +97,21 @@ export interface variant_detailed {
 	 * if not set, the variant is available in all languages
 	 */
 	languages?: SupportedLanguages[]
+
+	/**
+	 * which line is this variant available from:
+	 * main: this variant is available in booster packs (default)
+	 * parallel: this variant is available in specific products i.e. build and battle kits, preconstructed decks
+	 * restricted: this variant was only available to attendees of a specific event
+	 * exclusive: this variant was only available to workers, winners, top cuts of a specific event or job
+	 *
+	 * None of these are locked and maybe expanded upon as time progresses, when deciding what line to use for a variant
+	 * if it's available in more than one pick the lower line. i.e. some cards in the build and battle kits will be
+	 * available in boosters and therefore are 'main line' but some others the 'non-holo holos' would be parallel
+	 *
+	 * this is meant to assist with sperating out collections between full set/master set/grandmaster set
+	 */
+	line?: VariantLine
 
 	thirdParty?: {
 		tcgplayer?: number

--- a/meta/definitions/api.d.ts
+++ b/meta/definitions/api.d.ts
@@ -68,6 +68,7 @@ interface variant_detailed {
 		tcgplayer?: number
 	}
 	variantId: string
+	line: string
 }
 
 export interface SetResume {

--- a/meta/translations/de.json
+++ b/meta/translations/de.json
@@ -301,5 +301,11 @@
 		"phanphy-error": "phanphy-fehler",
 		"peelable-ditto": "Abziehbares Ditto",
 		"missing-retreat-cost": "Fehlende Rückzugskosten"
+	},
+	"variantLine": {
+		"main": "main",
+		"parallel": "parallel",
+		"restricted": "restricted",
+		"exclusive": "exclusive"
 	}
 }

--- a/meta/translations/es.json
+++ b/meta/translations/es.json
@@ -301,5 +301,11 @@
 		"phanphy-error": "Error de phanphy",
 		"peelable-ditto": "Ditto despegable",
 		"missing-retreat-cost": "Coste de retirada ausente"
+	},
+	"variantLine": {
+		"main": "main",
+		"parallel": "parallel",
+		"restricted": "restricted",
+		"exclusive": "exclusive"
 	}
 }

--- a/meta/translations/fr.json
+++ b/meta/translations/fr.json
@@ -301,5 +301,11 @@
 		"phanphy-error": "Erreur de phanphy",
 		"peelable-ditto": "Ditto décollable",
 		"missing-retreat-cost": "Coût de retraite manquant"
+	},
+	"variantLine": {
+		"main": "main",
+		"parallel": "parallel",
+		"restricted": "restricted",
+		"exclusive": "exclusive"
 	}
 }

--- a/meta/translations/it.json
+++ b/meta/translations/it.json
@@ -301,5 +301,11 @@
 		"phanphy-error": "Errore di phanphy",
 		"peelable-ditto": "Ditto rimovibile",
 		"missing-retreat-cost": "Costo di ritirata mancante"
+	},
+	"variantLine": {
+		"main": "main",
+		"parallel": "parallel",
+		"restricted": "restricted",
+		"exclusive": "exclusive"
 	}
 }

--- a/meta/translations/pt.json
+++ b/meta/translations/pt.json
@@ -300,5 +300,11 @@
 		"phanphy-error": "error de phanphy",
 		"peelable-ditto": "Ditto destacável",
 		"misisng-retreat-cost": "Custo de recuo ausente"
+	},
+	"variantLine": {
+		"main": "main",
+		"parallel": "parallel",
+		"restricted": "restricted",
+		"exclusive": "exclusive"
 	}
 }

--- a/server/compiler/utils/cardUtil.ts
+++ b/server/compiler/utils/cardUtil.ts
@@ -52,7 +52,8 @@ function variantsToVariantsDetailed(variants: CardSingle['variants'],lang: Suppo
 			type: type as VariantType,
 			size: translate('variantSize', "standard", lang) as any,
 			stamp: stamps.length > 0 ? stamps as Array<VariantStamps> : undefined,
-			variantId: "generated"
+			variantId: "generated",
+			line: "main"
 		});
 	};
 

--- a/server/compiler/utils/translationUtil.ts
+++ b/server/compiler/utils/translationUtil.ts
@@ -5,7 +5,7 @@ import pt from '../../../meta/translations/pt.json'
 import de from '../../../meta/translations/de.json'
 import fr from '../../../meta/translations/fr.json'
 
-type translatable = 'types' | 'rarity' | 'stage' | 'category' | 'suffix' | 'abilityType' | 'trainerType' | 'energyType' | 'variantType' | 'variantSize' | 'variantFoil' | 'variantStamp' | 'variantSubtype'
+type translatable = 'types' | 'rarity' | 'stage' | 'category' | 'suffix' | 'abilityType' | 'trainerType' | 'energyType' | 'variantType' | 'variantSize' | 'variantFoil' | 'variantStamp' | 'variantSubtype' | 'variantLine'
 
 const translations: Record<string, Record<translatable, Record<string, string>>> = {
 	es,

--- a/server/compiler/utils/variantUtil.ts
+++ b/server/compiler/utils/variantUtil.ts
@@ -39,6 +39,7 @@ export function formatVariant(variant: variant_detailed, lang: SupportedLanguage
 			? variant.stamp.map((stamp) => translate('variantStamp', stamp, lang))
 			: undefined,
 		foil: variant.foil ? translate('variantFoil', variant.foil, lang) : undefined,
+		line: variant.line ? translate('variantLine', variant.line, lang) : translate('variantLine', "main", lang),
 		thirdParty: variant.thirdParty
 	};
 }


### PR DESCRIPTION
## Changes
Adds `line` to variant detailed. this line is used to separate variants based on how they are obtained. raised out of the issue of trying to distinguish between a holo released in booster packs and a non-holo variant released in build and battle kits. 

This defines four line types:
**Main**: found in booster packs
**Parallel**: found in specific products bbk, pre constructed
**Restricted**: given out at a specific event or promotion
**Exclusive**: given out at a specific event for either working, topcut, winners. or for performing a specific job: professor program.

variants currently default to main line at compile time. so in theory only need to adjust the line for the other 3

none of these lines are locked in a new reasons can be added to expand on them. if a card is available in two of the lines always use the more available line. i.e. precons will likely have main line cards in them. those cards should be treated as main line and the non-holo holos should be treated as parallel as they are not available in booster packs

