### PR TITLE
fix(data): Add Italian name for Plasma Blast

### DIFF
--- a/data/Black & White/Plasma Blast.ts
+++ b/data/Black & White/Plasma Blast.ts
@@ -7,6 +7,7 @@ const bw10: Set = {
 	name: {
 		en: "Plasma Blast",
 		fr: "Explosion Plasma",
+		it: "Esplosione Plasma",
 		de: "Plasma-Blaster",
 		pt: "Explosão de Plasma" // also "Explosão Plasma" in the PTCGO
 	},


### PR DESCRIPTION
## Changes

Add the missing official Italian name for Black & White—Plasma Blast:

- `it: "Esplosione Plasma"`

## Details

The expansion was physically released in Italian as **Nero e Bianco—Esplosione Plasma**. The missing set-level locale currently prevents the Italian `bw10` set and its cards from being generated, even though all 105 card records already contain top-level Italian names, including secret rares 102–105.

This is intentionally a narrow set-metadata correction. It does not add or infer Italian rules text, images, or set-wide normal/holo/reverse variant availability.

Evidence:

- Official Pokémon Italia expansion page: https://www.pokemon.com/it/gcc/nero-e-bianco-esplosione-plasma
- Italian release/checklist reference (105 cards: 101 regular + 4 secret): https://wiki.pokemoncentral.it/Esplosione_Plasma_(GCC)

Validation:

- `npm run validate`
- Focused Italian compiler build
- Confirmed generated `bw10` contains 105 Italian cards
- Confirmed representative ordinary, Archeops, full-art, and secret-rare records
- `git diff --check`
