### PR TITLE
Add missing German translations for pop3

### DIFF
--- a/data/POP/POP Series 3/1.ts
+++ b/data/POP/POP Series 3/1.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 3'
 const card: Card = {
 	name: {
 		en: "Blastoise",
-		fr: "Tortank"
+		fr: "Tortank",
+		de: "Turtok"
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Wartortle",
-		fr: "Carabaffe"
+		fr: "Carabaffe",
+		de: "Schillok"
 	},
 
 	stage: "Stage2",
@@ -35,11 +37,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Smash Turn",
-				fr: "Tour fracassant"
+				fr: "Tour fracassant",
+				de: "Abdrehender Schmetterer"
 			},
 			effect: {
 				en: "After your attack, you may switch Blastoise with 1 of your Benched Pokémon.",
-				fr: "Après votre attaque, vous pouvez échanger Tortank avec 1 des Pokémon de votre Banc."
+				fr: "Après votre attaque, vous pouvez échanger Tortank avec 1 des Pokémon de votre Banc.",
+				de: "Nach deinem Angriff kannst du Turtok gegen 1 Pokémon auf deiner Bank austauschen."
 			},
 			damage: 30,
 
@@ -53,11 +57,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Rocket Tackle",
-				fr: "Lance roquette"
+				fr: "Lance roquette",
+				de: "Raketenstart"
 			},
 			effect: {
 				en: "Blastoise does 10 damage to itself. Flip a coin. If heads, prevent all damage done to Blastoise by attacks during your opponent's next turn.",
-				fr: "Tortank s'inflige 10 dégâts. Lancez une pièce. Si c'est face, prévenez tous les dégâts infligés à Tortank par des attaques lors du prochain tour de votre adversaire."
+				fr: "Tortank s'inflige 10 dégâts. Lancez une pièce. Si c'est face, prévenez tous les dégâts infligés à Tortank par des attaques lors du prochain tour de votre adversaire.",
+				de: "Turtok fügt sich selbst 10 Schadenspunkte zu. Wirf 1 Münze. Verhindere bei „Kopf“ allen Schaden, der Turtok während des nächsten Zuges durch Angriffe deines Gegners zugefügt wird."
 			},
 			damage: 60,
 

--- a/data/POP/POP Series 3/10.ts
+++ b/data/POP/POP Series 3/10.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 3'
 const card: Card = {
 	name: {
 		en: "High Pressure System",
-		fr: "Système à haute pression"
+		fr: "Système à haute pression",
+		de: "Hochdrucksystem"
 	},
 
 	illustrator: "Ken Ikuji",
@@ -14,7 +15,8 @@ const card: Card = {
 
 	effect: {
 		en: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card. Each player pays Colorless less to retreat his or her Fire and Water Pokémon.",
-		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez-la si une autre carte Stade est mise en jeu. Si une autre carte comportant le même nom est en jeu, vous ne pouvez pas jouer cette carte.\n\nChaque joueur ne paye pas de  pour faire battre en retraite ses Pokémon  et ."
+		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez-la si une autre carte Stade est mise en jeu. Si une autre carte comportant le même nom est en jeu, vous ne pouvez pas jouer cette carte.\n\nChaque joueur ne paye pas de  pour faire battre en retraite ses Pokémon  et .",
+		de: "Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadion-Karte ins Spiel kommt. Wenn sich bereits eine Karte mit diesem Namen im Spiel befindet, kannst du diese Karte nicht spielen. Jeder Spieler bezahlt {C} weniger, um seine {R} und {W} Pokémon zurückzuziehen."
 	},
 
 	trainerType: "Stadium",

--- a/data/POP/POP Series 3/11.ts
+++ b/data/POP/POP Series 3/11.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 3'
 const card: Card = {
 	name: {
 		en: "Low Pressure System",
-		fr: "Système à basse pression"
+		fr: "Système à basse pression",
+		de: "Tiefdrucksystem"
 	},
 
 	illustrator: "Shin-ichi Yoshikawa",
@@ -14,7 +15,8 @@ const card: Card = {
 
 	effect: {
 		en: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card. Each Grass and Lightning Pokémon in play (both yours and your opponent's) gets +10 HP.",
-		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez-la si une autre carte Stade est mise en jeu. Si une autre carte comportant le même nom est en jeu, vous ne pouvez pas jouer cette carte.\n\nChaque Pokémon  et  en jeu (les vôtres et ceux de votre adversaire) obtient 10 PV de plus."
+		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez-la si une autre carte Stade est mise en jeu. Si une autre carte comportant le même nom est en jeu, vous ne pouvez pas jouer cette carte.\n\nChaque Pokémon  et  en jeu (les vôtres et ceux de votre adversaire) obtient 10 PV de plus.",
+		de: "Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadion-Karte ins Spiel kommt. Wenn sich bereits eine Karte mit diesem Namen im Spiel befindet, kannst du diese Karte nicht spielen. Alle {G} und {L} Pokémon im Spiel (deine und die deines Gegners) erhalten + 10 KP."
 	},
 
 	trainerType: "Stadium",

--- a/data/POP/POP Series 3/12.ts
+++ b/data/POP/POP Series 3/12.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 3'
 const card: Card = {
 	name: {
 		en: "Ditto",
-		fr: "Metamorph"
+		fr: "Metamorph",
+		de: "Ditto"
 	},
 
 	illustrator: "Yuka Morii",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Psybeam",
-				fr: "Rafale psy"
+				fr: "Rafale psy",
+				de: "Psystrahl"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
-				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus."
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: 20,
 
@@ -51,12 +54,14 @@ const card: Card = {
 
 		name: {
 			en: "Duplicate",
-			fr: "Duplicata"
+			fr: "Duplicata",
+			de: "Duplizieren"
 		},
 
 		effect: {
 			en: "Once during your turn (before your attack), you may search your deck for another Ditto and switch it with Ditto. (Any cards attached to Ditto, damage counters, Special Conditions, and effects on it are now on the new Pokémon.) If you do, put Ditto on top of your deck. Shuffle your deck afterward. You can’t use more than 1 Duplicate Poké-Power each turn.",
-			fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez chercher dans votre deck un autre Metamorph et l'échanger avec Metamorph. (Toutes les cartes attachées à Metamorph, marqueurs de dégât, États Spéciaux et autres effets se trouvent maintenant sur le nouveau Pokémon.) Placez alors Metamorph au dessus de votre deck. Ensuite, mélangez votre deck. Vous ne pouvez pas utiliser plus d'1 Poké-Power Duplicata par tour."
+			fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez chercher dans votre deck un autre Metamorph et l'échanger avec Metamorph. (Toutes les cartes attachées à Metamorph, marqueurs de dégât, États Spéciaux et autres effets se trouvent maintenant sur le nouveau Pokémon.) Placez alors Metamorph au dessus de votre deck. Ensuite, mélangez votre deck. Vous ne pouvez pas utiliser plus d'1 Poké-Power Duplicata par tour.",
+			de: "Einmal während deines Zuges (vor deinem Angriff) kannst du dein Deck nach einer anderen Ditto Karte durchsuchen und diese gegen Ditto austauschen. (Alle an Ditto angelegten Karten sowie Schadensmarken, Spezielle Zustände und Effekte auf Ditto werden auf das neue Ditto übertragen.) Wenn du dies machst, lege Ditto auf dein Deck. Mische dein Deck danach. Du kannst nicht mehr als 1 Duplizieren Poké-Power pro Zug einsetzen."
 		}
 	}],
 

--- a/data/POP/POP Series 3/13.ts
+++ b/data/POP/POP Series 3/13.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 3'
 const card: Card = {
 	name: {
 		en: "Eevee",
-		fr: "Evoli"
+		fr: "Evoli",
+		de: "Evoli"
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -29,7 +30,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Tackle",
-				fr: "Charge"
+				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 10,
@@ -42,11 +44,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Take Down",
-				fr: "Bélier"
+				fr: "Bélier",
+				de: "Bodycheck"
 			},
 			effect: {
 				en: "Eevee does 10 damage to itself.",
-				fr: "Evoli s'inflige 10 dégâts."
+				fr: "Evoli s'inflige 10 dégâts.",
+				de: "Evoli fügt sich selbst 10 Schadenspunkte zu."
 			},
 			damage: 30,
 

--- a/data/POP/POP Series 3/14.ts
+++ b/data/POP/POP Series 3/14.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 3'
 const card: Card = {
 	name: {
 		en: "Ivysaur",
-		fr: "Herbizarre"
+		fr: "Herbizarre",
+		de: "Bisaknosp"
 	},
 
 	illustrator: "Midori Harada",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Gouge",
-				fr: "Griffes rétractiles"
+				fr: "Griffes rétractiles",
+				de: "Klauen ausfahren"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 10 more damage.",
-				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires."
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -46,11 +49,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Poisonpowder",
-				fr: "Poudre Toxik"
+				fr: "Poudre Toxik",
+				de: "Giftpuder"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned.",
-				fr: "Le Pokémon Défenseur est maintenant Empoisonné."
+				fr: "Le Pokémon Défenseur est maintenant Empoisonné.",
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet."
 			},
 			damage: 40,
 

--- a/data/POP/POP Series 3/15.ts
+++ b/data/POP/POP Series 3/15.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 3'
 const card: Card = {
 	name: {
 		en: "Marshtomp",
-		fr: "Flobio"
+		fr: "Flobio",
+		de: "Moorabbel"
 	},
 
 	illustrator: "Midori Harada",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Mudkip",
-		fr: "Gobou"
+		fr: "Gobou",
+		de: "Hydropi"
 	},
 
 	stage: "Stage1",
@@ -34,7 +36,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Mud Slap",
-				fr: "Coud'boue"
+				fr: "Coud'boue",
+				de: "Lehmschelle"
 			},
 
 			damage: 20,
@@ -48,11 +51,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Double-edge",
-				fr: "Damoclès"
+				fr: "Damoclès",
+				de: "Austeiler"
 			},
 			effect: {
 				en: "Marshtomp does 10 damage to itself.",
-				fr: "Flobio s'inflige 10 dégâts."
+				fr: "Flobio s'inflige 10 dégâts.",
+				de: "Moorabbel fügt sich selbst 10 Schadenspunkte zu."
 			},
 			damage: 40,
 

--- a/data/POP/POP Series 3/16.ts
+++ b/data/POP/POP Series 3/16.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 3'
 const card: Card = {
 	name: {
 		en: "Pichu Bros.",
-		fr: "Pichu Bros."
+		fr: "Pichu Bros.",
+		de: "Gebrüder Pichu"
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -30,11 +31,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Bustle",
-				fr: "Remue-ménage"
+				fr: "Remue-ménage",
+				de: "Hetzen"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads. If either coin is heads, the Defending Pokémon is now Confused.",
-				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces. Si vous obtenez au moins 1 face, le Pokémon Défenseur est maintenant Confus."
+				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces. Si vous obtenez au moins 1 face, le Pokémon Défenseur est maintenant Confus.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu. Wenn mindestens einer der Würfe „Kopf“ zeigt, ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: "20×",
 

--- a/data/POP/POP Series 3/17.ts
+++ b/data/POP/POP Series 3/17.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 3'
 const card: Card = {
 	name: {
 		en: "Ho-Oh ex",
-		fr: "Ho-Oh ex"
+		fr: "Ho-Oh ex",
+		de: "Ho-oh ex"
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -27,11 +28,13 @@ const card: Card = {
 			type: "Poke-POWER",
 			name: {
 				en: "Golden Wing",
-				fr: "Aile dorée"
+				fr: "Aile dorée",
+				de: "Goldener Flügel"
 			},
 			effect: {
 				en: "If Ho-Oh ex would be Knocked Out by damage from an opponent's attack, you may move up to 2 Energy attached to Ho-Oh ex to your Pokémon in any way you like.",
-				fr: "Si Ho-Oh ex doit être mis K.O par les dégâts d'une attaque de votre adversaire, vous pouvez déplacer jusqu'à 2 Énergies attachées à Ho-Oh ex sur vos Pokémon, de la façon que vous voulez."
+				fr: "Si Ho-Oh ex doit être mis K.O par les dégâts d'une attaque de votre adversaire, vous pouvez déplacer jusqu'à 2 Énergies attachées à Ho-Oh ex sur vos Pokémon, de la façon que vous voulez.",
+				de: "Wenn Ho-Oh ex durch die Schadenspunkte eines gegnerischen Angriffs kampfunfähig gemacht würde, kannst du bis zu 2 Energiekarten, die an Ho-Oh ex angelegt sind, auf beliebige Weise an deine Pokémon anlegen."
 			},
 		},
 	],
@@ -45,11 +48,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Rainbow Burn",
-				fr: "Brûlure arcenciel"
+				fr: "Brûlure arcenciel",
+				de: "Regenbogenfeuer"
 			},
 			effect: {
 				en: "Does 10 damage plus 20 more damage for each type of basic Energy card attached to Ho-Oh ex.",
-				fr: "Inflige 10 dégâts plus 20 dégâts supplémentaires pour chaque type de carte Énergie de base attaché à Ho-Oh ex."
+				fr: "Inflige 10 dégâts plus 20 dégâts supplémentaires pour chaque type de carte Énergie de base attaché à Ho-Oh ex.",
+				de: "Dieser Angriff fügt 10 Schadenspunkte plus 20 weitere Schadenspunkte für jede unterschiedliche Sorte Basis-Energiekarten, die an Ho-Oh ex angelegt sind, zu."
 			},
 			damage: "10+",
 

--- a/data/POP/POP Series 3/2.ts
+++ b/data/POP/POP Series 3/2.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 3'
 const card: Card = {
 	name: {
 		en: "Flareon",
-		fr: "Pyroli"
+		fr: "Pyroli",
+		de: "Flamara"
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Eevee",
-		fr: "Evoli"
+		fr: "Evoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -35,11 +37,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Quick Attack",
-				fr: "Vive-attaque"
+				fr: "Vive-attaque",
+				de: "Ruckzuckhieb"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage.",
-				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires."
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -52,11 +56,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Fire Spin",
-				fr: "Danseflamme"
+				fr: "Danseflamme",
+				de: "Feuerwirbel"
 			},
 			effect: {
 				en: "Discard 2 basic Energy cards attached to Flareon or this attack does nothing.",
-				fr: "Défaussez 2 cartes Énergie de base attachées à Pyroli ou cette attaque est sans effet."
+				fr: "Défaussez 2 cartes Énergie de base attachées à Pyroli ou cette attaque est sans effet.",
+				de: "Entferne 2 Basis-Energiekarten von Flamara und lege sie auf den Ablagestapel, sonst hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 70,
 

--- a/data/POP/POP Series 3/3.ts
+++ b/data/POP/POP Series 3/3.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 3'
 const card: Card = {
 	name: {
 		en: "Jolteon",
-		fr: "Voltali"
+		fr: "Voltali",
+		de: "Blitza"
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Eevee",
-		fr: "Evoli"
+		fr: "Evoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -35,11 +37,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Thundershock",
-				fr: "Éclair"
+				fr: "Éclair",
+				de: "Donnerschock"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
-				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé."
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -52,11 +56,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Pin Missile",
-				fr: "Dard-nuée"
+				fr: "Dard-nuée",
+				de: "Nadelrakete"
 			},
 			effect: {
 				en: "Flip 4 coins. This attack does 20 damage times the number of heads.",
-				fr: "Lancez 4 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces."
+				fr: "Lancez 4 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
+				de: "Wirf 4 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 

--- a/data/POP/POP Series 3/4.ts
+++ b/data/POP/POP Series 3/4.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 3'
 const card: Card = {
 	name: {
 		en: "Minun",
-		fr: "Negapi"
+		fr: "Negapi",
+		de: "Minun"
 	},
 
 	illustrator: "Sumiyoshi Kizuki",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Cheer Up",
-				fr: "Courage !"
+				fr: "Courage !",
+				de: "Aufmuntern"
 			},
 			effect: {
 				en: "Draw a card. If you have Plusle in play, draw 2 cards instead.",
-				fr: "Piochez une carte. Si vous avez Posipi en jeu, piochez 2 cartes à la place."
+				fr: "Piochez une carte. Si vous avez Posipi en jeu, piochez 2 cartes à la place.",
+				de: "Ziehe 1 Karte. Wenn du Plusle im Spiel hast, ziehe 2 Karten."
 			},
 
 		},
@@ -44,11 +47,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Negative Ion",
-				fr: "Ion négatif"
+				fr: "Ion négatif",
+				de: "Negatives Ion"
 			},
 			effect: {
 				en: "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 10 (before applying Weakness and Resistance).",
-				fr: "Lors du prochain tour de votre adversaire, tous dégâts infligés par des attaques du Pokémon Défenseur sont réduits de 10 (avant application de la Faiblesse et de la Résistance)."
+				fr: "Lors du prochain tour de votre adversaire, tous dégâts infligés par des attaques du Pokémon Défenseur sont réduits de 10 (avant application de la Faiblesse et de la Résistance).",
+				de: "Während des nächsten Zuges deines Gegners werden alle Schadenspunkte, die vom Verteidigenden Pokémon zugefügt werden, um 10 Schadenspunkte reduziert (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 			damage: 20,
 
@@ -60,11 +65,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Power Bolt",
-				fr: "« Boulon d'alimentation »"
+				fr: "« Boulon d'alimentation »",
+				de: "Powerbolzen"
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon that has any Poké-Powers. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				fr: "Choisissez 1 des Pokémon de votre adversaire qui a un Poké-Power. Cette attaque inflige 30 dégâts à ce Pokémon. (N'appliquez pas la Faiblesse et la Résistance aux Pokémon de Banc.)"
+				fr: "Choisissez 1 des Pokémon de votre adversaire qui a un Poké-Power. Cette attaque inflige 30 dégâts à ce Pokémon. (N'appliquez pas la Faiblesse et la Résistance aux Pokémon de Banc.)",
+				de: "Wähle 1 Pokémon deines Gegners aus, das eine Poké-Power besitzt. Dieser Angriff fügt dem gewählten Pokémon 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			}
 
 		},

--- a/data/POP/POP Series 3/5.ts
+++ b/data/POP/POP Series 3/5.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 3'
 const card: Card = {
 	name: {
 		en: "Plusle",
-		fr: "Posipi"
+		fr: "Posipi",
+		de: "Plusle"
 	},
 
 	illustrator: "Sumiyoshi Kizuki",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Cheer Up",
-				fr: "Courage !"
+				fr: "Courage !",
+				de: "Aufmuntern"
 			},
 			effect: {
 				en: "Draw a card. If you have Minun in play, draw 2 cards instead.",
-				fr: "Piochez une carte. Si vous avez Négapi en jeu, piochez 2 cartes à la place."
+				fr: "Piochez une carte. Si vous avez Négapi en jeu, piochez 2 cartes à la place.",
+				de: "Ziehe 1 Karte. Wenn du Minun im Spiel hast, ziehe 2 Karten."
 			},
 
 		},
@@ -44,11 +47,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Positive Ion",
-				fr: "Ion positif"
+				fr: "Ion positif",
+				de: "Positives Ion"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 10 more damage.",
-				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires."
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -60,11 +65,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Body Bolt",
-				fr: "« Boulon corporel »"
+				fr: "« Boulon corporel »",
+				de: "Bodybolzen"
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon that has any Poké-Bodies. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				fr: "Choisissez 1 des Pokémon de votre adversaire qui a un Poké-Body. Cette attaque inflige 30 dégâts à ce Pokémon. (N'appliquez pas la Faiblesse et la Résistance aux Pokémon de Banc.)"
+				fr: "Choisissez 1 des Pokémon de votre adversaire qui a un Poké-Body. Cette attaque inflige 30 dégâts à ce Pokémon. (N'appliquez pas la Faiblesse et la Résistance aux Pokémon de Banc.)",
+				de: "Wähle 1 Pokémon deines Gegners aus, das einen Poké-Body besitzt. Dieser Angriff fügt dem gewählten Pokémon 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			}
 
 		},

--- a/data/POP/POP Series 3/6.ts
+++ b/data/POP/POP Series 3/6.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 3'
 const card: Card = {
 	name: {
 		en: "Vaporeon",
-		fr: "Aquali"
+		fr: "Aquali",
+		de: "Aquana"
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Diglett",
-		fr: "Evoli"
+		fr: "Evoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -34,7 +36,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Bite",
-				fr: "Morsure"
+				fr: "Morsure",
+				de: "Biss"
 			},
 
 			damage: 20,
@@ -47,11 +50,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Water Gun",
-				fr: "Pistolet à O"
+				fr: "Pistolet à O",
+				de: "Aquaknarre"
 			},
 			effect: {
 				en: "Does 30 damage plus 20 more damage for each Water Energy attached to Vaporeon but not used to pay for this attack's Energy cost. You can't add more than 40 damage in this way.",
-				fr: "Inflige 30 dégâts plus 20 dégâts supplémentaires pour chaque Énergie  attachée à Aquali en plus du coût en Énergie de cette attaque. Vous ne pouvez pas ajouter plus de 40 dégâts de cette façon."
+				fr: "Inflige 30 dégâts plus 20 dégâts supplémentaires pour chaque Énergie  attachée à Aquali en plus du coût en Énergie de cette attaque. Vous ne pouvez pas ajouter plus de 40 dégâts de cette façon.",
+				de: "Dieser Angriff fügt 30 Schadenspunkte plus 20 weitere Schadenspunkte für jede an Aquana angelegte {W}-Energie zu, die nicht zum Zahlen der Energiekosten für diesen Angriff verwendet wurde. Es lassen sich so nicht mehr als 40 Schadenspunkte hinzufügen."
 			},
 			damage: "30+",
 

--- a/data/POP/POP Series 3/7.ts
+++ b/data/POP/POP Series 3/7.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 3'
 const card: Card = {
 	name: {
 		en: "Combusken",
-		fr: "Galifeu"
+		fr: "Galifeu",
+		de: "Jungglut"
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -29,7 +30,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Scratch",
-				fr: "Griffe"
+				fr: "Griffe",
+				de: "Kratzer"
 			},
 
 			damage: 10,
@@ -43,11 +45,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Flamethrower",
-				fr: "Lance-flamme"
+				fr: "Lance-flamme",
+				de: "Flammenwurf"
 			},
 			effect: {
 				en: "Discard a Fire Energy attached to Combusken.",
-				fr: "Défaussez une Énergie  attachée à Galifeu."
+				fr: "Défaussez une Énergie  attachée à Galifeu.",
+				de: "Entferne eine {R}-Energie von Jungglut und lege sie auf den Ablagestapel."
 			},
 			damage: 50,
 

--- a/data/POP/POP Series 3/8.ts
+++ b/data/POP/POP Series 3/8.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 3'
 const card: Card = {
 	name: {
 		en: "Donphan",
-		fr: "Donphan"
+		fr: "Donphan",
+		de: "Donphan"
 	},
 
 	illustrator: "Tomoaki Imakuni",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Sniff Out",
-				fr: "Flairer"
+				fr: "Flairer",
+				de: "Rumschnüffeln"
 			},
 			effect: {
 				en: "Put any 1 card from your discard pile into your hand.",
-				fr: "Placez n'importe quelle carte de votre pile de défausse dans votre main."
+				fr: "Placez n'importe quelle carte de votre pile de défausse dans votre main.",
+				de: "Wähle 1 Karte aus deinem Ablagestapel und nimm sie auf deine Hand."
 			},
 
 		},
@@ -45,11 +48,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Fury Attack",
-				fr: "Furie"
+				fr: "Furie",
+				de: "Furienschlag"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 30 damage times the number of heads.",
-				fr: "Lancez 3 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face."
+				fr: "Lancez 3 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "30×",
 

--- a/data/POP/POP Series 3/9.ts
+++ b/data/POP/POP Series 3/9.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 3'
 const card: Card = {
 	name: {
 		en: "Forretress",
-		fr: "Foretress"
+		fr: "Foretress",
+		de: "Forstellka"
 	},
 
 	illustrator: "Midori Harada",
@@ -30,7 +31,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Tackle",
-				fr: "Charge"
+				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 20,
@@ -44,11 +46,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Toxic",
-				fr: "Toxik"
+				fr: "Toxik",
+				de: "Toxin"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned. Put 2 damage counters instead of 1 on the Defending Pokémon between turns.",
-				fr: "Le Pokémon Défenseur est maintenant Empoisonné. Placez 2 marqueurs de dégât au lieu d'1 sur le Pokémon Défenseur entre deux tours."
+				fr: "Le Pokémon Défenseur est maintenant Empoisonné. Placez 2 marqueurs de dégât au lieu d'1 sur le Pokémon Défenseur entre deux tours.",
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet. Lege zwischen den Zügen 2 Schadensmarken anstelle von 1 Schadensmarke auf das Verteidigende Pokémon."
 			},
 			damage: 20,
 


### PR DESCRIPTION
## Add missing German translations for pop3

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
