### PR TITLE
(patch): zh-tw Sword & Shield (Set A) sc1a Correct Set Compile, Added DexId, Illustrator and Rarity

### DIFF
--- a/data-asia/S/SC1a/001.ts
+++ b/data-asia/S/SC1a/001.ts
@@ -8,6 +8,8 @@ const card: Card = {
 		'zh-tw': "飛天螳螂"
 	},
 
+	dexId: [123],
+	rarity: 'Common',
 	illustrator: "KEIICHIRO ITO",
 	category: "Pokemon",
 	hp: 80,

--- a/data-asia/S/SC1a/001.ts
+++ b/data-asia/S/SC1a/001.ts
@@ -1,5 +1,5 @@
-import Set from "."
 import { Card } from "../../../interfaces"
+import Set from "../Sc1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/001.ts
+++ b/data-asia/S/SC1a/001.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/002.ts
+++ b/data-asia/S/SC1a/002.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "強顎雞母蟲"
 	},
 
+	dexId: [736],
 	illustrator: "Tomokazu Komiya",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Grass"],

--- a/data-asia/S/SC1a/002.ts
+++ b/data-asia/S/SC1a/002.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/003.ts
+++ b/data-asia/S/SC1a/003.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "霹靂電球"
 	},
 
+	dexId: [100],
 	illustrator: "Hasegawa Saki",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 50,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/003.ts
+++ b/data-asia/S/SC1a/003.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/004.ts
+++ b/data-asia/S/SC1a/004.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "頑皮雷彈"
 	},
 
+	dexId: [101],
 	illustrator: "otumami",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/004.ts
+++ b/data-asia/S/SC1a/004.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/005.ts
+++ b/data-asia/S/SC1a/005.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/005.ts
+++ b/data-asia/S/SC1a/005.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "電擊獸"
 	},
 
+	dexId: [125],
 	illustrator: "Midori Harada",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/006.ts
+++ b/data-asia/S/SC1a/006.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "電擊魔獸"
 	},
 
+	dexId: [466],
 	illustrator: "tetsuya koizumi",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/006.ts
+++ b/data-asia/S/SC1a/006.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/007.ts
+++ b/data-asia/S/SC1a/007.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "燈籠魚"
 	},
 
+	dexId: [170],
 	illustrator: "Sumiyoshi Kizuki",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/007.ts
+++ b/data-asia/S/SC1a/007.ts
@@ -1,4 +1,4 @@
-import Set from "../Sc1a"
+import Set from "../SC1a"
 import { Card } from "../../../interfaces"
 
 const card: Card = {

--- a/data-asia/S/SC1a/007.ts
+++ b/data-asia/S/SC1a/007.ts
@@ -1,4 +1,4 @@
-import Set from "."
+import Set from "../Sc1a"
 import { Card } from "../../../interfaces"
 
 const card: Card = {

--- a/data-asia/S/SC1a/008.ts
+++ b/data-asia/S/SC1a/008.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "電燈怪"
 	},
 
+	dexId: [171],
 	illustrator: "Naoyo Kimura",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/008.ts
+++ b/data-asia/S/SC1a/008.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/009.ts
+++ b/data-asia/S/SC1a/009.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "小貓怪"
 	},
 
+	dexId: [403],
 	illustrator: "Uta",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/009.ts
+++ b/data-asia/S/SC1a/009.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/010.ts
+++ b/data-asia/S/SC1a/010.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "勒克貓"
 	},
 
+	dexId: [404],
 	illustrator: "ryoma uratsuka",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/010.ts
+++ b/data-asia/S/SC1a/010.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/011.ts
+++ b/data-asia/S/SC1a/011.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "倫琴貓"
 	},
 
+	dexId: [405],
 	illustrator: "Hasuno",
+	rarity: "Rare",
 	category: "Pokemon",
 	hp: 160,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/011.ts
+++ b/data-asia/S/SC1a/011.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/012.ts
+++ b/data-asia/S/SC1a/012.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "傘電蜥"
 	},
 
+	dexId: [694],
 	illustrator: "0313",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/012.ts
+++ b/data-asia/S/SC1a/012.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/013.ts
+++ b/data-asia/S/SC1a/013.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "光電傘蜥"
 	},
 
+	dexId: [695],
 	illustrator: "SATOSHI NAKAI",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/013.ts
+++ b/data-asia/S/SC1a/013.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/014.ts
+++ b/data-asia/S/SC1a/014.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "蟲電寶"
 	},
 
+	dexId: [737],
 	illustrator: "Masakazu Fukuda",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/014.ts
+++ b/data-asia/S/SC1a/014.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/015.ts
+++ b/data-asia/S/SC1a/015.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/015.ts
+++ b/data-asia/S/SC1a/015.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "鍬農炮蟲"
 	},
 
+	dexId: [738],
 	illustrator: "kawayoo",
+	rarity: "Rare",
 	category: "Pokemon",
 	hp: 150,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/016.ts
+++ b/data-asia/S/SC1a/016.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/016.ts
+++ b/data-asia/S/SC1a/016.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "卡璞・鳴鳴V"
 	},
 
+	dexId: [785],
 	illustrator: "PLANETA Tsuji",
+	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/017.ts
+++ b/data-asia/S/SC1a/017.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "來電汪"
 	},
 
+	dexId: [835],
 	illustrator: "Akira Komayama",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/017.ts
+++ b/data-asia/S/SC1a/017.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/018.ts
+++ b/data-asia/S/SC1a/018.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "逐電犬"
 	},
 
+	dexId: [836],
 	illustrator: "Misa Tsutsui",
+	rarity: "Rare",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/018.ts
+++ b/data-asia/S/SC1a/018.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/019.ts
+++ b/data-asia/S/SC1a/019.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "逐電犬V"
 	},
 
+	dexId: [836],
 	illustrator: "aky CG Works",
+	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/019.ts
+++ b/data-asia/S/SC1a/019.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/020.ts
+++ b/data-asia/S/SC1a/020.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/020.ts
+++ b/data-asia/S/SC1a/020.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "毒電嬰"
 	},
 
+	dexId: [848],
 	illustrator: "nagimiso",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/021.ts
+++ b/data-asia/S/SC1a/021.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/021.ts
+++ b/data-asia/S/SC1a/021.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "顫弦蠑螈"
 	},
 
+	dexId: [849],
 	illustrator: "TOKIYA",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/022.ts
+++ b/data-asia/S/SC1a/022.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "顫弦蠑螈V"
 	},
 
+	dexId: [849],
 	illustrator: "5ban Graphics",
+	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/022.ts
+++ b/data-asia/S/SC1a/022.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/023.ts
+++ b/data-asia/S/SC1a/023.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "顫弦蠑螈V"
 	},
 
+	dexId: [849],
 	illustrator: "5ban Graphics",
+	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/023.ts
+++ b/data-asia/S/SC1a/023.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/024.ts
+++ b/data-asia/S/SC1a/024.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/024.ts
+++ b/data-asia/S/SC1a/024.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "顫弦蠑螈VMAX"
 	},
 
+	dexId: [849],
 	illustrator: "5ban Graphics",
+	rarity: "Rare",
 	category: "Pokemon",
 	hp: 320,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/025.ts
+++ b/data-asia/S/SC1a/025.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "啪嚓海膽"
 	},
 
+	dexId: [871],
 	illustrator: "Akira Komayama",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/025.ts
+++ b/data-asia/S/SC1a/025.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/026.ts
+++ b/data-asia/S/SC1a/026.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "啪嚓海膽V"
 	},
 
+	dexId: [871],
 	illustrator: "PLANETA Igarashi",
+	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 170,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/026.ts
+++ b/data-asia/S/SC1a/026.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/027.ts
+++ b/data-asia/S/SC1a/027.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "莫魯貝可"
 	},
 
+	dexId: [877],
 	illustrator: "Kouki Saitou",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/027.ts
+++ b/data-asia/S/SC1a/027.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/028.ts
+++ b/data-asia/S/SC1a/028.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "莫魯貝可V"
 	},
 
+	dexId: [877],
 	illustrator: "5ban Graphics",
+	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 170,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/028.ts
+++ b/data-asia/S/SC1a/028.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/029.ts
+++ b/data-asia/S/SC1a/029.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "莫魯貝可VMAX"
 	},
 
+	dexId: [877],
 	illustrator: "5ban Graphics",
+	rarity: "Rare",
 	category: "Pokemon",
 	hp: 300,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/029.ts
+++ b/data-asia/S/SC1a/029.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/030.ts
+++ b/data-asia/S/SC1a/030.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "皮皮"
 	},
 
+	dexId: [35],
 	illustrator: "sowsow",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/030.ts
+++ b/data-asia/S/SC1a/030.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/031.ts
+++ b/data-asia/S/SC1a/031.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/031.ts
+++ b/data-asia/S/SC1a/031.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "皮可西"
 	},
 
+	dexId: [36],
 	illustrator: "miki kudo",
+	rarity: "Rare",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/032.ts
+++ b/data-asia/S/SC1a/032.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "伽勒爾 小火馬"
 	},
 
+	dexId: [77],
 	illustrator: "Saya Tsuruta",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/032.ts
+++ b/data-asia/S/SC1a/032.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/033.ts
+++ b/data-asia/S/SC1a/033.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "伽勒爾 小火馬"
 	},
 
+	dexId: [77],
 	illustrator: "kirisAki",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/033.ts
+++ b/data-asia/S/SC1a/033.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/034.ts
+++ b/data-asia/S/SC1a/034.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "伽勒爾 烈焰馬"
 	},
 
+	dexId: [78],
 	illustrator: "You Iribi",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 100,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/034.ts
+++ b/data-asia/S/SC1a/034.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/035.ts
+++ b/data-asia/S/SC1a/035.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "鬼斯"
 	},
 
+	dexId: [92],
 	illustrator: "Taira Akitsu",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/035.ts
+++ b/data-asia/S/SC1a/035.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/036.ts
+++ b/data-asia/S/SC1a/036.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "鬼斯通"
 	},
 
+	dexId: [93],
 	illustrator: "HYOGONOSUKE",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/036.ts
+++ b/data-asia/S/SC1a/036.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/037.ts
+++ b/data-asia/S/SC1a/037.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "耿鬼"
 	},
 
+	dexId: [94],
 	illustrator: "Eri Yamaki",
+	rarity: "Rare",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/037.ts
+++ b/data-asia/S/SC1a/037.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/038.ts
+++ b/data-asia/S/SC1a/038.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "天然雀"
 	},
 
+	dexId: [177],
 	illustrator: "Naoyo Kimura",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/038.ts
+++ b/data-asia/S/SC1a/038.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/039.ts
+++ b/data-asia/S/SC1a/039.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/039.ts
+++ b/data-asia/S/SC1a/039.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "天然鳥"
 	},
 
+	dexId: [178],
 	illustrator: "so-taro",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/040.ts
+++ b/data-asia/S/SC1a/040.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "果然翁V"
 	},
 
+	dexId: [202],
 	illustrator: "Ayaka Yoshida",
+	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/040.ts
+++ b/data-asia/S/SC1a/040.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/041.ts
+++ b/data-asia/S/SC1a/041.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "伽勒爾 太陽珊瑚"
 	},
 
+	dexId: [222],
 	illustrator: "Mitsuhiro Arita",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/041.ts
+++ b/data-asia/S/SC1a/041.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/042.ts
+++ b/data-asia/S/SC1a/042.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "伽勒爾 魔靈珊瑚"
 	},
 
+	dexId: [864],
 	illustrator: "Kagemaru Himeno",
+	rarity: "Rare",
 	category: "Pokemon",
 	hp: 100,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/042.ts
+++ b/data-asia/S/SC1a/042.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/043.ts
+++ b/data-asia/S/SC1a/043.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "食夢夢"
 	},
 
+	dexId: [517],
 	illustrator: "Asako Ito",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/043.ts
+++ b/data-asia/S/SC1a/043.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/044.ts
+++ b/data-asia/S/SC1a/044.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/044.ts
+++ b/data-asia/S/SC1a/044.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "夢夢蝕"
 	},
 
+	dexId: [518],
 	illustrator: "MAHOU",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/045.ts
+++ b/data-asia/S/SC1a/045.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "象徵鳥"
 	},
 
+	dexId: [561],
 	illustrator: "Naoyo Kimura",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/045.ts
+++ b/data-asia/S/SC1a/045.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/046.ts
+++ b/data-asia/S/SC1a/046.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "沙丘娃"
 	},
 
+	dexId: [769],
 	illustrator: "Yuka Morii",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/046.ts
+++ b/data-asia/S/SC1a/046.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/047.ts
+++ b/data-asia/S/SC1a/047.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "噬沙堡爺"
 	},
 
+	dexId: [770],
 	illustrator: "Hasuno",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/047.ts
+++ b/data-asia/S/SC1a/047.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/048.ts
+++ b/data-asia/S/SC1a/048.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "來悲茶"
 	},
 
+	dexId: [854],
 	illustrator: "Saya Tsuruta",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 30,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/048.ts
+++ b/data-asia/S/SC1a/048.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/049.ts
+++ b/data-asia/S/SC1a/049.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "怖思壺"
 	},
 
+	dexId: [855],
 	illustrator: "Shin Nagasawa",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/049.ts
+++ b/data-asia/S/SC1a/049.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/050.ts
+++ b/data-asia/S/SC1a/050.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/050.ts
+++ b/data-asia/S/SC1a/050.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "怖思壺V"
 	},
 
+	dexId: [855],
 	illustrator: "PLANETA Igarashi",
+	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 170,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/051.ts
+++ b/data-asia/S/SC1a/051.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "迷布莉姆"
 	},
 
+	dexId: [856],
 	illustrator: "Mina Nakai",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/051.ts
+++ b/data-asia/S/SC1a/051.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/052.ts
+++ b/data-asia/S/SC1a/052.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "提布莉姆"
 	},
 
+	dexId: [857],
 	illustrator: "kirisAki",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/052.ts
+++ b/data-asia/S/SC1a/052.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/053.ts
+++ b/data-asia/S/SC1a/053.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/053.ts
+++ b/data-asia/S/SC1a/053.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "布莉姆溫"
 	},
 
+	dexId: [858],
 	illustrator: "Kagemaru Himeno",
+	rarity: "Rare",
 	category: "Pokemon",
 	hp: 150,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/054.ts
+++ b/data-asia/S/SC1a/054.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "小仙奶"
 	},
 
+	dexId: [868],
 	illustrator: "Mina Nakai",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 50,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/054.ts
+++ b/data-asia/S/SC1a/054.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/055.ts
+++ b/data-asia/S/SC1a/055.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "霜奶仙"
 	},
 
+	dexId: [869],
 	illustrator: "Mizue",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/055.ts
+++ b/data-asia/S/SC1a/055.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/056.ts
+++ b/data-asia/S/SC1a/056.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "愛管侍"
 	},
 
+	dexId: [876],
 	illustrator: "Mizue",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 100,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/056.ts
+++ b/data-asia/S/SC1a/056.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/057.ts
+++ b/data-asia/S/SC1a/057.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "愛管侍V"
 	},
 
+	dexId: [876],
 	illustrator: "5ban Graphics",
+	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 180,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/057.ts
+++ b/data-asia/S/SC1a/057.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/058.ts
+++ b/data-asia/S/SC1a/058.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "多龍梅西亞"
 	},
 
+	dexId: [885],
 	illustrator: "Akira Komayama",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/058.ts
+++ b/data-asia/S/SC1a/058.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/059.ts
+++ b/data-asia/S/SC1a/059.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "多龍奇"
 	},
 
+	dexId: [886],
 	illustrator: "Kouki Saitou",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/059.ts
+++ b/data-asia/S/SC1a/059.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/060.ts
+++ b/data-asia/S/SC1a/060.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "多龍巴魯托"
 	},
 
+	dexId: [887],
 	illustrator: "Shin Nagasawa",
+	rarity: "Rare",
 	category: "Pokemon",
 	hp: 150,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/060.ts
+++ b/data-asia/S/SC1a/060.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/061.ts
+++ b/data-asia/S/SC1a/061.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "多龍巴魯托V"
 	},
 
+	dexId: [887],
 	illustrator: "aky CG Works",
+	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/061.ts
+++ b/data-asia/S/SC1a/061.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/062.ts
+++ b/data-asia/S/SC1a/062.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "多龍巴魯托VMAX"
 	},
 
+	dexId: [887],
 	illustrator: "aky CG Works",
+	rarity: "Rare",
 	category: "Pokemon",
 	hp: 320,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/062.ts
+++ b/data-asia/S/SC1a/062.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/063.ts
+++ b/data-asia/S/SC1a/063.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "伽勒爾 大蔥鴨"
 	},
 
+	dexId: [83],
 	illustrator: "Akira Komayama",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/063.ts
+++ b/data-asia/S/SC1a/063.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/064.ts
+++ b/data-asia/S/SC1a/064.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "伽勒爾 蔥遊兵"
 	},
 
+	dexId: [865],
 	illustrator: "You Iribi",
+	rarity: "Rare",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/064.ts
+++ b/data-asia/S/SC1a/064.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/065.ts
+++ b/data-asia/S/SC1a/065.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "飛腿郎"
 	},
 
+	dexId: [106],
 	illustrator: "Shigenori Negishi",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/065.ts
+++ b/data-asia/S/SC1a/065.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/066.ts
+++ b/data-asia/S/SC1a/066.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "快拳郎"
 	},
 
+	dexId: [107],
 	illustrator: "Shigenori Negishi",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/066.ts
+++ b/data-asia/S/SC1a/066.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/067.ts
+++ b/data-asia/S/SC1a/067.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "獨角犀牛"
 	},
 
+	dexId: [111],
 	illustrator: "Sekio",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 100,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/067.ts
+++ b/data-asia/S/SC1a/067.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/068.ts
+++ b/data-asia/S/SC1a/068.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "鑽角犀獸"
 	},
 
+	dexId: [112],
 	illustrator: "KEIICHIRO ITO",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/068.ts
+++ b/data-asia/S/SC1a/068.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/069.ts
+++ b/data-asia/S/SC1a/069.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "超甲狂犀"
 	},
 
+	dexId: [464],
 	illustrator: "Satoshi Shirai",
+	rarity: "Rare",
 	category: "Pokemon",
 	hp: 190,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/069.ts
+++ b/data-asia/S/SC1a/069.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/070.ts
+++ b/data-asia/S/SC1a/070.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "樹才怪"
 	},
 
+	dexId: [185],
 	illustrator: "Yukiko Baba",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 100,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/070.ts
+++ b/data-asia/S/SC1a/070.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/071.ts
+++ b/data-asia/S/SC1a/071.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "朝北鼻"
 	},
 
+	dexId: [299],
 	illustrator: "Miki Tanaka",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/071.ts
+++ b/data-asia/S/SC1a/071.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/072.ts
+++ b/data-asia/S/SC1a/072.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "瑪沙那"
 	},
 
+	dexId: [307],
 	illustrator: "Yukiko Baba",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/072.ts
+++ b/data-asia/S/SC1a/072.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/073.ts
+++ b/data-asia/S/SC1a/073.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "恰雷姆"
 	},
 
+	dexId: [308],
 	illustrator: "Suwama Chiaki",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/073.ts
+++ b/data-asia/S/SC1a/073.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/074.ts
+++ b/data-asia/S/SC1a/074.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/074.ts
+++ b/data-asia/S/SC1a/074.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "泥泥鰍"
 	},
 
+	dexId: [339],
 	illustrator: "Atsuko Nishida",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/075.ts
+++ b/data-asia/S/SC1a/075.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "鯰魚王"
 	},
 
+	dexId: [340],
 	illustrator: "kawayoo",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/075.ts
+++ b/data-asia/S/SC1a/075.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/076.ts
+++ b/data-asia/S/SC1a/076.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "天秤偶"
 	},
 
+	dexId: [343],
 	illustrator: "Uta",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/076.ts
+++ b/data-asia/S/SC1a/076.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/077.ts
+++ b/data-asia/S/SC1a/077.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "念力土偶"
 	},
 
+	dexId: [344],
 	illustrator: "Tomokazu Komiya",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/077.ts
+++ b/data-asia/S/SC1a/077.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/078.ts
+++ b/data-asia/S/SC1a/078.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "雷吉洛克V"
 	},
 
+	dexId: [377],
 	illustrator: "PLANETA Tsuji",
+	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/078.ts
+++ b/data-asia/S/SC1a/078.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/079.ts
+++ b/data-asia/S/SC1a/079.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "伽勒爾 哭哭面具"
 	},
 
+	dexId: [562],
 	illustrator: "Akira Komayama",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/079.ts
+++ b/data-asia/S/SC1a/079.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/080.ts
+++ b/data-asia/S/SC1a/080.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "伽勒爾 死神板"
 	},
 
+	dexId: [867],
 	illustrator: "TOKIYA",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 100,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/080.ts
+++ b/data-asia/S/SC1a/080.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/081.ts
+++ b/data-asia/S/SC1a/081.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "龜腳腳"
 	},
 
+	dexId: [688],
 	illustrator: "Saya Tsuruta",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/081.ts
+++ b/data-asia/S/SC1a/081.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/082.ts
+++ b/data-asia/S/SC1a/082.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "龜足巨鎧"
 	},
 
+	dexId: [689],
 	illustrator: "Anesaki Dynamic",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/082.ts
+++ b/data-asia/S/SC1a/082.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/083.ts
+++ b/data-asia/S/SC1a/083.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/083.ts
+++ b/data-asia/S/SC1a/083.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "小炭仔"
 	},
 
+	dexId: [837],
 	illustrator: "Misa Tsutsui",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/084.ts
+++ b/data-asia/S/SC1a/084.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "大炭車"
 	},
 
+	dexId: [838],
 	illustrator: "Mitsuhiro Arita",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 100,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/084.ts
+++ b/data-asia/S/SC1a/084.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/085.ts
+++ b/data-asia/S/SC1a/085.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "巨炭山"
 	},
 
+	dexId: [839],
 	illustrator: "Shin Nagasawa",
+	rarity: "Rare",
 	category: "Pokemon",
 	hp: 160,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/085.ts
+++ b/data-asia/S/SC1a/085.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/086.ts
+++ b/data-asia/S/SC1a/086.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "沙包蛇"
 	},
 
+	dexId: [843],
 	illustrator: "Misa Tsutsui",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/086.ts
+++ b/data-asia/S/SC1a/086.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/087.ts
+++ b/data-asia/S/SC1a/087.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "沙螺蟒"
 	},
 
+	dexId: [844],
 	illustrator: "Kouki Saitou",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/087.ts
+++ b/data-asia/S/SC1a/087.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/088.ts
+++ b/data-asia/S/SC1a/088.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/088.ts
+++ b/data-asia/S/SC1a/088.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "沙螺蟒V"
 	},
 
+	dexId: [844],
 	illustrator: "aky CG Works",
+	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/089.ts
+++ b/data-asia/S/SC1a/089.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "拳拳蛸"
 	},
 
+	dexId: [852],
 	illustrator: "Mina Nakai",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/089.ts
+++ b/data-asia/S/SC1a/089.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/090.ts
+++ b/data-asia/S/SC1a/090.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "八爪武師"
 	},
 
+	dexId: [853],
 	illustrator: "Shin Nagasawa",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/090.ts
+++ b/data-asia/S/SC1a/090.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/091.ts
+++ b/data-asia/S/SC1a/091.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "列陣兵"
 	},
 
+	dexId: [870],
 	illustrator: "Misa Tsutsui",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/091.ts
+++ b/data-asia/S/SC1a/091.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/092.ts
+++ b/data-asia/S/SC1a/092.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "列陣兵V"
 	},
 
+	dexId: [870],
 	illustrator: "aky CG Works",
+	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 160,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/092.ts
+++ b/data-asia/S/SC1a/092.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/093.ts
+++ b/data-asia/S/SC1a/093.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "巨石丁"
 	},
 
+	dexId: [874],
 	illustrator: "Kouki Saitou",
+	rarity: "Rare",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/093.ts
+++ b/data-asia/S/SC1a/093.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/094.ts
+++ b/data-asia/S/SC1a/094.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "巨石丁V"
 	},
 
+	dexId: [874],
 	illustrator: "5ban Graphics",
+	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/094.ts
+++ b/data-asia/S/SC1a/094.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/095.ts
+++ b/data-asia/S/SC1a/095.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "巨石丁VMAX"
 	},
 
+	dexId: [874],
 	illustrator: "5ban Graphics",
+	rarity: "Rare",
 	category: "Pokemon",
 	hp: 330,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/095.ts
+++ b/data-asia/S/SC1a/095.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/096.ts
+++ b/data-asia/S/SC1a/096.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "伽勒爾 喵喵"
 	},
 
+	dexId: [52],
 	illustrator: "kirisAki",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/096.ts
+++ b/data-asia/S/SC1a/096.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/097.ts
+++ b/data-asia/S/SC1a/097.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "伽勒爾 喵喵"
 	},
 
+	dexId: [52],
 	illustrator: "Misa Tsutsui",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/097.ts
+++ b/data-asia/S/SC1a/097.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/098.ts
+++ b/data-asia/S/SC1a/098.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "伽勒爾 喵頭目"
 	},
 
+	dexId: [863],
 	illustrator: "Mitsuhiro Arita",
+	rarity: "Rare",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/098.ts
+++ b/data-asia/S/SC1a/098.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/099.ts
+++ b/data-asia/S/SC1a/099.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "伽勒爾 喵頭目"
 	},
 
+	dexId: [863],
 	illustrator: "Naoki Saito",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/099.ts
+++ b/data-asia/S/SC1a/099.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/100.ts
+++ b/data-asia/S/SC1a/100.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "巨鉗螳螂"
 	},
 
+	dexId: [212],
 	illustrator: "Ryuta Fuse",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/100.ts
+++ b/data-asia/S/SC1a/100.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/101.ts
+++ b/data-asia/S/SC1a/101.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "大嘴娃"
 	},
 
+	dexId: [303],
 	illustrator: "AKIRA EGAWA",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/101.ts
+++ b/data-asia/S/SC1a/101.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/102.ts
+++ b/data-asia/S/SC1a/102.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/102.ts
+++ b/data-asia/S/SC1a/102.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "銅鏡怪"
 	},
 
+	dexId: [436],
 	illustrator: "Midori Harada",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/103.ts
+++ b/data-asia/S/SC1a/103.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "青銅鐘"
 	},
 
+	dexId: [437],
 	illustrator: "MAHOU",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/103.ts
+++ b/data-asia/S/SC1a/103.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/104.ts
+++ b/data-asia/S/SC1a/104.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "大朝北鼻"
 	},
 
+	dexId: [476],
 	illustrator: "Anesaki Dynamic",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/104.ts
+++ b/data-asia/S/SC1a/104.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/105.ts
+++ b/data-asia/S/SC1a/105.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "種子鐵球"
 	},
 
+	dexId: [597],
 	illustrator: "Yuka Morii",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/105.ts
+++ b/data-asia/S/SC1a/105.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/106.ts
+++ b/data-asia/S/SC1a/106.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "堅果啞鈴"
 	},
 
+	dexId: [598],
 	illustrator: "Midori Harada",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/106.ts
+++ b/data-asia/S/SC1a/106.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/107.ts
+++ b/data-asia/S/SC1a/107.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "伽勒爾 泥巴魚"
 	},
 
+	dexId: [618],
 	illustrator: "Kouki Saitou",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/107.ts
+++ b/data-asia/S/SC1a/107.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/108.ts
+++ b/data-asia/S/SC1a/108.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "駒刀小兵"
 	},
 
+	dexId: [624],
 	illustrator: "Motofumi Fujiwara",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/108.ts
+++ b/data-asia/S/SC1a/108.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/109.ts
+++ b/data-asia/S/SC1a/109.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "劈斬司令"
 	},
 
+	dexId: [625],
 	illustrator: "kawayoo",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/109.ts
+++ b/data-asia/S/SC1a/109.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/110.ts
+++ b/data-asia/S/SC1a/110.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "鐵蟻"
 	},
 
+	dexId: [632],
 	illustrator: "Hideki Ishikawa",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 100,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/110.ts
+++ b/data-asia/S/SC1a/110.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/111.ts
+++ b/data-asia/S/SC1a/111.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "獨劍鞘"
 	},
 
+	dexId: [679],
 	illustrator: "Sekio",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/111.ts
+++ b/data-asia/S/SC1a/111.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/112.ts
+++ b/data-asia/S/SC1a/112.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "雙劍鞘"
 	},
 
+	dexId: [680],
 	illustrator: "Aya Kusube",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/112.ts
+++ b/data-asia/S/SC1a/112.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/113.ts
+++ b/data-asia/S/SC1a/113.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/113.ts
+++ b/data-asia/S/SC1a/113.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "堅盾劍怪"
 	},
 
+	dexId: [681],
 	illustrator: "Ryuta Fuse",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 140,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/114.ts
+++ b/data-asia/S/SC1a/114.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "鋼鎧鴉"
 	},
 
+	dexId: [823],
 	illustrator: "Shin Nagasawa",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 170,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/114.ts
+++ b/data-asia/S/SC1a/114.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/115.ts
+++ b/data-asia/S/SC1a/115.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/115.ts
+++ b/data-asia/S/SC1a/115.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "銅象"
 	},
 
+	dexId: [878],
 	illustrator: "kirisAki",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 100,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/116.ts
+++ b/data-asia/S/SC1a/116.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "大王銅象"
 	},
 
+	dexId: [879],
 	illustrator: "Hitoshi Ariga",
+	rarity: "Rare",
 	category: "Pokemon",
 	hp: 190,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/116.ts
+++ b/data-asia/S/SC1a/116.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/117.ts
+++ b/data-asia/S/SC1a/117.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "大王銅象V"
 	},
 
+	dexId: [879],
 	illustrator: "5ban Graphics",
+	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/117.ts
+++ b/data-asia/S/SC1a/117.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/118.ts
+++ b/data-asia/S/SC1a/118.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/118.ts
+++ b/data-asia/S/SC1a/118.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "大王銅象VMAX"
 	},
 
+	dexId: [879],
 	illustrator: "5ban Graphics",
+	rarity: "Rare",
 	category: "Pokemon",
 	hp: 340,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/119.ts
+++ b/data-asia/S/SC1a/119.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "鋁鋼龍"
 	},
 
+	dexId: [884],
 	illustrator: "Ryuta Fuse",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/119.ts
+++ b/data-asia/S/SC1a/119.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/120.ts
+++ b/data-asia/S/SC1a/120.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "鋁鋼龍"
 	},
 
+	dexId: [884],
 	illustrator: "Shin Nagasawa",
+	rarity: "Rare",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/120.ts
+++ b/data-asia/S/SC1a/120.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/121.ts
+++ b/data-asia/S/SC1a/121.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "蒼響"
 	},
 
+	dexId: [888],
 	illustrator: "Kouki Saitou",
+	rarity: "Rare",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/121.ts
+++ b/data-asia/S/SC1a/121.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/122.ts
+++ b/data-asia/S/SC1a/122.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "蒼響V"
 	},
 
+	dexId: [888],
 	illustrator: "5ban Graphics",
+	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/122.ts
+++ b/data-asia/S/SC1a/122.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/123.ts
+++ b/data-asia/S/SC1a/123.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "藏瑪然特"
 	},
 
+	dexId: [889],
 	illustrator: "Kouki Saitou",
+	rarity: "Rare",
 	category: "Pokemon",
 	hp: 130,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/123.ts
+++ b/data-asia/S/SC1a/123.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/124.ts
+++ b/data-asia/S/SC1a/124.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "藏瑪然特V"
 	},
 
+	dexId: [889],
 	illustrator: "aky CG Works",
+	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 230,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/124.ts
+++ b/data-asia/S/SC1a/124.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/125.ts
+++ b/data-asia/S/SC1a/125.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "喵喵V"
 	},
 
+	dexId: [52],
 	illustrator: "aky CG Works",
+	rarity: "Double rare",
 	category: "Pokemon",
 	hp: 180,
 	types: ["Colorless"],

--- a/data-asia/S/SC1a/125.ts
+++ b/data-asia/S/SC1a/125.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/126.ts
+++ b/data-asia/S/SC1a/126.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "喵喵VMAX"
 	},
 
+	dexId: [52],
 	illustrator: "aky CG Works",
+	rarity: "Rare",
 	category: "Pokemon",
 	hp: 300,
 	types: ["Colorless"],

--- a/data-asia/S/SC1a/126.ts
+++ b/data-asia/S/SC1a/126.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/127.ts
+++ b/data-asia/S/SC1a/127.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "卡比獸"
 	},
 
+	dexId: [143],
 	illustrator: "Eri Yamaki",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 150,
 	types: ["Colorless"],

--- a/data-asia/S/SC1a/127.ts
+++ b/data-asia/S/SC1a/127.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/128.ts
+++ b/data-asia/S/SC1a/128.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "咕咕"
 	},
 
+	dexId: [163],
 	illustrator: "Yumi",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Colorless"],

--- a/data-asia/S/SC1a/128.ts
+++ b/data-asia/S/SC1a/128.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/129.ts
+++ b/data-asia/S/SC1a/129.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "貓頭夜鷹"
 	},
 
+	dexId: [164],
 	illustrator: "kawayoo",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 110,
 	types: ["Colorless"],

--- a/data-asia/S/SC1a/129.ts
+++ b/data-asia/S/SC1a/129.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/130.ts
+++ b/data-asia/S/SC1a/130.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "泡沫栗鼠"
 	},
 
+	dexId: [572],
 	illustrator: "Sekio",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Colorless"],

--- a/data-asia/S/SC1a/130.ts
+++ b/data-asia/S/SC1a/130.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/131.ts
+++ b/data-asia/S/SC1a/131.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/131.ts
+++ b/data-asia/S/SC1a/131.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "奇諾栗鼠"
 	},
 
+	dexId: [573],
 	illustrator: "sui",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 90,
 	types: ["Colorless"],

--- a/data-asia/S/SC1a/132.ts
+++ b/data-asia/S/SC1a/132.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "貪心栗鼠"
 	},
 
+	dexId: [819],
 	illustrator: "Mina Nakai",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 70,
 	types: ["Colorless"],

--- a/data-asia/S/SC1a/132.ts
+++ b/data-asia/S/SC1a/132.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/133.ts
+++ b/data-asia/S/SC1a/133.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "藏飽栗鼠"
 	},
 
+	dexId: [820],
 	illustrator: "kirisAki",
+	rarity: "Uncommon",
 	category: "Pokemon",
 	hp: 120,
 	types: ["Colorless"],

--- a/data-asia/S/SC1a/133.ts
+++ b/data-asia/S/SC1a/133.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/134.ts
+++ b/data-asia/S/SC1a/134.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "稚山雀"
 	},
 
+	dexId: [821],
 	illustrator: "Akira Komayama",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 60,
 	types: ["Colorless"],

--- a/data-asia/S/SC1a/134.ts
+++ b/data-asia/S/SC1a/134.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/135.ts
+++ b/data-asia/S/SC1a/135.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "藍鴉"
 	},
 
+	dexId: [822],
 	illustrator: "Anesaki Dynamic",
+	rarity: "Common",
 	category: "Pokemon",
 	hp: 80,
 	types: ["Colorless"],

--- a/data-asia/S/SC1a/135.ts
+++ b/data-asia/S/SC1a/135.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/136.ts
+++ b/data-asia/S/SC1a/136.ts
@@ -9,6 +9,7 @@ const card: Card = {
 	},
 
 	illustrator: "sadaji",
+	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {

--- a/data-asia/S/SC1a/136.ts
+++ b/data-asia/S/SC1a/136.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/137.ts
+++ b/data-asia/S/SC1a/137.ts
@@ -9,6 +9,7 @@ const card: Card = {
 	},
 
 	illustrator: "Ryo Ueda",
+	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {

--- a/data-asia/S/SC1a/137.ts
+++ b/data-asia/S/SC1a/137.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/138.ts
+++ b/data-asia/S/SC1a/138.ts
@@ -9,6 +9,7 @@ const card: Card = {
 	},
 
 	illustrator: "Studio Bora Inc.",
+	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {

--- a/data-asia/S/SC1a/138.ts
+++ b/data-asia/S/SC1a/138.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/139.ts
+++ b/data-asia/S/SC1a/139.ts
@@ -9,6 +9,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
+	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {

--- a/data-asia/S/SC1a/139.ts
+++ b/data-asia/S/SC1a/139.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/140.ts
+++ b/data-asia/S/SC1a/140.ts
@@ -9,6 +9,7 @@ const card: Card = {
 	},
 
 	illustrator: "Toyste Beach",
+	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {

--- a/data-asia/S/SC1a/140.ts
+++ b/data-asia/S/SC1a/140.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/141.ts
+++ b/data-asia/S/SC1a/141.ts
@@ -9,6 +9,7 @@ const card: Card = {
 	},
 
 	illustrator: "Yoshinobu Saito",
+	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {

--- a/data-asia/S/SC1a/141.ts
+++ b/data-asia/S/SC1a/141.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/142.ts
+++ b/data-asia/S/SC1a/142.ts
@@ -9,6 +9,7 @@ const card: Card = {
 	},
 
 	illustrator: "Ryo Ueda",
+	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {

--- a/data-asia/S/SC1a/142.ts
+++ b/data-asia/S/SC1a/142.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/143.ts
+++ b/data-asia/S/SC1a/143.ts
@@ -9,6 +9,7 @@ const card: Card = {
 	},
 
 	illustrator: "Toyste Beach",
+	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {

--- a/data-asia/S/SC1a/143.ts
+++ b/data-asia/S/SC1a/143.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/144.ts
+++ b/data-asia/S/SC1a/144.ts
@@ -9,6 +9,7 @@ const card: Card = {
 	},
 
 	illustrator: "Studio Bora Inc.",
+	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {

--- a/data-asia/S/SC1a/144.ts
+++ b/data-asia/S/SC1a/144.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/145.ts
+++ b/data-asia/S/SC1a/145.ts
@@ -9,6 +9,7 @@ const card: Card = {
 	},
 
 	illustrator: "Toyste Beach",
+	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {

--- a/data-asia/S/SC1a/145.ts
+++ b/data-asia/S/SC1a/145.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/146.ts
+++ b/data-asia/S/SC1a/146.ts
@@ -9,6 +9,7 @@ const card: Card = {
 	},
 
 	illustrator: "Yusuke Ohmura",
+	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {

--- a/data-asia/S/SC1a/146.ts
+++ b/data-asia/S/SC1a/146.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/147.ts
+++ b/data-asia/S/SC1a/147.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/147.ts
+++ b/data-asia/S/SC1a/147.ts
@@ -9,6 +9,7 @@ const card: Card = {
 	},
 
 	illustrator: "Yusuke Ohmura",
+	rarity: "Rare",
 	category: "Trainer",
 
 	effect: {

--- a/data-asia/S/SC1a/148.ts
+++ b/data-asia/S/SC1a/148.ts
@@ -9,6 +9,7 @@ const card: Card = {
 	},
 
 	illustrator: "Naoki Saito",
+	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {

--- a/data-asia/S/SC1a/148.ts
+++ b/data-asia/S/SC1a/148.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/149.ts
+++ b/data-asia/S/SC1a/149.ts
@@ -9,6 +9,7 @@ const card: Card = {
 	},
 
 	illustrator: "Hideki Ishikawa",
+	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {

--- a/data-asia/S/SC1a/149.ts
+++ b/data-asia/S/SC1a/149.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/150.ts
+++ b/data-asia/S/SC1a/150.ts
@@ -9,6 +9,7 @@ const card: Card = {
 	},
 
 	illustrator: "take",
+	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {

--- a/data-asia/S/SC1a/150.ts
+++ b/data-asia/S/SC1a/150.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/151.ts
+++ b/data-asia/S/SC1a/151.ts
@@ -9,6 +9,7 @@ const card: Card = {
 	},
 
 	illustrator: "5ban Graphics",
+	rarity: "Uncommon",
 	category: "Trainer",
 
 	effect: {

--- a/data-asia/S/SC1a/151.ts
+++ b/data-asia/S/SC1a/151.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/152.ts
+++ b/data-asia/S/SC1a/152.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		'zh-tw': "高速雷能量"
 	},
 
+	rarity: "Uncommon",
 	category: "Energy",
 
 	effect: {

--- a/data-asia/S/SC1a/152.ts
+++ b/data-asia/S/SC1a/152.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/153.ts
+++ b/data-asia/S/SC1a/153.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		'zh-tw': "恐怖超能量"
 	},
 
+	rarity: "Uncommon",
 	category: "Energy",
 
 	effect: {

--- a/data-asia/S/SC1a/153.ts
+++ b/data-asia/S/SC1a/153.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/154.ts
+++ b/data-asia/S/SC1a/154.ts
@@ -8,6 +8,7 @@ const card: Card = {
 		'zh-tw': "極光能量"
 	},
 
+	rarity: "Uncommon",
 	category: "Energy",
 
 	effect: {

--- a/data-asia/S/SC1a/154.ts
+++ b/data-asia/S/SC1a/154.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/155.ts
+++ b/data-asia/S/SC1a/155.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "逐電犬V"
 	},
 
+	dexId: [836],
 	illustrator: "aky CG Works",
+	rarity: "Character Super Rare",
 	category: "Pokemon",
 	hp: 200,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/155.ts
+++ b/data-asia/S/SC1a/155.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/156.ts
+++ b/data-asia/S/SC1a/156.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "顫弦蠑螈V"
 	},
 
+	dexId: [849],
 	illustrator: "5ban Graphics",
+	rarity: "Character Super Rare",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/156.ts
+++ b/data-asia/S/SC1a/156.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/157.ts
+++ b/data-asia/S/SC1a/157.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "莫魯貝可V"
 	},
 
+	dexId: [877],
 	illustrator: "5ban Graphics",
+	rarity: "Character Super Rare",
 	category: "Pokemon",
 	hp: 170,
 	types: ["Lightning"],

--- a/data-asia/S/SC1a/157.ts
+++ b/data-asia/S/SC1a/157.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/158.ts
+++ b/data-asia/S/SC1a/158.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "果然翁V"
 	},
 
+	dexId: [202],
 	illustrator: "Ayaka Yoshida",
+	rarity: "Character Super Rare",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/158.ts
+++ b/data-asia/S/SC1a/158.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/159.ts
+++ b/data-asia/S/SC1a/159.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "愛管侍V"
 	},
 
+	dexId: [876],
 	illustrator: "5ban Graphics",
+	rarity: "Character Super Rare",
 	category: "Pokemon",
 	hp: 180,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/159.ts
+++ b/data-asia/S/SC1a/159.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/160.ts
+++ b/data-asia/S/SC1a/160.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "多龍巴魯托V"
 	},
 
+	dexId: [887],
 	illustrator: "aky CG Works",
+	rarity: "Character Super Rare",
 	category: "Pokemon",
 	hp: 210,
 	types: ["Psychic"],

--- a/data-asia/S/SC1a/160.ts
+++ b/data-asia/S/SC1a/160.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/161.ts
+++ b/data-asia/S/SC1a/161.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/161.ts
+++ b/data-asia/S/SC1a/161.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "沙螺蟒V"
 	},
 
+	dexId: [844],
 	illustrator: "aky CG Works",
+	rarity: "Character Super Rare",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/162.ts
+++ b/data-asia/S/SC1a/162.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/162.ts
+++ b/data-asia/S/SC1a/162.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "列陣兵V"
 	},
 
+	dexId: [870],
 	illustrator: "aky CG Works",
+	rarity: "Character Super Rare",
 	category: "Pokemon",
 	hp: 160,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/163.ts
+++ b/data-asia/S/SC1a/163.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "巨石丁V"
 	},
 
+	dexId: [874],
 	illustrator: "5ban Graphics",
+	rarity: "Character Super Rare",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Fighting"],

--- a/data-asia/S/SC1a/163.ts
+++ b/data-asia/S/SC1a/163.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/164.ts
+++ b/data-asia/S/SC1a/164.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "大王銅象V"
 	},
 
+	dexId: [879],
 	illustrator: "5ban Graphics",
+	rarity: "Character Super Rare",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/164.ts
+++ b/data-asia/S/SC1a/164.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/165.ts
+++ b/data-asia/S/SC1a/165.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "蒼響V"
 	},
 
+	dexId: [888],
 	illustrator: "5ban Graphics",
+	rarity: "Character Super Rare",
 	category: "Pokemon",
 	hp: 220,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/165.ts
+++ b/data-asia/S/SC1a/165.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/166.ts
+++ b/data-asia/S/SC1a/166.ts
@@ -8,7 +8,9 @@ const card: Card = {
 		'zh-tw': "藏瑪然特V"
 	},
 
+	dexId: [889],
 	illustrator: "aky CG Works",
+	rarity: "Character Super Rare",
 	category: "Pokemon",
 	hp: 230,
 	types: ["Metal"],

--- a/data-asia/S/SC1a/166.ts
+++ b/data-asia/S/SC1a/166.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/167.ts
+++ b/data-asia/S/SC1a/167.ts
@@ -9,6 +9,7 @@ const card: Card = {
 	},
 
 	illustrator: "Yusuke Ohmura",
+	rarity: "Character Super Rare",
 	category: "Trainer",
 
 	effect: {

--- a/data-asia/S/SC1a/167.ts
+++ b/data-asia/S/SC1a/167.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/168.ts
+++ b/data-asia/S/SC1a/168.ts
@@ -9,6 +9,7 @@ const card: Card = {
 	},
 
 	illustrator: "Yusuke Ohmura",
+	rarity: "Character Super Rare",
 	category: "Trainer",
 
 	effect: {

--- a/data-asia/S/SC1a/168.ts
+++ b/data-asia/S/SC1a/168.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/169.ts
+++ b/data-asia/S/SC1a/169.ts
@@ -9,6 +9,7 @@ const card: Card = {
 	},
 
 	illustrator: "Naoki Saito",
+	rarity: "Character Super Rare",
 	category: "Trainer",
 
 	effect: {

--- a/data-asia/S/SC1a/169.ts
+++ b/data-asia/S/SC1a/169.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/170.ts
+++ b/data-asia/S/SC1a/170.ts
@@ -8,7 +8,8 @@ const card: Card = {
 		'zh-tw': "寶可夢中心的姐姐"
 	},
 
-	illustrator: "kirisAki",
+	illustrator: "Sanosuke Sakuma",
+	rarity: "Character Super Rare",
 	category: "Trainer",
 
 	effect: {

--- a/data-asia/S/SC1a/170.ts
+++ b/data-asia/S/SC1a/170.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/171.ts
+++ b/data-asia/S/SC1a/171.ts
@@ -8,7 +8,8 @@ const card: Card = {
 		'zh-tw': "赫普"
 	},
 
-	illustrator: "Ken Sugimori",
+	illustrator: "Naoki Saito",
+	rarity: "Character Super Rare",
 	category: "Trainer",
 
 	effect: {

--- a/data-asia/S/SC1a/171.ts
+++ b/data-asia/S/SC1a/171.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,

--- a/data-asia/S/SC1a/172.ts
+++ b/data-asia/S/SC1a/172.ts
@@ -8,7 +8,8 @@ const card: Card = {
 		'zh-tw': "亞洛"
 	},
 
-	illustrator: "take",
+	illustrator: "Hitoshi Ariga",
+	rarity: "Character Super Rare",
 	category: "Trainer",
 
 	effect: {

--- a/data-asia/S/SC1a/172.ts
+++ b/data-asia/S/SC1a/172.ts
@@ -1,5 +1,5 @@
 import { Card } from "../../../interfaces"
-import Set from "../Sc1a"
+import Set from "../SC1a"
 
 const card: Card = {
 	set: Set,


### PR DESCRIPTION
closes #1658 

## Changes

- corrected set import
- added missing attributes: `rarity`, `dexId`, `illustrators`

## Details

- added missing rarity, illustrators and dexids
- referenced data from this (indonesian data set which is same as taiwanese) https://www.tcgcollector.com/sets/11850/sword-and-shield-set-a?setCardCountMode=anyCardVariant&releaseDateOrder=newToOld&displayAs=images

