### PR TITLE
Add missing German translations for bw3

### DIFF
--- a/data/Black & White/Noble Victories/1.ts
+++ b/data/Black & White/Noble Victories/1.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Leaf Boomerang",
 				fr: "Feuille-Boomerang",
+				de: "Blätter-Bumerang"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "Leavanny dress it in clothes they made for it when it hatched. It hides its head in its hood while it is sleeping.",
+		de: "Gleich nach dem Schlüpfen näht Matrifol ihm ein Kleidchen. Wenn es schläft, verbirgt es den Kopf unter einer Haube."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/10.ts
+++ b/data/Black & White/Noble Victories/10.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Foongus",
 		fr: "Trompignon",
+		de: "Tarnpignon"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Toxic",
 				fr: "Toxik",
+				de: "Toxin"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned. Put 2 damage counters instead of 1 on that Pokémon between turns.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné. Placez 2 marqueurs de dégâts au lieu d'un sur le Pokémon ciblé entre chaque tour.",
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet. Lege zwischen den Zügen 2 Schadensmarken anstelle von 1 Schadensmarke auf das Pokémon."
 			},
 
 		},
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Body Slam",
 				fr: "Plaquage",
+				de: "Bodyslam"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 30,
 
@@ -84,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "They show off their Poké Ball caps to lure prey, but very few Pokémon are fooled by this.",
+		de: "Um Beute anzulocken, bietet es seinen Hut feil, der einem Pokéball ähnelt. Doch kaum ein Pokémon fällt darauf herein."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/100.ts
+++ b/data/Black & White/Noble Victories/100.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Energy Press",
 				fr: "Pression Énergétique",
+				de: "Energiedruck"
 			},
 			effect: {
 				en: "Does 20 more damage for each Energy attached to the Defending Pokémon.",
 				fr: "Inflige 20 dégâts supplémentaires pour chaque Énergie attachée au Pokémon Défenseur.",
+				de: "Dieser Angriff fügt 20 weitere Schadenspunkte für jede an das Verteidigende Pokémon angelegte Energie zu."
 			},
 			damage: 20,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Iron Breaker",
 				fr: "Brise-Fer",
+				de: "Eisenbrecher"
 			},
 			effect: {
 				en: "The Defending Pokémon can't attack during your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas attaquer pendant le prochain tour de votre adversaire.",
+				de: "Das Verteidigende Pokémon kann während des nächsten Zuges deines Gegners nicht angreifen."
 			},
 			damage: 80,
 
@@ -82,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "It has a body and heart of steel. Its glare is sufficient to make even an unruly Pokémon obey it.",
+		de: "Sein Körper und sein Herz sind aus Stahl. Ein böser Blick genügt und selbst die wildesten Pokémon unterwerfen sich ihm."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/101.ts
+++ b/data/Black & White/Noble Victories/101.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cada jugador baraja las cartas de su mano en su baraja. Luego, cada jugador roba una carta por cada una de las cartas de Premio que le queden.",
 		it: "Ogni giocatore rimischia le carte che ha in mano nel proprio mazzo. Quindi, ogni giocatore pesca una carta per ogni carta Premio che gli resta.",
 		pt: "Cada jogador embaralha sua mão em seu próprio baralho. Cada jogador então compra um card para cada um de seus cards de Prêmio restantes.",
-		de: "Jeder Spieler mischt seine Hand zurück in sein Deck. Anschließend zieht jeder Spieler eine Karte für jede seiner noch übrigen Preiskarten."
+		de: "Jeder Spieler mischt seine Hand zurück in sein Deck. Anschließend zieht jeder Spieler eine Karte für jede seiner noch übrigen Preiskarten. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Black & White/Noble Victories/102.ts
+++ b/data/Black & White/Noble Victories/102.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Fury Swipes",
 				fr: "Combo-Griffe",
+				de: "Kratzfurie"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 10,
 
@@ -52,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Pay Day",
 				fr: "Jackpot",
+				de: "Zahltag"
 			},
 			effect: {
 				en: "Draw a card.",
 				fr: "Piochez une carte.",
+				de: "Ziehe 1 Karte."
 			},
 			damage: 20,
 
@@ -73,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "This is an extremely rare Meowth card. Maybe good fortune will come to you if you hold this card!",
+		de: "Dies ist eine sehr seltene Mauzi-Karte. Vielleicht bringt sie dir ja Glück, wenn du sie auf der Hand hast!"
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/11.ts
+++ b/data/Black & White/Noble Victories/11.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Mysterious Evolution",
 				fr: "Évolution Mystérieuse",
+				de: "Mysteriöse Entwicklung"
 			},
 			effect: {
 				en: "If Karrablast is in play, search your deck for a card that evolves from this Pokémon and put it onto this Pokémon. (This counts as evolving this Pokémon.) Shuffle your deck afterward.",
 				fr: "Si Carabing est en jeu, cherchez dans votre deck une carte Évolution de ce Pokémon et placez-la sur ce Pokémon. (Cela équivaut à faire évoluer ce Pokémon.) Mélangez ensuite votre deck.",
+				de: "Wenn Laukaps im Spiel ist, durchsuche dein Deck nach einer Karte, zu der sich dieses Pokémon entwickelt, und lege sie auf dieses Pokémon (dies zählt als Entwicklung dieses Pokémon). Mische anschließend dein Deck."
 			},
 
 		},
@@ -50,6 +52,7 @@ const card: Card = {
 			name: {
 				en: "Ram",
 				fr: "Collision",
+				de: "Ramme"
 			},
 
 			damage: 10,
@@ -68,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "It evolves when bathed in an electric-like energy along with Karrablast. The reason is still unknown.",
+		de: "Führt man ihm mit Laukaps elektrische Energie zu, entwickelt es sich. Niemand kennt den Grund dafür."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/12.ts
+++ b/data/Black & White/Noble Victories/12.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Shelmet",
 		fr: "Escargaume",
+		de: "Schnuthelm"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Acid Spray",
 				fr: "Bombe Acide",
+				de: "Säurespeier"
 			},
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, défaussez une Énergie attachée au Pokémon Défenseur.",
+				de: "Wirf 1 Münze. Lege bei „Kopf“ 1 an das Verteidigende Pokémon angelegte Energie auf den Ablagestapel."
 			},
 			damage: 20,
 
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Slashing Strike",
 				fr: "Coup Déchirant",
+				de: "Schlitzender Schlag"
 			},
 			effect: {
 				en: "This Pokémon can't use Slashing Strike during your next turn.",
 				fr: "Ce Pokémon ne peut pas utiliser Coup Déchirant pendant votre prochain tour.",
+				de: "Dieses Pokémon kann Schlitzender Schlag während deines nächsten Zuges nicht einsetzen."
 			},
 			damage: 60,
 
@@ -77,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "Having removed its heavy shell, it becomes very light and can fight with ninja-like movements.",
+		de: "Seit es die schwere Muschel abgestreift hat, ist es viel leichter. Nun gleichen seine Kampfbewegungen denen eines Ninja."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/13.ts
+++ b/data/Black & White/Noble Victories/13.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Double Draw",
 				fr: "Double Pioche",
+				de: "Zweifachzug"
 			},
 			effect: {
 				en: "Draw 2 cards.",
 				fr: "Piochez 2 cartes.",
+				de: "Ziehe 2 Karten."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Leaf Wallop",
 				fr: "Rafale de Feuilles",
+				de: "Blattprügel"
 			},
 			effect: {
 				en: "During your next turn, this Pokémon's Leaf Wallop attack does 40 more damage (before applying Weakness and Resistance).",
 				fr: "Pendant votre prochain tour, l'attaque Rafale de Feuilles de ce Pokémon inflige 40 dégâts supplémentaires (avant application de la Faiblesse et de la Résistance).",
+				de: "Während deines nächsten Zuges fügt die Attacke Blattprügel dieses Pokémon 40 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 			damage: 40,
 
@@ -79,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "Its head sprouts horns as sharp as blades. Using whirlwind-like movements, it confounds and swiftly cuts opponents.",
+		de: "Das Horn an seinem Kopf ist eine scharfe Klinge. Neckt seine Gegner mit quirligen Bewegungen und greift blitzartig an."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/14.ts
+++ b/data/Black & White/Noble Victories/14.ts
@@ -59,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Stored Power",
 				fr: "Force Ajoutée",
+				de: "Kraftvorrat"
 			},
 			effect: {
 				en: "Move all Energy attached to this Pokémon to 1 of your Benched Pokémon.",
 				fr: "Déplacez toutes les Énergies attachées à ce Pokémon vers 1 de vos Pokémon de Banc.",
+				de: "Verschiebe alle an dieses Pokémon angelegte Energie auf 1 Pokémon auf deiner Bank."
 			},
 			damage: 30,
 
@@ -80,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon brings victory. It is said that Trainers with Victini always win, regardless of the type of encounter.",
+		de: "Ein siegverheißendes Pokémon. Man sagt, Trainer, die ein Victini in ihrem Team haben, seien unschlagbar."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/15.ts
+++ b/data/Black & White/Noble Victories/15.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "V-create",
 				fr: "Coup Victoire",
+				de: "V-Generator"
 			},
 			effect: {
 				en: "If you have 4 or fewer Benched Pokémon, this attack does nothing.",
 				fr: "Si vous avez 4 Pokémon de Banc ou moins, cette attaque ne fait rien.",
+				de: "Dieser Angriff hat keine Auswirkungen, wenn du 4 oder weniger Pokémon auf deiner Bank hast."
 			},
 			damage: 100,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon brings victory. It is said that Trainers with Victini always win, regardless of the type of encounter.",
+		de: "Ein siegverheißendes Pokémon. Man sagt, Trainer, die ein Victini in ihrem Team haben, seien unschlagbar."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/16.ts
+++ b/data/Black & White/Noble Victories/16.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Beat",
 				fr: "Bataille",
+				de: "Verprügler"
 			},
 
 			damage: 10,
@@ -50,10 +51,12 @@ const card: Card = {
 			name: {
 				en: "Lunge",
 				fr: "Coup Rapide",
+				de: "Ausfall"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 60,
 
@@ -71,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon lives in caves in volcanoes. The fire within the tuft on its head can reach 600° F.",
+		de: "Das Feuer in seinem Kopfbüschel erreicht Temperaturen von bis zu 300 Grad. Es ist in Vulkanhöhlen zu Hause."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/17.ts
+++ b/data/Black & White/Noble Victories/17.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pansear",
 		fr: "Flamajou",
+		de: "Grillmak"
 	},
 
 	stage: "Stage1",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Scratch",
 				fr: "Griffe",
+				de: "Kratzer"
 			},
 
 			damage: 20,
@@ -55,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Double Fire",
 				fr: "Double Feu",
+				de: "Duplexfeuer"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 80 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 80 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 80 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 80,
 
@@ -76,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "A flame burns inside its body. It scatters embers from its head and tail to sear its opponents.",
+		de: "Es entfacht in seinem Körper ein Feuer und verkohlt Gegner mit Funken aus seinem Kopf und Schweif."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/18.ts
+++ b/data/Black & White/Noble Victories/18.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Singe",
 				fr: "Roussi",
+				de: "Versengung"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Burned.",
 				fr: "Le Pokémon Défenseur est maintenant Brûlé.",
+				de: "Das Verteidigende Pokémon ist jetzt verbrannt."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Incinerate",
 				fr: "Calcination",
+				de: "Einäschern"
 			},
 			effect: {
 				en: "Before doing damage, discard a Pokémon Tool card attached to the Defending Pokémon.",
 				fr: "Avant d'infliger des dégâts, défaussez une carte Outil Pokémon attachée au Pokémon Défenseur.",
+				de: "Lege, bevor du Schaden zufügst, 1 an das Verteidigende Pokémon angelegte Pokémon-Ausrüstung auf den Ablagestapel deines Gegners."
 			},
 			damage: 30,
 
@@ -72,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "Using their very hot, flame-covered tongues, they burn through Durant's steel bodies and consume their insides.",
+		de: "Mit seiner brandheißen Zunge bringt es Fermicula zum Schmelzen, um so an sein weiches Inneres zu gelangen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/19.ts
+++ b/data/Black & White/Noble Victories/19.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Ember",
 				fr: "Flammèche",
+				de: "Glut"
 			},
 			effect: {
 				en: "Flip a coin. If tails, discard an Energy attached to this Pokémon.",
 				fr: "Lancez une pièce. Si c'est pile, défaussez une Énergie attachée à ce Pokémon.",
+				de: "Wirf 1 Münze. Lege bei „Zahl“ 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel."
 			},
 			damage: 20,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon was believed to have been born from the sun. When it evolves, its entire body is engulfed in flames.",
+		de: "Bislang vermutet man, es sei ein Produkt der Sonne. Bei der Entwicklung ist sein ganzer Körper in Flammen gehüllt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/2.ts
+++ b/data/Black & White/Noble Victories/2.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Sewaddle",
 		fr: "Larveyette",
+		de: "Strawickl"
 	},
 
 	stage: "Stage1",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 20,
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "String Shot",
 				fr: "Sécrétion",
+				de: "Fadenschuss"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 20,
 
@@ -75,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "Forests where Swadloon live have superb foliage because the nutrients they make from fallen leaves nourish the plant life.",
+		de: "Es wandelt herabgefallenes Laub in Nährstoffe um. In Wäldern, wo es Folikon gibt, fühlen sich Pflanzen pudelwohl."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/20.ts
+++ b/data/Black & White/Noble Victories/20.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Take Down",
 				fr: "Bélier",
+				de: "Bodycheck"
 			},
 			effect: {
 				en: "This Pokémon does 10 damage to itself.",
 				fr: "Ce Pokémon s'inflige 10 dégâts.",
+				de: "Dieses Pokémon fügt sich selbst 10 Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "The base of volcanoes is where they make their homes. They shoot fire from their five horns to repel attacking enemies.",
+		de: "Es lebt am Fuß von Vulkanen. Mit Gegnern räumt es auf, indem es aus seinen fünf Hörnern Flammen auf sie abfeuert."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/21.ts
+++ b/data/Black & White/Noble Victories/21.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Larvesta",
 		fr: "Pyronille",
+		de: "Ignivor"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Fiery Dance",
 				fr: "Danse du Feu",
+				de: "Feuerreigen"
 			},
 			effect: {
 				en: "Attach a basic Energy card from your discard pile to 1 of your Pokémon.",
 				fr: "Attachez une carte Énergie de base de votre pile de défausse à 1 de vos Pokémon.",
+				de: "Lege 1 Basis-Energiekarte von deinem Ablagestapel an 1 deiner Pokémon an."
 			},
 			damage: 30,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Heat Wave",
 				fr: "Canicule",
+				de: "Hitzewelle"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Burned.",
 				fr: "Le Pokémon Défenseur est maintenant Brûlé.",
+				de: "Das Verteidigende Pokémon ist jetzt verbrannt."
 			},
 			damage: 60,
 
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "When volcanic ash darkened the atmosphere, it is said that Volcarona's fire provided a replacement for the sun.",
+		de: "Es heißt, als das Land einst unter einer düsteren Wolke aus Vulkanasche lag, übernahm es die Rolle der Sonne."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/22.ts
+++ b/data/Black & White/Noble Victories/22.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Vibration",
 				fr: "Vibration",
+				de: "Schwingung"
 			},
 
 			damage: 10,
@@ -49,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Mud Shot",
 				fr: "Tir de Boue",
+				de: "Lehmschuss"
 			},
 
 			damage: 20,
@@ -67,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "By vibrating its cheeks, it emits sound waves imperceptible to humans. It uses the rhythm of these sounds to talk.",
+		de: "Erzeugt mit seinen Wangen für Menschen unhörbare Schallwellen. Es verständigt sich über den Rhythmus dieser Wellen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/23.ts
+++ b/data/Black & White/Noble Victories/23.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Tympole",
 		fr: "Tritonde",
+		de: "Schallquap"
 	},
 
 	stage: "Stage1",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Mud Shot",
 				fr: "Tir de Boue",
+				de: "Lehmschuss"
 			},
 
 			damage: 20,
@@ -55,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Round",
 				fr: "Chant Canon",
+				de: "Kanon"
 			},
 			effect: {
 				en: "Does 20 damage times the number of your Pokémon that have the Round attack.",
 				fr: "Inflige 20 dégâts multipliés par le nombre de vos Pokémon possédant l'attaque Chant Canon.",
+				de: "Dieser Angriff fügt 20 Schadenspunkte für jedes deiner Pokémon zu, das Kanon beherrscht."
 			},
 			damage: 20,
 
@@ -76,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives in water and on land. It uses its long, sticky tongue to capture prey.",
+		de: "Es lebt zu Wasser und zu Lande. Mit seiner langen, klebrigen Zunge umklammert und fängt es seine Beute."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/24.ts
+++ b/data/Black & White/Noble Victories/24.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Palpitoad",
 		fr: "Batracné",
+		de: "Mebrana"
 	},
 
 	stage: "Stage2",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Round",
 				fr: "Chant Canon",
+				de: "Kanon"
 			},
 			effect: {
 				en: "Does 30 damage times the number of your Pokémon that have the Round attack.",
 				fr: "Inflige 30 dégâts multipliés par le nombre de vos Pokémon possédant l'attaque Chant Canon.",
+				de: "Dieser Angriff fügt 30 Schadenspunkte für jedes deiner Pokémon zu, das Kanon beherrscht."
 			},
 			damage: 30,
 
@@ -59,6 +62,7 @@ const card: Card = {
 			name: {
 				en: "Hyper Voice",
 				fr: "Mégaphone",
+				de: "Schallwelle"
 			},
 
 			damage: 70,
@@ -77,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "It increases the power of its punches by vibrating the bumps on its fists. It can turn a boulder to rubble with one punch.",
+		de: "Wenn es die Beulen an seinen Fäusten zum Schwingen bringt, kann es doppelt so fest zuschlagen und Felsen zertrümmern."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/25.ts
+++ b/data/Black & White/Noble Victories/25.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Water Gun",
 				fr: "Pistolet à O",
+				de: "Aquaknarre"
 			},
 
 			damage: 30,
@@ -51,6 +52,7 @@ const card: Card = {
 			name: {
 				en: "Surf",
 				fr: "Surf",
+				de: "Surfer"
 			},
 
 			damage: 60,
@@ -69,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "Restored from a fossil, this Pokémon can dive to depths beyond half a mile.",
+		de: "Es wurde aus einem urzeitlichen Fossil reanimiert. Es kann in Tiefen von bis zu 1 000 Metern abtauchen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/26.ts
+++ b/data/Black & White/Noble Victories/26.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Tirtouga",
 		fr: "Carapagos",
+		de: "Galapaflos"
 	},
 
 	stage: "Stage1",
@@ -66,10 +67,12 @@ const card: Card = {
 			name: {
 				en: "Crunch",
 				fr: "Mâchouille",
+				de: "Knirscher"
 			},
 			effect: {
 				en: "Discard an Energy attached to the Defending Pokémon.",
 				fr: "Défaussez une Énergie attachée au Pokémon Défenseur.",
+				de: "Lege 1 an das Verteidigende Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 80,
 
@@ -87,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "They can live both in the ocean and on land. A slap from one of them is enough to open a hole in the bottom of a tanker.",
+		de: "Es lebt im Meer und an Land. Es ist so stark, dass es mit einem einzigen Hieb ein Loch in ein Schiff reißen kann."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/27.ts
+++ b/data/Black & White/Noble Victories/27.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Icicle Barb",
 				fr: "Barbelé de Glace",
+				de: "Eisdorn"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 weitere Schadenspunkte zu."
 			},
 			damage: 10,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon formed from icicles bathed in energy from the morning sun. It sleeps buried in snow.",
+		de: "Ein Eiszapfen, der durch die Energie der aufgehenden Sonne zum Pokémon wurde. Nachts deckt es sich mit Schnee zu."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/28.ts
+++ b/data/Black & White/Noble Victories/28.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Vanillite",
 		fr: "Sorbébé",
+		de: "Gelatini"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Ice Beam",
 				fr: "Laser Glace",
+				de: "Eisstrahl"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 20,
 
@@ -58,6 +61,7 @@ const card: Card = {
 			name: {
 				en: "Frost Breath",
 				fr: "Souffle Glacé",
+				de: "Eisesodem"
 			},
 
 			damage: 40,
@@ -76,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It conceals itself from enemy eyes by creating many small ice particles and hiding among them.",
+		de: "Es erzeugt viele kleine Eiskörner, mit denen es sich vor seinen Gegnern versteckt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/29.ts
+++ b/data/Black & White/Noble Victories/29.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Vanillish",
 		fr: "Sorboul",
+		de: "Gelatroppo"
 	},
 
 	stage: "Stage2",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Double Freeze",
 				fr: "Double Gelure",
+				de: "Doppelfroster"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 40 damage times the number of heads. If either of them is heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 40 dégâts multipliés par le nombre de côtés face. Si vous obtenez au moins un côté face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl „Kopf“ zu. Wenn eine oder beide Münzen „Kopf“ zeigen, ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 40,
 
@@ -58,6 +61,7 @@ const card: Card = {
 			name: {
 				en: "Frost Breath",
 				fr: "Souffle Glacé",
+				de: "Eisesodem"
 			},
 
 			damage: 60,
@@ -76,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "If both heads get angry simultaneously, this Pokémon expels a blizzard, burying everything in snow.",
+		de: "Bringt man beide Köpfe in Rage, stößt sein Horn heftige Eisböen aus, und alles in seiner Umgebung versinkt in Schnee."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/3.ts
+++ b/data/Black & White/Noble Victories/3.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Swadloon",
 		fr: "Couverdure",
+		de: "Folikon"
 	},
 
 	stage: "Stage2",
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Cutting Arm",
 				fr: "Bras Coupant",
+				de: "Schneidarm"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 more damage for each heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts supplémentaires pour chaque côté face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 40,
 
@@ -86,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "Upon finding a small Pokémon, it weaves clothing for it from leaves, using cutters on its arms and sticky silk.",
+		de: "Findet es ein junges Pokémon, kann es nicht anders, als ihm mit seinen Scheren und Klebefäden ein Kleidchen zu nähen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/30.ts
+++ b/data/Black & White/Noble Victories/30.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Rain Splash",
 				fr: "Pluie Éclaboussante",
+				de: "Regenplatscher"
 			},
 
 			damage: 20,
@@ -55,6 +56,7 @@ const card: Card = {
 
 	description: {
 		en: "With its thin, veil-like arms wrapped around the body of its opponent, it sinks to the ocean floor.",
+		de: "Schlingt seine dünnen, schleierartigen Arme um den Gegner und lässt sich mit ihm zum Meeresgrund sinken."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/31.ts
+++ b/data/Black & White/Noble Victories/31.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Frillish",
 		fr: "Viskuse",
+		de: "Quabbel"
 	},
 
 	stage: "Stage1",
@@ -64,10 +65,12 @@ const card: Card = {
 			name: {
 				en: "Hydro Pump",
 				fr: "Hydrocanon",
+				de: "Hydropumpe"
 			},
 			effect: {
 				en: "Does 20 more damage for each Water Energy attached to this Pokémon.",
 				fr: "Inflige 20 dégâts supplémentaires pour chaque Énergie Water attachée à ce Pokémon.",
+				de: "Dieser Angriff fügt 20 weitere Schadenspunkte für jede an dieses Pokémon angelegte {W}-Energie zu."
 			},
 			damage: 10,
 
@@ -85,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "The fate of ships and crew that wander into Jellicent's habitats: all sunken, all lost, all vanished.",
+		de: "Dringt ein Schiff in sein Revier ein, bringt es dieses zum Kentern und saugt die Lebensenergie aus der Besatzung."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/32.ts
+++ b/data/Black & White/Noble Victories/32.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Icy Wind",
 				fr: "Vent Glace",
+				de: "Eissturm"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Ice Shard",
 				fr: "Éclats Glace",
+				de: "Eissplitter"
 			},
 			effect: {
 				en: "If the Defending Pokémon is a Fighting Pokémon, this attack does 40 more damage.",
 				fr: "Si le Pokémon Défenseur est un Pokémon Fighting, cette attaque inflige 40 dégâts supplémentaires.",
+				de: "Wenn das Verteidigende Pokémon ein {F}-Pokémon ist, fügt dieser Angriff 40 weitere Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -72,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "They are born in snow clouds. They use chains made of ice crystals to capture prey.",
+		de: "Es fängt seine Beute mit Ketten, die sich aus Eiskristallen zusammensetzen. Entstanden ist es aus einer Schneewolke."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/33.ts
+++ b/data/Black & White/Noble Victories/33.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Ice Chain",
 				fr: "Chaîne de Glace",
+				de: "Eiskette"
 			},
 			effect: {
 				en: "Switch the Defending Pokémon with 1 of your opponent's Benched Pokémon.",
 				fr: "Échangez le Pokémon Défenseur avec 1 des Pokémon de Banc de votre adversaire.",
+				de: "Tausche das Verteidigende Pokémon gegen 1 Pokémon auf der Bank deines Gegners aus."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Frost Vanish",
 				fr: "Poudreuse d'Escampette",
+				de: "Frostauflöser"
 			},
 			effect: {
 				en: "You may return this Pokémon and all cards attached to it to your hand.",
 				fr: "Vous pouvez reprendre ce Pokémon et toutes les cartes qui lui sont attachées dans votre main.",
+				de: "Du kannst dieses Pokémon und alle daran angelegten Karten zurück auf deine Hand nehmen."
 			},
 			damage: 40,
 
@@ -72,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "They are born in snow clouds. They use chains made of ice crystals to capture prey.",
+		de: "Es fängt seine Beute mit Ketten, die sich aus Eiskristallen zusammensetzen. Entstanden ist es aus einer Schneewolke."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/34.ts
+++ b/data/Black & White/Noble Victories/34.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Outrage",
 				fr: "Colère",
+				de: "Wutanfall"
 			},
 			effect: {
 				en: "Does 10 more damage for each damage counter on this Pokémon.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque marqueur de dégâts placé sur ce Pokémon.",
+				de: "Dieser Angriff fügt 10 weitere Schadenspunkte für jede Schadensmarke auf diesem Pokémon zu."
 			},
 			damage: 20,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Glaciate",
 				fr: "Ère Glaciaire",
+				de: "Eiszeit"
 			},
 			effect: {
 				en: "This attack does 30 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige 30 dégâts à chacun des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt jedem Pokémon deines Gegners 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -74,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "It generates powerful, freezing energy inside itself, but its body became frozen when the energy leaked out.",
+		de: "Sein Körper erzeugt in seinem Inneren gewaltige Mengen an Kälteenergie. Tritt diese jedoch aus, gefriert sein Körper."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/35.ts
+++ b/data/Black & White/Noble Victories/35.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Agility",
 				fr: "Hâte",
+				de: "Agilität"
 			},
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, évitez tous les effets d'attaques (y compris les dégâts) infligés à ce Pokémon pendant le prochain tour de votre adversaire.",
+				de: "Wirf 1 Münze. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die diesem Pokémon zugefügt werden."
 			},
 			damage: 10,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "When thunderclouds cover the sky, it will appear. It can catch lightning with its mane and store the electricity.",
+		de: "Es erscheint, wenn Gewitterwolken den Himmel verdunkeln. Es fängt mit seiner Mähne Blitze und hortet ihre Energie."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/36.ts
+++ b/data/Black & White/Noble Victories/36.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Blitzle",
 		fr: "Zébibron",
+		de: "Elezeba"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Quick Attack",
 				fr: "Vive-Attaque",
+				de: "Ruckzuckhieb"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 10,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Shock Bolt",
 				fr: "Choc'Éclair",
+				de: "Schock-Blitz"
 			},
 			effect: {
 				en: "Flip a coin. If tails, discard all Lightning Energy attached to this Pokémon.",
 				fr: "Lancez une pièce. Si c'est pile, défaussez toutes les Énergies Lightning attachées à ce Pokémon.",
+				de: "Wirf 1 Münze. Lege bei „Zahl“ alle an dieses Pokémon angelegte {L}-Energie auf deinen Ablagestapel."
 			},
 			damage: 90,
 
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "They have lightning-like movements. When Zebstrika run at full speed, the sound of thunder reverberates.",
+		de: "Es ist explosiv wie ein Blitz. Galoppiert es mit voller Geschwindigkeit drauflos, kann man Donnerhall vernehmen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/37.ts
+++ b/data/Black & White/Noble Victories/37.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Electrichain",
 				fr: "Électrichaîne",
+				de: "Stromkette"
 			},
 			effect: {
 				en: "Does 20 more damage if you have any Lightning Pokémon on your Bench.",
 				fr: "Inflige 20 dégâts supplémentaires si vous avez un Pokémon Lightning sur votre Banc.",
+				de: "Dieser Angriff fügt 20 weitere Schadenspunkte zu, wenn sich mindestens 1 {L}-Pokémon auf deiner Bank befindet."
 			},
 			damage: 10,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "They live on treetops and glide using the inside of a cape-like membrane while discharging electricity.",
+		de: "Lebt in den Wipfeln der Waldbäume. Während es durch die Lüfte gleitet, entlädt es Strom aus seinen Fluglappen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/38.ts
+++ b/data/Black & White/Noble Victories/38.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Thunder Wave",
 				fr: "Cage-Éclair",
+				de: "Donnerwelle"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 10,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "While one alone doesn't have much power, a chain of many Tynamo can be as powerful as lightning.",
+		de: "Allein erzeugt es nur wenig Strom, doch tritt es geschlossen im Schwarm auf, gleicht seine Kraft der eines Blitzes."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/39.ts
+++ b/data/Black & White/Noble Victories/39.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 10,
@@ -54,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "While one alone doesn't have much power, a chain of many Tynamo can be as powerful as lightning.",
+		de: "Allein erzeugt es nur wenig Strom, doch tritt es geschlossen im Schwarm auf, gleicht seine Kraft der eines Blitzes."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/4.ts
+++ b/data/Black & White/Noble Victories/4.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Ram",
 				fr: "Collision",
+				de: "Ramme"
 			},
 
 			damage: 10,
@@ -49,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Absorb",
 				fr: "Vol-Vie",
+				de: "Absorber"
 			},
 			effect: {
 				en: "Heal 10 damage from this Pokémon.",
 				fr: "Soignez 10 dégâts à ce Pokémon.",
+				de: "Heile 10 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 10,
 
@@ -77,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "Since they prefer moist, nutrient-rich soil, the areas where Petilil live are known to be good for growing plants.",
+		de: "Da es nährstoffreiche Erde bevorzugt, kann man in Gebieten, in denen es lebt, für gewöhnlich reiche Ernten erwarten."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/40.ts
+++ b/data/Black & White/Noble Victories/40.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Tynamo",
 		fr: "Anchwatt",
+		de: "Zapplardin"
 	},
 
 	stage: "Stage1",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Una vez durante tu turno (antes de tu ataque), puedes unir una carta de Energía Lightning de tu pila de descartes a 1 de tus Pokémon en Banca.",
 				it: "Una sola volta durante il tuo turno, prima di attaccare, puoi assegnare a uno dei tuoi Pokémon in panchina una carta Energia Lightning dalla tua pila degli scarti.",
 				pt: "Uma vez na sua vez de jogar (antes de atacar), você poderá ligar um card de Energia Lightning da sua pilha de descarte a 1 dos seus Pokémon no Banco.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 Lightning-Energiekarte von deinem Ablagestapel an 1 Pokémon auf deiner Bank anlegen."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 {L}-Energiekarte von deinem Ablagestapel an 1 Pokémon auf deiner Bank anlegen."
 			},
 		},
 	],
@@ -65,6 +66,7 @@ const card: Card = {
 			name: {
 				en: "Electric Ball",
 				fr: "Boule de Foudre",
+				de: "Stromball"
 			},
 
 			damage: 50,
@@ -83,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "They coil around foes and shock them with electricity-generating organs that seem simply to be circular patterns.",
+		de: "Die rund gemaserten Flächen erzeugen Strom. Es schlingt sich um den Gegner, presst sie gegen ihn und aktiviert sie."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/41.ts
+++ b/data/Black & White/Noble Victories/41.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eelektrik",
 		fr: "Lampéroie",
+		de: "Zapplalek"
 	},
 
 	stage: "Stage2",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Acid",
 				fr: "Acide",
+				de: "Säure"
 			},
 			effect: {
 				en: "The Defending Pokémon can't retreat during your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas battre en retraite pendant le prochain tour de votre adversaire.",
+				de: "Das Verteidigende Pokémon kann sich während des nächsten Zuges deines Gegners nicht zurückziehen."
 			},
 			damage: 30,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Wild Charge",
 				fr: "Éclair Fou",
+				de: "Stromstoß"
 			},
 			effect: {
 				en: "This Pokémon does 10 damage to itself.",
 				fr: "Ce Pokémon s'inflige 10 dégâts.",
+				de: "Dieses Pokémon fügt sich selbst 10 Schadenspunkte zu."
 			},
 			damage: 90,
 
@@ -80,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "They crawl out of the ocean using their arms. They will attack prey on shore and immediately drag it into the ocean.",
+		de: "Es schleppt sich mithilfe seiner Arme an Land, schnappt nach seiner Beute und zerrt sie augenblicklich ins Meer."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/42.ts
+++ b/data/Black & White/Noble Victories/42.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Mud Shot",
 				fr: "Tir de Boue",
+				de: "Lehmschuss"
 			},
 
 			damage: 20,
@@ -51,10 +52,12 @@ const card: Card = {
 			name: {
 				en: "Thunder",
 				fr: "Fatal-Foudre",
+				de: "Donner"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this Pokémon does 30 damage to itself.",
 				fr: "Lancez une pièce. Si c'est pile, ce Pokémon s'inflige 30 dégâts.",
+				de: "Wirf 1 Münze. Bei „Zahl“ fügt sich dieses Pokémon selbst 30 Schadenspunkte zu."
 			},
 			damage: 60,
 
@@ -72,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "Its skin is very hard, so it is unhurt even if stepped on by sumo wrestlers. It smiles when transmitting electricity.",
+		de: "Dank seiner dicken Haut hält es selbst das Gewicht eines Sumoringers aus. Wenn es Stromschläge verteilt, grinst es."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/43.ts
+++ b/data/Black & White/Noble Victories/43.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "V-blast",
 				fr: "Explo-Victoire",
+				de: "V-Kracher"
 			},
 			effect: {
 				en: "Flip 2 coins. If either of them is tails, this attack does nothing.",
 				fr: "Lancez 2 pièces. Si vous obtenez au moins un côté pile, cette attaque ne fait rien.",
+				de: "Wirf 2 Münzen. Wenn eine oder beide Münzen „Zahl“ zeigen, hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 120,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "It creates an unlimited supply of energy inside its body, which it shares with those who touch it.",
+		de: "Es erzeugt im Inneren seines Körpers grenzenlose Energie, die es mit jedem teilt, der mit ihm in Berührung kommt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/44.ts
+++ b/data/Black & White/Noble Victories/44.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Perplex",
 				fr: "Affolement",
+				de: "Perplex"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: 10,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "Each of them carries a mask that used to be its face when it was human. Sometimes they look at it and cry.",
+		de: "Seine Maske ist ein Abbild des Gesichts, das es als Mensch hatte. Manchmal weint es, wenn man ihm in die Augen sieht."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/45.ts
+++ b/data/Black & White/Noble Victories/45.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Ambush",
 				fr: "Embuscade",
+				de: "Hinterhalt"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 weitere Schadenspunkte zu."
 			},
 			damage: 10,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "These Pokémon arose from the spirits of people interred in graves in past ages. Each retains memories of its former life.",
+		de: "Es entsteht aus den Seelen von längst begrabenen Menschen und kann sich noch immer an deren Vergangenheit erinnern."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/46.ts
+++ b/data/Black & White/Noble Victories/46.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Yamask",
 		fr: "Tutafeh",
+		de: "Makabaja"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Damagriiigus",
 				fr: "Tutankarnage",
+				de: "Schadtoll"
 			},
 			effect: {
 				en: "Move all damage counters from 1 of your Benched Pokémon to the Defending Pokémon.",
 				fr: "Déplacez tous les marqueurs de dégâts de l'un de vos Pokémon de Banc vers le Pokémon Défenseur.",
+				de: "Verschiebe alle Schadensmarken von 1 Pokémon auf deiner Bank auf das Verteidigende Pokémon."
 			},
 
 		},
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Perplex",
 				fr: "Affolement",
+				de: "Perplex"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Confused.",
 				fr: "Le Pokémon Défenseur est maintenant Confus.",
+				de: "Das Verteidigende Pokémon ist jetzt verwirrt."
 			},
 			damage: 30,
 
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "It has been said that they swallow those who get too close and turn them into mummies. They like to eat gold nuggets.",
+		de: "Angeblich verschlingt es jeden, der sich ihm auch nur nähert. Besonders gern frisst es Klumpen aus reinem Gold."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/47.ts
+++ b/data/Black & White/Noble Victories/47.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Yamask",
 		fr: "Tutafeh",
+		de: "Makabaja"
 	},
 
 	stage: "Stage1",
@@ -64,10 +65,12 @@ const card: Card = {
 			name: {
 				en: "Ambush",
 				fr: "Embuscade",
+				de: "Hinterhalt"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 40,
 
@@ -85,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "They pretend to be elaborate coffins to teach lessons to grave robbers. Their bodies are covered in pure gold.",
+		de: "Es tarnt sich als prächtiger Sarkophag und zieht Grabräubern die Ohren lang. Sein Körper ist mit Gold überzogen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/48.ts
+++ b/data/Black & White/Noble Victories/48.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Garbage Collection",
 				fr: "Fouille Poubelle",
+				de: "Müllabfuhr"
 			},
 			effect: {
 				en: "Put a card from your discard pile on top of your deck.",
 				fr: "Mettez n'importe quelle carte de votre pile de défausse sur le dessus de votre deck.",
+				de: "Lege 1 beliebige Karte von deinem Ablagestapel auf dein Deck."
 			},
 
 		},
@@ -51,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Sludge Bomb",
 				fr: "Bomb-Beurk",
+				de: "Matschbombe"
 			},
 
 			damage: 20,
@@ -69,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "The combination of garbage bags and industrial waste caused the chemical reaction that created this Pokémon.",
+		de: "Eine Mülltüte, der Industrieabfälle und chemische Reaktionen neues Leben eingehaucht haben."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/49.ts
+++ b/data/Black & White/Noble Victories/49.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Trubbish",
 		fr: "Miamiasme",
+		de: "Unratütox"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Gentle Wrap",
 				fr: "Enveloppe Douce",
+				de: "Sanfte Umarmung"
 			},
 			effect: {
 				en: "The Defending Pokémon can't retreat during your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas battre en retraite pendant le prochain tour de votre adversaire.",
+				de: "Das Verteidigende Pokémon kann sich während des nächsten Zuges deines Gegners nicht zurückziehen."
 			},
 			damage: 30,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Gunk Shot",
 				fr: "Détricanon",
+				de: "Mülltreffer"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné.",
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet."
 			},
 			damage: 60,
 
@@ -80,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "They absorb garbage and make it part of their bodies. They shoot poisonous liquid from their right-hand fingertips.",
+		de: "Es verschlingt Abfall und macht ihn zu einem Teil seines Körpers. Mit seinen rechten Fingerspitzen versprüht es Gift."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/5.ts
+++ b/data/Black & White/Noble Victories/5.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Petilil",
 		fr: "Chlorobule",
+		de: "Lilminip"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Aromax",
 				fr: "Parfum Régénérant",
+				de: "Aromax"
 			},
 			effect: {
 				en: "Heal all damage from 1 of your Benched Pokémon.",
 				fr: "Soignez tous les dégâts de l'un de vos Pokémon de Banc.",
+				de: "Heile allen Schaden bei 1 Pokémon auf deiner Bank."
 			},
 
 		},
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Windmill",
 				fr: "Moulin à Vent",
+				de: "Windmühle"
 			},
 			effect: {
 				en: "Switch this Pokémon with 1 of your Benched Pokémon.",
 				fr: "Échangez ce Pokémon avec 1 de vos Pokémon de Banc.",
+				de: "Tausche dieses Pokémon gegen 1 Pokémon auf deiner Bank aus."
 			},
 			damage: 30,
 
@@ -84,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "The fragrance of the garland on its head has a relaxing effect. It withers if a Trainer does not take good care of it.",
+		de: "Der Duft des Blumenschmucks auf seinem Kopf wirkt beruhigend. Damit der Schmuck nicht verwelkt, muss man es gut pflegen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/50.ts
+++ b/data/Black & White/Noble Victories/50.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Rollout",
 				fr: "Roulade",
+				de: "Walzer"
 			},
 
 			damage: 10,
@@ -54,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "They drive away attackers by unleashing psychic power. They can use telepathy to talk with others.",
+		de: "Es wehrt Angreifer ab, indem es Psycho-Kräfte auf sie ansetzt. Es kommuniziert telepathisch mit Artgenossen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/51.ts
+++ b/data/Black & White/Noble Victories/51.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Solosis",
 		fr: "Nucléos",
+		de: "Monozyto"
 	},
 
 	stage: "Stage1",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Rollout",
 				fr: "Roulade",
+				de: "Walzer"
 			},
 
 			damage: 20,
@@ -59,6 +61,7 @@ const card: Card = {
 
 	description: {
 		en: "Since they have two divided brains, at times they suddenly try to take two different actions at once.",
+		de: "Wegen seines gespaltenen Denkapparates kann es vorkommen, dass es sich abrupt einer anderen Tätigkeit zuwendet."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/52.ts
+++ b/data/Black & White/Noble Victories/52.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Duosion",
 		fr: "Méios",
+		de: "Mitodos"
 	},
 
 	stage: "Stage2",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Future Sight",
 				fr: "Prescience",
+				de: "Seher"
 			},
 			effect: {
 				en: "Look at the top 5 cards of your deck and put them back on top of your deck in any order.",
 				fr: "Regardez les 5 cartes du dessus de votre deck et replacez-les sur le dessus de votre deck dans l'ordre de votre choix.",
+				de: "Schau dir die obersten 5 Karten deines Decks an und lege sie in beliebiger Reihenfolge zurück auf dein Deck."
 			},
 
 		},
@@ -55,10 +58,12 @@ const card: Card = {
 			name: {
 				en: "Net Force",
 				fr: "Force Accrue",
+				de: "Netzkraft"
 			},
 			effect: {
 				en: "Does 40 damage times the number of Reuniclus you have in play.",
 				fr: "Inflige 40 dégâts multipliés par le nombre de Symbios que vous avez en jeu.",
+				de: "Dieser Angriff fügt 40 Schadenspunkte für jedes Zytomega, das du im Spiel hast, zu."
 			},
 			damage: 40,
 
@@ -76,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "When Reuniclus shake hands, a network forms between their brains, increasing their psychic power.",
+		de: "Schütteln sich zwei von ihnen die Hände, bilden ihre Denkapparate ein Netzwerk und ihre Psycho-Kräfte werden stärker."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/53.ts
+++ b/data/Black & White/Noble Victories/53.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Duosion",
 		fr: "Méios",
+		de: "Mitodos"
 	},
 
 	stage: "Stage2",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Dizzy Punch",
 				fr: "Uppercut",
+				de: "Irrschlag"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 30 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 30,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Mind Bend",
 				fr: "Contrôleur d'Esprit",
+				de: "Gedankenverbiegung"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Confused.",
 				fr: "Le Pokémon Défenseur est maintenant Confus.",
+				de: "Das Verteidigende Pokémon ist jetzt verwirrt."
 			},
 			damage: 60,
 
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "These remarkably intelligent Pokémon fight by controlling arms that can grip with rock-crushing power.",
+		de: "Sein Griff ist so stark, dass es damit ganze Felsen zermalmen kann. Es ist sehr intelligent."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/54.ts
+++ b/data/Black & White/Noble Victories/54.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Headbutt",
 				fr: "Coup d'Boule",
+				de: "Kopfnuss"
 			},
 
 			damage: 10,
@@ -48,10 +49,12 @@ const card: Card = {
 			name: {
 				en: "Calm Mind",
 				fr: "Plénitude",
+				de: "Gedankengut"
 			},
 			effect: {
 				en: "Heal 30 damage from this Pokémon.",
 				fr: "Soignez 30 dégâts à ce Pokémon.",
+				de: "Heile 30 Schadenspunkte bei diesem Pokémon."
 			},
 
 		},
@@ -68,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon had never been seen until it appeared from far in the desert 50 years ago.",
+		de: "Bevor es vor 50 Jahren urplötzlich aus den Tiefen der Wüste erschien, hatte es kein Mensch je zuvor gesehen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/55.ts
+++ b/data/Black & White/Noble Victories/55.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "First Contact",
 				fr: "Premier Contact",
+				de: "Erstkontakt"
 			},
 			effect: {
 				en: "Search your deck for 2 Basic Pokémon and put them onto your Bench. Shuffle your deck afterward.",
 				fr: "Cherchez 2 Pokémon de base dans votre deck et placez-les sur votre Banc. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 2 Basis-Pokémon-Karten und lege sie auf deine Bank. Mische anschließend dein Deck."
 			},
 
 		},
@@ -51,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Headbutt",
 				fr: "Coup d'Boule",
+				de: "Kopfnuss"
 			},
 
 			damage: 20,
@@ -69,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "It uses its strong psychic power to squeeze its opponent's brain, causing unendurable headaches.",
+		de: "Es verfügt über mächtige Psycho-Kräfte, mit denen es die Hirne seiner Gegner verwirrt, um ihnen Kopfweh zu bereiten."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/56.ts
+++ b/data/Black & White/Noble Victories/56.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Elgyem",
 		fr: "Lewsor",
+		de: "Pygraulon"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Synchronoise",
 				fr: "Synchropeine",
+				de: "Synchrolärm"
 			},
 			effect: {
 				en: "Does 20 damage to each of your opponent's Benched Pokémon that shares a type with the Defending Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 20 dégâts à chacun des Pokémon de Banc de votre adversaire ayant un type en commun avec le Pokémon Défenseur.  (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt jedem Pokémon auf der Bank deines Gegners, das denselben Typ wie das Verteidigende Pokémon hat, 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 20,
 
@@ -57,6 +60,7 @@ const card: Card = {
 			name: {
 				en: "Psyshot",
 				fr: "Piqûre Psy",
+				de: "Psychoschuss"
 			},
 
 			damage: 40,
@@ -75,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "It uses psychic power to control an opponent's brain and tamper with its memories.",
+		de: "Es manipuliert die Gehirne seiner Gegner mit Psycho-Kräften, indem es die Bilder ihrer Erinnerungen umgestaltet."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/57.ts
+++ b/data/Black & White/Noble Victories/57.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Searing Flame",
 				fr: "Flammes Calcinantes",
+				de: "Sengende Flammen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Burned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Brûlé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verbrannt."
 			},
 			damage: 20,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "Litwick shines a light that absorbs the life energy of people and Pokémon, which becomes the fuel it burns.",
+		de: "Es entfacht eine Flamme, die von der Lebensenergie eines Menschen oder eines Pokémon zehrt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/58.ts
+++ b/data/Black & White/Noble Victories/58.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Teleportation Burst",
 				fr: "Téléportation Explosive",
+				de: "Blitz-Teleportation"
 			},
 			effect: {
 				en: "Switch this Pokémon with 1 of your Benched Pokémon.",
 				fr: "Échangez ce Pokémon avec 1 de vos Pokémon de Banc.",
+				de: "Tausche dieses Pokémon gegen 1 Pokémon auf deiner Bank aus."
 			},
 			damage: 10,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "While shining a light and pretending to be a guide, it leaches off the life force of any who follow it.",
+		de: "Es entzündet ein Licht und gibt vor, dem Gegner den Weg zu weisen, doch eigtl. saugt es ihm seine Lebensenergie ab."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/59.ts
+++ b/data/Black & White/Noble Victories/59.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Litwick",
 		fr: "Funécire",
+		de: "Lichtel"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Luring Light",
 				fr: "Appât Lumineux",
+				de: "Köderleuchte"
 			},
 			effect: {
 				en: "Switch the Defending Pokémon with 1 of your opponent's Benched Pokémon.",
 				fr: "Échangez le Pokémon Défenseur avec 1 des Pokémon de Banc de votre adversaire.",
+				de: "Tausche das Verteidigende Pokémon gegen 1 Pokémon auf der Bank deines Gegners aus."
 			},
 
 		},
@@ -56,6 +59,7 @@ const card: Card = {
 			name: {
 				en: "Will-O-Wisp",
 				fr: "Feu Follet",
+				de: "Irrlicht"
 			},
 
 			damage: 30,
@@ -74,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "This ominous Pokémon is feared. Through cities it wanders, searching for the spirits of the fallen.",
+		de: "Es irrt ziellos auf der Suche nach den Seelen der Verstorbenen durch die Stadt. Als Unglücksbringer gefürchtet."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/6.ts
+++ b/data/Black & White/Noble Victories/6.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Withdraw",
 				fr: "Repli",
+				de: "Panzerschutz"
 			},
 			effect: {
 				en: "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, évitez tous les dégâts infligés à ce Pokémon par des attaques pendant le prochain tour de votre adversaire.",
+				de: "Wirf 1 Münze. Bei „Kopf“ verhindere allen Schaden, der diesem Pokémon während des nächsten Zuges deines Gegners durch Angriffe zugefügt würde."
 			},
 
 		},
@@ -51,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Slash",
 				fr: "Tranche",
+				de: "Schlitzer"
 			},
 
 			damage: 20,
@@ -69,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "The Pokémon can easily melt holes in hard rocks with a liquid secreted from its mouth.",
+		de: "Das ätzende Sekret aus seinem Mund erlaubt es ihm, ohne Weiteres Steine auszuhöhlen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/60.ts
+++ b/data/Black & White/Noble Victories/60.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Lampent",
 		fr: "Mélancolux",
+		de: "Laternecto"
 	},
 
 	stage: "Stage2",
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Eerie Glow",
 				fr: "Lueur Sinistre",
+				de: "Gruselglühen"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Burned and Confused.",
 				fr: "Le Pokémon Défenseur est maintenant Brûlé et Confus.",
+				de: "Das Verteidigende Pokémon ist jetzt verbrannt und verwirrt."
 			},
 			damage: 50,
 
@@ -86,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It absorbs a spirit, which it then burns. By waving the flames on its arms, it puts its foes into a hypnotic trance.",
+		de: "Es saugt die Seelen seiner Opfer aus und verbrennt sie. Nutzt seine Arme als Pendel, um den Gegner zu hypnotisieren."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/61.ts
+++ b/data/Black & White/Noble Victories/61.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Boldore",
 		fr: "Géolithe",
+		de: "Sedimantur"
 	},
 
 	stage: "Stage2",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Core Cannon",
 				fr: "Super Canon",
+				de: "Kernkanone"
 			},
 			effect: {
 				en: "This attack does 20 damage to 1 of your opponent's Pokémon for each Fighting Energy attached to this Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige 20 dégâts à 1 des Pokémon de votre adversaire pour chaque Énergie Fighting attachée à ce Pokémon. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 1 Pokémon deines Gegners 20 Schadenspunkte für jede an dieses Pokémon angelegte {F}-Energie zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -58,6 +61,7 @@ const card: Card = {
 			name: {
 				en: "Power Gem",
 				fr: "Rayon Gemme",
+				de: "Juwelenkraft"
 			},
 
 			damage: 90,
@@ -76,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "Compressing the energy from its internal core lets it fire off an attack capable of blowing away a mountain.",
+		de: "Es kann ganze Berge einebnen, indem es Energie entlädt, die es in seinem Kern gesammelt und verdichtet hat."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/62.ts
+++ b/data/Black & White/Noble Victories/62.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Pummel",
 				fr: "Martelage",
+				de: "Trommler"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 weitere Schadenspunkte zu."
 			},
 			damage: 10,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "It fights by swinging a piece of lumber around. It is close to evolving when it can handle the lumber without difficulty.",
+		de: "Greift Gegner mit einem Holzbalken an. Fällt es ihm leicht, den schweren Balken zu tragen, ist seine Entwicklung nah."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/63.ts
+++ b/data/Black & White/Noble Victories/63.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Timburr",
 		fr: "Charpenti",
+		de: "Praktibalk"
 	},
 
 	stage: "Stage1",
@@ -42,6 +43,7 @@ const card: Card = {
 			name: {
 				en: "Strength",
 				fr: "Force",
+				de: "Stärke"
 			},
 
 			damage: 30,
@@ -56,10 +58,12 @@ const card: Card = {
 			name: {
 				en: "Pummel",
 				fr: "Martelage",
+				de: "Trommler"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 40,
 
@@ -77,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon is so muscular and strongly built that even a group of wrestlers could not make it budge an inch.",
+		de: "Selbst wenn es mit voller Wucht von einem Profi-Ringer angegriffen wird, lässt es dies dank seines Muskeltrainings kalt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/64.ts
+++ b/data/Black & White/Noble Victories/64.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gurdurr",
 		fr: "Ouvrifier",
+		de: "Strepoli"
 	},
 
 	stage: "Stage2",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Este Pokémon obtiene 20 PV más por cada Energía Fighting unida a él.",
 				it: "Questo Pokémon ha 20 PV in più per ogni Energia Fighting assegnatagli.",
 				pt: "Este Pokémon recebe mais 20 PS para cada Energia Fighting ligada a ele.",
-				de: "Dieses Pokémon erhält +20 KP für jede an es angelegte Fighting-Energie."
+				de: "Dieses Pokémon erhält +20 KP für jede an es angelegte {F}-Energie."
 			},
 		},
 	],
@@ -66,10 +67,12 @@ const card: Card = {
 			name: {
 				en: "Top Down",
 				fr: "Écras'Montagne",
+				de: "Kopfüber"
 			},
 			effect: {
 				en: "Flip a coin until you get tails. For each heads, discard the top card of your opponent's deck.",
 				fr: "Lancez une pièce jusqu'à ce que vous obteniez un côté pile. Pour chaque côté face, défaussez la carte du dessus du deck de votre adversaire.",
+				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Lege pro „Kopf“ die oberste Karte vom Deck deines Gegners auf seinen Ablagestapel."
 			},
 			damage: 80,
 
@@ -87,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "It it thought that Conkeldurr taught humans how to make concrete more than 2,000 years ago.",
+		de: "Man nimmt an, dass es der Menschheit vor ca. 2 000 Jahren das Betonmischen beigebracht hat."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/65.ts
+++ b/data/Black & White/Noble Victories/65.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gurdurr",
 		fr: "Ouvrifier",
+		de: "Strepoli"
 	},
 
 	stage: "Stage2",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Chip Away",
 				fr: "Attrition",
+				de: "Zermürben"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by any effects on the Defending Pokémon.",
 				fr: "Les dégâts de cette attaque ne sont affectés par aucun effet en action sur le Pokémon Défenseur.",
+				de: "Der Schaden dieses Angriffs wird durch Effekte auf dem Verteidigenden Pokémon nicht verändert."
 			},
 			damage: 40,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Swing Around",
 				fr: "Balançoire",
+				de: "Gegenschwung"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 30 more damage for each heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts supplémentaires pour chaque côté face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 60,
 
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "They use concrete pillars as walking canes. They know moves that enable them to swing the pillars freely in battle.",
+		de: "Besitzt die Fähigkeit, die Säulen, die es als Gehstöcke verwendet, ganz ohne Krafteinsatz umherzuschwingen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/66.ts
+++ b/data/Black & White/Noble Victories/66.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Rock Throw",
 				fr: "Jet-Pierres",
+				de: "Steinwurf"
 			},
 
 			damage: 20,
@@ -49,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Acrobatics",
 				fr: "Acrobatie",
+				de: "Akrobatik"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 more damage for each heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts supplémentaires pour chaque côté face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -70,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "Said to be an ancestor of bird Pokémon, they were unable to fly and moved about by hopping from one branch to another.",
+		de: "Man nennt es den Urvater der Vogel-Pokémon. Da es nicht fliegen kann, bewegt es sich hüpfend von Ast zu Ast."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/67.ts
+++ b/data/Black & White/Noble Victories/67.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Archen",
 		fr: "Arkéapti",
+		de: "Flapteryx"
 	},
 
 	stage: "Stage1",
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Rock Slide",
 				fr: "Éboulement",
+				de: "Steinhagel"
 			},
 			effect: {
 				en: "Does 10 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à 2 des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 2 Pokémon auf der Bank deines Gegners je 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 60,
 
@@ -86,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "They are intelligent and will cooperate to catch prey. From the ground, they use a running start to take flight.",
+		de: "Bevor es abhebt, nimmt es am Boden Anlauf. Es ist schlau genug, seine Beute zusammen mit Artgenossen zu jagen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/68.ts
+++ b/data/Black & White/Noble Victories/68.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Trickle",
 				fr: "Goutte à Goutte",
+				de: "Rieseln"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 30 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 30,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Thundershock",
 				fr: "Éclair",
+				de: "Donnerschock"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 50,
 
@@ -82,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "It conceals itself in the mud of the seashore. Then it waits. When prey touch it, it delivers a volt of electricity.",
+		de: "Es vergräbt sich im Morast am Meeresboden. Wird es von seiner Beute gestreift, lähmt es sie mit Strom."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/69.ts
+++ b/data/Black & White/Noble Victories/69.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Pound",
 				fr: "Écras'Face",
+				de: "Pfund"
 			},
 
 			damage: 10,
@@ -49,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "High Jump Kick",
 				fr: "Pied Voltige",
+				de: "Turmkick"
 			},
 
 			damage: 30,
@@ -67,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "In fights, they dominate with onslaughts of flowing, continuous attack. With their sharp claws, they cut enemies.",
+		de: "Es deckt seine Gegner mit filigranen Attacken in Serie ein und schlitzt sie mit seinen spitzen Klauen auf."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/7.ts
+++ b/data/Black & White/Noble Victories/7.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Dwebble",
 		fr: "Crabicoque",
+		de: "Lithomith"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "X-Scissor",
 				fr: "Plaie-Croix",
+				de: "Kreuzschere"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 50 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 50 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 50 weitere Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Reckless Charge",
 				fr: "Attaque Imprudente",
+				de: "Waghalsiger Sturmangriff"
 			},
 			effect: {
 				en: "This Pokémon does 10 damage to itself.",
 				fr: "Ce Pokémon s'inflige 10 dégâts.",
+				de: "Dieses Pokémon fügt sich selbst 10 Schadenspunkte zu."
 			},
 			damage: 80,
 
@@ -80,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "Competing for territory, Crustle fight viciously. The one whose boulder is broken is the loser of the battle.",
+		de: "Revierkonflikte führen oft zu heftigen Kämpfen zwischen ihnen. Gewonnen hat, wer das gegnerische Haus zerstört."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/70.ts
+++ b/data/Black & White/Noble Victories/70.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Mienfoo",
 		fr: "Kungfouine",
+		de: "Lin-Fu"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Feint",
 				fr: "Ruse",
+				de: "Offenlegung"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by Resistance.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Résistance.",
+				de: "Der Schaden dieses Angriffs wird durch Resistenz nicht verändert."
 			},
 			damage: 30,
 
@@ -57,6 +60,7 @@ const card: Card = {
 			name: {
 				en: "High Jump Kick",
 				fr: "Pied Voltige",
+				de: "Turmkick"
 			},
 
 			damage: 50,
@@ -75,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "It wield the fur on its arms like a whip. Its arms attacks come with such rapidity that they cannot even be seen.",
+		de: "Es benutzt das Fell an seinen Armen als Peitsche. Beide Arme bewegen sich dabei mit atemberaubender Geschwindigkeit."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/71.ts
+++ b/data/Black & White/Noble Victories/71.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Dynamic Punch",
 				fr: "Dynamopoing",
+				de: "Wuchtschlag"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage and the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires et le Pokémon Défenseur est maintenant Confus.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu und das Verteidigende Pokémon ist jetzt verwirrt."
 			},
 			damage: 20,
 
@@ -65,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "These Pokémon are thought to have been created by the science of an ancient and mysterious civilization.",
+		de: "Man nimmt an, dass es ein Produkt der verblüffenden wissenschaftlichen Künste einer uralten Zivilisation sei."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/72.ts
+++ b/data/Black & White/Noble Victories/72.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Golett",
 		fr: "Gringolem",
+		de: "Golbit"
 	},
 
 	stage: "Stage1",
@@ -43,10 +44,12 @@ const card: Card = {
 			name: {
 				en: "Hammer Arm",
 				fr: "Marto-Poing",
+				de: "Hammerarm"
 			},
 			effect: {
 				en: "Discard the top card of your opponent's deck.",
 				fr: "Défaussez la carte du dessus du deck de votre adversaire.",
+				de: "Lege die oberste Karte vom Deck deines Gegners auf seinen Ablagestapel."
 			},
 			damage: 60,
 
@@ -61,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Hurricane Punch",
 				fr: "Poing Ouragan",
+				de: "Hurrikanhieb"
 			},
 			effect: {
 				en: "Flip 4 coins. This attack does 50 damage times the number of heads.",
 				fr: "Lancez 4 pièces. Cette attaque inflige 50 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 4 Münzen. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 50,
 
@@ -89,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said that Golurk were ordered to protect people and Pokémon by the ancient people who made them.",
+		de: "Man munkelt, sein Schöpfer habe ihm aufgetragen, schützend über Pokémon und Menschen zu wachen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/73.ts
+++ b/data/Black & White/Noble Victories/73.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Retaliate",
 				fr: "Vengeance",
+				de: "Heimzahlung"
 			},
 			effect: {
 				en: "If any of your Pokémon were Knocked Out by damage from an opponent's attack during his or her last turn, this attack does 60 more damage.",
 				fr: "Si l'un de vos Pokémon a été mis K.O. par les dégâts d'une attaque de votre adversaire pendant son dernier tour, cette attaque inflige 60 dégâts supplémentaires.",
+				de: "Falls eins deiner Pokémon während des letzten Zuges deines Gegners durch Schaden eines gegnerischen Angriffs kampfunfähig gemacht wurde, fügt dieser Angriff 60 weitere Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -54,6 +56,7 @@ const card: Card = {
 			name: {
 				en: "Land Crush",
 				fr: "Écras'Terre",
+				de: "Schollenbrecher"
 			},
 
 			damage: 90,
@@ -72,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "Its charge is strong enough to break through a giant castle wall in one blow. This Pokémon is spoken of in legends.",
+		de: "Seine Angriffskraft genügt, um selbst mächtige Wälle niederzureißen. Ein Held zahlreicher Legenden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/74.ts
+++ b/data/Black & White/Noble Victories/74.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Abundant Harvest",
 				fr: "Récolte Abondante",
+				de: "Hülle und Fülle"
 			},
 			effect: {
 				en: "Attach a basic Energy card from your discard pile to this Pokémon.",
 				fr: "Attachez une carte Énergie de base de votre pile de défausse à ce Pokémon.",
+				de: "Lege 1 Basis-Energiekarte von deinem Ablagestapel an dieses Pokémon an."
 			},
 
 		},
@@ -52,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Gaia Hammer",
 				fr: "Marteau de Gaïa",
+				de: "Gaia-Hammer"
 			},
 			effect: {
 				en: "Does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à chaque Pokémon de Banc (les vôtres et ceux de votre adversaire). (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt jedem Pokémon auf der Bank (deinen und denen deines Gegners) 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 80,
 
@@ -80,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "Lands visited by Landorus grant such bountiful crops that it has been hailed as \"The Guardian of the Fields.\"",
+		de: "Da an Orten, wo es sich blicken lässt, mit reicher Ernte zu rechnen ist, nennt man es auch den „Herrn des Ackerbaus“."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/75.ts
+++ b/data/Black & White/Noble Victories/75.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Iron Head",
 				fr: "Tête de Fer",
+				de: "Eisenschädel"
 			},
 			effect: {
 				en: "Flip a coin until you get tails. This attack does 10 damage times the number of heads.",
 				fr: "Lancez une pièce jusqu'à ce que vous obteniez un côté pile. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 10,
 
@@ -64,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "They fight at Bisharp's command. They cling to their prey and inflict damage by sinking their blades into it.",
+		de: "Im Kampf folgt es den Befehlen von Caesurio. Es nimmt sein Opfer in die Zange und verletzt es mit seinen Klingen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/76.ts
+++ b/data/Black & White/Noble Victories/76.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pawniard",
 		fr: "Scalpion",
+		de: "Gladiantri"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Finishing Blow",
 				fr: "Coup de Grâce",
+				de: "Finalhieb"
 			},
 			effect: {
 				en: "If the Defending Pokémon already has any damage counters on it, this attack does 50 more damage.",
 				fr: "Si le Pokémon Défenseur a déjà des marqueurs de dégâts, cette attaque inflige 50 dégâts supplémentaires.",
+				de: "Wenn auf dem Verteidigenden Pokémon bereits mindestens 1 Schadensmarke liegt, fügt dieser Angriff 50 weitere Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Night Slash",
 				fr: "Tranche-Nuit",
+				de: "Nachthieb"
 			},
 			effect: {
 				en: "Switch this Pokémon with 1 of your Benched Pokémon.",
 				fr: "Échangez ce Pokémon avec 1 de vos Pokémon de Banc.",
+				de: "Tausche dieses Pokémon gegen 1 Pokémon auf deiner Bank aus."
 			},
 			damage: 30,
 
@@ -85,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "Bisharp pursues prey in the company of a large group of Pawniard. Then Bisharp finishes off the prey.",
+		de: "Es rückt seinen Opfern mit einer Schar von Gladiantri im Gefolge auf den Pelz. Den letzten Hieb übernimmt es selbst."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/77.ts
+++ b/data/Black & White/Noble Victories/77.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Headbutt",
 				fr: "Coup d'Boule",
+				de: "Kopfnuss"
 			},
 
 			damage: 10,
@@ -49,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
+				de: "Biss"
 			},
 
 			damage: 20,
@@ -74,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "They cannot see, so they tackle and bite to learn about their surroundings. Their bodies are covered in wounds.",
+		de: "Da es nichts sehen kann, sucht es seine Umgebung mit Rempel- und Bissattacken ab und ist immer mit Wunden übersät."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/78.ts
+++ b/data/Black & White/Noble Victories/78.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Deino",
 		fr: "Solochi",
+		de: "Kapuno"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Double Hit",
 				fr: "Coup Double",
+				de: "Doppelschlag"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -58,6 +61,7 @@ const card: Card = {
 			name: {
 				en: "Strength",
 				fr: "Force",
+				de: "Stärke"
 			},
 
 			damage: 50,
@@ -83,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "Since their two heads do not get along and compete with each other for food, they always eat too much.",
+		de: "Seine zwei Köpfe liegen stets im Streit. So wird jede Mahlzeit ein Wettstreit für sie, bei dem sich beide überfressen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/79.ts
+++ b/data/Black & White/Noble Victories/79.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Zweilous",
 		fr: "Diamat",
+		de: "Duodino"
 	},
 
 	stage: "Stage2",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Todas las Energía unidas a este Pokémon son Energía Darkness en vez del tipo habitual.",
 				it: "Tutte le Energie assegnate a questo Pokémon sono Energie Darkness anziché del loro solito tipo.",
 				pt: "Toda Energia ligada a este Pokémon é Energia Darkness em vez do tipo usual.",
-				de: "Alle Energien, die an dieses Pokémon angelegt sind, liefern Darkness-Energie anstelle ihres normalen Typs."
+				de: "Alle Energien, die an dieses Pokémon angelegt sind, liefern {D}-Energie anstelle ihres normalen Typs."
 			},
 		},
 	],
@@ -66,10 +67,12 @@ const card: Card = {
 			name: {
 				en: "Berserker Blade",
 				fr: "Lame Folle",
+				de: "Berserkerklinge"
 			},
 			effect: {
 				en: "Does 40 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 40 dégâts à 2 des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 2 Pokémon auf der Bank deines Gegners je 40 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 60,
 
@@ -94,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "The heads on their arms do not have brains. They use all three heads to consume and destroy everything.",
+		de: "Die Köpfe an seinen beiden Armen haben kein eigenes Gehirn. Seine drei Mäuler kauen alles radikal kurz und klein."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/8.ts
+++ b/data/Black & White/Noble Victories/8.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Mysterious Evolution",
 				fr: "Évolution Mystérieuse",
+				de: "Mysteriöse Entwicklung"
 			},
 			effect: {
 				en: "If Shelmet is in play, search your deck for a card that evolves from this Pokémon and put it onto this Pokémon. (This counts as evolving this Pokémon.) Shuffle your deck afterward.",
 				fr: "Si Escargaume est en jeu, cherchez dans votre deck une carte Évolution de ce Pokémon et placez-la sur ce Pokémon. (Cela équivaut à faire évoluer ce Pokémon.) Mélangez ensuite votre deck.",
+				de: "Wenn Schnuthelm im Spiel ist, durchsuche dein Deck nach einer Karte, zu der sich dieses Pokémon entwickelt, und lege sie auf dieses Pokémon (dies zählt als Entwicklung dieses Pokémon). Mische anschließend dein Deck."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Fury Attack",
 				fr: "Furie",
+				de: "Furienschlag"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 10,
 
@@ -72,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "When they feel threatened, they spit acidic liquid to drive attackers away. This Pokémon targets Shelmet.",
+		de: "Fühlt es sich bedroht, wehrt es sich, indem es ätzende Flüssigkeit speit. Hat es auf Schnuthelm abgesehen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/80.ts
+++ b/data/Black & White/Noble Victories/80.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Karrablast",
 		fr: "Carabing",
+		de: "Laukaps"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Guard Press",
 				fr: "Pression de Garde",
+				de: "Schutzdruck"
 			},
 			effect: {
 				en: "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, tous les dégâts infligés à ce Pokémon par des attaques sont réduits de 20 (après application de la Faiblesse et de la Résistance).",
+				de: "Während des nächsten Zuges deines Gegners wird Schaden, der diesem Pokémon durch Angriffe zugefügt wird, um 20 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 			damage: 40,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Twineedle",
 				fr: "Double-Dard",
+				de: "Duonadel"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 70 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 70 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 70 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 70,
 
@@ -87,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "These Pokémon evolve by wearing the shell covering of a Shelmet. The steel armor protects their whole body.",
+		de: "Es ist bei der Entwicklung in die Muschel eines Schnuthelm geschlüpft. Die Eisenrüstung schützt seinen ganzen Körper."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/81.ts
+++ b/data/Black & White/Noble Victories/81.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Pierce",
 				fr: "Transpercement",
+				de: "Durchbohren"
 			},
 
 			damage: 10,
@@ -49,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Cut",
 				fr: "Coupe",
+				de: "Zerschneider"
 			},
 
 			damage: 20,
@@ -74,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "Blades comprise this Pokémon's entire body. If battling dulls the blades, it sharpens them on stones by the river.",
+		de: "Sein Körper ist mit Klingen übersät, die es an Felsen eines Flussbettes schärft, wenn sie im Kampf schartig werden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/82.ts
+++ b/data/Black & White/Noble Victories/82.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pawniard",
 		fr: "Scalpion",
+		de: "Gladiantri"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Energy Stream",
 				fr: "Courant d'Énergie",
+				de: "Energiestrom"
 			},
 			effect: {
 				en: "Attach a Metal Energy card from your discard pile to this Pokémon.",
 				fr: "Attachez une carte Énergie Metal de votre pile de défausse à ce Pokémon.",
+				de: "Lege 1 {M}-Energiekarte von deinem Ablagestapel an dieses Pokémon an."
 			},
 			damage: 20,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Metal Scissors",
 				fr: "Ciseaux d'Acier",
+				de: "Metallscheren"
 			},
 			effect: {
 				en: "Does 20 more damage for each Metal Energy attached to this Pokémon.",
 				fr: "Inflige 20 dégâts supplémentaires pour chaque Énergie Metal attachée à ce Pokémon.",
+				de: "Dieser Angriff fügt 20 weitere Schadenspunkte für jede an dieses Pokémon angelegte {M}-Energie zu."
 			},
 			damage: 40,
 
@@ -86,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "It leads a group of Pawniard. It battles to become the boss, but will be driven from the group if it loses.",
+		de: "Anführer einer Schar von Gladiantri. Verliert es den Kampf um den Titel des Anführers, wird es ausgestoßen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/83.ts
+++ b/data/Black & White/Noble Victories/83.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Devour",
 				fr: "Voracité",
+				de: "Verschlinger"
 			},
 			effect: {
 				en: "For each of your Durant in play, discard the top card of your opponent's deck.",
 				fr: "Pour chacun de vos Fermite en jeu, défaussez la carte du dessus du deck de votre adversaire.",
+				de: "Lege für jedes deiner Fermicula im Spiel die oberste Karte vom Deck deines Gegners auf seinen Ablagestapel."
 			},
 
 		},
@@ -51,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Vice Grip",
 				fr: "Force Poigne",
+				de: "Klammer"
 			},
 
 			damage: 30,
@@ -76,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "They attack in groups, covering themselves in steel armor to protect themselves against Heatmor.",
+		de: "Ein eiserner Panzer umgibt seinen Leib. Angriffe von Furnifraß, seinem Feind, schlägt es in der Gruppe zurück."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/84.ts
+++ b/data/Black & White/Noble Victories/84.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Energy Press",
 				fr: "Pression Énergétique",
+				de: "Energiedruck"
 			},
 			effect: {
 				en: "Does 20 more damage for each Energy attached to the Defending Pokémon.",
 				fr: "Inflige 20 dégâts supplémentaires pour chaque Énergie attachée au Pokémon Défenseur.",
+				de: "Dieser Angriff fügt 20 weitere Schadenspunkte für jede an das Verteidigende Pokémon angelegte Energie zu."
 			},
 			damage: 20,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Iron Breaker",
 				fr: "Brise-Fer",
+				de: "Eisenbrecher"
 			},
 			effect: {
 				en: "The Defending Pokémon can't attack during your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas attaquer pendant le prochain tour de votre adversaire.",
+				de: "Das Verteidigende Pokémon kann während des nächsten Zuges deines Gegners nicht angreifen."
 			},
 			damage: 80,
 
@@ -82,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "It has a body and heart of steel. Its glare is sufficient to make even an unruly Pokémon obey it.",
+		de: "Sein Körper und sein Herz sind aus Stahl. Ein böser Blick genügt und selbst die wildesten Pokémon unterwerfen sich ihm."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/85.ts
+++ b/data/Black & White/Noble Victories/85.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Do the Wave",
 				fr: "Faites la Vague",
+				de: "Wellenreiten"
 			},
 			effect: {
 				en: "Does 10 damage times the number of your Benched Pokémon.",
 				fr: "Inflige 10 dégâts multipliés par le nombre de vos Pokémon de Banc.",
+				de: "Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl der Pokémon auf deiner Bank zu."
 			},
 			damage: 10,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "It touches others with the feelers on its ears, using the sound of their heartbeats to tell how they are feeling.",
+		de: "Berührt es jemanden mit den Fühlern an seinen Ohren, erfährt es durch den Herzschlag der Person, wie es ihr geht."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/86.ts
+++ b/data/Black & White/Noble Victories/86.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Dual Chop",
 				fr: "Double Baffe",
+				de: "Doppelhieb"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 10,
 
@@ -50,6 +52,7 @@ const card: Card = {
 
 	description: {
 		en: "They use their tusks to crush the berries they eat. Repeated regrowth makes their tusks strong and sharp.",
+		de: "Es knackt sich mit seinen Hauern Nüsse. Brechen seine Fangzähne ab, wächst an ihrer Stelle ein stärkeres Ersatzpaar."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/87.ts
+++ b/data/Black & White/Noble Victories/87.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Axew",
 		fr: "Coupenotte",
+		de: "Milza"
 	},
 
 	stage: "Stage1",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Scratch",
 				fr: "Griffe",
+				de: "Kratzer"
 			},
 
 			damage: 20,
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Dual Chop",
 				fr: "Double Baffe",
+				de: "Doppelhieb"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 30 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 30,
 
@@ -68,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "Since a broken tusk will not grow back, they diligently sharpen their tusks on river rocks after they've been fighting.",
+		de: "Da seine Hauer nicht mehr nachwachsen, wetzt es sie nach einem Kampf sachte an den Felsen eines Flussbettes."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/88.ts
+++ b/data/Black & White/Noble Victories/88.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Fraxure",
 		fr: "Incisache",
+		de: "Sharfax"
 	},
 
 	stage: "Stage2",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Dual Chop",
 				fr: "Double Baffe",
+				de: "Doppelhieb"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 50 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 50 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 50,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Giga Impact",
 				fr: "Giga Impact",
+				de: "Gigastoß"
 			},
 			effect: {
 				en: "This Pokémon can't attack during your next turn.",
 				fr: "Ce Pokémon ne peut pas attaquer pendant votre prochain tour.",
+				de: "Dieses Pokémon kann während deines nächsten Zuges nicht angreifen."
 			},
 			damage: 120,
 
@@ -73,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "They are kind but can be relentless when defending territory. They challenge foes with tusks that can cut steel.",
+		de: "Hat eine eher sanfte Natur, doch bei Eindringlingen kennt es keine Gnade. Seine Stoßzähne durchbohren sogar Eisen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/89.ts
+++ b/data/Black & White/Noble Victories/89.ts
@@ -60,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Clutch",
 				fr: "Serre",
+				de: "Greifer"
 			},
 			effect: {
 				en: "The Defending Pokémon can't retreat during your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas battre en retraite pendant le prochain tour de votre adversaire.",
+				de: "Das Verteidigende Pokémon kann sich während des nächsten Zuges deines Gegners nicht zurückziehen."
 			},
 			damage: 60,
 
@@ -74,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "It races through narrow caves, using its sharp claws to catch prey. The skin on its face is harder than a rock.",
+		de: "Es jagt durch enge Höhlengänge und spießt seine Gegner mit spitzen Klauen auf. Seine Kopfhaut ist fester als Stein."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/9.ts
+++ b/data/Black & White/Noble Victories/9.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Rollout",
 				fr: "Roulade",
+				de: "Walzer"
 			},
 
 			damage: 20,
@@ -61,6 +62,7 @@ const card: Card = {
 
 	description: {
 		en: "For some reason, this Pokémon resembles a Poké Ball. They release poison spores to repel those who try to catch them.",
+		de: "Es ähnelt einem Pokéball. Versucht man, es zu fangen, widersetzt es sich, indem es Giftsporen versprüht."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/90.ts
+++ b/data/Black & White/Noble Victories/90.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mira las 7 últimas cartas de tu baraja. Puedes enseñar a un Tirtouga que encuentres entre ellas y ponerlo en tu Banca. Pon el resto de cartas de nuevo en tu baraja y barájalas todas.",
 		it: "Guarda le ultime sette carte del tuo mazzo. Puoi mostrare un Tirtouga che hai trovato e metterlo nella tua panchina. Poi rimischia le altre carte nel tuo mazzo.",
 		pt: "Olhe os 7 cards de baixo do seu baralho. Você poderá revelar um Tirtouga que encontrar lá e colocá-lo em seu Banco. Embaralhe os demais cards de volta.",
-		de: "Schau dir die untersten 7 Karten deines Decks an. Falls du dort ein Galapaflos findest, kannst du es deinem Gegner zeigen und auf deine Bank legen. Mische die anderen Karten anschließend in dein Deck."
+		de: "Schau dir die untersten 7 Karten deines Decks an. Falls du dort ein Galapaflos findest, kannst du es deinem Gegner zeigen und auf deine Bank legen. Mische die anderen Karten anschließend in dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Noble Victories/91.ts
+++ b/data/Black & White/Noble Victories/91.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Si el Pokémon al que está unida esta carta es un Pokémon Básico, cualquier daño hecho a este Pokémon por ataques se reduce en 20 (después de aplicar Debilidad y Resistencia).",
 		it: "Se il Pokémon a cui è assegnata questa carta è un Pokémon Base, i danni inflitti a questo Pokémon da attacchi sono ridotti di 20, dopo aver applicato debolezza e resistenza.",
 		pt: "Se este card estiver ligado a um Pokémon Básico, qualquer dano causado a este Pokémon por ataques será reduzido em 20 (após a aplicação de Fraqueza e Resistência).",
-		de: "Wenn das Pokémon, an das diese Karte angelegt ist, ein Basis-Pokémon ist, wird der diesem Pokémon durch Angriffe zugefügte Schaden um 20 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn das Pokémon, an das diese Karte angelegt ist, ein Basis-Pokémon ist, wird der diesem Pokémon durch Angriffe zugefügte Schaden um 20 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden). Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Black & White/Noble Victories/92.ts
+++ b/data/Black & White/Noble Victories/92.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cada jugador baraja las cartas de su mano en su baraja. Luego, cada jugador roba una carta por cada una de las cartas de Premio que le queden.",
 		it: "Ogni giocatore rimischia le carte che ha in mano nel proprio mazzo. Quindi, ogni giocatore pesca una carta per ogni carta Premio che gli resta.",
 		pt: "Cada jogador embaralha sua mão em seu próprio baralho. Cada jogador então compra um card para cada um de seus cards de Prêmio restantes.",
-		de: "Jeder Spieler mischt seine Hand zurück in sein Deck. Anschließend zieht jeder Spieler eine Karte für jede seiner noch übrigen Preiskarten."
+		de: "Jeder Spieler mischt seine Hand zurück in sein Deck. Anschließend zieht jeder Spieler eine Karte für jede seiner noch übrigen Preiskarten. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Black & White/Noble Victories/93.ts
+++ b/data/Black & White/Noble Victories/93.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mira las 7 últimas cartas de tu baraja. Puedes enseñar a un Archen que encuentres entre ellas y ponerlo en tu Banca. Pon el resto de cartas de nuevo en tu baraja y barájalas todas.",
 		it: "Guarda le ultime sette carte del tuo mazzo. Puoi mostrare un Archen che hai trovato e aggiungerlo alla tua panchina. Poi rimischia le altre carte nel tuo mazzo.",
 		pt: "Olhe os 7 cards de baixo do seu baralho. Você poderá revelar um Archen que encontrar lá e colocá-lo em seu Banco. Embaralhe os demais cards de volta.",
-		de: "Schau dir die untersten 7 Karten deines Decks an. Falls du dort ein Flapteryx findest, kannst du es deinem Gegner zeigen und auf deine Bank legen. Mische die anderen Karten anschließend in dein Deck."
+		de: "Schau dir die untersten 7 Karten deines Decks an. Falls du dort ein Flapteryx findest, kannst du es deinem Gegner zeigen und auf deine Bank legen. Mische die anderen Karten anschließend in dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Noble Victories/94.ts
+++ b/data/Black & White/Noble Victories/94.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Si el Pokémon al que está unida esta carta es tu Pokémon Básico y resulta dañado por el ataque de un rival (incluso si ese Pokémon queda Fuera de Combate), pon 2 contadores de daño en el Pokémon Atacante.",
 		it: "Se il Pokémon a cui è stata assegnata questa carta è il tuo Pokémon attivo e viene danneggiato da un attacco del tuo avversario, anche se viene messo K.O., metti due segnalini danno sul Pokémon attaccante.",
 		pt: "Se este card estiver ligado a seu Pokémon Ativo e ele for danificado pelo ataque de um oponente (mesmo se esse Pokémon for Nocauteado), coloque 2 marcadores de danos no Pokémon Atacante.",
-		de: "Wenn das Pokémon, an dem diese Karte angelegt ist, dein Aktives Pokémon ist und durch einen gegnerischen Angriff Schaden erhält (auch wenn dieses Pokémon dadurch kampfunfähig wird), lege 2 Schadensmarken auf das Angreifende Pokémon."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn das Pokémon, an dem diese Karte angelegt ist, dein Aktives Pokémon ist und durch einen gegnerischen Angriff Schaden erhält (auch wenn dieses Pokémon dadurch kampfunfähig wird), lege 2 Schadensmarken auf das Angreifende Pokémon. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Black & White/Noble Victories/95.ts
+++ b/data/Black & White/Noble Victories/95.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon, en cualquier combinación, 3 cartas de Pokémon y de Energía Básica de tu pila de descartes de nuevo en tu baraja y barájalas todas.",
 		it: "Rimischia tre carte Pokémon e Energia base, in qualsiasi combinazione, dalla tua pila degli scarti nel tuo mazzo.",
 		pt: "Embaralhe qualquer combinação de 3 cards entre Pokémon e Energia básica de sua pilha de descarte em seu baralho.",
-		de: "Mische eine Kombination aus insgesamt 3 Pokémon- und Basis-Energiekarten von deinem Ablagestapel zurück in dein Deck."
+		de: "Mische eine Kombination aus insgesamt 3 Pokémon- und Basis-Energiekarten von deinem Ablagestapel zurück in dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Noble Victories/96.ts
+++ b/data/Black & White/Noble Victories/96.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Lanza una moneda. Si sale cara, busca en tu baraja una carta de Partidario, enséñala y ponla en tu mano. Baraja las cartas de tu baraja después.",
 		it: "Lancia una moneta. Se esce testa, cerca nel tuo mazzo una carta Aiuto, mostrala e aggiungila alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Jogue uma moeda. Se sair cara, procure um card de Apoiador em seu baralho, revele-o e coloque-o na sua mão. Em seguida, embaralhe seus cards.",
-		de: "Wirf 1 Münze. Durchsuche bei „Kopf“ dein Deck nach 1 Unterstützerkarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Wirf 1 Münze. Durchsuche bei „Kopf“ dein Deck nach 1 Unterstützerkarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Noble Victories/97.ts
+++ b/data/Black & White/Noble Victories/97.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Double Draw",
 				fr: "Double Pioche",
+				de: "Zweifachzug"
 			},
 			effect: {
 				en: "Draw 2 cards.",
 				fr: "Piochez 2 cartes.",
+				de: "Ziehe 2 Karten."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Leaf Wallop",
 				fr: "Rafale de Feuilles",
+				de: "Blattprügel"
 			},
 			effect: {
 				en: "During your next turn, this Pokémon's Leaf Wallop attack does 40 more damage (before applying Weakness and Resistance).",
 				fr: "Pendant votre prochain tour, l'attaque Rafale de Feuilles de ce Pokémon inflige 40 dégâts supplémentaires (avant application de la Faiblesse et de la Résistance).",
+				de: "Während deines nächsten Zuges fügt die Attacke Blattprügel dieses Pokémon 40 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 			damage: 40,
 
@@ -79,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "Its head sprouts horns as sharp as blades. Using whirlwind-like movements, it confounds and swiftly cuts opponents.",
+		de: "Das Horn an seinem Kopf ist eine scharfe Klinge. Neckt seine Gegner mit quirligen Bewegungen und greift blitzartig an."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/98.ts
+++ b/data/Black & White/Noble Victories/98.ts
@@ -59,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Stored Power",
 				fr: "Force Ajoutée",
+				de: "Kraftvorrat"
 			},
 			effect: {
 				en: "Move all Energy attached to this Pokémon to 1 of your Benched Pokémon.",
 				fr: "Déplacez toutes les Énergies attachées à ce Pokémon vers 1 de vos Pokémon de Banc.",
+				de: "Verschiebe alle an dieses Pokémon angelegte Energie auf 1 Pokémon auf deiner Bank."
 			},
 			damage: 30,
 
@@ -80,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon brings victory. It is said that Trainers with Victini always win, regardless of the type of encounter.",
+		de: "Ein siegverheißendes Pokémon. Man sagt, Trainer, die ein Victini in ihrem Team haben, seien unschlagbar."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Noble Victories/99.ts
+++ b/data/Black & White/Noble Victories/99.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Retaliate",
 				fr: "Vengeance",
+				de: "Heimzahlung"
 			},
 			effect: {
 				en: "If any of your Pokémon were Knocked Out by damage from an opponent's attack during his or her last turn, this attack does 60 more damage.",
 				fr: "Si l'un de vos Pokémon a été mis K.O. par les dégâts d'une attaque de votre adversaire pendant son dernier tour, cette attaque inflige 60 dégâts supplémentaires.",
+				de: "Falls eins deiner Pokémon während des letzten Zuges deines Gegners durch Schaden eines gegnerischen Angriffs kampfunfähig gemacht wurde, fügt dieser Angriff 60 weitere Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -54,6 +56,7 @@ const card: Card = {
 			name: {
 				en: "Land Crush",
 				fr: "Écras'Terre",
+				de: "Schollenbrecher"
 			},
 
 			damage: 90,
@@ -72,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "Its charge is strong enough to break through a giant castle wall in one blow. This Pokémon is spoken of in legends.",
+		de: "Seine Angriffskraft genügt, um selbst mächtige Wälle niederzureißen. Ein Held zahlreicher Legenden."
 	},
 
 	thirdParty: {


### PR DESCRIPTION
## Add missing German translations for bw3

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
