### PR TITLE
Add missing German translations for 2011bw

### DIFF
--- a/data/McDonald's Collection/McDonald's Collection 2011/1.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2011/1.ts
@@ -9,7 +9,8 @@ const card: Card = {
 	dexId: [495],
 
 	description: {
-		en: "It is very intelligent and calm. Being exposed to lots of sunlight makes its movements swifter."
+		en: "It is very intelligent and calm. Being exposed to lots of sunlight makes its movements swifter.",
+		de: "Eine kühle Denkernatur. Bekommt es genügend Sonnenlicht ab, erhöht sich die Geschwindigkeit seiner Bewegungen."
 	},
 
 	stage: "Basic",
@@ -17,20 +18,23 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Slam",
-			fr: "Souplesse"
+			fr: "Souplesse",
+			de: "Slam"
 		},
 
 		damage: "20×",
 
 		effect: {
 			en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
-			fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face."
+			fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+			de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 		}
 	}],
 
 	name: {
 		en: "Snivy",
-		fr: "Vipélierre"
+		fr: "Vipélierre",
+		de: "Serpifeu"
 	},
 
 	rarity: "None",

--- a/data/McDonald's Collection/McDonald's Collection 2011/10.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2011/10.ts
@@ -9,7 +9,8 @@ const card: Card = {
 	dexId: [599],
 
 	description: {
-		en: "The two minigears that mesh together are predetermined. Each will rebound from other minigears without meshing."
+		en: "The two minigears that mesh together are predetermined. Each will rebound from other minigears without meshing.",
+		de: "Seine zwei Teile greifen ineinander wie ein Uhrwerk. Jedes andere Objekt, das man mit ihm kombinieren will, wird abgestoßen."
 	},
 
 	stage: "Basic",
@@ -17,19 +18,22 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Charge Beam",
-			fr: "Rayon Chargé"
+			fr: "Rayon Chargé",
+			de: "Ladestrahl"
 		},
 
 		damage: 10,
 
 		effect: {
 			en: "Flip a coin. If heads, attach an Energy card from your discard pile to this Pokémon.",
-			fr: "Lancez une pièce. Si c'est face, cherchez une carte Énergie dans votre pile de défausse et attachez-la à ce Pokémon."
+			fr: "Lancez une pièce. Si c'est face, cherchez une carte Énergie dans votre pile de défausse et attachez-la à ce Pokémon.",
+			de: "Wirf 1 Münze. Lege bei „Kopf“ eine Energiekarte von deinem Ablagestapel an dieses Pokémon an."
 		}
 	}, {
 		name: {
 			en: "Irongrip",
-			fr: "Poigne de Fer"
+			fr: "Poigne de Fer",
+			de: "Eiserner Griff"
 		},
 
 		damage: 20
@@ -37,7 +41,8 @@ const card: Card = {
 
 	name: {
 		en: "Klink",
-		fr: "Tic"
+		fr: "Tic",
+		de: "Klikk"
 	},
 
 	rarity: "None",

--- a/data/McDonald's Collection/McDonald's Collection 2011/11.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2011/11.ts
@@ -9,7 +9,8 @@ const card: Card = {
 	dexId: [519],
 
 	description: {
-		en: "These Pokémon live in cities. They are accustomed to people. Flocks often gather in parks and plazas."
+		en: "These Pokémon live in cities. They are accustomed to people. Flocks often gather in parks and plazas.",
+		de: "Ein Pokémon, das in der Stadt zu Hause ist. Es ist sehr zutraulich und bevölkert in Scharen öffentliche Plätze und Parks."
 	},
 
 	stage: "Basic",
@@ -17,17 +18,20 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Growl",
-			fr: "Rugissement"
+			fr: "Rugissement",
+			de: "Heuler"
 		},
 
 		effect: {
 			en: "During your opponent’s next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance).",
-			fr: "Lors du prochain tour de votre adversaire, les dégâts infligés par les attaques du Pokémon Défenseur sont réduits de 20 (avant application de la Faiblesse et de la Résistance)."
+			fr: "Lors du prochain tour de votre adversaire, les dégâts infligés par les attaques du Pokémon Défenseur sont réduits de 20 (avant application de la Faiblesse et de la Résistance).",
+			de: "Während des nächsten Zuges deines Gegners Schaden, der durch Angriffe des Verteidigenden Pokémon zugefügt wird, um 20 Schadenspunkte reduziert (bevor Schwäche und Resistenz verrechnet werden)."
 		}
 	}, {
 		name: {
 			en: "Gust",
-			fr: "Tornade"
+			fr: "Tornade",
+			de: "Windstoß"
 		},
 
 		damage: 10
@@ -35,7 +39,8 @@ const card: Card = {
 
 	name: {
 		en: "Pidove",
-		fr: "Poichigeon"
+		fr: "Poichigeon",
+		de: "Dusselgurr"
 	},
 
 	rarity: "None",

--- a/data/McDonald's Collection/McDonald's Collection 2011/12.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2011/12.ts
@@ -9,7 +9,8 @@ const card: Card = {
 	dexId: [531],
 
 	description: {
-		en: "It touches others with the feelers on its ears, using the sound of their heartbeats to tell how they are feeling."
+		en: "It touches others with the feelers on its ears, using the sound of their heartbeats to tell how they are feeling.",
+		de: "Berührt es jemanden mit den Fühlern an seinen Ohren, erfährt es durch den Herzschlag der Person, wie es ihr geht."
 	},
 
 	stage: "Basic",
@@ -17,20 +18,23 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Double Slap",
-			fr: "Torgnoles"
+			fr: "Torgnoles",
+			de: "Duplexhieb"
 		},
 
 		damage: "30×",
 
 		effect: {
 			en: "Flip 2 coins. This attack does 30 damage times the number of heads.",
-			fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face."
+			fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
+			de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 		}
 	}],
 
 	name: {
 		en: "Audino",
-		fr: "Nanméouïe"
+		fr: "Nanméouïe",
+		de: "Ohrdoch"
 	},
 
 	rarity: "None",

--- a/data/McDonald's Collection/McDonald's Collection 2011/2.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2011/2.ts
@@ -9,7 +9,8 @@ const card: Card = {
 	dexId: [556],
 
 	description: {
-		en: "It uses an up-tempo song and dance to drive away the bird Pokémon that prey on its flower seeds."
+		en: "It uses an up-tempo song and dance to drive away the bird Pokémon that prey on its flower seeds.",
+		de: "Verjagt Vogel-Pokémon, die auf seine Blüten aus sind, mit einem flotten Tänzchen und lauter Untermalung."
 	},
 
 	stage: "Basic",
@@ -17,32 +18,37 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Mega Drain",
-			fr: "Méga-Sangsue"
+			fr: "Méga-Sangsue",
+			de: "Megasauger"
 		},
 
 		damage: 20,
 
 		effect: {
 			en: "Heal 20 damage from this Pokémon.",
-			fr: "Soigne 20 dégâts infligés à ce Pokémon."
+			fr: "Soigne 20 dégâts infligés à ce Pokémon.",
+			de: "Heile 20 Schadenspunkte bei diesem Pokémon."
 		}
 	}, {
 		name: {
 			en: "Pin Missile",
-			fr: "Dard-Nuée"
+			fr: "Dard-Nuée",
+			de: "Nadelrakete"
 		},
 
 		damage: "20×",
 
 		effect: {
 			en: "Flip 4 coins. This attack does 20 damage times the number of heads.",
-			fr: "Lancez 4 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face."
+			fr: "Lancez 4 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+			de: "Wirf 4 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 		}
 	}],
 
 	name: {
 		en: "Maractus",
-		fr: "Maracachi"
+		fr: "Maracachi",
+		de: "Maracamba"
 	},
 
 	rarity: "None",

--- a/data/McDonald's Collection/McDonald's Collection 2011/3.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2011/3.ts
@@ -9,7 +9,8 @@ const card: Card = {
 	dexId: [498],
 
 	description: {
-		en: "It blows fire through its nose. When it catches a cold, the fire becomes pitch-black smoke instead."
+		en: "It blows fire through its nose. When it catches a cold, the fire becomes pitch-black smoke instead.",
+		de: "Es schießt Flammen aus seinem Rüssel. Ist es erkältet, kommt statt Feuer aber nur pechschwarzer Rauch zum Vorschein."
 	},
 
 	stage: "Basic",
@@ -17,20 +18,23 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Ember",
-			fr: "Flammèche"
+			fr: "Flammèche",
+			de: "Glut"
 		},
 
 		damage: 30,
 
 		effect: {
 			en: "Discard an Energy attached to this Pokémon.",
-			fr: "Défaussez une Énergie attachée à ce Pokémon."
+			fr: "Défaussez une Énergie attachée à ce Pokémon.",
+			de: "Lege 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel."
 		}
 	}],
 
 	name: {
 		en: "Tepig",
-		fr: "Gruikui"
+		fr: "Gruikui",
+		de: "Floink"
 	},
 
 	rarity: "None",

--- a/data/McDonald's Collection/McDonald's Collection 2011/4.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2011/4.ts
@@ -9,7 +9,8 @@ const card: Card = {
 	dexId: [501],
 
 	description: {
-		en: "It fights using the scalchop on its stomach. In response to an attack, it retaliates immediately by slashing."
+		en: "It fights using the scalchop on its stomach. In response to an attack, it retaliates immediately by slashing.",
+		de: "Kämpft mit der Muschel auf seinem Bauch. Pariert es einen Angriff, schlägt es sofort mit einer Schnitt-Attacke zurück."
 	},
 
 	stage: "Basic",
@@ -17,20 +18,23 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Water Pulse",
-			fr: "Vibraqua"
+			fr: "Vibraqua",
+			de: "Aquawelle"
 		},
 
 		damage: 20,
 
 		effect: {
 			en: "Flip a coin. If heads, the Defending Pokémon is now Asleep.",
-			fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Endormi."
+			fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Endormi.",
+			de: "Wirf 1 Münze. Bei „Kopf“ schläft das Verteidigende Pokémon jetzt."
 		}
 	}],
 
 	name: {
 		en: "Oshawott",
-		fr: "Moustillon"
+		fr: "Moustillon",
+		de: "Ottaro"
 	},
 
 	rarity: "None",

--- a/data/McDonald's Collection/McDonald's Collection 2011/5.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2011/5.ts
@@ -9,7 +9,8 @@ const card: Card = {
 	dexId: [594],
 
 	description: {
-		en: "Floating in the open sea is how they live. When they find a wounded Pokémon, they embrace it and bring it to shore."
+		en: "Floating in the open sea is how they live. When they find a wounded Pokémon, they embrace it and bring it to shore.",
+		de: "Es treibt durch den Ozean. Findet es ein verletztes Pokémon, nimmt es dieses auf und trägt es zurück an Land."
 	},
 
 	stage: "Basic",
@@ -17,14 +18,16 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Pound",
-			fr: "Écras'Face"
+			fr: "Écras'Face",
+			de: "Pfund"
 		},
 
 		damage: 20
 	}, {
 		name: {
 			en: "Wave Splash",
-			fr: "Grosse Vague"
+			fr: "Grosse Vague",
+			de: "Wellenplatscher"
 		},
 
 		damage: 60
@@ -32,7 +35,8 @@ const card: Card = {
 
 	name: {
 		en: "Alomomola",
-		fr: "Mamanbo"
+		fr: "Mamanbo",
+		de: "Mamolida"
 	},
 
 	rarity: "None",

--- a/data/McDonald's Collection/McDonald's Collection 2011/6.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2011/6.ts
@@ -9,7 +9,8 @@ const card: Card = {
 	dexId: [522],
 
 	description: {
-		en: "Its mane shines when it discharges electricity. They use their flashing manes to communicate with one another."
+		en: "Its mane shines when it discharges electricity. They use their flashing manes to communicate with one another.",
+		de: "Wenn es Strom entlädt, blitzt seine Mähne auf. Auf diese Weise kann es auch mit Artgenossen kommunizieren."
 	},
 
 	stage: "Basic",
@@ -17,20 +18,23 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Quick Attack",
-			fr: "Vive-Attaque"
+			fr: "Vive-Attaque",
+			de: "Ruckzuckhieb"
 		},
 
 		damage: "10+",
 
 		effect: {
 			en: "Flip a coin. If heads, this attack does 20 more damage.",
-			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires."
+			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+			de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 		}
 	}],
 
 	name: {
 		en: "Blitzle",
-		fr: "Zébibron"
+		fr: "Zébibron",
+		de: "Elezeba"
 	},
 
 	rarity: "None",

--- a/data/McDonald's Collection/McDonald's Collection 2011/7.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2011/7.ts
@@ -9,7 +9,8 @@ const card: Card = {
 	dexId: [517],
 
 	description: {
-		en: "It eats the dreams of people and Pokémon. When it eats a pleasant dream, it expels pink-colored mist."
+		en: "It eats the dreams of people and Pokémon. When it eats a pleasant dream, it expels pink-colored mist.",
+		de: "Es verschlingt die Träume der Menschen. Frisst es einen fröhlichen Traum, stößt es danach einen rosafarbenen Dunst aus."
 	},
 
 	stage: "Basic",
@@ -17,18 +18,21 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Yawn",
-			fr: "Bâillement"
+			fr: "Bâillement",
+			de: "Gähner"
 		},
 
 		effect: {
 			en: "The Defending Pokémon is now Asleep.",
-			fr: "Le Pokémon Défenseur est maintenant Endormi."
+			fr: "Le Pokémon Défenseur est maintenant Endormi.",
+			de: "Das Verteidigende Pokémon schläft jetzt."
 		}
 	}],
 
 	name: {
 		en: "Munna",
-		fr: "Munna"
+		fr: "Munna",
+		de: "Somniam"
 	},
 
 	rarity: "None",

--- a/data/McDonald's Collection/McDonald's Collection 2011/8.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2011/8.ts
@@ -9,7 +9,8 @@ const card: Card = {
 	dexId: [551],
 
 	description: {
-		en: "It moves along below the sand’s surface, except for its nose and eyes. A dark membrane shields its eyes from the sun."
+		en: "It moves along below the sand’s surface, except for its nose and eyes. A dark membrane shields its eyes from the sun.",
+		de: "Wenn es sich durch den Sand gräbt, ragen nur noch Nase und Augen hervor. Die schwarze Haut dient als Augenschutz."
 	},
 
 	stage: "Basic",
@@ -17,20 +18,23 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Sand Tomb",
-			fr: "Tourbi-Sable"
+			fr: "Tourbi-Sable",
+			de: "Sandgrab"
 		},
 
 		damage: 30,
 
 		effect: {
 			en: "The Defending Pokémon can’t retreat during your opponent’s next turn.",
-			fr: "Le Pokémon Défenseur ne peut pas battre en retraite durant le prochain tour de votre adversaire."
+			fr: "Le Pokémon Défenseur ne peut pas battre en retraite durant le prochain tour de votre adversaire.",
+			de: "Das Verteidigende Pokémon kann sich während des nächsten Zuges deines Gegners nicht zurückziehen."
 		}
 	}],
 
 	name: {
 		en: "Sandile",
-		fr: "Mascaïman"
+		fr: "Mascaïman",
+		de: "Ganovil"
 	},
 
 	rarity: "None",

--- a/data/McDonald's Collection/McDonald's Collection 2011/9.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2011/9.ts
@@ -9,7 +9,8 @@ const card: Card = {
 	dexId: [570],
 
 	description: {
-		en: "It changes into the forms of others to surprise them. Apparently, it often transforms into a silent child."
+		en: "It changes into the forms of others to surprise them. Apparently, it often transforms into a silent child.",
+		de: "Es übertölpelt andere, indem es verschiedene Gestalten annimmt. Angeblich tarnt es sich oft als wortkarges Kind."
 	},
 
 	stage: "Basic",
@@ -17,27 +18,31 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Scratch",
-			fr: "Griffe"
+			fr: "Griffe",
+			de: "Kratzer"
 		},
 
 		damage: 10
 	}, {
 		name: {
 			en: "Fury Swipes",
-			fr: "Combo-Griffe"
+			fr: "Combo-Griffe",
+			de: "Kratzfurie"
 		},
 
 		damage: "10×",
 
 		effect: {
 			en: "Flip 3 coins. This attack does 10 damage times the number of heads.",
-			fr: "Lancez 3 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face."
+			fr: "Lancez 3 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+			de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 		}
 	}],
 
 	name: {
 		en: "Zorua",
-		fr: "Zorua"
+		fr: "Zorua",
+		de: "Zorua"
 	},
 
 	rarity: "None",


### PR DESCRIPTION
## Add missing German translations for 2011bw

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
