### PR TITLE
(fix) Darkrai & Cresselia LEGEND: remove stray effect field duplicating its own attack

### DIFF
--- a/data/HeartGold & SoulSilver/Triumphant/99.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/99.ts
@@ -65,10 +65,6 @@ const card: Card = {
 	],
 	retreat: 2,
 
-	effect: {
-		en: "[2DD] Lost Crisis (100) Choose 2 Energy attached to Darkrai and Cresselia LEGEND and put them in the Lost Zone. If any of your opponent’s Pokémon would be Knocked Out by damage from the attack, put that Pokémon and all cards attached to it in the Lost Zone instead of discarding it."
-	},
-
 	variants: [
 		{
 			type: "holo",


### PR DESCRIPTION
data/HeartGold & SoulSilver/Triumphant/99.ts carries a top-level `effect` that holds a raw dump of the card’s own first attack, with the cost and damage inlined:

```
effect: {
    en: "[2DD] Lost Crisis (100) Choose 2 Energy attached to Darkrai and Cresselia LEGEND and put them in the Lost Zone. If any of your opponent’s Pokémon would be Knocked Out by damage from the attack, put that Pokémon and all cards attached to it in the Lost Zone instead of discarding it."
},
```

That attack is already in the file, properly structured:

```
attacks: [{
    name:   { en: "Lost Crisis", … },
    effect: { en: "Choose 2 Energy attached to Darkrai & Cresselia LEGEND and put them in the Lost Zone. …", fr: …, de: … },
    damage: 100,
    cost:   ["Darkness", "Darkness", "Colorless", "Colorless"]
}, …]
```

`[2DD]` and `(100)` are just that cost and damage written inline, so the top-level field is a duplicate in a shape nothing renders — and on a Pokémon card `effect` is meant for rules text rather than an attack.