### PR TITLE
Add missing German translations for pop8

### DIFF
--- a/data/POP/POP Series 8/1.ts
+++ b/data/POP/POP Series 8/1.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 8'
 const card: Card = {
 	name: {
 		en: "Heatran",
+		de: "Heatran"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -31,9 +32,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Body Slam",
+				de: "Bodyslam"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -47,9 +50,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Fire Spin",
+				de: "Feuerwirbel"
 			},
 			effect: {
 				en: "Discard 2 basic Energy cards attached to Heatran. (If you can’t discard cards, this attack does nothing.)",
+				de: "Entferne 2 Basis-Energiekarten von Heatran und lege sie auf deinen Ablagestapel. (Wenn du dies nicht tun kannst, hat dieser Angriff keine Auswirkungen.)"
 			},
 			damage: 90,
 
@@ -64,7 +69,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "It dwells in volcanic caves. It digs in with its cross-shaped feet to crawl on ceilings and walls."
+		en: "It dwells in volcanic caves. It digs in with its cross-shaped feet to crawl on ceilings and walls.",
+		de: "Es lebt in vulkanischen Höhlen. Mit seinen kreuzförmigen Klauen kann es sogar an der Decke laufen."
 	},
 
 	retreat: 3,

--- a/data/POP/POP Series 8/10.ts
+++ b/data/POP/POP Series 8/10.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 8'
 const card: Card = {
 	name: {
 		en: "Rare Candy",
+		de: "Sonderbonbon"
 	},
 
 	illustrator: "Ryo Ueda",
@@ -12,7 +13,8 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		en: "Choose 1 of your Basic Pokémon in play. If you have a Stage 1 or Stage 2 card that evolves from that Pokémon in your hand, put that card on the Basic Pokémon. (This counts as evolving that Pokémon.)"
+		en: "Choose 1 of your Basic Pokémon in play. If you have a Stage 1 or Stage 2 card that evolves from that Pokémon in your hand, put that card on the Basic Pokémon. (This counts as evolving that Pokémon.)",
+		de: "Wähle 1 deiner Basis-Pokémon im Spiel. Falls du eine Phase 1 oder Phase 2 Karte auf der Hand hast, die sich aus diesem Pokémon entwickelt, lege sie auf das Basis-Pokémon. (Das zählt als Entwickeln des gewählten Pokémon.)"
 	},
 
 	trainerType: "Item",

--- a/data/POP/POP Series 8/11.ts
+++ b/data/POP/POP Series 8/11.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 8'
 const card: Card = {
 	name: {
 		en: "Roseanne’s Research",
+		de: "Roxanas Nachforschungen"
 	},
 
 	illustrator: "Kanako Eo",
@@ -12,7 +13,8 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		en: "Search your deck for up to 2 in any combination of Basic Pokémon and basic Energy cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
+		en: "Search your deck for up to 2 in any combination of Basic Pokémon and basic Energy cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward.",
+		de: "Durchsuche dein Deck nach bis zu 2 Karten in beliebiger Kombination aus Basis-Pokémon- und Basis-Energiekarten. Zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 	},
 
 	trainerType: "Supporter",

--- a/data/POP/POP Series 8/12.ts
+++ b/data/POP/POP Series 8/12.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 8'
 const card: Card = {
 	name: {
 		en: "Chimchar",
+		de: "Panflam"
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -28,6 +29,7 @@ const card: Card = {
 
 			name: {
 				en: "Scratch",
+				de: "Kratzer"
 			},
 
 			damage: 10,
@@ -40,9 +42,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Ember",
+				de: "Glut"
 			},
 			effect: {
 				en: "Flip a coin. If tails, discard a Fire Energy attached to Chimchar.",
+				de: "Wirf 1 Münze. Bei „Zahl“ lege eine {R}-Energie, die an Panflam angelegt ist, auf deinen Ablagestapel."
 			},
 			damage: 30,
 
@@ -57,7 +61,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "It agilely scales sheer cliffs to live atop craggy mountains. Its fire is put out when it sleeps."
+		en: "It agilely scales sheer cliffs to live atop craggy mountains. Its fire is put out when it sleeps.",
+		de: "Es klettert behände steile Felsen hinauf, um auf Bergen zu leben. Sein Feuer ist aus, wenn es schläft."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 8/13.ts
+++ b/data/POP/POP Series 8/13.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 8'
 const card: Card = {
 	name: {
 		en: "Croagunk",
+		de: "Glibunkel"
 	},
 
 	illustrator: "Kouki Saitou",
@@ -30,9 +31,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Ghastly Sound",
+				de: "Grässliche Geräusche"
 			},
 			effect: {
 				en: "Flip a coin. If heads, your opponent can’t play any Supporter cards from his or her hand during his or her next turn.",
+				de: "Wirf 1 Münze. Bei „Kopf“ kann dein Gegner in seinem nächsten Zug keine Unterstützerkarten von seiner Hand spielen."
 			},
 
 		},
@@ -43,9 +46,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Finger Poke",
+				de: "Fingerstubser"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet."
 			},
 			damage: 20,
 
@@ -60,7 +65,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "Its cheeks hold poison sacs. It tries to catch foes off guard to jab them with toxic fingers."
+		en: "Its cheeks hold poison sacs. It tries to catch foes off guard to jab them with toxic fingers.",
+		de: "In seinen Backen sammelt sich Gift. Es versucht, Beute zu überraschen und mit Giftfingern zu schnappen."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 8/14.ts
+++ b/data/POP/POP Series 8/14.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 8'
 const card: Card = {
 	name: {
 		en: "Happiny",
+		de: "Wonneira"
 	},
 
 	illustrator: "Yuka Morii",
@@ -28,9 +29,11 @@ const card: Card = {
 			type: "Poke-POWER",
 			name: {
 				en: "Baby Evolution",
+				de: "Baby Evolution"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may put Chansey from your hand onto Happiny (this counts as evolving Happiny) and remove all damage counters from Happiny.",
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du Chaneira von deiner Hand auf Wonneira legen (das zählt als Entwickeln von Wonneira). Entferne alle Schadensmarken von Wonneira."
 			},
 		},
 	],
@@ -40,9 +43,11 @@ const card: Card = {
 
 			name: {
 				en: "Lively",
+				de: "Aufpäppeln"
 			},
 			effect: {
 				en: "Remove 2 damage counters from 1 of your Pokémon.",
+				de: "Entferne 2 Schadensmarken von 1 deiner Pokémon."
 			},
 
 		},
@@ -56,7 +61,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "It loves round white things. It carries an egg-shaped rock in imitation of CHANSEY."
+		en: "It loves round white things. It carries an egg-shaped rock in imitation of CHANSEY.",
+		de: "Es liebt runde, weiße Dinge. Es trägt einen eiförmigen Stein bei sich, und imitiert damit CHANEIRA."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 8/15.ts
+++ b/data/POP/POP Series 8/15.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 8'
 const card: Card = {
 	name: {
 		en: "Piplup",
+		de: "Plinfa"
 	},
 
 	illustrator: "Atsuko Nishida",
@@ -28,6 +29,7 @@ const card: Card = {
 
 			name: {
 				en: "Peck",
+				de: "Schnabel"
 			},
 
 			damage: 10,
@@ -40,9 +42,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Water Splash",
+				de: "Wasserplatscher"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 10 more damage.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -57,7 +61,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "Because it is very proud, it hates accepting food from people. Its thick down guards it from cold."
+		en: "Because it is very proud, it hates accepting food from people. Its thick down guards it from cold.",
+		de: "Es ist sehr stolz und nimmt daher kein Futter von anderen an. Seine dicken Daunen schützen vor Kälte."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 8/16.ts
+++ b/data/POP/POP Series 8/16.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 8'
 const card: Card = {
 	name: {
 		en: "Riolu",
+		de: "Riolu"
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -28,9 +29,11 @@ const card: Card = {
 			type: "Poke-BODY",
 			name: {
 				en: "Inner Focus",
+				de: "Konzentrator"
 			},
 			effect: {
 				en: "Riolu can’t be Paralyzed.",
+				de: "Riolu kann nicht gelähmt werden."
 			},
 		},
 	],
@@ -42,9 +45,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Quick Attack",
+				de: "Ruckzuckhieb"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 10 more damage.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -59,7 +64,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "Its body is lithe yet powerful. It can crest three mountains and cross two canyons in one night."
+		en: "Its body is lithe yet powerful. It can crest three mountains and cross two canyons in one night.",
+		de: "Sein Körper ist schlank, aber kräftig. Es kann in einer Nacht 3 Berge und 2 Täler durchqueren."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 8/17.ts
+++ b/data/POP/POP Series 8/17.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 8'
 const card: Card = {
 	name: {
 		en: "Turtwig",
+		de: "Chelast"
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -28,6 +29,7 @@ const card: Card = {
 
 			name: {
 				en: "Tackle",
+				de: "Tackle"
 			},
 
 			damage: 10,
@@ -39,6 +41,7 @@ const card: Card = {
 			],
 			name: {
 				en: "Razor Leaf",
+				de: "Rasierblatt"
 			},
 
 			damage: 20,
@@ -61,7 +64,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "Made from soil, the shell on its back hardens when it drinks water. It lives along lakes."
+		en: "Made from soil, the shell on its back hardens when it drinks water. It lives along lakes.",
+		de: "Es besteht aus Erdreich. Trinkt es Wasser, verhärtet sich der Panzer auf seinem Rücken. Es lebt an Seen."
 	},
 
 	retreat: 2,

--- a/data/POP/POP Series 8/2.ts
+++ b/data/POP/POP Series 8/2.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 8'
 const card: Card = {
 	name: {
 		en: "Lucario",
+		de: "Lucario"
 	},
 
 	illustrator: "Kent Kanetsuna",
@@ -23,6 +24,7 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Riolu",
+		de: "Riolu"
 	},
 
 	stage: "Stage1",
@@ -35,9 +37,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Blocking Punch",
+				de: "Abwehrhieb"
 			},
 			effect: {
 				en: "During your opponent’s next turn, any damage done to Lucario by attacks is reduced by 20 (after applying Weakness and Resistance).",
+				de: "Während des nächsten Zuges deines Gegners wird Schaden, der Lucario durch Angriffe zugefügt wird, um 20 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 			damage: 40,
 
@@ -50,9 +54,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Striking Kick",
+				de: "Erstaunlicher Kick"
 			},
 			effect: {
 				en: "This attack’s damage isn’t affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon.",
+				de: "Resistenz, Poké-Power, Poké-Body und alle anderen Effekte auf dem Verteidigenden Pokémon haben keine Auswirkungen auf die Schadenspunkte dieses Angriffs."
 			},
 			damage: 60,
 
@@ -67,7 +73,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "By catching the aura emanating from others, it can read their thoughts and movements."
+		en: "By catching the aura emanating from others, it can read their thoughts and movements.",
+		de: "Es nimmt dies Aura seines Gegners wahr. So kann es dessen Gedanken und Bewegungen erkennen."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 8/3.ts
+++ b/data/POP/POP Series 8/3.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 8'
 const card: Card = {
 	name: {
 		en: "Luxray",
+		de: "Luxtra"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -23,6 +24,7 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Luxio",
+		de: "Luxio"
 	},
 
 	stage: "Stage2",
@@ -32,9 +34,11 @@ const card: Card = {
 			type: "Poke-BODY",
 			name: {
 				en: "Intimidating Fang",
+				de: "Beeindruckende Fangzähne"
 			},
 			effect: {
 				en: "As long as Luxray is your Active Pokémon, any damage done by an opponent’s attack is reduced by 10 (before applying Weakness and Resistance).",
+				de: "Solange Luxtra dein Aktives Pokémon ist, wird aller Schaden von gegnerischen Angriffen um 10 Schadenspunkte reduziert (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 		},
 	],
@@ -49,9 +53,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Thunder",
+				de: "Donner"
 			},
 			effect: {
 				en: "Flip a coin. If tails, Luxray does 40 damage to itself.",
+				de: "Wirf 1 Münze. Bei „Zahl“ fügt sich Luxtra selbst 40 Schadenspunkte zu."
 			},
 			damage: 120,
 
@@ -73,7 +79,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "When its eyes gleam gold, it can spot hiding prey–even those taking shelter behind a wall."
+		en: "When its eyes gleam gold, it can spot hiding prey–even those taking shelter behind a wall.",
+		de: "Leuchten seine Augen golden auf, kann es Beute, die sich versteckt, sehen. Es kann durch Wände sehen."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 8/4.ts
+++ b/data/POP/POP Series 8/4.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 8'
 const card: Card = {
 	name: {
 		en: "Probopass",
+		de: "Voluminas"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -23,6 +24,7 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Nosepass",
+		de: "Nasgnet"
 	},
 
 	stage: "Stage1",
@@ -35,9 +37,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Rock Slide",
+				de: "Steinhagel"
 			},
 			effect: {
 				en: "Does 10 damage to 2 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)",
+				de: "Dieser Angriff fügt 2 Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 20,
 
@@ -50,9 +54,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Triple Nose",
+				de: "Dreifachnase"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 50 damage plus 20 more damage for each heads.",
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 50 Schadenspunkte plus 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "50+",
 
@@ -74,7 +80,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "It exudes strong magnetium from all cover. It controls three small units called Mini-Noses."
+		en: "It exudes strong magnetium from all cover. It controls three small units called Mini-Noses.",
+		de: "Es gibt starken Magnetismus ab. Es steuert drei kleine Einheiten, die sich Mininasen nennen."
 	},
 
 	retreat: 3,

--- a/data/POP/POP Series 8/5.ts
+++ b/data/POP/POP Series 8/5.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 8'
 const card: Card = {
 	name: {
 		en: "Yanmega",
+		de: "Yanmega"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -23,6 +24,7 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Yanma",
+		de: "Yanma"
 	},
 
 	stage: "Stage1",
@@ -34,9 +36,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Supersonic",
+				de: "Superschall"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 
 		},
@@ -49,9 +53,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Air Slash",
+				de: "Luftschnitt"
 			},
 			effect: {
 				en: "Flip a coin. If tails, discard an Energy attached to Yanmega.",
+				de: "Wirf 1 Münze. Bei „Zahl“ lege 1 an Yanmega angelegte Energie auf deinen Ablagestapel."
 			},
 			damage: 70,
 
@@ -73,7 +79,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "By churning its wings, it creates shock waves that inflict critical internal injuries to foes."
+		en: "By churning its wings, it creates shock waves that inflict critical internal injuries to foes.",
+		de: "Durch die Bewegung seiner Flügel entstehen Schockwellen, die dem Gegner innere Verletzungen zufügen."
 	},
 
 	retreat: 0,

--- a/data/POP/POP Series 8/6.ts
+++ b/data/POP/POP Series 8/6.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 8'
 const card: Card = {
 	name: {
 		en: "Cherrim",
+		de: "Kinoso"
 	},
 
 	illustrator: "Atsuko Nishida",
@@ -23,6 +24,7 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Cherubi",
+		de: "Kikugi"
 	},
 
 	stage: "Stage1",
@@ -34,9 +36,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Worry Seed",
+				de: "Sorgensamen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: 20,
 
@@ -48,9 +52,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Magical Leaf",
+				de: "Zauberblatt"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 20 more damage and remove 3 damage counters from Cherrim.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 20 weitere Schadenspunkte zu und entferne 3 Schadensmarken von Kinoso."
 			},
 			damage: "20+",
 
@@ -72,7 +78,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "It blooms during times of strong sunlight. It tries to make up for everything it endured as a bud."
+		en: "It blooms during times of strong sunlight. It tries to make up for everything it endured as a bud.",
+		de: "In Zeiten mit viel Sonnenschein blüht es auf. Es holt nach, was ihm als Knospe verwehrt blieb."
 	},
 
 	retreat: 2,

--- a/data/POP/POP Series 8/7.ts
+++ b/data/POP/POP Series 8/7.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 8'
 const card: Card = {
 	name: {
 		en: "Carnivine",
+		de: "Venuflibis"
 	},
 
 	illustrator: "Kouki Saitou",
@@ -31,9 +32,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Swallow Up",
+				de: "Runterschlucken"
 			},
 			effect: {
 				en: "Before doing damage, count the remaining HP of the Defending Pokémon and Carnivine. If the Defending Pokémon has fewer remaining HP than Carnivine’s, this attack does 60 damage instead.",
+				de: "Bevor der Schaden zugefügt wird, vergleiche die verbliebenen KP von dem Verteidigenden Pokémon und Venuflibis. Wenn das Verteidigende Pokémon weniger verbliebene KP hat als Venuflibis, fügt dieser Angriff 60 Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -45,9 +48,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Wring Out",
+				de: "Auswringen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed and discard an Energy card attached to the Defending Pokémon.",
+				de: "Wirf 1 Münze. Bei „Kopf“ lege eine Energiekarte, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners und das Verteidigende Pokémon ist jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -69,7 +74,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "It attracts prey with its sweet-smelling saliva, then chomps down. It takes a whole day to eat prey."
+		en: "It attracts prey with its sweet-smelling saliva, then chomps down. It takes a whole day to eat prey.",
+		de: "Sein süßlich riechender Speichel zieht Beute an, die es frisst. Es braucht einen Tag, sie zu fressen."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 8/8.ts
+++ b/data/POP/POP Series 8/8.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 8'
 const card: Card = {
 	name: {
 		en: "Luxio",
+		de: "Luxio"
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -23,6 +24,7 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Shinx",
+		de: "Sheinux"
 	},
 
 	stage: "Stage1",
@@ -34,9 +36,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Fasten Claws",
+				de: "Klauen anlegen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 30 more damage.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 30 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -48,9 +52,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Thunder Fang",
+				de: "Donnerzahn"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 30,
 
@@ -72,7 +78,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "Its claws loose electricity with enough amperage to cause fainting. They live in small groups."
+		en: "Its claws loose electricity with enough amperage to cause fainting. They live in small groups.",
+		de: "Seine Krallen geben Elektrizität ab, die stark genug ist, jemanden bewusstlos zu machen."
 	},
 
 	retreat: 0,

--- a/data/POP/POP Series 8/9.ts
+++ b/data/POP/POP Series 8/9.ts
@@ -4,6 +4,7 @@ import Set from '../POP Series 8'
 const card: Card = {
 	name: {
 		en: "Night Maintenance",
+		de: "Nächtliche Wartung"
 	},
 
 	illustrator: "Ryo Ueda",
@@ -12,7 +13,8 @@ const card: Card = {
 	set: Set,
 
 	effect: {
-		en: "Search your discard pile for up to 3 in any combination of Pokémon and basic Energy cards. Show them to your opponent and shuffle them into your deck."
+		en: "Search your discard pile for up to 3 in any combination of Pokémon and basic Energy cards. Show them to your opponent and shuffle them into your deck.",
+		de: "Durchsuche deinen Ablagestapel nach bis zu 3 Karten in beliebiger Kombination aus Pokémon- und Basis-Energiekarten. Zeige sie deinem Gegner und mische sie in dein Deck."
 	},
 
 	trainerType: "Item",


### PR DESCRIPTION
## Add missing German translations for pop8

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
