### PR TITLE
fix: Base1 Base Set en Corrected Duplicate 1st Edition Shadowless entry for 77

### DIFF
--- a/data/Base/Base Set/77.ts
+++ b/data/Base/Base Set/77.ts
@@ -41,7 +41,6 @@ const card: Card = {
 		{
 			type: "normal",
 			subtype: "shadowless",
-			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 107073
 			},


### PR DESCRIPTION
closes #N/A

## Changes

Base set 77 had incorrect entry with 1st edition

## Details

Copy paste error. 1st Edition stamp was incorrectly added which made duplicate variants.

Before Change:
1st edition shadowless
1st edition shadowless

After Change:
1st edition shadowless
shadowless
