### PR TITLE
Add missing German translations for tk-ex-latio

### DIFF
--- a/data/Trainer kits/EX trainer Kit (Latios)/1.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/1.ts
@@ -7,7 +7,8 @@ const card: Card = {
 
 	name: {
 		en: "Electrike",
-		fr: "Dynavolt"
+		fr: "Dynavolt",
+		de: "Frizelbliz"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -26,7 +27,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Headbutt",
-			fr: "Coup d'boule"
+			fr: "Coup d'boule",
+			de: "Kopfnuss"
 		},
 		damage: 10
 	}],

--- a/data/Trainer kits/EX trainer Kit (Latios)/10.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/10.ts
@@ -4,7 +4,8 @@ import Set from '../EX trainer Kit (Latios)'
 const card: Card = {
 	name: {
 		en: "Lightning Energy",
-		fr: "Énergie Électrique"
+		fr: "Énergie Électrique",
+		de: "Elektro-Energie"
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/EX trainer Kit (Latios)/2.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/2.ts
@@ -7,7 +7,8 @@ const card: Card = {
 
 	name: {
 		en: "Latios",
-		fr: "Latios"
+		fr: "Latios",
+		de: "Latios"
 	},
 
 	illustrator: "Kyoko Koizumi",
@@ -27,11 +28,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Gather Energy",
-			fr: "Rassemblement d'énergie"
+			fr: "Rassemblement d'énergie",
+			de: "Energie sammeln"
 		},
 		effect: {
 			en: "Flip a coin. If heads, search your deck for a basic Energy card and attach it to 1 of your Pokémon. Shuffle your deck afterward.",
-			fr: "Lancez une pièce. Si c'est face, choisissez dans votre deck une carte Énergie de base et attachez-la à 1 de vos Pokémon. Ensuite, mélangez votre deck."
+			fr: "Lancez une pièce. Si c'est face, choisissez dans votre deck une carte Énergie de base et attachez-la à 1 de vos Pokémon. Ensuite, mélangez votre deck.",
+			de: "Wirf 1 Münze. Durchsuche bei „Kopf“ dein Deck nach einer Basis-Energiekarte und lege sie an eines deiner Pokémon im Spiel an. Mische dein Deck danach."
 		},
 		damage: 20
 	}, {
@@ -42,7 +45,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Dragon Claw",
-			fr: "Griffe de dragon"
+			fr: "Griffe de dragon",
+			de: "Drachenklaue"
 		},
 		damage: 40
 	}],

--- a/data/Trainer kits/EX trainer Kit (Latios)/3.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/3.ts
@@ -7,7 +7,8 @@ const card: Card = {
 
 	name: {
 		en: "Linoone",
-		fr: "Lineon"
+		fr: "Lineon",
+		de: "Geradaks"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Zigzagoon",
-		fr: "Zigzaton"
+		fr: "Zigzaton",
+		de: "Zigzachs"
 	},
 
 	attacks: [{
@@ -31,11 +33,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Seek Out",
-			fr: "À la recherche"
+			fr: "À la recherche",
+			de: "Spürnase"
 		},
 		effect: {
 			en: "Search your deck for up to 2 cards and put them into your hand. Shuffle your deck afterward.",
-			fr: "Choisissez deux cartes dans votre deck. Montrez-les à votre adversaire et placez-les dans votre main. Mélangez ensuite votre deck."
+			fr: "Choisissez deux cartes dans votre deck. Montrez-les à votre adversaire et placez-les dans votre main. Mélangez ensuite votre deck.",
+			de: "Durchsuche dein Deck nach 2 beliebigen Karten, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 		}
 	}, {
 		cost: [
@@ -44,11 +48,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Continuous Headbutt",
-			fr: "Coup d'boule sans fin"
+			fr: "Coup d'boule sans fin",
+			de: "Anhaltender Kopstoß"
 		},
 		effect: {
 			en: "Flip a coin until you get tails. This attack does 40 damage times the number of heads.",
-			fr: "Lancez une pièce jusqu'à ce que ce soit pile. Cette attaque inflige 40 dégâts multipliés par le nombre de face."
+			fr: "Lancez une pièce jusqu'à ce que ce soit pile. Cette attaque inflige 40 dégâts multipliés par le nombre de face.",
+			de: "Wirf solange eine Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Für jedesmal, wo die Münze „Kopf“ gezeigt hat, fügt dieser Angriff 40 Schadenspunkte zu."
 		},
 		damage: "40×"
 	}],

--- a/data/Trainer kits/EX trainer Kit (Latios)/4.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/4.ts
@@ -7,7 +7,8 @@ const card: Card = {
 
 	name: {
 		en: "Magnemite",
-		fr: "Magneti"
+		fr: "Magneti",
+		de: "Magnetilo"
 	},
 
 	illustrator: "Tomokazu Komiya",
@@ -26,7 +27,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Rollout",
-			fr: "Roulade"
+			fr: "Roulade",
+			de: "Walzer"
 		},
 		damage: 10
 	}, {
@@ -36,7 +38,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Hook",
-			fr: "Crochet"
+			fr: "Crochet",
+			de: "Haken"
 		},
 		damage: 20
 	}],

--- a/data/Trainer kits/EX trainer Kit (Latios)/5.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/5.ts
@@ -7,7 +7,8 @@ const card: Card = {
 
 	name: {
 		en: "Magneton",
-		fr: "Magneton"
+		fr: "Magneton",
+		de: "Magneton"
 	},
 
 	illustrator: "Kyoko Umemoto",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Magnemite",
-		fr: "Magnéti"
+		fr: "Magnéti",
+		de: "Magnetilo"
 	},
 
 	attacks: [{
@@ -32,7 +34,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Ram",
-			fr: "Collision"
+			fr: "Collision",
+			de: "Ramme"
 		},
 		damage: 20
 	}, {
@@ -43,11 +46,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Triple Smash",
-			fr: "Triple éclate"
+			fr: "Triple éclate",
+			de: "Dreifachschmetterer"
 		},
 		effect: {
 			en: "Flip 3 coins. This attack does 20 damage plus 20 more damage for each heads.",
-			fr: "Lancez trois pièces. Cette attaque inflige 20 dégâts plus 20 dégâts multipliés par le nombre de faces."
+			fr: "Lancez trois pièces. Cette attaque inflige 20 dégâts plus 20 dégâts multipliés par le nombre de faces.",
+			de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte plus 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 		},
 		damage: "20+"
 	}],

--- a/data/Trainer kits/EX trainer Kit (Latios)/6.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/6.ts
@@ -7,7 +7,8 @@ const card: Card = {
 
 	name: {
 		en: "Pikachu",
-		fr: "Pikachu"
+		fr: "Pikachu",
+		de: "Pikachu"
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -26,7 +27,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Scratch",
-			fr: "Griffe"
+			fr: "Griffe",
+			de: "Kratzer"
 		},
 		damage: 10
 	}, {
@@ -37,7 +39,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Pika Bolt",
-			fr: "Pik'éclair"
+			fr: "Pik'éclair",
+			de: "Pikaschuss"
 		},
 		damage: 40
 	}],

--- a/data/Trainer kits/EX trainer Kit (Latios)/7.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/7.ts
@@ -7,7 +7,8 @@ const card: Card = {
 
 	name: {
 		en: "Zigzagoon",
-		fr: "Zigzaton"
+		fr: "Zigzaton",
+		de: "Zigzachs"
 	},
 
 	illustrator: "Atsuko Nishida",
@@ -26,11 +27,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Fury Swipes",
-			fr: "Combo-griffe"
+			fr: "Combo-griffe",
+			de: "Kratzfurie"
 		},
 		effect: {
 			en: "Flip 3 coins. This attack does 10 damage times the number of heads.",
-			fr: "Lancez trois pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de face."
+			fr: "Lancez trois pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de face.",
+			de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 		},
 		damage: "10×"
 	}],

--- a/data/Trainer kits/EX trainer Kit (Latios)/8.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/8.ts
@@ -4,7 +4,8 @@ import Set from '../EX trainer Kit (Latios)'
 const card: Card = {
 	name: {
 		en: "Potion",
-		fr: "Potion"
+		fr: "Potion",
+		de: "Trank"
 	},
 
 	illustrator: "Keiji Kinebuchi",
@@ -14,7 +15,8 @@ const card: Card = {
 
 	effect: {
 		en: "Remove 2 damage counters from 1 of your Pokémon (remove 1 damage counter if that Pokémon has only 1).",
-		fr: "Soignez 30 dégâts à 1 de vos Pokémon."
+		fr: "Soignez 30 dégâts à 1 de vos Pokémon.",
+		de: "Entferne 2 Schadensmarken von 1 deiner Pokémon (1 falls dieses Pokémon nur 1 hat)."
 	},
 
 	trainerType: "Item",

--- a/data/Trainer kits/EX trainer Kit (Latios)/9.ts
+++ b/data/Trainer kits/EX trainer Kit (Latios)/9.ts
@@ -4,7 +4,8 @@ import Set from '../EX trainer Kit (Latios)'
 const card: Card = {
 	name: {
 		en: "Energy Search",
-		fr: "Recherche d'énergie"
+		fr: "Recherche d'énergie",
+		de: "Energiesuche"
 	},
 
 	illustrator: "Kai Ishikawa",
@@ -14,7 +15,8 @@ const card: Card = {
 
 	effect: {
 		en: "Search your deck for a basic Energy card, show it to your opponent, and put it into your hand. Shuffle your deck afterward",
-		fr: "Cherchez dans votre deck une carte Énergie de base, montrez-la à votre adversaire et placez-la dans votre main. Mélangez ensuite votre deck."
+		fr: "Cherchez dans votre deck une carte Énergie de base, montrez-la à votre adversaire et placez-la dans votre main. Mélangez ensuite votre deck.",
+		de: "Durchsuche dein Deck nach einer Basis-Energiekarte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 	},
 
 	trainerType: "Item",


### PR DESCRIPTION
## Add missing German translations for tk-ex-latio

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
