### PR TITLE
Add missing German translations for pop7

### DIFF
--- a/data/POP/POP Series 7/1.ts
+++ b/data/POP/POP Series 7/1.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 7'
 const card: Card = {
 	name: {
 		en: "Ampharos",
-		fr: "Ampharos"
+		fr: "Ampharos",
+		de: "Ampharos"
 	},
 
 	illustrator: "Kouki Saitou",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Flaaffy",
-		fr: "Lainergie"
+		fr: "Lainergie",
+		de: "Waaty"
 	},
 
 	stage: "Stage2",
@@ -32,11 +34,13 @@ const card: Card = {
 			type: "Poke-BODY",
 			name: {
 				en: "Jamming",
-				fr: "Encombrement"
+				fr: "Encombrement",
+				de: "Störung"
 			},
 			effect: {
 				en: "After your opponent plays a Supporter card from his or her hand, put 1 damage counter on each of your opponent's Pokémon. You can't use more than 1 Jamming Poké-Body each turn.",
-				fr: "Une fois que votre adversaire a joué une carte Supporter de sa main, placez 1 marqueur de dégât sur chacun des Pokémon de votre adversaire. Vous ne pouvez pas utiliser plus d'1 Poké-Body Encombrement par tour."
+				fr: "Une fois que votre adversaire a joué une carte Supporter de sa main, placez 1 marqueur de dégât sur chacun des Pokémon de votre adversaire. Vous ne pouvez pas utiliser plus d'1 Poké-Body Encombrement par tour.",
+				de: "Nachdem dein Gegner eine Unterstützerkarte von seiner Hand gespielt hat, lege 1 Schadensmarke auf jedes Pokémon deines Gegners. Du kannst nicht mehr als 1 Störung Poké-Body pro Zug einsetzen."
 			},
 		},
 	],
@@ -50,11 +54,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Cluster Bolt",
-				fr: "Groupe d'éclairs"
+				fr: "Groupe d'éclairs",
+				de: "Streublitz"
 			},
 			effect: {
 				en: "You may discard all Lightning Energy attached to Ampharos. If you do, this attack does 20 damage to each of your opponent's Benched Pokémon that has any Energy cards attached to it. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				fr: "Vous pouvez défausser toutes les Énergies  attachées à Pharamp. Cette attaque inflige alors 20 dégâts à chacun des Pokémon de Banc de votre adversaire possédant des cartes Énergie. (Vous ne pouvez pas appliquer la Faiblesse ou la Résistance aux Pokémon de Banc.)"
+				fr: "Vous pouvez défausser toutes les Énergies  attachées à Pharamp. Cette attaque inflige alors 20 dégâts à chacun des Pokémon de Banc de votre adversaire possédant des cartes Énergie. (Vous ne pouvez pas appliquer la Faiblesse ou la Résistance aux Pokémon de Banc.)",
+				de: "Du kannst alle {L}-Energien, die an Ampharos angelegt sind, auf deinen Ablagestapel legen. Wenn du das machst, fügt dieser Angriff allen Pokémon auf der Bank deines Gegners, an denen mindestens eine Energiekarte angelegt ist, 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 70,
 
@@ -74,7 +80,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "The tip of its tail shines brightly. In the olden days, people sent signals using the tail’s light."
+		en: "The tip of its tail shines brightly. In the olden days, people sent signals using the tail’s light.",
+		de: "Seine Schweifspitze leuchtet hell. In alten Zeiten hat man mit seiner Hilfe Lichtsignale gegeben."
 	},
 
 	retreat: 3,

--- a/data/POP/POP Series 7/10.ts
+++ b/data/POP/POP Series 7/10.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 7'
 const card: Card = {
 	name: {
 		en: "Wormadam Sandy Cloak",
-		fr: "Wormadam Sandy Cloak"
+		fr: "Wormadam Sandy Cloak",
+		de: "Burmadame Sandumhang"
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Burmy",
-		fr: "Cheniti Cape Sable"
+		fr: "Cheniti Cape Sable",
+		de: "Burmy"
 	},
 
 	stage: "Stage1",
@@ -32,11 +34,13 @@ const card: Card = {
 			type: "Poke-BODY",
 			name: {
 				en: "Sandy Cloak",
-				fr: "Cape sable"
+				fr: "Cape sable",
+				de: "Sandumhang"
 			},
 			effect: {
 				en: "Prevent all effects, excluding damage, done to Wormadam Sandy Cloak.",
-				fr: "Prévenez tous les effets d'une attaque, dégâts exclus, infligés à Cheniselle Cape Sable par des Pokémon de votre adversaire."
+				fr: "Prévenez tous les effets d'une attaque, dégâts exclus, infligés à Cheniselle Cape Sable par des Pokémon de votre adversaire.",
+				de: "Verhindere alle Effekte von Angriffen, außer Schaden, die Wurmadame Sandumhang zugefügt würden."
 			},
 		},
 	],
@@ -50,11 +54,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Push Over",
-				fr: "Facilité"
+				fr: "Facilité",
+				de: "Umschubsen"
 			},
 			effect: {
 				en: "Does 40 damage plus 10 more damage for each Fighting Energy attached to Wormadam Sandy Cloak.",
-				fr: "Inflige 40 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  attachée à Cheniselle Cape Sable."
+				fr: "Inflige 40 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  attachée à Cheniselle Cape Sable.",
+				de: "Dieser Angriff fügt 40 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Burmadame Sandumhang angelegte {F}-Energie zu."
 			},
 			damage: "40+",
 
@@ -74,7 +80,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "When BURMY evolved, it cloak became a part of this Pokémon’s body. The cloak is never shed."
+		en: "When BURMY evolved, it cloak became a part of this Pokémon’s body. The cloak is never shed.",
+		de: "Als sich BURMY entwickelte, wurde sein Umhang Teil des Körpers. Es legt den Umhang niemals ab."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 7/11.ts
+++ b/data/POP/POP Series 7/11.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 7'
 const card: Card = {
 	name: {
 		en: "Burmy Plant Cloak",
-		fr: "Burmy Plant Cloak"
+		fr: "Burmy Plant Cloak",
+		de: "Burmy Pflanzenumhang"
 	},
 
 	illustrator: "Kouki Saitou",
@@ -27,11 +28,13 @@ const card: Card = {
 			type: "Poke-POWER",
 			name: {
 				en: "Wear Cloak",
-				fr: "Cape"
+				fr: "Cape",
+				de: "Umhang tragen"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), if Burmy Plant Cloak is your Active Pokémon, you may search your discard pile for a basic Grass Energy card and attach it to Burmy Plant Cloak.",
-				fr: "Une seule fois lors de votre tour (avant votre attaque), si Cheniti Cape Plante est votre Pokémon Actif, vous pouvez choisir dans votre pile de défausse une carte Énergie de base  et l'attacher à Cheniti Cape Plante."
+				fr: "Une seule fois lors de votre tour (avant votre attaque), si Cheniti Cape Plante est votre Pokémon Actif, vous pouvez choisir dans votre pile de défausse une carte Énergie de base  et l'attacher à Cheniti Cape Plante.",
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn Burmy Pflanzenumhang dein Aktives Pokémon ist, deinen Ablagestapel nach einer {G}-Basis-Energiekarte durchsuchen und an Burmy Pflanzenumhang anlegen."
 			},
 		},
 	],
@@ -43,11 +46,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Plant Cloak Tackle",
-				fr: "Charge cape plante"
+				fr: "Charge cape plante",
+				de: "Pflanzenumhang Tackle"
 			},
 			effect: {
 				en: "If Burmy Plant Cloak has any Grass Energy attached to it, this attack does 10 damage plus 10 more damage.",
-				fr: "Si Cheniti Cape Plante possède de l'Énergie , cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires."
+				fr: "Si Cheniti Cape Plante possède de l'Énergie , cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires.",
+				de: "Wenn an Burmy Pflanzenumhang mindestens 1 {G}-Energie angelegt ist, fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -61,7 +66,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "To shelter itself from cold, wintry winds, it covers itself with a cloak made of twigs and leaves."
+		en: "To shelter itself from cold, wintry winds, it covers itself with a cloak made of twigs and leaves.",
+		de: "Um sich vor dem eisigen Winterwind zu schützen, legt es sich unter einen Umhang aus Ästen und Laub."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 7/12.ts
+++ b/data/POP/POP Series 7/12.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 7'
 const card: Card = {
 	name: {
 		en: "Burmy Sandy Cloak",
-		fr: "Burmy Sandy Cloak"
+		fr: "Burmy Sandy Cloak",
+		de: "Burmy Sandumhang"
 	},
 
 	illustrator: "Midori Harada",
@@ -27,11 +28,13 @@ const card: Card = {
 			type: "Poke-POWER",
 			name: {
 				en: "Wear Cloak",
-				fr: "Cape"
+				fr: "Cape",
+				de: "Umhang tragen"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), if Burmy Sandy Cloak is your Active Pokémon, you may search your discard pile for a basic Fighting Energy card and attach it to Burmy Sandy Cloak.",
-				fr: "Une seule fois lors de votre tour (avant votre attaque), si Cheniti Cape Sable est votre Pokémon Actif, vous pouvez choisir dans votre pile de défausse une carte Énergie de base  et l'attacher à Cheniti Cape Sable."
+				fr: "Une seule fois lors de votre tour (avant votre attaque), si Cheniti Cape Sable est votre Pokémon Actif, vous pouvez choisir dans votre pile de défausse une carte Énergie de base  et l'attacher à Cheniti Cape Sable.",
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn Burmy Sandumhang dein Aktives Pokémon ist, deinen Ablagestapel nach einer {F}-Basis-Energiekarte durchsuchen und an Burmy Sandumhang anlegen."
 			},
 		},
 	],
@@ -43,11 +46,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Sandy Cloak Tackle",
-				fr: "Charge cape sable"
+				fr: "Charge cape sable",
+				de: "Sandumhang Tackle"
 			},
 			effect: {
 				en: "If Burmy Sandy Cloak has any Fighting Energy attached to it, this attack does 10 damage plus 10 more damage.",
-				fr: "Si Cheniti Cape Sable possède de l'Énergie , cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires."
+				fr: "Si Cheniti Cape Sable possède de l'Énergie , cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires.",
+				de: "Wenn an Burmy Sandumhang mindestens 1 {F}-Energie angelegt ist, fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -61,7 +66,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "To shelter itself from cold, wintry winds, it covers itself with a cloak made of twigs and leaves."
+		en: "To shelter itself from cold, wintry winds, it covers itself with a cloak made of twigs and leaves.",
+		de: "Um sich vor dem eisigen Winterwind zu schützen, legt es sich unter einen Umhang aus Ästen und Laub."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 7/13.ts
+++ b/data/POP/POP Series 7/13.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 7'
 const card: Card = {
 	name: {
 		en: "Corsola",
-		fr: "Corsola"
+		fr: "Corsola",
+		de: "Corasonn"
 	},
 
 	illustrator: "Midori Harada",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Rally",
-				fr: "Regroupement"
+				fr: "Regroupement",
+				de: "Mobilisieren"
 			},
 			effect: {
 				en: "Search your deck for up to 3 different types of Basic Pokémon and put them onto your Bench. Shuffle your deck afterward.",
-				fr: "Choisissez dans votre deck jusqu'à 3 types de Pokémon de base différents et placez-les sur votre Banc. Ensuite, mélangez votre deck."
+				fr: "Choisissez dans votre deck jusqu'à 3 types de Pokémon de base différents et placez-les sur votre Banc. Ensuite, mélangez votre deck.",
+				de: "Durchsuche dein Deck nach bis zu 3 Basis-Pokémon-Karten unterschiedlichen Typs und lege sie auf deine Bank. Mische dein Deck danach."
 			},
 
 		},
@@ -44,7 +47,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Hook",
-				fr: "Crochet"
+				fr: "Crochet",
+				de: "Haken"
 			},
 
 			damage: 30,
@@ -59,7 +63,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "Many live in the clean seas of the south. They apparently can’t live in polluted waters."
+		en: "Many live in the clean seas of the south. They apparently can’t live in polluted waters.",
+		de: "Viele von ihnen leben in den sauberen Seen im Süden. In verschmutzten können sie nicht leben."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 7/14.ts
+++ b/data/POP/POP Series 7/14.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 7'
 const card: Card = {
 	name: {
 		en: "Mareep",
-		fr: "Mareep"
+		fr: "Mareep",
+		de: "Voltilamm"
 	},
 
 	illustrator: "Atsuko Nishida",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Thundershock",
-				fr: "Éclair"
+				fr: "Éclair",
+				de: "Donnerschock"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
-				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé."
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 
@@ -45,7 +48,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Static Shock",
-				fr: "Choc statique"
+				fr: "Choc statique",
+				de: "Statischer Schock"
 			},
 
 			damage: 20,
@@ -66,7 +70,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "Its fluffy coat swells to double when static electricity builds up. Touching it can be shocking."
+		en: "Its fluffy coat swells to double when static electricity builds up. Touching it can be shocking.",
+		de: "Sein weiches Fell wird doppelt so dick, wenn sich Elektrizität aufbaut."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 7/15.ts
+++ b/data/POP/POP Series 7/15.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 7'
 const card: Card = {
 	name: {
 		en: "Ralts",
-		fr: "Ralts"
+		fr: "Ralts",
+		de: "Trasla"
 	},
 
 	illustrator: "Sumiyoshi Kizuki",
@@ -29,7 +30,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Smack",
-				fr: "Claque"
+				fr: "Claque",
+				de: "Klatscher"
 			},
 
 			damage: 10,
@@ -41,11 +43,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Confuse Ray",
-				fr: "Onde folie"
+				fr: "Onde folie",
+				de: "Konfustrahl"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
-				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus."
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon ist jetzt verwirrt."
 			},
 
 		},
@@ -58,7 +62,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "It uses the horns on its head to sense human emotions. It is said to appear in front of cheerful people."
+		en: "It uses the horns on its head to sense human emotions. It is said to appear in front of cheerful people.",
+		de: "Mit dem Horn kann es menschliche Gefühle wahrnehmen. Es erscheint fröhlichen Menschen."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 7/16.ts
+++ b/data/POP/POP Series 7/16.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 7'
 const card: Card = {
 	name: {
 		en: "Sentret",
-		fr: "Sentret"
+		fr: "Sentret",
+		de: "Wiesor"
 	},
 
 	illustrator: "Midori Harada",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Grope",
-				fr: "À l'aveuglette"
+				fr: "À l'aveuglette",
+				de: "Herumtasten"
 			},
 			effect: {
 				en: "Look at the top 2 cards of your deck, choose 1 of them, and put it into your hand. Put the other card on the bottom of your deck.",
-				fr: "Regardez les 2 cartes du dessus de votre deck, choisissez-en 1 et placez-la dans votre main. Replacez l'autre carte au dessous de votre deck."
+				fr: "Regardez les 2 cartes du dessus de votre deck, choisissez-en 1 et placez-la dans votre main. Replacez l'autre carte au dessous de votre deck.",
+				de: "Schau dir die obersten 2 Karten deines Decks an. Wähle 1 von ihnen und nimm sie auf die Hand. Lege die andere Karte unter dein Deck."
 			},
 
 		},
@@ -43,7 +46,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Scratch",
-				fr: "Griffe"
+				fr: "Griffe",
+				de: "Kratzer"
 			},
 
 			damage: 10,
@@ -58,7 +62,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "It has a very nervous nature. It stands up high on its tail so it can scan wide areas."
+		en: "It has a very nervous nature. It stands up high on its tail so it can scan wide areas.",
+		de: "Ein sehr nervöses PKMN. Es steht auf seinem Schweif und betrachtet seine Umgebung ganz genau."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 7/17.ts
+++ b/data/POP/POP Series 7/17.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 7'
 const card: Card = {
 	name: {
 		en: "Spinda",
-		fr: "Spinda"
+		fr: "Spinda",
+		de: "Pandir"
 	},
 
 	illustrator: "Atsuko Nishida",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Dish Out",
-				fr: "Distribution"
+				fr: "Distribution",
+				de: "Austeilen"
 			},
 			effect: {
 				en: "Draw a card from the top and the bottom of your deck.",
-				fr: "Piochez une carte du dessus et du dessous de votre deck."
+				fr: "Piochez une carte du dessus et du dessous de votre deck.",
+				de: "Ziehe die oberste und unterste Karte deines Decks."
 			},
 
 		},
@@ -43,11 +46,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Synchro Punch",
-				fr: "Synchro-poing"
+				fr: "Synchro-poing",
+				de: "Drehhieb"
 			},
 			effect: {
 				en: "If any basic Energy card attached to Spinda is the same type as any Energy attached to the Defending Pokémon, this attack does 10 damage plus 30 more damage.",
-				fr: "Si une carte Énergie attachée à Spinda est du même type qu'une carte Énergie attachée au Pokémon Défenseur, cette attaque inflige 10 dégâts plus 30 dégâts supplémentaires."
+				fr: "Si une carte Énergie attachée à Spinda est du même type qu'une carte Énergie attachée au Pokémon Défenseur, cette attaque inflige 10 dégâts plus 30 dégâts supplémentaires.",
+				de: "Wenn an Pandir mindestens 1 Basis-Energiekarte desselben Typs wie eine an das Verteidigende Pokémon angelegte Energiekarte angelegt ist, fügt dieser Angriff 10 Schadenspunkte plus 30 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -61,7 +66,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "No two SPINDA have the same pattern of spots. Its tottering step fouls the aim of foes."
+		en: "No two SPINDA have the same pattern of spots. Its tottering step fouls the aim of foes.",
+		de: "Das Muster eines PANDIR ist wie ein Fingerabdruck. Sein Taumeln senkt die gegn. Zielsicherheit."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 7/2.ts
+++ b/data/POP/POP Series 7/2.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 7'
 const card: Card = {
 	name: {
 		en: "Gallade",
-		fr: "Gallade"
+		fr: "Gallade",
+		de: "Galagladi"
 	},
 
 	illustrator: "Daisuke Ito",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Kirlia",
-		fr: "Kirlia"
+		fr: "Kirlia",
+		de: "Kirlia"
 	},
 
 	stage: "Stage2",
@@ -35,11 +37,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Sonic Blade",
-				fr: "Lame sonique"
+				fr: "Lame sonique",
+				de: "Schallklinge"
 			},
 			effect: {
 				en: "Put damage counters on the Defending Pokémon until it is 50 HP away from being Knocked Out. If you do, your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon.",
-				fr: "Placez des marqueurs de dégât sur le Pokémon Défenseur jusqu'à ce qu'il soit à 50 PV d'être mis K.O. Votre adversaire échange alors le Pokémon Défenseur avec 1 des Pokémon de son Banc."
+				fr: "Placez des marqueurs de dégât sur le Pokémon Défenseur jusqu'à ce qu'il soit à 50 PV d'être mis K.O. Votre adversaire échange alors le Pokémon Défenseur avec 1 des Pokémon de son Banc.",
+				de: "Lege so viele Schadensmarken auf das Verteidigende Pokémon, dass es nur noch 50 Schadenspunkte davon entfernt ist, kampfunfähig zu sein. Wenn du das machst, tauscht dein Gegner das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
 			},
 
 		},
@@ -51,11 +55,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Psychic Cut",
-				fr: "Coupe Psycho"
+				fr: "Coupe Psycho",
+				de: "Psychoklinge"
 			},
 			effect: {
 				en: "You may choose as many of your face-down Prize cards as you like and put them face up. If you do, this attack does 60 damage plus 20 more damage for each Prize card you chose. (These cards remain face up for the rest of the game.)",
-				fr: "Vous pouvez choisir autant de cartes Récompense se trouvant face cachée que vous le voulez et les retourner. Cette attaque inflige alors 60 dégâts plus 20 dégâts supplémentaires pour chaque carte Récompense choisie. (Ces cartes restent retournées pour le reste de la partie)."
+				fr: "Vous pouvez choisir autant de cartes Récompense se trouvant face cachée que vous le voulez et les retourner. Cette attaque inflige alors 60 dégâts plus 20 dégâts supplémentaires pour chaque carte Récompense choisie. (Ces cartes restent retournées pour le reste de la partie).",
+				de: "Du kannst beliebig viele deiner verdeckten Preise wählen und aufdecken. Wenn du das machst, fügt dieser Angriff 60 Schadenspunkte plus 20 weitere Schadenspunkte für jeden so gewählten Preis zu. (Die gewählten Preise werden nicht wieder verdeckt.)"
 			},
 			damage: "60+",
 
@@ -69,7 +75,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "A master of courtesy and swordsmanship, it fights using extending swords on it elbows."
+		en: "A master of courtesy and swordsmanship, it fights using extending swords on it elbows.",
+		de: "Es kämpft, indem es die Schwerter an seinen Ellbogen verlängert. Es ist ein Meister des Kampfes."
 	},
 
 	retreat: 2,

--- a/data/POP/POP Series 7/3.ts
+++ b/data/POP/POP Series 7/3.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 7'
 const card: Card = {
 	name: {
 		en: "Latias",
-		fr: "Latias"
+		fr: "Latias",
+		de: "Latias"
 	},
 
 	illustrator: "Daisuke Ito",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Miraculous Light",
-				fr: "Lumière miraculeuse"
+				fr: "Lumière miraculeuse",
+				de: "Wundersames Licht"
 			},
 			effect: {
 				en: "Remove 2 damage counters and all Special Conditions from Latias.",
-				fr: "Retirez à Latias 2 marqueurs de dégât ainsi que tous ses États Spéciaux."
+				fr: "Retirez à Latias 2 marqueurs de dégât ainsi que tous ses États Spéciaux.",
+				de: "Entferne 2 Schadensmarken und alle Speziellen Zustände von Latias."
 			},
 			damage: 10,
 
@@ -46,11 +49,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Mist Ball",
-				fr: "Boule de brume"
+				fr: "Boule de brume",
+				de: "Nebelball"
 			},
 			effect: {
 				en: "Discard a Fire and a Water Energy attached to Latias.",
-				fr: "Défaussez une Énergie  et une Énergie  attachée à Latias."
+				fr: "Défaussez une Énergie  et une Énergie  attachée à Latias.",
+				de: "Lege 1 {R}-Energie und 1 {W}-Energie, die an Latias angelegt sind, auf deinen Ablagestapel."
 			},
 			damage: 80,
 
@@ -71,7 +76,8 @@ const card: Card = {
 	],
 	description: {
 		en: "Its body is covered with a down that can refract light in such a way that it becomes invisble.",
-		fr: "Son corps est recouvert d'un duvet qui reflète la lumière et le rend invisible."
+		fr: "Son corps est recouvert d'un duvet qui reflète la lumière et le rend invisible.",
+		de: "Sein Körper ist mit Daunen bedeckt, die das Licht so brechen, dass das PKMN unsichtbar wird."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 7/4.ts
+++ b/data/POP/POP Series 7/4.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 7'
 const card: Card = {
 	name: {
 		en: "Latios",
-		fr: "Latios"
+		fr: "Latios",
+		de: "Latios"
 	},
 
 	illustrator: "Daisuke Ito",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Energy Draw",
-				fr: "Absorption d'énergie"
+				fr: "Absorption d'énergie",
+				de: "Energieanziehung"
 			},
 			effect: {
 				en: "Flip a coin. If heads, search your deck for a basic Energy card and attach it to Latios. Shuffle your deck afterward.",
-				fr: "Lancez une pièce. Si c'est face, choisissez dans votre deck une carte Énergie de base et attachez-la à Latios. Ensuite, mélangez votre deck."
+				fr: "Lancez une pièce. Si c'est face, choisissez dans votre deck une carte Énergie de base et attachez-la à Latios. Ensuite, mélangez votre deck.",
+				de: "Wirf 1 Münze. Bei „Kopf“ durchsuche dein Deck nach 1 Basis-Energiekarte und lege sie an Latios an. Mische dein Deck danach."
 			},
 			damage: 10,
 
@@ -47,11 +50,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Luster Purge",
-				fr: "Lumi-Eclat"
+				fr: "Lumi-Eclat",
+				de: "Scheinwerfer"
 			},
 			effect: {
 				en: "Discard 3 Energy attached to Latios.",
-				fr: "Défaussez 3 Énergies attachée à Latios."
+				fr: "Défaussez 3 Énergies attachée à Latios.",
+				de: "Lege 3 Energien, die an Latios angelegt sind, auf deinen Ablagestapel."
 			},
 			damage: 120,
 
@@ -72,7 +77,8 @@ const card: Card = {
 	],
 	description: {
 		en: "A highly intelligent Pokémon. By folding back its wings in flight, it can overtake jet planes.",
-		fr: "Un Pokémon très intelligent. Il peut voler plus vite qu'un avion à réaction en repliant ses ailes."
+		fr: "Un Pokémon très intelligent. Il peut voler plus vite qu'un avion à réaction en repliant ses ailes.",
+		de: "Ein hochintelligentes PKMN. Wenn es im Flug seine Flügel nach hinten legt, ist es schneller als ein Jet."
 	},
 
 	retreat: 2,

--- a/data/POP/POP Series 7/5.ts
+++ b/data/POP/POP Series 7/5.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 7'
 const card: Card = {
 	name: {
 		en: "Mothim",
-		fr: "Mothim"
+		fr: "Mothim",
+		de: "Moterpel"
 	},
 
 	illustrator: "Kazuyuki Kano",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Burmy",
-		fr: "Cheniti"
+		fr: "Cheniti",
+		de: "Burmy"
 	},
 
 	stage: "Stage1",
@@ -32,11 +34,13 @@ const card: Card = {
 
 			name: {
 				en: "Silver Wind",
-				fr: "Vent argenté"
+				fr: "Vent argenté",
+				de: "Silberhauch"
 			},
 			effect: {
 				en: "During your next turn, if an attack does damage to the Defending Pokémon (after applying Weakness and Resistance), that attack does 40 more damage.",
-				fr: "Lors de votre prochain tour, si une attaque inflige des dégâts au Pokémon Défenseur (après application de la Faiblesse et de la Résistance), cette attaque inflige 40 dégâts supplémentaires."
+				fr: "Lors de votre prochain tour, si une attaque inflige des dégâts au Pokémon Défenseur (après application de la Faiblesse et de la Résistance), cette attaque inflige 40 dégâts supplémentaires.",
+				de: "Während deines nächsten Zuges, wenn ein Angriff dem Verteidigenden Pokémon Schaden zufügt (nachdem Schwäche und Resistenz verrechnet wurden), fügt dieser Angriff 40 weitere Schadenspunkte zu."
 			},
 
 		},
@@ -47,11 +51,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Raging Scales",
-				fr: "Écailles enragées"
+				fr: "Écailles enragées",
+				de: "Wütende Schuppen"
 			},
 			effect: {
 				en: "If Mothim has any damage counters on it, this attack does 30 damage plus 40 more damage.",
-				fr: "Si Papilord possède des marqueurs de dégât, cette attaque inflige 30 dégâts plus 40 dégâts supplémentaires."
+				fr: "Si Papilord possède des marqueurs de dégât, cette attaque inflige 30 dégâts plus 40 dégâts supplémentaires.",
+				de: "Wenn auf Moterpel mindestens 1 Schadensmarke liegt, fügt dieser Angriff 30 Schadenspunkte plus 40 weitere Schadenspunkte zu."
 			},
 			damage: "30+",
 
@@ -71,7 +77,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "It loves the honey of flowers and steals honey collected by COMBEE."
+		en: "It loves the honey of flowers and steals honey collected by COMBEE.",
+		de: "Es liebt Honig und stiehlt den Honig, der von WADRIBIE gesammelt wurde."
 	},
 
 	retreat: 0,

--- a/data/POP/POP Series 7/6.ts
+++ b/data/POP/POP Series 7/6.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 7'
 const card: Card = {
 	name: {
 		en: "Delibird",
-		fr: "Delibird"
+		fr: "Delibird",
+		de: "Botogel"
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -27,11 +28,13 @@ const card: Card = {
 
 			name: {
 				en: "Present",
-				fr: "Cadeau"
+				fr: "Cadeau",
+				de: "Geschenk"
 			},
 			effect: {
 				en: "Flip a coin. If heads, search your deck for any 1 card and put it into your hand. Shuffle your deck afterward.",
-				fr: "Lancez une pièce. Si c'est face, choisissez 1 carte dans votre deck et placez-la dans votre main. Ensuite, mélangez votre deck."
+				fr: "Lancez une pièce. Si c'est face, choisissez 1 carte dans votre deck et placez-la dans votre main. Ensuite, mélangez votre deck.",
+				de: "Wirf 1 Münze. Bei „Kopf“ durchsuche dein Deck nach 1 Karte und nimm sie auf die Hand. Mische dein Deck danach."
 			},
 
 		},
@@ -41,7 +44,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Ice Ball",
-				fr: "Ball'glace"
+				fr: "Ball'glace",
+				de: "Frostbeule"
 			},
 
 			damage: 20,
@@ -56,7 +60,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "It carries food rolled up in its tail. It has the habit of sharing food with people lost in mountains."
+		en: "It carries food rolled up in its tail. It has the habit of sharing food with people lost in mountains.",
+		de: "Im eingerollten Schweif transportiert es Futter, das es mit denen teilt, die sich verlaufen haben."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 7/7.ts
+++ b/data/POP/POP Series 7/7.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 7'
 const card: Card = {
 	name: {
 		en: "Flaaffy",
-		fr: "Flaaffy"
+		fr: "Flaaffy",
+		de: "Waaty"
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Mareep",
-		fr: "Wattouat"
+		fr: "Wattouat",
+		de: "Voltilamm"
 	},
 
 	stage: "Stage1",
@@ -34,11 +36,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Attract Current",
-				fr: "Courant électrique"
+				fr: "Courant électrique",
+				de: "Stromanziehung"
 			},
 			effect: {
 				en: "Search your deck for a Lightning Energy card and attach it to 1 of your Pokémon. Shuffle your deck afterward.",
-				fr: "Cherchez dans votre deck une carte Énergie  et attachez-la à 1 de vos Pokémon. Ensuite, mélangez votre deck."
+				fr: "Cherchez dans votre deck une carte Énergie  et attachez-la à 1 de vos Pokémon. Ensuite, mélangez votre deck.",
+				de: "Durchsuche dein Deck nach einer {L}-Energiekarte und lege sie 1 deiner Pokémon an. Mische dein Deck danach."
 			},
 			damage: 10,
 
@@ -51,11 +55,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Electromagnetic Kick",
-				fr: "Coup électromagnétique"
+				fr: "Coup électromagnétique",
+				de: "Elektromagnetischer Kick"
 			},
 			effect: {
 				en: "Flip a coin. If tails, Flaaffy does 10 damage to itself.",
-				fr: "Lancez une pièce. Si c'est pile, Lainergie s'inflige 10 dégâts."
+				fr: "Lancez une pièce. Si c'est pile, Lainergie s'inflige 10 dégâts.",
+				de: "Wirf 1 Münze. Bei „Zahl“ fügt sich Waaty selbst 10 Schadenspunkte zu."
 			},
 			damage: 60,
 
@@ -75,7 +81,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "If its coat becomes fully charged with electricity, its tail lights up. It fire hair that zaps on impact."
+		en: "If its coat becomes fully charged with electricity, its tail lights up. It fire hair that zaps on impact.",
+		de: "Hat es sich mit Elektrizität aufgeladen, leuchtet sein Schweif und es feuert Haare ab, die sich entladen."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 7/8.ts
+++ b/data/POP/POP Series 7/8.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 7'
 const card: Card = {
 	name: {
 		en: "Kirlia",
-		fr: "Kirlia"
+		fr: "Kirlia",
+		de: "Kirlia"
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Ralts",
-		fr: "Tarsal"
+		fr: "Tarsal",
+		de: "Trasla"
 	},
 
 	stage: "Stage1",
@@ -34,11 +36,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Psychic Research",
-				fr: "Recherche psy"
+				fr: "Recherche psy",
+				de: "Psychoforschung"
 			},
 			effect: {
 				en: "Search your discard pile for a Supporter card and use the effect of that card as the effect of this attack. (The Supporter card remains in your discard pile.)",
-				fr: "Choisissez dans votre pile de défausse une carte Supporter et utilisez l'effet de cette carte comme l'effet de cette carte comme l'effet de cette attaque. (La carte Supporter reste dans la pile de défausse.)"
+				fr: "Choisissez dans votre pile de défausse une carte Supporter et utilisez l'effet de cette carte comme l'effet de cette carte comme l'effet de cette attaque. (La carte Supporter reste dans la pile de défausse.)",
+				de: "Durchsuche deinen Ablagestapel nach 1 Unterstützerkarte und nutze ihren Effekt als Effekt dieses Angriffs. (Die Unterstützerkarte bleibt in deinem Ablagestapel.)"
 			},
 
 		},
@@ -50,11 +54,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Telekinesis",
-				fr: "Télékinésie"
+				fr: "Télékinésie",
+				de: "Telekinese"
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance.",
-				fr: "Choisissez 1 des Pokémon de votre adversaire. Cette attaque lui inflige 40 dégâts. Les dégâts de cette attaque ne sont pas affectés par la Faiblesse ou la Résistance."
+				fr: "Choisissez 1 des Pokémon de votre adversaire. Cette attaque lui inflige 40 dégâts. Les dégâts de cette attaque ne sont pas affectés par la Faiblesse ou la Résistance.",
+				de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 40 Schadenspunkte zu. Der Schaden dieses Angriffs wird durch Schwäche und Resistenz des gewählten Pokémon nicht verändert."
 			},
 
 		},
@@ -67,7 +73,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "It is highly perceptive of its Trainer’s feelings. It dances when it is feeling happy."
+		en: "It is highly perceptive of its Trainer’s feelings. It dances when it is feeling happy.",
+		de: "Es nimmt die Gefühle seines Trainers deutlich wahr. Wenn es glücklich ist, tanzt es."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 7/9.ts
+++ b/data/POP/POP Series 7/9.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 7'
 const card: Card = {
 	name: {
 		en: "Stantler",
-		fr: "Stantler"
+		fr: "Stantler",
+		de: "Damhirplex"
 	},
 
 	illustrator: "Kouki Saitou",
@@ -27,11 +28,13 @@ const card: Card = {
 
 			name: {
 				en: "Lead",
-				fr: "Avance"
+				fr: "Avance",
+				de: "Führen"
 			},
 			effect: {
 				en: "Search your deck for a Supporter card, show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
-				fr: "Cherchez dans votre deck une carte Supporter, montrez-la à votre adversaire, puis ajoutez-la à votre main. Mélangez ensuite votre deck."
+				fr: "Cherchez dans votre deck une carte Supporter, montrez-la à votre adversaire, puis ajoutez-la à votre main. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 1 Unterstützerkarte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 			},
 
 		},
@@ -42,11 +45,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Frighten Horn",
-				fr: "Corne qui fait peur"
+				fr: "Corne qui fait peur",
+				de: "Angsthorn"
 			},
 			effect: {
 				en: "If the Defending Pokémon isn't an Evolved Pokémon, that Pokémon is now Confused.",
-				fr: "Si le Pokémon Défenseur n'est pas un Pokémon Évolué, il est maintenant Confus."
+				fr: "Si le Pokémon Défenseur n'est pas un Pokémon Évolué, il est maintenant Confus.",
+				de: "Wenn das Verteidigende Pokémon kein entwickeltes Pokémon ist, ist es jetzt verwirrt."
 			},
 			damage: 20,
 
@@ -60,7 +65,8 @@ const card: Card = {
 		},
 	],
 	description: {
-		en: "Staring at its antlers creates an odd sensation as if one were being drawn into their centers."
+		en: "Staring at its antlers creates an odd sensation as if one were being drawn into their centers.",
+		de: "Starrt man auf sein Geweih, bekommt man das seltsame Gefühl, in dessen Mitte gezogen zu werden."
 	},
 
 	retreat: 1,


### PR DESCRIPTION
## Add missing German translations for pop7

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
