### PR TITLE
Add missing German translations for pop2

### DIFF
--- a/data/POP/POP Series 2/1.ts
+++ b/data/POP/POP Series 2/1.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 2'
 const card: Card = {
 	name: {
 		en: "Entei",
-		fr: "Entei"
+		fr: "Entei",
+		de: "Entei"
 	},
 
 	illustrator: "Kouki Saitou",
@@ -30,11 +31,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Stomp",
-				fr: "Écrasement"
+				fr: "Écrasement",
+				de: "Stampfer"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage.",
-				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires."
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -47,11 +50,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Fire Spin",
-				fr: "Danseflamme"
+				fr: "Danseflamme",
+				de: "Feuerwirbel"
 			},
 			effect: {
 				en: "Discard 2 Basic Energy cards attached to Entei or this attack does nothing.",
-				fr: "Défaussez 2 cartes Énergie de base attachées à Entei ou cette attaque est sans effet."
+				fr: "Défaussez 2 cartes Énergie de base attachées à Entei ou cette attaque est sans effet.",
+				de: "Entferne 2 Basis-Energiekarten von Entei und lege sie auf den Ablagestapel, sonst hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 50,
 

--- a/data/POP/POP Series 2/10.ts
+++ b/data/POP/POP Series 2/10.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 2'
 const card: Card = {
 	name: {
 		en: "Pokémon Park",
-		fr: "Parc Pokémon"
+		fr: "Parc Pokémon",
+		de: "Pokémon Park*"
 	},
 
 	illustrator: "Kazuo Yazawa",
@@ -15,7 +16,8 @@ const card: Card = {
 
 	effect: {
 		en: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card. Once during each player's turn, when that player attaches an Energy card from his or her hand to 1 of his or her Benched Pokémon, he or she removes 1 damage counter from that Pokémon.",
-		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez-la si une autre carte Stade est mise en jeu.\n\nUne seule fois lors du tour de chaque joueur, lorsqu'un joueur attache une carte Énergie de sa main à 1 des Pokémon de son Banc, il retire à ce Pokémon 1 marqueur de dégât."
+		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez-la si une autre carte Stade est mise en jeu.\n\nUne seule fois lors du tour de chaque joueur, lorsqu'un joueur attache une carte Énergie de sa main à 1 des Pokémon de son Banc, il retire à ce Pokémon 1 marqueur de dégât.",
+		de: "Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadion-Karte ins Spiel kommt. Ein Mal während jedes seiner Züge entfernt ein Spieler, wenn er eine Energiekarte aus seiner Hand an 1 der Pokémon auf seiner Bank anlegt, 1 Schadensmarke von diesem Pokémon, falls vorhanden."
 	},
 
 	retreat: 0,

--- a/data/POP/POP Series 2/11.ts
+++ b/data/POP/POP Series 2/11.ts
@@ -15,7 +15,8 @@ const card: Card = {
 
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Draw 3 cards. Then discard any 1 card from your hand.",
-		fr: "Vous ne pouvez jouer qu'une seule carte Supporter par tour. Lorsque vous la jouez, placez-la à côté de votre Pokémon Actif. À la fin du tour, défaussez-la.\n\nPiochez 3 cartes. Ensuite, défaussez une carte de votre main."
+		fr: "Vous ne pouvez jouer qu'une seule carte Supporter par tour. Lorsque vous la jouez, placez-la à côté de votre Pokémon Actif. À la fin du tour, défaussez-la.\n\nPiochez 3 cartes. Ensuite, défaussez une carte de votre main.",
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Akives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Ziehe 3 Karten. Lege danach 1 Karte von deiner Hand auf deinen Ablagestapel."
 	},
 
 	retreat: 0,

--- a/data/POP/POP Series 2/12.ts
+++ b/data/POP/POP Series 2/12.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 2'
 const card: Card = {
 	name: {
 		en: "Bulbasaur",
-		fr: "Bulbizarre"
+		fr: "Bulbizarre",
+		de: "Bisasam"
 	},
 
 	illustrator: "Midori Harada",
@@ -29,7 +30,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Bite",
-				fr: "Morsure"
+				fr: "Morsure",
+				de: "Biss"
 			},
 
 			damage: 10,
@@ -42,7 +44,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Razor Leaf",
-				fr: "Tranch'herbe"
+				fr: "Tranch'herbe",
+				de: "Rasierblatt"
 			},
 
 			damage: 20,

--- a/data/POP/POP Series 2/13.ts
+++ b/data/POP/POP Series 2/13.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 2'
 const card: Card = {
 	name: {
 		en: "Cacnea",
-		fr: "Cacnea"
+		fr: "Cacnea",
+		de: "Tuska"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Sand Attack",
-				fr: "Jet de Sable"
+				fr: "Jet de Sable",
+				de: "Sandangriff"
 			},
 			effect: {
 				en: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
-				fr: "Si le Pokémon Défenseur essaye d'attaquer lors du prochain tour de votre adversaire, celui-ci lance une pièce. Si c'est pile, cette attaque est sans effet."
+				fr: "Si le Pokémon Défenseur essaye d'attaquer lors du prochain tour de votre adversaire, celui-ci lance une pièce. Si c'est pile, cette attaque est sans effet.",
+				de: "Wenn das Verteidigende Pokémon im nächsten Zug angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat der entsprechende Angriff keine Auswirkungen."
 			},
 			damage: 10,
 

--- a/data/POP/POP Series 2/14.ts
+++ b/data/POP/POP Series 2/14.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 2'
 const card: Card = {
 	name: {
 		en: "Luvdisc",
-		fr: "Lovdisc"
+		fr: "Lovdisc",
+		de: "Liebiskus"
 	},
 
 	illustrator: "Atsuko Nishida",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Paralyzing Kiss",
-				fr: "Baiser paralysant"
+				fr: "Baiser paralysant",
+				de: "Lähmender Kuss"
 			},
 			effect: {
 				en: "If there are 2 Defending Pokémon in play, choose 1 of the Defending Pokémon. That Pokémon is now Paralyzed. (If there is only 1 Defending Pokémon, this attack does nothing.)",
-				fr: "S'il y a 2 Pokémon Défenseurs en jeu, choisissez-en un. Ce Pokémon est maintenant Paralysé. (S'il n'y a qu'1 Pokémon Défenseur, cette attaque est sans effet.)"
+				fr: "S'il y a 2 Pokémon Défenseurs en jeu, choisissez-en un. Ce Pokémon est maintenant Paralysé. (S'il n'y a qu'1 Pokémon Défenseur, cette attaque est sans effet.)",
+				de: "Wenn sich 2 Verteidigende Pokémon im Spiel befinden, wähle 1 von ihnen. Das gewählte Pokémon ist jetzt gelähmt. (Wenn nur 1 Verteidigendes Pokémon vorhanden ist, hat dieser Angriff keine Auswirkung.)"
 			},
 
 		},
@@ -44,11 +47,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Fast Stream",
-				fr: "Torrent"
+				fr: "Torrent",
+				de: "Reißender Strom"
 			},
 			effect: {
 				en: "Move 1 Energy card attached to the Defending Pokémon to the other Defending Pokémon. (Ignore this effect if your opponent has only 1 Defending Pokémon.)",
-				fr: "Prenez une carte Énergie attachée au Pokémon Défenseur et attachez-la à l'autre Pokémon Défenseur. (Ne tenez pas compte de cet effet si votre adversaire ne possède qu'un seul Pokémon Défenseur)."
+				fr: "Prenez une carte Énergie attachée au Pokémon Défenseur et attachez-la à l'autre Pokémon Défenseur. (Ne tenez pas compte de cet effet si votre adversaire ne possède qu'un seul Pokémon Défenseur).",
+				de: "Nimm 1 Energiekarte von dem Verteidigenden Pokémon und lege sie an das andere Verteidigende Pokémon an. (Dieser Effekt hat keine Auswirkung, wenn der Gegner nur 1 Verteidigendes Pokémon hat.)"
 			},
 			damage: 20,
 

--- a/data/POP/POP Series 2/15.ts
+++ b/data/POP/POP Series 2/15.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 2'
 const card: Card = {
 	name: {
 		en: "Phanpy",
-		fr: "Phanpy"
+		fr: "Phanpy",
+		de: "Phanpy"
 	},
 
 	illustrator: "Tomokazu Komiya",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Double Spin",
-				fr: "Double tour"
+				fr: "Double tour",
+				de: "Doppeldreher"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
-				fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de faces."
+				fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de faces.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10×",
 
@@ -45,11 +48,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Body Slam",
-				fr: "Plaquage"
+				fr: "Plaquage",
+				de: "Bodyslam"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
-				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé."
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 

--- a/data/POP/POP Series 2/16.ts
+++ b/data/POP/POP Series 2/16.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 2'
 const card: Card = {
 	name: {
 		en: "Pikachu",
-		fr: "Pikachu"
+		fr: "Pikachu",
+		de: "Pikachu"
 	},
 
 	illustrator: "Yuka Morii",
@@ -29,7 +30,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Gnaw",
-				fr: "Rogne"
+				fr: "Rogne",
+				de: "Nagen"
 			},
 
 			damage: 10,
@@ -42,11 +44,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Thunder Jolt",
-				fr: "Secousse tonnerre"
+				fr: "Secousse tonnerre",
+				de: "Donnerrüttler"
 			},
 			effect: {
 				en: "Flip a coin. If tails, Pikachu does 10 damage to itself.",
-				fr: "Lancez une pièce. Si c'est pile, Pikachu s'inflige 10 dégâts."
+				fr: "Lancez une pièce. Si c'est pile, Pikachu s'inflige 10 dégâts.",
+				de: "Wirf eine Münze. Bei „Zahl“ fügt Pikachu sich selbst 10 Schadenspunkte zu."
 			},
 			damage: 30,
 

--- a/data/POP/POP Series 2/17.ts
+++ b/data/POP/POP Series 2/17.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 2'
 const card: Card = {
 	name: {
 		en: "Celebi ex",
-		fr: "Celebi ex"
+		fr: "Celebi ex",
+		de: "Celebi ex"
 	},
 
 	illustrator: "Ryo Ueda",
@@ -27,11 +28,13 @@ const card: Card = {
 			type: "Poke-POWER",
 			name: {
 				en: "Time Reversal",
-				fr: "Remonter dans le temps"
+				fr: "Remonter dans le temps",
+				de: "Zeit Umkehrung"
 			},
 			effect: {
 				en: "Once during your turn, when you put Celebi ex from your hand onto your Bench, you may search your discard pile for a card, show it to your opponent, and put it on top of your deck.",
-				fr: "Une seule fois pendant votre tour, lorsque vous placez Celebi ex de votre main sur votre Banc, vous pouvez chercher une carte dans votre pile de défausse. Montrez-la à votre adversaire et placez-la au dessus de votre deck."
+				fr: "Une seule fois pendant votre tour, lorsque vous placez Celebi ex de votre main sur votre Banc, vous pouvez chercher une carte dans votre pile de défausse. Montrez-la à votre adversaire et placez-la au dessus de votre deck.",
+				de: "Während deines Zuges, wenn du Celebi ex auf die Bank legst, kannst du ein Mal deinen Ablagestapel nach 1 Karte durchsuchen, sie deinem Gegner zeigen und auf dein Deck legen."
 			},
 		},
 	],
@@ -44,11 +47,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Psychic Shield",
-				fr: "Bouclier psychique"
+				fr: "Bouclier psychique",
+				de: "Psychoschild"
 			},
 			effect: {
 				en: "Prevent all effects of attacks, including damage, done to Celebi ex by your opponent's Pokémon-ex during your opponent's next turn.",
-				fr: "Prévenez tous les effets d'une attaque, dégâts inclus, infligés à Celebi ex par le Pokémon-ex de votre adversaire lors du prochain tour de votre adversaire."
+				fr: "Prévenez tous les effets d'une attaque, dégâts inclus, infligés à Celebi ex par le Pokémon-ex de votre adversaire lors du prochain tour de votre adversaire.",
+				de: "Verhindere während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die Celebi ex von gegnerischen Pokémon-ex zugefügt werden."
 			},
 			damage: 30,
 

--- a/data/POP/POP Series 2/2.ts
+++ b/data/POP/POP Series 2/2.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 2'
 const card: Card = {
 	name: {
 		en: "Pidgeot",
-		fr: "Roucarnage"
+		fr: "Roucarnage",
+		de: "Tauboss"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pidgeotto",
-		fr: "Roucoups"
+		fr: "Roucoups",
+		de: "Tauboga"
 	},
 
 	stage: "Stage2",
@@ -32,11 +34,13 @@ const card: Card = {
 			type: "Poke-POWER",
 			name: {
 				en: "Beating Wings",
-				fr: "Badelaile"
+				fr: "Badelaile",
+				de: "Schlagende Flügel"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), if Pidgeot is your Active Pokémon, you may shuffle 1 of your Benched Pokémon and all cards attached to it into your deck. This power can't be used if Pidgeot is affected by a Special Condition.",
-				fr: "Une seule fois pendant votre tour (avant votre attaque), si Roucarnage est votre Pokémon Actif, vous pouvez mélanger un des Pokémon de votre Banc et toutes les cartes qui lui sont attachées à votre deck. Ce pouvoir ne peut être utilisé si Roucarnage est affecté par un État spécial."
+				fr: "Une seule fois pendant votre tour (avant votre attaque), si Roucarnage est votre Pokémon Actif, vous pouvez mélanger un des Pokémon de votre Banc et toutes les cartes qui lui sont attachées à votre deck. Ce pouvoir ne peut être utilisé si Roucarnage est affecté par un État spécial.",
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, falls Tauboss dein Aktives Pokémon ist, 1 der Pokémon auf deiner Bank und alle daran angelegten Karten in dein Deck mischen. Diese Fähigkeit kann nicht verwendet werden, falls Tauboss von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -50,11 +54,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Sharp Beak",
-				fr: "Bec-aiguisé"
+				fr: "Bec-aiguisé",
+				de: "Scharfschnabel"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 30 more damage.",
-				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts plus 30 dégâts supplémentaires."
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts plus 30 dégâts supplémentaires.",
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 30 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 

--- a/data/POP/POP Series 2/3.ts
+++ b/data/POP/POP Series 2/3.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 2'
 const card: Card = {
 	name: {
 		en: "Raikou",
-		fr: "Raikou"
+		fr: "Raikou",
+		de: "Raikou"
 	},
 
 	illustrator: "Kouki Saitou",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Roar",
-				fr: "Hurlement"
+				fr: "Hurlement",
+				de: "Gebrüll"
 			},
 			effect: {
 				en: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon, if any.",
-				fr: "Si votre adversaire a des Pokémon sur son Banc, il choisit l'un d'eux et l'échange contre le Pokémon Défenseur."
+				fr: "Si votre adversaire a des Pokémon sur son Banc, il choisit l'un d'eux et l'échange contre le Pokémon Défenseur.",
+				de: "Dein Gegner tauscht das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
 			},
 
 		},
@@ -45,11 +48,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Thunder",
-				fr: "Fatal-Foudre"
+				fr: "Fatal-Foudre",
+				de: "Donner"
 			},
 			effect: {
 				en: "Flip a coin. If tails, Raikou does 20 damage to itself.",
-				fr: "Lancez une pièce. Si c'est pile, Raikou s'inflige 20 dégâts."
+				fr: "Lancez une pièce. Si c'est pile, Raikou s'inflige 20 dégâts.",
+				de: "Wirf eine Münze. Bei „Zahl“ fügt Raikou sich selbst 20 Schadenspunkte zu."
 			},
 			damage: 50,
 

--- a/data/POP/POP Series 2/4.ts
+++ b/data/POP/POP Series 2/4.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 2'
 const card: Card = {
 	name: {
 		en: "Suicune",
-		fr: "Suicune"
+		fr: "Suicune",
+		de: "Suicune"
 	},
 
 	illustrator: "Kouki Saitou",
@@ -27,11 +28,13 @@ const card: Card = {
 			type: "Poke-BODY",
 			name: {
 				en: "Mirror Coat",
-				fr: "Voile miroir"
+				fr: "Voile miroir",
+				de: "Spiegelcape"
 			},
 			effect: {
 				en: "If Suicune is Burned or Poisoned by an opponent's attack (even if Suicune is Knocked Out), the Attacking Pokémon is now affected by the same Special Conditions (1 if there is only 1).",
-				fr: "Si Suicune est Brûlé ou Empoisonné par une attaque de votre adversaire (même si Suicune est mis K.O.), le Pokémon Attaquant est maintenant affecté par les mêmes États Spéciaux (ou 1 s'il n'y en a qu'1)."
+				fr: "Si Suicune est Brûlé ou Empoisonné par une attaque de votre adversaire (même si Suicune est mis K.O.), le Pokémon Attaquant est maintenant affecté par les mêmes États Spéciaux (ou 1 s'il n'y en a qu'1).",
+				de: "Wenn Suicune durch einen Angriff deines Gegners verbrannt oder vergiftet wird (auch wenn Suicune kampfunfähig wird), wird das Angreifende Pokémon jetzt auch von diesen Speziellen Zuständen betroffen (1 falls nur 1 vorhanden)."
 			},
 		},
 	],
@@ -44,11 +47,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Bubblebeam",
-				fr: "Bulles d'O"
+				fr: "Bulles d'O",
+				de: "Blubbstrahl"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
-				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé."
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 

--- a/data/POP/POP Series 2/5.ts
+++ b/data/POP/POP Series 2/5.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 2'
 const card: Card = {
 	name: {
 		en: "Tauros",
-		fr: "Tauros"
+		fr: "Tauros",
+		de: "Tauros"
 	},
 
 	illustrator: "Kouki Saitou",
@@ -30,11 +31,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Rage",
-				fr: "Frénésie"
+				fr: "Frénésie",
+				de: "Raserei"
 			},
 			effect: {
 				en: "Does 10 damage plus 10 more damage for each damage counter on Tauros.",
-				fr: "Inflige 10 dégâts plus 10 dégâts supplémentaires pour chaque marqueur de dégât sur Tauros."
+				fr: "Inflige 10 dégâts plus 10 dégâts supplémentaires pour chaque marqueur de dégât sur Tauros.",
+				de: "Fügt 10 Schadenspunkte plus 10 weitere Schadenspunkte für jede Schadensmarke auf Tauros zu."
 			},
 			damage: "10+",
 
@@ -47,11 +50,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Take Down",
-				fr: "Bélier"
+				fr: "Bélier",
+				de: "Bodycheck"
 			},
 			effect: {
 				en: "Tauros does 10 damage to itself.",
-				fr: "Tauros s'inflige 10 dégâts."
+				fr: "Tauros s'inflige 10 dégâts.",
+				de: "Tauros fügt sich selbst 10 Schadenspunkte zu."
 			},
 			damage: 40,
 

--- a/data/POP/POP Series 2/6.ts
+++ b/data/POP/POP Series 2/6.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 2'
 const card: Card = {
 	name: {
 		en: "Venusaur",
-		fr: "Florizarre"
+		fr: "Florizarre",
+		de: "Bisaflor"
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Ivysaur",
-		fr: "Herbizarre"
+		fr: "Herbizarre",
+		de: "Bisaknosp"
 	},
 
 	stage: "Stage2",
@@ -36,11 +38,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Wide Solarbeam",
-				fr: "« Grand rayon solaire »"
+				fr: "« Grand rayon solaire »",
+				de: "Geteilter Solarstrahl"
 			},
 			effect: {
 				en: "Does 20 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				fr: "Inflige 20 dégâts à 2 des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)"
+				fr: "Inflige 20 dégâts à 2 des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 2 gegnerischen Pokémon auf der Bank (1 wenn nur 1 vorhanden ist) 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 20,
 
@@ -54,11 +58,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Hard Plant",
-				fr: "« Herbe forte »"
+				fr: "« Herbe forte »",
+				de: "Steinharte Pflanze"
 			},
 			effect: {
 				en: "Venusaur can't use Hard Plant during your next turn.",
-				fr: "Florizarre ne peut pas utiliser Herbe forte lors de votre prochain tour."
+				fr: "Florizarre ne peut pas utiliser Herbe forte lors de votre prochain tour.",
+				de: "Bisaflor kann Steinharte Pflanze in deinem nächsten Zug nicht benutzen."
 			},
 			damage: 80,
 

--- a/data/POP/POP Series 2/7.ts
+++ b/data/POP/POP Series 2/7.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 2'
 const card: Card = {
 	name: {
 		en: "Ivysaur",
-		fr: "Herbizarre"
+		fr: "Herbizarre",
+		de: "Bisaknosp"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Bulbasaur",
-		fr: "Bulbizarre"
+		fr: "Bulbizarre",
+		de: "Bisasam"
 	},
 
 	stage: "Stage1",
@@ -34,11 +36,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Poison Seed",
-				fr: "Graine poison"
+				fr: "Graine poison",
+				de: "Giftsamen"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned.",
-				fr: "Le Pokémon Défenseur est maintenant Empoisonné."
+				fr: "Le Pokémon Défenseur est maintenant Empoisonné.",
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet."
 			},
 
 		},
@@ -50,7 +54,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Razor Leaf",
-				fr: "Tranch'herbe"
+				fr: "Tranch'herbe",
+				de: "Rasierblatt"
 			},
 
 			damage: 50,

--- a/data/POP/POP Series 2/8.ts
+++ b/data/POP/POP Series 2/8.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 2'
 const card: Card = {
 	name: {
 		en: "Mr. Briney's Compassion",
-		fr: "La compassion de M. Briney"
+		fr: "La compassion de M. Briney",
+		de: "Mr. Bracks Mitgefühl"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -15,7 +16,8 @@ const card: Card = {
 
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Choose 1 of your Pokémon in play (excluding Pokémon-ex). Return that Pokémon and all cards attached to it to your hand.",
-		fr: "Vous ne pouvez jouer qu'une seule carte Supporter par tour. Lorsque vous jouez cette carte, placez-la à côté de votre Pokémon Actif. À la fin du tour, défaussez-la.\n\nChoisissez 1 des Pokémon que vous avez en jeu (sauf les Pokémon-ex). Reprenez dans votre main ce Pokémon ainsi que toutes les cartes qui lui sont attachées."
+		fr: "Vous ne pouvez jouer qu'une seule carte Supporter par tour. Lorsque vous jouez cette carte, placez-la à côté de votre Pokémon Actif. À la fin du tour, défaussez-la.\n\nChoisissez 1 des Pokémon que vous avez en jeu (sauf les Pokémon-ex). Reprenez dans votre main ce Pokémon ainsi que toutes les cartes qui lui sont attachées.",
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Wähle 1 deiner Pokémon (außer Pokémon-ex). Nimm das ausgewählte Pokémon und alle daran angelegten Karten zurück auf deine Hand."
 	},
 
 	retreat: 0,

--- a/data/POP/POP Series 2/9.ts
+++ b/data/POP/POP Series 2/9.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 2'
 const card: Card = {
 	name: {
 		en: "Multi Technical Machine 01",
-		fr: "Machine multi-technique 01"
+		fr: "Machine multi-technique 01",
+		de: "Vielzweckmaschine 01"
 	},
 
 	illustrator: '"Big Mama" Tagawa"Big Mama\" Tagawa',
@@ -15,7 +16,8 @@ const card: Card = {
 
 	effect: {
 		en: "Attach this card to 1 of your Pokémon in play. That Pokémon may use this card’s attack instead of its own. At the end of your turn, discard Multi Technical Machine 01.",
-		fr: "Attachez cette carte à 1 des Pokémon que vous avez en jeu. Ce Pokémon peut utiliser l'attaque de cette carte à la place de ses attaques. À la fin de votre tour, défaussez Machine multi-technique 01."
+		fr: "Attachez cette carte à 1 des Pokémon que vous avez en jeu. Ce Pokémon peut utiliser l'attaque de cette carte à la place de ses attaques. À la fin de votre tour, défaussez Machine multi-technique 01.",
+		de: "Lege diese Karte an eines deiner Pokémon an. Dieses Pokémon kann diesen Angriff anstelle seiner eigenen verwenden. Lege die Vielzweckmaschine 01 am Ende deines Zuges auf deinen Ablagestapel."
 	},
 
 	attacks: [
@@ -25,9 +27,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Paralyzing Gaze",
+				de: "Lähmender Blick"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Paralyzed.",
+				de: "Das Verteidigende Pokémon ist jetzt gelähmt."
 			},
 		},
 	],


### PR DESCRIPTION
## Add missing German translations for pop2

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
