### PR TITLE
(fix) Chikorita (EX Hidden Legends 55): remove stray effect field duplicating its own attack

### DIFF
--- a/data/EX/Hidden Legends/55.ts
+++ b/data/EX/Hidden Legends/55.ts
@@ -37,10 +37,6 @@ const card: Card = {
 		},
 	],
 
-	effect: {
-		en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned."
-	},
-
 	attacks: [
 		{
 			name: {


### PR DESCRIPTION
data/EX/Hidden Legends/55.ts carries a top-level `effect` holding the text of the card’s own first attack:

```
effect: {
    en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned."
},
```

That string is byte-identical to `attacks[0].effect.en`, which is already in the file with its translations:

```
attacks: [{
    name:   { en: "Poisonpowder", fr: "Poudre toxik", de: … },
    cost:   ["Colorless"],
    effect: {
        en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned.",
        fr: "Lancez une pièce. Si c’est face, le Pokémon Défenseur est maintenant Empoisonné.",
        de: …
    }
}, … ]
```

So the top-level field is a duplicate in a shape nothing renders — on a Pokémon card `effect` is meant for rules text, not an attack.