### PR TITLE
(fix) Volbeat (EX Sandstorm 53): remove stray effect field duplicating its own attack

### DIFF
--- a/data/EX/Sandstorm/53.ts
+++ b/data/EX/Sandstorm/53.ts
@@ -45,10 +45,6 @@ const card: Card = {
 		},
 	],
 
-	effect: {
-		en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned. If tails, the Defending Pokémon is now Asleep."
-	},
-
 	attacks: [{
 		cost: ["Colorless"],
 


### PR DESCRIPTION
data/EX/Sandstorm/53.ts carries a top-level `effect` holding the text of the card’s own first attack:

```
effect: {
    en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned. If tails, the Defending Pokémon is now Asleep."
},
```

That string is byte-identical to `attacks[0].effect.en`, which is already in the file with its translations:

```
attacks: [{
    cost:   ["Colorless"],
    name:   { en: "Toxic Vibration", fr: "Vibration toxik", de: … },
    effect: {
        en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned. If tails, the Defending Pokémon is now Asleep.",
        fr: "Lancez une pièce. Si c’est face, le Pokémon Défenseur est maintenant Empoisonné. …",
        de: …
    }
}, … ]
```

So the top-level field is a duplicate in a shape nothing renders — on a Pokémon card `effect` is meant for rules text, not an attack.