### PR TITLE
Add missing German translations for pop6

### DIFF
--- a/data/POP/POP Series 6/1.ts
+++ b/data/POP/POP Series 6/1.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 6'
 const card: Card = {
 	name: {
 		en: "Bastiodon",
-		fr: "Bastiodon"
+		fr: "Bastiodon",
+		de: "Bollterus"
 	},
 
 	illustrator: "Kazuyuki Kano",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Shieldon",
-		fr: "Dinoclier"
+		fr: "Dinoclier",
+		de: "Schilterus"
 	},
 
 	stage: "Stage2",
@@ -32,11 +34,13 @@ const card: Card = {
 			type: "Poke-BODY",
 			name: {
 				en: "Protective Wall",
-				fr: "Mur protecteur"
+				fr: "Mur protecteur",
+				de: "Schutzwall"
 			},
 			effect: {
 				en: "Prevent all damage done to your Benched Pokémon by your opponent's attacks.",
-				fr: "Prévenez tous les dégâts infligés à vos Pokémon de Banc par des attaques de votre adversaire."
+				fr: "Prévenez tous les dégâts infligés à vos Pokémon de Banc par des attaques de votre adversaire.",
+				de: "Verhindere allen Schaden, der Pokémon auf deiner Bank durch gegnerische Angriffe zugefügt wird."
 			},
 		},
 	],
@@ -50,11 +54,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Anger Revenge",
-				fr: "Vengeance furieuse"
+				fr: "Vengeance furieuse",
+				de: "Zornesrache"
 			},
 			effect: {
 				en: "If Bastiodon was damaged by an attack during your opponent's last turn, this attack does 40 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				fr: "Si des dégâts ont été infligés à Bastiodon par une attaque lors du dernier tour de votre adversaire, cette attaque inflige 40 dégâts à 1 des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)"
+				fr: "Si des dégâts ont été infligés à Bastiodon par une attaque lors du dernier tour de votre adversaire, cette attaque inflige 40 dégâts à 1 des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
+				de: "Wenn Bollterus im letzten Zug deines Gegners durch einen Angriff Schaden zugefügt wurde, fügt dieser Angriff 1 Pokémon auf der Bank deines Gegners 40 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 60,
 
@@ -74,7 +80,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "Any frontal attack is repulsed. It is a docile Pokémon that feeds on grass and berries."
+		en: "Any frontal attack is repulsed. It is a docile Pokémon that feeds on grass and berries.",
+		de: "Jeder Frontalangriff wird abgeschmettert. Dieses friedliche PKMN ernährt sich von Gras und Beeren."
 	},
 
 	retreat: 3,

--- a/data/POP/POP Series 6/10.ts
+++ b/data/POP/POP Series 6/10.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 6'
 const card: Card = {
 	name: {
 		en: "Staravia",
-		fr: "Staravia"
+		fr: "Staravia",
+		de: "Staravia"
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Starly",
-		fr: "Étourmi"
+		fr: "Étourmi",
+		de: "Staralili"
 	},
 
 	stage: "Stage1",
@@ -35,11 +37,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Whirlwind",
-				fr: "Cyclone"
+				fr: "Cyclone",
+				de: "Wirbelwind"
 			},
 			effect: {
 				en: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon.",
-				fr: "Votre adversaire échange le Pokémon Défenseur avec 1 des Pokémon de son Banc."
+				fr: "Votre adversaire échange le Pokémon Défenseur avec 1 des Pokémon de son Banc.",
+				de: "Dein Gegner tauscht das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
 			},
 			damage: 20,
 
@@ -51,11 +55,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Clutch",
-				fr: "Serre"
+				fr: "Serre",
+				de: "Greifer"
 			},
 			effect: {
 				en: "The Defending Pokémon can't retreat during your opponent's next turn.",
-				fr: "Le Pokémon Défenseur ne peut pas battre en retraite pendant le prochain tour de votre adversaire."
+				fr: "Le Pokémon Défenseur ne peut pas battre en retraite pendant le prochain tour de votre adversaire.",
+				de: "Das Verteidigende Pokémon kann sich im nächsten Zug deines Gegners nicht zurückziehen."
 			},
 			damage: 20,
 
@@ -75,7 +81,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "It flies around forests and fields in search of bug Pokémon. It stays within a huge flock."
+		en: "It flies around forests and fields in search of bug Pokémon. It stays within a huge flock.",
+		de: "Auf der Suche nach Käfer-PKMN fliegt es über Wiesen und Wälder. Es bleibt in einem großen Schwarm."
 	},
 
 	retreat: 0,

--- a/data/POP/POP Series 6/11.ts
+++ b/data/POP/POP Series 6/11.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 6'
 const card: Card = {
 	name: {
 		en: "Bidoof",
-		fr: "Bidoof"
+		fr: "Bidoof",
+		de: "Bidiza"
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Amnesia",
-				fr: "Amnésie"
+				fr: "Amnésie",
+				de: "Amnesie"
 			},
 			effect: {
 				en: "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn.",
-				fr: "Choisissez 1 des attaques du Pokémon Défenseur. Ce Pokémon ne peut pas utiliser cette attaque lors du prochain tour de votre adversaire."
+				fr: "Choisissez 1 des attaques du Pokémon Défenseur. Ce Pokémon ne peut pas utiliser cette attaque lors du prochain tour de votre adversaire.",
+				de: "Wähle 1 Angriff des Verteidigenden Pokémon. Dieses Pokémon kann den gewählten Angriff im nächsten Zug deines Gegners nicht einsetzen."
 			},
 
 		},
@@ -43,11 +46,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Scavenge",
-				fr: "Farfouille"
+				fr: "Farfouille",
+				de: "Aasfresser"
 			},
 			effect: {
 				en: "Search your discard pile for a Trainer card, show it to your opponent, an put it into your hand.",
-				fr: "Choisissez une carte Dresseur dans votre pile de défausse, montrez-la à votre adversaire et placez-la dans votre main."
+				fr: "Choisissez une carte Dresseur dans votre pile de défausse, montrez-la à votre adversaire et placez-la dans votre main.",
+				de: "Durchsuche deinen Ablagestapel nach einer Trainerkarte, zeige sie deinem Gegner und nimm sie auf die Hand."
 			},
 
 		},
@@ -60,7 +65,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "With nerves of steel, nothing can perturb it. It is more agile and active than it appears."
+		en: "With nerves of steel, nothing can perturb it. It is more agile and active than it appears.",
+		de: "Es hat Nerven wie Drahtseile, nichts kann es erschüttern. Es ist agiler und aktiver, als es scheint."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 6/12.ts
+++ b/data/POP/POP Series 6/12.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 6'
 const card: Card = {
 	name: {
 		en: "Buneary",
-		fr: "Buneary"
+		fr: "Buneary",
+		de: "Haspiror"
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -29,7 +30,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Splash",
-				fr: "Trempette"
+				fr: "Trempette",
+				de: "Platscher"
 			},
 
 			damage: 10,
@@ -42,11 +44,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Jump Kick",
-				fr: "Pied Sauté"
+				fr: "Pied Sauté",
+				de: "Sprungkick"
 			},
 			effect: {
 				en: "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				fr: "Inflige 10 dégâts à 1 des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)"
+				fr: "Inflige 10 dégâts à 1 des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 1 Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 10,
 
@@ -60,7 +64,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "It slams foes by sharply uncoiling is rolled ears. It stings enough to make a grown-up cry in pain."
+		en: "It slams foes by sharply uncoiling is rolled ears. It stings enough to make a grown-up cry in pain.",
+		de: "Es entrollt seine Ohren sehr schnell, um seine Gegner schmerzhaft zu schlagen."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 6/13.ts
+++ b/data/POP/POP Series 6/13.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 6'
 const card: Card = {
 	name: {
 		en: "Cherubi",
-		fr: "Cherubi"
+		fr: "Cherubi",
+		de: "Kikugi"
 	},
 
 	illustrator: "Atsuko Nishida",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Sleep Powder",
-				fr: "Poudre dodo"
+				fr: "Poudre dodo",
+				de: "Schlafpuder"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
-				fr: "Le Pokémon Défenseur est maintenant Endormi."
+				fr: "Le Pokémon Défenseur est maintenant Endormi.",
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 
 		},
@@ -44,11 +47,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Leech Seed",
-				fr: "Vampigraine"
+				fr: "Vampigraine",
+				de: "Egelsamen"
 			},
 			effect: {
 				en: "If this attack does any damage to the Defending Pokémon (after applying Weakness and Resistance), remove 1 damage counter from Cherubi.",
-				fr: "Si cette attaque inflige des dégâts au Pokémon Défenseur (après application de la Faiblesse et de la Résistance), retirez 1 marqueur de dégât à Ceribou."
+				fr: "Si cette attaque inflige des dégâts au Pokémon Défenseur (après application de la Faiblesse et de la Résistance), retirez 1 marqueur de dégât à Ceribou.",
+				de: "Falls dieser Angriff dem Verteidigenden Pokémon Schaden zufügt (nachdem Schwäche und Resistenz verrechnet wurden), entferne 1 Schadensmarke von Kikugi."
 			},
 			damage: 20,
 
@@ -68,7 +73,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "The small ball holds the nutrients needed for evolution. Apparently, it is very sweet and tasty."
+		en: "The small ball holds the nutrients needed for evolution. Apparently, it is very sweet and tasty.",
+		de: "Das kleine Bällchen enthält alles, was es für die Entwicklung braucht. Es ist süß und lecker."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 6/14.ts
+++ b/data/POP/POP Series 6/14.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 6'
 const card: Card = {
 	name: {
 		en: "Chimchar",
-		fr: "Chimchar"
+		fr: "Chimchar",
+		de: "Panflam"
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -27,7 +28,8 @@ const card: Card = {
 
 			name: {
 				en: "Scratch",
-				fr: "Griffe"
+				fr: "Griffe",
+				de: "Kratzer"
 			},
 
 			damage: 10,
@@ -40,11 +42,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Ember",
-				fr: "Flammèche"
+				fr: "Flammèche",
+				de: "Glut"
 			},
 			effect: {
 				en: "Flip a coin. If heads discard a Fire Energy attached to Chimchar.",
-				fr: "Lancez une pièce. Si c'est pile, défaussez une Énergie  attachée à Ouisticram."
+				fr: "Lancez une pièce. Si c'est pile, défaussez une Énergie  attachée à Ouisticram.",
+				de: "Wirf 1 Münze. Bei „Zahl“ lege eine {R}-Energie, die an Panflam angelegt ist, auf deinen Ablagestapel."
 			},
 			damage: 30,
 
@@ -58,7 +62,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "It agilely scales cliffs to live atop craggy mountains. Its fire is put out when it sleeps."
+		en: "It agilely scales cliffs to live atop craggy mountains. Its fire is put out when it sleeps.",
+		de: "Es klettert behände steile Felsen hinauf, um auf Bergen zu leben. Sein Feuer ist aus, wenn es schläft."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 6/15.ts
+++ b/data/POP/POP Series 6/15.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 6'
 const card: Card = {
 	name: {
 		en: "Piplup",
-		fr: "Piplup"
+		fr: "Piplup",
+		de: "Plinfa"
 	},
 
 	illustrator: "Atsuko Nishida",
@@ -27,7 +28,8 @@ const card: Card = {
 
 			name: {
 				en: "Peck",
-				fr: "Picpic"
+				fr: "Picpic",
+				de: "Schnabel"
 			},
 
 			damage: 10,
@@ -40,11 +42,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Water Spash",
-				fr: "Éclaboussure"
+				fr: "Éclaboussure",
+				de: "Wasserplatscher"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 10 more damage.",
-				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires."
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -58,7 +62,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "Because it is very proud, it hates accepting food from people. Its thick down guards it from cold."
+		en: "Because it is very proud, it hates accepting food from people. Its thick down guards it from cold.",
+		de: "Es ist sehr stolz und nimmt daher kein Futter von anderen an. Seine dicken Daunen schützen vor Kälte."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 6/16.ts
+++ b/data/POP/POP Series 6/16.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 6'
 const card: Card = {
 	name: {
 		en: "Starly",
-		fr: "Starly"
+		fr: "Starly",
+		de: "Staralili"
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -29,7 +30,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Gust",
-				fr: "Tornade"
+				fr: "Tornade",
+				de: "Windstoß"
 			},
 
 			damage: 10,
@@ -42,11 +44,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Quick Attack",
-				fr: "Vive-attaque"
+				fr: "Vive-attaque",
+				de: "Ruckzuckhieb"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage.",
-				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires."
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -66,7 +70,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "They flock in great numbers. Though small, they flap their wings with great power."
+		en: "They flock in great numbers. Though small, they flap their wings with great power.",
+		de: "Ihr Schwarm ist stets groß. Obwohl es kleine PKMN sind, schwingen sie ihre Flügel mit enormer Kraft."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 6/17.ts
+++ b/data/POP/POP Series 6/17.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 6'
 const card: Card = {
 	name: {
 		en: "Turtwig",
-		fr: "Turtwig"
+		fr: "Turtwig",
+		de: "Chelast"
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -27,7 +28,8 @@ const card: Card = {
 
 			name: {
 				en: "Tackle",
-				fr: "Charge"
+				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 10,
@@ -39,7 +41,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Razor Leaf",
-				fr: "Tranch'herbe"
+				fr: "Tranch'herbe",
+				de: "Rasierblatt"
 			},
 
 			damage: 20,
@@ -60,7 +63,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "Made from soil, the shell on its back hardens when it drinks water. It lives along lakes."
+		en: "Made from soil, the shell on its back hardens when it drinks water. It lives along lakes.",
+		de: "Es besteht aus Erdreich. Trinkt es Wasser, verhärtet sich der Panzer auf seinem Rücken. Es lebt an Seen."
 	},
 
 	retreat: 2,

--- a/data/POP/POP Series 6/2.ts
+++ b/data/POP/POP Series 6/2.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 6'
 const card: Card = {
 	name: {
 		en: "Lucario",
-		fr: "Lucario"
+		fr: "Lucario",
+		de: "Lucario"
 	},
 
 	illustrator: "Kouki Saitou",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Riolu",
-		fr: "Riolu"
+		fr: "Riolu",
+		de: "Riolu"
 	},
 
 	stage: "Stage1",
@@ -34,11 +36,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Feint",
-				fr: "Ruse"
+				fr: "Ruse",
+				de: "Offenlegung"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by Resistance.",
-				fr: "Les dégâts de cette attaque ne sont pas affectés par la Résistance."
+				fr: "Les dégâts de cette attaque ne sont pas affectés par la Résistance.",
+				de: "Der Schaden dieses Angriffs wird durch die Resistenz des Verteidigenden Pokémon nicht verändert."
 			},
 			damage: 30,
 
@@ -50,11 +54,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Aura Sphere",
-				fr: "Aurasphère"
+				fr: "Aurasphère",
+				de: "Aurasphäre"
 			},
 			effect: {
 				en: "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				fr: "Inflige 20 dégâts à 1 des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)"
+				fr: "Inflige 20 dégâts à 1 des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 1 Pokémon auf der Bank deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 40,
 
@@ -68,7 +74,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "It has the ability to sense the auras of all things. It understands human speech."
+		en: "It has the ability to sense the auras of all things. It understands human speech.",
+		de: "Es besitzt die Fähigkeit, die Aura aller Dinge zu spüren. Es versteht die menschliche Sprache."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 6/3.ts
+++ b/data/POP/POP Series 6/3.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 6'
 const card: Card = {
 	name: {
 		en: "Manaphy",
-		fr: "Manaphy"
+		fr: "Manaphy",
+		de: "Manaphy"
 	},
 
 	illustrator: "Atsuko Nishida",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Call for Family",
-				fr: "Appel à la famille"
+				fr: "Appel à la famille",
+				de: "Familienruf"
 			},
 			effect: {
 				en: "Search your deck for a Basic Pokémon and put it onto your Bench. Shuffle your deck afterward.",
-				fr: "Choisissez dans votre deck un Pokémon de Base et placez-le sur votre Banc. Ensuite, mélangez votre deck."
+				fr: "Choisissez dans votre deck un Pokémon de Base et placez-le sur votre Banc. Ensuite, mélangez votre deck.",
+				de: "Durchsuche dein Deck nach 1 Basis-Pokémon-Karte und lege sie auf deine Bank. Mische dein Deck danach."
 			},
 
 		},
@@ -44,11 +47,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Aqua Ring",
-				fr: "Anneau hydro"
+				fr: "Anneau hydro",
+				de: "Wasserring"
 			},
 			effect: {
 				en: "Switch Manaphy with 1 of your Benched Pokémon.",
-				fr: "Échangez Manaphy avec 1 des Pokémon de votre Banc."
+				fr: "Échangez Manaphy avec 1 des Pokémon de votre Banc.",
+				de: "Tausche Manaphy gegen 1 Pokémon auf deiner Bank aus."
 			},
 			damage: 30,
 
@@ -62,7 +67,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "Born on a cold seafloor, it will swim great distances to return to its birthplace."
+		en: "Born on a cold seafloor, it will swim great distances to return to its birthplace.",
+		de: "Geboren auf dem Meeresboden, legt es große Entfernungen zurück, um dorthin zurückzukehren."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 6/4.ts
+++ b/data/POP/POP Series 6/4.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 6'
 const card: Card = {
 	name: {
 		en: "Pachirisu",
-		fr: "Pachirisu"
+		fr: "Pachirisu",
+		de: "Pachirisu"
 	},
 
 	illustrator: "Atsuko Nishida",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Minor Errand-Running",
-				fr: "Rendez-vous mineur"
+				fr: "Rendez-vous mineur",
+				de: "Kleine Besorgung"
 			},
 			effect: {
 				en: "Search your deck for a basic Energy card, show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
-				fr: "Choisissez dans votre deck une Carte Énergie de base, montrez-la à votre adversaire et placez-la dans votre main. Ensuite, mélangez votre deck."
+				fr: "Choisissez dans votre deck une Carte Énergie de base, montrez-la à votre adversaire et placez-la dans votre main. Ensuite, mélangez votre deck.",
+				de: "Durchsuche dein Deck nach einer Basis-Energiekarte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 			},
 
 		},
@@ -43,11 +46,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Thunder Jolt",
-				fr: "Secousse tonnerre"
+				fr: "Secousse tonnerre",
+				de: "Donnerrüttler"
 			},
 			effect: {
 				en: "Flip a coin. If tails, Pachirisu does 10 damage to itself.",
-				fr: "Lancez une pièce. Si c'est pile, Pachirisu s'inflige 10 dégâts."
+				fr: "Lancez une pièce. Si c'est pile, Pachirisu s'inflige 10 dégâts.",
+				de: "Wirf 1 Münze. Bei „Zahl“ fügt sich Pachirisu selbst 10 Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -67,7 +72,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "It makes fur balls that crackle with static electricity. It stores them with berries in tree holes."
+		en: "It makes fur balls that crackle with static electricity. It stores them with berries in tree holes.",
+		de: "Es bildet ein Fellknäuel, der vor statischer Energie knistert. Es speichert die Energie in Bäumen."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 6/5.ts
+++ b/data/POP/POP Series 6/5.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 6'
 const card: Card = {
 	name: {
 		en: "Rampardos",
-		fr: "Rampardos"
+		fr: "Rampardos",
+		de: "Rameidon"
 	},
 
 	illustrator: "Kazuyuki Kano",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Cherrim",
-		fr: "Kranidos"
+		fr: "Kranidos",
+		de: "Koknodon"
 	},
 
 	stage: "Stage2",
@@ -35,11 +37,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Assurance",
-				fr: "Assurance"
+				fr: "Assurance",
+				de: "Gewissheit"
 			},
 			effect: {
 				en: "As long as the Defending Pokémon's remaining HP is 60 or less, this attack's base damage is 60 instead of 30.",
-				fr: "Tant qu'il reste un maximum de 60 PV au Pokémon Défenseur, les dégâts de base de cette attaque sont de 60 au lieu de 30."
+				fr: "Tant qu'il reste un maximum de 60 PV au Pokémon Défenseur, les dégâts de base de cette attaque sont de 60 au lieu de 30.",
+				de: "Solange die verbliebenen KP des Verteidigenden Pokémon 60 oder weniger betragen, beträgt der Grundschaden dieses Angriffs 60 Schadenspunkte anstelle von 30 Schadenspunkten."
 			},
 			damage: 30,
 
@@ -52,11 +56,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Hasty Headbutt",
-				fr: "Coup d'boule rapide"
+				fr: "Coup d'boule rapide",
+				de: "Hastige Kopfnuss"
 			},
 			effect: {
 				en: "Rampardos does 20 damage to itself. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon.",
-				fr: "Charkos s'inflige 20 dégâts. Les dégâts de cette attaque ne sont pas affectés par la Faiblesse, la Résistance, les Poké-Power, les Poké-Bodies ou tout autre effet sur le Pokémon Défenseur."
+				fr: "Charkos s'inflige 20 dégâts. Les dégâts de cette attaque ne sont pas affectés par la Faiblesse, la Résistance, les Poké-Power, les Poké-Bodies ou tout autre effet sur le Pokémon Défenseur.",
+				de: "Rameidon fügt sich selbst 20 Schadenspunkte zu. Schwäche, Resistenz, Poké-Power, Poké-Body und alle anderen Effekte auf dem Verteidigenden Pokémon haben keine Auswirkungen auf die Schadenspunkte dieses Angriffs."
 			},
 			damage: 100,
 
@@ -70,7 +76,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "Its powerful head butt has enough power to shatter even the most durable things upon impact."
+		en: "Its powerful head butt has enough power to shatter even the most durable things upon impact.",
+		de: "Sein kräftiger Kopfstoß hat genug Kraft, um selbst die stabilsten Dinge zu zerschmettern."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 6/6.ts
+++ b/data/POP/POP Series 6/6.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 6'
 const card: Card = {
 	name: {
 		en: "Drifloon",
-		fr: "Drifloon"
+		fr: "Drifloon",
+		de: "Driftlon"
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Blowing Wind",
-				fr: "Vent violent"
+				fr: "Vent violent",
+				de: "Windböe"
 			},
 			effect: {
 				en: "Flip a coin. If heads, put 1 of your Benched Pokémon and all cards attached to it on top of your deck. Shuffle your deck afterward.",
-				fr: "Lancez une pièce. Si c'est face, placez 1 de vos Pokémon de Banc et toutes les cartes qui lui sont attachées au dessus de votre deck. Ensuite, mélangez votre deck."
+				fr: "Lancez une pièce. Si c'est face, placez 1 de vos Pokémon de Banc et toutes les cartes qui lui sont attachées au dessus de votre deck. Ensuite, mélangez votre deck.",
+				de: "Wirf 1 Münze. Bei „Kopf“ lege 1 der Pokémon auf deiner Bank und alle an es angelegten Karten auf dein Deck. Mische dein Deck danach."
 			},
 
 		},
@@ -44,11 +47,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Ominous Wind",
-				fr: "Vent Mauvais"
+				fr: "Vent Mauvais",
+				de: "Unheilböen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused and can't retreat during your opponent's next turn.",
-				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus et ne peut pas battre en retraite lors du prochain tour de votre adversaire."
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus et ne peut pas battre en retraite lors du prochain tour de votre adversaire.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt und kann sich im nächsten Zug deines Gegners nicht zurückziehen."
 			},
 			damage: 10,
 
@@ -68,7 +73,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "A Pokémon formed by the spirits of people and Pokémon. It loves damp, humid seasons."
+		en: "A Pokémon formed by the spirits of people and Pokémon. It loves damp, humid seasons.",
+		de: "Ein PKMN, entstanden aus den Gefühlen von Menschen und PKMN. Es mag feuchte Jahreszeiten."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 6/7.ts
+++ b/data/POP/POP Series 6/7.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 6'
 const card: Card = {
 	name: {
 		en: "Gible",
-		fr: "Gible"
+		fr: "Gible",
+		de: "Kaumalat"
 	},
 
 	illustrator: "Kouki Saitou",
@@ -31,12 +32,14 @@ const card: Card = {
 
 			name: {
 				en: "Surprise Attack",
-				fr: "Attaque surprise"
+				fr: "Attaque surprise",
+				de: "Sinelbeere"
 			},
 
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
-				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet."
+				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet.",
+				de: "Entferne am Ende deines Zuges 1 Schadensmarke von Kaumalat."
 			},
 
 			damage: 30,

--- a/data/POP/POP Series 6/8.ts
+++ b/data/POP/POP Series 6/8.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 6'
 const card: Card = {
 	name: {
 		en: "Riolu",
-		fr: "Riolu"
+		fr: "Riolu",
+		de: "Riolu"
 	},
 
 	illustrator: "Kouki Saitou",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Wild Kick",
-				fr: "Coup déchaîné"
+				fr: "Coup déchaîné",
+				de: "Stürmischer Kick"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
-				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet."
+				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet.",
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 30,
 
@@ -47,7 +50,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "The aura that emanates from its body intensifies to alert others if it is afraid or sad."
+		en: "The aura that emanates from its body intensifies to alert others if it is afraid or sad.",
+		de: "Die Aura, die dieses PKMN umgibt, verstärkt sich, wenn es zeigen will, dass es ängstlich oder traurig ist."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 6/9.ts
+++ b/data/POP/POP Series 6/9.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 6'
 const card: Card = {
 	name: {
 		en: "Pikachu",
-		fr: "Pikachu"
+		fr: "Pikachu",
+		de: "Pikachu"
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -30,11 +31,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Spark",
-				fr: "Étincelle"
+				fr: "Étincelle",
+				de: "Sinelbeere"
 			},
 			effect: {
 				en: "Does 10 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				fr: "Inflige 10 dégâts à 2 des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)"
+				fr: "Inflige 10 dégâts à 2 des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
+				de: "Entferne am Ende deines Zuges 1 Schadensmarke von Pikachu."
 			},
 			damage: 10,
 


### PR DESCRIPTION
## Add missing German translations for pop6

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
