### PR TITLE
Add missing German translations for tk-ex-p

### DIFF
--- a/data/Trainer kits/EX trainer Kit 2 (Plusle)/1.ts
+++ b/data/Trainer kits/EX trainer Kit 2 (Plusle)/1.ts
@@ -7,7 +7,8 @@ const card: Card = {
 
 	name: {
 		en: "Beldum",
-		fr: "Terhal"
+		fr: "Terhal",
+		de: "Tanhel"
 	},
 
 	illustrator: "Kouki Saitou",
@@ -26,11 +27,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Call for Family",
-			fr: "Appel à la famille"
+			fr: "Appel à la famille",
+			de: "Familienruf"
 		},
 		effect: {
 			en: "Search your deck for a Basic Pokémon and put it onto your Bench. Shuffle your deck afterward.",
-			fr: "Choisissez un Pokémon de base dans votre deck et placez-le sur votre Banc. Ensuite, mélangez votre deck."
+			fr: "Choisissez un Pokémon de base dans votre deck et placez-le sur votre Banc. Ensuite, mélangez votre deck.",
+			de: "Durchsuche dein Deck nach einem Basis-Pokémon und lege es auf deine Bank. Mische dein Deck danach."
 		}
 	}, {
 		cost: [
@@ -38,11 +41,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Metal Ball",
-			fr: "Boule métallique"
+			fr: "Boule métallique",
+			de: "Metallball"
 		},
 		effect: {
 			en: "Put 1 damage counter on the Defending Pokémon.",
-			fr: "Placez 1 marqueur de dégât sur le Pokémon Défenseur."
+			fr: "Placez 1 marqueur de dégât sur le Pokémon Défenseur.",
+			de: "Lege 1 Schadensmarke auf das Verteidigende Pokémon."
 		}
 	}],
 

--- a/data/Trainer kits/EX trainer Kit 2 (Plusle)/10.ts
+++ b/data/Trainer kits/EX trainer Kit 2 (Plusle)/10.ts
@@ -4,7 +4,8 @@ import Set from '../EX trainer Kit 2 (Plusle)'
 const card: Card = {
 	name: {
 		en: "Professor Cozmo's Discovery",
-		fr: "La découverte du Professeur Kosmo"
+		fr: "La découverte du Professeur Kosmo",
+		de: "Professor Kosmos Entdeckung"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -15,7 +16,8 @@ const card: Card = {
 
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Flip a coin. If heads, draw the bottom 3 cards of your deck. If tails, draw the top 2 cards of your deck.",
-		fr: "Vous ne pouvez jouer qu'une seule carte Supporter par tour. Lorsque vous la jouez, placez-la à côté de votre Pokémon Actif. À la fin du tour, défaussez-la."
+		fr: "Vous ne pouvez jouer qu'une seule carte Supporter par tour. Lorsque vous la jouez, placez-la à côté de votre Pokémon Actif. À la fin du tour, défaussez-la.",
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Wirf 1 Münze. Ziehe bei „Kopf“ die untersten 3 Karten deines Decks. Ziehe bei „Zahl“ die obersten 2 Karten deines Decks."
 	},
 
 	retreat: 0,

--- a/data/Trainer kits/EX trainer Kit 2 (Plusle)/11.ts
+++ b/data/Trainer kits/EX trainer Kit 2 (Plusle)/11.ts
@@ -4,7 +4,8 @@ import Set from '../EX trainer Kit 2 (Plusle)'
 const card: Card = {
 	name: {
 		en: "Lightning Energy",
-		fr: "Énergie Électrique"
+		fr: "Énergie Électrique",
+		de: "Elektro-Energie"
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/EX trainer Kit 2 (Plusle)/12.ts
+++ b/data/Trainer kits/EX trainer Kit 2 (Plusle)/12.ts
@@ -4,7 +4,8 @@ import Set from '../EX trainer Kit 2 (Plusle)'
 const card: Card = {
 	name: {
 		en: "Psychic Energy",
-		fr: "Énergie Psy"
+		fr: "Énergie Psy",
+		de: "Psycho-Energie"
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/EX trainer Kit 2 (Plusle)/2.ts
+++ b/data/Trainer kits/EX trainer Kit 2 (Plusle)/2.ts
@@ -7,7 +7,8 @@ const card: Card = {
 
 	name: {
 		en: "Electrike",
-		fr: "Dynavolt"
+		fr: "Dynavolt",
+		de: "Frizelbliz"
 	},
 
 	illustrator: "Hiroki Fuchino",
@@ -26,11 +27,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Recharge",
-			fr: "Recharger"
+			fr: "Recharger",
+			de: "Auffüllen"
 		},
 		effect: {
 			en: "Search your deck for a Lightning Energy card and attach it to Electrike. Shuffle your deck afterward.",
-			fr: "Cherchez dans votre deck 1 carte Énergie  et attachez-la à Dynavolt. Ensuite, mélangez votre deck."
+			fr: "Cherchez dans votre deck 1 carte Énergie  et attachez-la à Dynavolt. Ensuite, mélangez votre deck.",
+			de: "Durchsuche dein Deck nach einer {L}-Energiekarte und lege sie an Frizelbliz an. Mische dein Deck danach."
 		}
 	}, {
 		cost: [
@@ -39,11 +42,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Quick Attack",
-			fr: "Vive-attaque"
+			fr: "Vive-attaque",
+			de: "Ruckzuckhieb"
 		},
 		effect: {
 			en: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage.",
-			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires."
+			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires.",
+			de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 		},
 		damage: "10+"
 	}],

--- a/data/Trainer kits/EX trainer Kit 2 (Plusle)/3.ts
+++ b/data/Trainer kits/EX trainer Kit 2 (Plusle)/3.ts
@@ -7,7 +7,8 @@ const card: Card = {
 
 	name: {
 		en: "Grumpig",
-		fr: "Groret"
+		fr: "Groret",
+		de: "Groink"
 	},
 
 	illustrator: "Atsuko Nishida",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Spoink",
-		fr: "Spoink"
+		fr: "Spoink",
+		de: "Spoink"
 	},
 
 	attacks: [{
@@ -31,11 +33,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Snap Tail",
-			fr: "Claquement de queue"
+			fr: "Claquement de queue",
+			de: "Schnappender Schweif"
 		},
 		effect: {
 			en: "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-			fr: "Choisissez 1 des Pokémon de votre adversaire. Cette attaque lui inflige 10 dégâts. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)"
+			fr: "Choisissez 1 des Pokémon de votre adversaire. Cette attaque lui inflige 10 dégâts. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
+			de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 		}
 	}, {
 		cost: [
@@ -44,7 +48,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Psypunch",
-			fr: "Coup de poing psy"
+			fr: "Coup de poing psy",
+			de: "Psyhieb"
 		},
 		damage: 40
 	}],

--- a/data/Trainer kits/EX trainer Kit 2 (Plusle)/4.ts
+++ b/data/Trainer kits/EX trainer Kit 2 (Plusle)/4.ts
@@ -7,7 +7,8 @@ const card: Card = {
 
 	name: {
 		en: "Meowth",
-		fr: "Miaouss"
+		fr: "Miaouss",
+		de: "Mauzi"
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -26,11 +27,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Collect",
-			fr: "Collectionner"
+			fr: "Collectionner",
+			de: "Sammeln"
 		},
 		effect: {
 			en: "Draw a card.",
-			fr: "Piochez une carte."
+			fr: "Piochez une carte.",
+			de: "Ziehe 1 Karte."
 		}
 	}, {
 		cost: [
@@ -39,7 +42,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Cat Kick",
-			fr: "Coup d'patte"
+			fr: "Coup d'patte",
+			de: "Katzenkick"
 		},
 		damage: 20
 	}],

--- a/data/Trainer kits/EX trainer Kit 2 (Plusle)/5.ts
+++ b/data/Trainer kits/EX trainer Kit 2 (Plusle)/5.ts
@@ -7,7 +7,8 @@ const card: Card = {
 
 	name: {
 		en: "Metang",
-		fr: "Metang"
+		fr: "Metang",
+		de: "Metang"
 	},
 
 	illustrator: "Hisao Nakamura",
@@ -22,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Beldum",
-		fr: "Terhal"
+		fr: "Terhal",
+		de: "Tanhel"
 	},
 
 	attacks: [{
@@ -32,11 +34,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Psychic Boom",
-			fr: "Psycho-boom"
+			fr: "Psycho-boom",
+			de: "Psychoknall"
 		},
 		effect: {
 			en: "Does 10 damage plus 10 more damage for each Energy attached to the Defending Pokémon.",
-			fr: "Inflige 10 dégâts plus 10 dégâts supplémentaires pour chaque Énergie attachée au Pokémon Défenseur."
+			fr: "Inflige 10 dégâts plus 10 dégâts supplémentaires pour chaque Énergie attachée au Pokémon Défenseur.",
+			de: "Fügt 10 Schadenspunkte plus 10 weitere Schadenspunkte für jede am Verteidigenden Pokémon angelegte Energie zu."
 		},
 		damage: "10+"
 	}, {
@@ -47,11 +51,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Quick Blow",
-			fr: "Coup d'poing éclair"
+			fr: "Coup d'poing éclair",
+			de: "Schnellschlag"
 		},
 		effect: {
 			en: "Flip a coin. If heads, this attack does 40 damage plus 20 more damage.",
-			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 40 dégâts plus 20 dégâts supplémentaires."
+			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 40 dégâts plus 20 dégâts supplémentaires.",
+			de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 40 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 		},
 		damage: "40+"
 	}],

--- a/data/Trainer kits/EX trainer Kit 2 (Plusle)/6.ts
+++ b/data/Trainer kits/EX trainer Kit 2 (Plusle)/6.ts
@@ -7,7 +7,8 @@ const card: Card = {
 
 	name: {
 		en: "Plusle",
-		fr: "Posipi"
+		fr: "Posipi",
+		de: "Plusle"
 	},
 
 	illustrator: "Katsura Tabata",
@@ -26,11 +27,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Pickup Power",
-			fr: "Pouvoir ramassage"
+			fr: "Pouvoir ramassage",
+			de: "Kraft aufsammeln"
 		},
 		effect: {
 			en: "Search your discard pile for an Energy card, show it to your opponent, and put it into your hand.",
-			fr: "Choisissez une carte Énergie dans votre pile de défausse, montrez-la à votre adversaire et placez-la dans votre main."
+			fr: "Choisissez une carte Énergie dans votre pile de défausse, montrez-la à votre adversaire et placez-la dans votre main.",
+			de: "Durchsuche deinen Ablagestapel nach einer Energiekarte. Zeige sie deinem Gegner und nimm sie auf die Hand."
 		}
 	}, {
 		cost: [
@@ -39,11 +42,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Rear Spark",
-			fr: "Étincelle arrière"
+			fr: "Étincelle arrière",
+			de: "Hinterer Funke"
 		},
 		effect: {
 			en: "Does 20 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)",
-			fr: "Inflige 20 dégâts à 1 des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)"
+			fr: "Inflige 20 dégâts à 1 des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
+			de: "Fügt 1 gegnerischen Pokémon auf der Bank 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 		},
 		damage: 10
 	}],

--- a/data/Trainer kits/EX trainer Kit 2 (Plusle)/7.ts
+++ b/data/Trainer kits/EX trainer Kit 2 (Plusle)/7.ts
@@ -7,7 +7,8 @@ const card: Card = {
 
 	name: {
 		en: "Spoink",
-		fr: "Spoink"
+		fr: "Spoink",
+		de: "Spoink"
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -26,11 +27,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Knock Away",
-			fr: "Asticotage"
+			fr: "Asticotage",
+			de: "Zurückschlagen"
 		},
 		effect: {
 			en: "Flip a coin. If heads, this attack does 10 damage plus 10 more damage.",
-			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires."
+			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires.",
+			de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 		},
 		damage: "10+"
 	}],

--- a/data/Trainer kits/EX trainer Kit 2 (Plusle)/8.ts
+++ b/data/Trainer kits/EX trainer Kit 2 (Plusle)/8.ts
@@ -4,7 +4,8 @@ import Set from '../EX trainer Kit 2 (Plusle)'
 const card: Card = {
 	name: {
 		en: "Energy Search",
-		fr: "Recherche d'énergie"
+		fr: "Recherche d'énergie",
+		de: "Energiesuche"
 	},
 
 	illustrator: "Kai Ishikawa",
@@ -14,7 +15,8 @@ const card: Card = {
 
 	effect: {
 		en: "Search your deck for a basic Energy card, show it to your opponent, and put it into your hand. Shuffle your deck afterward",
-		fr: "Choisissez dans votre deck une carte Énergie de base, montrez-la à votre adversaire et placez-la dans votre main. Mélangez ensuite votre deck."
+		fr: "Choisissez dans votre deck une carte Énergie de base, montrez-la à votre adversaire et placez-la dans votre main. Mélangez ensuite votre deck.",
+		de: "Durchsuche dein Deck nach einer Basis-Energiekarte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 	},
 
 	trainerType: "Item",

--- a/data/Trainer kits/EX trainer Kit 2 (Plusle)/9.ts
+++ b/data/Trainer kits/EX trainer Kit 2 (Plusle)/9.ts
@@ -4,7 +4,8 @@ import Set from '../EX trainer Kit 2 (Plusle)'
 const card: Card = {
 	name: {
 		en: "Potion",
-		fr: "Potion"
+		fr: "Potion",
+		de: "Trank"
 	},
 
 	illustrator: "Keiji Kinebuchi",
@@ -14,7 +15,8 @@ const card: Card = {
 
 	effect: {
 		en: "Remove 2 damage counters from 1 of your Pokémon (remove 1 damage counter if that Pokémon has only 1).",
-		fr: "Soignez 30 dégâts à 1 de vos Pokémon."
+		fr: "Soignez 30 dégâts à 1 de vos Pokémon.",
+		de: "Entferne bis zu 2 Schadensmarken von einem Deiner Pokémon."
 	},
 
 	trainerType: "Item",


### PR DESCRIPTION
## Add missing German translations for tk-ex-p

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
