### PR TITLE
(fix) Dark Explorers: typo in the German set name

### DIFF
--- a/data/Black & White/Dark Explorers.ts
+++ b/data/Black & White/Dark Explorers.ts
@@ -8,7 +8,7 @@ const bw5: Set = {
 		en: "Dark Explorers",
 		fr: "Explorateurs Obscurs",
 		it: "Esploratori delle Tenebre",
-		de: "Erfoscher der Finsternis",
+		de: "Erforscher der Finsternis",
 		es: "Oscuros Exploradores",
 		pt: "Exploradores da Escuridão"
 	},


### PR DESCRIPTION
The German name of `bw5` is missing an `r`:

```
de: "Erfoscher der Finsternis",
```

It should be **Erforscher** der Finsternis — from *erforschen*, to explore.