### PR TITLE
Add missing German translations for bw2

### DIFF
--- a/data/Black & White/Emerging Powers/1.ts
+++ b/data/Black & White/Emerging Powers/1.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Collect",
 				fr: "Collecte",
+				de: "Sammeln"
 			},
 			effect: {
 				en: "Draw a card.",
 				fr: "Piochez une carte.",
+				de: "Ziehe 1 Karte."
 			},
 
 		},
@@ -51,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Scratch",
 				fr: "Griffe",
+				de: "Kratzer"
 			},
 
 			damage: 20,
@@ -76,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon dwells deep in the forest. Eating a leaf from its head whisks weariness away as if by magic.",
+		de: "Es lebt tief im Wald. Beißt man in die Kräuter auf seinem Kopf, fühlt man sich auf wundersame Weise erfrischt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/10.ts
+++ b/data/Black & White/Emerging Powers/10.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Cotton Guard",
 				fr: "Cotogarde",
+				de: "Watteschild"
 			},
 			effect: {
 				en: "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 10 (after applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, tous les dégâts infligés à ce Pokémon par des attaques sont réduits de 10 (après application de la Faiblesse et de la Résistance).",
+				de: "Während des nächsten Zuges deines Gegners wird Schaden, der diesem Pokémon durch Angriffe zugefügt wird, um 10 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 			damage: 10,
 
@@ -64,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "When attacked, it escapes by shooting cotton from its body. The cotton serves as a decoy to distract the attacker.",
+		de: "Wird es angegriffen, verstreut es zur Täuschung Watte. Es flieht, während der Gegner nach dem wahren Waumboll sucht."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/11.ts
+++ b/data/Black & White/Emerging Powers/11.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cottonee",
 		fr: "Doudouvet",
+		de: "Waumboll"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Helping Hand",
 				fr: "Coup d'Main",
+				de: "Rechte Hand"
 			},
 			effect: {
 				en: "Search your deck for a basic Energy card and attach it to 1 of your Benched Pokémon. Shuffle your deck afterward.",
 				fr: "Cherchez une carte Énergie de base dans votre deck et attachez-la à 1 de vos Pokémon de Banc. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 1 Basis-Energiekarte und lege sie an 1 Pokémon auf deiner Bank an. Mische anschließend dein Deck."
 			},
 
 		},
@@ -55,10 +58,12 @@ const card: Card = {
 			name: {
 				en: "Cotton Guard",
 				fr: "Cotogarde",
+				de: "Watteschild"
 			},
 			effect: {
 				en: "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 30 (after applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, tous les dégâts infligés à ce Pokémon par des attaques sont réduits de 30 (après application de la Faiblesse et de la Résistance).",
+				de: "Während des nächsten Zuges deines Gegners wird Schaden, der diesem Pokémon durch Angriffe zugefügt wird, um 30 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 			damage: 30,
 
@@ -83,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Like the wind, it can slip through any gap, no matter how small. It leaves balls of white fluff behind.",
+		de: "Passiert wie ein Luftzug mühelos jeden noch so engen Spalt und hinterlässt dort nichts als ein weißes Fellknäuel."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/12.ts
+++ b/data/Black & White/Emerging Powers/12.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cottonee",
 		fr: "Doudouvet",
+		de: "Waumboll"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Encore",
 				fr: "Encore",
+				de: "Zugabe"
 			},
 			effect: {
 				en: "Choose 1 of the Defending Pokémon's attacks. During your opponent's next turn, that Pokémon can use only that attack.",
 				fr: "Choisissez 1 des attaques du Pokémon Défenseur. Pendant le prochain tour de votre adversaire, le Pokémon ciblé ne peut utiliser que l'attaque choisie.",
+				de: "Wähle 1 Angriff des Verteidigenden Pokémon. Dieses Pokémon kann während des nächsten Zuges deines Gegners nur den gewählten Angriff einsetzen."
 			},
 			damage: 20,
 
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "U-turn",
 				fr: "Demi-Tour",
+				de: "Kehrtwende"
 			},
 			effect: {
 				en: "Switch this Pokémon with 1 of your Benched Pokémon.",
 				fr: "Échangez ce Pokémon avec 1 de vos Pokémon de Banc.",
+				de: "Tausche dieses Pokémon gegen 1 Pokémon auf deiner Bank aus."
 			},
 			damage: 40,
 
@@ -85,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "Riding whirlwinds, they appear. These Pokémon sneak through gaps into houses and cause all sorts of mischief.",
+		de: "Es kommt auf Sturmböen geritten und dringt durch kleine Spalten in Häuser ein, um dort Schabernack zu treiben."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/13.ts
+++ b/data/Black & White/Emerging Powers/13.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Stun Spore",
 				fr: "Para-Spore",
+				de: "Stachelspore"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 
 		},
@@ -51,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Cut",
 				fr: "Coupe",
+				de: "Zerschneider"
 			},
 
 			damage: 20,
@@ -76,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "The leaves on its head are very bitter. Eating one of these leaves is known to refresh a tired body.",
+		de: "Die Blätter auf seinem Kopf schmecken furchtbar bitter, doch sie helfen ausgezeichnet gegen Erschöpfung."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/14.ts
+++ b/data/Black & White/Emerging Powers/14.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Petilil",
 		fr: "Chlorobule",
+		de: "Lilminip"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Bemusing Aroma",
 				fr: "Parfum Troublant",
+				de: "Betörendes Aroma"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed and Poisoned. If tails, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé et Empoisonné. Si c'est pile, le Pokémon Défenseur est maintenant Confus.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert und vergiftet. Bei „Zahl“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: 20,
 
@@ -58,6 +61,7 @@ const card: Card = {
 			name: {
 				en: "Cut",
 				fr: "Coupe",
+				de: "Zerschneider"
 			},
 
 			damage: 60,
@@ -83,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "Even veteran Trainers face a challenge in getting its beautiful flower to bloom. This Pokémon is popular with celebrities.",
+		de: "Bei Promis ist es sehr beliebt. Auch gestandene Trainer tun sich schwer damit, seine Blüte schön aufblühen zu lassen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/15.ts
+++ b/data/Black & White/Emerging Powers/15.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 10,
@@ -49,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Wild Kick",
 				fr: "Coup Déchaîné",
+				de: "Stürmischer Kick"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 40,
 
@@ -77,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "The turning of the seasons changes the color and scent of this Pokémon's fur. People use it to mark the seasons.",
+		de: "Sein Fell und sein Geruch ändern sich mit dem Wechsel der Jahreszeiten. Es ist der Bote des Saisonwechsels."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/16.ts
+++ b/data/Black & White/Emerging Powers/16.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Deerling",
 		fr: "Vivaldaim",
+		de: "Sesokitz"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Push Down",
 				fr: "Renversement",
+				de: "Runterdrücken"
 			},
 			effect: {
 				en: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon.",
 				fr: "Votre adversaire échange le Pokémon Défenseur avec 1 de ses Pokémon de Banc.",
+				de: "Dein Gegner tauscht das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
 			},
 			damage: 30,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Take Down",
 				fr: "Bélier",
+				de: "Bodycheck"
 			},
 			effect: {
 				en: "This Pokémon does 20 damage to itself.",
 				fr: "Ce Pokémon s'inflige 20 dégâts.",
+				de: "Dieses Pokémon fügt sich selbst 20 Schadenspunkte zu."
 			},
 			damage: 60,
 
@@ -86,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "The plants growing on its horns change according to the season. The leaders of the herd possess magnificent horns.",
+		de: "Je nach Jahreszeit wächst eine andere Pflanze auf seinem Geweih. Exemplare mit prächtiger Krone führen die Herde an."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/17.ts
+++ b/data/Black & White/Emerging Powers/17.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Giga Drain",
 				fr: "Giga-Sangsue",
+				de: "Gigasauger"
 			},
 			effect: {
 				en: "Heal from this Pokémon the same amount of damage you did to the Defending Pokémon.",
 				fr: "Soignez à ce Pokémon la même quantité de dégâts que vous avez infligée au Pokémon Défenseur.",
+				de: "Heile bei diesem Pokémon genauso viel Schaden, wie du dem Verteidigenden Pokémon zugefügt hast."
 			},
 			damage: 30,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Sacred Sword",
 				fr: "Lame Sainte",
+				de: "Sanctoklinge"
 			},
 			effect: {
 				en: "This Pokémon can't use Sacred Sword during your next turn.",
 				fr: "Ce Pokémon ne peut pas utiliser Lame Sainte pendant votre prochain tour.",
+				de: "Dieses Pokémon kann während deines nächsten Zuges Sanctoklinge nicht einsetzen."
 			},
 			damage: 100,
 
@@ -82,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon fought humans in order to protect its friends. Legends about it continue to be passed down.",
+		de: "Es kämpfte einst gegen die Menschen, um seine Freunde zu beschützen. Nun erzählt man sich Legenden von ihm."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/18.ts
+++ b/data/Black & White/Emerging Powers/18.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Collect",
 				fr: "Collecte",
+				de: "Sammeln"
 			},
 			effect: {
 				en: "Draw a card.",
 				fr: "Piochez une carte.",
+				de: "Ziehe 1 Karte."
 			},
 
 		},
@@ -51,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Scratch",
 				fr: "Griffe",
+				de: "Kratzer"
 			},
 
 			damage: 20,
@@ -69,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon lives in caves in volcanoes. The fire within the tuft on its head can reach 600º F.",
+		de: "Das Feuer in seinem Kopfbüschel erreicht Temperaturen von bis zu 300 Grad. Es ist in Vulkanhöhlen zu Hause."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/19.ts
+++ b/data/Black & White/Emerging Powers/19.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pansear",
 		fr: "Flamajou",
+		de: "Grillmak"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Water's Power",
 				fr: "Pouvoir Submergeant",
+				de: "Wassermacht"
 			},
 			effect: {
 				en: "If this Pokémon has any Water Energy attached to it, the Defending Pokémon is now Asleep.",
 				fr: "Si de l'Énergie Water est attachée à ce Pokémon, le Pokémon Défenseur est maintenant Endormi.",
+				de: "Wenn an dieses Pokémon bereits {W}-Energie angelegt ist, schläft das Verteidigende Pokémon jetzt."
 			},
 			damage: 30,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Flamethrower",
 				fr: "Lance-Flamme",
+				de: "Flammenwurf"
 			},
 			effect: {
 				en: "Discard an Energy attached to this Pokémon.",
 				fr: "Défaussez une Énergie attachée à ce Pokémon.",
+				de: "Lege 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel."
 			},
 			damage: 70,
 
@@ -80,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "A flame burns inside its body. It scatters embers from its head and tail to sear its opponents.",
+		de: "Es entfacht in seinem Körper ein Feuer und verkohlt Gegner mit Funken aus seinem Kopf und Schweif."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/2.ts
+++ b/data/Black & White/Emerging Powers/2.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pansage",
 		fr: "Feuillajou",
+		de: "Vegimak"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Fire's Power",
 				fr: "Pouvoir Incendiaire",
+				de: "Feuermacht"
 			},
 			effect: {
 				en: "If this Pokémon has any Fire Energy attached to it, the Defending Pokémon is now Burned.",
 				fr: "Si de l'Énergie Fire est attachée à ce Pokémon, le Pokémon Défenseur est maintenant Brûlé.",
+				de: "Wenn an dieses Pokémon bereits {R}-Energie angelegt ist, ist das Verteidigende Pokémon jetzt verbrannt."
 			},
 			damage: 30,
 
@@ -59,6 +62,7 @@ const card: Card = {
 			name: {
 				en: "Seed Bomb",
 				fr: "Canon Graine",
+				de: "Samenbomben"
 			},
 
 			damage: 60,
@@ -84,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Ill tempered, it fights by swinging its barbed tail around wildly. The leaf growing on its head is very bitter.",
+		de: "Ein hitziger Geselle, der im Kampf seinen dornigen Schweif umherschwingt. Auf seinem Kopf wachsen bittere Kräuter."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/20.ts
+++ b/data/Black & White/Emerging Powers/20.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 10,
@@ -50,6 +51,7 @@ const card: Card = {
 			name: {
 				en: "Combustion",
 				fr: "Fournaise",
+				de: "Glühen"
 			},
 
 			damage: 30,
@@ -68,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "When its internal fire is burning, it cannot calm down and it runs around. When the fire diminishes, it falls asleep.",
+		de: "Solang das Feuer in ihm brennt, rennt es rastlos durch die Gegend. Geht ihm das Brennmaterial aus, wird es schläfrig."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/21.ts
+++ b/data/Black & White/Emerging Powers/21.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Darumaka",
 		fr: "Darumarond",
+		de: "Flampion"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Rock Smash",
 				fr: "Éclate-Roc",
+				de: "Zertrümmerer"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -60,10 +63,12 @@ const card: Card = {
 			name: {
 				en: "Fire Punch",
 				fr: "Poing de Feu",
+				de: "Flammenschlag"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Burned.",
 				fr: "Le Pokémon Défenseur est maintenant Brûlé.",
+				de: "Das Verteidigende Pokémon ist jetzt verbrannt."
 			},
 			damage: 70,
 
@@ -81,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "Its internal fire burns at 2,500º F, making enough power that it can destroy a dump truck with one punch.",
+		de: "Erhitzt das Innere seines Körpers auf 1400 Grad und erlangt so dieKraft, um mit der Faust Laster zu zerstören."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/22.ts
+++ b/data/Black & White/Emerging Powers/22.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Collect",
 				fr: "Collecte",
+				de: "Sammeln"
 			},
 			effect: {
 				en: "Draw a card.",
 				fr: "Piochez une carte.",
+				de: "Ziehe 1 Karte."
 			},
 
 		},
@@ -51,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Scratch",
 				fr: "Griffe",
+				de: "Kratzer"
 			},
 
 			damage: 20,
@@ -69,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "It does not thrive in dry environments. It keeps itself damp by shooting water stored in its head tuft from its tail.",
+		de: "Es wringt Wasser aus dem Büschel auf seinem Kopf und bespritzt damit Gegner. Kein Pokémon für trockene Gegenden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/23.ts
+++ b/data/Black & White/Emerging Powers/23.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Panpour",
 		fr: "Flotajou",
+		de: "Sodamak"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Grass' Power",
 				fr: "Pouvoir Fertilisant",
+				de: "Pflanzenmacht"
 			},
 			effect: {
 				en: "If this Pokémon has any Grass Energy attached to it, heal 20 damage from this Pokémon.",
 				fr: "Si de l'Énergie Grass est attachée à ce Pokémon, soignez 20 dégâts à ce Pokémon.",
+				de: "Wenn an dieses Pokémon bereits {G}-Energie angelegt ist, heile 20 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 30,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Rushing Water",
 				fr: "Courant Fort",
+				de: "Stromschnelle"
 			},
 			effect: {
 				en: "Move an Energy attached to the Defending Pokémon to 1 of your opponent's Benched Pokémon.",
 				fr: "Déplacez une Énergie attachée au Pokémon Défenseur vers 1 des Pokémon de Banc de votre adversaire.",
+				de: "Verschiebe 1 an das Verteidigende Pokémon angelegte Energie auf 1 Pokémon auf der Bank deines Gegners."
 			},
 			damage: 60,
 
@@ -80,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "The tuft on its head holds water. When the level runs low, it replenishes the tuft by siphoning up water with its tail.",
+		de: "Speichert Wasser im Büschel auf seinem Kopf. Sinkt der Wasserstand, tankt es über seinen Schweif neue Flüssigkeit."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/24.ts
+++ b/data/Black & White/Emerging Powers/24.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Flail",
 				fr: "Fléau",
+				de: "Dreschflegel"
 			},
 			effect: {
 				en: "Does 10 damage times the number of damage counters on this Pokémon.",
 				fr: "Inflige 10 dégâts multipliés par le nombre de marqueurs de dégâts placés sur ce Pokémon.",
+				de: "Dieser Angriff fügt 10 Schadenspunkte für jede Schadensmarke auf diesem Pokémon zu."
 			},
 			damage: 10,
 
@@ -53,10 +55,12 @@ const card: Card = {
 			name: {
 				en: "Final Gambit",
 				fr: "Tout ou Rien",
+				de: "Wagemut"
 			},
 			effect: {
 				en: "Flip 2 coins. If both of them are tails, this Pokémon does 80 damage to itself.",
 				fr: "Lancez 2 pièces. Si vous obtenez 2 côtés pile, ce Pokémon s'inflige 80 dégâts.",
+				de: "Wirf 2 Münzen. Zeigen beide „Zahl“, fügt sich dieses Pokémon selbst 80 Schadenspunkte zu."
 			},
 			damage: 80,
 
@@ -74,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "Red and blue Basculin get along so poorly, they'll start fighting instantly. These Pokémon are very hostile.",
+		de: "Rot gestreifte und blau gestreifte Exemplare kriegen sich sofort in die Haare. Ein äußerst aggressives Pokémon."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/25.ts
+++ b/data/Black & White/Emerging Powers/25.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 10,
@@ -49,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Splatter",
 				fr: "Crépitement",
+				de: "Verspritzer"
 			},
 			effect: {
 				en: "Does 30 damage to one of your oppoent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 30 dégâts à 1 des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 1 Pokémon deines Gegners 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -69,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "Red and blue Basculin usually do not get along, but sometimes members of one school mingle with the other's school.",
+		de: "Rot gestreifte und blau gestreifte Exemplare sind sich feindlich gesonnen. Doch ist jeder Schwarm bunt gemischt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/26.ts
+++ b/data/Black & White/Emerging Powers/26.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Roost",
 				fr: "Atterrissage",
+				de: "Ruheort"
 			},
 			effect: {
 				en: "Heal 40 damage from this Pokémon. This Pokémon can't retreat during your next turn.",
 				fr: "Soignez 40 dégâts à ce Pokémon. Ce Pokémon ne peut pas battre en retraite pendant votre prochain tour.",
+				de: "Heile 40 Schadenspunkte bei diesem Pokémon. Dieses Pokémon kann sich während deines nächsten Zuges nicht zurückziehen."
 			},
 
 		},
@@ -51,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Rain Splash",
 				fr: "Pluie Éclaboussante",
+				de: "Regenplatscher"
 			},
 
 			damage: 20,
@@ -76,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "When attacked, it uses its feathers to splash water, escaping under cover of the spray.",
+		de: "Gerät es in Gefahr, versprüht es Wasser aus seinem Federkleid und nutzt den Sprühregen, um Reißaus zu nehmen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/27.ts
+++ b/data/Black & White/Emerging Powers/27.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Ducklett",
 		fr: "Couaneton",
+		de: "Piccolente"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Wing Dance",
 				fr: "Danse Aérienne",
+				de: "Schwingentanz"
 			},
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, évitez tous les effets d'attaques (y compris les dégâts) infligés à ce Pokémon pendant le prochain tour de votre adversaire.",
+				de: "Wirf 1 Münze. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die diesem Pokémon zugefügt werden."
 			},
 			damage: 30,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Air Slash",
 				fr: "Lame d'Air",
+				de: "Luftschnitt"
 			},
 			effect: {
 				en: "Discard an Energy attached to this Pokémon.",
 				fr: "Défaussez une Énergie attachée à ce Pokémon.",
+				de: "Lege 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel."
 			},
 			damage: 70,
 
@@ -87,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "It administers sharp, powerful pecks with its bill. It whips its long neck to deliver forceful repeated strikes.",
+		de: "Es beugt seinen langen Hals, um mehrmals in Folge mit seinem Schnabel zu einer gnadenlosen Pick-Attacke anzusetzen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/28.ts
+++ b/data/Black & White/Emerging Powers/28.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Powder Snow",
 				fr: "Poudreuse",
+				de: "Pulverschnee"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Asleep.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Endormi.",
+				de: "Wirf 1 Münze. Bei „Kopf“ schläft das Verteidigende Pokémon jetzt."
 			},
 			damage: 10,
 
@@ -52,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Rest",
 				fr: "Repos",
+				de: "Erholung"
 			},
 			effect: {
 				en: "Heal 60 damage from this Pokémon. This Pokémon is now Asleep.",
 				fr: "Soignez 60 dégâts à ce Pokémon. Ce Pokémon est maintenant Endormi.",
+				de: "Heile 60 Schadenspunkte bei diesem Pokémon. Dieses Pokémon schläft jetzt."
 			},
 
 		},
@@ -72,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "When it is not feeling well, its mucus gets watery and the power of its Ice-type moves decreases.",
+		de: "Wenn es kränkelt, wird der Schleim aus seiner Nase flüssiger und seine Eis-Attacken verlieren an Stärke."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/29.ts
+++ b/data/Black & White/Emerging Powers/29.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Icicle Punch",
 				fr: "Poing Stalactite",
+				de: "Eiswatsche"
 			},
 
 			damage: 30,
@@ -55,6 +56,7 @@ const card: Card = {
 
 	description: {
 		en: "Its nose is always running. It sniffs the snot back up because the mucus provides the raw material for its moves.",
+		de: "Der Schleim, der stets aus seiner Nase hängt, treibt seine Attacken an. Zieht es ihn hoch, steht ein Angriff bevor."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/3.ts
+++ b/data/Black & White/Emerging Powers/3.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 10,
@@ -48,10 +49,12 @@ const card: Card = {
 			name: {
 				en: "String Shot",
 				fr: "Sécrétion",
+				de: "Fadenschuss"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 
 		},
@@ -68,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "Leavanny dress it in clothes they made for it when it hatched. It hides its head in its hood while it is sleeping.",
+		de: "Gleich nach dem Schlüpfen näht Matrifol ihm ein Kleidchen. Wenn es schläft, verbirgt es den Kopf unter einer Haube."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/30.ts
+++ b/data/Black & White/Emerging Powers/30.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cubchoo",
 		fr: "Polarhume",
+		de: "Petznief"
 	},
 
 	stage: "Stage1",
@@ -43,10 +44,12 @@ const card: Card = {
 			name: {
 				en: "Sheer Cold",
 				fr: "Glaciation",
+				de: "Eiseskälte"
 			},
 			effect: {
 				en: "The Defending Pokémon can't attack during your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas attaquer pendant le prochain tour de votre adversaire.",
+				de: "Das Verteidigende Pokémon kann während des nächsten Zuges deines Gegners nicht angreifen."
 			},
 			damage: 50,
 
@@ -61,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Icicle Crash",
 				fr: "Chute Glace",
+				de: "Eiszapfhagel"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by Resistance.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Résistance.",
+				de: "Der Schaden dieses Angriffs wird durch Resistenz nicht verändert."
 			},
 			damage: 80,
 
@@ -82,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "It can make its breath freeze at will. Very able in the water, it swims around in northern seas and catches prey.",
+		de: "Kann seinen eigenen Atem zum Gefrieren bringen. Es schwimmt auf der Suche nach Beute die nördlichen Meere ab."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/31.ts
+++ b/data/Black & White/Emerging Powers/31.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cubchoo",
 		fr: "Polarhume",
+		de: "Petznief"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Icy Wind",
 				fr: "Vent Glace",
+				de: "Eissturm"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 			damage: 30,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Superpower",
 				fr: "Surpuissance",
+				de: "Kraftkoloss"
 			},
 			effect: {
 				en: "You may do 20 more damage. If you do, this Pokémon does 20 damage to itself.",
 				fr: "Vous pouvez infliger 20 dégâts supplémentaires. Dans ce cas, ce Pokémon s'inflige 20 dégâts.",
+				de: "Du kannst mit diesem Angriff 20 weitere Schadenspunkte zufügen. Wenn du das machst, fügt dieses Pokémon sich selbst 20 Schadenspunkte zu."
 			},
 			damage: 60,
 
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "It freezes its breath to create fangs and claws of ice to fight with. Cold northern areas are its habitat.",
+		de: "Kämpft mit Reißzähnen aus Eis, die es aus gefrorenem Atem herstellt. Es lebt im Norden, wo es kalt ist."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/32.ts
+++ b/data/Black & White/Emerging Powers/32.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Thundershock",
 				fr: "Éclair",
+				de: "Donnerschock"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 10,
 
@@ -52,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Acrobatics",
 				fr: "Acrobatie",
+				de: "Akrobatik"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 more damage for each heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts supplémentaires pour chaque côté face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 10,
 
@@ -73,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "The energy made in its cheeks' electric pouches is stored inside its membranes and released while it is gliding.",
+		de: "Im Flug entlädt es Strom, den es mit seinen Backentaschen erzeugt und in seinen Fluglappen gespeichert hat."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/33.ts
+++ b/data/Black & White/Emerging Powers/33.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Gnaw",
 				fr: "Ronge",
+				de: "Nagen"
 			},
 
 			damage: 10,
@@ -54,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "Joltik that live in cities have learned a technique for sucking electricity from the outlets in houses.",
+		de: "Wattzapf, die in der Stadt leben, haben die Fähigkeit, aus den Steckdosen von Wohnhäusern Strom abzuzapfen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/34.ts
+++ b/data/Black & White/Emerging Powers/34.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Joltik",
 		fr: "Statitik",
+		de: "Wattzapf"
 	},
 
 	stage: "Stage1",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Gnaw",
 				fr: "Ronge",
+				de: "Nagen"
 			},
 
 			damage: 20,
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Stun Needle",
 				fr: "Para-Dard",
+				de: "Betäubungsnadel"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 30,
 
@@ -75,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "When attacked, they create an electric barrier by spitting out many electrically charged threads.",
+		de: "Wird es angegriffen, spuckt es mit vielen elektrisch geladenen Fäden um sich und baut sich eine Elektrobarriere."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/35.ts
+++ b/data/Black & White/Emerging Powers/35.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Charge",
 				fr: "Chargeur",
+				de: "Ladevorgang"
 			},
 			effect: {
 				en: "Search your deck for a Lightning Energy card and attach it to this Pokémon. Shuffle your deck afterward.",
 				fr: "Cherchez une carte Énergie Lightning dans votre deck et attachez-la à ce Pokémon. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 1 {L}-Energiekarte und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
 			},
 
 		},
@@ -52,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Disaster Volt",
 				fr: "Éclair Désastre",
+				de: "Stromschwall"
 			},
 			effect: {
 				en: "Discard an Energy attached to this Pokémon.",
 				fr: "Défaussez une Énergie attachée à ce Pokémon.",
+				de: "Lege 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel."
 			},
 			damage: 80,
 
@@ -73,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "The spikes on its tail discharge immense bolts of lightning. It flies around the Unova region firing off lightning bolts.",
+		de: "Es greift mit elektrischer Ladung aus den Dornen seiner Rute an und bombardiert Einall aus der Luft mit Blitzen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/36.ts
+++ b/data/Black & White/Emerging Powers/36.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Psy Bolt",
 				fr: "Choc Mental",
+				de: "Konfusion"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 20,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "Its habitat is dark forests and caves. It emits ultrasonic waves from its nose to learn about its surroundings.",
+		de: "Wohnt in dunklen Wäldern und Höhlen. Es sendet Ultraschallwellen mit seiner Nase aus, um die Gegend abzutasten."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/37.ts
+++ b/data/Black & White/Emerging Powers/37.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Woobat",
 		fr: "Chovsourir",
+		de: "Fleknoil"
 	},
 
 	stage: "Stage1",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Psyshot",
 				fr: "Piqûre Psy",
+				de: "Psychoschuss"
 			},
 
 			damage: 30,
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Phat Sound",
 				fr: "Cri Perçant",
+				de: "Fetter Sound"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 10 damage times the number of heads to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Lancez 3 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face à chacun des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Wirf 3 Münzen. Dieser Angriff fügt jedem Pokémon deines Gegners 10 Schadenspunkte mal der Anzahl „Kopf“ zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -81,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "Anyone who comes into contact with the ultrasonic waves emitted by a courting male experiences a positive mood shift.",
+		de: "Wer den Ultraschallwellen eines Männchens in der Balz ausgesetzt wird, verfällt in eine euphorische Stimmung."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/38.ts
+++ b/data/Black & White/Emerging Powers/38.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Poison Sting",
 				fr: "Dard-Venin",
+				de: "Giftstachel"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Empoisonné.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet."
 			},
 
 		},
@@ -51,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 20,
@@ -69,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "It discovers what is going on around it by using the feelers on its head and tail. It is brutally aggressive.",
+		de: "Mit seinen Ruten und den Fühlern an seinem Kopf tastet es die Umgebung ab. Ein überaus aggressiver Geselle."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/39.ts
+++ b/data/Black & White/Emerging Powers/39.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Venipede",
 		fr: "Venipatte",
+		de: "Toxiped"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Venoshock",
 				fr: "Choc Venin",
+				de: "Giftschock"
 			},
 			effect: {
 				en: "If the Defending Pokémon is Poisoned, this attack does 60 more damage.",
 				fr: "Si le Pokémon Défenseur est Empoisonné, cette attaque inflige 60 dégâts supplémentaires.",
+				de: "Wenn das Verteidigende Pokémon vergiftet ist, fügt dieser Angriff 60 weitere Schadenspunkte zu."
 			},
 			damage: 10,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Steamroller",
 				fr: "Bulldoboule",
+				de: "Quetschwalze"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by Resistance.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Résistance.",
+				de: "Der Schaden dieses Angriffs wird durch Resistenz nicht verändert."
 			},
 			damage: 40,
 
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "It is usually motionless, but when attacked, it rotates at high speed and then crashes into its opponent.",
+		de: "An sich ist es harmlos. Bringt man es jedoch in Bedrängnis, setzt es sich mit blitzschnellen Rollattacken zur Wehr."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/4.ts
+++ b/data/Black & White/Emerging Powers/4.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Gnaw",
 				fr: "Ronge",
+				de: "Nagen"
 			},
 
 			damage: 10,
@@ -49,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Razor Leaf",
 				fr: "Tranch'Herbe",
+				de: "Rasierblatt"
 			},
 
 			damage: 20,
@@ -67,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon makes clothes for itself. It chews up leaves and sews them with sticky thread extruded from its mouth.",
+		de: "Schneidert sich ein Kleid, indem es sich Blätter zurechtbeißt und sie mit Klebefäden aus seinem Mund zusammennäht."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/40.ts
+++ b/data/Black & White/Emerging Powers/40.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Whirlipede",
 		fr: "Scobolide",
+		de: "Rollum"
 	},
 
 	stage: "Stage2",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Toxic Claws",
 				fr: "Griffes Toxiques",
+				de: "Giftige Klauen"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned. Put 2 damage counters instead of 1 on that Pokémon between turns.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné. Placez 2 marqueurs de dégâts au lieu d'un sur le Pokémon ciblé entre chaque tour.",
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet. Lege zwischen den Zügen 2 Schadensmarken anstelle von 1 Schadensmarke auf das Pokémon."
 			},
 			damage: 30,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Wild Horn",
 				fr: "Corne Sauvage",
+				de: "Wildhorn"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 more damage for each heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts supplémentaires pour chaque côté face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 50,
 
@@ -80,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "With quick movements, it chases down its foes, attacking relentlessly with its horns until it prevails.",
+		de: "Holt Gegner flinken Fußes ein und greift sie mit den Hörnern an seinem Kopf an. Gnade ist ihm ein Fremdwort."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/41.ts
+++ b/data/Black & White/Emerging Powers/41.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Reflect",
 				fr: "Protection",
+				de: "Reflektor"
 			},
 			effect: {
 				en: "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 40 (after applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, tous les dégâts infligés à ce Pokémon par des attaques sont réduits de 40 (après application de la Faiblesse et de la Résistance).",
+				de: "Während des nächsten Zuges deines Gegners wird Schaden, der diesem Pokémon durch Angriffe zugefügt wird, um 40 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 
 		},
@@ -52,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Telekinesis",
 				fr: "Lévikinésie",
+				de: "Telekinese"
 			},
 			effect: {
 				en: "Does 50 damage to 1 of your opponent's Pokémon. This attack's damage isn't affected by Weakness or Resistance.",
 				fr: "Inflige 50 dégâts à 1 des Pokémon de votre adversaire. Les dégâts de cette attaque ne sont pas affectés par la Faiblesse ou la Résistance.",
+				de: "Dieser Angriff fügt 1 Pokémon deines Gegners 50 Schadenspunkte zu. Der Schaden dieses Angriffs wird durch Schwäche und Resistenz nicht verändert."
 			},
 
 		},
@@ -79,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "The guardians of an ancient city, they use their psychic power to attack enemies that invade their territory.",
+		de: "Einst war es der Wächter einer Stadt aus uralten Zeiten. Wer sich in sein Revier wagt, lernt seine Psycho-Kräfte kennen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/42.ts
+++ b/data/Black & White/Emerging Powers/42.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Quick Turn",
 				fr: "Vif Retournement",
+				de: "Schnelldrehung"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 10,
 
@@ -53,10 +55,12 @@ const card: Card = {
 			name: {
 				en: "Psychic Assault",
 				fr: "Assaut Psychique",
+				de: "Psycho-Ansturm"
 			},
 			effect: {
 				en: "Does 10 more damage for each damage counter on the Defending Pokémon.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque marqueur de dégâts placé sur le Pokémon Défenseur.",
+				de: "Dieser Angriff fügt 10 weitere Schadenspunkte für jede Schadensmarke auf dem Verteidigenden Pokémon zu."
 			},
 			damage: 40,
 
@@ -81,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "They never vary the route they fly, because their memories of guarding an ancient city remain steadfast.",
+		de: "Erinnerungen an seine Tage als Wächter einer uralten Stadt veranlassen es, Tag für Tag dieselbe Route abzufliegen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/43.ts
+++ b/data/Black & White/Emerging Powers/43.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Hypnotic Gaze",
 				fr: "Regard Hypnotique",
+				de: "Hypnotischer Blick"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Double Slap",
 				fr: "Torgnoles",
+				de: "Duplexhieb"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -72,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "Their ribbonlike feelers increase their psychic power. They are always staring at something.",
+		de: "Die schleifenförmigen Fühler erhöhen seine Psycho-Kräfte. Es scheint stets irgendetwas anzustarren."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/44.ts
+++ b/data/Black & White/Emerging Powers/44.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Smack",
 				fr: "Claque",
+				de: "Klatscher"
 			},
 
 			damage: 20,
@@ -55,6 +56,7 @@ const card: Card = {
 
 	description: {
 		en: "They intently observe both Trainers and Pokémon. Apparently, they are looking at something that only Gothita can see.",
+		de: "Beobachtet andere Pokémon und Trainer mit durchdringendem Blick, als könne es etwas erkennen, das keiner sonst sieht."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/45.ts
+++ b/data/Black & White/Emerging Powers/45.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gothita",
 		fr: "Scrutella",
+		de: "Mollimorba"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Double Slap",
 				fr: "Torgnoles",
+				de: "Duplexhieb"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Psybeam",
 				fr: "Rafale Psy",
+				de: "Psystrahl"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Confused.",
 				fr: "Le Pokémon Défenseur est maintenant Confus.",
+				de: "Das Verteidigende Pokémon ist jetzt verwirrt."
 			},
 			damage: 20,
 
@@ -78,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "They use hypnosis to control people and Pokémon. Tales of Gothorita leading people astray are told in every corner.",
+		de: "Es manipuliert Pokémon und Menschen mit Hypnosetricks. In Märchen tritt es oft als Entführer auf."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/46.ts
+++ b/data/Black & White/Emerging Powers/46.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gothita",
 		fr: "Scrutella",
+		de: "Mollimorba"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Deleting Glare",
 				fr: "Regard Dépouillant",
+				de: "Destruktorblick"
 			},
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy attached to 1 of your opponent's Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, défaussez une Énergie attachée à 1 des Pokémon de votre adversaire.",
+				de: "Wirf 1 Münze. Lege bei „Kopf“ 1 an das gegnerische Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 
 		},
@@ -57,6 +60,7 @@ const card: Card = {
 			name: {
 				en: "Super Psy Bolt",
 				fr: "Super Psy",
+				de: "Super-Psischlag"
 			},
 
 			damage: 50,
@@ -75,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "Starlight is the source of their power. At night, they mark star positions by using psychic power to float stones.",
+		de: "Zieht seine Energie aus dem Sternenlicht. Bei Nacht bringt es Steine zum Schweben und bildet damit Sternzeichen nach."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/47.ts
+++ b/data/Black & White/Emerging Powers/47.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gothorita",
 		fr: "Mesmérella",
+		de: "Hypnomorba"
 	},
 
 	stage: "Stage2",
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Madkinesis",
 				fr: "Mentalisme",
+				de: "Irrkinese"
 			},
 			effect: {
 				en: "Does 20 more damage for each Psychic Energy attached to this Pokémon.",
 				fr: "Inflige 20 dégâts supplémentaires pour chaque Énergie Psychic attachée à ce Pokémon.",
+				de: "Dieser Angriff fügt 20 weitere Schadenspunkte für jede an dieses Pokémon angelegte {P}-Energie zu."
 			},
 			damage: 30,
 
@@ -86,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "Starry skies thousands of light-years away are visible in the space distorted by their intense psychic power.",
+		de: "Durch seine mächtigen Psycho-Kräfte krümmt sich der Raum und Bilder eines Lichtjahre entfernten Ortes erscheinen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/48.ts
+++ b/data/Black & White/Emerging Powers/48.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gothorita",
 		fr: "Mesmérella",
+		de: "Hypnomorba"
 	},
 
 	stage: "Stage2",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Smack",
 				fr: "Claque",
+				de: "Klatscher"
 			},
 
 			damage: 30,
@@ -55,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Mental Shock",
 				fr: "Choc Émotionnel",
+				de: "Schockstarre"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused. If tails, discard an Energy attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus. Si c'est pile, défaussez une Énergie attachée au Pokémon Défenseur.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt. Lege bei „Zahl“ 1 an das Verteidigende Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 60,
 
@@ -76,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "They can predict the future from the placement and movement of the stars. They can see Trainers' life spans.",
+		de: "Kann anhand der Sternenkonstellationen die Zukunft voraussagen. Es weiß sogar, wie alt sein Trainer werden wird."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/49.ts
+++ b/data/Black & White/Emerging Powers/49.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Harden",
 				fr: "Armure",
+				de: "Härtner"
 			},
 			effect: {
 				en: "During your opponent's next turn, if this Pokémon would be damaged by an attack, prevent that attack's damage done to this Pokémon if that damage is 40 or less.",
 				fr: "Pendant le prochain tour de votre adversaire, si ce Pokémon doit subir les dégâts d'une attaque, évitez les dégâts infligés à ce Pokémon si ces dégâts sont de 40 ou moins.",
+				de: "Wenn diesem Pokémon während des nächsten Zuges deines Gegners durch einen Angriff 40 oder weniger Schadenspunkte zugefügt würden, verhindere diesen Schaden."
 			},
 
 		},
@@ -52,6 +54,7 @@ const card: Card = {
 			name: {
 				en: "Headbutt",
 				fr: "Coup d'Boule",
+				de: "Kopfnuss"
 			},
 
 			damage: 40,
@@ -70,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "Its ear is hexagonal in shape. Compressed underground, its body is as hard as steel.",
+		de: "Hat ein sechseckiges Ohr. Sein durch das Erdreich gepresster Körper steht Stahl in Sachen Härte in nichts nach."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/5.ts
+++ b/data/Black & White/Emerging Powers/5.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Sewaddle",
 		fr: "Larveyette",
+		de: "Strawickl"
 	},
 
 	stage: "Stage1",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Gnaw",
 				fr: "Ronge",
+				de: "Nagen"
 			},
 
 			damage: 20,
@@ -55,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Double Razor Leaf",
 				fr: "Double Tranch'Herbe",
+				de: "Doppel-Rasierblatt"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 50 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 50 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 50,
 
@@ -76,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It protects itself from the cold by wrapping up in leaves. It stays on the move, eating leaves in forests.",
+		de: "Es schützt sich vor Kälte, indem es sich in Blätter einwickelt. Es durchstreift Wälder und frisst herabgefallenes Laub."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/50.ts
+++ b/data/Black & White/Emerging Powers/50.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Headbutt",
 				fr: "Coup d'Boule",
+				de: "Kopfnuss"
 			},
 
 			damage: 10,
@@ -49,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Reckless Charge",
 				fr: "Attaque Imprudente",
+				de: "Waghalsiger Sturmangriff"
 			},
 			effect: {
 				en: "This Pokémon does 10 damage to itself.",
 				fr: "Ce Pokémon s'inflige 10 dégâts.",
+				de: "Dieses Pokémon fügt sich selbst 10 Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -70,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "They were discovered a hundred years ago in an earthquake fissure. Inside each one is an energy core.",
+		de: "Wurde vor 100 Jahren nach einem großen Erdbeben in einer Erdspalte entdeckt. Es trägt eine Energiesphäre in sich."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/51.ts
+++ b/data/Black & White/Emerging Powers/51.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Roggenrola",
 		fr: "Nodulithe",
+		de: "Kiesling"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Smack Down",
 				fr: "Anti-Air",
+				de: "Katapult"
 			},
 			effect: {
 				en: "If the Defending Pokémon has Fighting Resistance, this attack does 60 more damage.",
 				fr: "Si le Pokémon Défenseur a une Résistance à Fighting, cette attaque inflige 60 dégâts supplémentaires.",
+				de: "Wenn das Verteidigende Pokémon eine Resistenz gegenüber {F} hat, fügt dieser Angriff 60 weitere Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -60,6 +63,7 @@ const card: Card = {
 			name: {
 				en: "Power Gem",
 				fr: "Rayon Gemme",
+				de: "Juwelenkraft"
 			},
 
 			damage: 80,
@@ -78,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "When it overflows with power, the orange crystal on its body glows. It looks for underground water in caves.",
+		de: "Wenn es voller Kraft steckt, funkeln die orangefarbenen Kristalle an seinem Leib. Es sucht Höhlen nach Grundwasser ab."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/52.ts
+++ b/data/Black & White/Emerging Powers/52.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Roggenrola",
 		fr: "Nodulithe",
+		de: "Kiesling"
 	},
 
 	stage: "Stage1",
@@ -42,6 +43,7 @@ const card: Card = {
 			name: {
 				en: "Headbutt",
 				fr: "Coup d'Boule",
+				de: "Kopfnuss"
 			},
 
 			damage: 30,
@@ -56,10 +58,12 @@ const card: Card = {
 			name: {
 				en: "Hard Crash",
 				fr: "Grosse Gamelle",
+				de: "Einstürzer"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage. If tails, this Pokémon does 20 damage to itself.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires. Si c'est pile, ce Pokémon s'inflige 20 dégâts.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu. Bei „Zahl“ fügt sich dieses Pokémon selbst 20 Schadenspunkte zu."
 			},
 			damage: 60,
 
@@ -77,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Because its energy was too great to be contained, the energy leaked and formed orange crystals.",
+		de: "Energie, die ungehindert aus seinem Körper austrat, hat sich an ihm zu orangefarbenen Kristallen verfestigt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/53.ts
+++ b/data/Black & White/Emerging Powers/53.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Boldore",
 		fr: "Géolithe",
+		de: "Sedimantur"
 	},
 
 	stage: "Stage2",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Shear",
 				fr: "Prospection",
+				de: "Scherer"
 			},
 			effect: {
 				en: "Discard the top 5 cards of your deck. If any of those cards are Fighting Energy cards, attach them to this Pokémon.",
 				fr: "Défaussez les 5 cartes du dessus de votre deck. Si vous y trouvez des cartes Énergie Fighting, attachez-les à ce Pokémon.",
+				de: "Lege die obersten 5 Karten deines Decks auf deinen Ablagestapel. Wenn darunter {F}-Energiekarten sind, lege sie an dieses Pokémon an."
 			},
 
 		},
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Rock Bullet",
 				fr: "Fronde",
+				de: "Steinkugel"
 			},
 			effect: {
 				en: "Does 20 more damage for each Fighting Energy attached to this Pokémon.",
 				fr: "Inflige 20 dégâts supplémentaires pour chaque Énergie Fighting attachée à ce Pokémon.",
+				de: "Dieser Angriff fügt 20 weitere Schadenspunkte für jede an dieses Pokémon angelegte {F}-Energie zu."
 			},
 			damage: 40,
 
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "The solar energy absorbed by its body's orange crystals is magnified internally and fired from its mouth.",
+		de: "Es absorbiert über seine orangefarbenen Kristalle das Sonnenlicht und schießt die so gewonnene Energie aus seinem Maul."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/54.ts
+++ b/data/Black & White/Emerging Powers/54.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Hone Claws",
 				fr: "Aiguisage",
+				de: "Klauenwetzer"
 			},
 			effect: {
 				en: "During your next turn, each of this Pokémon's attacks does 30 more damage (before applying Weakness and Resistance).",
 				fr: "Pendant votre prochain tour, chaque attaque de ce Pokémon inflige 30 dégâts supplémentaires (avant application de la Faiblesse et de la Résistance).",
+				de: "Während deines nächsten Zuges fügt jeder Angriff dieses Pokémon 30 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 
 		},
@@ -50,6 +52,7 @@ const card: Card = {
 			name: {
 				en: "Scratch",
 				fr: "Griffe",
+				de: "Kratzer"
 			},
 
 			damage: 10,
@@ -75,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "It can dig through the ground at a speed of 30 mph. It could give a car running aboveground a good race.",
+		de: "Es gräbt sich mit 50 km/h durch das Erdreich und kann beinahe schon mit den Autos an der Oberfläche Schritt halten."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/55.ts
+++ b/data/Black & White/Emerging Powers/55.ts
@@ -38,6 +38,7 @@ const card: Card = {
 			name: {
 				en: "Mud-Slap",
 				fr: "Coud'Boue",
+				de: "Lehmschelle"
 			},
 
 			damage: 40,
@@ -63,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "It makes its way swiftly through the soil by putting both claws together and rotating at high speed.",
+		de: "Es führt seine beiden Klauen zusammen, dreht sich rapide um die eigene Achse und gräbt sich ratzfatz durch das Erdreich."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/56.ts
+++ b/data/Black & White/Emerging Powers/56.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Drilbur",
 		fr: "Rototaupe",
+		de: "Rotomurf"
 	},
 
 	stage: "Stage1",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Metal Claw",
 				fr: "Griffe Acier",
+				de: "Metallklaue"
 			},
 
 			damage: 30,
@@ -55,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Drill Run",
 				fr: "Tunnelier",
+				de: "Schlagbohrer"
 			},
 			effect: {
 				en: "Discard an Energy attached to the Defending Pokémon.",
 				fr: "Défaussez une Énergie attachée au Pokémon Défenseur.",
+				de: "Lege 1 an das Verteidigende Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 80,
 
@@ -83,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "It can help in tunnel construction. Its drill has evolved into steel strong enough to bore through iron plates.",
+		de: "Seine zu Stahl weiterentwickelten Bohrer kriegen selbst Eisenplatten klein. Im Tunnelbau ist es ein absolutes Ass."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/57.ts
+++ b/data/Black & White/Emerging Powers/57.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Drilbur",
 		fr: "Rototaupe",
+		de: "Rotomurf"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Dig",
 				fr: "Tunnel",
+				de: "Schaufler"
 			},
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, évitez tous les effets d'attaques (y compris les dégâts) infligés à ce Pokémon pendant le prochain tour de votre adversaire.",
+				de: "Wirf 1 Münze. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die diesem Pokémon zugefügt werden."
 			},
 			damage: 30,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Earthquake",
 				fr: "Séisme",
+				de: "Erdbeben"
 			},
 			effect: {
 				en: "Does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à chacun de vos Pokémon de Banc. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt jedem Pokémon auf deiner Bank 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 70,
 
@@ -87,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "More than 300 feet below the surface, they build mazelike nests. Their activity can be destructive to subway tunnels.",
+		de: "Sein verworrener Bau liegt 100 Meter tief unter der Erde. Gelegentlich gräbt es auch U-Bahn-Schächte an."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/58.ts
+++ b/data/Black & White/Emerging Powers/58.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Scarf Hold",
 				fr: "Kesa-Gatame",
+				de: "Schalhalter"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon can't attack during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur ne peut pas attaquer pendant le prochain tour de votre adversaire.",
+				de: "Wirf 1 Münze. Bei „Kopf“ kann das Verteidigende Pokémon während des nächsten Zuges deines Gegners nicht angreifen."
 			},
 			damage: 30,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "When it tightens its belt, it becomes stronger. Wild Throh use vines to weave their own belts.",
+		de: "Zurrt es seinen Gürtel fest, gewinnt es an Kraft. Wilde Exemplare flechten sich ihren Gürtel in Handarbeit aus Ranken."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/59.ts
+++ b/data/Black & White/Emerging Powers/59.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Five Fierce Chops",
 				fr: "Volée de Coups",
+				de: "Fünferhacker"
 			},
 			effect: {
 				en: "Flip 5 coins. This attack does 20 damage times the number of heads. This Pokémon can't attack during your next turn.",
 				fr: "Lancez 5 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face. Ce Pokémon ne peut pas attaquer pendant votre prochain tour.",
+				de: "Wirf 5 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu. Dieses Pokémon kann während deines nächsten Zuges nicht angreifen."
 			},
 			damage: 20,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "Tying their belts gets them pumped and makes their punches more destructive. Disturbing their training angers them.",
+		de: "Zieht es den Gürtel fest, werden seine Hiebe stärker. Kann es gar nicht leiden, wenn man es beim Training stört."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/6.ts
+++ b/data/Black & White/Emerging Powers/6.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Sewaddle",
 		fr: "Larveyette",
+		de: "Strawickl"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Grass Cocooning",
 				fr: "Cocon Vert",
+				de: "Pflanzenhülle"
 			},
 			effect: {
 				en: "Heal 40 damage from this Pokémon.",
 				fr: "Soignez 40 dégâts à ce Pokémon.",
+				de: "Heile 40 Schadenspunkte bei diesem Pokémon."
 			},
 
 		},
@@ -56,6 +59,7 @@ const card: Card = {
 			name: {
 				en: "Razor Leaf",
 				fr: "Tranch'Herbe",
+				de: "Rasierblatt"
 			},
 
 			damage: 20,
@@ -74,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "Forests where Swadloon live have superb foliage because the nutrients they make from fallen leaves nourish the plant life.",
+		de: "Es wandelt herabgefallenes Laub in Nährstoffe um. In Wäldern, wo es Folikon gibt, fühlen sich Pflanzen pudelwohl."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/60.ts
+++ b/data/Black & White/Emerging Powers/60.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
+				de: "Biss"
 			},
 
 			damage: 20,
@@ -55,6 +56,7 @@ const card: Card = {
 
 	description: {
 		en: "They live buried in the sands of the desert. The sun-warmed sands prevent their body temperature from dropping.",
+		de: "Es lebt im Wüstensand. Der durch die Sonne erhitzte Sand gewährleistet, dass es immer schön warm eingepackt ist."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/61.ts
+++ b/data/Black & White/Emerging Powers/61.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Sandile",
 		fr: "Mascaïman",
+		de: "Ganovil"
 	},
 
 	stage: "Stage1",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
+				de: "Biss"
 			},
 
 			damage: 20,
@@ -55,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Crunch",
 				fr: "Mâchouille",
+				de: "Knirscher"
 			},
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, défaussez une Énergie attachée au Pokémon Défenseur.",
+				de: "Wirf 1 Münze. Lege bei „Kopf“ 1 an das Verteidigende Pokémon angelegte Energie auf den Ablagestapel."
 			},
 			damage: 40,
 
@@ -76,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "They live in groups of a few individuals. Protective membranes shield their eyes from sandstorms.",
+		de: "Bildet mit mehreren Artgenossen ein Rudel. Eine Membran schützt seine Augen vor Sandstürmen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/62.ts
+++ b/data/Black & White/Emerging Powers/62.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Krokorok",
 		fr: "Escroco",
+		de: "Rokkaiman"
 	},
 
 	stage: "Stage2",
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Thrash",
 				fr: "Mania",
+				de: "Fuchtler"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage. If tails, this Pokémon does 20 damage to itself.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires. Si c'est pile, ce Pokémon s'inflige 20 dégâts.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu. Bei „Zahl“ fügt sich dieses Pokémon selbst 20 Schadenspunkte zu."
 			},
 			damage: 70,
 
@@ -93,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "They never allow prey to escape. Their jaws are so powerful, they can crush the body of an automobile.",
+		de: "Hat es seine Beute erblickt, gibt es kein Entrinnen mehr. Sein mächtiger Kiefer knackt selbst Karosserien."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/63.ts
+++ b/data/Black & White/Emerging Powers/63.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Boulder Crush",
 				fr: "Rocher Écrasant",
+				de: "Felsenquetscher"
 			},
 
 			damage: 40,
@@ -51,10 +52,12 @@ const card: Card = {
 			name: {
 				en: "Sacred Sword",
 				fr: "Lame Sainte",
+				de: "Sanctoklinge"
 			},
 			effect: {
 				en: "This Pokémon can't use Sacred Sword during your next turn.",
 				fr: "Ce Pokémon ne peut pas utiliser Lame Sainte pendant votre prochain tour.",
+				de: "Dieses Pokémon kann während deines nächsten Zuges Sanctoklinge nicht einsetzen."
 			},
 			damage: 100,
 
@@ -72,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon came to the defense of Pokémon that had lost their homes in a war among humans.",
+		de: "Einst bäumte es sich gegen die Menschen auf, deren Kriege zahllose Pokémon heimatlos gemacht hatten."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/64.ts
+++ b/data/Black & White/Emerging Powers/64.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Knock Off",
 				fr: "Sabotage",
+				de: "Abschlag"
 			},
 			effect: {
 				en: "Flip a coin. If heads, discard a random card from your opponent's hand.",
 				fr: "Lancez une pièce. Si c'est face, défaussez au hasard une carte de la main de votre adversaire.",
+				de: "Wirf 1 Münze. Nimm bei „Kopf“ 1 zufällige Karte aus der verdeckten Hand deines Gegners und lege sie auf dessen Ablagestapel."
 			},
 			damage: 20,
 
@@ -65,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "They steal from people for fun, but their victims can't help but forgive them. Their deceptively cute act is perfect.",
+		de: "Es stibitzt den Leuten spaßeshalber ihr Hab und Gut, doch dank seiner reizenden Natur kann ihm niemand lang böse sein."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/65.ts
+++ b/data/Black & White/Emerging Powers/65.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Purrloin",
 		fr: "Chacripan",
+		de: "Felilou"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Feint Attack",
 				fr: "Feinte",
+				de: "Finte"
 			},
 			effect: {
 				en: "Does 30 damage to 1 of your opponent's Pokémon. This attack's damage isn't affected by Weakness, Resistance, or any other effects on that Pokémon.",
 				fr: "Inflige 30 dégâts à 1 des Pokémon de votre adversaire. Les dégâts de cette attaque ne sont pas affectés par la Faiblesse, la Résistance ou tout autre effet en action sur le Pokémon ciblé.",
+				de: "Dieser Angriff fügt 1 Pokémon deines Gegners 30 Schadenspunkte zu. Der Schaden dieses Angriffs wird durch Schwäche, Resistenz oder alle anderen Effekte auf dem gewählten Pokémon nicht verändert."
 			},
 
 		},
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Claw Rend",
 				fr: "Déchirure",
+				de: "Reißer"
 			},
 			effect: {
 				en: "If the Defending Pokémon already has any damage counters on it, this attack does 30 more damage.",
 				fr: "Si le Pokémon Défenseur a déjà des marqueurs de dégâts, cette attaque inflige 30 dégâts supplémentaires.",
+				de: "Wenn auf dem Verteidigenden Pokémon bereits mindestens 1 Schadensmarke liegt, fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: 50,
 
@@ -85,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "These Pokémon vanish and appear unexpectedly. Many Trainers are drawn to their beautiful form and fur.",
+		de: "Kommt und geht, wann es will. Sein reizendes Aussehen und Fell ziehen Trainer in Scharen an."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/66.ts
+++ b/data/Black & White/Emerging Powers/66.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Ram",
 				fr: "Collision",
+				de: "Ramme"
 			},
 
 			damage: 10,
@@ -49,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Rising Lunge",
 				fr: "Botte Secrète",
+				de: "Aufwärtsstoß"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 weitere Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -77,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It changes into the forms of others to surprise them. Apparently, it often transforms into a silent child.",
+		de: "Es übertölpelt andere, indem es verschiedene Gestalten annimmt. Angeblich tarnt es sich oft als wortkarges Kind."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/67.ts
+++ b/data/Black & White/Emerging Powers/67.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Zorua",
 		fr: "Zorua",
+		de: "Zorua"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Fury Swipes",
 				fr: "Combo-Griffe",
+				de: "Kratzfurie"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -58,6 +61,7 @@ const card: Card = {
 			name: {
 				en: "Night Daze",
 				fr: "Explonuit",
+				de: "Nachtflut"
 			},
 
 			damage: 80,
@@ -83,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "Bonds between these Pokémon are very strong. It protects the safety of its pack by tricking its opponents.",
+		de: "Seit jeher beschützt es das Rudel, indem es die Gestalt des Feindes annimmt. Es ist sehr loyal zu seinen Artgenossen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/68.ts
+++ b/data/Black & White/Emerging Powers/68.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Rear Guard",
 				fr: "Garde Arrière",
+				de: "Rückendeckung"
 			},
 			effect: {
 				en: "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 30 (after applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, tous les dégâts infligés à ce Pokémon par des attaques sont réduits de 30 (après application de la Faiblesse et de la Résistance).",
+				de: "Während des nächsten Zuges deines Gegners wird Schaden, der diesem Pokémon durch Angriffe zugefügt wird, um 30 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 
 		},
@@ -51,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Gust",
 				fr: "Tornade",
+				de: "Windstoß"
 			},
 
 			damage: 20,
@@ -76,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "They tend to guard their posteriors with suitable bones they have found. They pursue weak Pokémon.",
+		de: "Es schlüpft in einen passenden Schädel, um sein Hinterteil zu schützen, und scheucht schwache Pokémon umher."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/69.ts
+++ b/data/Black & White/Emerging Powers/69.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Vullaby",
 		fr: "Vostourno",
+		de: "Skallyk"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Bone Rush",
 				fr: "Charge-Os",
+				de: "Knochenhatz"
 			},
 			effect: {
 				en: "Flip a coin until you get tails. This attack does 30 damage times the number of heads.",
 				fr: "Lancez une pièce jusqu'à ce que vous obteniez un côté pile. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 30,
 
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Dark Pulse",
 				fr: "Vibrobscur",
+				de: "Finsteraura"
 			},
 			effect: {
 				en: "Does 10 more damage for each Darkness Energy attached to all of your Pokémon.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque Énergie Darkness attachée à tous vos Pokémon.",
+				de: "Dieser Angriff fügt für jede {D}-Energie, die an deine Pokémon angelegt ist, 10 weitere Schadenpunkte zu."
 			},
 			damage: 20,
 
@@ -85,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "Watching from the sky, they swoop to strike weakened Pokémon on the ground. They decorate themselves with bones.",
+		de: "Es überblickt das Areal aus der Luft und stürzt sich auf ein geschwächtes Opfer. Trägt gern Knochenschmuck."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/7.ts
+++ b/data/Black & White/Emerging Powers/7.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Swadloon",
 		fr: "Couverdure",
+		de: "Folikon"
 	},
 
 	stage: "Stage2",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Nurturing",
 				fr: "Affection",
+				de: "Großziehen"
 			},
 			effect: {
 				en: "Choose 1 of your Pokémon. Search your deck for a card that evolves from that Pokémon and put it onto that Pokémon. (This counts as evolving that Pokémon.) Shuffle your deck afterward.",
 				fr: "Choisissez 1 de vos Pokémon. Cherchez dans votre deck une carte Évolution du Pokémon choisi et placez-la sur celui-ci. (Cela équivaut à faire évoluer le Pokémon choisi.) Mélangez ensuite votre deck.",
+				de: "Wähle 1 deiner Pokémon im Spiel. Durchsuche dein Deck nach einer Karte, zu der sich das Pokémon entwickelt, und lege diese auf das gewählte Pokémon (dies zählt als Entwicklung des Pokémon). Mische anschließend dein Deck."
 			},
 
 		},
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "X-Scissor",
 				fr: "Plaie-Croix",
+				de: "Kreuzschere"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 50 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 50 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 50 weitere Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -77,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "Upon finding a small Pokémon, it weaves clothing for it from leaves, using the cutters on its arms and sticky silk.",
+		de: "Findet es ein junges Pokémon, kann es nicht anders, als ihm mit seinen Scheren und Klebefäden ein Kleidchen zu nähen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/70.ts
+++ b/data/Black & White/Emerging Powers/70.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Pin Missile",
 				fr: "Dard-Nuée",
+				de: "Nadelrakete"
 			},
 			effect: {
 				en: "Flip 4 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 4 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 4 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 10,
 
@@ -65,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "They stick their spikes into cave walls and absorb the minerals they find in the rock.",
+		de: "Es hakt sich mit seinen Dornen in den Wänden von Höhlen fest und saugt die Mineralien aus dem Gestein."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/71.ts
+++ b/data/Black & White/Emerging Powers/71.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Pierce",
 				fr: "Transpercement",
+				de: "Durchbohren"
 			},
 
 			damage: 20,
@@ -62,6 +63,7 @@ const card: Card = {
 
 	description: {
 		en: "When threatened, it attacks by shooting a barrage of spikes, which gives it a chance to escape by rolling away.",
+		de: "Fühlt es sich bedroht, wehrt es sich, indem es eine großzügige Salve Dornen abfeuert."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/72.ts
+++ b/data/Black & White/Emerging Powers/72.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Ferroseed",
 		fr: "Grindur",
+		de: "Kastadur"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Steel Feelers",
 				fr: "Tentacules d'Acier",
+				de: "Stahlfühler"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 30 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 30,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Gyro Ball",
 				fr: "Gyroballe",
+				de: "Gyroball"
 			},
 			effect: {
 				en: "Switch this Pokémon with 1 of your Benched Pokémon. Then, your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon.",
 				fr: "Échangez ce Pokémon avec 1 de vos Pokémon de Banc. Ensuite, votre adversaire échange le Pokémon Défenseur avec 1 de ses Pokémon de Banc.",
+				de: "Tausche dieses Pokémon gegen 1 Pokémon auf deiner Bank aus. Danach tauscht dein Gegner das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
 			},
 			damage: 60,
 
@@ -86,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "They attach themselves to cave ceilings, firing steel spikes at targets passing beneath them.",
+		de: "Es setzt sich an der Decke von Höhlen fest und wirft seine dornengespickten Schlingen auf vorbeigehende Beute ab."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/73.ts
+++ b/data/Black & White/Emerging Powers/73.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Ferroseed",
 		fr: "Grindur",
+		de: "Kastadur"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Iron Defense",
 				fr: "Mur de Fer",
+				de: "Eisenabwehr"
 			},
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, évitez tous les effets d'attaques (y compris les dégâts) infligés à ce Pokémon pendant le prochain tour de votre adversaire.",
+				de: "Wirf 1 Münze. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die diesem Pokémon zugefügt werden."
 			},
 
 		},
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Power Whip",
 				fr: "Mégafouet",
+				de: "Blattgeißel"
 			},
 			effect: {
 				en: "Does 10 damage for each Energy attached to this Pokémon to one of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts pour chaque Énergie attachée à ce Pokémon à 1 des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt einem Pokémon deines Gegners 10 Schadenspunkte für jede an dieses Pokémon angelegte Energie zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -83,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It fights by swinging around its three spiky feelers. A hit from these steel spikes can reduce a boulder to rubble.",
+		de: "Seine drei dornengespickten Schlingen, unter denen sogar große Felsen zu Bruch gehen, dienen ihm als Angriffswerkzeug."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/74.ts
+++ b/data/Black & White/Emerging Powers/74.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Spinning Attack",
 				fr: "Attaque Tournante",
+				de: "Rundumangriff"
 			},
 
 			damage: 10,
@@ -50,10 +51,12 @@ const card: Card = {
 			name: {
 				en: "Gear Grind",
 				fr: "Lancécrou",
+				de: "Klikkdiskus"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 30 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 30,
 
@@ -78,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Interlocking two bodies and spinning around generates the energy they need to live.",
+		de: "Es gewinnt lebenswichtige Energie, indem es seine zwei Einzelteile ineinander verzahnt und rotieren lässt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/75.ts
+++ b/data/Black & White/Emerging Powers/75.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Klink",
 		fr: "Tic",
+		de: "Klikk"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Metal Sound",
 				fr: "Strido-Son",
+				de: "Metallsound"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Confused.",
 				fr: "Le Pokémon Défenseur est maintenant Confus.",
+				de: "Das Verteidigende Pokémon ist jetzt verwirrt."
 			},
 
 		},
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Guard Press",
 				fr: "Pression de Garde",
+				de: "Schutzdruck"
 			},
 			effect: {
 				en: "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, tous les dégâts infligés à ce Pokémon par des attaques sont réduits de 20 (après application de la Faiblesse et de la Résistance).",
+				de: "Während des nächsten Zuges deines Gegners wird Schaden, der diesem Pokémon durch Angriffe zugefügt wird, um 20 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 			damage: 60,
 
@@ -85,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "Spinning minigears are rotated at high speed and repeatedly fired away. It is dangerous if the gears don't return.",
+		de: "Lässt seine Einzelteile rapide rotieren und feuert sie auf Gegner ab. Kehren sie nicht zurück, wird es brenzlig."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/76.ts
+++ b/data/Black & White/Emerging Powers/76.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Klang",
 		fr: "Clic",
+		de: "Kliklak"
 	},
 
 	stage: "Stage2",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Charge Beam",
 				fr: "Rayon Chargé",
+				de: "Ladestrahl"
 			},
 			effect: {
 				en: "Attach an Energy card from your discard pile to this Pokémon.",
 				fr: "Attachez une carte Énergie de votre pile de défausse à ce Pokémon.",
+				de: "Nimm 1 Energiekarte von deinem Ablagestapel und lege sie an dieses Pokémon an."
 			},
 			damage: 30,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Zap Cannon",
 				fr: "Élecanon",
+				de: "Blitzkanone"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this Pokémon can't use Zap Cannon during your next turn.",
 				fr: "Lancez une pièce. Si c'est pile, ce Pokémon ne peut pas utiliser Élecanon pendant votre prochain tour.",
+				de: "Wirf 1 Münze. Bei „Zahl“ kann dieses Pokémon Blitzkanone während deines nächsten Zuges nicht einsetzen."
 			},
 			damage: 80,
 
@@ -86,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "The gear with the red core is rotated at high speed for a rapid energy charge.",
+		de: "Indem es das Rad mit dem roten Zentrum mit hohem Tempo zum Rotieren bringt, kann es eine Turboladung durchführen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/77.ts
+++ b/data/Black & White/Emerging Powers/77.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Metal Horns",
 				fr: "Cornes de Métal",
+				de: "Metallhörner"
 			},
 			effect: {
 				en: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon.",
 				fr: "Votre adversaire échange le Pokémon Défenseur avec 1 de ses Pokémon de Banc.",
+				de: "Dein Gegner tauscht das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
 			},
 			damage: 30,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Sacred Sword",
 				fr: "Lame Sainte",
+				de: "Sanctoklinge"
 			},
 			effect: {
 				en: "This Pokémon can't use Sacred Sword during your next turn.",
 				fr: "Ce Pokémon ne peut pas utiliser Lame Sainte pendant votre prochain tour.",
+				de: "Dieses Pokémon kann während deines nächsten Zuges Sanctoklinge nicht einsetzen."
 			},
 			damage: 100,
 
@@ -82,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "This legendary Pokémon battled against humans to protect Pokémon. Its personality is calm and composed.",
+		de: "Ein Legendäres Pokémon, das sich zum Schutz der Pokémon mit den Menschen anlegte. Eine kühle, gelassene Natur."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/78.ts
+++ b/data/Black & White/Emerging Powers/78.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Hyper Fang",
 				fr: "Croc de Mort",
+				de: "Hyperzahn"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+				de: "Wirf eine Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 30,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "Extremely cautious, they take shifts to maintain a constant watch of their nest. They feel insecure without a lookout.",
+		de: "Hortet in seinen Backentaschen Futter, um tagelang Wache stehen zu können, und gibt Kameraden über seine Rute Signale."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/79.ts
+++ b/data/Black & White/Emerging Powers/79.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Patrat",
 		fr: "Ratentif",
+		de: "Nagelotz"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Watcheck",
 				fr: "Contrôle Radar",
+				de: "Kukmardeck"
 			},
 			effect: {
 				en: "Look at the top 5 cards of your opponent's deck and put them back on top of his or her deck in any order.",
 				fr: "Regardez les 5 cartes du dessus du deck de votre adversaire et replacez-les sur le dessus de son deck dans l'ordre de votre choix.",
+				de: "Schau dir die obersten 5 Karten des Decks deines Gegners an und lege sie in beliebiger Reihenfolge zurück auf sein Deck."
 			},
 
 		},
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Quick Tail Smash",
 				fr: "Rapid'Claqueue",
+				de: "Schneller Schmetterschweif"
 			},
 			effect: {
 				en: "Before doing damage, you may flip a coin. If heads, this attack does 60 more damage. If tails, this attack does nothing.",
 				fr: "Avant d'infliger des dégâts, vous pouvez lancer une pièce. Si c'est face, cette attaque inflige 60 dégâts supplémentaires. Si c'est pile, cette attaque ne fait rien.",
+				de: "Bevor du Schaden zufügst, kannst du 1 Münze werfen. Bei „Kopf“ fügt dieser Angriff 60 weitere Schadenspunkte zu. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 20,
 
@@ -77,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "When they see an enemy, their tails stand high, and they spit the seeds of berries stored in their cheek pouches.",
+		de: "Bespuckt Gegner mit Kernen von Beeren aus seinen Backentaschen. Erspäht es einen Feind, richtet es den Schweif auf."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/8.ts
+++ b/data/Black & White/Emerging Powers/8.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Swadloon",
 		fr: "Couverdure",
+		de: "Folikon"
 	},
 
 	stage: "Stage2",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Slash",
 				fr: "Tranche",
+				de: "Schlitzer"
 			},
 
 			damage: 30,
@@ -55,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Triple Cutter",
 				fr: "Triple Lame",
+				de: "Dreifachschnitt"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 60 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 60 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 60 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 60,
 
@@ -76,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It keeps its eggs warm with heat from fermenting leaves. It also uses leaves to make warm wrappings for Sewaddle.",
+		de: "Nutzt die Hitze kompostierenden Laubes zum Ausbrüten von Eiern. Es fertigt aus Blättern Kleidchen für Strawickl an."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/80.ts
+++ b/data/Black & White/Emerging Powers/80.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Gust",
 				fr: "Tornade",
+				de: "Windstoß"
 			},
 
 			damage: 20,
@@ -62,6 +63,7 @@ const card: Card = {
 
 	description: {
 		en: "Each follows its Trainer's orders as best it can, but they sometimes fail to understand complicated commands.",
+		de: "Gewöhnlich hört es zwar auf das, was sein Trainer sagt, doch manchmal kommt es mit komplizierten Befehlen nicht klar."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/81.ts
+++ b/data/Black & White/Emerging Powers/81.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pidove",
 		fr: "Poichigeon",
+		de: "Dusselgurr"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Claw",
 				fr: "Ergots",
+				de: "Klaue"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 30,
 
@@ -58,6 +61,7 @@ const card: Card = {
 			name: {
 				en: "Wing Attack",
 				fr: "Cru-Aile",
+				de: "Flügelschlag"
 			},
 
 			damage: 50,
@@ -83,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "Many people believe that, deep in the forest where Tranquill live, there is a peaceful place where there is no war.",
+		de: "Viele Leute glauben, dass es tief in seinem heimatlichen Wald ein Land der Harmonie gibt, wo man keine Kriege kennt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/82.ts
+++ b/data/Black & White/Emerging Powers/82.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Tranquill",
 		fr: "Colombeau",
+		de: "Navitaub"
 	},
 
 	stage: "Stage2",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Tailwind",
 				fr: "Vent Arrière",
+				de: "Rückenwind"
 			},
 			effect: {
 				en: "Attach an Energy card from your hand to 1 of your Pokémon.",
 				fr: "Attachez une carte Énergie de votre main à 1 de vos Pokémon.",
+				de: "Lege 1 Energiekarte von deiner Hand an 1 deiner Pokémon an."
 			},
 
 		},
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Feather Strike",
 				fr: "Tir de Plumes",
+				de: "Federschlag"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 40 more damage. If tails, discard an Energy attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 40 dégâts supplémentaires. Si c'est pile, défaussez une Énergie attachée au Pokémon Défenseur.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 40 weitere Schadenspunkte zu. Lege bei „Zahl“ 1 an das Verteidigende Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 40,
 
@@ -85,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "Males have plumage on their heads. They will never let themselves fell close to anyone other than their Trainers.",
+		de: "Männliche Exemplare tragen eine Verzierung am Kopf. Lässt sich von Natur aus nur auf seinen Trainer ein."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/83.ts
+++ b/data/Black & White/Emerging Powers/83.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Powerful Slap",
 				fr: "Grosse Baffe",
+				de: "Kraftklatscher"
 			},
 			effect: {
 				en: "Flip a coin for each Energy attached to this Pokémon. This attack does 40 damage times the number of heads.",
 				fr: "Lancez une pièce pour chaque Énergie attachée à ce Pokémon. Cette attaque inflige 40 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf für jede an dieses Pokémon angelegte Energie 1 Münze. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 40,
 
@@ -53,10 +55,12 @@ const card: Card = {
 			name: {
 				en: "Heal Pulse",
 				fr: "Vibra Soin",
+				de: "Heilwoge"
 			},
 			effect: {
 				en: "Heal 50 damage from 1 of your Pokémon.",
 				fr: "Soignez 50 dégâts à 1 de vos Pokémon.",
+				de: "Heile 50 Schadenspunkte bei 1 deiner Pokémon."
 			},
 
 		},
@@ -73,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "Its auditory sense is astounding. It has a radar-like ability to understand its surrounding through slight sounds.",
+		de: "Hat ein außerordentlich feines Gehör. Es tastet seine Umgebung auf jedes noch so leise Geräusch ab wie ein Radar."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/84.ts
+++ b/data/Black & White/Emerging Powers/84.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Last Resort",
 				fr: "Dernierecour",
+				de: "Zuflucht"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 30,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "These Pokémon prefer a tidy habitat. They are always sweeping and dusting, using their tails as brooms.",
+		de: "Ein Pokémon mit Putzfimmel. Es benutzt seinen Schweif als Staubwedel und fegt seinen Bau, bis alles picobello ist."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/85.ts
+++ b/data/Black & White/Emerging Powers/85.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Minccino",
 		fr: "Chinchidou",
+		de: "Picochilla"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Captivate",
 				fr: "Séduction",
+				de: "Liebreiz"
 			},
 			effect: {
 				en: "Switch the Defending Pokémon with 1 of your opponent's Benched Pokémon.",
 				fr: "Échangez le Pokémon Défenseur avec 1 des Pokémon de Banc de votre adversaire.",
+				de: "Tausche das Verteidigende Pokémon gegen 1 Pokémon auf der Bank deines Gegners aus."
 			},
 
 		},
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Fluffy Tail",
 				fr: "Queue Touffue",
+				de: "Schlummerschweif"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 			damage: 30,
 
@@ -77,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "Their white fur feels amazing to touch. Their fur repels dust and prevents static electricity from building up.",
+		de: "Sein weißer Flaum fühlt sich wunderbar flauschig an und zieht weder Staub noch statische Elektrizität an."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/86.ts
+++ b/data/Black & White/Emerging Powers/86.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Peck",
 				fr: "Picpic",
+				de: "Schnabel"
 			},
 
 			damage: 10,
@@ -49,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Slash",
 				fr: "Tranche",
+				de: "Schlitzer"
 			},
 
 			damage: 20,
@@ -74,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "They will challenge anything, even strong opponents, without fear. Their frequent fights help them become stronger.",
+		de: "Es zettelt willkürlich Kämpfe an, egal wie stark der Gegner auch ist. Es gewinnt an Stärke, indem es seine Fehler analysiert."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/87.ts
+++ b/data/Black & White/Emerging Powers/87.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Peck",
 				fr: "Picpic",
+				de: "Schnabel"
 			},
 
 			damage: 10,
@@ -49,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Claw",
 				fr: "Ergots",
+				de: "Klaue"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 30,
 
@@ -77,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "They crush berries with their talons. They bravely stand up to any opponent, no matter how strong it is.",
+		de: "Kann mit seinen Füßen Nüsse zermalmen. Es stellt sich jedem noch so starken Gegner tapfer zum Kampf."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/88.ts
+++ b/data/Black & White/Emerging Powers/88.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Rufflet",
 		fr: "Furaiglon",
+		de: "Geronimatz"
 	},
 
 	stage: "Stage1",
@@ -42,6 +43,7 @@ const card: Card = {
 			name: {
 				en: "Wing Attack",
 				fr: "Cru-Aile",
+				de: "Flügelschlag"
 			},
 
 			damage: 40,
@@ -56,10 +58,12 @@ const card: Card = {
 			name: {
 				en: "Brave Bird",
 				fr: "Rapace",
+				de: "Sturzflug"
 			},
 			effect: {
 				en: "This Pokémon does 30 damage to itself.",
 				fr: "Ce Pokémon s'inflige 30 dégâts.",
+				de: "Dieses Pokémon fügt sich selbst 30 Schadenspunkte zu."
 			},
 			damage: 90,
 
@@ -84,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "The more scars they have, the more respect these brave soldiers of the sky get from their peers.",
+		de: "Ein tapferer Krieger der Lüfte. Je mehr Narben es vorweisen kann, desto mehr Respekt zollen ihm seine Artgenossen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/89.ts
+++ b/data/Black & White/Emerging Powers/89.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Energy Wheel",
 				fr: "Roue d'Énergie",
+				de: "Energierad"
 			},
 			effect: {
 				en: "Move an Energy from 1 of your Benched Pokémon to this Pokémon.",
 				fr: "Déplacez une Énergie de l'un de vos Pokémon de Banc vers ce Pokémon.",
+				de: "Verschiebe 1 an 1 Pokémon auf deiner Bank angelegte Energie auf dieses Pokémon."
 			},
 
 		},
@@ -52,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Hurricane",
 				fr: "Vent Violent",
+				de: "Orkan"
 			},
 			effect: {
 				en: "Move a basic Energy from this Pokémon to 1 of your Benched Pokémon.",
 				fr: "Déplacez une Énergie de base de ce Pokémon vers 1 de vos Pokémon de Banc.",
+				de: "Verschiebe 1 an dieses Pokémon angelegte Basis-Energie auf 1 Pokémon auf deiner Bank."
 			},
 			damage: 80,
 
@@ -80,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "The lower half of its body is wrapped in a cloud of energy. It zooms through the sky at 200 mph.",
+		de: "Sein Unterkörper ist in eine wolkenartige Energieschicht gehüllt. Es jagt mit bis zu 300 km/h durch die Lüfte."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/9.ts
+++ b/data/Black & White/Emerging Powers/9.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Absorb",
 				fr: "Vol-Vie",
+				de: "Absorber"
 			},
 			effect: {
 				en: "Heal 10 damage from this Pokémon.",
 				fr: "Soignez 10 dégâts à ce Pokémon.",
+				de: "Heile 10 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 10,
 
@@ -64,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "They go wherever the wind takes them. On rainy days, their bodies are heavier, so they take shelter beneath big trees.",
+		de: "Lässt sich unbekümmert vom Wind treiben. Regen beschwert seinen Körper, sodass es unter großen Bäumen Schutz sucht."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/90.ts
+++ b/data/Black & White/Emerging Powers/90.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba cartas hasta que tengas 6 cartas en tu mano.",
 		it: "Pesca fino ad avere sei carte in mano.",
 		pt: "Compre cards até ter 6 cards em sua mão.",
-		de: "Ziehe so viele Karten, bis du 6 Karten auf der Hand hast."
+		de: "Ziehe so viele Karten, bis du 6 Karten auf der Hand hast. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Black & White/Emerging Powers/91.ts
+++ b/data/Black & White/Emerging Powers/91.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba 3 cartas.",
 		it: "Pesca tre carte.",
 		pt: "Compre 3 cards.",
-		de: "Ziehe 3 Karten."
+		de: "Ziehe 3 Karten. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Black & White/Emerging Powers/92.ts
+++ b/data/Black & White/Emerging Powers/92.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Lanza una moneda. Si sale cara, descarta una Energía unida a 1 de los Pokémon de tu rival.",
 		it: "Lancia una moneta. Se esce testa, scarta un’Energia assegnata a uno dei Pokémon del tuo avversario.",
 		pt: "Você pode jogar tantos cards de Item quanto desejar na sua vez (antes de atacar).",
-		de: "Wirf 1 Münze. Lege bei „Kopf“ 1 an ein gegnerisches Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
+		de: "Wirf 1 Münze. Lege bei „Kopf“ 1 an ein gegnerisches Pokémon angelegte Energie auf den Ablagestapel deines Gegners. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Emerging Powers/93.ts
+++ b/data/Black & White/Emerging Powers/93.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mira las 7 primeras cartas de tu baraja. Puedes enseñar un Pokémon que encuentres entre ellas y ponerlo en tu mano. Pon el resto de cartas de nuevo en tu baraja y barájalas todas.",
 		it: "Guarda le prime sette carte del tuo mazzo. Puoi mostrare un Pokémon che hai trovato e aggiungerlo alle carte che hai in mano. Poi rimischia le altre carte nel tuo mazzo.",
 		pt: "Olhe os 7 cards de cima do seu baralho. Você poderá revelar um Pokémon que encontrar lá e colocá-lo em sua mão. Embaralhe os demais cards de volta.",
-		de: "Schau dir die obersten 7 Karten deines Decks an. Du kannst 1 darunter gefundenes Pokémon zeigen und es auf deine Hand nehmen. Mische die anderen Karten anschließend zurück in dein Deck."
+		de: "Schau dir die obersten 7 Karten deines Decks an. Du kannst 1 Pokémon, das du dort gefunden hast, deinem Gegner zeigen und auf deine Hand nehmen. Mische die anderen Karten zurück in dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Emerging Powers/94.ts
+++ b/data/Black & White/Emerging Powers/94.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cura todos los puntos de daño a 1 de tus Pokémon. Después, descarta todas las Energías unidas a ese Pokémon.",
 		it: "Cura uno dei tuoi Pokémon da tutti i danni. Poi scarta tutta l’Energia assegnata a quel Pokémon.",
 		pt: "Cure todos os danos de 1 dos seus Pokémon. Em seguida, descarte toda a Energia ligada a este Pokémon.",
-		de: "Heile allen Schaden bei 1 deiner Pokémon. Lege alle Energien, die an das Pokémon angelegt sind, auf deinen Ablagestapel."
+		de: "Heile allen Schaden bei 1 deiner Pokémon. Lege alle Energien, die an das Pokémon angelegt sind, auf deinen Ablagestapel. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Emerging Powers/95.ts
+++ b/data/Black & White/Emerging Powers/95.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Lanza 1 moneda. Si sale cara, cambia 1 de los Pokémon en Banca de tu rival por su Pokémon Activo.",
 		it: "Lancia una moneta. Se esce testa, scambia uno dei Pokémon nella panchina del tuo avversario con il suo Pokémon attivo.",
 		pt: "Jogue uma moeda. Se sair cara, troque 1 dos Pokémon no Banco do seu oponente pelo Pokémon Ativo desse oponente.",
-		de: "Wirf 1 Münze. Bei „Kopf“ kannst du 1 Pokémon auf der Bank deines Gegners gegen sein Aktives Pokémon austauschen."
+		de: "Tausche das Aktive Pokémon deines Gegners gegen 1 Pokémon auf seiner Bank aus. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Emerging Powers/96.ts
+++ b/data/Black & White/Emerging Powers/96.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Puedes jugar tantas cartas de Objeto como quieras durante tu turno (antes de tu ataque).",
 		it: "Puoi giocare tutte le carte Strumento che vuoi durante il tuo turno, prima di attaccare.",
 		pt: "Jogue uma moeda. Se sair cara, coloque um card da sua pilha de descarte em cima do seu baralho.",
-		de: "Wirf 1 Münze. Lege bei „Kopf“ 1 Karte von deinem Ablagestapel auf dein Deck."
+		de: "Wirf 1 Münze. Lege bei „Kopf“ 1 Karte von deinem Ablagestapel auf dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Emerging Powers/97.ts
+++ b/data/Black & White/Emerging Powers/97.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Charge",
 				fr: "Chargeur",
+				de: "Ladevorgang"
 			},
 			effect: {
 				en: "Search your deck for a Lightning Energy card and attach it to this Pokémon. Shuffle your deck afterward.",
 				fr: "Cherchez une carte Énergie Lightning dans votre deck et attachez-la à ce Pokémon. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 1 {L}-Energiekarte und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
 			},
 
 		},
@@ -52,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Disaster Volt",
 				fr: "Éclair Désastre",
+				de: "Stromschwall"
 			},
 			effect: {
 				en: "Discard an Energy attached to this Pokémon.",
 				fr: "Défaussez une Énergie attachée à ce Pokémon.",
+				de: "Lege 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel."
 			},
 			damage: 80,
 
@@ -73,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "The spikes on its tail discharge immense bolts of lightning. It flies around the Unova region firing off lightning bolts.",
+		de: "Es greift mit elektrischer Ladung aus den Dornen seiner Rute an und bombardiert Einall aus der Luft mit Blitzen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Emerging Powers/98.ts
+++ b/data/Black & White/Emerging Powers/98.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Energy Wheel",
 				fr: "Roue d'Énergie",
+				de: "Energierad"
 			},
 			effect: {
 				en: "Move an Energy from 1 of your Benched Pokémon to this Pokémon.",
 				fr: "Déplacez une Énergie de l'un de vos Pokémon de Banc vers ce Pokémon.",
+				de: "Verschiebe 1 an 1 Pokémon auf deiner Bank angelegte Energie auf dieses Pokémon."
 			},
 
 		},
@@ -52,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Hurricane",
 				fr: "Vent Violent",
+				de: "Orkan"
 			},
 			effect: {
 				en: "Move a basic Energy from this Pokémon to 1 of your Benched Pokémon.",
 				fr: "Déplacez une Énergie de base de ce Pokémon vers 1 de vos Pokémon de Banc.",
+				de: "Verschiebe 1 an dieses Pokémon angelegte Basis-Energie auf 1 Pokémon auf deiner Bank."
 			},
 			damage: 80,
 
@@ -80,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "The lower half of its body is wrapped in a cloud of energy. It zooms through the sky at 200 mph.",
+		de: "Sein Unterkörper ist in eine wolkenartige Energieschicht gehüllt. Es jagt mit bis zu 300 km/h durch die Lüfte."
 	},
 
 	thirdParty: {


### PR DESCRIPTION
## Add missing German translations for bw2

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
