### PR TITLE
Add missing German translations for pop1

### DIFF
--- a/data/POP/POP Series 1/1.ts
+++ b/data/POP/POP Series 1/1.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 1'
 const card: Card = {
 	name: {
 		en: "Blaziken",
-		fr: "Brasegali"
+		fr: "Brasegali",
+		de: "Lohgock"
 	},
 
 	illustrator: "Katsura Tabata",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Combusken",
-		fr: "Galifeu"
+		fr: "Galifeu",
+		de: "Jungglut"
 	},
 
 	stage: "Stage2",
@@ -35,7 +37,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Fire Punch",
-				fr: "Poing de feu"
+				fr: "Poing de feu",
+				de: "Feuerschlag"
 			},
 
 			damage: 40,
@@ -49,11 +52,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Double Kick",
-				fr: "Double pied"
+				fr: "Double pied",
+				de: "Doppelkick"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 50 damage times the number of heads.",
-				fr: "Lancez 2 pièces. Cette attaque inflige 50 dégâts multipliés par le nombre de faces."
+				fr: "Lancez 2 pièces. Cette attaque inflige 50 dégâts multipliés par le nombre de faces.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "50×",
 

--- a/data/POP/POP Series 1/10.ts
+++ b/data/POP/POP Series 1/10.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 1'
 const card: Card = {
 	name: {
 		en: "Torkoal",
-		fr: "Chartor"
+		fr: "Chartor",
+		de: "Qurtel"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Amnesia",
-				fr: "Amnésie"
+				fr: "Amnésie",
+				de: "Amnesie"
 			},
 			effect: {
 				en: "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn.",
-				fr: "Choisissez une des attaques du Pokémon Défenseur. Ce Pokémon ne peut pas utiliser cette attaque lors du prochain tour de votre adversaire."
+				fr: "Choisissez une des attaques du Pokémon Défenseur. Ce Pokémon ne peut pas utiliser cette attaque lors du prochain tour de votre adversaire.",
+				de: "Wähle 1 der Angriffe des Verteidigenden Pokémon. Dieses Pokémon kann den gewählten Angriff im nächsten Zug deines Gegners nicht anwenden."
 			},
 
 		},
@@ -44,11 +47,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Body Slam",
-				fr: "Plaquage"
+				fr: "Plaquage",
+				de: "Bodyslam"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
-				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé."
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 

--- a/data/POP/POP Series 1/11.ts
+++ b/data/POP/POP Series 1/11.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 1'
 const card: Card = {
 	name: {
 		en: "Larvitar",
-		fr: "Embrylex"
+		fr: "Embrylex",
+		de: "Larvitar"
 	},
 
 	illustrator: "Hisao Nakamura",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Sand Attack",
-				fr: "Jet de sable"
+				fr: "Jet de sable",
+				de: "Sandangriff"
 			},
 			effect: {
 				en: "If the Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
-				fr: "Si le Pokémon Défenseur essaye d'attaquer lors du prochain tour de votre adversaire, votre adversaire lance une pièce. Si c'est pile, cette attaque est sans effet."
+				fr: "Si le Pokémon Défenseur essaye d'attaquer lors du prochain tour de votre adversaire, votre adversaire lance une pièce. Si c'est pile, cette attaque est sans effet.",
+				de: "Wenn das Verteidigende Pokémon im nächsten Zug angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat der entsprechende Angriff keine Auswirkungen."
 			},
 			damage: 10,
 

--- a/data/POP/POP Series 1/12.ts
+++ b/data/POP/POP Series 1/12.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 1'
 const card: Card = {
 	name: {
 		en: "Minun",
-		fr: "Negapi"
+		fr: "Negapi",
+		de: "Minun"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Thunder Wave",
-				fr: "Cage-éclair"
+				fr: "Cage-éclair",
+				de: "Donnerwelle"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
-				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé."
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 
@@ -45,11 +48,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Spark",
-				fr: "Étincelle"
+				fr: "Étincelle",
+				de: "Funkenregen"
 			},
 			effect: {
 				en: "Choose 2 of your opponent's Benched Pokémon. This attack does 10 damage to each of those Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				fr: "Choisissez 2 des Pokémon du Banc de votre adversaire. Cette attaque inflige 10 dégâts à chacun de ces Pokémon. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc)."
+				fr: "Choisissez 2 des Pokémon du Banc de votre adversaire. Cette attaque inflige 10 dégâts à chacun de ces Pokémon. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc).",
+				de: "Wähle 2 Pokémon auf der Bank deines Gegners. Dieser Angriff fügt beiden gewählten Pokémon 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 10,
 

--- a/data/POP/POP Series 1/13.ts
+++ b/data/POP/POP Series 1/13.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 1'
 const card: Card = {
 	name: {
 		en: "Plusle",
-		fr: "Posipi"
+		fr: "Posipi",
+		de: "Plusle"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Quick Attack",
-				fr: "Vive-attaque"
+				fr: "Vive-attaque",
+				de: "Ruckzuckhieb"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 10 more damage.",
-				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires."
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -45,11 +48,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Agility",
-				fr: "Hâte"
+				fr: "Hâte",
+				de: "Agilität"
 			},
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Plusle during your opponent's next turn.",
-				fr: "Lancez une pièce. Si c'est face, prévenez tous les effets d'une attaque, dégâts inclus, infligés à Posipi lors du prochain tour de votre adversaire."
+				fr: "Lancez une pièce. Si c'est face, prévenez tous les effets d'une attaque, dégâts inclus, infligés à Posipi lors du prochain tour de votre adversaire.",
+				de: "Wirf 1 Münze. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Auswirkungen von Angriffen (einschließlich Schaden), die Plusle zugefügt werden."
 			},
 			damage: 20,
 

--- a/data/POP/POP Series 1/14.ts
+++ b/data/POP/POP Series 1/14.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 1'
 const card: Card = {
 	name: {
 		en: "Surskit",
-		fr: "Arakdo"
+		fr: "Arakdo",
+		de: "Gehweiher"
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Bubble",
-				fr: "Écume"
+				fr: "Écume",
+				de: "Blubber"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
-				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé."
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 

--- a/data/POP/POP Series 1/15.ts
+++ b/data/POP/POP Series 1/15.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 1'
 const card: Card = {
 	name: {
 		en: "Swellow",
-		fr: "Heledelle"
+		fr: "Heledelle",
+		de: "Schwalboss"
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Tailow",
-		fr: "Nirondelle"
+		fr: "Nirondelle",
+		de: "Schwalbini"
 	},
 
 	stage: "Stage1",
@@ -34,11 +36,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Focus Energy",
-				fr: "Puissance"
+				fr: "Puissance",
+				de: "Energiefokus"
 			},
 			effect: {
 				en: "During your next turn, base damage of Swellow's Agility is 70 instead of 30.",
-				fr: "Lors de votre prochain tour, la base des dégâts d'Hâte d'Heledelle est de 70 au lieu de 30."
+				fr: "Lors de votre prochain tour, la base des dégâts d'Hâte d'Heledelle est de 70 au lieu de 30.",
+				de: "In deinem nächsten Zug beträgt der Grundschaden des Angriffs Agilität 70 Schadenspunkte anstelle von 30 Schadenspunkte."
 			},
 
 		},
@@ -49,11 +53,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Agility",
-				fr: "Hâte"
+				fr: "Hâte",
+				de: "Agilität"
 			},
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Swellow during your opponent's next turn.",
-				fr: "Lancez une pièce. Si c'est face, prévenez tous les effets d'une attaque, dégâts inclus, infligés à Heledelle lors du prochain tour de votre adversaire."
+				fr: "Lancez une pièce. Si c'est face, prévenez tous les effets d'une attaque, dégâts inclus, infligés à Heledelle lors du prochain tour de votre adversaire.",
+				de: "Wirf 1 Münze. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Auswirkungen von Angriffen (einschließlich Schaden), die Schwalboss zugefügt werden."
 			},
 			damage: 30,
 

--- a/data/POP/POP Series 1/16.ts
+++ b/data/POP/POP Series 1/16.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 1'
 const card: Card = {
 	name: {
 		en: "Armaldo ex",
-		fr: "Armaldo ex"
+		fr: "Armaldo ex",
+		de: "Armaldo ex"
 	},
 
 	illustrator: "Hikaru Koike",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Anorith",
-		fr: "Anorith"
+		fr: "Anorith",
+		de: "Anorith"
 	},
 
 	stage: "Stage2",
@@ -35,11 +37,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Twin-blade",
-				fr: "Double épée"
+				fr: "Double épée",
+				de: "Doppelklinge"
 			},
 			effect: {
 				en: "Does 30 damage to each Defending Pokémon.",
-				fr: "Inflige 30 dégâts à chacun des Pokémon Défenseurs."
+				fr: "Inflige 30 dégâts à chacun des Pokémon Défenseurs.",
+				de: "Dieser Angriff fügt allen Verteidigenden Pokémon 30 Schadenspunkte zu."
 			},
 
 		},
@@ -53,11 +57,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Supersonic Claws",
-				fr: "Griffes supersoniques"
+				fr: "Griffes supersoniques",
+				de: "Überschallklauen"
 			},
 			effect: {
 				en: "This attack's damage is not affected by Resistance.",
-				fr: "Les dégâts de cette attaque ne sont pas affectés par la Résistance."
+				fr: "Les dégâts de cette attaque ne sont pas affectés par la Résistance.",
+				de: "Der Schaden dieses Angriffs wird durch die Resistenz des Verteidigenden Pokémon nicht verringert."
 			},
 			damage: 80,
 

--- a/data/POP/POP Series 1/17.ts
+++ b/data/POP/POP Series 1/17.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 1'
 const card: Card = {
 	name: {
 		en: "Tyranitar ex",
-		fr: "Tyranocif ex"
+		fr: "Tyranocif ex",
+		de: "Despotar ex"
 	},
 
 	illustrator: "Hisao Nakamura",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pupitar",
-		fr: "Ymphect"
+		fr: "Ymphect",
+		de: "Pupitar"
 	},
 
 	stage: "Stage2",
@@ -34,7 +36,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Scratch",
-				fr: "Griffe"
+				fr: "Griffe",
+				de: "Kratzer"
 			},
 
 			damage: 20,
@@ -49,11 +52,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Critical Crush",
-				fr: "Écrasement sévère"
+				fr: "Écrasement sévère",
+				de: "Entscheidender Schlag"
 			},
 			effect: {
 				en: "Discard 2 Basic Energy cards attached to Tyranitar ex or this attack does nothing.",
-				fr: "Défaussez 2 cartes Énergie de base attachées à Tyranocif ex ou cette attaque est sans effet."
+				fr: "Défaussez 2 cartes Énergie de base attachées à Tyranocif ex ou cette attaque est sans effet.",
+				de: "Lege 2 an Despotar angelegte Energiekarten auf deinen Ablagestapel oder dieser Angriff hat keine Auswirkungen."
 			},
 			damage: 80,
 

--- a/data/POP/POP Series 1/2.ts
+++ b/data/POP/POP Series 1/2.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 1'
 const card: Card = {
 	name: {
 		en: "Metagross",
-		fr: "Metalosse"
+		fr: "Metalosse",
+		de: "Metagross"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Metang",
-		fr: "Métang"
+		fr: "Métang",
+		de: "Metang"
 	},
 
 	stage: "Stage2",
@@ -35,7 +37,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Metal Claw",
-				fr: "Griffe acier"
+				fr: "Griffe acier",
+				de: "Metallklaue"
 			},
 
 			damage: 30,
@@ -50,11 +53,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Hyper Beam",
-				fr: "Ultralaser"
+				fr: "Ultralaser",
+				de: "Hyperstrahl"
 			},
 			effect: {
 				en: "Flip a coin. If heads, discard 1 Energy attached to the Defending Pokémon.",
-				fr: "Lancez une pièce. Si c'est face, défaussez 1 Énergie attachée au Pokémon Défenseur."
+				fr: "Lancez une pièce. Si c'est face, défaussez 1 Énergie attachée au Pokémon Défenseur.",
+				de: "Wirf 1 Münze. Bei „Kopf“ lege 1 Energiekarte von dem Verteidigenden Pokémon auf den Ablagestapel deines Gegners."
 			},
 			damage: 50,
 

--- a/data/POP/POP Series 1/3.ts
+++ b/data/POP/POP Series 1/3.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 1'
 const card: Card = {
 	name: {
 		en: "Rayquaza",
-		fr: "Rayquaza"
+		fr: "Rayquaza",
+		de: "Rayquaza"
 	},
 
 	illustrator: "Katsura Tabata",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Fly",
-				fr: "Vol"
+				fr: "Vol",
+				de: "Fliegen"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing. If heads, prevent all effects of an attack, including damage, done to Rayquaza during your opponent's next turn.",
-				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet. Si c'est face, prévenez tous les effets d'une attaque, dégâts inclus, infligés à Rayquaza lors du prochain tour de votre adversaire."
+				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet. Si c'est face, prévenez tous les effets d'une attaque, dégâts inclus, infligés à Rayquaza lors du prochain tour de votre adversaire.",
+				de: "Wirf 1 Münze. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte von Angriffen (einschließlich Schaden), die Rayquaza zugefügt werden. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 10,
 
@@ -45,7 +48,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Dragon Claw",
-				fr: "Griffe de dragon"
+				fr: "Griffe de dragon",
+				de: "Drachenklaue"
 			},
 
 			damage: 30,

--- a/data/POP/POP Series 1/4.ts
+++ b/data/POP/POP Series 1/4.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 1'
 const card: Card = {
 	name: {
 		en: "Sceptile",
-		fr: "Jungko"
+		fr: "Jungko",
+		de: "Gewaldro"
 	},
 
 	illustrator: "Hiromichi Sugiyama",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Grovyle",
-		fr: "Massko"
+		fr: "Massko",
+		de: "Reptain"
 	},
 
 	stage: "Stage2",
@@ -34,11 +36,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Cling",
-				fr: "« Corps à corps »"
+				fr: "« Corps à corps »",
+				de: "Festklammern"
 			},
 			effect: {
 				en: "After your attack, remove from Sceptile the number of damage counters equal to the damage you did to the Defending Pokémon. If Sceptile has fewer damage counters than that, remove all of them.",
-				fr: "Après votre attaque, retirez à Jungko un nombre de marqueurs de dégât équivalent aux dégâts que vous avez infligés au Pokémon Défenseur. Si Jungko a moins de marqueurs de dégât, retirez-les lui tous."
+				fr: "Après votre attaque, retirez à Jungko un nombre de marqueurs de dégât équivalent aux dégâts que vous avez infligés au Pokémon Défenseur. Si Jungko a moins de marqueurs de dégât, retirez-les lui tous.",
+				de: "Entferne nach deinem Angriff Schadensmarken von Gewaldro entsprechend der Höhe der Schadenspunkte, die dem Verteidigenden Pokémon zugefügt wurden. Sollten weniger Schadensmarken auf Gewaldro liegen, entferne alle."
 			},
 			damage: 20,
 
@@ -51,11 +55,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Leaf Blade",
-				fr: "Lame-feuille"
+				fr: "Lame-feuille",
+				de: "Blattklinge"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 40 damage plus 30 more damage.",
-				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 40 dégâts plus 30 dégâts supplémentaires."
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 40 dégâts plus 30 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 40 Schadenspunkte plus 30 weitere Schadenspunkte zu."
 			},
 			damage: "40+",
 

--- a/data/POP/POP Series 1/5.ts
+++ b/data/POP/POP Series 1/5.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 1'
 const card: Card = {
 	name: {
 		en: "Swampert",
-		fr: "Laggron"
+		fr: "Laggron",
+		de: "Sumpex"
 	},
 
 	illustrator: "Hiromichi Sugiyama",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Marshtomp",
-		fr: "Flobio"
+		fr: "Flobio",
+		de: "Moorabbel"
 	},
 
 	stage: "Stage2",
@@ -34,11 +36,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Bubble",
-				fr: "Écume"
+				fr: "Écume",
+				de: "Blubber"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
-				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé."
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -51,11 +55,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Mud Splash",
-				fr: "Jet d'boue"
+				fr: "Jet d'boue",
+				de: "Schlammspritzer"
 			},
 			effect: {
 				en: "If your opponent has any Benched Pokémon, choose 1 of them and flip a coin. If heads, this attack does 20 damage to that Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)",
-				fr: "Si votre adversaire possède des Pokémon de Banc, choisissez-en un et lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts à ce Pokémon. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc.)"
+				fr: "Si votre adversaire possède des Pokémon de Banc, choisissez-en un et lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts à ce Pokémon. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc.)",
+				de: "Wähle 1 Pokémon auf der Bank hat deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 50,
 

--- a/data/POP/POP Series 1/6.ts
+++ b/data/POP/POP Series 1/6.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 1'
 const card: Card = {
 	name: {
 		en: "Beautifly",
-		fr: "Charmillon"
+		fr: "Charmillon",
+		de: "Papinella"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Silcoon",
-		fr: "Armulys"
+		fr: "Armulys",
+		de: "Schaloko"
 	},
 
 	stage: "Stage2",
@@ -35,11 +37,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Blot",
-				fr: "Pâté"
+				fr: "Pâté",
+				de: "Klecks"
 			},
 			effect: {
 				en: "Remove 1 damage counter from Beautifly.",
-				fr: "Retirez à Charmillon 1 marqueur de dégât."
+				fr: "Retirez à Charmillon 1 marqueur de dégât.",
+				de: "Entferne 1 Schadensmarke von Papinella."
 			},
 			damage: 30,
 
@@ -52,11 +56,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Whirlwind",
-				fr: "Cyclone"
+				fr: "Cyclone",
+				de: "Wirbelwind"
 			},
 			effect: {
 				en: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon.",
-				fr: "Votre adversaire échange le Pokémon Défenseur avec 1 des Pokémon de son Banc."
+				fr: "Votre adversaire échange le Pokémon Défenseur avec 1 des Pokémon de son Banc.",
+				de: "Dein Gegner tauscht das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
 			},
 			damage: 40,
 

--- a/data/POP/POP Series 1/7.ts
+++ b/data/POP/POP Series 1/7.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 1'
 const card: Card = {
 	name: {
 		en: "Masquerain",
-		fr: "Maskadra"
+		fr: "Maskadra",
+		de: "Maskergen"
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Surskit",
-		fr: "Arakdo"
+		fr: "Arakdo",
+		de: "Gehweiher"
 	},
 
 	stage: "Stage1",
@@ -34,11 +36,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Quick Attack",
-				fr: "Vive-attaque"
+				fr: "Vive-attaque",
+				de: "Ruckzuckhieb"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage.",
-				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires."
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -51,7 +55,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Gust",
-				fr: "Tornade"
+				fr: "Tornade",
+				de: "Windstoß"
 			},
 
 			damage: 50,

--- a/data/POP/POP Series 1/8.ts
+++ b/data/POP/POP Series 1/8.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 1'
 const card: Card = {
 	name: {
 		en: "Murkrow",
-		fr: "Cornèbre"
+		fr: "Cornèbre",
+		de: "Kramurx"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -27,11 +28,13 @@ const card: Card = {
 			type: "Poke-BODY",
 			name: {
 				en: "Insomnia",
-				fr: "Insomnie"
+				fr: "Insomnie",
+				de: "Schlaflosigkeit"
 			},
 			effect: {
 				en: "Murkrow can't be Asleep.",
-				fr: "Cornèbre ne peut pas être Endormi."
+				fr: "Cornèbre ne peut pas être Endormi.",
+				de: "Kramurx kann nicht in Schlaf versetzt werden."
 			},
 		},
 	],
@@ -44,11 +47,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Feint Attack",
-				fr: "Feinte"
+				fr: "Feinte",
+				de: "Finte"
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon.",
-				fr: "Choisissez un des Pokémon de votre adversaire. Cette attaque lui inflige 20 dégâts. Les dégâts de cette attaque ne sont pas affectés par la Faiblesse, la Résistance, les Poké-Powers, les Poké-Bodies ou tout autre effet."
+				fr: "Choisissez un des Pokémon de votre adversaire. Cette attaque lui inflige 20 dégâts. Les dégâts de cette attaque ne sont pas affectés par la Faiblesse, la Résistance, les Poké-Powers, les Poké-Bodies ou tout autre effet.",
+				de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt diesem Pokémon 20 Schadenspunkte zu. Schwäche, Resistenz, Poké-Power, Poké-Body und alle anderen Effekte auf dem Verteidigenden Pokémon haben keine Auswirkungen auf die Schadenspunkte dieses Angriffs."
 			},
 
 		},

--- a/data/POP/POP Series 1/9.ts
+++ b/data/POP/POP Series 1/9.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 1'
 const card: Card = {
 	name: {
 		en: "Pupitar",
-		fr: "Ymphect"
+		fr: "Ymphect",
+		de: "Pupitar"
 	},
 
 	illustrator: "Hisao Nakamura",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Larvitar",
-		fr: "Embrylex"
+		fr: "Embrylex",
+		de: "Larvitar"
 	},
 
 	stage: "Stage1",
@@ -35,11 +37,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Rock Smash",
-				fr: "Éclate-roc"
+				fr: "Éclate-roc",
+				de: "Zertrümmerer"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 10 more damage.",
-				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires."
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 


### PR DESCRIPTION
## Add missing German translations for pop1

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
