### PR TITLE
fix(data): restore English name for Aquapolis 128

### DIFF
--- a/data/E-Card/Aquapolis/128.ts
+++ b/data/E-Card/Aquapolis/128.ts
@@ -3,6 +3,7 @@ import Set from '../Aquapolis'
 
 const card: Card = {
 	name: {
+		en: "Memory Berry",
 		de: "Memory Berry",
 		fr: "Baie de mémoire"
 	},


### PR DESCRIPTION
## Summary

- Restores `name.en = "Memory Berry"` for Aquapolis #128.
- The card record already exists and contains English effect text, but the English name is currently absent.
- TCGdex's language compiler excludes cards when the requested language name is missing, so `ecard2-128` is currently omitted from English output.

## Root cause

The English name was unintentionally removed during PR #1373 (`094a3d82df`, *fix(data): complete missing french text for legacy trainer cards*) while translation data was being updated.

## Impact

Before: English Aquapolis emits 185 identities; `ecard2-128` is absent.
After: English Aquapolis emits 186 identities; `ecard2-128` is present as `Memory Berry`.

## Validation

- Repository validation (`tsc --noEmit`) passes.
- The patch changes exactly one card identity in English output.
- No unrelated Aquapolis data is modified.
