### PR TITLE
Add missing German translations for bw1

### DIFF
--- a/data/Black & White/Black & White/1.ts
+++ b/data/Black & White/Black & White/1.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 10,
@@ -49,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Vine Whip",
 				fr: "Fouet Lianes",
+				de: "Rankenhieb"
 			},
 
 			damage: 20,
@@ -74,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "They photosynthesize by bathing their tails in sunlight. When they are not feeling well, their tails droop.",
+		de: "Fängt mit dem Schweif Sonnenlicht auf, um Fotosynthese zu betreiben. Fehlt ihm die Kraft, hängt sein Schweif schlaff herab."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/10.ts
+++ b/data/Black & White/Black & White/10.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Petilil",
 		fr: "Chlorobule",
+		de: "Lilminip"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Petal Dance",
 				fr: "Danse-Fleur",
+				de: "Blättertanz"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 30 damage times the number of heads. This Pokémon is now Confused.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face. Ce Pokémon est maintenant Confus.",
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu. Dieses Pokémon ist jetzt verwirrt."
 			},
 			damage: 30,
 
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Leaf Storm",
 				fr: "Tempêteverte",
+				de: "Blättersturm"
 			},
 			effect: {
 				en: "Heal 20 damage from each of your Grass Pokémon.",
 				fr: "Soignez 20 dégâts à chacun de vos Pokémon Grass.",
+				de: "Heile 20 Schadenspunkte bei jedem deiner {G}-Pokémon."
 			},
 			damage: 30,
 
@@ -85,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "The fragrance of the garland on its head has a relaxing effect. It withers if a Trainer does not take good care of it.",
+		de: "Der Duft des Blumenschmucks auf seinem Kopf wirkt beruhigend. Damit der Schmuck nicht verwelkt, muss man es gut pflegen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/100.ts
+++ b/data/Black & White/Black & White/100.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cura 30 puntos de daño a 1 de tus Pokémon.",
 		it: "Cura uno dei tuoi Pokémon da 30 danni.",
 		pt: "Cura 30 de danos de 1 Pokémon seu.",
-		de: "Heile 30 Schadenspunkte bei 1 deiner Pokémon."
+		de: "Heile 30 Schadenspunkte bei 1 deiner Pokémon. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Black & White/101.ts
+++ b/data/Black & White/Black & White/101.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta las cartas de tu mano y roba 7 cartas.",
 		it: "Scarta la tua mano e pesca sette carte.",
 		pt: "Descarte sua mão e compre 7 cards.",
-		de: "Lege deine Handkarten auf deinen Ablagestapel und ziehe 7 neue Karten."
+		de: "Lege deine Handkarten auf deinen Ablagestapel und ziehe 7 neue Karten. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Black & White/Black & White/102.ts
+++ b/data/Black & White/Black & White/102.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon un Pokémon Básico de tu pila de descartes en tu Banca.",
 		it: "Prendi un Pokémon Base dalla tua pila degli scarti e mettilo in panchina.",
 		pt: "Coloque um Pokémon Básico da sua pilha de descarte em seu Banco.",
-		de: "Nimm 1 Basis-Pokémon von deinem Ablagestapel und lege es auf deine Bank."
+		de: "Nimm 1 Basis-Pokémon von deinem Ablagestapel und lege es auf deine Bank. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Black & White/103.ts
+++ b/data/Black & White/Black & White/103.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Lanza una moneda. Si sale cara, pon 1 de tus Pokémon y todas las cartas unidas a él en tu mano.",
 		it: "Lancia una moneta. Se esce testa, riprendi in mano uno dei tuoi Pokémon e tutte le carte a esso assegnate.",
 		pt: "Jogue uma moeda. Se sair cara, coloque 1 dos seus Pokémon e todos os cards ligados a ele em sua mão.",
-		de: "Wirf 1 Münze. Nimm bei „Kopf“ 1 deiner Pokémon und alle daran angelegten Karten zurück auf deine Hand."
+		de: "Wirf 1 Münze. Nimm bei „Kopf“ 1 deiner Pokémon und alle daran angelegten Karten zurück auf deine Hand. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Black & White/104.ts
+++ b/data/Black & White/Black & White/104.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cambia tu Pokémon Activo por 1 de tus Pokémon en Banca.",
 		it: "Scambia il tuo Pokémon attivo con uno dei tuoi Pokémon in panchina.",
 		pt: "Troque seu Pokémon Ativo por 1 dos seus Pokémon no Banco.",
-		de: "Tausche dein Aktives Pokémon gegen 1 Pokémon auf deiner Bank aus."
+		de: "Tausche dein Aktives Pokémon gegen 1 Pokémon auf deiner Bank aus. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Black & White/11.ts
+++ b/data/Black & White/Black & White/11.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Mega Drain",
 				fr: "Méga-Sangsue",
+				de: "Megasauger"
 			},
 			effect: {
 				en: "Heal 20 damage from this Pokémon.",
 				fr: "Soignez 20 dégâts infligés à ce Pokémon.",
+				de: "Heile 20 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 20,
 
@@ -53,10 +55,12 @@ const card: Card = {
 			name: {
 				en: "Pin Missile",
 				fr: "Dard-Nuée",
+				de: "Nadelrakete"
 			},
 			effect: {
 				en: "Flip 4 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 4 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 4 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -81,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "It uses an up-tempo song and dance to drive away the bird Pokémon that prey on its flower seeds.",
+		de: "Verjagt Vogel-Pokémon, die auf seine Blüten aus sind, mit einem flotten Tänzchen und lauter Untermalung."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/113.ts
+++ b/data/Black & White/Black & White/113.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Outrage",
 				fr: "Colère",
+				de: "Wutanfall"
 			},
 			effect: {
 				en: "Does 10 more damage for each damage counter on this Pokémon.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque marqueur de dégâts placé sur ce Pokémon.",
+				de: "Dieser Angriff fügt 10 weitere Schadenspunkte für jede Schadensmarke auf diesem Pokémon zu."
 			},
 			damage: 20,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Blue Flare",
 				fr: "Flamme Bleue",
+				de: "Blauflammen"
 			},
 			effect: {
 				en: "Discard 2 Fire Energy attached to this Pokémon.",
 				fr: "Défaussez 2 Énergies Fire attachées à ce Pokémon.",
+				de: "Lege 2 an dieses Pokémon angelegte {R}-Energien auf deinen Ablagestapel."
 			},
 			damage: 120,
 
@@ -75,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon appears in legends. It sends flames into the air from its tail, burning up everything around it.",
+		de: "Ein aus Mythen bekanntes Pokémon. Es wirbelt mit seinem Schweif Feuer auf, mit dem es alles in Asche legt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/114.ts
+++ b/data/Black & White/Black & White/114.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Outrage",
 				fr: "Colère",
+				de: "Wutanfall"
 			},
 			effect: {
 				en: "Does 10 more damage for each damage counter on this Pokémon.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque marqueur de dégâts placé sur ce Pokémon.",
+				de: "Dieser Angriff fügt 10 weitere Schadenspunkte für jede Schadensmarke auf diesem Pokémon zu."
 			},
 			damage: 20,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Bolt Strike",
 				fr: "ChargeFoudre",
+				de: "Blitzschlag"
 			},
 			effect: {
 				en: "This Pokémon does 40 damage to itself.",
 				fr: "Ce Pokémon s’inflige 40 dégâts.",
+				de: "Dieses Pokémon fügt sich selbst 40 Schadenspunkte zu."
 			},
 			damage: 120,
 
@@ -75,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon appears in legends. In its tail, it has a giant generator that creates electricity.",
+		de: "Ein Pokémon, von dem schon in Sagen die Rede ist. Sein Schweif enthält ein gewaltiges Organ zur Stromerzeugung."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/115.ts
+++ b/data/Black & White/Black & White/115.ts
@@ -33,10 +33,12 @@ const card: Card = {
 			name: {
 				fr: "Énergisant",
 				en: "Energize",
+				de: "Energiezufuhr"
 			},
 			effect: {
 				fr: "Attachez une carte Énergie Lightning de votre pile de défausse à ce Pokémon.",
-				en: "Attach a Lightning Energy card from your discard pile to this Pokémon."
+				en: "Attach a Lightning Energy card from your discard pile to this Pokémon.",
+				de: "Nimm 1 {L}-Energiekarte von deinem Ablagestapel und lege sie an dieses Pokémon an."
 			},
 
 		},
@@ -49,10 +51,12 @@ const card: Card = {
 			name: {
 				fr: "Tonnerre",
 				en: "Thunderbolt",
+				de: "Donnerblitz"
 			},
 			effect: {
 				en: "Discard all Energy attached to this Pokémon.",
 				fr: "Défaussez toutes les Énergies attachées à ce Pokémon.",
+				de: "Lege alle an dieses Pokémon angelegten Energien auf deinen Ablagestapel."
 			},
 			damage: 80,
 
@@ -70,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "This is an extremely rare Pikachu card. You're very lucky to have found it!",
+		de: "Du hast diese sehr seltene Pikachu-Karte gefunden. Du Glückspilz!"
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/12.ts
+++ b/data/Black & White/Black & White/12.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Constant Rattle",
 				fr: "Secousses Successives",
+				de: "Rasseltanz"
 			},
 			effect: {
 				en: "Flip 3 coins. If 1 of them is heads, this attack does 10 damage. If 2 of them are heads, this attack does 30 damage. If all of them are heads, this attack does 60 damage.",
 				fr: "Lancez 3 pièces. Si vous obtenez un côté face, cette attaque inflige 10 dégâts. Si vous obtenez 2 côtés face, cette attaque inflige 30 dégâts. Si vous obtenez seulement des côtés face, cette attaque inflige 60 dégâts.",
+				de: "Wirf 3 Münzen. Zeigt 1 davon „Kopf“, fügt dieser Angriff 10 Schadenspunkte zu. Zeigen 2 davon „Kopf“, fügt dieser Angriff 30 Schadenspunkte zu. Zeigen alle Münzen „Kopf“, fügt dieser Angriff 60 Schadenspunkte zu."
 			},
 
 		},
@@ -52,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Giga Drain",
 				fr: "Giga-Sangsue",
+				de: "Gigasauger"
 			},
 			effect: {
 				en: "Heal from this Pokémon the same amount of damage you did to the Defending Pokémon.",
 				fr: "Soignez à ce Pokémon la même quantité de dégâts que vous avez infligée au Pokémon Défenseur.",
+				de: "Heile bei diesem Pokémon genauso viel Schaden, wie du dem Verteidigenden Pokémon zugefügt hast."
 			},
 			damage: 50,
 
@@ -80,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "Arid regions are their habitat. They move rhythmically, making a sound similar to maracas.",
+		de: "Erzeugt durch rhythmische Bewegungen Laute, die dem Klang von Maracas ähneln. Lebt an trockenen Orten."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/13.ts
+++ b/data/Black & White/Black & White/13.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Double Kick",
 				fr: "Double Pied",
+				de: "Doppelkick"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 10,
 
@@ -52,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Leech Seed",
 				fr: "Vampigraine",
+				de: "Egelsamen"
 			},
 			effect: {
 				en: "Heal 10 damage from this Pokémon.",
 				fr: "Soignez 10 dégâts à ce Pokémon.",
+				de: "Heile 10 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 20,
 
@@ -80,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "The color and scent of their fur changes to match the mountain grass. When they sense hostility, they hide in the grass.",
+		de: "Sein Fell nimmt Farbe und Duft des Feldes oder des Grases unter ihm an. Bei Gefahr sucht es im hohen Gras Schutz."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/14.ts
+++ b/data/Black & White/Black & White/14.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Deerling",
 		fr: "Vivaldaim",
+		de: "Sesokitz"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Nature Power",
 				fr: "Force-Nature",
+				de: "Natur-Kraft"
 			},
 			effect: {
 				en: "Does 10 more damage for each Grass Energy attached to both your and your opponent's Pokémon.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque Énergie Grass attachée à vos Pokémon et à ceux de votre adversaire.",
+				de: "Dieser Angriff fügt für jede an Pokémon (deine und die deines Gegners) angelegte {G}-Energie 10 weitere Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Horn Leech",
 				fr: "Encornebois",
+				de: "Holzgeweih"
 			},
 			effect: {
 				en: "Heal 20 damage from this Pokémon.",
 				fr: "Soignez 20 dégâts à ce Pokémon.",
+				de: "Heile 20 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 60,
 
@@ -86,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "They migrate according to the seasons. People can tell the season by looking at Sawsbuck's horns.",
+		de: "An seinem Geweih kann man ablesen, wann eine neue Jahreszeit beginnt. Sein Revier wechselt mit jeder neuen Jahreszeit."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/15.ts
+++ b/data/Black & White/Black & White/15.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 10,
@@ -49,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Rollout",
 				fr: "Roulade",
+				de: "Walzer"
 			},
 
 			damage: 20,
@@ -67,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "It can deftly dodge its foe's attacks while shooting fireballs from its nose. It roasts berries before it eats them.",
+		de: "Weicht flink gegnerischen Angriffen aus und schießt Flammen aus dem Rüssel, mit denen es gern auch mal Nüsse röstet."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/16.ts
+++ b/data/Black & White/Black & White/16.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Take Down",
 				fr: "Bélier",
+				de: "Bodycheck"
 			},
 			effect: {
 				en: "This Pokémon does 10 damage to itself.",
 				fr: "Ce Pokémon s’inflige 10 dégâts.",
+				de: "Dieses Pokémon fügt sich selbst 10 Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "It can deftly dodge its foe's attacks while shooting fireballs from its nose. It roasts berries before it eats them.",
+		de: "Weicht flink gegnerischen Angriffen aus und schießt Flammen aus dem Rüssel, mit denen es gern auch mal Nüsse röstet."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/17.ts
+++ b/data/Black & White/Black & White/17.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Tepig",
 		fr: "Gruikui",
+		de: "Floink"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Flame Charge",
 				fr: "Nitrocharge",
+				de: "Nitroladung"
 			},
 			effect: {
 				en: "Search your deck for a Fire Energy card and attach it to this Pokémon. Shuffle your deck afterward.",
 				fr: "Cherchez une carte Énergie Fire dans votre deck et attachez-la à ce Pokémon. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 1 {R}-Energiekarte und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
 			},
 
 		},
@@ -57,6 +60,7 @@ const card: Card = {
 			name: {
 				en: "Heat Crash",
 				fr: "Tacle Feu",
+				de: "Brandstempel"
 			},
 
 			damage: 50,
@@ -75,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "When its internal fire flares up, its movements grow sharper and faster. When in trouble, it emits smoke.",
+		de: "Lodert das Feuer in ihm auf, bewegt es sich geschmeidiger und schneller. Bei Gefahr lässt es ordentlich Dampf ab."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/18.ts
+++ b/data/Black & White/Black & White/18.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Tepig",
 		fr: "Gruikui",
+		de: "Floink"
 	},
 
 	stage: "Stage1",
@@ -42,6 +43,7 @@ const card: Card = {
 			name: {
 				en: "Rollout",
 				fr: "Roulade",
+				de: "Walzer"
 			},
 
 			damage: 20,
@@ -56,10 +58,12 @@ const card: Card = {
 			name: {
 				en: "Flamethrower",
 				fr: "Lance-Flamme",
+				de: "Flammenwurf"
 			},
 			effect: {
 				en: "Discard an Energy attached to this Pokémon.",
 				fr: "Défaussez une Énergie attachée à ce Pokémon.",
+				de: "Lege 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel."
 			},
 			damage: 70,
 
@@ -77,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "When its internal fire flares up, its movements grow sharper and faster. When in trouble, it emits smoke.",
+		de: "Lodert das Feuer in ihm auf, bewegt es sich geschmeidiger und schneller. Bei Gefahr lässt es ordentlich Dampf ab."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/19.ts
+++ b/data/Black & White/Black & White/19.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pignite",
 		fr: "Grotichon",
+		de: "Ferkokel"
 	},
 
 	stage: "Stage2",
@@ -43,6 +44,7 @@ const card: Card = {
 			name: {
 				en: "Heat Crash",
 				fr: "Tacle Feu",
+				de: "Brandstempel"
 			},
 
 			damage: 50,
@@ -58,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Flare Blitz",
 				fr: "Boutefeu",
+				de: "Flammenblitz"
 			},
 			effect: {
 				en: "Discard all Fire Energy attached to this Pokémon.",
 				fr: "Défaussez toutes les Énergies Fire attachées à ce Pokémon.",
+				de: "Lege alle an dieses Pokémon angelegten {R}-Energien auf deinen Ablagestapel."
 			},
 			damage: 150,
 
@@ -79,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "It can throw a fire punch by setting its fists on fire with its fiery chin. It cares deeply about its friends.",
+		de: "Steckt mit dem Feuer um sein Kinn seine Fäuste in Brand und holt zu feurigen Fausthieben aus. Zeigt großen Teamgeist."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/2.ts
+++ b/data/Black & White/Black & White/2.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Leaf Blade",
 				fr: "Lame-Feuille",
+				de: "Laubklinge"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 more damage.",
 				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 30 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: 10,
 
@@ -65,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "They photosynthesize by bathing their tails in sunlight. When they are not feeling well, their tails droop.",
+		de: "Fängt mit dem Schweif Sonnenlicht auf, um Fotosynthese zu betreiben. Fehlt ihm die Kraft, hängt sein Schweif schlaff herab."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/20.ts
+++ b/data/Black & White/Black & White/20.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pignite",
 		fr: "Grotichon",
+		de: "Ferkokel"
 	},
 
 	stage: "Stage2",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Todas las veces que quieras durante tu turno (antes de tu ataque), puedes unir una carta de Energía Fire de tu mano a 1 de tus Pokémon.",
 				it: "Durante il tuo turno, prima di attaccare, puoi assegnare a piacimento le carte Energia Fire che hai in mano ai tuoi Pokémon.",
 				pt: "Sempre que desejar, na sua vez de jogar (antes de atacar), você poderá ligar um card de Energia Fire da sua mão a 1 dos seus Pokémon.",
-				de: "Beliebig oft während deines Zuges (vor deinem Angriff) kannst du 1 Fire-Energiekarte von deiner Hand an 1 deiner Pokémon anlegen."
+				de: "Beliebig oft während deines Zuges (vor deinem Angriff) kannst du 1 {R}-Energiekarte von deiner Hand an 1 deiner Pokémon anlegen."
 			},
 		},
 	],
@@ -66,6 +67,7 @@ const card: Card = {
 			name: {
 				en: "Heat Crash",
 				fr: "Tacle Feu",
+				de: "Brandstempel"
 			},
 
 			damage: 80,
@@ -84,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "It can throw a fire punch by setting its fists on fire with its fiery chin. It cares deeply about its friends.",
+		de: "Steckt mit dem Feuer um sein Kinn seine Fäuste in Brand und holt zu feurigen Fausthieben aus. Zeigt großen Teamgeist."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/21.ts
+++ b/data/Black & White/Black & White/21.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Scratch",
 				fr: "Griffe",
+				de: "Kratzer"
 			},
 
 			damage: 10,
@@ -50,6 +51,7 @@ const card: Card = {
 			name: {
 				en: "Live Coal",
 				fr: "Charbon Mutant",
+				de: "Glühende Kohlen"
 			},
 
 			damage: 30,
@@ -68,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "When it is angered, the temperature of its head tuft reaches 600° F. It uses its tuft to roast berries.",
+		de: "Ist es wütend, erreicht das Büschel auf seinem Kopf Temperaturen von bis zu 300 Grad. Es röstet sich damit auch Nüsse."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/22.ts
+++ b/data/Black & White/Black & White/22.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pansear",
 		fr: "Flamajou",
+		de: "Grillmak"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Flame Burst",
 				fr: "Rebondifeu",
+				de: "Funkenflug"
 			},
 			effect: {
 				en: "Does 20 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 20 dégâts à 2 des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 2 Pokémon auf der Bank deines Gegners je 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 20,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Fury Swipes",
 				fr: "Combo-Griffe",
+				de: "Kratzfurie"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 40 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 40 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 40,
 
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "It loves sweets because they become energy for the fire burning inside its body.",
+		de: "Am liebsten isst es Süßigkeiten. Es wandelt sie in Energie um, mit der es das Feuer in seinem Körper schürt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/23.ts
+++ b/data/Black & White/Black & White/23.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Firebreathing",
 				fr: "Souffle-Feu",
+				de: "Feuerhauch"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 more damage.",
 				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 10 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 weitere Schadenspunkte zu."
 			},
 			damage: 10,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "Darumaka's droppings are hot, so people used to put them in their clothes to keep themselves warm.",
+		de: "Früher nutzte man die heißen Ausscheidungen von Flampion, um sich den Körper zu wärmen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/24.ts
+++ b/data/Black & White/Black & White/24.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Singe",
 				fr: "Roussi",
+				de: "Versengung"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Burned.",
 				fr: "Le Pokémon Défenseur est maintenant Brûlé.",
+				de: "Das Verteidigende Pokémon ist jetzt verbrannt."
 			},
 
 		},
@@ -51,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Rollout",
 				fr: "Roulade",
+				de: "Walzer"
 			},
 
 			damage: 20,
@@ -69,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "Darumaka's droppings are hot, so people used to put them in their clothes to keep themselves warm.",
+		de: "Früher nutzte man die heißen Ausscheidungen von Flampion, um sich den Körper zu wärmen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/25.ts
+++ b/data/Black & White/Black & White/25.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Darumaka",
 		fr: "Darumarond",
+		de: "Flampion"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Fire Fang",
 				fr: "Crocs Feu",
+				de: "Feuerzahn"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Burned.",
 				fr: "Le Pokémon Défenseur est maintenant Brûlé.",
+				de: "Das Verteidigende Pokémon ist jetzt verbrannt."
 			},
 			damage: 20,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Thrash",
 				fr: "Mania",
+				de: "Fuchtler"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage. If tails, this Pokémon does 20 damage to itself.",
 				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 20 dégâts supplémentaires. Si c’est pile, ce Pokémon s’inflige 20 dégâts.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu. Bei „Zahl“ fügt sich dieses Pokémon selbst 20 Schadenspunkte zu."
 			},
 			damage: 70,
 
@@ -80,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "When weakened in battle, it transforms into a stone statue, then it sharpens its mind and fights on mentally.",
+		de: "Schwächt man es im Kampf, wird es reglos wie ein Stein und horcht in sich hinein, um mit der Kraft seines Geistes zu kämpfen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/26.ts
+++ b/data/Black & White/Black & White/26.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Outrage",
 				fr: "Colère",
+				de: "Wutanfall"
 			},
 			effect: {
 				en: "Does 10 more damage for each damage counter on this Pokémon.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque marqueur de dégâts placé sur ce Pokémon.",
+				de: "Dieser Angriff fügt 10 weitere Schadenspunkte für jede Schadensmarke auf diesem Pokémon zu."
 			},
 			damage: 20,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Blue Flare",
 				fr: "Flamme Bleue",
+				de: "Blauflammen"
 			},
 			effect: {
 				en: "Discard 2 Fire Energy attached to this Pokémon.",
 				fr: "Défaussez 2 Énergies Fire attachées à ce Pokémon.",
+				de: "Lege 2 an dieses Pokémon angelegte {R}-Energien auf deinen Ablagestapel."
 			},
 			damage: 120,
 
@@ -75,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon appears in legends. It sends flames into the air from its tail, burning up everything around it.",
+		de: "Ein aus Mythen bekanntes Pokémon. Es wirbelt mit seinem Schweif Feuer auf, mit dem es alles in Asche legt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/27.ts
+++ b/data/Black & White/Black & White/27.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 10,
@@ -49,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Water Gun",
 				fr: "Pistolet à O",
+				de: "Aquaknarre"
 			},
 
 			damage: 20,
@@ -67,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "The scalchop on its stomach is made from the same elements as claws. It detaches the scalchop for use as a blade.",
+		de: "Die Muschel auf seinem Bauch besteht aus demselben Material wie seine Krallen. Nimmt es sie ab, fungiert sie als Klinge."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/28.ts
+++ b/data/Black & White/Black & White/28.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Razor Shell",
 				fr: "Coquilame",
+				de: "Kalkklinge"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "The scalchop on its stomach is made from the same elements as claws. It detaches the scalchop for use as a blade.",
+		de: "Die Muschel auf seinem Bauch besteht aus demselben Material wie seine Krallen. Nimmt es sie ab, fungiert sie als Klinge."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/29.ts
+++ b/data/Black & White/Black & White/29.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Oshawott",
 		fr: "Moustillon",
+		de: "Ottaro"
 	},
 
 	stage: "Stage1",
@@ -42,6 +43,7 @@ const card: Card = {
 			name: {
 				en: "Water Gun",
 				fr: "Pistolet à O",
+				de: "Aquaknarre"
 			},
 
 			damage: 30,
@@ -56,10 +58,12 @@ const card: Card = {
 			name: {
 				en: "Razor Shell",
 				fr: "Coquilame",
+				de: "Kalkklinge"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 40,
 
@@ -77,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Scalchop techniques differ from one Dewott to another. It never neglects maintaining its scalchops.",
+		de: "Wie es seine Attacken ausführt, ist von Exemplar zu Exemplar unterschiedlich. Es gibt sehr auf seine Muscheln acht."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/3.ts
+++ b/data/Black & White/Black & White/3.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Snivy",
 		fr: "Vipélierre",
+		de: "Serpifeu"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Wrap",
 				fr: "Ligotage",
+				de: "Wickel"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c’est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 20,
 
@@ -57,6 +60,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 30,
@@ -82,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "They avoid attacks by sinking into the shadows of thick foliage. They retaliate with masterful whipping techniques.",
+		de: "Es verschwindet im wuchernden Dickicht, um Angriffen auszuweichen, und kontert mit einem gekonnten Rutenhieb."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/30.ts
+++ b/data/Black & White/Black & White/30.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Oshawott",
 		fr: "Moustillon",
+		de: "Ottaro"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Aqua Tail",
 				fr: "Hydroqueue",
+				de: "Nassschweif"
 			},
 			effect: {
 				en: "Flip a coin for each Water Energy attached to this Pokémon. This attack does 10 more damage for each heads.",
 				fr: "Lancez une pièce pour chaque Énergie Water attachée à ce Pokémon. Cette attaque inflige 10 dégâts supplémentaires pour chaque côté face.",
+				de: "Wirf für jede an dieses Pokémon angelegte {W}-Energie 1 Münze. Dieser Angriff fügt 10 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 30,
 
@@ -63,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "Scalchop techniques differ from one Dewott to another. It never neglects maintaining its scalchops.",
+		de: "Wie es seine Attacken ausführt, ist von Exemplar zu Exemplar unterschiedlich. Es gibt sehr auf seine Muscheln acht."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/31.ts
+++ b/data/Black & White/Black & White/31.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Dewott",
 		fr: "Mateloutre",
+		de: "Zwottronin"
 	},
 
 	stage: "Stage2",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Pike",
 				fr: "Javelot",
+				de: "Langspieß"
 			},
 			effect: {
 				en: "Does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 30 dégâts à 1 des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 1 Pokémon auf der Bank deines Gegners 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 30,
 
@@ -59,6 +62,7 @@ const card: Card = {
 			name: {
 				en: "Surf",
 				fr: "Surf",
+				de: "Surfer"
 			},
 
 			damage: 80,
@@ -77,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Part of the armor on its anterior legs becomes a giant sword. Its cry alone is enough to intimidate most enemies.",
+		de: "Schüchtert Gegner allein durch seinen Ruf ein. Ein Teil der Panzerung an seinen Vorderbeinen dient ihm als Langschwert."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/32.ts
+++ b/data/Black & White/Black & White/32.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Dewott",
 		fr: "Mateloutre",
+		de: "Zwottronin"
 	},
 
 	stage: "Stage2",
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Hydro Pump",
 				fr: "Hydrocanon",
+				de: "Hydropumpe"
 			},
 			effect: {
 				en: "Does 10 more damage for each Water Energy attached to this Pokémon.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque Énergie Water attachée à ce Pokémon.",
+				de: "Dieser Angriff fügt 10 weitere Schadenspunkte für jede an dieses Pokémon angelegte {W}-Energie zu."
 			},
 			damage: 70,
 
@@ -86,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "Part of the armor on its anterior legs becomes a giant sword. Its cry alone is enough to intimidate most enemies.",
+		de: "Schüchtert Gegner allein durch seinen Ruf ein. Ein Teil der Panzerung an seinen Vorderbeinen dient ihm als Langschwert."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/33.ts
+++ b/data/Black & White/Black & White/33.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Scratch",
 				fr: "Griffe",
+				de: "Kratzer"
 			},
 
 			damage: 10,
@@ -50,6 +51,7 @@ const card: Card = {
 			name: {
 				en: "Water Gun",
 				fr: "Pistolet à O",
+				de: "Aquaknarre"
 			},
 
 			damage: 30,
@@ -68,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "It does not thrive in dry environments. It keeps itself damp by shooting water stored in its head tuft from its tail.",
+		de: "Es wringt Wasser aus dem Büschel auf seinem Kopf und bespritzt damit Gegner. Kein Pokémon für trockene Gegenden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/34.ts
+++ b/data/Black & White/Black & White/34.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Panpour",
 		fr: "Flotajou",
+		de: "Sodamak"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Scald",
 				fr: "Ébullition",
+				de: "Siedewasser"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Burned.",
 				fr: "Le Pokémon Défenseur est maintenant Brûlé.",
+				de: "Das Verteidigende Pokémon ist jetzt verbrannt."
 			},
 			damage: 20,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Fury Swipes",
 				fr: "Combo-Griffe",
+				de: "Kratzfurie"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 40 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 40 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 40,
 
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "The high-pressure water expelled from its tail is so powerful, it can destroy a concrete wall.",
+		de: "Es schießt mit so hohem Druck Wasser aus seinem Schweif, dass selbst Betonwände den Kürzeren ziehen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/35.ts
+++ b/data/Black & White/Black & White/35.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Crunch",
 				fr: "Mâchouille",
+				de: "Knirscher"
 			},
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c’est face, défaussez une Énergie attachée au Pokémon Défenseur.",
+				de: "Wirf 1 Münze. Lege bei „Kopf“ 1 an das Verteidigende Pokémon angelegte Energie auf den Ablagestapel."
 			},
 			damage: 30,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "Red and blue Basculin get along so poorly, they'll start fighting instantly. These Pokémon are very hostile.",
+		de: "Rot gestreifte und blau gestreifte Exemplare kriegen sich sofort in die Haare. Ein äußerst aggressives Pokémon."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/36.ts
+++ b/data/Black & White/Black & White/36.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Water Gun",
 				fr: "Pistolet à O",
+				de: "Aquaknarre"
 			},
 
 			damage: 10,
@@ -61,6 +62,7 @@ const card: Card = {
 
 	description: {
 		en: "These bird Pokémon are excellent divers. They swim around in the water eating their favorite food—peat moss.",
+		de: "Es schwimmt das Gewässer auf der Suche nach Torfmoos, seiner Leibspeise, ab. Ein talentierter Taucher."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/37.ts
+++ b/data/Black & White/Black & White/37.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Ducklett",
 		fr: "Couaneton",
+		de: "Piccolente"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Feather Dance",
 				fr: "Danse-Plume",
+				de: "Daunenreigen"
 			},
 			effect: {
 				en: "During your next turn, each of this Pokémon's attacks does 40 more damage(before applying Weakness and Resistance).",
 				fr: "Pendant votre prochain tour, chaque attaque de ce Pokémon inflige 40 dégâts supplémentaires (avant application de la Faiblesse et de la Résistance).",
+				de: "Während deines nächsten Zuges fügt jeder Angriff dieses Pokémon 40 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 
 		},
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Aqua Ring",
 				fr: "Anneau Hydro",
+				de: "Wasserring"
 			},
 			effect: {
 				en: "Switch this Pokémon with 1 of your Benched Pokémon.",
 				fr: "Échangez ce Pokémon avec 1 de vos Pokémon de Banc.",
+				de: "Tausche dieses Pokémon gegen 1 Pokémon auf deiner Bank aus."
 			},
 			damage: 40,
 
@@ -84,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "Swanna start to dance at dusk. The one dancing in the middle is the leader of the flock.",
+		de: "Wenn der Morgen dämmert, fangen sie an zu tanzen. Das Swaroness in der Mitte führt die Gruppe an."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/38.ts
+++ b/data/Black & White/Black & White/38.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Pound",
 				fr: "Écras'Face",
+				de: "Pfund"
 			},
 
 			damage: 20,
@@ -52,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Wave Splash",
 				fr: "Grosse Vague",
+				de: "Wellenplatscher"
 			},
 
 			damage: 60,
@@ -70,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "Floating in the open sea is how they live. When they find a wounded Pokémon, they embrace it and bring it to shore.",
+		de: "Es treibt durch den Ozean. Findet es ein verletztes Pokémon, nimmt es dieses auf und trägt es zurück an Land."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/39.ts
+++ b/data/Black & White/Black & White/39.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Water Pulse",
 				fr: "Vibraqua",
+				de: "Aquawelle"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 			damage: 20,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Hydro Pump",
 				fr: "Hydrocanon",
+				de: "Hydropumpe"
 			},
 			effect: {
 				en: "Does 10 more damage for each Water Energy attached to this Pokémon.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque Énergie Water attachée à ce Pokémon.",
+				de: "Dieser Angriff fügt 10 weitere Schadenspunkte für jede an dieses Pokémon angelegte {W}-Energie zu."
 			},
 			damage: 40,
 
@@ -75,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "Floating in the open sea is how they live. When they find a wounded Pokémon, they embrace it and bring it to shore.",
+		de: "Es treibt durch den Ozean. Findet es ein verletztes Pokémon, nimmt es dieses auf und trägt es zurück an Land."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/4.ts
+++ b/data/Black & White/Black & White/4.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Snivy",
 		fr: "Vipélierre",
+		de: "Serpifeu"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Wring Out",
 				fr: "Essorage",
+				de: "Auswringen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed and discard an Energy attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c’est face, le Pokémon Défenseur est maintenant Paralysé, et vous défaussez une Énergie attachée au Pokémon Défenseur.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert. Lege außerdem 1 an das Verteidigende Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 30,
 
@@ -70,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "They avoid attacks by sinking into the shadows of thick foliage. They retaliate with masterful whipping techniques.",
+		de: "Es verschwindet im wuchernden Dickicht, um Angriffen auszuweichen, und kontert mit einem gekonnten Rutenhieb."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/40.ts
+++ b/data/Black & White/Black & White/40.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Rear Kick",
 				fr: "Ruade",
+				de: "Rückwärtskick"
 			},
 
 			damage: 20,
@@ -55,6 +56,7 @@ const card: Card = {
 
 	description: {
 		en: "When thunderclouds cover the sky, it will appear. It can catch lightning with its mane and store the electricity.",
+		de: "Es erscheint, wenn Gewitterwolken den Himmel verdunkeln. Es fängt mit seiner Mähne Blitze und hortet ihre Energie."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/41.ts
+++ b/data/Black & White/Black & White/41.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Stomp",
 				fr: "Écrasement",
+				de: "Stampfer"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 more damage.",
 				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 10 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 weitere Schadenspunkte zu."
 			},
 			damage: 10,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "Its mane shines when it discharges electricity. They use their flashing manes to communicate with one another.",
+		de: "Wenn es Strom entlädt, blitzt seine Mähne auf. Auf diese Weise kann es auch mit Artgenossen kommunizieren."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/42.ts
+++ b/data/Black & White/Black & White/42.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Blitzle",
 		fr: "Zébibron",
+		de: "Elezeba"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Stomp",
 				fr: "Écrasement",
+				de: "Stampfer"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Wild Charge",
 				fr: "Éclair Fou",
+				de: "Stromstoß"
 			},
 			effect: {
 				en: "This Pokémon does 10 damage to itself.",
 				fr: "Ce Pokémon s’inflige 10 dégâts.",
+				de: "Dieses Pokémon fügt sich selbst 10 Schadenspunkte zu."
 			},
 			damage: 70,
 
@@ -80,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "This ill-tempered Pokémon is dangerous because when it's angry, it shoots lightning from its mane in all directions.",
+		de: "Ein stürmischer Geselle. Besonders gefährlich ist es, wenn es wütend ist und in alle Richtungen Stromsalven entlädt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/43.ts
+++ b/data/Black & White/Black & White/43.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Blitzle",
 		fr: "Zébibron",
+		de: "Elezeba"
 	},
 
 	stage: "Stage1",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Rear Kick",
 				fr: "Ruade",
+				de: "Rückwärtskick"
 			},
 
 			damage: 30,
@@ -55,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Electrispark",
 				fr: "Arc Électrique",
+				de: "Stromfunke"
 			},
 			effect: {
 				en: "Does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à chacun des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt jedem Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 70,
 
@@ -76,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "They have lightning-like movements. When Zebstrika run at full speed, the sound of thunder reverberates.",
+		de: "Es ist explosiv wie ein Blitz. Galoppiert es mit voller Geschwindigkeit drauflos, kann es man Donnerhall vernehmen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/44.ts
+++ b/data/Black & White/Black & White/44.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Stun Needle",
 				fr: "Para-Dard",
+				de: "Betäubungsnadel"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c’est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 10,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "They attach themselves to large-bodied Pokémon and absorb static electricity, which they store in an electric pouch.",
+		de: "Es pflanzt sich an großen Pokémon fest und zapft ihnen elektrische Energie ab. Diese hortet es in seinen Ladetaschen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/45.ts
+++ b/data/Black & White/Black & White/45.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Leech Life",
 				fr: "Vampirisme",
+				de: "Blutsauger"
 			},
 			effect: {
 				en: "Heal from this Pokémon the same amount of damage you did to the Defending Pokémon.",
 				fr: "Soignez à ce Pokémon la même quantité de dégâts que vous avez infligée au Pokémon Défenseur.",
+				de: "Heile bei diesem Pokémon genauso viel Schaden, wie du dem Verteidigenden Pokémon zugefügt hast."
 			},
 			damage: 10,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "They attach themselves to large-bodied Pokémon and absorb static electricity, which they store in an electric pouch.",
+		de: "Es pflanzt sich an großen Pokémon fest und zapft ihnen elektrische Energie ab. Diese hortet es in seinen Ladetaschen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/46.ts
+++ b/data/Black & White/Black & White/46.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Joltik",
 		fr: "Statitik",
+		de: "Wattzapf"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Electroweb",
 				fr: "Toile Élek",
+				de: "Elektronetz"
 			},
 			effect: {
 				en: "The Defending Pokémon can't retreat during your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas battre en retraite lors du prochain tour de votre adversaire.",
+				de: "Das Verteidigende Pokémon kann sich während des nächsten Zuges deines Gegners nicht zurückziehen."
 			},
 			damage: 20,
 
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Leech Life",
 				fr: "Vampirisme",
+				de: "Blutsauger"
 			},
 			effect: {
 				en: "Heal from this Pokémon the same amount of damage you did to the Defending Pokémon.",
 				fr: "Soignez à ce Pokémon la même quantité de dégâts que vous avez infligée au Pokémon Défenseur.",
+				de: "Heile bei diesem Pokémon genauso viel Schaden, wie du dem Verteidigenden Pokémon zugefügt hast."
 			},
 			damage: 40,
 
@@ -78,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "They employ an electrically charged web to trap their prey. While it is immobilized by shock, they leisurely consume it.",
+		de: "Lässt seine Beute in elektrisch geladene Fäden tappen. Solang diese durch den Schock gelähmt ist, labt es sich an ihr."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/47.ts
+++ b/data/Black & White/Black & White/47.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Outrage",
 				fr: "Colère",
+				de: "Wutanfall"
 			},
 			effect: {
 				en: "Does 10 more damage for each damage counter on this Pokémon.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque marqueur de dégâts placé sur ce Pokémon.",
+				de: "Dieser Angriff fügt 10 weitere Schadenspunkte für jede Schadensmarke auf diesem Pokémon zu."
 			},
 			damage: 20,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Bolt Strike",
 				fr: "ChargeFoudre",
+				de: "Blitzschlag"
 			},
 			effect: {
 				en: "This Pokémon does 40 damage to itself.",
 				fr: "Ce Pokémon s’inflige 40 dégâts.",
+				de: "Dieses Pokémon fügt sich selbst 40 Schadenspunkte zu."
 			},
 			damage: 120,
 
@@ -75,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon appears in legends. In its tail, it has a giant generator that creates electricity.",
+		de: "Ein Pokémon, von dem schon in Sagen die Rede ist. Sein Schweif enthält ein gewaltiges Organ zur Stromerzeugung."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/48.ts
+++ b/data/Black & White/Black & White/48.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Hypnosis",
 				fr: "Hypnose",
+				de: "Hypnose"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Dream Eater",
 				fr: "Dévorêve",
+				de: "Traumfresser"
 			},
 			effect: {
 				en: "If the Defending Pokémon is not Asleep, this attack does nothing.",
 				fr: "Si le Pokémon Défenseur n’est pas Endormi, cette attaque ne fait rien.",
+				de: "Wenn das Verteidigende Pokémon nicht schläft, hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 60,
 
@@ -72,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "Munna always float in the air. People whose dreams are eaten by them forget what the dreams had been about.",
+		de: "Frisst es den Traum eines Menschen, vergisst der Träumer dessen Inhalt. Es schwebt stets durch die Luft."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/49.ts
+++ b/data/Black & White/Black & White/49.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Munna",
 		fr: "Munna",
+		de: "Somniam"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Hypnotic Ray",
 				fr: "Onde Hypnotique",
+				de: "Hypnotischer Strahl"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 			damage: 20,
 
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Dream Eater",
 				fr: "Dévorêve",
+				de: "Traumfresser"
 			},
 			effect: {
 				en: "If the Defending Pokémon is not Asleep, this attack does nothing.",
 				fr: "Si le Pokémon Défenseur n’est pas Endormi, cette attaque ne fait rien.",
+				de: "Wenn das Verteidigende Pokémon nicht schläft, hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 90,
 
@@ -78,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "The mist emanating from their foreheads is packed with the dreams of people and Pokémon.",
+		de: "Der Dunst, der aus seiner Stirn tritt, enthält die Träume unzähliger Menschen und Pokémon."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/5.ts
+++ b/data/Black & White/Black & White/5.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Servine",
 		fr: "Lianaja",
+		de: "Efoserp"
 	},
 
 	stage: "Stage2",
@@ -42,6 +43,7 @@ const card: Card = {
 			name: {
 				en: "Vine Whip",
 				fr: "Fouet Lianes",
+				de: "Rankenhieb"
 			},
 
 			damage: 40,
@@ -55,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Leaf Storm",
 				fr: "Tempêteverte",
+				de: "Blättersturm"
 			},
 			effect: {
 				en: "Heal 20 damage from each of your Grass Pokémon.",
 				fr: "Soignez 20 dégâts à chacun de vos Pokémon Grass.",
+				de: "Heile 20 Schadenspunkte bei jedem deiner {G}-Pokémon."
 			},
 			damage: 60,
 
@@ -83,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "They raise their heads to intimidate opponents but only give it their all when fighting a powerful opponent.",
+		de: "Versetzt Gegner in Ehrfurcht, indem es den Kopf weit in die Höhe streckt. Zeigt nur starken Gegnern seine wahre Macht."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/50.ts
+++ b/data/Black & White/Black & White/50.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Gust",
 				fr: "Tornade",
+				de: "Windstoß"
 			},
 
 			damage: 10,
@@ -61,6 +62,7 @@ const card: Card = {
 
 	description: {
 		en: "Its habitat is dark forests and caves. It emits ultrasonic waves from its nose to learn about its surroundings.",
+		de: "Wohnt in dunklen Wäldern und Höhlen. Es sendet Ultraschallwellen mit seiner Nase aus, um die Gegend abzutasten."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/51.ts
+++ b/data/Black & White/Black & White/51.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Woobat",
 		fr: "Chovsourir",
+		de: "Fleknoil"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Attract",
 				fr: "Attraction",
+				de: "Anziehung"
 			},
 			effect: {
 				en: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
 				fr: "Si le Pokémon Défenseur essaie d’attaquer pendant le prochain tour de votre adversaire, ce dernier lance une pièce. Si c’est pile, son attaque ne fait rien.",
+				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 
 		},
@@ -56,6 +59,7 @@ const card: Card = {
 			name: {
 				en: "Heart Stamp",
 				fr: "Crèvecœur",
+				de: "Herzstempel"
 			},
 
 			damage: 40,
@@ -81,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "It emits sound waves of various frequencies from its nose, including some powerful enough to destroy rocks.",
+		de: "Es sendet über seine Nase Schallwellen mit verschiedenen Frequenzen aus. Mit manchen kann es sogar Felsen zerstören."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/52.ts
+++ b/data/Black & White/Black & White/52.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Ram",
 				fr: "Collision",
+				de: "Ramme"
 			},
 
 			damage: 10,
@@ -50,6 +51,7 @@ const card: Card = {
 			name: {
 				en: "Rollout",
 				fr: "Roulade",
+				de: "Walzer"
 			},
 
 			damage: 30,
@@ -68,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "Its bite injects a potent poison, enough to paralyze large bird Pokémon that try to prey on it.",
+		de: "Es beißt Angreifer und injiziert ihnen Gift, das selbst große Vogel-Pokémon, seine natürlichen Feinde, lähmt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/53.ts
+++ b/data/Black & White/Black & White/53.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Venipede",
 		fr: "Venipatte",
+		de: "Toxiped"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Poison Sting",
 				fr: "Dard-Venin",
+				de: "Giftstachel"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné.",
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet."
 			},
 			damage: 20,
 
@@ -59,6 +62,7 @@ const card: Card = {
 			name: {
 				en: "Rollout",
 				fr: "Roulade",
+				de: "Walzer"
 			},
 
 			damage: 50,
@@ -77,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Protected by a hard shell, it spins its body like a wheel and crashes furiously into its enemies.",
+		de: "Von einem harten Schutzpanzer umgeben. Es greift seine Gegner an, indem es mit Karacho wie ein Rad in sie hineinrollt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/54.ts
+++ b/data/Black & White/Black & White/54.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Whirlipede",
 		fr: "Scobolide",
+		de: "Rollum"
 	},
 
 	stage: "Stage2",
@@ -43,10 +44,12 @@ const card: Card = {
 			name: {
 				en: "Steamroller",
 				fr: "Bulldoboule",
+				de: "Quetschwalze"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by Resistance.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Résistance.",
+				de: "Der Schaden dieses Angriffs wird durch Resistenz nicht verändert."
 			},
 			damage: 60,
 
@@ -61,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Poison Claws",
 				fr: "Griffes Empoisonnées",
+				de: "Giftkrallen"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné.",
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet."
 			},
 			damage: 80,
 
@@ -82,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "Highly aggressive, it uses the claws near its neck to dig into its opponent and poison them.",
+		de: "Rammt den Gegner mit den Zacken an seinem Hals und verpasst ihm eine Ladung Gift. Von Natur aus sehr angriffslustig."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/55.ts
+++ b/data/Black & White/Black & White/55.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Cell Culture",
 				fr: "Culture Cellulaire",
+				de: "Zellkultur"
 			},
 			effect: {
 				en: "Search your deck for Solosis and put it onto your Bench. Shuffle your deck afterward.",
 				fr: "Cherchez Nucléos dans votre deck et placez-le sur votre Banc. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach Monozyto und lege es auf deine Bank. Mische anschließend dein Deck."
 			},
 
 		},
@@ -51,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Rollout",
 				fr: "Roulade",
+				de: "Walzer"
 			},
 
 			damage: 20,
@@ -69,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "Because their bodies are enveloped in a special liquid, they can survive in any environment.",
+		de: "Da sein Körper von einer speziellen Flüssigkeit umgeben ist, kann es in jedem Umfeld überleben."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/56.ts
+++ b/data/Black & White/Black & White/56.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Solosis",
 		fr: "Nucléos",
+		de: "Monozyto"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Recover",
 				fr: "Soin",
+				de: "Genesung"
 			},
 			effect: {
 				en: "Discard an Energy attached to this Pokémon and heal all damage from this Pokémon.",
 				fr: "Défaussez une Énergie attachée à ce Pokémon et soignez tous les dégâts de ce Pokémon.",
+				de: "Lege 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel und heile allen Schaden bei diesem Pokémon."
 			},
 
 		},
@@ -56,6 +59,7 @@ const card: Card = {
 			name: {
 				en: "Rollout",
 				fr: "Roulade",
+				de: "Walzer"
 			},
 
 			damage: 30,
@@ -74,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "When their brains, now divided in two, are thinking the same thought, these Pokémon exhibit their maximum power.",
+		de: "Kommen beide Hälften seines gespaltenen Denkapparates auf dieselbe Idee, entfesselt sich seine volle Kraft."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/57.ts
+++ b/data/Black & White/Black & White/57.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Duosion",
 		fr: "Méios",
+		de: "Mitodos"
 	},
 
 	stage: "Stage2",
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Psywave",
 				fr: "Vague Psy",
+				de: "Psywelle"
 			},
 			effect: {
 				en: "Does 10 more damage for each Energy attached to the Defending Pokémon.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque Énergie attachée au Pokémon Défenseur.",
+				de: "Dieser Angriff fügt 10 weitere Schadenspunkte für jede an das Verteidigende Pokémon angelegte Energie zu."
 			},
 			damage: 30,
 
@@ -86,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "These remarkably intelligent Pokémon fight by controlling arms that can grip with rock-crushing power.",
+		de: "Sein Griff ist so stark, dass es damit ganze Felsen zermalmen kann. Es ist sehr intelligent."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/58.ts
+++ b/data/Black & White/Black & White/58.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Pound",
 				fr: "Écras'Face",
+				de: "Pfund"
 			},
 
 			damage: 30,
@@ -55,6 +56,7 @@ const card: Card = {
 
 	description: {
 		en: "It fights by swinging a piece of timber around. It is close to evolving when it can handle the lumber without difficulty.",
+		de: "Greift Gegner mit einem Holzbalken an. Fällt es ihm leicht, den schweren Balken zu tragen, ist seine Entwicklung nah."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/59.ts
+++ b/data/Black & White/Black & White/59.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Low Kick",
 				fr: "Balayage",
+				de: "Fußkick"
 			},
 
 			damage: 10,
@@ -49,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Pound",
 				fr: "Écras'Face",
+				de: "Pfund"
 			},
 
 			damage: 20,
@@ -67,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "These Pokémon appear at building sites and help out with construction. They always carry squared logs.",
+		de: "Trägt stets einen Holzbalken bei sich. Es taucht hier und da auf Baustellen auf und hilft dort den Arbeitern aus."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/6.ts
+++ b/data/Black & White/Black & White/6.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Servine",
 		fr: "Lianaja",
+		de: "Efoserp"
 	},
 
 	stage: "Stage2",
@@ -64,10 +65,12 @@ const card: Card = {
 			name: {
 				en: "Leaf Tornado",
 				fr: "Phytomixeur",
+				de: "Grasmixer"
 			},
 			effect: {
 				en: "Move as many Grass Energy attached to your Pokémon to your other Pokémon in any way you like.",
 				fr: "Déplacez autant d’Énergies Grass attachées à vos Pokémon que vous voulez vers vos autres Pokémon, de la manière que vous voulez.",
+				de: "Verschiebe beliebig viele an deine Pokémon angelegten {G}-Energien nach Belieben auf deine anderen Pokémon."
 			},
 			damage: 60,
 
@@ -92,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "They raise their heads to intimidate opponents but only give it their all when fighting a powerful opponent.",
+		de: "Versetzt Gegner in Ehrfurcht, indem es den Kopf weit in die Höhe streckt. Zeigt nur starken Gegnern seine wahre Macht."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/60.ts
+++ b/data/Black & White/Black & White/60.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Timburr",
 		fr: "Charpenti",
+		de: "Praktibalk"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Bulk Up",
 				fr: "Gonflette",
+				de: "Protzer"
 			},
 			effect: {
 				en: "During your next turn, each of this Pokémon's attacks does 20 more damage (before applying Weakness and Resistance).",
 				fr: "Lors de votre prochain tour, chaque attaque de ce Pokémon inflige 20 dégâts supplémentaires (avant application de la Faiblesse et de la Résistance).",
+				de: "Während deines nächsten Zuges fügt jeder Angriff dieses Pokémon 20 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 			damage: 20,
 
@@ -58,6 +61,7 @@ const card: Card = {
 			name: {
 				en: "Pound",
 				fr: "Écras'Face",
+				de: "Pfund"
 			},
 
 			damage: 60,
@@ -76,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "They strengthen their bodies by carrying steel beams. They show off their big muscles to their friends.",
+		de: "Zu Trainingszwecken trägt es immer einen Stahlträger bei sich. Unter Kollegen gibt es nur zu gern mit seinen Muskeln an."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/61.ts
+++ b/data/Black & White/Black & White/61.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Circle Throw",
 				fr: "Projection",
+				de: "Überkopfwurf"
 			},
 			effect: {
 				en: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon.",
 				fr: "Votre adversaire échange le Pokémon Défenseur avec l’un de ses Pokémon de Banc.",
+				de: "Dein Gegner tauscht das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
 			},
 			damage: 30,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Storm Throw",
 				fr: "Yama Arashi",
+				de: "Bergsturm"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by Resistance.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Résistance.",
+				de: "Der Schaden dieses Angriffs wird durch Resistenz nicht verändert."
 			},
 			damage: 80,
 
@@ -75,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "When they encounter foes bigger than themselves, they try to throw them. They always travel in packs of five.",
+		de: "Hat von Natur aus den Drang, Gegner zu werfen, die größer sind als es selbst. Es bildet stets Fünferrudel."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/62.ts
+++ b/data/Black & White/Black & White/62.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Low Sweep",
 				fr: "Balayette",
+				de: "Fußtritt"
 			},
 
 			damage: 20,
@@ -49,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Beatdown",
 				fr: "Dérouillée",
+				de: "Niederprügler"
 			},
 
 			damage: 40,
@@ -67,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "The sound of Sawk punching boulders and trees can be heard all the way from the mountains where they train.",
+		de: "Am Fuß von Bergen, wo Karadonis trainiert, ertönt das Echo von Fäusten, die gegen Felsen und Bäume schlagen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/63.ts
+++ b/data/Black & White/Black & White/63.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Sand Tomb",
 				fr: "Tombe de Sable",
+				de: "Sandgrab"
 			},
 			effect: {
 				en: "The Defending Pokémon can't retreat during your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas battre en retraite durant le prochain tour de votre adversaire.",
+				de: "Das Verteidigende Pokémon kann sich im nächsten Zug deines Gegners nicht zurückziehen."
 			},
 			damage: 10,
 
@@ -53,6 +55,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
+				de: "Biss"
 			},
 
 			damage: 30,
@@ -78,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "It moves along below the sand's surface, except for its nose and eyes. A dark membrane shields its eyes from the sun.",
+		de: "Wenn es sich durch den Sand gräbt, ragen nur noch Nase und Augen hervor. Die schwarze Haut dient als Augenschutz."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/64.ts
+++ b/data/Black & White/Black & White/64.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Sandile",
 		fr: "Mascaïman",
+		de: "Ganovil"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Torment",
 				fr: "Tourmente",
+				de: "Folterknecht"
 			},
 			effect: {
 				en: "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn.",
 				fr: "Choisissez 1 des attaques du Pokémon Défenseur. Le Pokémon Défenseur ne pourra pas l'utiliser lors du prochain tour de votre adversaire.",
+				de: "Wähle 1 Angriff des Verteidigenden Pokémon. Das Pokémon kann den gewählten Angriff während des nächsten Zuges deines Gegners nicht einsetzen."
 			},
 			damage: 10,
 
@@ -58,6 +61,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
+				de: "Biss"
 			},
 
 			damage: 50,
@@ -83,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "The special membrane covering its eyes can sense the heat of objects, so it can see its surroundings even in darkness.",
+		de: "Die spezielle Membran um seine Augen fungiert als Wärmesensor, durch den es sich auch im Dunkeln zurechtfindet."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/65.ts
+++ b/data/Black & White/Black & White/65.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Krokorok",
 		fr: "Escroco",
+		de: "Rokkaiman"
 	},
 
 	stage: "Stage2",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Torment",
 				fr: "Tourmente",
+				de: "Folterknecht"
 			},
 			effect: {
 				en: "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn.",
 				fr: "Choisissez 1 des attaques du Pokémon Défenseur. Le Pokémon Défenseur ne pourra pas l'utiliser lors du prochain tour de votre adversaire.",
+				de: "Wähle 1 Angriff des Verteidigenden Pokémon. Das Pokémon kann den gewählten Angriff während des nächsten Zuges deines Gegners nicht einsetzen."
 			},
 			damage: 30,
 
@@ -60,10 +63,12 @@ const card: Card = {
 			name: {
 				en: "Krookoroll",
 				fr: "Crocoroulade",
+				de: "Gator-Rolle"
 			},
 			effect: {
 				en: "If the Defending Pokémon already has any damage counters on it, this attack does 40 more damage.",
 				fr: "Si le Pokémon Défenseur a déjà des marqueurs de dégâts, cette attaque inflige 40 dégâts supplémentaires.",
+				de: "Wenn auf dem Verteidigenden Pokémon bereits mindestens 1 Schadensmarke liegt, fügt dieser Angriff 40 weitere Schadenspunkte zu."
 			},
 			damage: 60,
 
@@ -88,6 +93,7 @@ const card: Card = {
 
 	description: {
 		en: "It can expand the focus of its eyes, enabling it to see objects in the far distance as if it were using binoculars.",
+		de: "Seine Augen können wie ein Fernglas weit entfernte Objekte näher heranholen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/66.ts
+++ b/data/Black & White/Black & White/66.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Scratch",
 				fr: "Griffe",
+				de: "Kratzer"
 			},
 
 			damage: 10,
@@ -49,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Slash",
 				fr: "Tranche",
+				de: "Schlitzer"
 			},
 
 			damage: 20,
@@ -74,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "Its cute act is a ruse. When victims let down their guard, they find their items taken. It attacks with sharp claws.",
+		de: "Es lenkt die Menschen durch sein süßes Verhalten ab, um sie zu bestehlen. Ist es wütend, kratzt es gern mal."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/67.ts
+++ b/data/Black & White/Black & White/67.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Purrloin",
 		fr: "Chacripan",
+		de: "Felilou"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Taunt",
 				fr: "Provoc",
+				de: "Verhöhner"
 			},
 			effect: {
 				en: "Switch the Defending Pokémon with 1 of your opponent's Benched Pokémon.",
 				fr: "Échangez le Pokémon Défenseur avec 1 des Pokémon de Banc de votre adversaire.",
+				de: "Tausche das Verteidigende Pokémon gegen 1 Pokémon auf der Bank deines Gegners aus."
 			},
 
 		},
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Sucker Punch",
 				fr: "Coup Bas",
+				de: "Tiefschlag"
 			},
 			effect: {
 				en: "If this Pokémon has any Darkness Energy attached to it, this attack does 30 more damage.",
 				fr: "Si de l'Énergie Darkness est attachée à ce Pokémon, cette attaque inflige 30 dégâts supplémentaires.",
+				de: "Wenn an dieses Pokémon bereits mindestens 1 {D}-Energie angelegt ist, fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -84,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "Stealthily, it sneaks up on its target, striking from behind before its victim has a chance to react.",
+		de: "Verbirgt seine Aura und nähert sich seinem Gegner völlig unbemerkt von hinten, um ihm den Garaus zu machen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/68.ts
+++ b/data/Black & White/Black & White/68.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Headbutt",
 				fr: "Coup d'Boule",
+				de: "Kopfnuss"
 			},
 
 			damage: 10,
@@ -61,6 +62,7 @@ const card: Card = {
 
 	description: {
 		en: "Its skin has a rubbery elasticity, so it can reduce damage by defensively pulling its skin up to its neck.",
+		de: "Es zieht seine gummiartige Haut bis zum Hals hinauf und nimmt eine Abwehrhaltung ein, um sich vor Schaden zu schützen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/69.ts
+++ b/data/Black & White/Black & White/69.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Scraggy",
 		fr: "Baggiguane",
+		de: "Zurrokex"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Spit Acid",
 				fr: "Crachat d’Acide",
+				de: "Säurespucker"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Burned. Flip a coin. If heads, the Defending Pokémon is also Paralyzed.",
 				fr: "Le Pokémon Défenseur est maintenant Brûlé. Lancez une pièce. Si c’est face, le Pokémon Défenseur est aussi Paralysé.",
+				de: "Das Verteidigende Pokémon ist jetzt verbrannt. Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt auch paralysiert."
 			},
 			damage: 20,
 
@@ -58,6 +61,7 @@ const card: Card = {
 			name: {
 				en: "High Jump Kick",
 				fr: "Pied Voltige",
+				de: "Turmkick"
 			},
 
 			damage: 70,
@@ -83,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "Groups of them beat up anything that enters their territory. Each can spit acidic liquid from its mouth.",
+		de: "Es geht im Rudel gegen Eindringlinge vor. Aus seinem Mund speit es eine ätzende Flüssigkeit."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/7.ts
+++ b/data/Black & White/Black & White/7.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Scratch",
 				fr: "Griffe",
+				de: "Kratzer"
 			},
 
 			damage: 10,
@@ -50,6 +51,7 @@ const card: Card = {
 			name: {
 				en: "Vine Whip",
 				fr: "Fouet Lianes",
+				de: "Rankenhieb"
 			},
 
 			damage: 30,
@@ -75,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "It shares the leaf on its head with weary-looking Pokémon. These leaves are known to relieve stress.",
+		de: "Schwächelnden Pokémon gibt es ein paar der Kräuter auf seinem Kopf ab und hilft ihnen so wieder auf die Beine."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/70.ts
+++ b/data/Black & White/Black & White/70.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Lunge",
 				fr: "Coup Rapide",
+				de: "Ausfall"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c’est pile, cette attaque ne fait rien.",
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 30,
 
@@ -65,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "To protect themselves from danger, they hide their true identities by transforming into people and Pokémon.",
+		de: "Es tarnt sich als Mensch oder als andere Pokémon. Es schützt sich vor Gefahren, indem es seine wahre Gestalt geheim hält."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/71.ts
+++ b/data/Black & White/Black & White/71.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Zorua",
 		fr: "Zorua",
+		de: "Zorua"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Nasty Plot",
 				fr: "Machination",
+				de: "Ränkeschmied"
 			},
 			effect: {
 				en: "Search your deck for a card and put it into your hand. Shuffle your deck afterward.",
 				fr: "Cherchez une carte dans votre deck et ajoutez-la à votre main. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 1 Karte und nimm sie auf deine Hand. Mische anschließend dein Deck."
 			},
 
 		},
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Foul Play",
 				fr: "Tricherie",
+				de: "Schmarotzer"
 			},
 			effect: {
 				en: "Choose 1 of the Defending Pokémon's attacks and use it as this attack.",
 				fr: "Choisissez 1 des attaques du Pokémon Défenseur et utilisez-la à la place de cette attaque.",
+				de: "Wähle 1 Angriff des Verteidigenden Pokémon und verwende ihn als diesen Angriff."
 			},
 
 		},
@@ -83,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Each has the ability to fool a large group of people simultaneously. They protect their lair with illusory scenery.",
+		de: "Kann auf einen Schlag große Massen von Menschen täuschen. Es kreiert Illusionen, um sein Revier zu schützen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/72.ts
+++ b/data/Black & White/Black & White/72.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Surprise Attack",
 				fr: "Attaque Surprise",
+				de: "Überraschungsangriff"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c’est pile, cette attaque ne fait rien.",
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 20,
 
@@ -64,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "Its wings are too tiny to allow it to fly. As the time approaches for it to evolve, it discards the bones it was wearing.",
+		de: "Seine Flügel sind noch zu klein zum Fliegen. Kurz bevor es sich entwickelt, wirft es seine Schädelwindel ab."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/73.ts
+++ b/data/Black & White/Black & White/73.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Vullaby",
 		fr: "Vostourno",
+		de: "Skallyk"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Blindside",
 				fr: "Angle Mort",
+				de: "Aus heiterem Himmel"
 			},
 			effect: {
 				en: "Does 50 damage to 1 of your opponent's Pokémon that has any damage counters on it. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 50 dégâts à 1 des Pokémon de votre adversaire ayant au moins 1 marqueur de dégâts. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 1 Pokémon deines Gegners, auf dem bereits mindestens 1 Schadensmarke liegt, 50 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Punishment",
 				fr: "Punition",
+				de: "Strafattacke"
 			},
 			effect: {
 				en: "If the Defending Pokémon is a Stage 2 Pokémon, this attack does 60 more damage.",
 				fr: "Si le Pokémon Défenseur est un Pokémon de Niveau 2, cette attaque inflige 60 dégâts supplémentaires.",
+				de: "Wenn das Verteidigende Pokémon ein Phase-2-Pokémon ist, fügt dieser Angriff 60 weitere Schadenspunkte zu."
 			},
 			damage: 40,
 
@@ -85,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "It makes a nest out of bones it finds. It grabs weakened prey in its talons and hauls it to its nest of bones.",
+		de: "Es baut sein Nest aus Knochen. Ist seine Beute geschwächt, packt es sie mit den Beinen und trägt sie zu seinem Nest."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/74.ts
+++ b/data/Black & White/Black & White/74.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Bind",
 				fr: "Étreinte",
+				de: "Klammergriff"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c’est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 10,
 
@@ -64,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "The two minigears that mesh together are predetermined. Each will rebound from other minigears without meshing.",
+		de: "Seine zwei Teile greifen ineinander wie ein Uhrwerk. Jedes andere Objekt, das man mit ihm kombinieren will, wird abgestoßen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/75.ts
+++ b/data/Black & White/Black & White/75.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Klink",
 		fr: "Tic",
+		de: "Klikk"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Bind",
 				fr: "Étreinte",
+				de: "Klammergriff"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c’est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 10,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Gear Grind",
 				fr: "Lancécrou",
+				de: "Klikkdiskus"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 60 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 60 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 60 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 60,
 
@@ -86,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "By changing the direction in which it rotates, it communicates its feelings to others. When angry, it rotates faster.",
+		de: "Teilt Artgenossen seine Gefühlslage mit, indem es die Umlaufrichtung ändert. Wenn es wütend ist, dreht es sich schneller."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/76.ts
+++ b/data/Black & White/Black & White/76.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Klang",
 		fr: "Clic",
+		de: "Kliklak"
 	},
 
 	stage: "Stage2",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Todas las veces que quieras durante tu turno (antes de tu ataque), puedes mover una Energía Metal unida a 1 de tus Pokémon a otro de tus Pokémon.",
 				it: "Durante il tuo turno, prima di attaccare, puoi distribuire a piacimento le Energie Metal assegnate ai tuoi Pokémon.",
 				pt: "Sempre que desejar, na sua vez de jogar (antes de atacar), você poderá mover uma Energia Metal ligada a 1 dos seus Pokémon para outro dos seus Pokémon.",
-				de: "Beliebig oft während deines Zuges (vor deinem Angriff) kannst du 1 Metal-Energie von 1 deiner Pokémon auf 1 anderes deiner Pokémon verschieben."
+				de: "Beliebig oft während deines Zuges (vor deinem Angriff) kannst du 1 {M}-Energie von 1 deiner Pokémon auf 1 anderes deiner Pokémon verschieben."
 			},
 		},
 	],
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Gear Grind",
 				fr: "Lancécrou",
+				de: "Klikkdiskus"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 80 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 80 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 80 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 80,
 
@@ -93,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "Its red core functions as an energy tank. It fires the charged energy through its spikes into an area.",
+		de: "Der rote Zentralbestandteil dient als Energiespeicher. Darin geladene Energie feuert es über seine Stacheln ab."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/77.ts
+++ b/data/Black & White/Black & White/77.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 10,
@@ -49,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
+				de: "Biss"
 			},
 
 			damage: 20,
@@ -67,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "Using food stored in cheek pouches, they can keep watches for days. They use their tails to communicate with others.",
+		de: "Hortet in seinen Backentaschen Futter, um tagelang Wache stehen zu können, und gibt Kameraden über seine Rute Signale."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/78.ts
+++ b/data/Black & White/Black & White/78.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Hyper Fang",
 				fr: "Croc de Mort",
+				de: "Hyperzahn"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c’est pile, cette attaque ne fait rien.",
+				de: "Wirf eine Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 30,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "Extremely cautious, they take shifts to maintain a constant watch of their nest. They feel insecure without a lookout.",
+		de: "Sie sind von Natur aus vorsichtig und bewachen in Schichten ihren Bau. Hält niemand Wache, werden sie unruhig."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/79.ts
+++ b/data/Black & White/Black & White/79.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Patrat",
 		fr: "Ratentif",
+		de: "Nagelotz"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Confuse Ray",
 				fr: "Onde Folie",
+				de: "Konfustrahl"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Confused.",
 				fr: "Le Pokémon Défenseur est maintenant Confus.",
+				de: "Das Verteidigende Pokémon ist jetzt verwirrt."
 			},
 
 		},
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Hyper Fang",
 				fr: "Croc de Mort",
+				de: "Hyperzahn"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c’est pile, cette attaque ne fait rien.",
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 60,
 
@@ -78,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "They make the patterns on their bodies shine in order to threaten predators. Keen eyesight lets them see in the dark.",
+		de: "Schüchtert Gegner ein, indem es die Maserung seines Fells aufblitzen lässt. Auch im Dunkeln entgeht ihm nichts."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/8.ts
+++ b/data/Black & White/Black & White/8.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pansage",
 		fr: "Feuillajou",
+		de: "Vegimak"
 	},
 
 	stage: "Stage1",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Seed Bomb",
 				fr: "Canon Graine",
+				de: "Samenbomben"
 			},
 
 			damage: 30,
@@ -55,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Fury Swipes",
 				fr: "Combo-Griffe",
+				de: "Kratzfurie"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 40 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 40 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 40,
 
@@ -83,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "It attacks enemies with strikes of its thorn-covered tail. This Pokémon is wild tempered.",
+		de: "Wer sich mit diesem temperamentvollen Pokémon anlegt, bekommt seinen mit Dornen bestückten Schweif zu spüren."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/80.ts
+++ b/data/Black & White/Black & White/80.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Pickup",
 				fr: "Ramassage",
+				de: "Mitnahme"
 			},
 			effect: {
 				en: "Put an Item card from your discard pile into your hand.",
 				fr: "Prenez une carte Objet dans votre pile de défausse et ajoutez-la à votre main.",
+				de: "Nimm 1 Itemkarte von deinem Ablagestapel auf deine Hand."
 			},
 
 		},
@@ -50,6 +52,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
+				de: "Biss"
 			},
 
 			damage: 10,
@@ -68,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "It faces strong opponents with great courage. But, when at a disadvantage in a fight, this intelligent Pokémon flees.",
+		de: "Ein kluges Pokémon, das sich zwar tapfer auch starken Gegnern zum Kampf stellt, aber unfaire Begegnungen zu meiden weiß."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/81.ts
+++ b/data/Black & White/Black & White/81.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Collect",
 				fr: "Collectionner",
+				de: "Sammeln"
 			},
 			effect: {
 				en: "Draw a card.",
 				fr: "Piochez une carte.",
+				de: "Ziehe 1 Karte."
 			},
 
 		},
@@ -51,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 20,
@@ -69,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "The long hair around its face provides an amazing radar that lets it sense subtle changes in its surroundings.",
+		de: "Das lange Fell um sein Gesicht fungiert als Hightech-Radar, mit dem es fein säuberlich seine Umgebung abtastet."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/82.ts
+++ b/data/Black & White/Black & White/82.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Lillipup",
 		fr: "Ponchiot",
+		de: "Yorkleff"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Collect",
 				fr: "Collectionner",
+				de: "Sammeln"
 			},
 			effect: {
 				en: "Draw 3 cards.",
 				fr: "Piochez 3 cartes.",
+				de: "Ziehe 3 Karten."
 			},
 
 		},
@@ -58,6 +61,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
+				de: "Biss"
 			},
 
 			damage: 50,
@@ -76,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It loyally follows its Trainer's orders. For ages, they have helped Trainers raise Pokémon.",
+		de: "Folgt treu den Befehlen seines Trainers. Schon seit jeher ist es als rechte Hand der Pokémon-Trainer bekannt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/83.ts
+++ b/data/Black & White/Black & White/83.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Herdier",
 		fr: "Ponchien",
+		de: "Terribark"
 	},
 
 	stage: "Stage2",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Odor Sleuth",
 				fr: "Flair",
+				de: "Schnüffler"
 			},
 			effect: {
 				en: "Flip 3 coins. For each heads, put a card from your discard pile into your hand.",
 				fr: "Lancez 3 pièces. Pour chaque côté face, prenez une carte dans votre pile de défausse et ajoutez-la à votre main.",
+				de: "Wirf 3 Münzen. Nimm pro „Kopf“ 1 Karte von deinem Ablagestapel auf deine Hand."
 			},
 
 		},
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Giga Impact",
 				fr: "Giga Impact",
+				de: "Gigastoß"
 			},
 			effect: {
 				en: "This Pokémon can't attack during your next turn.",
 				fr: "Ce Pokémon ne peut pas attaquer pendant votre prochain tour.",
+				de: "Dieses Pokémon kann während deines nächsten Zuges nicht angreifen."
 			},
 			damage: 90,
 
@@ -80,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "This extremely wise Pokémon excels at rescuing people stranded at sea or in the mountains.",
+		de: "Seine Stärke ist es, Menschen zu retten, die auf hoher See oder in den Bergen in Not geraten. Ein sehr kluges Pokémon."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/84.ts
+++ b/data/Black & White/Black & White/84.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Quick Attack",
 				fr: "Vive-Attaque",
+				de: "Ruckzuckhieb"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 more damage.",
 				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 10 dégâts supplémentaires.",
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 10 weitere Schadenspunkte zu."
 			},
 			damage: 10,
 
@@ -64,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "Each follows its Trainer's orders as best it can, but they sometimes fail to understand complicated commands.",
+		de: "Gewöhnlich hört es zwar auf das, was sein Trainer sagt, doch manchmal kommt es mit komplizierten Befehlen nicht klar."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/85.ts
+++ b/data/Black & White/Black & White/85.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pidove",
 		fr: "Poichigeon",
+		de: "Dusselgurr"
 	},
 
 	stage: "Stage1",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Gust",
 				fr: "Tornade",
+				de: "Windstoß"
 			},
 
 			damage: 20,
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Quick Attack",
 				fr: "Vive-Attaque",
+				de: "Ruckzuckhieb"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 more damage.",
 				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 30 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -82,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "It can return to its Trainer's location regardless of the distance separating them.",
+		de: "Egal wie weit es auch von seinem Trainer entfernt ist, es findet immer wieder zu ihm zurück."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/86.ts
+++ b/data/Black & White/Black & White/86.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Tranquill",
 		fr: "Colombeau",
+		de: "Navitaub"
 	},
 
 	stage: "Stage2",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Fly",
 				fr: "Vol",
+				de: "Fliegen"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c’est pile, cette attaque ne fait rien. Si c’est face, évitez tous les effets d’attaques (y compris les dégâts) infligés à ce Pokémon pendant le prochain tour de votre adversaire.",
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die diesem Pokémon zugefügt werden."
 			},
 			damage: 50,
 
@@ -59,6 +62,7 @@ const card: Card = {
 			name: {
 				en: "Cutting Wind",
 				fr: "Vent Glacial",
+				de: "Schneidender Wind"
 			},
 
 			damage: 70,
@@ -84,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Males swing their head plumage to threaten opponents. The females' flying abilities surpass those of the males.",
+		de: "Männchen schrecken Gegner ab, indem sie ihren Kopfschmuck schütteln. Weibchen verfügen über bessere Flugfertigkeiten."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/87.ts
+++ b/data/Black & White/Black & White/87.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Doubleslap",
 				fr: "Torgnoles",
+				de: "Duplexhieb"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 30 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 30,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "It touches others with the feelers on its ears, using the sound of their heartbeats to tell how they are feeling.",
+		de: "Berührt es jemanden mit den Fühlern an seinen Ohren, erfährt es durch den Herzschlag der Person, wie es ihr geht."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/88.ts
+++ b/data/Black & White/Black & White/88.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Tail Slap",
 				fr: "Plumo-Queue",
+				de: "Kehrschelle"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 10,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "They greet one another by rubbing each other with their tails, which are always kept well groomed and clean.",
+		de: "Sie sorgen dafür, dass ihre Schweife stets schön sauber sind, da sie diese zur Begrüßung aneinanderreiben."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/89.ts
+++ b/data/Black & White/Black & White/89.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Minccino",
 		fr: "Chinchidou",
+		de: "Picochilla"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Tail Slap",
 				fr: "Plumo-Queue",
+				de: "Kehrschelle"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Do the Wave",
 				fr: "Faites la Vague",
+				de: "Wellenreiten"
 			},
 			effect: {
 				en: "Does 20 damage times the number of your Benched Pokémon.",
 				fr: "Inflige 20 dégâts multipliés par le nombre de vos Pokémon de Banc.",
+				de: "Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl der Pokémon auf deiner Bank zu."
 			},
 			damage: 20,
 
@@ -78,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "Their white fur is coated in a special oil that makes it easy for them to deflect attacks.",
+		de: "Sein weißer Flaum ist mit einem speziellen Öl überzogen. Gegnerische Angriffe gleiten daran einfach ab."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/9.ts
+++ b/data/Black & White/Black & White/9.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Magical Leaf",
 				fr: "Feuillemagik",
+				de: "Zauberblatt"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 more damage and heal 10 damage from this Pokémon.",
 				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 10 dégâts supplémentaires et vous soignez 10 dégâts à ce Pokémon.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 weitere Schadenspunkte zu und heilt 10 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 10,
 
@@ -64,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "Since they prefer moist, nutrient-rich soil, the areas where Petilil live are known to be good for growing plants.",
+		de: "Da es nährstoffreiche Erde bevorzugt, kann man in Gebieten, in denen es lebt, für gewöhnlich reiche Ernten erwarten."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/90.ts
+++ b/data/Black & White/Black & White/90.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Horn Attack",
 				fr: "Koud'Korne",
+				de: "Hornattacke"
 			},
 
 			damage: 20,
@@ -51,10 +52,12 @@ const card: Card = {
 			name: {
 				en: "Double Stomp",
 				fr: "Double Écrasement",
+				de: "Doppelstampfer"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 more damage for each heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts supplémentaires pour chaque côté face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 30,
 
@@ -72,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "They charge wildly and headbutt everything. Their headbutts have enough destructive force to derail a train.",
+		de: "Rammt seine Gegner ohne Rücksicht auf Verluste mit dem Kopf und vermag damit sogar Züge zum Entgleisen zu bringen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/91.ts
+++ b/data/Black & White/Black & White/91.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Revenge",
 				fr: "Vendetta",
+				de: "Vergeltung"
 			},
 			effect: {
 				en: "If any of your Pokémon were Knocked Out by damage from an opponent's attack during his or her last turn, this attack does 70 more damage.",
 				fr: "Si l’un de vos Pokémon a été mis K.O. par les dégâts d'une attaque de votre adversaire lors de son dernier tour, cette attaque inflige 70 dégâts supplémentaires.",
+				de: "Falls eins deiner Pokémon während des letzten Zuges deines Gegners durch einen gegnerischen Angriff kampfunfähig gemacht wurde, fügt dieser Angriff 70 weitere Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -55,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Head Charge",
 				fr: "Peignée",
+				de: "Steinschädel"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this Pokémon does 20 damage to itself.",
 				fr: "Lancez une pièce. Si c’est pile, ce Pokémon s’inflige 20 dégâts.",
+				de: "Wirf 1 Münze. Bei „Zahl“ fügt sich dieses Pokémon selbst 20 Schadenspunkte zu."
 			},
 			damage: 80,
 
@@ -76,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "Their fluffy fur absorbs damage, even if they strike foes with a fierce headbutt.",
+		de: "Sein zotteliges Fell fängt selbst nach einer seiner wuchtigen Rempelattacken einiges an Schaden ab."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Black & White/92.ts
+++ b/data/Black & White/Black & White/92.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon 2 cartas de Energía Básica de tu pila de descartes en tu mano.",
 		it: "Prendi due carte Energia base dalla tua pila degli scarti e aggiungile a quelle che hai in mano.",
 		pt: "Coloque 2 cards de Energia básica da sua pilha de descarte em sua mão.",
-		de: "Nimm 2 Basis-Energiekarten von deinem Ablagestapel auf deine Hand."
+		de: "Nimm 2 Basis-Energiekarten von deinem Ablagestapel auf deine Hand. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Black & White/93.ts
+++ b/data/Black & White/Black & White/93.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja una carta de Energía Básica, enséñala y ponla en tu mano. Baraja las cartas de tu baraja después.",
 		it: "Cerca nel tuo mazzo una carta Energia base, mostrala e aggiungila a quelle che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure um card de Energia básica no seu baralho, revele-o e coloque-o na sua mão. Em seguida, embaralhe seu baralho.",
-		de: "Durchsuche dein Deck nach 1 Basis-Energiekarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach 1 Basis-Energiekarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Black & White/94.ts
+++ b/data/Black & White/Black & White/94.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mueve una Energía Básica de 1 de tus Pokémon a otro de tus Pokémon.",
 		it: "Sposta un’Energia base da uno dei tuoi Pokémon a un altro.",
 		pt: "Mova uma Energia básica de 1 dos seus Pokémon para outro dos seus Pokémon.",
-		de: "Verschiebe 1 an 1 deiner Pokémon angelegte Basis-Energie auf ein anderes deiner Pokémon."
+		de: "Verschiebe 1 an 1 deiner Pokémon angelegte Basis-Energie auf ein anderes deiner Pokémon. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Black & White/95.ts
+++ b/data/Black & White/Black & White/95.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Elimina todas las Condiciones Especiales de tu Pokémon Activo.",
 		it: "Rimuovi tutte le condizioni speciali dal tuo Pokémon attivo.",
 		pt: "Remova todas as Condições Especiais do seu Pokémon Ativo.",
-		de: "Alle Speziellen Zustände auf deinem Aktiven Pokémon verlieren ihre Wirkung."
+		de: "Alle Speziellen Zustände auf deinem Aktiven Pokémon verlieren ihre Wirkung. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Black & White/96.ts
+++ b/data/Black & White/Black & White/96.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Durante este turno, los ataques de tus Pokémon hacen 10 puntos de daño más a los Pokémon Activos (antes de aplicar Debilidad y Resistencia).",
 		it: "Durante questo turno, gli attacchi dei tuoi Pokémon infliggono 10 danni in più al Pokémon attivo, prima di aver applicato debolezza e resistenza.",
 		pt: "Nesta vez de jogar, os ataques do seu Pokémon causam 10 de danos extras ao Pokémon Ativo (antes de aplicar Fraqueza e Resistência).",
-		de: "Während dieses Zuges fügen alle Angriffe deines Pokémon den Aktiven Pokémon 10 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
+		de: "Während dieses Zuges fügen alle Angriffe deines Pokémon den Aktiven Pokémon 10 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden). Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Black & White/97.ts
+++ b/data/Black & White/Black & White/97.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Lanza una moneda. Si sale cara, busca en tu baraja un Pokémon, enséñalo y ponlo en tu mano. Baraja las cartas de tu baraja después.",
 		it: "Lancia una moneta. Se esce testa, cerca nel tuo mazzo un Pokémon, mostralo e aggiungilo alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Jogue uma moeda. Se sair cara, procure um Pokémon em seu baralho, revele-o e coloque-o na sua mão. Em seguida, embaralhe seu baralho.",
-		de: "Wirf 1 Münze. Durchsuche bei „Kopf“ dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck."
+		de: "Wirf 1 Münze. Durchsuche bei „Kopf“ dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Black & White/98.ts
+++ b/data/Black & White/Black & White/98.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mira las 5 primeras cartas de tu baraja y vuelve a colocarlas en la parte superior de tu baraja en el orden que quieras.",
 		it: "Guarda le prime cinque carte del tuo mazzo e rimettile in cima al mazzo nell’ordine che preferisci.",
 		pt: "Olhe os 5 cards de cima do seu baralho e coloque-os de volta em cima do seu baralho em qualquer ordem.",
-		de: "Schau dir die obersten 5 Karten deines Decks an und lege sie in beliebiger Reihenfolge zurück auf dein Deck."
+		de: "Schau dir die obersten 5 Karten deines Decks an und lege sie in beliebiger Reihenfolge zurück auf dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Black & White/99.ts
+++ b/data/Black & White/Black & White/99.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Enseña un Pokémon de tu mano y ponlo en la parte superior de tu baraja. Si lo haces, busca en tu baraja un Pokémon, enséñalo y ponlo en tu mano. Baraja las cartas de tu baraja después.",
 		it: "Mostra un Pokémon che hai in mano e mettilo in cima al tuo mazzo. A questo punto cerca nel tuo mazzo un Pokémon, mostra anche questo e aggiungilo alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Revele um Pokémon em sua mão e coloque-o em cima do seu baralho. Se fizer isso, procure um Pokémon em seu baralho, revele-o e coloque-o na sua mão. Em seguida, embaralhe seu baralho.",
-		de: "Nimm 1 Pokémon von deiner Hand, zeige es deinem Gegner und lege es auf dein Deck. Wenn du das machst, durchsuche dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck."
+		de: "Nimm 1 Pokémon von deiner Hand, zeige es deinem Gegner und lege es auf dein Deck. Wenn du das machst, durchsuche dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",


### PR DESCRIPTION
## Add missing German translations for bw1

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
