### PR TITLE
Add missing German translations for bw4

### DIFF
--- a/data/Black & White/Next Destinies/1.ts
+++ b/data/Black & White/Next Destinies/1.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Power Pinch",
 				fr: "Pinces Vigoureuses",
+				de: "Kraftkniff"
 			},
 			effect: {
 				en: "Flip 2 coins. For each heads, discard an Energy attached to the Defending Pokémon.",
 				fr: "Lancez 2 pièces. Pour chaque côté face, défaussez une Énergie attachée au Pokémon Défenseur.",
+				de: "Wirf 2 Münzen. Lege pro „Kopf“ 1 an das Verteidigende Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 
 		},
@@ -53,10 +55,12 @@ const card: Card = {
 			name: {
 				en: "Grip and Squeeze",
 				fr: "Empoigne Puissante",
+				de: "Grapschen und Quetschen"
 			},
 			effect: {
 				en: "The Defending Pokémon can't retreat during your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas battre en retraite pendant le prochain tour de votre adversaire.",
+				de: "Das Verteidigende Pokémon kann sich während des nächsten Zuges deines Gegners nicht zurückziehen."
 			},
 			damage: 70,
 
@@ -74,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "It grips prey with its pincers until the prey is torn in half. What it can't tear, it tosses far.",
+		de: "Es hält seine Beute mit seiner Zange fest und teilt sie dann. Was es nicht teilen kann, wirft es fort."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/10.ts
+++ b/data/Black & White/Next Destinies/10.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Stoke",
 				fr: "Attisement",
+				de: "Anheizen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, search your deck for a Fire Energy card and attach it to this Pokémon. Shuffle your deck afterward.",
 				fr: "Lancez une pièce. Si c'est face, cherchez une carte Énergie Fire dans votre deck et attachez-la à ce Pokémon. Mélangez ensuite votre deck.",
+				de: "Wirf 1 Münze. Durchsuche bei „Kopf“ dein Deck nach 1 {R}-Energiekarte und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Firebreathing",
 				fr: "Souffle-Feu",
+				de: "Feuerhauch"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 10,
 
@@ -72,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon with a loyal nature, it will remain motionless until it is given an order by its Trainer.",
+		de: "Ein loyales Pokémon. Es wird erst dann aktiv, wenn sein Trainer ihm Anweisungen gegeben hat."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/100.ts
+++ b/data/Black & White/Next Destinies/100.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pignite",
 		fr: "Grotichon",
+		de: "Ferkokel"
 	},
 
 	stage: "Stage2",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Todas las veces que quieras durante tu turno (antes de tu ataque), puedes unir una carta de Energía Fire de tu mano a 1 de tus Pokémon.",
 				it: "Durante il tuo turno, prima di attaccare, puoi assegnare a piacimento le carte Energia Fire che hai in mano ai tuoi Pokémon.",
 				pt: "Sempre que desejar, na sua vez de jogar (antes de atacar), você poderá ligar um card de Energia Fire da sua mão a 1 dos seus Pokémon.",
-				de: "Beliebig oft während deines Zuges (vor deinem Angriff) kannst du 1 Fire-Energiekarte von deiner Hand an 1 deiner Pokémon anlegen."
+				de: "Beliebig oft während deines Zuges (vor deinem Angriff) kannst du 1 {R}-Energiekarte von deiner Hand an 1 deiner Pokémon anlegen."
 			},
 		},
 	],
@@ -66,6 +67,7 @@ const card: Card = {
 			name: {
 				en: "Heat Crash",
 				fr: "Tacle Feu",
+				de: "Brandstempel"
 			},
 
 			damage: 80,
@@ -84,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "This extremely rare Pokémon is a different color than usual. It is very hard to find.",
+		de: "Dieses sehr seltene Pokémon hat eine andere Farbe als üblich. Es ist sehr schwer zu finden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/101.ts
+++ b/data/Black & White/Next Destinies/101.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Lampent",
 		fr: "Mélancolux",
+		de: "Laternecto"
 	},
 
 	stage: "Stage2",
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Eerie Glow",
 				fr: "Lueur Sinistre",
+				de: "Gruselglühen"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Burned and Confused.",
 				fr: "Le Pokémon Défenseur est maintenant Brûlé et Confus.",
+				de: "Das Verteidigende Pokémon ist jetzt verbrannt und verwirrt."
 			},
 			damage: 50,
 
@@ -86,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "This extremely rare Pokémon is a different color than usual. It is very hard to find.",
+		de: "Dieses sehr seltene Pokémon hat eine andere Farbe als üblich. Es ist sehr schwer zu finden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/102.ts
+++ b/data/Black & White/Next Destinies/102.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Zorua",
 		fr: "Zorua",
+		de: "Zorua"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Nasty Plot",
 				fr: "Machination",
+				de: "Ränkeschmied"
 			},
 			effect: {
 				en: "Search your deck for a card and put it into your hand. Shuffle your deck afterward.",
 				fr: "Cherchez une carte dans votre deck puis ajoutez-la à votre main. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 1 Karte und nimm sie auf deine Hand. Mische anschließend dein Deck."
 			},
 
 		},
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Foul Play",
 				fr: "Tricherie",
+				de: "Schmarotzer"
 			},
 			effect: {
 				en: "Choose 1 of the Defending Pokémon's attacks and use it as this attack.",
 				fr: "Choisissez 1 des attaques du Pokémon Défenseur et utilisez-la en tant que cette attaque.",
+				de: "Wähle 1 Angriff des Verteidigenden Pokémon und verwende ihn als diesen Angriff."
 			},
 
 		},
@@ -83,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "This extremely rare Pokémon is a different color than usual. It is very hard to find.",
+		de: "Dieses sehr seltene Pokémon hat eine andere Farbe als üblich. Es ist sehr schwer zu finden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/103.ts
+++ b/data/Black & White/Next Destinies/103.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Zweilous",
 		fr: "Diamat",
+		de: "Duodino"
 	},
 
 	stage: "Stage2",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Todas las Energía unidas a este Pokémon son Energía Darkness en vez del tipo habitual.",
 				it: "Tutte le Energie assegnate a questo Pokémon sono Energie Darkness anziché del loro solito tipo.",
 				pt: "Toda Energia ligada a este Pokémon é Energia Darkness em vez do tipo usual.",
-				de: "Alle Energien, die an dieses Pokémon angelegt sind, liefern Darkness-Energie anstelle ihres normalen Typs."
+				de: "Alle Energien, die an dieses Pokémon angelegt sind, liefern {D}-Energie anstelle ihres normalen Typs."
 			},
 		},
 	],
@@ -66,10 +67,12 @@ const card: Card = {
 			name: {
 				en: "Berserker Blade",
 				fr: "Lame Folle",
+				de: "Berserkerklinge"
 			},
 			effect: {
 				en: "Does 40 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 40 dégâts à 2 des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 2 Pokémon auf der Bank deines Gegners je 40 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 60,
 
@@ -94,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "This extremely rare Pokémon is a different color than usual. It is very hard to find.",
+		de: "Dieses sehr seltene Pokémon hat eine andere Farbe als üblich. Es ist sehr schwer zu finden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/11.ts
+++ b/data/Black & White/Next Destinies/11.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Combustion",
 				fr: "Fournaise",
+				de: "Glühen"
 			},
 
 			damage: 20,
@@ -55,6 +56,7 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon with a loyal nature, it will remain motionless until it is given an order by its Trainer.",
+		de: "Ein loyales Pokémon. Es wird erst dann aktiv, wenn sein Trainer ihm Anweisungen gegeben hat."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/12.ts
+++ b/data/Black & White/Next Destinies/12.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Growlithe",
 		fr: "Caninos",
+		de: "Fukano"
 	},
 
 	stage: "Stage1",
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Fire Spin",
 				fr: "Danseflamme",
+				de: "Feuerwirbel"
 			},
 			effect: {
 				en: "Flip a coin. If tails, discard 2 Energy attached to this Pokémon.",
 				fr: "Lancez une pièce. Si c'est pile, défaussez 2 Énergies attachées à ce Pokémon.",
+				de: "Wirf 1 Münze. Lege bei „Zahl“ 2 an dieses Pokémon angelegte Energien auf deinen Ablagestapel."
 			},
 			damage: 100,
 
@@ -86,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "Its proud and regal appearance has captured the hearts of people since long ago.",
+		de: "Mit seiner stolzen und königlichen Erscheinung gewinnt es die Herzen der Menschen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/13.ts
+++ b/data/Black & White/Next Destinies/13.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Growlithe",
 		fr: "Caninos",
+		de: "Fukano"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Crunch",
 				fr: "Mâchouille",
+				de: "Knirscher"
 			},
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, défaussez une Énergie attachée au Pokémon Défenseur.",
+				de: "Wirf 1 Münze. Lege bei „Kopf“ 1 an das Verteidigende Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 30,
 
@@ -59,6 +62,7 @@ const card: Card = {
 			name: {
 				en: "Heat Blast",
 				fr: "Explosion de Chaleur",
+				de: "Hitzestoß"
 			},
 
 			damage: 70,
@@ -77,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Its proud and regal appearance has captured the hearts of people since long ago.",
+		de: "Mit seiner stolzen und königlichen Erscheinung gewinnt es die Herzen der Menschen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/14.ts
+++ b/data/Black & White/Next Destinies/14.ts
@@ -38,10 +38,12 @@ const card: Card = {
 			name: {
 				en: "Searing Flame",
 				fr: "Flammes Calcinantes",
+				de: "Sengende Flammen"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Burned.",
 				fr: "Le Pokémon Défenseur est maintenant Brûlé.",
+				de: "Das Verteidigende Pokémon ist jetzt verbrannt."
 			},
 			damage: 50,
 
@@ -56,10 +58,12 @@ const card: Card = {
 			name: {
 				en: "Fire Blast",
 				fr: "Déflagration",
+				de: "Feuersturm"
 			},
 			effect: {
 				en: "Discard a Fire Energy attached to this Pokémon.",
 				fr: "Défaussez une Énergie Fire attachée à ce Pokémon.",
+				de: "Lege 1 an dieses Pokémon angelegte {R}-Energie auf deinen Ablagestapel."
 			},
 			damage: 90,
 
@@ -84,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "One of the legendary bird Pokémon. It is said that its appearance indicates the coming of spring.",
+		de: "Eines der Legendären Vogel-Pokémon. Es wird als Bote des Frühlings angesehen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/15.ts
+++ b/data/Black & White/Next Destinies/15.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Flare",
 				fr: "Flamboiement",
+				de: "Flackern"
 			},
 
 			damage: 30,
@@ -55,6 +56,7 @@ const card: Card = {
 
 	description: {
 		en: "When it is angered, the temperature of its head tuft reaches 600° F. It uses its tuft to roast berries.",
+		de: "Ist es wütend, erreicht das Büschel auf seinem Kopf Temperaturen von bis zu 300 Grad. Es röstet sich damit auch Nüsse."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/16.ts
+++ b/data/Black & White/Next Destinies/16.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pansear",
 		fr: "Flamajou",
+		de: "Grillmak"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Collect",
 				fr: "Collecte",
+				de: "Sammeln"
 			},
 			effect: {
 				en: "Draw 3 cards.",
 				fr: "Piochez 3 cartes.",
+				de: "Ziehe 3 Karten."
 			},
 
 		},
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Stadium Burn",
 				fr: "Stade en Flammes",
+				de: "Stadionbrand"
 			},
 			effect: {
 				en: "If there is any Stadium card in play, this attack does 30 more damage and the Defending Pokémon is now Burned.",
 				fr: "S'il y a une carte Stade en jeu, cette attaque inflige 30 dégâts supplémentaires et le Pokémon Défenseur est maintenant Brûlé.",
+				de: "Wenn eine Stadionkarte im Spiel ist, fügt dieser Angriff 30 weitere Schadenspunkte zu und das Verteidigende Pokémon ist jetzt verbrannt."
 			},
 			damage: 30,
 
@@ -77,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It loves sweets because they become energy for the fire burning inside its body.",
+		de: "Am liebsten isst es Süßigkeiten. Es wandelt sie in Energie um, mit der es das Feuer in seinem Körper schürt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/17.ts
+++ b/data/Black & White/Next Destinies/17.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Hammer In",
 				fr: "Enfoncer",
+				de: "Einhämmern"
 			},
 
 			damage: 20,
@@ -55,6 +56,7 @@ const card: Card = {
 
 	description: {
 		en: "Darumaka's droppings are hot, so people used to put them in their clothes to keep themselves warm.",
+		de: "Früher nutzte man die heißen Ausscheidungen von Flampion, um sich den Körper zu wärmen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/18.ts
+++ b/data/Black & White/Next Destinies/18.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Flare",
 				fr: "Flamboiement",
+				de: "Flackern"
 			},
 
 			damage: 10,
@@ -54,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "While shining a light and pretending to be a guide, it leaches off the life force of any who follow it.",
+		de: "Es entzündet ein Licht und gibt vor, dem Gegner den Weg zu weisen, doch eigtl. saugt es ihm seine Lebensenergie ab."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/19.ts
+++ b/data/Black & White/Next Destinies/19.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Litwick",
 		fr: "Funécire",
+		de: "Lichtel"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Ember",
 				fr: "Flammèche",
+				de: "Glut"
 			},
 			effect: {
 				en: "Flip a coin. If tails, discard an Energy attached to this Pokémon.",
 				fr: "Lancez une pièce. Si c'est pile, défaussez une Énergie attachée à ce Pokémon.",
+				de: "Wirf 1 Münze. Lege bei „Zahl“ 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel."
 			},
 			damage: 40,
 
@@ -63,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "It arrives near the moment of death and steals spirit from the body.",
+		de: "Es erscheint im Augenblick des Todes und verschlingt die Seele des Verblichenen, sofort nachdem sie den Körper verlässt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/2.ts
+++ b/data/Black & White/Next Destinies/2.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Trip Over",
 				fr: "Croche-Pied",
+				de: "Stolperer"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 weitere Schadenspunkte zu."
 			},
 			damage: 10,
 
@@ -64,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "When it dangles from a tree branch, it looks just like an acorn. It enjoys scaring other Pokémon.",
+		de: "Es sieht aus wie eine Eichel, die am Baum hängt. Es liebt es, andere Pokémon zu erschrecken."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/20.ts
+++ b/data/Black & White/Next Destinies/20.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Lampent",
 		fr: "Mélancolux",
+		de: "Laternecto"
 	},
 
 	stage: "Stage2",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Flame Burst",
 				fr: "Rebondifeu",
+				de: "Funkenflug"
 			},
 			effect: {
 				en: "Does 30 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 30 dégâts à 2 des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 2 Pokémon auf der Bank deines Gegners je 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 30,
 
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Inferno",
 				fr: "Feu d'Enfer",
+				de: "Inferno"
 			},
 			effect: {
 				en: "Discard all Energy attached to this Pokémon. The Defending Pokémon is now Burned.",
 				fr: "Défaussez toutes les Énergies attachées à ce Pokémon. Le Pokémon Défenseur est maintenant Brûlé.",
+				de: "Lege alle an dieses Pokémon angelegten Energien auf deinen Ablagestapel. Das Verteidigende Pokémon ist jetzt verbrannt."
 			},
 			damage: 80,
 
@@ -78,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "Being consumed in Chandelure's flame burns up the spirit, leaving the body behind.",
+		de: "Es saugt die Seele eines jeden auf, der in seinen Feuerkranz gerät, bis nur noch eine leere Hülle von ihm übrig ist."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/21.ts
+++ b/data/Black & White/Next Destinies/21.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Outrage",
 				fr: "Colère",
+				de: "Wutanfall"
 			},
 			effect: {
 				en: "Does 10 more damage for each damage counter on this Pokémon.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque marqueur de dégâts placé sur ce Pokémon.",
+				de: "Dieser Angriff fügt 10 weitere Schadenspunkte für jede Schadensmarke auf diesem Pokémon zu."
 			},
 			damage: 20,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Blue Flare",
 				fr: "Flamme Bleue",
+				de: "Blauflammen"
 			},
 			effect: {
 				en: "Discard 2 Fire Energy attached to this Pokémon.",
 				fr: "Défaussez 2 Énergies Fire attachées à ce Pokémon.",
+				de: "Lege 2 an dieses Pokémon angelegte {R}-Energien auf deinen Ablagestapel."
 			},
 			damage: 120,
 
@@ -75,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon appears in legends. It sends flames into the air from its tail, burning up everything around it.",
+		de: "Ein aus Mythen bekanntes Pokémon. Es wirbelt mit seinem Schweif Feuer auf, mit dem es alles in Asche legt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/22.ts
+++ b/data/Black & White/Next Destinies/22.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Glinting Claw",
 				fr: "Griffe Scintillante",
+				de: "Schimmernde Klaue"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: 50,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Brave Fire",
 				fr: "Flammes de Bravoure",
+				de: "Tapferes Feuer"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this Pokémon does 50 damage to itself.",
 				fr: "Lancez une pièce. Si c'est pile, ce Pokémon s'inflige 50 dégâts.",
+				de: "Wirf 1 Münze. Bei „Zahl“ fügt sich dieses Pokémon selbst 50 Schadenspunkte zu."
 			},
 			damage: 150,
 

--- a/data/Black & White/Next Destinies/23.ts
+++ b/data/Black & White/Next Destinies/23.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Recover",
 				fr: "Soin",
+				de: "Genesung"
 			},
 			effect: {
 				en: "Discard an Energy attached to this Pokémon and heal all damage from this Pokémon.",
 				fr: "Défaussez une Énergie attachée à ce Pokémon et soignez tous les dégâts de ce Pokémon.",
+				de: "Lege 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel und heile allen Schaden bei diesem Pokémon."
 			},
 
 		},
@@ -50,6 +52,7 @@ const card: Card = {
 			name: {
 				en: "Water Gun",
 				fr: "Pistolet à O",
+				de: "Aquaknarre"
 			},
 
 			damage: 10,
@@ -68,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "If its body is torn, it can grow back if the red core remains. The core flashes at midnight.",
+		de: "Wird sein Köper verletzt, kann es sich regenerieren, sofern der rote Kern intakt ist."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/24.ts
+++ b/data/Black & White/Next Destinies/24.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Staryu",
 		fr: "Stari",
+		de: "Sterndu"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Confuse Ray",
 				fr: "Onde Folie",
+				de: "Konfustrahl"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Confused.",
 				fr: "Le Pokémon Défenseur est maintenant Confus.",
+				de: "Das Verteidigende Pokémon ist jetzt verwirrt."
 			},
 
 		},
@@ -55,10 +58,12 @@ const card: Card = {
 			name: {
 				en: "Swift",
 				fr: "Météores",
+				de: "Sternschauer"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by Weakness, Resistance, or any other effects on the Defending Pokémon.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Faiblesse, la Résistance ou tout autre effet en action sur le Pokémon Défenseur.",
+				de: "Der Schaden dieses Angriffs wird durch Schwäche, Resistenz oder alle anderen Effekte auf dem Verteidigenden Pokémon nicht verändert."
 			},
 			damage: 50,
 
@@ -76,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "At the center of its body is a red core, which sends mysterious radio signals into the night sky.",
+		de: "In der Körpermitte befindet sich ein roter Kern, der mysteriöse Radiowellen in die Nacht sendet."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/25.ts
+++ b/data/Black & White/Next Destinies/25.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Call for Family",
 				fr: "Appel à la Famille",
+				de: "Familienruf"
 			},
 			effect: {
 				en: "Search your deck for 2 Basic Pokémon and put them onto your Bench. Shuffle your deck afterward.",
 				fr: "Cherchez 2 Pokémon de base dans votre deck et placez-les sur votre Banc. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 2 Basis-Pokémon und lege sie auf deine Bank. Mische anschließend dein Deck."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Reckless Charge",
 				fr: "Attaque Imprudente",
+				de: "Waghalsiger Sturmangriff"
 			},
 			effect: {
 				en: "This Pokémon does 20 damage to itself.",
 				fr: "Ce Pokémon s'inflige 20 dégâts.",
+				de: "Dieses Pokémon fügt sich selbst 20 Schadenspunkte zu."
 			},
 			damage: 40,
 
@@ -72,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "It loves crossing the sea with people and Pokémon on its back. It understands human speech.",
+		de: "Es liebt es, das Meer mit Pokémon und Menschen auf dem Rücken zu überqueren. Es versteht die Menschen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/26.ts
+++ b/data/Black & White/Next Destinies/26.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Water Arrow",
 				fr: "Flèche d'Eau",
+				de: "Wasserpfeil"
 			},
 			effect: {
 				en: "This attack does 20 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige 20 dégâts à 1 des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 1 Pokémon deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -53,6 +55,7 @@ const card: Card = {
 			name: {
 				en: "Surf",
 				fr: "Surf",
+				de: "Surfer"
 			},
 
 			damage: 60,
@@ -71,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "It loves crossing the sea with people and Pokémon on its back. It understands human speech.",
+		de: "Es liebt es, das Meer mit Pokémon und Menschen auf dem Rücken zu überqueren. Es versteht die Menschen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/27.ts
+++ b/data/Black & White/Next Destinies/27.ts
@@ -38,10 +38,12 @@ const card: Card = {
 			name: {
 				en: "Ice Beam",
 				fr: "Laser Glace",
+				de: "Eisstrahl"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 50,
 
@@ -56,6 +58,7 @@ const card: Card = {
 			name: {
 				en: "Ice Wing",
 				fr: "Aile Glace",
+				de: "Frostschwinge"
 			},
 
 			damage: 80,
@@ -81,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "A legendary bird Pokémon. It can create blizzards by freezing moisture in the air.",
+		de: "Ein Legendäres Vogel-Pokémon. Es kann Blizzards verursachen, indem es Feuchtigkeit gefriert."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/28.ts
+++ b/data/Black & White/Next Destinies/28.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Water Gun",
 				fr: "Pistolet à O",
+				de: "Aquaknarre"
 			},
 
 			damage: 30,
@@ -55,6 +56,7 @@ const card: Card = {
 
 	description: {
 		en: "The water stored inside the tuft on its head is full of nutrients. Plants that receive its water grow large.",
+		de: "Das Wasser, das es im Büschel auf seinem Kopf sammelt, ist äußerst nahrhaft und verhilft Pflanzen zu großem Wachstum."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/29.ts
+++ b/data/Black & White/Next Destinies/29.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Panpour",
 		fr: "Flotajou",
+		de: "Sodamak"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Collect",
 				fr: "Collecte",
+				de: "Sammeln"
 			},
 			effect: {
 				en: "Draw 3 cards.",
 				fr: "Piochez 3 cartes.",
+				de: "Ziehe 3 Karten."
 			},
 
 		},
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Stadium Wave",
 				fr: "Innondation du Stade",
+				de: "Stadionwoge"
 			},
 			effect: {
 				en: "If there is any Stadium card in play, this attack does 30 more damage and the Defending Pokémon is now Asleep.",
 				fr: "S'il y a une carte Stade en jeu, cette attaque inflige 30 dégâts supplémentaires et le Pokémon Défenseur est maintenant Endormi.",
+				de: "Wenn eine Stadionkarte im Spiel ist, fügt dieser Angriff 30 weitere Schadenspunkte zu und das Verteidigende Pokémon schläft jetzt."
 			},
 			damage: 30,
 
@@ -77,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "The tuft on its head holds water. When the level runs low, it replenishes the tuft by siphoning up water with its tail.",
+		de: "Speichert Wasser im Büschel auf seinem Kopf. Sinkt der Wasserstand, tankt es über seinen Schweif neue Flüssigkeit."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/3.ts
+++ b/data/Black & White/Next Destinies/3.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Beat",
 				fr: "Bataille",
+				de: "Verprügler"
 			},
 
 			damage: 10,
@@ -49,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Double Headbutt",
 				fr: "Double Coup d'Boule",
+				de: "Doppelte Kopfnuss"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 10 more damage for each heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts supplémentaires pour chaque côté face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 10,
 
@@ -70,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "Its legs are short. Whenever it stumbles, its stiff antennae clack with a xylophone-like sound.",
+		de: "Seine Beine sind kurz. Stolpert es, klappern seine starren Antennen und klingen wie ein Xylophon."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/30.ts
+++ b/data/Black & White/Next Destinies/30.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
+				de: "Biss"
 			},
 
 			damage: 10,
@@ -48,10 +49,12 @@ const card: Card = {
 			name: {
 				en: "Bared Fangs",
 				fr: "Crocs à Vif",
+				de: "Gebleckte Fänge"
 			},
 			effect: {
 				en: "If, before this Pokémon does damage, the Defending Pokémon has no damage counters on it, this attack does nothing.",
 				fr: "Si, avant que ce Pokémon inflige des dégâts, le Pokémon Défenseur n'a aucun marqueur de dégâts, cette attaque ne fait rien.",
+				de: "Falls, bevor dieses Pokémon Schaden zufügt, auf dem Verteidigenden Pokémon keine Schadensmarken liegen, hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 40,
 
@@ -69,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "Red and blue Basculin usually do not get along, but sometimes members of one school mingle with the other's school.",
+		de: "Rot gestreifte und blau gestreifte Exemplare sind sich feindlich gesonnen. Doch ist jeder Schwarm bunt gemischt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/31.ts
+++ b/data/Black & White/Next Destinies/31.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Beat",
 				fr: "Bataille",
+				de: "Verprügler"
 			},
 
 			damage: 10,
@@ -49,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Icy Snow",
 				fr: "Verglas",
+				de: "Eisiger Schnee"
 			},
 
 			damage: 20,
@@ -67,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "The temperature of their breath is -58° F. They create snow crystals and make snow fall in the areas around them.",
+		de: "Die Temperatur seines Odems liegt bei minus 50° C. Es erzeugt Eiskristalle und lässt es in seiner Umgebung schneien."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/32.ts
+++ b/data/Black & White/Next Destinies/32.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Vanillite",
 		fr: "Sorbébé",
+		de: "Gelatini"
 	},
 
 	stage: "Stage1",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Icy Snow",
 				fr: "Verglas",
+				de: "Eisiger Schnee"
 			},
 
 			damage: 20,
@@ -55,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Icy Wind",
 				fr: "Vent Glace",
+				de: "Eissturm"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Asleep.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Endormi.",
+				de: "Wirf 1 Münze. Bei „Kopf“ schläft das Verteidigende Pokémon jetzt."
 			},
 			damage: 50,
 
@@ -76,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "Snowy mountains are this Pokémon's habitat. During an ancient ice age, they moved to southern areas.",
+		de: "Es lebt auf schneebedeckten Bergen. Vor vielen Jahren fand es während einer Eiszeit seinen Weg in den Süden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/33.ts
+++ b/data/Black & White/Next Destinies/33.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Vanillish",
 		fr: "Sorboul",
+		de: "Gelatroppo"
 	},
 
 	stage: "Stage2",
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Crushing Ice",
 				fr: "Brise-Glace",
+				de: "Berstendes Eis"
 			},
 			effect: {
 				en: "Does 10 more damage for each Colorless in the Defending Pokémon's Retreat Cost.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque Colorless dans le coût de Retraite du Pokémon Défenseur.",
+				de: "Dieser Angriff fügt 10 weitere Schadenspunkte für jede {C}-Energie in den Rückzugskosten des Verteidigenden Pokémon zu."
 			},
 			damage: 60,
 
@@ -86,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "Swallowing large amounts of water, they make snow clouds inside their bodies and attack their foes with violent blizzards.",
+		de: "Schluckt Unmengen an Wasser, die es in sich zu Schneewolken verwandelt, und plagt Gegner mit hartem Schneetreiben."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/34.ts
+++ b/data/Black & White/Next Destinies/34.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Bubble",
 				fr: "Écume",
+				de: "Blubber"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Spit Poison",
 				fr: "Crache-Venin",
+				de: "Giftspucke"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné.",
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet."
 			},
 
 		},
@@ -71,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "They paralyze prey with poison, then drag them down to their lairs, five miles below the surface.",
+		de: "Es lähmt seine Beute mit Gift und verschleppt sie in seinen Unterschlupf, acht Kilometer unter dem Meeresspiegel."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/35.ts
+++ b/data/Black & White/Next Destinies/35.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Frillish",
 		fr: "Viskuse",
+		de: "Quabbel"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Vengeful Wish",
 				fr: "Désir de Vengeance",
+				de: "Rachewunsch"
 			},
 			effect: {
 				en: "If this Pokémon was damaged by an attack during your opponent's last turn, this attack does the same amount of damage to the Defending Pokémon.",
 				fr: "Si ce Pokémon a subi les dégâts d'une attaque pendant le dernier tour de votre adversaire, cette attaque inflige la même quantité de dégâts au Pokémon Défenseur.",
+				de: "Falls diesem Pokémon während des letzten Zuges deines Gegners Schaden durch einen Angriff zugefügt wurde, fügt dieser Angriff dem Verteidigenden Pokémon genauso viel Schaden zu."
 			},
 
 		},
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Absorb Life",
 				fr: "Absorption",
+				de: "Lebensverkoster"
 			},
 			effect: {
 				en: "Heal 30 damage from this Pokémon.",
 				fr: "Soignez 30 dégâts à ce Pokémon.",
+				de: "Heile 30 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 30,
 
@@ -78,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "They propel themselves by expelling absorbed seawater from their bodies. Their favorite food is life energy.",
+		de: "Es bewegt sich wie mit einer Düse fort, indem es Meerwasser ausstößt. Seine Leibspeise ist Lebensenergie."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/36.ts
+++ b/data/Black & White/Next Destinies/36.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Sniffle",
 				fr: "Reniflement",
+				de: "Schniefen"
 			},
 			effect: {
 				en: "During your next turn, this Pokémon's Belt attack's base damage is 40.",
 				fr: "Pendant votre prochain tour, les dégâts de base de l'attaque Taloche de ce Pokémon sont de 40.",
+				de: "Während deines nächsten Zuges beträgt der Grundschaden der Attacke Versohler dieses Pokémon 40 Schadenspunkte."
 			},
 
 		},
@@ -51,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Belt",
 				fr: "Taloche",
+				de: "Versohler"
 			},
 
 			damage: 20,
@@ -69,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "Its nose is always running. It sniffs the snot back up because the mucus provides the raw material for its moves.",
+		de: "Der Schleim, der stets aus seiner Nase hängt, treibt seine Attacken an. Zieht es ihn hoch, steht ein Angriff bevor."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/37.ts
+++ b/data/Black & White/Next Destinies/37.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cubchoo",
 		fr: "Polarhume",
+		de: "Petznief"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Daunt",
 				fr: "Découragement",
+				de: "Entmutigen"
 			},
 			effect: {
 				en: "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, tous les dégâts infligés par des attaques du Pokémon Défenseur sont réduits de 20 (avant application de la Faiblesse et de la Résistance).",
+				de: "Während des nächsten Zuges deines Gegners wird Schaden, der durch Angriffe des Verteidigenden Pokémon zugefügt wird, um 20 Schadenspunkte reduziert (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 			damage: 40,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Ambush",
 				fr: "Embuscade",
+				de: "Hinterhalt"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: 60,
 
@@ -80,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "It can make its breath freeze at will. Very able in the water, it swims around in northern seas and catches prey.",
+		de: "Kann seinen eigenen Atem zum Gefrieren bringen. Es schwimmt auf der Suche nach Beute die nördlichen Meere ab."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/38.ts
+++ b/data/Black & White/Next Destinies/38.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Frozen Wings",
 				fr: "Ailes Gelées",
+				de: "Starre Schwingen"
 			},
 			effect: {
 				en: "Discard a Special Energy attached to the Defending Pokémon.",
 				fr: "Défaussez une Énergie spéciale attachée au Pokémon Défenseur.",
+				de: "Lege 1 an das Verteidigende Pokémon angelegte Spezial-Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 60,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Hail Blizzard",
 				fr: "Tempêtegrêle",
+				de: "Hagelblizzard"
 			},
 			effect: {
 				en: "This Pokémon can't use Hail Blizzard during your next turn.",
 				fr: "Ce Pokémon ne peut pas utiliser Tempêtegrêle pendant votre prochain tour.",
+				de: "Dieses Pokémon kann während deines nächsten Zuges Hagelblizzard nicht einsetzen."
 			},
 			damage: 120,
 

--- a/data/Black & White/Next Destinies/39.ts
+++ b/data/Black & White/Next Destinies/39.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Thundershock",
 				fr: "Éclair",
+				de: "Donnerschock"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 10,
 
@@ -52,6 +54,7 @@ const card: Card = {
 			name: {
 				en: "Tail Whap",
 				fr: "Queue Battoir",
+				de: "Schweifvertrimmer"
 			},
 
 			damage: 20,
@@ -70,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "It occasionally uses an electric shock to recharge a fellow Pikachu that is in a weakened state.",
+		de: "Es verwendet hin und wieder Elektrizität, um ein anderes, geschwächtes Pikachu aufzuladen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/4.ts
+++ b/data/Black & White/Next Destinies/4.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Kricketot",
 		fr: "Crikzik",
+		de: "Zirpurze"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "White Noise",
 				fr: "Sommeil Profond",
+				de: "Weißes Rauschen"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 			damage: 20,
 
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Draining Cut",
 				fr: "Vampitranche",
+				de: "Zehrender Schnitt"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 40 damage times the number of heads. Heal from this Pokémon the same amount of damage you did to the Defending Pokémon.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 40 dégâts multipliés par le nombre de côtés face. Soignez à ce Pokémon la même quantité de dégâts que vous avez infligée au Pokémon Défenseur.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl „Kopf“ zu. Heile bei diesem Pokémon genauso viel Schaden, wie du dem Verteidigenden Pokémon zugefügt hast."
 			},
 			damage: 40,
 
@@ -78,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "There is a village that hosts a contest based on the amazingly variable cries of this Pokémon.",
+		de: "Es gibt ein Dorf, das basierend auf den imposanten Rufen dieses Pokémon einen Wettbewerb veranstaltet."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/40.ts
+++ b/data/Black & White/Next Destinies/40.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pikachu",
 		fr: "Pikachu",
+		de: "Pikachu"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Thundershock",
 				fr: "Éclair",
+				de: "Donnerschock"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 20,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Slam",
 				fr: "Souplesse",
+				de: "Slam"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 80 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 80 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 80 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 80,
 
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "Its tail discharges electricity into the ground, protecting it from getting shocked.",
+		de: "Es entlädt Elektrizität in den Boden, um sich auf diese Weise vor elektrischen Schlägen zu schützen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/41.ts
+++ b/data/Black & White/Next Destinies/41.ts
@@ -38,10 +38,12 @@ const card: Card = {
 			name: {
 				en: "Random Spark",
 				fr: "Étincelle Surprise",
+				de: "Zufälliger Funke"
 			},
 			effect: {
 				en: "This attack does 50 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige 50 dégâts à 1 des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 1 Pokémon deines Gegners 50 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -55,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Thundering Hurricane",
 				fr: "Rafale d'Éclairs",
+				de: "Donnernder Orkan"
 			},
 			effect: {
 				en: "Flip 4 coins. This attack does 50 damage times the number of heads.",
 				fr: "Lancez 4 pièces. Cette attaque inflige 50 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 4 Münzen. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 50,
 
@@ -83,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "A legendary Pokémon that is said to live in thunderclouds. It freely controls lightning bolts.",
+		de: "Ein Legendäres Vogel-Pokémon, das in Gewitterwolken leben soll. Es kontrolliert Blitze."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/42.ts
+++ b/data/Black & White/Next Destinies/42.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Jump On",
 				fr: "Saut",
+				de: "Draufspringen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 weitere Schadenspunkte zu."
 			},
 			damage: 10,
 
@@ -52,6 +54,7 @@ const card: Card = {
 			name: {
 				en: "Static Shock",
 				fr: "Choc Statique",
+				de: "Statischer Schock"
 			},
 
 			damage: 20,
@@ -70,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "The extension and contraction of its muscles generates electricity. It glows when in trouble.",
+		de: "Es erzeugt Elektrizität durch das Strecken und Zusammenziehen seiner Muskeln. Bei Bedrohung glüht es."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/43.ts
+++ b/data/Black & White/Next Destinies/43.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Reckless Charge",
 				fr: "Attaque Imprudente",
+				de: "Waghalsiger Sturmangriff"
 			},
 			effect: {
 				en: "This Pokémon does 10 damage to itself.",
 				fr: "Ce Pokémon s'inflige 10 dégâts.",
+				de: "Dieses Pokémon fügt sich selbst 10 Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "The extension and contraction of its muscles generates electricity. It glows when in trouble.",
+		de: "Es erzeugt Elektrizität durch das Strecken und Zusammenziehen seiner Muskeln. Bei Bedrohung glüht es."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/44.ts
+++ b/data/Black & White/Next Destinies/44.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Shinx",
 		fr: "Lixy",
+		de: "Sheinux"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Jump On",
 				fr: "Saut",
+				de: "Draufspringen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Wild Charge",
 				fr: "Éclair Fou",
+				de: "Stromstoß"
 			},
 			effect: {
 				en: "This Pokémon does 10 damage to itself.",
 				fr: "Ce Pokémon s'inflige 10 dégâts.",
+				de: "Dieses Pokémon fügt sich selbst 10 Schadenspunkte zu."
 			},
 			damage: 60,
 
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "Strong electricity courses through the tips of its sharp claws. A light scratch causes fainting in foes.",
+		de: "Durch die Spitzen seiner scharfen Krallen strömt Elektrizität. Selbst kleine Kratzer verursachen Ohnmacht."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/45.ts
+++ b/data/Black & White/Next Destinies/45.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Shinx",
 		fr: "Lixy",
+		de: "Sheinux"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Quick Turn",
 				fr: "Vif Retournement",
+				de: "Schnelldrehung"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -57,6 +60,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
+				de: "Biss"
 			},
 
 			damage: 30,
@@ -75,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "Strong electricity courses through the tips of its sharp claws. A light scratch causes fainting in foes.",
+		de: "Durch die Spitzen seiner scharfen Krallen strömt Elektrizität. Selbst kleine Kratzer verursachen Ohnmacht."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/46.ts
+++ b/data/Black & White/Next Destinies/46.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Luxio",
 		fr: "Luxio",
+		de: "Luxio"
 	},
 
 	stage: "Stage2",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Flash Impact",
 				fr: "Impact-Flash",
+				de: "Blitzeinschlag"
 			},
 			effect: {
 				en: "Does 20 damage to 1 of your Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 20 dégâts à 1 de vos Pokémon. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 1 deiner Pokémon 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 60,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Crunch",
 				fr: "Mâchouille",
+				de: "Knirscher"
 			},
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, défaussez une Énergie attachée au Pokémon Défenseur.",
+				de: "Wirf 1 Münze. Lege bei „Kopf“ 1 an das Verteidigende Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 80,
 
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "It can see clearly through walls to track down its prey and seek its lost young.",
+		de: "Es kann durch Wände sehen und spürt auf diese Weise Beute und verlorengegangene Junge auf."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/47.ts
+++ b/data/Black & White/Next Destinies/47.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Thunder Jolt",
 				fr: "Secousse Tonnerre",
+				de: "Donnerrüttler"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this Pokémon does 10 damage to itself.",
 				fr: "Lancez une pièce. Si c'est pile, ce Pokémon s'inflige 10 dégâts.",
+				de: "Wirf 1 Münze. Bei „Zahl“ fügt sich dieses Pokémon selbst 10 Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "Its mane shines when it discharges electricity. They use their flashing manes to communicate with one another.",
+		de: "Wenn es Strom entlädt, blitzt seine Mähne auf. Auf diese Weise kann es auch mit Artgenossen kommunizieren."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/48.ts
+++ b/data/Black & White/Next Destinies/48.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Blitzle",
 		fr: "Zébibron",
+		de: "Elezeba"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Disconnect",
 				fr: "Déconnexion",
+				de: "Unterbrechen"
 			},
 			effect: {
 				en: "Your opponent can't play any Item cards from his or her hand during his or her next turn.",
 				fr: "Votre adversaire ne peut pas jouer de cartes Objet de sa main pendant son prochain tour.",
+				de: "Dein Gegner kann während seines nächsten Zuges keine Itemkarten von seiner Hand spielen."
 			},
 			damage: 40,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Lightning Crash",
 				fr: "Chute d'Éclairs",
+				de: "Blitzstoß"
 			},
 			effect: {
 				en: "Discard all Lightning Energy attached to this Pokémon. This attack does 80 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Défaussez toutes les Énergies Lightning attachées à ce Pokémon. Cette attaque inflige 80 dégâts à 1 des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Lege alle an dieses Pokémon angelegten {L}-Energien auf deinen Ablagestapel. Dieser Angriff fügt 1 Pokémon deines Gegners 80 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "They have lightning-like movements. When Zebstrika run at full speed, the sound of thunder reverberates.",
+		de: "Es ist explosiv wie ein Blitz. Galoppiert es mit voller Geschwindigkeit drauflos, kann man Donnerhall vernehmen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/49.ts
+++ b/data/Black & White/Next Destinies/49.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Bounce",
 				fr: "Rebond",
+				de: "Sprungfeder"
 			},
 			effect: {
 				en: "Switch this Pokémon with 1 of your Benched Pokémon.",
 				fr: "Échangez ce Pokémon avec 1 de vos Pokémon de Banc.",
+				de: "Tausche dieses Pokémon gegen 1 Pokémon auf deiner Bank aus."
 			},
 			damage: 30,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "The energy made in its cheeks' electric pouches is stored inside its membrane and released while it is gliding.",
+		de: "Im Flug entlädt es Strom, den es mit seinen Backentaschen erzeugt und in seinen Fluglappen gespeichert hat."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/5.ts
+++ b/data/Black & White/Next Destinies/5.ts
@@ -34,10 +34,12 @@ const card: Card = {
 			name: {
 				en: "Synthesis",
 				fr: "Synthèse",
+				de: "Synthese"
 			},
 			effect: {
 				en: "Search your deck for a Grass Energy card and attach it to 1 of your Pokémon. Shuffle your deck afterward.",
 				fr: "Cherchez une carte Énergie Grass dans votre deck et attachez-la à 1 de vos Pokémon. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 1 {G}-Energiekarte und lege sie an 1 deiner Pokémon an. Mische anschließend dein Deck."
 			},
 
 		},
@@ -49,10 +51,12 @@ const card: Card = {
 			name: {
 				en: "Revenge Blast",
 				fr: "Explo-Vengeance",
+				de: "Rachestoß"
 			},
 			effect: {
 				en: "Does 30 more damage for each Prize card your opponent has taken.",
 				fr: "Inflige 30 dégâts supplémentaires pour chaque carte Récompense que votre adversaire a récupérée.",
+				de: "Dieser Angriff fügt 30 weitere Schadenspunkte für jede Preiskarte zu, die dein Gegner bereits genommen hat."
 			},
 			damage: 30,
 

--- a/data/Black & White/Next Destinies/50.ts
+++ b/data/Black & White/Next Destinies/50.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Outrage",
 				fr: "Colère",
+				de: "Wutanfall"
 			},
 			effect: {
 				en: "Does 10 more damage for each damage counter on this Pokémon.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque marqueur de dégâts placé sur ce Pokémon.",
+				de: "Dieser Angriff fügt 10 weitere Schadenspunkte für jede Schadensmarke auf diesem Pokémon zu."
 			},
 			damage: 20,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Bolt Strike",
 				fr: "ChargeFoudre",
+				de: "Blitzschlag"
 			},
 			effect: {
 				en: "This Pokémon does 40 damage to itself.",
 				fr: "Ce Pokémon s'inflige 40 dégâts.",
+				de: "Dieses Pokémon fügt sich selbst 40 Schadenspunkte zu."
 			},
 			damage: 120,
 
@@ -75,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon appears in legends. In its tail, it has a giant generator that creates electricity.",
+		de: "Ein Pokémon, von dem schon in Sagen die Rede ist. Sein Schweif enthält ein gewaltiges Organ zur Stromerzeugung."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/51.ts
+++ b/data/Black & White/Next Destinies/51.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Glinting Claw",
 				fr: "Griffe Scintillante",
+				de: "Schimmernde Klaue"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: 50,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Strong Volt",
 				fr: "Décharge Foudroyante",
+				de: "Voltkraft"
 			},
 			effect: {
 				en: "Discard 2 Energy attached to this Pokémon.",
 				fr: "Défaussez 2 Énergies attachées à ce Pokémon.",
+				de: "Lege 2 an dieses Pokémon angelegte Energien auf deinen Ablagestapel."
 			},
 			damage: 150,
 

--- a/data/Black & White/Next Destinies/52.ts
+++ b/data/Black & White/Next Destinies/52.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Nasty Goo",
 				fr: "Glu Fétide",
+				de: "Ekelschleim"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 20,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "It was born when sludge in a dirty stream was exposed to the moon's X-rays. It appears among filth.",
+		de: "Es wurde geboren, als Schlamm von den Strahlen des Mondes getroffen wurde. Es erscheint, wo Unrat ist."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/53.ts
+++ b/data/Black & White/Next Destinies/53.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Grimer",
 		fr: "Tadmorv",
+		de: "Sleima"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Gentle Wrap",
 				fr: "Enveloppe Douce",
+				de: "Sanfte Umarmung"
 			},
 			effect: {
 				en: "The Defending Pokémon can't retreat during your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas battre en retraite pendant le prochain tour de votre adversaire.",
+				de: "Das Verteidigende Pokémon kann sich während des nächsten Zuges deines Gegners nicht zurückziehen."
 			},
 			damage: 20,
 
@@ -60,10 +63,12 @@ const card: Card = {
 			name: {
 				en: "Toxic Secretion",
 				fr: "Sécrétion Toxique",
+				de: "Giftiges Sekret"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned. Put 2 damage counters instead of 1 on that Pokémon between turns.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné. Placez 2 marqueurs de dégâts au lieu d'un sur le Pokémon ciblé entre chaque tour.",
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet. Lege zwischen den Zügen 2 Schadensmarken anstelle von 1 Schadensmarke auf das Pokémon."
 			},
 			damage: 60,
 
@@ -81,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "A toxic fluids seeps from its body. The fluid instantly kills plants and trees on contact.",
+		de: "Sein Körper sondert eine giftige Substanz ab, die bei Kontakt Pflanzen und Bäume vernichtet."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/54.ts
+++ b/data/Black & White/Next Destinies/54.ts
@@ -35,10 +35,12 @@ const card: Card = {
 			name: {
 				en: "X Ball",
 				fr: "X Ball",
+				de: "X-Ball"
 			},
 			effect: {
 				en: "Does 20 damage times the amount of Energy attached to this Pokémon and the Defending Pokémon.",
 				fr: "Inflige 20 dégâts multipliés par le nombre d'Énergies attachées à ce Pokémon et au Pokémon Défenseur.",
+				de: "Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl der an dieses und an das Verteidigende Pokémon angelegten Energien zu."
 			},
 			damage: 20,
 
@@ -52,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Psydrive",
 				fr: "Psykoforce",
+				de: "Psycho-Antrieb"
 			},
 			effect: {
 				en: "Discard an Energy attached to this Pokémon.",
 				fr: "Défaussez une Énergie attachée à ce Pokémon.",
+				de: "Lege 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel."
 			},
 			damage: 120,
 

--- a/data/Black & White/Next Destinies/55.ts
+++ b/data/Black & White/Next Destinies/55.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Psyshot",
 				fr: "Piqûre Psy",
+				de: "Psychoschuss"
 			},
 
 			damage: 10,
@@ -49,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Smack",
 				fr: "Claque",
+				de: "Klatscher"
 			},
 
 			damage: 20,
@@ -67,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "If its horns capture the warm feelings of people or Pokémon, its body warms up slightly.",
+		de: "Es erfasst warme Gefühle von Menschen und Pokémon mit seinen Hörnern und wärmt sich daran auf."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/56.ts
+++ b/data/Black & White/Next Destinies/56.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Ralts",
 		fr: "Tarsal",
+		de: "Trasla"
 	},
 
 	stage: "Stage1",
@@ -42,6 +43,7 @@ const card: Card = {
 			name: {
 				en: "Smack",
 				fr: "Claque",
+				de: "Klatscher"
 			},
 
 			damage: 20,
@@ -56,10 +58,12 @@ const card: Card = {
 			name: {
 				en: "Psychic",
 				fr: "Psyko",
+				de: "Psychokinese"
 			},
 			effect: {
 				en: "Does 10 more damage for each Energy attached to the Defending Pokémon.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque Énergie attachée au Pokémon Défenseur.",
+				de: "Dieser Angriff fügt 10 weitere Schadenspunkte für jede an das Verteidigende Pokémon angelegte Energie zu."
 			},
 			damage: 40,
 
@@ -77,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "If its Trainer becomes happy, it overflows with energy, dancing joyously while spinning about.",
+		de: "Ist sein Trainer glücklich, tanzt es in einem Schwall von Energie fröhlich umher."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/57.ts
+++ b/data/Black & White/Next Destinies/57.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Kirlia",
 		fr: "Kirlia",
+		de: "Kirlia"
 	},
 
 	stage: "Stage2",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Cada Energía Psychic Básica unida a tus Pokémon Psychic proporciona Energía PsychicPsychic. No puedes aplicar más de 1 Habilidad Espejismo Psíquico a la vez.",
 				it: "Ogni Energia base Psychic assegnata ai tuoi Pokémon Psychic fornisce PsychicPsychic. Può essere applicata solo un’abilità Psicomiraggio alla volta.",
 				pt: "Cada Energia Psychic básica ligada ao seu Pokémon Psychic fornece Energias PsychicPsychic. Não é possível aplicar mais de 1 habilidade Miragem Psíquica ao mesmo tempo.",
-				de: "Jede an deine Psychic-Pokémon angelegte Psychic-Basis-Energie liefert PsychicPsychic-Energie. Du kannst nicht mehr als jeweils 1 Fähigkeit Psycho-Trugbild anwenden."
+				de: "Jede an deine {P}-Pokémon angelegte {P}-Basis-Energie liefert {P}{P}-Energie. Du kannst nicht mehr als jeweils 1 Fähigkeit Psycho-Trugbild anwenden."
 			},
 		},
 	],
@@ -66,10 +67,12 @@ const card: Card = {
 			name: {
 				en: "Mind Shock",
 				fr: "Choc Cérébral",
+				de: "Verstandesschock"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by Weakness or Resistance.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Faiblesse ou la Résistance.",
+				de: "Der Schaden dieses Angriffs wird durch Schwäche und Resistenz nicht verändert."
 			},
 			damage: 60,
 
@@ -87,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "To protect its Trainer, it will expend all its psychic power to create a small black hole.",
+		de: "Erzeugt ein kleines schwarzes Loch mithilfe all seiner Psycho-Kräfte, um seinen Trainer zu schützen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/58.ts
+++ b/data/Black & White/Next Destinies/58.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Ram",
 				fr: "Collision",
+				de: "Ramme"
 			},
 
 			damage: 20,
@@ -55,6 +56,7 @@ const card: Card = {
 
 	description: {
 		en: "It eats the dreams of people and Pokémon. When it eats a pleasant dream, it expels pink-colored mist.",
+		de: "Es verschlingt die Träume der Menschen. Frisst es einen fröhlichen Traum, stößt es danach einen rosafarbenen Dunst aus."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/59.ts
+++ b/data/Black & White/Next Destinies/59.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Munna",
 		fr: "Munna",
+		de: "Somniam"
 	},
 
 	stage: "Stage1",
@@ -64,10 +65,12 @@ const card: Card = {
 			name: {
 				en: "Fluffy Dream",
 				fr: "Rêve Douillet",
+				de: "Schlummertraum"
 			},
 			effect: {
 				en: "This Pokémon is now Asleep.",
 				fr: "Ce Pokémon est maintenant Endormi.",
+				de: "Dieses Pokémon schläft jetzt."
 			},
 			damage: 40,
 
@@ -85,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "With the mist from its forehead, it can create shapes of things from dreams it has eaten.",
+		de: "Kann Träume, die es verspeist hat, wahr werden lassen. Die Trauminhalte nehmen über den Dunst aus seiner Stirn Form an."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/6.ts
+++ b/data/Black & White/Next Destinies/6.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Seed Bomb",
 				fr: "Canon Graine",
+				de: "Samenbomben"
 			},
 
 			damage: 30,
@@ -62,6 +63,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon dwells deep in the forest. Eating a leaf from its head whisks weariness away as if by magic.",
+		de: "Es lebt tief im Wald. Beißt man in die Kräuter auf seinem Kopf, fühlt man sich auf wundersame Weise erfrischt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/60.ts
+++ b/data/Black & White/Next Destinies/60.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Darumaka",
 		fr: "Darumarond",
+		de: "Flampion"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Synchrodraw",
 				fr: "Pioche Synchro",
+				de: "Synchronzug"
 			},
 			effect: {
 				en: "Shuffle your hand into your deck. Then, draw a number of cards equal to the number of cards in your opponent's hand.",
 				fr: "Mélangez votre main avec votre deck. Ensuite, piochez un nombre de cartes égal au nombre de cartes dans la main de votre adversaire.",
+				de: "Mische deine Handkarten in dein Deck. Ziehe anschließend genauso viele Karten, wie dein Gegner auf der Hand hat."
 			},
 
 		},
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "DarMAXitan",
 				fr: "DaruMax",
+				de: "FlampiviMAX"
 			},
 			effect: {
 				en: "Flip a coin for each Energy attached to this Pokémon. This attack does 50 damage times the number of heads.",
 				fr: "Lancez une pièce pour chaque Énergie attachée à ce Pokémon. Cette attaque inflige 50 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf für jede an dieses Pokémon angelegte Energie 1 Münze. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 50,
 
@@ -77,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "When weakened in battle, it transforms into a stone statue. Then it sharpens its mind and fights on mentally.",
+		de: "Schwächt man es im Kampf, wird es reglos wie ein Stein und horcht in sich hinein, um mit der Kraft seines Geistes zu kämpfen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/61.ts
+++ b/data/Black & White/Next Destinies/61.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Psy Bolt",
 				fr: "Choc Mental",
+				de: "Konfusion"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 10,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "It uses its strong psychic power to squeeze its opponent's brain, causing unendurable headaches.",
+		de: "Es verfügt über mächtige Psycho-Kräfte, mit denen es die Hirne seiner Gegner verwirrt, um ihnen Kopfweh zu bereiten."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/62.ts
+++ b/data/Black & White/Next Destinies/62.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Elgyem",
 		fr: "Lewsor",
+		de: "Pygraulon"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Brain Control",
 				fr: "Contrôle Cérébral",
+				de: "Gedankenkontrolle"
 			},
 			effect: {
 				en: "Your opponent reveals his or her hand. Choose a card from there and put it on the bottom of your opponent's deck.",
 				fr: "Votre adversaire montre sa main. Choisissez-y une carte et mettez-la en dessous du deck de votre adversaire.",
+				de: "Dein Gegner deckt seine Handkarten auf. Wähle 1 dieser Karten und lege sie unter das Deck deines Gegners."
 			},
 
 		},
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Psybeam",
 				fr: "Rafale Psy",
+				de: "Psystrahl"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Confused.",
 				fr: "Le Pokémon Défenseur est maintenant Confus.",
+				de: "Das Verteidigende Pokémon ist jetzt verwirrt."
 			},
 			damage: 40,
 
@@ -78,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "It can manipulate an opponent's memory. Apparently, it communicates by flashing its three different-colored fingers.",
+		de: "Manipuliert das gegnerische Gedächtnis. Lässt es seine drei bunten Finger aufleuchten, kommuniziert es offenbar."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/63.ts
+++ b/data/Black & White/Next Destinies/63.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Punch",
 				fr: "Koud'Poing",
+				de: "Boxhieb"
 			},
 
 			damage: 10,
@@ -49,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Quick Attack",
 				fr: "Vive-Attaque",
+				de: "Ruckzuckhieb"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 10,
 
@@ -70,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "It has the peculiar power of being able to see emotions such as joy and rage in the form of waves.",
+		de: "Es hat die eigenartige Fähigkeit, Gefühle wie Freude oder Wut in Wellenform zu sehen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/64.ts
+++ b/data/Black & White/Next Destinies/64.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Riolu",
 		fr: "Riolu",
+		de: "Riolu"
 	},
 
 	stage: "Stage1",
@@ -64,10 +65,12 @@ const card: Card = {
 			name: {
 				en: "Aura Sphere",
 				fr: "Aurasphère",
+				de: "Aurasphäre"
 			},
 			effect: {
 				en: "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 20 dégâts à 1 des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 1 Pokémon auf der Bank deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 50,
 
@@ -85,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "A well-trained one can sense auras to identify and take in the feelings of creatures over half a mile away.",
+		de: "Ist es trainiert, spürt es Auren, um Gefühle entfernter Kreaturen zu erkennen und aufzunehmen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/65.ts
+++ b/data/Black & White/Next Destinies/65.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Sand Jet",
 				fr: "Sablage",
+				de: "Sandstrahl"
 			},
 			effect: {
 				en: "This attack does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige 20 dégâts à 1 des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 1 Pokémon auf der Bank deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -52,6 +54,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
+				de: "Biss"
 			},
 
 			damage: 30,
@@ -77,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It shuts its nostrils tight then travels through sand as if walking. They form colonies of around ten.",
+		de: "Es schließt seine Nasenlöcher und reist dann durch den Sand. Bildet Kolonien mit einer Größe von ca. 10."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/66.ts
+++ b/data/Black & White/Next Destinies/66.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Hippopotas",
 		fr: "Hippopotas",
+		de: "Hippopotas"
 	},
 
 	stage: "Stage1",
@@ -43,10 +44,12 @@ const card: Card = {
 			name: {
 				en: "Sand Bazooka",
 				fr: "Canon à Sable",
+				de: "Sand-Bazooka"
 			},
 			effect: {
 				en: "You may move a basic Energy attached to this Pokémon to 1 of your Benched Pokémon.",
 				fr: "Vous pouvez déplacer une Énergie de base attachée à ce Pokémon vers 1 de vos Pokémon de Banc.",
+				de: "Du kannst 1 an dieses Pokémon angelegte Basis-Energie auf 1 Pokémon auf deiner Bank verschieben."
 			},
 			damage: 70,
 
@@ -61,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Rock Tumble",
 				fr: "Roule-Pierre",
+				de: "Rollende Felsen"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by Resistance.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Résistance.",
+				de: "Der Schaden dieses Angriffs wird durch Resistenz nicht verändert."
 			},
 			damage: 90,
 
@@ -89,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "It is surprisingly quick to anger. It holds its mouth agape as a display of its strength.",
+		de: "Es wird überraschend schnell wütend. Als Zeichen seiner Stärke sperrt es sein Maul auf."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/67.ts
+++ b/data/Black & White/Next Destinies/67.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Triple Smash",
 				fr: "Triple Éclate",
+				de: "Dreifachschmetterer"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 10,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "They has mastered elegant combos. As they concentrate, their battle moves become swifter and more precise.",
+		de: "Ein Meister der Attacken in Serie. Wenn es sich geistig sammelt, werden die Attacken geschmeidiger und flotter."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/68.ts
+++ b/data/Black & White/Next Destinies/68.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Mienfoo",
 		fr: "Kungfouine",
+		de: "Lin-Fu"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Haul In",
 				fr: "Mainmise",
+				de: "Einziehen"
 			},
 			effect: {
 				en: "Search your deck for 2 Pokémon Tool cards, reveal them, and put them into your hand. Shuffle your deck afterward.",
 				fr: "Cherchez 2 cartes Outil Pokémon dans votre deck, montrez-les, puis ajoutez-les à votre main. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 2 Pokémon-Ausrüstungen, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
 			},
 
 		},
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Meditate",
 				fr: "Yoga",
+				de: "Meditation"
 			},
 			effect: {
 				en: "Does 10 more damage for each damage counter on the Defending Pokémon.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque marqueur de dégâts placé sur le Pokémon Défenseur.",
+				de: "Dieser Angriff fügt 10 weitere Schadenspunkte für jede Schadensmarke auf dem Verteidigenden Pokémon zu."
 			},
 			damage: 30,
 
@@ -77,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "They use the long fur on their arms as a whip to strike their opponents.",
+		de: "Es geht seinen Gegnern ans Leder, indem es ihnen mit dem langen Fell seiner Arme wie mit einer Peitsche Hiebe verpasst."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/69.ts
+++ b/data/Black & White/Next Destinies/69.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Corner",
 				fr: "Angle",
+				de: "Bedrängen"
 			},
 			effect: {
 				en: "The Defending Pokémon can't retreat during your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas battre en retraite pendant le prochain tour de votre adversaire.",
+				de: "Das Verteidigende Pokémon kann sich während des nächsten Zuges deines Gegners nicht zurückziehen."
 			},
 			damage: 10,
 
@@ -52,6 +54,7 @@ const card: Card = {
 			name: {
 				en: "Scratch",
 				fr: "Griffe",
+				de: "Kratzer"
 			},
 
 			damage: 20,
@@ -77,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "A smart and sneaky Pokémon. A pair may work together to steal eggs by having one lure the parents away.",
+		de: "Ein raffiniertes Pokémon, das in Zusammenarbeit mit einem anderen Sniebel gern Eier stiehlt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/7.ts
+++ b/data/Black & White/Next Destinies/7.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pansage",
 		fr: "Feuillajou",
+		de: "Vegimak"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Collect",
 				fr: "Collecte",
+				de: "Sammeln"
 			},
 			effect: {
 				en: "Draw 3 cards.",
 				fr: "Piochez 3 cartes.",
+				de: "Ziehe 3 Karten."
 			},
 
 		},
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Stadium Drain",
 				fr: "Vampire de Stade",
+				de: "Stadionsauger"
 			},
 			effect: {
 				en: "If there is any Stadium card in play, this attack does 30 more damage and heal 30 damage from this Pokémon.",
 				fr: "S'il y a une carte Stade en jeu, cette attaque inflige 30 dégâts supplémentaires et vous soignez 30 dégâts à ce Pokémon.",
+				de: "Wenn eine Stadionkarte im Spiel ist, füge mit diesem Angriff 30 weitere Schadenspunkte zu und heile 30 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 30,
 
@@ -84,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "Ill tempered, it fights by swinging its barbed tail around wildly. The leaf growing on its head is very bitter.",
+		de: "Ein hitziger Geselle, der im Kampf seinen dornigen Schweif umherschwingt. Auf seinem Kopf wachsen bittere Kräuter."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/70.ts
+++ b/data/Black & White/Next Destinies/70.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Sneasel",
 		fr: "Farfuret",
+		de: "Sniebel"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Dark Penalty",
 				fr: "Punition Obscure",
+				de: "Dunkle Strafe"
 			},
 			effect: {
 				en: "If the Defending Pokémon has no Pokémon Tool card attached to it, this attack does nothing.",
 				fr: "S'il n'y a pas de carte Outil Pokémon attachée au Pokémon Défenseur, cette attaque ne fait rien.",
+				de: "Wenn an das Verteidigende Pokémon keine Pokémon-Ausrüstung angelegt ist, hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 90,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Fury Swipes",
 				fr: "Combo-Griffe",
+				de: "Kratzfurie"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 30 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 30,
 
@@ -86,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "Evolution made it even more devious. It communicates by clawing signs in boulders.",
+		de: "Wird durch Entwicklung noch verschlagener. Kommuniziert durch in Felsen gekratzte Zeichen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/71.ts
+++ b/data/Black & White/Next Destinies/71.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Seedot",
 		fr: "Grainipiot",
+		de: "Samurzel"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Surprise Punch",
 				fr: "Raclée Surprise",
+				de: "Überraschungshieb"
 			},
 			effect: {
 				en: "Move an Energy attached to the Defending Pokémon to 1 of your opponent's Benched Pokémon.",
 				fr: "Déplacez une Énergie attachée au Pokémon Défenseur vers 1 des Pokémon de Banc de votre adversaire.",
+				de: "Verschiebe 1 an das Verteidigende Pokémon angelegte Energie auf 1 Pokémon auf der Bank deines Gegners."
 			},
 			damage: 20,
 
@@ -70,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "The sound of its grass flute makes its listeners uneasy. It lives deep in forests.",
+		de: "Der Ton seiner Grasflöte beunruhigt die, die ihn hören. Es lebt tief in den Wäldern."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/72.ts
+++ b/data/Black & White/Next Destinies/72.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Nuzleaf",
 		fr: "Pifeuil",
+		de: "Blanas"
 	},
 
 	stage: "Stage2",
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Whirlwind",
 				fr: "Cyclone",
+				de: "Wirbelwind"
 			},
 			effect: {
 				en: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon.",
 				fr: "Votre adversaire échange le Pokémon Défenseur avec 1 de ses Pokémon de Banc.",
+				de: "Dein Gegner tauscht das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
 			},
 			damage: 60,
 
@@ -93,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "By flapping its leafy fan, it can whip up gusts of 100 ft/second that can level houses.",
+		de: "Seine großen Fächer erzeugen Böen, die eine Geschwindigkeit von 30 m/sek erreichen können."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/73.ts
+++ b/data/Black & White/Next Destinies/73.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Shed Skin",
 				fr: "Mue",
+				de: "Expidermis"
 			},
 			effect: {
 				en: "Heal 40 damage from this Pokémon.",
 				fr: "Soignez 40 dégâts à ce Pokémon.",
+				de: "Heile 40 Schadenspunkte bei diesem Pokémon."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Lunge",
 				fr: "Coup Rapide",
+				de: "Ausfall"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 40,
 
@@ -79,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "It immediately headbutts anyones that makes eye contact with it. Its skull is massively thick.",
+		de: "Es hat einen dicken Schädel und versetzt jedem, mit dem sich sein Blick kreuzt, eine Kopfnuss."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/74.ts
+++ b/data/Black & White/Next Destinies/74.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Scraggy",
 		fr: "Baggiguane",
+		de: "Zurrokex"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Rock Head",
 				fr: "Tête de Roc",
+				de: "Steinhaupt"
 			},
 			effect: {
 				en: "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, tous les dégâts infligés à ce Pokémon par des attaques sont réduits de 20 (après application de la Faiblesse et de la Résistance).",
+				de: "Während des nächsten Zuges deines Gegners wird Schaden, der diesem Pokémon durch Angriffe zugefügt wird, um 20 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 			damage: 20,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Hammer Kick",
 				fr: "Marto-Pied",
+				de: "Hammerkick"
 			},
 			effect: {
 				en: "If this Pokémon has fewer remaining HP than the Defending Pokémon, this attack does 30 more damage.",
 				fr: "S'il reste moins de PV à ce Pokémon qu'au Pokémon Défenseur, cette attaque inflige 30 dégâts supplémentaires.",
+				de: "Wenn dieses Pokémon weniger verbliebene KP hat als das Verteidigende Pokémon, fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: 50,
 
@@ -86,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "It can smash concrete blocks with its kicking attacks. The one with the biggest crest is the group leader.",
+		de: "Wählt seinen Anführer über die Größe des Kamms auf dem Kopf. Ein Tritt von ihm reicht, um Betonblöcke zu zertrümmern."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/75.ts
+++ b/data/Black & White/Next Destinies/75.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Knock Away",
 				fr: "Asticotage",
+				de: "Zurückschlagen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 weitere Schadenspunkte zu."
 			},
 			damage: 10,
 
@@ -54,6 +56,7 @@ const card: Card = {
 			name: {
 				en: "Spinning Attack",
 				fr: "Attaque Tournante",
+				de: "Rundumangriff"
 			},
 
 			damage: 40,
@@ -79,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "There are researchers who believe this Pokémon reflected like a mirror in the distant past.",
+		de: "Manche Forscher glauben, dass dieses Pokémon in der Vergangenheit wie ein Spiegel reflektierte."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/76.ts
+++ b/data/Black & White/Next Destinies/76.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Bronzor",
 		fr: "Archéomire",
+		de: "Bronzel"
 	},
 
 	stage: "Stage1",
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Oracle Inflict",
 				fr: "Supplice de l'Oracle",
+				de: "Orakelstrafe"
 			},
 			effect: {
 				en: "Does 10 more damage for each card in your opponent's hand.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque carte dans la main de votre adversaire.",
+				de: "Dieser Angriff fügt für jede Karte in der Hand deines Gegners 10 weitere Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -93,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "It brought rains by opening portals to another world. It was revered as a bringer of plentiful harvests.",
+		de: "Ihm wurden reiche Ernten zugeschrieben, da es durch Portale in andere Welten Regenfälle brachte."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/77.ts
+++ b/data/Black & White/Next Destinies/77.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Self Destruct",
 				fr: "Destruction",
+				de: "Finale"
 			},
 			effect: {
 				en: "This Pokémon does 60 damage to itself.",
 				fr: "Ce Pokémon s'inflige 60 dégâts.",
+				de: "Dieses Pokémon fügt sich selbst 60 Schadenspunkte zu."
 			},
 			damage: 60,
 
@@ -65,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "When threatened, it attacks by shooting a barrage of spikes, which gives it a chance to escape by rolling away.",
+		de: "Fühlt es sich bedroht, wehrt es sich, indem es eine großzügige Salve Dornen abfeuert."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/78.ts
+++ b/data/Black & White/Next Destinies/78.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Sing",
 				fr: "Berceuse",
+				de: "Gesang"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Double Slap",
 				fr: "Torgnoles",
+				de: "Duplexhieb"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -72,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "When it wavers its big, round eyes, it begins singing a lullaby that makes everyone drowsy.",
+		de: "Sobald es mit seinen großen, runden Augen rollt, fängt es an, ein Lied zu singen und jeder schläft ein."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/79.ts
+++ b/data/Black & White/Next Destinies/79.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Jigglypuff",
 		fr: "Rondoudou",
+		de: "Pummeluff"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Round",
 				fr: "Chant Canon",
+				de: "Kanon"
 			},
 			effect: {
 				en: "Does 20 damage times the number of your Pokémon that have the Round attack.",
 				fr: "Inflige 20 dégâts multipliés par le nombre de vos Pokémon possédant l'attaque Chant Canon.",
+				de: "Dieser Angriff fügt 20 Schadenspunkte für jedes deiner Pokémon zu, das Kanon beherrscht."
 			},
 			damage: 20,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Hypnoblast",
 				fr: "Hypnoblast",
+				de: "Hypnoschuss"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Asleep.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Endormi.",
+				de: "Wirf 1 Münze. Bei „Kopf“ schläft das Verteidigende Pokémon jetzt."
 			},
 			damage: 60,
 
@@ -80,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "Its fine fur feels sublime to the touch. It can expand its body by inhaling air.",
+		de: "Sein feines Fell fühlt sich herrlich an. Es kann sich größer machen, indem es Luft einatmet."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/8.ts
+++ b/data/Black & White/Next Destinies/8.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Find a Friend",
 				fr: "Trouver un Ami",
+				de: "Freunde finden"
 			},
 			effect: {
 				en: "Flip a coin. If heads, search your deck for a Pokémon, reveal it, and put it into your hand. Shuffle your deck afterward.",
 				fr: "Lancez une pièce. Si c'est face, cherchez un Pokémon dans votre deck, montrez-le, puis ajoutez-le à votre main. Mélangez ensuite votre deck.",
+				de: "Wirf 1 Münze. Durchsuche bei „Kopf“ dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Rising Lunge",
 				fr: "Botte Secrète",
+				de: "Aufwärtsstoß"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 10,
 
@@ -79,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "It lures people in with its Poké Ball pattern, then releases poison spores. Why it resembles a Poké Ball is unknown.",
+		de: "Fällt ein Trainer auf sein Äußeres herein, das komischerweise einem Pokéball ähnelt, besprüht es ihn mit Giftsporen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/80.ts
+++ b/data/Black & White/Next Destinies/80.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Double Scratch",
 				fr: "Double Écorchure",
+				de: "Doppelkratzer"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 10,
 
@@ -52,6 +54,7 @@ const card: Card = {
 			name: {
 				en: "Cat Kick",
 				fr: "Coup d'Patte",
+				de: "Katzenkick"
 			},
 
 			damage: 20,
@@ -70,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "It is nocturnal in nature. If it spots something shiny, its eyes glitter brightly.",
+		de: "Ein nachtaktives Pokémon. Sieht es etwas Schimmerndes, fangen seine Augen an zu glänzen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/81.ts
+++ b/data/Black & White/Next Destinies/81.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Meowth",
 		fr: "Miaouss",
+		de: "Mauzi"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Nasty Plot",
 				fr: "Machination",
+				de: "Ränkeschmied"
 			},
 			effect: {
 				en: "Search your deck for a card and put it into your hand. Shuffle your deck afterward.",
 				fr: "Cherchez une carte dans votre deck puis ajoutez-la à votre main. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 1 Karte und nimm sie auf deine Hand. Mische anschließend dein Deck."
 			},
 
 		},
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Shadow Claw",
 				fr: "Griffe Ombre",
+				de: "Dunkelklaue"
 			},
 			effect: {
 				en: "Flip a coin. If heads, discard a random card from your opponent's hand.",
 				fr: "Lancez une pièce. Si c'est face, défaussez au hasard une carte de la main de votre adversaire.",
+				de: "Wirf 1 Münze. Nimm bei „Kopf“ 1 zufällige Karte aus der verdeckten Hand deines Gegners und lege sie auf dessen Ablagestapel."
 			},
 			damage: 30,
 
@@ -77,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "A very haughty Pokémon. Among fans, the size of the jewel in its forehead is a topic of much talk.",
+		de: "Ein sehr stolzes Pokémon. Für Fans ist die Größe des Juwels auf seiner Stirn Anlass für Diskussionen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/82.ts
+++ b/data/Black & White/Next Destinies/82.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Giga Power",
 				fr: "Giga Pouvoir",
+				de: "Gigakraft"
 			},
 			effect: {
 				en: "You may do 20 more damage. If you do, this Pokémon does 20 damage to itself.",
 				fr: "Vous pouvez infliger 20 dégâts supplémentaires. Dans ce cas, ce Pokémon s'inflige 20 dégâts.",
+				de: "Du kannst mit diesem Angriff 20 weitere Schadenspunkte zufügen. Wenn du das machst, fügt dieses Pokémon sich selbst 20 Schadenspunkte zu."
 			},
 			damage: 60,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Raging Hammer",
 				fr: "Marteau Rageur",
+				de: "Wuthammer"
 			},
 			effect: {
 				en: "Does 10 more damage for each damage counter on this Pokémon.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque marqueur de dégâts placé sur ce Pokémon.",
+				de: "Dieser Angriff fügt 10 weitere Schadenspunkte für jede Schadensmarke auf diesem Pokémon zu."
 			},
 			damage: 50,
 

--- a/data/Black & White/Next Destinies/83.ts
+++ b/data/Black & White/Next Destinies/83.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Scout",
 				fr: "Espionnage",
+				de: "Späher"
 			},
 			effect: {
 				en: "Your opponent reveals his or her hand.",
 				fr: "Votre adversaire montre sa main.",
+				de: "Dein Gegner deckt seine Handkarten auf."
 			},
 
 		},
@@ -51,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Gust",
 				fr: "Tornade",
+				de: "Windstoß"
 			},
 
 			damage: 20,
@@ -76,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "These Pokémon live in cities. They are accustomed to people. Flocks often gather in parks and plazas.",
+		de: "Ein Pokémon, das in der Stadt zu Hause ist. Es ist sehr zutraulich und bevölkert in Scharen öffentliche Plätze und Parks."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/84.ts
+++ b/data/Black & White/Next Destinies/84.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Call for Family",
 				fr: "Appel à la Famille",
+				de: "Familienruf"
 			},
 			effect: {
 				en: "Search your deck for a Basic Pokémon and put it onto your Bench. Shuffle your deck afterward.",
 				fr: "Cherchez un Pokémon de base dans votre deck et placez-le sur votre Banc. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 1 Basis-Pokémon und lege es auf deine Bank. Mische anschließend dein Deck."
 			},
 
 		},
@@ -51,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Tail Smack",
 				fr: "Coup de Queue",
+				de: "Schweifschlag"
 			},
 
 			damage: 20,
@@ -69,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "These Pokémon prefer a tidy habitat. They are always sweeping and dusting, using their tails as brooms.",
+		de: "Ein Pokémon mit Putzfimmel. Es benutzt seinen Schweif als Staubwedel und fegt seinen Bau, bis alles picobello ist."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/85.ts
+++ b/data/Black & White/Next Destinies/85.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Minccino",
 		fr: "Chinchidou",
+		de: "Picochilla"
 	},
 
 	stage: "Stage1",
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Echoed Voice",
 				fr: "Écho",
+				de: "Widerhall"
 			},
 			effect: {
 				en: "During your next turn, this Pokémon's Echoed Voice attack does 50 more damage (before applying Weakness and Resistance).",
 				fr: "Pendant votre prochain tour, l'attaque Écho de ce Pokémon inflige 50 dégâts supplémentaires (avant application de la Faiblesse et de la Résistance).",
+				de: "Während deines nächsten Zuges fügt die Attacke Widerhall dieses Pokémon 50 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 			damage: 50,
 
@@ -86,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "Their white fur is coated in a special oil that makes it easy for them to deflect attacks.",
+		de: "Sein weißer Flaum ist mit einem speziellen Öl überzogen. Gegnerische Angriffe gleten daran einfach ab."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/86.ts
+++ b/data/Black & White/Next Destinies/86.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja 3 cartas de Energía Básica, enséñalas y ponlas en tu mano. Baraja las cartas de tu baraja después.",
 		it: "Cerca nel tuo mazzo tre carte Energia base, mostrale e aggiungile a quelle che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure em seu baralho 3 cards de Energia básica, revele-os e coloque-os na sua mão. Em seguida, embaralhe seus cards.",
-		de: "Durchsuche dein Deck nach 3 Basis-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach 3 Basis-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Black & White/Next Destinies/87.ts
+++ b/data/Black & White/Next Destinies/87.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Si tu Pokémon Activo queda Fuera de Combate por el daño del ataque de tu rival, puedes mover 1 carta de Energía Básica que estuviera unida a ese Pokémon al Pokémon al que esté unida esta carta.",
 		it: "Quando il tuo Pokémon attivo viene messo K.O. dai danni inflitti da un attacco del tuo avversario, puoi spostare una carta Energia base che gli era stata assegnata sul Pokémon a cui è assegnata questa carta.",
 		pt: "Quando seu Pokémon Ativo for Nocauteado pelos danos causados por um ataque do oponente, você poderá mover 1 card de Energia básica que estava ligado àquele Pokémon para o Pokémon ao qual esse card está ligado.",
-		de: "Wenn dein Aktives Pokémon durch den Schaden eines gegnerischen Angriffs kampfunfähig wird, kannst du 1 Basis-Energiekarte, die an dieses Pokémon angelegt war, auf das Pokémon verschieben, an das diese Karte angelegt ist."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn dein Aktives Pokémon durch den Schaden eines gegnerischen Angriffs kampfunfähig wird, kannst du 1 Basis-Energiekarte, die an dieses Pokémon angelegt war, auf das Pokémon verschieben, an das diese Karte angelegt ist. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Black & White/Next Destinies/88.ts
+++ b/data/Black & White/Next Destinies/88.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja a un Pokémon con un Coste de Retirada de 3 o más, enséñalo y ponlo en tu mano. Baraja las cartas de tu baraja después.",
 		it: "Cerca nel tuo mazzo un Pokémon con un costo di ritirata di almeno tre, mostralo e aggiungilo alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure em seu baralho um Pokémon com Custo para Recuar maior ou igual a 3, revele-o e coloque-o na sua mão. Em seguida, embaralhe seus cards.",
-		de: "Durchsuche dein Deck nach 1 Pokémon mit Rückzugskosten von 3 oder mehr, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach 1 Pokémon mit Rückzugskosten von 3 oder mehr, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Next Destinies/89.ts
+++ b/data/Black & White/Next Destinies/89.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja a un Pokémon con 90 PV o menos, enséñalo y ponlo en tu mano. Baraja las cartas de tu baraja después.",
 		it: "Cerca nel tuo mazzo un Pokémon con un massimo di 90 PV, mostralo e aggiungilo alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure em seu baralho um Pokémon com PS igual ou inferior a 90, revele-o e coloque-o na sua mão. Em seguida, embaralhe seus cards.",
-		de: "Durchsuche dein Deck nach 1 Pokémon mit 90 oder weniger KP, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach 1 Pokémon mit 90 oder weniger KP, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Next Destinies/9.ts
+++ b/data/Black & White/Next Destinies/9.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Foongus",
 		fr: "Trompignon",
+		de: "Tarnpignon"
 	},
 
 	stage: "Stage1",
@@ -64,10 +65,12 @@ const card: Card = {
 			name: {
 				en: "Rising Lunge",
 				fr: "Botte Secrète",
+				de: "Aufwärtsstoß"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -92,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "It lures prey close by dancing and waving its arm caps, which resemble Poké Balls, in a swaying motion.",
+		de: "Es lockt seine Beute an, indem es die Hüte in Form von Pokébällen an seinen Armen rüttelt und einen Tanz aufführt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Next Destinies/90.ts
+++ b/data/Black & White/Next Destinies/90.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Una vez durante el turno de cada jugador, ese jugador puede curar 20 puntos de daño a 1 de sus Pokémon en Banca.",
 		it: "Una sola volta durante il turno di ciascun giocatore, quel giocatore può curare 20 danni da uno dei suoi Pokémon in panchina.",
 		pt: "Uma vez, durante a vez de jogar de cada jogador, aquele jogador poderá curar 20 de danos de 1 dos seus Pokémon no Banco.",
-		de: "Einmal während seines Zuges darf jeder Spieler 20 Schadenspunkte bei 1 seiner Pokémon auf der Bank heilen."
+		de: "Einmal während seines Zuges darf jeder Spieler 20 Schadenspunkte bei 1 seiner Pokémon auf der Bank heilen. Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 
 	trainerType: "Stadium",

--- a/data/Black & White/Next Destinies/91.ts
+++ b/data/Black & White/Next Destinies/91.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "El Coste de Retirada de cada Pokémon Básico en juego es de Colorless menos.",
 		it: "Il costo di ritirata di ciascun Pokémon Base in gioco è ridotto di Colorless.",
 		pt: "O Custo para Recuar de cada Pokémon Básico em jogo é de um Colorless a menos.",
-		de: "Die Rückzugskosten aller Basis-Pokémon im Spiel verringern sich um Colorless."
+		de: "Die Rückzugskosten aller Basis-Pokémon im Spiel verringern sich um {C}. Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 
 	trainerType: "Stadium",

--- a/data/Black & White/Next Destinies/92.ts
+++ b/data/Black & White/Next Destinies/92.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Doble Energía Incolora proporciona Energía ColorlessColorless.",
 		it: "Un’Energia Incolore doppia fornisce ColorlessColorless.",
 		pt: "A Energia Incolor Dupla fornece Energias ColorlessColorless .",
-		de: "Doppel-Farblos-Energie liefert ColorlessColorless-Energie."
+		de: "Doppel-Farblos-Energie liefert {C}{C}-Energie."
 	},
 
 	energyType: "Special",

--- a/data/Black & White/Next Destinies/93.ts
+++ b/data/Black & White/Next Destinies/93.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Esta carta proporciona Energía Colorless. Si el Pokémon al que está unida esta carta es un Pokémon Básico, esta carta proporciona todos los tipos de Energía, pero solo 1 Energía a la vez.",
 		it: "Questa carta fornisce Colorless. Se il Pokémon a cui è assegnata questa carta è un Pokémon Base, questa carta fornisce un’Energia di un tipo qualsiasi, ma solo una alla volta.",
 		pt: "Este card fornece Energia Colorless. Se o Pokémon ao qual este card está ligado for um Pokémon Básico, o card fornecerá todos os tipos de Energia, mas apenas 1 Energia de cada vez.",
-		de: "Diese Karte liefert Colorless-Energie. Wenn diese Karte an ein Basis-Pokémon angelegt ist, zählt sie als jeder beliebige Energietyp, spendet aber immer nur jeweils 1 Energie."
+		de: "Diese Karte liefert {C}-Energie. Wenn diese Karte an ein Basis-Pokémon angelegt ist, zählt sie als jeder beliebige Energietyp, spendet aber immer nur jeweils 1 Energie."
 	},
 
 	energyType: "Special",

--- a/data/Black & White/Next Destinies/94.ts
+++ b/data/Black & White/Next Destinies/94.ts
@@ -34,10 +34,12 @@ const card: Card = {
 			name: {
 				en: "Synthesis",
 				fr: "Synthèse",
+				de: "Synthese"
 			},
 			effect: {
 				en: "Search your deck for a Grass Energy card and attach it to 1 of your Pokémon. Shuffle your deck afterward.",
 				fr: "Cherchez une carte Énergie Grass dans votre deck et attachez-la à 1 de vos Pokémon. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 1 {G}-Energiekarte und lege sie an 1 deiner Pokémon an. Mische anschließend dein Deck."
 			},
 
 		},
@@ -49,10 +51,12 @@ const card: Card = {
 			name: {
 				en: "Revenge Blast",
 				fr: "Explo-Vengeance",
+				de: "Rachestoß"
 			},
 			effect: {
 				en: "Does 30 more damage for each Prize card your opponent has taken.",
 				fr: "Inflige 30 dégâts supplémentaires pour chaque carte Récompense que votre adversaire a récupérée.",
+				de: "Dieser Angriff fügt 30 weitere Schadenspunkte für jede Preiskarte zu, die dein Gegner bereits genommen hat."
 			},
 			damage: 30,
 

--- a/data/Black & White/Next Destinies/95.ts
+++ b/data/Black & White/Next Destinies/95.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Glinting Claw",
 				fr: "Griffe Scintillante",
+				de: "Schimmernde Klaue"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: 50,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Brave Fire",
 				fr: "Flammes de Bravoure",
+				de: "Tapferes Feuer"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this Pokémon does 50 damage to itself.",
 				fr: "Lancez une pièce. Si c'est pile, ce Pokémon s'inflige 50 dégâts.",
+				de: "Wirf 1 Münze. Bei „Zahl“ fügt sich dieses Pokémon selbst 50 Schadenspunkte zu."
 			},
 			damage: 150,
 

--- a/data/Black & White/Next Destinies/96.ts
+++ b/data/Black & White/Next Destinies/96.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Frozen Wings",
 				fr: "Ailes Gelées",
+				de: "Starre Schwingen"
 			},
 			effect: {
 				en: "Discard a Special Energy attached to the Defending Pokémon.",
 				fr: "Défaussez une Énergie spéciale attachée au Pokémon Défenseur.",
+				de: "Lege 1 an das Verteidigende Pokémon angelegte Spezial-Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 60,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Hail Blizzard",
 				fr: "Tempêtegrêle",
+				de: "Hagelblizzard"
 			},
 			effect: {
 				en: "This Pokémon can't use Hail Blizzard during your next turn.",
 				fr: "Ce Pokémon ne peut pas utiliser Tempêtegrêle pendant votre prochain tour.",
+				de: "Dieses Pokémon kann während deines nächsten Zuges Hagelblizzard nicht einsetzen."
 			},
 			damage: 120,
 

--- a/data/Black & White/Next Destinies/97.ts
+++ b/data/Black & White/Next Destinies/97.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Glinting Claw",
 				fr: "Griffe Scintillante",
+				de: "Schimmernde Klaue"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: 50,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Strong Volt",
 				fr: "Décharge Foudroyante",
+				de: "Voltkraft"
 			},
 			effect: {
 				en: "Discard 2 Energy attached to this Pokémon.",
 				fr: "Défaussez 2 Énergies attachées à ce Pokémon.",
+				de: "Lege 2 an dieses Pokémon angelegte Energien auf deinen Ablagestapel."
 			},
 			damage: 150,
 

--- a/data/Black & White/Next Destinies/98.ts
+++ b/data/Black & White/Next Destinies/98.ts
@@ -35,10 +35,12 @@ const card: Card = {
 			name: {
 				en: "X Ball",
 				fr: "X Ball",
+				de: "X-Ball"
 			},
 			effect: {
 				en: "Does 20 damage times the amount of Energy attached to this Pokémon and the Defending Pokémon.",
 				fr: "Inflige 20 dégâts multipliés par le nombre d'Énergies attachées à ce Pokémon et au Pokémon Défenseur.",
+				de: "Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl der an dieses und an das Verteidigende Pokémon angelegten Energien zu."
 			},
 			damage: 20,
 
@@ -52,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Psydrive",
 				fr: "Psykoforce",
+				de: "Psycho-Antrieb"
 			},
 			effect: {
 				en: "Discard an Energy attached to this Pokémon.",
 				fr: "Défaussez une Énergie attachée à ce Pokémon.",
+				de: "Lege 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel."
 			},
 			damage: 120,
 

--- a/data/Black & White/Next Destinies/99.ts
+++ b/data/Black & White/Next Destinies/99.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Giga Power",
 				fr: "Giga Pouvoir",
+				de: "Gigakraft"
 			},
 			effect: {
 				en: "You may do 20 more damage. If you do, this Pokémon does 20 damage to itself.",
 				fr: "Vous pouvez infliger 20 dégâts supplémentaires. Dans ce cas, ce Pokémon s'inflige 20 dégâts.",
+				de: "Du kannst mit diesem Angriff 20 weitere Schadenspunkte zufügen. Wenn du das machst, fügt dieses Pokémon sich selbst 20 Schadenspunkte zu."
 			},
 			damage: 60,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Raging Hammer",
 				fr: "Marteau Rageur",
+				de: "Wuthammer"
 			},
 			effect: {
 				en: "Does 10 more damage for each damage counter on this Pokémon.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque marqueur de dégâts placé sur ce Pokémon.",
+				de: "Dieser Angriff fügt 10 weitere Schadenspunkte für jede Schadensmarke auf diesem Pokémon zu."
 			},
 			damage: 50,
 


### PR DESCRIPTION
## Add missing German translations for bw4

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
