### PR TITLE
Add missing German translations for tk-ex-latia

### DIFF
--- a/data/Trainer kits/EX trainer Kit (Latias)/1.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/1.ts
@@ -7,7 +7,8 @@ const card: Card = {
 
 	name: {
 		en: "Bagon",
-		fr: "Draby"
+		fr: "Draby",
+		de: "Kindwurm"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -27,7 +28,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Headbutt",
-				fr: "Coup d'boule"
+				fr: "Coup d'boule",
+				de: "Kopfnuss"
 			},
 			damage: 10
 		}, {
@@ -37,7 +39,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Flare",
-				fr: "Enflammer"
+				fr: "Enflammer",
+				de: "Flackern"
 			},
 			damage: 20
 		}],

--- a/data/Trainer kits/EX trainer Kit (Latias)/10.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/10.ts
@@ -4,7 +4,8 @@ import Set from '../EX trainer Kit (Latias)'
 const card: Card = {
 	name: {
 		en: "Fire Energy",
-		fr: "Énergie Feu"
+		fr: "Énergie Feu",
+		de: "Feuer-Energie"
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/EX trainer Kit (Latias)/2.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/2.ts
@@ -7,7 +7,8 @@ const card: Card = {
 
 	name: {
 		en: "Combusken",
-		fr: "Galifeu"
+		fr: "Galifeu",
+		de: "Jungglut"
 	},
 
 	illustrator: "Kouki Saitou",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Torchic",
-		fr: "Poussifeu"
+		fr: "Poussifeu",
+		de: "Flemmli"
 	},
 
 	attacks: [{
@@ -31,7 +33,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Flare",
-			fr: "Intimidation"
+			fr: "Intimidation",
+			de: "Flackern"
 		},
 		damage: 20
 	}, {
@@ -42,11 +45,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Double Kick",
-			fr: "Double pied"
+			fr: "Double pied",
+			de: "Doppelkick"
 		},
 		effect: {
 			en: "Flip 2 coins. This attack does 40 damage times the number of heads.",
-			fr: "Lancez deux pièces. Cette attaque inflige 40 dégâts multipliés par le nombre de face."
+			fr: "Lancez deux pièces. Cette attaque inflige 40 dégâts multipliés par le nombre de face.",
+			de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl „Kopf“ zu."
 		},
 		damage: "40×"
 	}],

--- a/data/Trainer kits/EX trainer Kit (Latias)/3.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/3.ts
@@ -7,7 +7,8 @@ const card: Card = {
 
 	name: {
 		en: "Delcatty",
-		fr: "Delcatty"
+		fr: "Delcatty",
+		de: "Enekoro"
 	},
 
 	illustrator: "Midori Harada",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Skitty",
-		fr: "Skitty"
+		fr: "Skitty",
+		de: "Eneco"
 	},
 
 	attacks: [{
@@ -32,7 +34,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Scratch",
-			fr: "Griffe"
+			fr: "Griffe",
+			de: "Kratzer"
 		},
 		damage: 30
 	}, {
@@ -43,11 +46,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Ultra Energy Source",
-			fr: "Source d'énergie ultra"
+			fr: "Source d'énergie ultra",
+			de: "Ultra Energiequelle"
 		},
 		effect: {
 			en: "Does 10 damage times the number of basic Energy cards attached to all of the Active Pokémon (both yours and your opponent’s).",
-			fr: "Inflige 10 dégâts multipliés par le nombre de cartes Énergie attachées aux Pokémon Actifs (les vôtres et ceux de votre adversaire)."
+			fr: "Inflige 10 dégâts multipliés par le nombre de cartes Énergie attachées aux Pokémon Actifs (les vôtres et ceux de votre adversaire).",
+			de: "Fügt für jede Basis-Energie, die an allen Aktiven Pokémon (deine und die deines Gegners) angelegt ist, 10 Schadenspunkte zu."
 		},
 		damage: "10×"
 	}],

--- a/data/Trainer kits/EX trainer Kit (Latias)/4.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/4.ts
@@ -7,7 +7,8 @@ const card: Card = {
 
 	name: {
 		en: "Latias",
-		fr: "Latias"
+		fr: "Latias",
+		de: "Latias"
 	},
 
 	illustrator: "Nakaoka",
@@ -26,11 +27,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Dragon Dew",
-			fr: "Goutte de dragon"
+			fr: "Goutte de dragon",
+			de: "Drachentau"
 		},
 		effect: {
 			en: "Remove 1 damage counter from 1 of your Pokémon.",
-			fr: "Retirez 1 marqueur de dégât à 1 de vos Pokémon."
+			fr: "Retirez 1 marqueur de dégât à 1 de vos Pokémon.",
+			de: "Entferne 1 Schadensmarke von einem deiner Pokémon."
 		},
 		damage: 10
 	}, {
@@ -41,7 +44,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Heat Blast",
-			fr: "Explosion de chaleur"
+			fr: "Explosion de chaleur",
+			de: "Hitzestoß"
 		},
 		damage: 40
 	}],

--- a/data/Trainer kits/EX trainer Kit (Latias)/5.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/5.ts
@@ -7,7 +7,8 @@ const card: Card = {
 
 	name: {
 		en: "Numel",
-		fr: "Chamallot"
+		fr: "Chamallot",
+		de: "Camaub"
 	},
 
 	illustrator: "Yuka Morii",
@@ -26,11 +27,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Firebreathing",
-			fr: "Souffle-feu"
+			fr: "Souffle-feu",
+			de: "Feuerhauch"
 		},
 		effect: {
 			en: "Flip a coin. If heads, this attack does 10 damage plus 10 more damage.",
-			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires."
+			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires.",
+			de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 		},
 		damage: "10+"
 	}, {
@@ -40,7 +43,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Tackle",
-			fr: "Charge"
+			fr: "Charge",
+			de: "Tackle"
 		},
 		damage: 20
 	}],

--- a/data/Trainer kits/EX trainer Kit (Latias)/6.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/6.ts
@@ -7,7 +7,8 @@ const card: Card = {
 
 	name: {
 		en: "Skitty",
-		fr: "Skitty"
+		fr: "Skitty",
+		de: "Eneco"
 	},
 
 	illustrator: "Atsuko Nishida",
@@ -26,7 +27,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Tackle",
-			fr: "Charge"
+			fr: "Charge",
+			de: "Tackle"
 		},
 		damage: 10
 	}, {
@@ -36,11 +38,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Lunge",
-			fr: "Coup rapide"
+			fr: "Coup rapide",
+			de: "Ausfall"
 		},
 		effect: {
 			en: "Flip a coin. If tails, this attack does nothing.",
-			fr: "Lancez une pièce. Si c'est pile, l'attaque est sans effet."
+			fr: "Lancez une pièce. Si c'est pile, l'attaque est sans effet.",
+			de: "Wirf eine Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 		},
 		damage: 30
 	}],

--- a/data/Trainer kits/EX trainer Kit (Latias)/7.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/7.ts
@@ -7,7 +7,8 @@ const card: Card = {
 
 	name: {
 		en: "Torchic",
-		fr: "Poussifeu"
+		fr: "Poussifeu",
+		de: "Flemmli"
 	},
 
 	illustrator: "Hironobu Yoshida",
@@ -27,11 +28,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Firebreathing",
-			fr: "Souffle-feu"
+			fr: "Souffle-feu",
+			de: "Feuerhauch"
 		},
 		effect: {
 			en: "Flip a coin. If heads, this attack does 20 damage plus 20 more damage.",
-			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts plus 20 dégâts supplémentaires."
+			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts plus 20 dégâts supplémentaires.",
+			de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 		},
 		damage: "20+"
 	}],

--- a/data/Trainer kits/EX trainer Kit (Latias)/8.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/8.ts
@@ -4,7 +4,8 @@ import Set from '../EX trainer Kit (Latias)'
 const card: Card = {
 	name: {
 		en: "Potion",
-		fr: "Potion"
+		fr: "Potion",
+		de: "Trank"
 	},
 
 	illustrator: "Keiji Kinebuchi",
@@ -14,7 +15,8 @@ const card: Card = {
 
 	effect: {
 		en: "Remove 2 damage counters from 1 of your Pokémon (remove 1 damage counter if that Pokémon has only 1).",
-		fr: "Soignez 30 dégâts à 1 de vos Pokémon."
+		fr: "Soignez 30 dégâts à 1 de vos Pokémon.",
+		de: "Entferne 2 Schadensmarken von 1 deiner Pokémon (1 falls dieses Pokémon nur 1 hat)."
 	},
 
 	trainerType: "Item",

--- a/data/Trainer kits/EX trainer Kit (Latias)/9.ts
+++ b/data/Trainer kits/EX trainer Kit (Latias)/9.ts
@@ -4,7 +4,8 @@ import Set from '../EX trainer Kit (Latias)'
 const card: Card = {
 	name: {
 		en: "Energy Search",
-		fr: "Recherche d'énergie"
+		fr: "Recherche d'énergie",
+		de: "Energiesuche"
 	},
 
 	illustrator: "Kai Ishikawa",
@@ -14,7 +15,8 @@ const card: Card = {
 
 	effect: {
 		en: "Search your deck for a basic Energy card, show it to your opponent, and put it into your hand. Shuffle your deck afterward",
-		fr: "Cherchez dans votre deck une carte Énergie de base, montrez-la à votre adversaire et placez-la dans votre main. Mélangez ensuite votre deck."
+		fr: "Cherchez dans votre deck une carte Énergie de base, montrez-la à votre adversaire et placez-la dans votre main. Mélangez ensuite votre deck.",
+		de: "Durchsuche dein Deck nach einer Basis-Energiekarte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 	},
 
 	trainerType: "Item",


### PR DESCRIPTION
## Add missing German translations for tk-ex-latia

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
