### PR TITLE
fix(data): correct Archeops-line holo and reverse variants

### DIFF
--- a/data/Black & White/Dark Explorers/110.ts
+++ b/data/Black & White/Dark Explorers/110.ts
@@ -88,6 +88,12 @@ const card: Card = {
 		en: "This extremely rare Pokémon is a different color than usual. It is very hard to find.",
 	},
 
+	variants: [
+		{
+			type: "holo"
+		}
+	],
+
 	thirdParty: {
 		cardmarket: 280438,
 		tcgplayer: 83610

--- a/data/Black & White/Noble Victories/66.ts
+++ b/data/Black & White/Noble Victories/66.ts
@@ -72,6 +72,16 @@ const card: Card = {
 		en: "Said to be an ancestor of bird Pokémon, they were unable to fly and moved about by hopping from one branch to another.",
 	},
 
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse",
+			languages: ["en", "fr", "es", "it", "de"]
+		}
+	],
+
 	thirdParty: {
 		cardmarket: 280189,
 		tcgplayer: 83607

--- a/data/Black & White/Noble Victories/67.ts
+++ b/data/Black & White/Noble Victories/67.ts
@@ -88,6 +88,16 @@ const card: Card = {
 		en: "They are intelligent and will cooperate to catch prey. From the ground, they use a running start to take flight.",
 	},
 
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse",
+			languages: ["en", "fr", "es", "it", "de"]
+		}
+	],
+
 	thirdParty: {
 		cardmarket: 280190,
 		tcgplayer: 83609

--- a/data/Black & White/Noble Victories/93.ts
+++ b/data/Black & White/Noble Victories/93.ts
@@ -27,6 +27,16 @@ const card: Card = {
 
 	trainerType: "Item",
 
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse",
+			languages: ["en", "fr", "es", "it", "de"]
+		}
+	],
+
 	thirdParty: {
 		cardmarket: 280216,
 		tcgplayer: 88159

--- a/data/Black & White/Plasma Blast/53.ts
+++ b/data/Black & White/Plasma Blast/53.ts
@@ -79,6 +79,16 @@ const card: Card = {
 		en: "It was revived from an ancient fossil. Not able to fly, it lived in treetops and hopped from one branch to another.",
 	},
 
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse",
+			languages: ["en", "fr", "it", "de"]
+		}
+	],
+
 	thirdParty: {
 		cardmarket: 281074,
 		tcgplayer: 83608

--- a/data/Black & White/Plasma Blast/54.ts
+++ b/data/Black & White/Plasma Blast/54.ts
@@ -80,6 +80,16 @@ const card: Card = {
 		en: "It runs better than it flies. It takes off into the sky by running at a speed of 25 mph.",
 	},
 
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse",
+			languages: ["en", "fr", "it", "de"]
+		}
+	],
+
 	thirdParty: {
 		cardmarket: 281075,
 		tcgplayer: 83611

--- a/data/Black & White/Plasma Blast/54.ts
+++ b/data/Black & White/Plasma Blast/54.ts
@@ -82,7 +82,7 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "holo"
 		},
 		{
 			type: "reverse",

--- a/data/Black & White/Plasma Blast/82.ts
+++ b/data/Black & White/Plasma Blast/82.ts
@@ -27,6 +27,16 @@ const card: Card = {
 
 	trainerType: "Item",
 
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse",
+			languages: ["en", "fr", "it", "de"]
+		}
+	],
+
 	thirdParty: {
 		cardmarket: 281103,
 		tcgplayer: 88160

--- a/data/Sun & Moon/Unified Minds/120.ts
+++ b/data/Sun & Moon/Unified Minds/120.ts
@@ -79,6 +79,15 @@ const card: Card = {
 		en: "Once thought to be the ancestor of all bird Pokémon, some of the latest research suggests that may not be the case.",
 	},
 
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
+
 	thirdParty: {
 		cardmarket: 388402,
 		tcgplayer: 195075

--- a/data/Sun & Moon/Unified Minds/121.ts
+++ b/data/Sun & Moon/Unified Minds/121.ts
@@ -102,6 +102,15 @@ const card: Card = {
 		en: "This ancient Pokémon's plumage is delicate, so if anyone other than an experienced professional tries to restore it, they will fail.",
 	},
 
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
+
 	thirdParty: {
 		cardmarket: 388407,
 		tcgplayer: 195077

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH272.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH272.ts
@@ -86,6 +86,18 @@ const card: Card = {
 		en: "It needs a running start to take off. If Archeops wants to fly, it first needs to run nearly 25 mph, building speed over a course of about 2.5 miles."
 	},
 
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"]
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			languages: ["en"]
+		}
+	],
+
 	thirdParty: {
 		cardmarket: 681801
 	}


### PR DESCRIPTION
## What

Adds explicit detailed variant metadata for ten existing international card records:

- Noble Victories: Archen 66, Archeops 67, Plume Fossil 93
- Dark Explorers: Archeops 110
- Plasma Blast: Archen 53, Archeops 54, Plume Fossil 82
- Unified Minds: Archen 120, Archeops 121
- SWSH Black Star Promos: Archeops SWSH272

## Why

The current API falls back to incorrect or incomplete variant booleans for these records:

- Noble Victories, Plasma Blast, and Unified Minds omit documented reverse-holo versions.
- The set-level language compilation lists no Portuguese reverse holos for Noble Victories or Plasma Blast, so the patch uses language-scoped reverse entries rather than applying the finish to every locale.[1]
- Dark Explorers 110/108 is a Secret Rare holofoil rather than a normal non-holo card.[5][6]
- SWSH272 is documented as a Line Holofoil prerelease promo carrying the Silver Tempest set logo, with an additional gold-foil Staff-stamped print.[14]

## Implementation

- Uses `Array<variant_detailed>` rather than the legacy boolean object.
- Keeps base and reverse variants distinct.
- Restricts Noble Victories reverse to `en`, `fr`, `es`, `it`, and `de`.
- Restricts Plasma Blast reverse to `en`, `fr`, `it`, and `de`.
- Leaves Unified Minds reverse unscoped because the set compilation lists reverse holos for all six international languages represented by these records: `en`, `de`, `fr`, `it`, `es`, and `pt`.[1]
- Models SWSH272 as:
  - holo + `set-logo`; and
  - English-only holo + `set-logo` + `staff`.

## Evidence method and confidence

Evidence is separated into two levels instead of treating one source as proof of every assertion:

- **Item-level evidence** identifies the exact card and demonstrates its English finish(es), rarity, or special printing. TCGplayer product catalogs, PriceCharting's item-specific catalog/sales records, and Bulbapedia release notes are used for this layer.
- **Set-level language evidence** comes from the Elite Fourum “Sets and Languages Compilation Overview,” whose stated purpose is to enumerate languages and consequential set variants, including reverse-holo omissions.[1] This supports the language scope but is **not** equivalent to a direct scan of every individual non-English card.

The supporting audit for these ten records contains 91 positive card/language/finish claims: 39 were recorded as directly confirmed and 52 as strongly supported at set level. The matrix below preserves that distinction.

## Claim-to-source matrix

| Record | Metadata added by this PR | Item-level support | Language-scope support | Confidence / limitation |
|---|---|---|---|---|
| Noble Victories Archen 66/101 | normal; reverse in `en/fr/es/it/de` | TCGplayer lists Normal and Reverse Holofoil for the exact English card.[2] Bulbapedia identifies 66/101.[15] | The compilation lists reverse holos for English, German, French, Italian, and Spanish, and explicitly says the Portuguese set had no reverse holos.[1] | English finishes directly cataloged; other language finishes and the Portuguese exclusion are set-level support. |
| Noble Victories Archeops 67/101 | normal; reverse in `en/fr/es/it/de` | TCGplayer lists Normal and Reverse Holofoil for 67/101.[3] Bulbapedia identifies the print.[5] | Same Noble Victories language entry as above.[1] | English finishes directly cataloged; non-English scope is set-level support. |
| Noble Victories Plume Fossil 93/101 | normal; reverse in `en/fr/es/it/de` | TCGplayer lists Normal and Reverse Holofoil for 93/101.[4] Bulbapedia identifies the print.[16] | Same Noble Victories language entry as above.[1] | English finishes directly cataloged; non-English scope is set-level support. |
| Dark Explorers Archeops 110/108 | holo | Bulbapedia identifies the 110/108 reprint as an Ultra-Rare Secret card.[5] PriceCharting's item page and completed-sale titles repeatedly identify it as holo/Secret Rare.[6] | The compilation lists Dark Explorers in English, German, French, Italian, and Portuguese; its reverse-holo note concerns ordinary parallels, not this Secret Rare base finish.[1] | English holo directly supported; applying the base holo finish to every localized record is set-level support rather than scan-by-scan confirmation. |
| Plasma Blast Archen 53/101 | normal; reverse in `en/fr/it/de` | TCGplayer lists Normal and Reverse Holofoil for the exact English card.[7] Bulbapedia identifies 53/101.[17] | The compilation lists reverse holos for English, German, French, and Italian, and explicitly says the Portuguese set had no reverse holos.[1] | English finishes directly cataloged; non-English scope and Portuguese exclusion are set-level support. |
| Plasma Blast Archeops 54/101 | holo; reverse in `en/fr/it/de` | The official Pokémon card database and Bulbapedia identify 54/101 as Rare Holo.[18][19] TCGplayer lists both Holofoil and Reverse Holofoil.[8] | Same Plasma Blast language entry as above.[1] | English base and reverse finishes are directly cataloged; the non-English scope is set-level support. |
| Plasma Blast Plume Fossil 82/101 | normal; reverse in `en/fr/it/de` | TCGplayer lists Normal and Reverse Holofoil for 82/101.[9] Bulbapedia identifies the Plasma Blast reprint.[16] | Same Plasma Blast language entry as above.[1] | English finishes directly cataloged; non-English scope and Portuguese exclusion are set-level support. |
| Unified Minds Archen 120/236 | normal; reverse, unscoped | TCGplayer lists Normal and Reverse Holofoil for 120/236.[10] PriceCharting separately catalogs and records sales of the English reverse.[12] | The compilation lists normal and reverse for all six relevant international languages: English, German, French, Italian, Spanish, and Portuguese.[1] | English finishes directly cataloged; other five languages are set-level support. |
| Unified Minds Archeops 121/236 | normal; reverse, unscoped | TCGplayer lists Normal and Reverse Holofoil for 121/236.[11] PriceCharting separately catalogs and records sales of the English reverse.[13] | Same Unified Minds language entry as above.[1] | English finishes directly cataloged; other five languages are set-level support. |
| SWSH Black Star Promo Archeops SWSH272 | Line Holofoil + set logo; English Staff-stamped variant | Bulbapedia states that SWSH272 is Line Holofoil with the Silver Tempest logo and that a gold-foil Staff print was distributed to prerelease staff.[14] | TCGdex image records directly show the localized Silver Tempest logo on English, French, German, Italian, and Spanish scans.[20][21][22][23][24] The official Brazilian Portuguese card database identifies the Portuguese SWSH272 promo, while Pokémon's Build & Battle documentation describes these prerelease cards as foil promos.[25][26] | Base promo treatment is directly evidenced in five languages and strongly supported for Portuguese by official card/product documentation. The Staff print remains English-scoped. |

## Evidence limitations

- The English item catalogs corroborate exact card/finish combinations but do not prove the same finish in every other language.
- The Elite Fourum compilation is collector-maintained secondary evidence. It explicitly documents the relevant set/language policies, but individual scans would be stronger evidence for each non-English claim.
- Absence claims—especially “no Portuguese reverse holo”—are based on the compilation's explicit set-level omission statement, not on proving a negative from marketplace search results.
- Follow-up verification resolved the two earlier review notes: Plasma Blast 54's base variant was corrected from `normal` to `holo`. For SWSH272, five localized scans directly show the set logo, and official Portuguese card/product documentation strongly supports the same prerelease treatment in Portuguese; no contradictory evidence was found, so no SWSH272 data change was needed.

## Deliberately excluded

- The Asian `S-P` numbering collision is tracked separately in #1958 and is not mixed into this data-only PR.
- Italian Plasma Blast set metadata is not added here; that is a separate localization gap.
- No images or third-party IDs are changed.

## Validation

Local validation on 2026-08-12:

```text
$ bun install --frozen-lockfile
154 packages installed

$ bun run validate
$ tsc --noEmit --project tsconfig.json
# exit code 0

$ git diff --check
# exit code 0
```

## Sources

[1] Elite Fourum — Sets and Languages Compilation Overview (see the Noble Victories, Dark Explorers, Plasma Blast, and Unified Minds entries): https://www.elitefourum.com/t/sets-and-languages-compilation-overview-list/16565/1

[2] TCGplayer — Archen, Noble Victories 66/101: https://www.tcgplayer.com/product/83607/pokemon-noble-victories-archen?Language=English

[3] TCGplayer — Archeops, Noble Victories 67/101: https://www.tcgplayer.com/product/83609/pokemon-noble-victories-archeops?Language=English

[4] TCGplayer — Plume Fossil, Noble Victories 93/101: https://www.tcgplayer.com/product/88159/pokemon-noble-victories-plume-fossil?Language=English

[5] Bulbapedia — Archeops (Noble Victories 67 / Dark Explorers 110): https://bulbapedia.bulbagarden.net/wiki/Archeops_(Noble_Victories_67)

[6] PriceCharting — Archeops 110, Dark Explorers: https://www.pricecharting.com/game/pokemon-dark-explorers/archeops-110

[7] TCGplayer — Archen, Plasma Blast 53/101: https://www.tcgplayer.com/product/83608/pokemon-plasma-blast-archen?Language=English

[8] TCGplayer — Archeops, Plasma Blast 54/101: https://www.tcgplayer.com/product/83611/pokemon-plasma-blast-archeops?Language=English

[9] TCGplayer — Plume Fossil, Plasma Blast 82/101: https://www.tcgplayer.com/product/88160/pokemon-plasma-blast-plume-fossil?Language=English

[10] TCGplayer — Archen, Unified Minds 120/236: https://www.tcgplayer.com/product/195075/pokemon-sm-unified-minds-archen?Language=English

[11] TCGplayer — Archeops, Unified Minds 121/236: https://www.tcgplayer.com/product/195077/pokemon-sm-unified-minds-archeops?Language=English

[12] PriceCharting — Archen Reverse Holo 120, Unified Minds: https://www.pricecharting.com/game/pokemon-unified-minds/archen-reverse-holo-120

[13] PriceCharting — Archeops Reverse Holo 121, Unified Minds: https://www.pricecharting.com/game/pokemon-unified-minds/archeops-reverse-holo-121

[14] Bulbapedia — Archeops (Silver Tempest 147 / SWSH272): https://bulbapedia.bulbagarden.net/wiki/Archeops_(Silver_Tempest_147)

[15] Bulbapedia — Archen (Noble Victories 66): https://bulbapedia.bulbagarden.net/wiki/Archen_(Noble_Victories_66)

[16] Bulbapedia — Plume Fossil (Noble Victories 93 / Plasma Blast 82): https://bulbapedia.bulbagarden.net/wiki/Plume_Fossil_(Noble_Victories_93)

[17] Bulbapedia — Archen (Plasma Blast 53): https://bulbapedia.bulbagarden.net/wiki/Archen_(Plasma_Blast_53)

[18] Bulbapedia — Archeops (Plasma Blast 54): https://bulbapedia.bulbagarden.net/wiki/Archeops_(Plasma_Blast_54)

[19] Pokémon — Archeops, Black & White—Plasma Blast 54/101: https://www.pokemon.com/us/pokemon-tcg/pokemon-cards/series/bw10/54/

[20] TCGdex asset — SWSH272 English scan: https://assets.tcgdex.net/en/swsh/swshp/SWSH272/high.webp

[21] TCGdex asset — SWSH272 French scan: https://assets.tcgdex.net/fr/swsh/swshp/SWSH272/high.webp

[22] TCGdex asset — SWSH272 German scan: https://assets.tcgdex.net/de/swsh/swshp/SWSH272/high.webp

[23] TCGdex asset — SWSH272 Italian scan: https://assets.tcgdex.net/it/swsh/swshp/SWSH272/high.webp

[24] TCGdex asset — SWSH272 Spanish scan: https://assets.tcgdex.net/es/swsh/swshp/SWSH272/high.webp

[25] Pokémon Brazil — Archeops, SWSH272 promo: https://www.pokemon.com/br/pokemon-estampas-ilustradas/cartas-de-pokemon/series/swshp/SWSH272/

[26] Pokémon — Silver Tempest Build & Battle Box (four unique foil prerelease promos): https://www.pokemon.com/uk/strategy/get-the-pokemon-tcg-sword-shield-silver-tempest-build-battle-box
