### PR TITLE
(fix) Poliwag (Expedition 125): remove Healing Berry's effect and trainerType

### DIFF
--- a/data/E-Card/Expedition Base Set/125.ts
+++ b/data/E-Card/Expedition Base Set/125.ts
@@ -11,10 +11,6 @@ const card: Card = {
 	illustrator: "Yuka Morii",
 	rarity: "Common",
 	category: "Pokemon",
-	effect: {
-		en: "Attach Healing Berry to 1 of your Pokémon that doesn't already have a Pokémon Tool card attached to it. If that Pokémon is Knocked Out, discard this card. At the end of any turn, if the Pokémon this card is attached to has 20 HP or less, remove 3 damage counters from that Pokémon and discard this card.",
-	},
-	trainerType: "Tool",
 	set: Set,
 
 	dexId: [60],


### PR DESCRIPTION
data/E-Card/Expedition Base Set/125.ts is a Pokémon card carrying two fields belonging to a Trainer:

```
category: "Pokemon",
effect: {
    en: "Attach Healing Berry to 1 of your Pokémon that doesn't already have a Pokémon Tool card attached to it. If that Pokémon is Knocked Out, discard this card. At the end of any turn, if the Pokémon this card is attached to has 20 HP or less, remove 3 damage counters from that Pokémon and discard this card.",
},
trainerType: "Tool",
```

Both belong to **Healing Berry**, `data/E-Card/Aquapolis/125.ts` — the same card number in the adjacent E-Card set:

```
name:        { en: "Healing Berry", … },
category:    "Trainer",
trainerType: "Tool",
effect: {
    en: "Attach Healing Berry to 1 of your Pokémon that doesn't already have a Pokémon Tool card attached to it. …"
}
```

The effect text is identical, and `trainerType` has no meaning on a Pokémon card — Poliwag is the only card in `data/` with `category: "Pokemon"` that has one. Poliwag's own attacks (Headbutt, Rollout) are unaffected.