### PR TITLE
Add missing German translations for pop9

### DIFF
--- a/data/POP/POP Series 9/1.ts
+++ b/data/POP/POP Series 9/1.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 9'
 const card: Card = {
 	name: {
 		en: "Garchomp",
-		fr: "Carchacrok"
+		fr: "Carchacrok",
+		de: "Knakrack"
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Gabite",
-		fr: "Carmache"
+		fr: "Carmache",
+		de: "Knarksel"
 	},
 
 	stage: "Stage2",
@@ -35,12 +37,14 @@ const card: Card = {
 
 			name: {
 				en: "Dragon Rage",
-				fr: "Draco-Rage"
+				fr: "Draco-Rage",
+				de: "Drachenwut"
 			},
 
 			effect: {
 				en: "Flip 2 coins. If either of them is tails, this attack does nothing.",
-				fr: "Lancez 2 pièces. Si vous obtenez au moins un côté pile, cette attaque ne fait rien."
+				fr: "Lancez 2 pièces. Si vous obtenez au moins un côté pile, cette attaque ne fait rien.",
+				de: "Wirf 2 Münzen. Wenn eine oder beide Münzen „Zahl“ gezeigt haben, hat dieser Angriff keine Auswirkungen."
 			},
 
 			damage: 80,
@@ -53,11 +57,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Jet Sword",
-				fr: "Jet Sword"
+				fr: "Jet Sword",
+				de: "Düsenschwert"
 			},
 			effect: {
 				en: "Discard 2 Energy attached to Garchomp and this attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				fr: "Défaussez deux Énergies attachées à Carchacrok. Cette attaque inflige 10 dégâts à chacun des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)"
+				fr: "Défaussez deux Énergies attachées à Carchacrok. Cette attaque inflige 10 dégâts à chacun des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Entferne 2 Energien, die an Knakrack angelegt sind, und lege sie auf deinen Ablagestapel und dieser Angriff fügt allen Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 100,
 
@@ -74,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "It flies at speeds equal to a jet fighter plane. It never allows its prey to escape.",
-		fr: "Il vole à la vitesse d'un avion à réaction et ne lâche jamais sa proie."
+		fr: "Il vole à la vitesse d'un avion à réaction et ne lâche jamais sa proie.",
+		de: "Es fliegt mit der Geschwindigkeit eines Kampfjets. Es lässt nicht zu, dass ihm seine Beute entkommt."
 	},
 
 	variants: [

--- a/data/POP/POP Series 9/10.ts
+++ b/data/POP/POP Series 9/10.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 9'
 const card: Card = {
 	name: {
 		en: "Pachirisu",
-		fr: "Pachirisu"
+		fr: "Pachirisu",
+		de: "Pachirisu"
 	},
 
 	illustrator: "Midori Harada",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Thunder Wave",
-				fr: "Cage-éclair"
+				fr: "Cage-éclair",
+				de: "Donnerwelle"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
-				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé."
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 
@@ -45,11 +48,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Poison Berry",
-				fr: "Gorgée de poison"
+				fr: "Gorgée de poison",
+				de: "Giftbeere"
 			},
 			effect: {
 				en: "If you have Croagunk in play, this attack does 20 damage plus 20 more damage and the Defending Pokémon is now Poisoned.",
-				fr: "Si vous avez un Cradopaud en jeu, cette attaque inflige 20 dégâts plus 20 dégâts supplémentaires et le Pokémon Défenseur est maintenant Empoisonné."
+				fr: "Si vous avez un Cradopaud en jeu, cette attaque inflige 20 dégâts plus 20 dégâts supplémentaires et le Pokémon Défenseur est maintenant Empoisonné.",
+				de: "Wenn du Glibunkel im Spiel hast, fügt dieser Angriff 20 Schadenspunkte plus 20 weitere Schadenspunkte zu und das Verteidigende Pokémon ist jetzt vergiftet."
 			},
 			damage: "20+",
 
@@ -72,7 +77,8 @@ const card: Card = {
 
 	description: {
 		en: "It makes electricity with pouches in its cheeks and shoots charges from its tail. It live atop trees.",
-		fr: "Les poches de ses joues produisent de l'électricité et sa queue envoie des éclairs. Il vit dans les arbres."
+		fr: "Les poches de ses joues produisent de l'électricité et sa queue envoie des éclairs. Il vit dans les arbres.",
+		de: "In seinen Backentaschen produziert es Elektrizität und entlädt sie über den Schweif. Es lebt in Baumwipfeln."
 	},
 
 	variants: [

--- a/data/POP/POP Series 9/11.ts
+++ b/data/POP/POP Series 9/11.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 9'
 const card: Card = {
 	name: {
 		en: "Pichu",
-		fr: "Pichu"
+		fr: "Pichu",
+		de: "Pichu"
 	},
 
 	illustrator: "Midori Harada",
@@ -27,11 +28,13 @@ const card: Card = {
 			type: "Poke-POWER",
 			name: {
 				en: "Baby Evolution",
-				fr: "Évolution Bébé"
+				fr: "Évolution Bébé",
+				de: "Baby Evolution"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may put Pikachu from your hand onto Pichu (this counts as evolving Pichu) and remove all damage counters from Pichu.",
-				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez placer Pikachu de votre main sur Pichu (vous le faites ainsi évoluer) et retirer à Pichu tous ses marqueurs de dégât."
+				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez placer Pikachu de votre main sur Pichu (vous le faites ainsi évoluer) et retirer à Pichu tous ses marqueurs de dégât.",
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du Pikachu von deiner Hand auf Pichu legen (das zählt als Entwickeln von Pichu). Entferne alle Schadensmarken von Pichu."
 			},
 		},
 	],
@@ -41,11 +44,13 @@ const card: Card = {
 
 			name: {
 				en: "Find a Friend",
-				fr: "Trouver un ami"
+				fr: "Trouver un ami",
+				de: "Freunde finden"
 			},
 			effect: {
 				en: "Flip a coin. If heads, search your deck for a Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
-				fr: "Lancez une pièce. Si c'est face, choisissez un Pokémon dans votre deck. Montrez-le à votre adversaire et placez-le dans votre main. Ensuite, mélangez votre deck."
+				fr: "Lancez une pièce. Si c'est face, choisissez un Pokémon dans votre deck. Montrez-le à votre adversaire et placez-le dans votre main. Ensuite, mélangez votre deck.",
+				de: "Wirf 1 Münze. Bei „Kopf“ durchsuche dein Deck nach einer Pokémon-Karte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 			},
 
 		},
@@ -65,7 +70,8 @@ const card: Card = {
 	],
 	description: {
 		en: "It plays with others by touching tails and setting off sparks. This appears to be a test of courage.",
-		fr: "Il prouve son courage en touchant la queue électrifiée de ses pairs."
+		fr: "Il prouve son courage en touchant la queue électrifiée de ses pairs.",
+		de: "Sie spielen miteinander, indem sie ihre Schweifspitzen aneinanderhalten und Funken fliegen lassen."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 9/12.ts
+++ b/data/POP/POP Series 9/12.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 9'
 const card: Card = {
 	name: {
 		en: "Buneary",
-		fr: "Laporeille"
+		fr: "Laporeille",
+		de: "Haspiror"
 	},
 
 	illustrator: "Midori Harada",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Dizzy Punch",
-				fr: "Uppercut"
+				fr: "Uppercut",
+				de: "Irrschlag"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
-				fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de faces."
+				fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de faces.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10×",
 
@@ -45,11 +48,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Defense Curl",
-				fr: "Boul'Armure"
+				fr: "Boul'Armure",
+				de: "Einigler"
 			},
 			effect: {
 				en: "Flip a coin. If heads, prevent all damage done to Buneary by attacks during your opponent's next turn.",
-				fr: "Lancez une pièce. Si c'est face, évitez tous les dégâts infligés à Laporeille lors du prochain tour de votre adversaire."
+				fr: "Lancez une pièce. Si c'est face, évitez tous les dégâts infligés à Laporeille lors du prochain tour de votre adversaire.",
+				de: "Wirf 1 Münze. Bei „Kopf“ verhindere allen Schaden, der Haspiror während des nächsten Zuges deines Gegners zugefügt wird."
 			},
 
 		},
@@ -63,7 +68,8 @@ const card: Card = {
 	],
 	description: {
 		en: "When it senses danger, it perks up its ears. On cold nights, it sleeps with its head tucked into its fur.",
-		fr: "Il dresse les oreilles quand il sent le danger. Il dort la tête dans sa fourrure pendant les nuits froides."
+		fr: "Il dresse les oreilles quand il sent le danger. Il dort la tête dans sa fourrure pendant les nuits froides.",
+		de: "Nimmt es Gefahr wahr, richtet es seine Ohren auf. In kalten Nächten vergräbt es den Kopf in seinem Fell."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 9/13.ts
+++ b/data/POP/POP Series 9/13.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 9'
 const card: Card = {
 	name: {
 		en: "Chimchar",
-		fr: "Ouisticram"
+		fr: "Ouisticram",
+		de: "Panflam"
 	},
 
 	illustrator: "Midori Harada",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Serial Swipes",
-				fr: "Grands coups en série"
+				fr: "Grands coups en série",
+				de: "Schlagserie"
 			},
 			effect: {
 				en: "Flip 4 coins. This attack does 10 damage times the number of heads.",
-				fr: "Lancez 4 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de faces."
+				fr: "Lancez 4 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de faces.",
+				de: "Wirf 4 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10×",
 
@@ -46,11 +49,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Sleepy",
-				fr: "Somnolent"
+				fr: "Somnolent",
+				de: "Verschlafen"
 			},
 			effect: {
 				en: "If you have Piplup in play, this attack does 40 damage plus 20 more damage and the Defending Pokémon is now Asleep.",
-				fr: "Si vous avez Tiplouf en jeu, cette attaque inflige 40 dégâts plus 20 dégâts supplémentaires et le Pokémon Défenseur est maintenant Endormi."
+				fr: "Si vous avez Tiplouf en jeu, cette attaque inflige 40 dégâts plus 20 dégâts supplémentaires et le Pokémon Défenseur est maintenant Endormi.",
+				de: "Wenn du Plinfa im Spiel hast, fügt dieser Angriff 40 Schadenspunkte plus 20 weitere Schadenspunkte zu und das Verteidigende Pokémon schläft jetzt."
 			},
 			damage: "40+",
 
@@ -65,7 +70,8 @@ const card: Card = {
 	],
 	description: {
 		en: "Its fiery rear end is fueld by gas made in its belly. Even rain can’t extinguish the fire.",
-		fr: "La flamme de sa queue est alimentée par un gaz de son estomac. Même la pluie ne saurait l'éteindre."
+		fr: "La flamme de sa queue est alimentée par un gaz de son estomac. Même la pluie ne saurait l'éteindre.",
+		de: "Das Feuer an seinem Hinterteil wird durch Gase im Bauch genährt. Selbst Regen löscht es nicht."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 9/14.ts
+++ b/data/POP/POP Series 9/14.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 9'
 const card: Card = {
 	name: {
 		en: "Gible",
-		fr: "Griknot"
+		fr: "Griknot",
+		de: "Kaumalat"
 	},
 
 	illustrator: "Hiroki Fuchino",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Push Down",
-				fr: "Enfoncer"
+				fr: "Enfoncer",
+				de: "Runterdrücken"
 			},
 			effect: {
 				en: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon.",
-				fr: "Votre adversaire échange le Pokémon Défenseur avec 1 de ses Pokémon de Banc."
+				fr: "Votre adversaire échange le Pokémon Défenseur avec 1 de ses Pokémon de Banc.",
+				de: "Dein Gegner tauscht das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
 			},
 			damage: 10,
 
@@ -48,7 +51,8 @@ const card: Card = {
 	],
 	description: {
 		en: "Its nests is small, horizontal holes in cave walls. It pounces to catch prey that stray too close.",
-		fr: "Il niche dans les petits trous horizontaux des murs des grottes. Il bondit pour saisir sa proie."
+		fr: "Il niche dans les petits trous horizontaux des murs des grottes. Il bondit pour saisir sa proie.",
+		de: "Es nistet in kleinen Löchern in Höhlenwänden. Es springt Beute, die sich zu nah heranwagt, an."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 9/15.ts
+++ b/data/POP/POP Series 9/15.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 9'
 const card: Card = {
 	name: {
 		en: "Pikachu",
-		fr: "Pikachu"
+		fr: "Pikachu",
+		de: "Pikachu"
 	},
 
 	illustrator: "Midori Harada",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Growl",
-				fr: "Rugissement"
+				fr: "Rugissement",
+				de: "Heuler"
 			},
 			effect: {
 				en: "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance).",
-				fr: "Lors du prochain tour de votre adversaire, tous dégâts infligés par des attaques au Pokémon Défenseur sont réduits de 20 (avant application de la Faiblesse et de la Résistance)."
+				fr: "Lors du prochain tour de votre adversaire, tous dégâts infligés par des attaques au Pokémon Défenseur sont réduits de 20 (avant application de la Faiblesse et de la Résistance).",
+				de: "Während des nächsten Zuges deines Gegners wird Schaden, der durch Angriffe des Verteidigenden Pokémon zugefügt wird, um 20 Schadenspunkte reduziert (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 
 		},
@@ -45,11 +48,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Numb",
-				fr: "Engourdi"
+				fr: "Engourdi",
+				de: "Betäuben"
 			},
 			effect: {
 				en: "If Pikachu evolved from Pichu during this turn, the Defending Pokémon is now Paralyzed.",
-				fr: "Si Pikachu évolue de Pichu lors de ce tour, le Pokémon Défenseur est maintenant Paralysé."
+				fr: "Si Pikachu évolue de Pichu lors de ce tour, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wenn sich Pikachu in diesem Zug aus Pichu entwickelt hat, ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 30,
 
@@ -70,7 +75,8 @@ const card: Card = {
 	],
 	description: {
 		en: "If it looses crackling power from the electric pouches on its cheeks, it is being wary.",
-		fr: "Si les poches électriques de ses joues crépitent, c'est qu'il est sur ses gardes."
+		fr: "Si les poches électriques de ses joues crépitent, c'est qu'il est sur ses gardes.",
+		de: "Ist es angespannt, setzt es knisternd Elektrizität aus seinen Backentaschen frei."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 9/16.ts
+++ b/data/POP/POP Series 9/16.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 9'
 const card: Card = {
 	name: {
 		en: "Piplup",
-		fr: "Tiplouf"
+		fr: "Tiplouf",
+		de: "Plinfa"
 	},
 
 	illustrator: "Midori Harada",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Water Sport",
-				fr: "Tourniquet"
+				fr: "Tourniquet",
+				de: "Nassmacher"
 			},
 			effect: {
 				en: "If Piplup has less Energy attached to it than the Defending Pokémon, this attack does 10 damage plus more 10 more damage.",
-				fr: "Si Tiplouf possède moins d'Énergies que le Pokémon Défenseur, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires."
+				fr: "Si Tiplouf possède moins d'Énergies que le Pokémon Défenseur, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires.",
+				de: "Wenn Plinfa weniger Energie angelegt ist als an das Verteidigende Pokémon, fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -46,11 +49,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Wavelet",
-				fr: "Vaguelette"
+				fr: "Vaguelette",
+				de: "Kleine Welle"
 			},
 			effect: {
 				en: "If you have Buizel in play, this attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				fr: "Si vous avez Mustébouée en jeu, cette attaque inflige 10 dégâts à chacun des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)"
+				fr: "Si vous avez Mustébouée en jeu, cette attaque inflige 10 dégâts à chacun des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
+				de: "Wenn du Bamelin im Spiel hast, fügt dieser Angriff jedem Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 40,
 
@@ -65,7 +70,8 @@ const card: Card = {
 	],
 	description: {
 		en: "It lives along shores in northern countries. A skilled swimmer, it dives for over 10 minutes to hunt.",
-		fr: "Il vit sur les côtes des régions nordiques. C'est un nageur doué, qui peut plonger durant 10 minutes."
+		fr: "Il vit sur les côtes des régions nordiques. C'est un nageur doué, qui peut plonger durant 10 minutes.",
+		de: "Es lebt an den Küsten der nördlichen Länder. Es kann über 10 Minuten unter Wasser bleiben."
 	},
 
 	retreat: 1,

--- a/data/POP/POP Series 9/17.ts
+++ b/data/POP/POP Series 9/17.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 9'
 const card: Card = {
 	name: {
 		en: "Turtwig",
-		fr: "Tortipouss"
+		fr: "Tortipouss",
+		de: "Chelast"
 	},
 
 	illustrator: "Midori Harada",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Absorb",
-				fr: "Vol-Vie"
+				fr: "Vol-Vie",
+				de: "Absorber"
 			},
 			effect: {
 				en: "Remove 1 damage counter from Turtwig.",
-				fr: "Retirez un marqueur de dégât à Tortipouss."
+				fr: "Retirez un marqueur de dégât à Tortipouss.",
+				de: "Entferne 1 Schadensmarke von Chelast."
 			},
 			damage: 10,
 
@@ -46,11 +49,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Parboil",
-				fr: "Parboil"
+				fr: "Parboil",
+				de: "Vorkochen"
 			},
 			effect: {
 				en: "If you have Chimchar in play, this attack does 40 damage plus 20 more damage and the Defending Pokémon is now Burned.",
-				fr: "Si vous avez Ouisticram en jeu, cette attaque inflige 40 dégâts plus 20 dégâts. Le Pokémon Défenseur est maintenant Brûlé."
+				fr: "Si vous avez Ouisticram en jeu, cette attaque inflige 40 dégâts plus 20 dégâts. Le Pokémon Défenseur est maintenant Brûlé.",
+				de: "Wenn du Panflam im Spiel hast, fügt dieser Angriff 40 Schadenspunkte plus 20 weitere Schadenspunkte zu und das Verteidigende Pokémon ist jetzt verbrannt."
 			},
 			damage: "40+",
 
@@ -71,7 +76,8 @@ const card: Card = {
 	],
 	description: {
 		en: "It undertakes photosynthesis with its body, making oxygen. The leaf on its head wilts if it is thirsty.",
-		fr: "Son corps produit de l'oxygène par photosynthèse. La feuille sur sa tête flétrit quand il a soif."
+		fr: "Son corps produit de l'oxygène par photosynthèse. La feuille sur sa tête flétrit quand il a soif.",
+		de: "Sein Körper lebt von der Photosynthese, die Sauerstoff freisetzt. Ist es durstig welkt sein Blatt."
 	},
 
 	retreat: 2,

--- a/data/POP/POP Series 9/2.ts
+++ b/data/POP/POP Series 9/2.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 9'
 const card: Card = {
 	name: {
 		en: "Manaphy",
-		fr: "Manaphy"
+		fr: "Manaphy",
+		de: "Manaphy"
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Dive",
-				fr: "Plongée"
+				fr: "Plongée",
+				de: "Taucher"
 			},
 			effect: {
 				en: "Look at the top 7 cards of your deck, choose 1 of them, and put it into your hand. Put the other cards back on top of your deck. Shuffle your deck afterward.",
-				fr: "Regardez les 7 cartes du dessus de votre deck. Choisissez-en 1 et placez-la dans votre main. Replacez les autres cartes au dessus de votre deck. Ensuite, mélangez votre deck."
+				fr: "Regardez les 7 cartes du dessus de votre deck. Choisissez-en 1 et placez-la dans votre main. Replacez les autres cartes au dessus de votre deck. Ensuite, mélangez votre deck.",
+				de: "Schau dir die obersten 7 Karten deines Decks an, wähle 1 von ihnen und nimm sie auf die Hand. Lege die restlichen Karten zurück auf dein Deck. Mische dein Deck danach."
 			},
 
 		},
@@ -43,11 +46,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Water Glow",
-				fr: "Eau scintillante"
+				fr: "Eau scintillante",
+				de: "Wasserschimmer"
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Remove from Manaphy the number of damage counters equal to the damage you did to that Pokémon.",
-				fr: "Choisissez 1 des Pokémon de votre adversaire. Cette attaque lui inflige 20 dégâts. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.) Ensuite, retirez à Manaphy autant de marqueurs de dégât que vous avez infligé de dégâts à ce Pokémon."
+				fr: "Choisissez 1 des Pokémon de votre adversaire. Cette attaque lui inflige 20 dégâts. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.) Ensuite, retirez à Manaphy autant de marqueurs de dégât que vous avez infligé de dégâts à ce Pokémon.",
+				de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.) Danach entferne von Manaphy Schadensmarken entsprechend der Höhe der Schadenspunkte, die dem gewählten Pokémon zugefügt wurden."
 			}
 
 		},
@@ -63,7 +68,8 @@ const card: Card = {
 
 	description: {
 		en: "It is born with a wondrous power that lets it bond with any kind of Pokémon.",
-		fr: "Il est né avec le pouvoir incroyable de créer des liens avec n'importe quel Pokémon."
+		fr: "Il est né avec le pouvoir incroyable de créer des liens avec n'importe quel Pokémon.",
+		de: "Es wird mit einer wundersamen Kraft geboren, die eine Bindung zu jedem anderen Pokémon möglich macht."
 	},
 
 	variants: [

--- a/data/POP/POP Series 9/3.ts
+++ b/data/POP/POP Series 9/3.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 9'
 const card: Card = {
 	name: {
 		en: "Raichu",
-		fr: "Raichu"
+		fr: "Raichu",
+		de: "Raichu"
 	},
 
 	illustrator: "Midori Harada",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pikachu",
-		fr: "Pikachu"
+		fr: "Pikachu",
+		de: "Pikachu"
 	},
 
 	stage: "Stage1",
@@ -35,11 +37,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Slam",
-				fr: "Souplesse"
+				fr: "Souplesse",
+				de: "Slam"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 30 damage times the number of heads.",
-				fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de faces."
+				fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de faces.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "30×",
 
@@ -53,12 +57,14 @@ const card: Card = {
 
 			name: {
 				en: "High Volt",
-				fr: "Voltage puissant"
+				fr: "Voltage puissant",
+				de: "Hochvolt"
 			},
 
 			effect: {
 				en: "If Raichu evolved from Pikachu during this turn, this attack's base damage is 100 instead of 60.",
-				fr: "Si Raichu évolue d'un Pokémon lors de ce tour, les dégâts de base de cette attaque sont de 100 au lieu de 60."
+				fr: "Si Raichu évolue d'un Pokémon lors de ce tour, les dégâts de base de cette attaque sont de 100 au lieu de 60.",
+				de: "Wenn sich Raichu in diesem Zug aus Pikachu entwickelt hat, beträgt der Grundschaden dieses Angriffs 100 Schadenspunkte."
 			},
 
 			damage: 60,
@@ -80,7 +86,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It can loose 100,000-volt bursts of electricity, instantly downing foes several times its size."
+		en: "It can loose 100,000-volt bursts of electricity, instantly downing foes several times its size.",
+		de: "Es kann 100 000 Volt mit einem Schlag freisetzen und so viel größere Gegner besiegen."
 	},
 
 	variants: [

--- a/data/POP/POP Series 9/4.ts
+++ b/data/POP/POP Series 9/4.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 9'
 const card: Card = {
 	name: {
 		en: "Regigigas",
-		fr: "Regigigas"
+		fr: "Regigigas",
+		de: "Regigigas"
 	},
 
 	illustrator: "Kent Kanetsuna",
@@ -31,11 +32,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Body Slam",
-				fr: "Plaquage"
+				fr: "Plaquage",
+				de: "Bodyslam"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
-				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé."
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -49,11 +52,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Double Stomp",
-				fr: "Double écrasement"
+				fr: "Double écrasement",
+				de: "Doppelstampfer"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 50 damage plus 20 more damage for each heads.",
-				fr: "Lancez 2 pièces. Cette attaque inflige 50 dégâts plus 20 dégâts supplémentaires pour chaque face."
+				fr: "Lancez 2 pièces. Cette attaque inflige 50 dégâts plus 20 dégâts supplémentaires pour chaque face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 50 Schadenspunkte plus 20 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "50+",
 
@@ -70,7 +75,8 @@ const card: Card = {
 
 	description: {
 		en: "There is an enduring legend that states this Pokémon towed continents with ropes.",
-		fr: "Une légende tenace veut que ce Pokémon ait traîné les continents en les attachant à des cordes."
+		fr: "Une légende tenace veut que ce Pokémon ait traîné les continents en les attachant à des cordes.",
+		de: "Es gibt eine Legende, wonach dieses PKMN die Kontinente mit einem Seil gezogen hat."
 	},
 
 	variants: [

--- a/data/POP/POP Series 9/5.ts
+++ b/data/POP/POP Series 9/5.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 9'
 const card: Card = {
 	name: {
 		en: "Rotom",
-		fr: "Motisma"
+		fr: "Motisma",
+		de: "Rotom"
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -27,11 +28,13 @@ const card: Card = {
 			type: "Poke-POWER",
 			name: {
 				en: "Type Shift",
-				fr: "Transfert de type"
+				fr: "Transfert de type",
+				de: "Typenwechsel"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may use this power. Rotom's type is Psychic until the end of your turn.",
-				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez utiliser ce pouvoir. Le type de Motisma est  jusqu'à la fin de votre tour."
+				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez utiliser ce pouvoir. Le type de Motisma est  jusqu'à la fin de votre tour.",
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du diese Poké-Power benutzen. Rotom erhält den Typ {P} bis zum Ende des Zuges."
 			},
 		},
 	],
@@ -44,11 +47,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Poltergeist",
-				fr: "Poltergeist"
+				fr: "Poltergeist",
+				de: "Poltergeist"
 			},
 			effect: {
 				en: "Look at your opponent's hand. This attack does 30 damage plus 10 more damage for each Trainer, Supporter, and Stadium card in your opponent's hand.",
-				fr: "Regardez la main de votre adversaire. Cette attaque inflige 30 dégâts plus 10 dégâts supplémentaires pour chaque carte Dresseur, Supporter et Stade dans la main de votre adversaire."
+				fr: "Regardez la main de votre adversaire. Cette attaque inflige 30 dégâts plus 10 dégâts supplémentaires pour chaque carte Dresseur, Supporter et Stade dans la main de votre adversaire.",
+				de: "Schau dir die Handkarten deines Gegners an. Dieser Angriff fügt 30 Schadenspunkte plus 10 weitere Schadenspunkte für jede Trainer-, Unterstützer- und Stadion-Karte, die du dort gefunden hast, zu."
 			},
 			damage: "30+",
 
@@ -71,7 +76,8 @@ const card: Card = {
 
 	description: {
 		en: "Its electric-like body can enter some kinds of machines and take control in order to make mischief.",
-		fr: "Son corps parcouru d'électricité lui permet de prendre le contrôle de certains appareils ménagers."
+		fr: "Son corps parcouru d'électricité lui permet de prendre le contrôle de certains appareils ménagers.",
+		de: "Es kann mit seinem Körper in elektrische Geräte eindringen und dann für Chaos sorgen."
 	},
 
 	variants: [

--- a/data/POP/POP Series 9/6.ts
+++ b/data/POP/POP Series 9/6.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 9'
 const card: Card = {
 	name: {
 		en: "Buizel",
-		fr: "Buizel"
+		fr: "Buizel",
+		de: "Bamelin"
 	},
 
 	illustrator: "Midori Harada",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Whirlpool",
-				fr: "Siphon"
+				fr: "Siphon",
+				de: "Whirlpool"
 			},
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy attached to the Defending Pokémon.",
-				fr: "Lancez une pièce. Si c'est face, défaussez une Énergie attachée au Pokémon Défenseur."
+				fr: "Lancez une pièce. Si c'est face, défaussez une Énergie attachée au Pokémon Défenseur.",
+				de: "Wirf 1 Münze. Bei „Kopf“ entferne 1 Energie, die an das Verteidigende Pokémon angelegt ist, und lege sie auf den Ablagestapel deines Gegners."
 			},
 
 		},
@@ -44,11 +47,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Super Fast",
-				fr: "« Super Rapide »"
+				fr: "« Super Rapide »",
+				de: "Superflink"
 			},
 			effect: {
 				en: "If you have Pachirisu in play, flip a coin. If heads, prevent all effects of an attack, including damage, done to Buizel during your opponent's next turn.",
-				fr: "Si vous avez un Pachirisu en jeu, lancez une pièce. Si c'est face, prévenez tous les effets d'une attaque, dégâts inclus, infligés à Mustébouée lors du prochain tour de votre adversaire."
+				fr: "Si vous avez un Pachirisu en jeu, lancez une pièce. Si c'est face, prévenez tous les effets d'une attaque, dégâts inclus, infligés à Mustébouée lors du prochain tour de votre adversaire.",
+				de: "Wenn du Pachirisu im Spiel hast, wirf 1 Münze. Verhindere bei „Kopf“ alle Effekte eines Angriffs, einschließlich Schaden, die Bamelin während des nächsten Zuges deines Gegners zugefügt würden."
 			},
 			damage: 30,
 
@@ -64,7 +69,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It swims by rotating its two tails like a screw. When it dives, its flotation sac collapses."
+		en: "It swims by rotating its two tails like a screw. When it dives, its flotation sac collapses.",
+		de: "Es schwimmt, indem es seine beiden Schweife wie eine Schiffsschraube rotieren lässt."
 	},
 
 	variants: [

--- a/data/POP/POP Series 9/7.ts
+++ b/data/POP/POP Series 9/7.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 9'
 const card: Card = {
 	name: {
 		en: "Croagunk",
-		fr: "Cradopaud"
+		fr: "Cradopaud",
+		de: "Glibunkel"
 	},
 
 	illustrator: "Midori Harada",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Knock Off",
-				fr: "Sabotage"
+				fr: "Sabotage",
+				de: "Abschlag"
 			},
 			effect: {
 				en: "Flip a coin. If heads, choose 1 card from your opponent's hand without looking and discard it.",
-				fr: "Lancez une pièce. Si c'est face, choisissez sans regarder 1 carte de la main de votre adversaire et défaussez-la."
+				fr: "Lancez une pièce. Si c'est face, choisissez sans regarder 1 carte de la main de votre adversaire et défaussez-la.",
+				de: "Wirf 1 Münze. Bei „Kopf“ wähle 1 Karte von der Hand deines Gegners (ohne sie vorher anzusehen) und lege sie auf seinen Ablagestapel."
 			},
 
 		},
@@ -44,11 +47,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Nimble",
-				fr: "Agilité"
+				fr: "Agilité",
+				de: "Beweglichkeit"
 			},
 			effect: {
 				en: "If you have Turtwig in play, remove from Croagunk the number of damage counters equal to the damage you did to the Defending Pokémon.",
-				fr: "Si vous avez un Tortipouss en jeu, retirez à Cradopaud autant de marqueurs de dégât que vous avez infligé de dégâts au Pokémon Défenseur."
+				fr: "Si vous avez un Tortipouss en jeu, retirez à Cradopaud autant de marqueurs de dégât que vous avez infligé de dégâts au Pokémon Défenseur.",
+				de: "Wenn du Chelast im Spiel hast, entferne von Glibunkel Schadensmarken in der Höhe der Schadenspunkte, die dem Verteidigenden Pokémon zugefügt wurden."
 			},
 			damage: 30,
 
@@ -65,7 +70,8 @@ const card: Card = {
 
 	description: {
 		en: "Inflating its poison sacs, it makes an eerie blubbering sound for intimidation.",
-		fr: "Il émet un gargouillis étrange en gonflant ses glandes de poison pour intimider l'ennemi."
+		fr: "Il émet un gargouillis étrange en gonflant ses glandes de poison pour intimider l'ennemi.",
+		de: "Wenn es seine giftigen Backen aufbläht, hört man ein unheimliches Geräusch, welches Gegner ängstigt."
 	},
 
 	variants: [

--- a/data/POP/POP Series 9/8.ts
+++ b/data/POP/POP Series 9/8.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 9'
 const card: Card = {
 	name: {
 		en: "Gabite",
-		fr: "Gabite"
+		fr: "Gabite",
+		de: "Knarksel"
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Gible",
-		fr: "Griknot"
+		fr: "Griknot",
+		de: "Kaumalat"
 	},
 
 	stage: "Stage1",
@@ -34,11 +36,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Burrow",
-				fr: "Terrier"
+				fr: "Terrier",
+				de: "Erdhöhle"
 			},
 			effect: {
 				en: "Flip a coin. If heads, prevent all damage done to Gabite by attacks during your opponent's next turn.",
-				fr: "Lancez une pièce. Si c'est face, prévenez tous les dégâts infligés à Carmache par des attaques lors du prochain tour de votre adversaire."
+				fr: "Lancez une pièce. Si c'est face, prévenez tous les dégâts infligés à Carmache par des attaques lors du prochain tour de votre adversaire.",
+				de: "Wirf 1 Münze. Bei „Kopf“ verhindere allen Schaden, der Knarksel während des nächsten Zuges deines Gegners durch Angriffe zugefügt würde."
 			},
 
 		},
@@ -50,11 +54,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Distored Wave",
-				fr: "Vague tordue"
+				fr: "Vague tordue",
+				de: "Verzerrte Welle"
 			},
 			effect: {
 				en: "Before doing damage, remove 2 damage counters from the Defending Pokémon.",
-				fr: "Avant d'infliger des dégâts, retirez au Pokémon Défenseur 2 marqueurs de dégât."
+				fr: "Avant d'infliger des dégâts, retirez au Pokémon Défenseur 2 marqueurs de dégât.",
+				de: "Bevor der Schaden zugefügt wird, entferne 2 Schadensmarken vom Verteidigenden Pokémon."
 			},
 			damage: 60,
 
@@ -70,7 +76,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It habitually digs up and hoards gems in its nest. Its loot is constantly targeted by thieves."
+		en: "It habitually digs up and hoards gems in its nest. Its loot is constantly targeted by thieves.",
+		de: "Es gräbt Edelsteine aus und hortet sie in seinem Nest. Daher ist dieses ein beliebtes Ziel mancher Diebe."
 	},
 
 	variants: [

--- a/data/POP/POP Series 9/9.ts
+++ b/data/POP/POP Series 9/9.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 9'
 const card: Card = {
 	name: {
 		en: "Lopunny",
-		fr: "Lockpin"
+		fr: "Lockpin",
+		de: "Schlapor"
 	},
 
 	illustrator: "Midori Harada",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Bastiodon",
-		fr: "Laporeille"
+		fr: "Laporeille",
+		de: "Haspiror"
 	},
 
 	stage: "Stage1",
@@ -35,11 +37,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Jump Kick",
-				fr: "Pied Saute"
+				fr: "Pied Saute",
+				de: "Sprungkick"
 			},
 			effect: {
 				en: "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				fr: "Inflige 20 dégâts à 1 des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)"
+				fr: "Inflige 20 dégâts à 1 des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 1 Pokémon auf der Bank deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 20,
 
@@ -52,11 +56,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Jazzed",
-				fr: "Plein d'entrain"
+				fr: "Plein d'entrain",
+				de: "Aufgeregt"
 			},
 			effect: {
 				en: "If Lopunny evolved from Buneary during this turn, remove all damage counters from Lopunny.",
-				fr: "Si Lockpin évolue de Laporeille lors de ce tour, retirez à Lockpin tous ses marqueurs de dégât."
+				fr: "Si Lockpin évolue de Laporeille lors de ce tour, retirez à Lockpin tous ses marqueurs de dégât.",
+				de: "Wenn sich Schlapor in diesem Zug aus Haspiror entwickelt hat, entferne alle Schadensmarken von Schlapor."
 			},
 			damage: 50,
 
@@ -73,7 +79,8 @@ const card: Card = {
 
 	description: {
 		en: "It is very conscious of its looks and never fails to groom its ears. It runs with sprightly jumps.",
-		fr: "Il est très coquet et n'oublie jamais de toiletter ses oreilles. Il avance en bonds énergiques."
+		fr: "Il est très coquet et n'oublie jamais de toiletter ses oreilles. Il avance en bonds énergiques.",
+		de: "Es ist sehr bedacht auf sein Äußeres und vergisst nie, seine Ohren zu kämmen."
 	},
 
 	variants: [


### PR DESCRIPTION
## Add missing German translations for pop9

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
