### PR TITLE
(fix) Remove French-only duplicate attack entries from 45 cards

### DIFF
--- a/data/Sun & Moon/Cosmic Eclipse/210.ts
+++ b/data/Sun & Moon/Cosmic Eclipse/210.ts
@@ -95,20 +95,6 @@ const card: Card = {
 			}
 
 		},
-		{
-			cost: [
-				"Colorless",
-				"Colorless",
-				"Colorless",
-			],
-			name: {
-				fr: "Plante Solaire-GX",
-			},
-			effect: {
-				fr: "Cette attaque inflige 50 dégâts à chacun des Pokémon de votre adversaire. Si au moins 2 Énergies supplémentaires sont attachées à ce Pokémon (en plus du coût de cette attaque), soignez tous les dégâts de vos Pokémon. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.) (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Cosmic Eclipse/211.ts
+++ b/data/Sun & Moon/Cosmic Eclipse/211.ts
@@ -103,19 +103,6 @@ const card: Card = {
 			damage: 50,
 
 		},
-		{
-			cost: [
-				"Grass",
-			],
-			name: {
-				fr: "Explosion Allergène-GX",
-			},
-			effect: {
-				fr: "Le Pokémon Actif de votre adversaire est maintenant Brûlé, Empoisonné et Paralysé. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-			damage: 50,
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Cosmic Eclipse/212.ts
+++ b/data/Sun & Moon/Cosmic Eclipse/212.ts
@@ -78,18 +78,6 @@ const card: Card = {
 			},
 
 		},
-		{
-			cost: [
-				"Fire",
-			],
-			name: {
-				fr: "Colonne de Flamme Écarlate-GX",
-			},
-			effect: {
-				fr: "Attachez 5 cartes Énergie de base de votre pile de défausse à vos Pokémon, de la manière que vous voulez. Si au moins une Énergie supplémentaire est attachée à ce Pokémon (en plus du coût de cette attaque), le Pokémon Actif de votre adversaire est maintenant Brûlé et Confus. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Cosmic Eclipse/214.ts
+++ b/data/Sun & Moon/Cosmic Eclipse/214.ts
@@ -80,21 +80,6 @@ const card: Card = {
 			damage: "100+",
 
 		},
-		{
-			cost: [
-				"Water",
-				"Water",
-				"Colorless",
-			],
-			name: {
-				fr: "Lance-Bulles-GX",
-			},
-			effect: {
-				fr: "Le Pokémon Actif de votre adversaire est maintenant Paralysé. Si au moins 3 Énergies Water supplémentaires sont attachées à ce Pokémon (en plus du coût de cette attaque), cette attaque inflige 150 dégâts supplémentaires. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-			damage: "100+",
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Cosmic Eclipse/215.ts
+++ b/data/Sun & Moon/Cosmic Eclipse/215.ts
@@ -80,21 +80,6 @@ const card: Card = {
 			damage: "100+",
 
 		},
-		{
-			cost: [
-				"Water",
-				"Water",
-				"Colorless",
-			],
-			name: {
-				fr: "Lance-Bulles-GX",
-			},
-			effect: {
-				fr: "Le Pokémon Actif de votre adversaire est maintenant Paralysé. Si au moins 3 Énergies Water supplémentaires sont attachées à ce Pokémon (en plus du coût de cette attaque), cette attaque inflige 150 dégâts supplémentaires. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-			damage: "100+",
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Cosmic Eclipse/216.ts
+++ b/data/Sun & Moon/Cosmic Eclipse/216.ts
@@ -81,21 +81,6 @@ const card: Card = {
 			damage: 200,
 
 		},
-		{
-			cost: [
-				"Psychic",
-				"Psychic",
-				"Colorless",
-			],
-			name: {
-				fr: "Lumière de la Protectrice-GX",
-			},
-			effect: {
-				fr: "Si vous avez joué Pleine Puissance de Lilie de votre main pendant ce tour, évitez tous les effets d’attaques, y compris les dégâts, infligés à chacun de vos Pokémon pendant le prochain tour de votre adversaire. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-			damage: 200,
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Cosmic Eclipse/223.ts
+++ b/data/Sun & Moon/Cosmic Eclipse/223.ts
@@ -92,18 +92,6 @@ const card: Card = {
 			}
 
 		},
-		{
-			cost: [
-				"Colorless",
-			],
-			name: {
-				fr: "Ordre Chaotique-GX",
-			},
-			effect: {
-				fr: "Tournez toutes vos cartes Récompense face découverte. (Ces cartes Récompense restent face découverte pour le reste de la partie.) Si au moins une Énergie Psychic supplémentaire et une Énergie Darkness supplémentaire sont attachées à ce Pokémon (en plus du coût de cette attaque), récupérez 2 cartes Récompense. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Dragon Majesty/7.ts
+++ b/data/Sun & Moon/Dragon Majesty/7.ts
@@ -53,20 +53,6 @@ const card: Card = {
 			damage: "20×",
 
 		},
-		{
-			cost: [
-				"Fire",
-				"Fire",
-			],
-			name: {
-				fr: "Infinité",
-			},
-			effect: {
-				fr: "Cette attaque inflige 20 dégâts pour chaque carte Énergie de base dans votre pile de défausse. Mélangez ensuite ces cartes avec votre deck.",
-			},
-			damage: "20×",
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Forbidden Light/31.ts
+++ b/data/Sun & Moon/Forbidden Light/31.ts
@@ -76,21 +76,6 @@ const card: Card = {
 			damage: 100,
 
 		},
-		{
-			cost: [
-				"Water",
-				"Water",
-				"Water",
-			],
-			name: {
-				fr: "Sauna Explosif",
-			},
-			effect: {
-				fr: "Cette attaque inflige 20 dégâts à chacun des Pokémon de Banc de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
-			},
-			damage: 100,
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Forbidden Light/74.ts
+++ b/data/Sun & Moon/Forbidden Light/74.ts
@@ -76,21 +76,6 @@ const card: Card = {
 			damage: 90,
 
 		},
-		{
-			cost: [
-				"Fighting",
-				"Fighting",
-				"Fighting",
-			],
-			name: {
-				fr: "Pluie de Diamants",
-			},
-			effect: {
-				fr: "Soignez 30 dégâts à chacun de vos Pokémon de Banc.",
-			},
-			damage: 90,
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Forbidden Light/96.ts
+++ b/data/Sun & Moon/Forbidden Light/96.ts
@@ -74,19 +74,6 @@ const card: Card = {
 			damage: 30,
 
 		},
-		{
-			cost: [
-				"Colorless",
-			],
-			name: {
-				fr: "Étoile Triptyque",
-			},
-			effect: {
-				fr: "Vous ne pouvez utiliser cette attaque que si vous avez des Pokémon Grass, Water et Lightning sur votre Banc. Cherchez jusqu’à 3 cartes Énergie de base dans votre deck et attachez-les à vos Pokémon, de la manière que vous voulez. Mélangez ensuite votre deck.",
-			},
-			damage: 30,
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Lost Thunder/144.ts
+++ b/data/Sun & Moon/Lost Thunder/144.ts
@@ -76,21 +76,6 @@ const card: Card = {
 			damage: 160,
 
 		},
-		{
-			cost: [
-				"Fairy",
-				"Fairy",
-				"Fairy",
-			],
-			name: {
-				fr: "Cornes Lumineuses",
-			},
-			effect: {
-				fr: "Ce Pokémon ne peut pas utiliser Cornes Lumineuses pendant votre prochain tour.",
-			},
-			damage: 160,
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Lost Thunder/19.ts
+++ b/data/Sun & Moon/Lost Thunder/19.ts
@@ -74,19 +74,6 @@ const card: Card = {
 			damage: 20,
 
 		},
-		{
-			cost: [
-				"Grass",
-			],
-			name: {
-				fr: "Vampigraine",
-			},
-			effect: {
-				fr: "Soignez 20 dégâts à ce Pokémon.",
-			},
-			damage: 20,
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/SM Black Star Promos/SM166.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM166.ts
@@ -71,19 +71,6 @@ const card: Card = {
 			damage: 10,
 
 		},
-		{
-			cost: [
-				"Water",
-			],
-			name: {
-				fr: "Éclaboussure Imposante-GX",
-			},
-			effect: {
-				fr: "Si au moins 7 Énergies Water supplémentaires sont attachées à ce Pokémon (en plus du coût de cette attaque), cette attaque inflige 100 dégâts à chacun des Pokémon de Banc de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.) (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-			damage: 10,
-
-		},
 	],
 	weaknesses: [
 		{

--- a/data/Sun & Moon/SM Black Star Promos/SM168.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM168.ts
@@ -74,21 +74,6 @@ const card: Card = {
 			damage: 200,
 
 		},
-		{
-			cost: [
-				"Lightning",
-				"Lightning",
-				"Lightning",
-			],
-			name: {
-				fr: "Escouade Foudroyante-GX",
-			},
-			effect: {
-				fr: "Si au moins 3 Énergies Lightning supplémentaires sont attachées à ce Pokémon (en plus du coût de cette attaque), cette attaque inflige 170 dégâts à l’un des Pokémon de Banc de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.) (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-			damage: 200,
-
-		},
 	],
 	weaknesses: [
 		{

--- a/data/Sun & Moon/SM Black Star Promos/SM169.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM169.ts
@@ -96,22 +96,6 @@ const card: Card = {
 			damage: 210,
 
 		},
-		{
-			cost: [
-				"Colorless",
-				"Colorless",
-				"Colorless",
-				"Colorless",
-			],
-			name: {
-				fr: "Amis Mégatonnes-GX",
-			},
-			effect: {
-				fr: "Si au moins une Énergie supplémentaire est attachée à ce Pokémon (en plus du coût de cette attaque), piochez jusqu’à avoir 10 cartes en main. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-			damage: 210,
-
-		},
 	],
 	weaknesses: [
 		{

--- a/data/Sun & Moon/SM Black Star Promos/SM201.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM201.ts
@@ -103,21 +103,6 @@ const card: Card = {
 			damage: "200+",
 
 		},
-		{
-			cost: [
-				"Fire",
-				"Fire",
-				"Fire",
-			],
-			name: {
-				fr: "Double Brasier-GX",
-			},
-			effect: {
-				fr: "Si au moins 3 Énergies Fire supplémentaires sont attachées à ce Pokémon (en plus du coût de cette attaque), cette attaque inflige 100 dégâts supplémentaires, et les dégâts de cette attaque ne sont affectés par aucun effet en action sur le Pokémon Actif de votre adversaire. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-			damage: "200+",
-
-		},
 	],
 	weaknesses: [
 		{

--- a/data/Sun & Moon/Team Up/10.ts
+++ b/data/Sun & Moon/Team Up/10.ts
@@ -53,20 +53,6 @@ const card: Card = {
 			damage: "30×",
 
 		},
-		{
-			cost: [
-				"Grass",
-				"Grass",
-			],
-			name: {
-				fr: "Tempête de Fleurs",
-			},
-			effect: {
-				fr: "Cette attaque inflige 30 dégâts multipliés par le nombre d’Énergies de base attachées à tous vos Pokémon.",
-			},
-			damage: "30×",
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Team Up/51.ts
+++ b/data/Sun & Moon/Team Up/51.ts
@@ -65,19 +65,6 @@ const card: Card = {
 			damage: 120,
 
 		},
-		{
-			cost: [
-				"Lightning",
-				"Lightning",
-				"Colorless",
-			],
-			name: {
-				fr: "Éclair Fulgurant",
-			},
-
-			damage: 120,
-
-		},
 	],
 	weaknesses: [
 		{

--- a/data/Sun & Moon/Ultra Prism/58.ts
+++ b/data/Sun & Moon/Ultra Prism/58.ts
@@ -77,22 +77,6 @@ const card: Card = {
 			damage: 160,
 
 		},
-		{
-			cost: [
-				"Psychic",
-				"Psychic",
-				"Psychic",
-				"Psychic",
-			],
-			name: {
-				fr: "Plongeon Critique",
-			},
-			effect: {
-				fr: "Défaussez 2 Énergies de ce Pokémon.",
-			},
-			damage: 160,
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Ultra Prism/62.ts
+++ b/data/Sun & Moon/Ultra Prism/62.ts
@@ -75,22 +75,6 @@ const card: Card = {
 			damage: "20×",
 
 		},
-		{
-			cost: [
-				"Psychic",
-				"Psychic",
-				"Psychic",
-				"Psychic",
-			],
-			name: {
-				fr: "Tempête Psy",
-			},
-			effect: {
-				fr: "Cette attaque inflige 20 dégâts multipliés par le nombre d’Énergies attachées aux Pokémon.",
-			},
-			damage: "20×",
-
-		},
 	],
 	weaknesses: [
 		{

--- a/data/Sun & Moon/Ultra Prism/77.ts
+++ b/data/Sun & Moon/Ultra Prism/77.ts
@@ -77,22 +77,6 @@ const card: Card = {
 			damage: 120,
 
 		},
-		{
-			cost: [
-				"Darkness",
-				"Darkness",
-				"Darkness",
-				"Darkness",
-			],
-			name: {
-				fr: "Sommeil Abyssal",
-			},
-			effect: {
-				fr: "Le Pokémon Actif de votre adversaire est maintenant Endormi. Votre adversaire lance 2 pièces au lieu d’une entre chaque tour. S’il obtient au moins un côté pile, le Pokémon reste Endormi.",
-			},
-			damage: 120,
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Ultra Prism/89.ts
+++ b/data/Sun & Moon/Ultra Prism/89.ts
@@ -77,22 +77,6 @@ const card: Card = {
 			damage: 160,
 
 		},
-		{
-			cost: [
-				"Metal",
-				"Metal",
-				"Metal",
-				"Metal",
-			],
-			name: {
-				fr: "Impact de Couronne",
-			},
-			effect: {
-				fr: "Ce Pokémon ne peut pas attaquer pendant votre prochain tour.",
-			},
-			damage: 160,
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Unbroken Bonds/1.ts
+++ b/data/Sun & Moon/Unbroken Bonds/1.ts
@@ -101,19 +101,6 @@ const card: Card = {
 			damage: 50,
 
 		},
-		{
-			cost: [
-				"Grass",
-			],
-			name: {
-				fr: "Jeu Chimérique-GX",
-			},
-			effect: {
-				fr: "Si le Pokémon de votre adversaire est mis K.O. par les dégâts de cette attaque, récupérez une carte Récompense supplémentaire. Si au moins 7 Énergies supplémentaires sont attachées à ce Pokémon (en plus du coût de cette attaque), récupérez 3 cartes Récompense supplémentaires au lieu d’une. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-			damage: 50,
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Unbroken Bonds/130.ts
+++ b/data/Sun & Moon/Unbroken Bonds/130.ts
@@ -98,21 +98,6 @@ const card: Card = {
 			damage: 200,
 
 		},
-		{
-			cost: [
-				"Fairy",
-				"Fairy",
-				"Fairy",
-			],
-			name: {
-				fr: "Miracle Magique-GX",
-			},
-			effect: {
-				fr: "Si au moins 3 Énergies Fairy supplémentaires sont attachées à ce Pokémon (en plus du coût de cette attaque), votre adversaire mélange sa main avec son deck. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-			damage: 200,
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Unbroken Bonds/191.ts
+++ b/data/Sun & Moon/Unbroken Bonds/191.ts
@@ -101,19 +101,6 @@ const card: Card = {
 			damage: 50,
 
 		},
-		{
-			cost: [
-				"Grass",
-			],
-			name: {
-				fr: "Jeu Chimérique-GX",
-			},
-			effect: {
-				fr: "Si le Pokémon de votre adversaire est mis K.O. par les dégâts de cette attaque, récupérez une carte Récompense supplémentaire. Si au moins 7 Énergies supplémentaires sont attachées à ce Pokémon (en plus du coût de cette attaque), récupérez 3 cartes Récompense supplémentaires au lieu d’une. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-			damage: 50,
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Unbroken Bonds/192.ts
+++ b/data/Sun & Moon/Unbroken Bonds/192.ts
@@ -101,19 +101,6 @@ const card: Card = {
 			damage: 50,
 
 		},
-		{
-			cost: [
-				"Grass",
-			],
-			name: {
-				fr: "Jeu Chimérique-GX",
-			},
-			effect: {
-				fr: "Si le Pokémon de votre adversaire est mis K.O. par les dégâts de cette attaque, récupérez une carte Récompense supplémentaire. Si au moins 7 Énergies supplémentaires sont attachées à ce Pokémon (en plus du coût de cette attaque), récupérez 3 cartes Récompense supplémentaires au lieu d’une. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-			damage: 50,
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Unbroken Bonds/194.ts
+++ b/data/Sun & Moon/Unbroken Bonds/194.ts
@@ -105,21 +105,6 @@ const card: Card = {
 			damage: "200+",
 
 		},
-		{
-			cost: [
-				"Fire",
-				"Fire",
-				"Fire",
-			],
-			name: {
-				fr: "Double Brasier-GX",
-			},
-			effect: {
-				fr: "Si au moins 3 Énergies Fire supplémentaires sont attachées à ce Pokémon (en plus du coût de cette attaque), cette attaque inflige 100 dégâts supplémentaires, et les dégâts de cette attaque ne sont affectés par aucun effet en action sur le Pokémon Actif de votre adversaire. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-			damage: "200+",
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Unbroken Bonds/20.ts
+++ b/data/Sun & Moon/Unbroken Bonds/20.ts
@@ -105,21 +105,6 @@ const card: Card = {
 			damage: "200+",
 
 		},
-		{
-			cost: [
-				"Fire",
-				"Fire",
-				"Fire",
-			],
-			name: {
-				fr: "Double Brasier-GX",
-			},
-			effect: {
-				fr: "Si au moins 3 Énergies Fire supplémentaires sont attachées à ce Pokémon (en plus du coût de cette attaque), cette attaque inflige 100 dégâts supplémentaires, et les dégâts de cette attaque ne sont affectés par aucun effet en action sur le Pokémon Actif de votre adversaire. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-			damage: "200+",
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Unified Minds/126.ts
+++ b/data/Sun & Moon/Unified Minds/126.ts
@@ -84,23 +84,6 @@ const card: Card = {
 			damage: 250,
 
 		},
-		{
-			cost: [
-				"Darkness",
-				"Darkness",
-				"Darkness",
-				"Darkness",
-				"Colorless",
-			],
-			name: {
-				fr: "Chute Giga-GX",
-			},
-			effect: {
-				fr: "Si au moins 5 Énergies supplémentaires sont attachées à ce Pokémon (en plus du coût de cette attaque), défaussez les 15 cartes du dessus du deck de votre adversaire. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-			damage: 250,
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Unified Minds/214.ts
+++ b/data/Sun & Moon/Unified Minds/214.ts
@@ -100,21 +100,6 @@ const card: Card = {
 			damage: 200,
 
 		},
-		{
-			cost: [
-				"Grass",
-				"Grass",
-				"Grass",
-			],
-			name: {
-				fr: "Pause Tropicale-GX",
-			},
-			effect: {
-				fr: "Si au moins 3 Énergies supplémentaires sont attachées à ce Pokémon (en plus du coût de cette attaque), votre adversaire mélange toutes les Énergies de tous ses Pokémon avec son deck. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-			damage: 200,
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Unified Minds/215.ts
+++ b/data/Sun & Moon/Unified Minds/215.ts
@@ -100,21 +100,6 @@ const card: Card = {
 			damage: 200,
 
 		},
-		{
-			cost: [
-				"Grass",
-				"Grass",
-				"Grass",
-			],
-			name: {
-				fr: "Pause Tropicale-GX",
-			},
-			effect: {
-				fr: "Si au moins 3 Énergies supplémentaires sont attachées à ce Pokémon (en plus du coût de cette attaque), votre adversaire mélange toutes les Énergies de tous ses Pokémon avec son deck. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-			damage: 200,
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Unified Minds/217.ts
+++ b/data/Sun & Moon/Unified Minds/217.ts
@@ -78,20 +78,6 @@ const card: Card = {
 			damage: "10+",
 
 		},
-		{
-			cost: [
-				"Water",
-				"Water",
-			],
-			name: {
-				fr: "Temps Heureux-GX",
-			},
-			effect: {
-				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 100 dégâts supplémentaires. Si au moins 6 Énergies Water supplémentaires sont attachées à ce Pokémon (en plus du coût de cette attaque), lancez 10 pièces à la place, et cette attaque inflige 100 dégâts supplémentaires pour chaque côté face. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-			damage: "10+",
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Unified Minds/218.ts
+++ b/data/Sun & Moon/Unified Minds/218.ts
@@ -78,20 +78,6 @@ const card: Card = {
 			damage: "10+",
 
 		},
-		{
-			cost: [
-				"Water",
-				"Water",
-			],
-			name: {
-				fr: "Temps Heureux-GX",
-			},
-			effect: {
-				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 100 dégâts supplémentaires. Si au moins 6 Énergies Water supplémentaires sont attachées à ce Pokémon (en plus du coût de cette attaque), lancez 10 pièces à la place, et cette attaque inflige 100 dégâts supplémentaires pour chaque côté face. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-			damage: "10+",
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Unified Minds/220.ts
+++ b/data/Sun & Moon/Unified Minds/220.ts
@@ -76,21 +76,6 @@ const card: Card = {
 			damage: "150+",
 
 		},
-		{
-			cost: [
-				"Lightning",
-				"Lightning",
-				"Colorless",
-			],
-			name: {
-				fr: "Tour d’Éclair-GX",
-			},
-			effect: {
-				fr: "Échangez ce Pokémon avec l’un de vos Pokémon de Banc. Si au moins 2 Énergies Lightning supplémentaires sont attachées à ce Pokémon (en plus du coût de cette attaque), cette attaque inflige 100 dégâts supplémentaires. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-			damage: "150+",
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Unified Minds/221.ts
+++ b/data/Sun & Moon/Unified Minds/221.ts
@@ -76,21 +76,6 @@ const card: Card = {
 			damage: "150+",
 
 		},
-		{
-			cost: [
-				"Lightning",
-				"Lightning",
-				"Colorless",
-			],
-			name: {
-				fr: "Tour d’Éclair-GX",
-			},
-			effect: {
-				fr: "Échangez ce Pokémon avec l’un de vos Pokémon de Banc. Si au moins 2 Énergies Lightning supplémentaires sont attachées à ce Pokémon (en plus du coût de cette attaque), cette attaque inflige 100 dégâts supplémentaires. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-			damage: "150+",
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Unified Minds/222.ts
+++ b/data/Sun & Moon/Unified Minds/222.ts
@@ -73,21 +73,6 @@ const card: Card = {
 			damage: 200,
 
 		},
-		{
-			cost: [
-				"Psychic",
-				"Psychic",
-				"Colorless",
-			],
-			name: {
-				fr: "Duo Miraculeux-GX",
-			},
-			effect: {
-				fr: "Si au moins une Énergie supplémentaire est attachée à ce Pokémon (en plus du coût de cette attaque), soignez tous les dégâts de vos Pokémon. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-			damage: 200,
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Unified Minds/225.ts
+++ b/data/Sun & Moon/Unified Minds/225.ts
@@ -84,23 +84,6 @@ const card: Card = {
 			damage: 250,
 
 		},
-		{
-			cost: [
-				"Darkness",
-				"Darkness",
-				"Darkness",
-				"Darkness",
-				"Colorless",
-			],
-			name: {
-				fr: "Chute Giga-GX",
-			},
-			effect: {
-				fr: "Si au moins 5 Énergies supplémentaires sont attachées à ce Pokémon (en plus du coût de cette attaque), défaussez les 15 cartes du dessus du deck de votre adversaire. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-			damage: 250,
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Unified Minds/226.ts
+++ b/data/Sun & Moon/Unified Minds/226.ts
@@ -84,23 +84,6 @@ const card: Card = {
 			damage: 250,
 
 		},
-		{
-			cost: [
-				"Darkness",
-				"Darkness",
-				"Darkness",
-				"Darkness",
-				"Colorless",
-			],
-			name: {
-				fr: "Chute Giga-GX",
-			},
-			effect: {
-				fr: "Si au moins 5 Énergies supplémentaires sont attachées à ce Pokémon (en plus du coût de cette attaque), défaussez les 15 cartes du dessus du deck de votre adversaire. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-			damage: 250,
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Unified Minds/35.ts
+++ b/data/Sun & Moon/Unified Minds/35.ts
@@ -78,20 +78,6 @@ const card: Card = {
 			damage: "10+",
 
 		},
-		{
-			cost: [
-				"Water",
-				"Water",
-			],
-			name: {
-				fr: "Temps Heureux-GX",
-			},
-			effect: {
-				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 100 dégâts supplémentaires. Si au moins 6 Énergies Water supplémentaires sont attachées à ce Pokémon (en plus du coût de cette attaque), lancez 10 pièces à la place, et cette attaque inflige 100 dégâts supplémentaires pour chaque côté face. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-			damage: "10+",
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Unified Minds/54.ts
+++ b/data/Sun & Moon/Unified Minds/54.ts
@@ -76,21 +76,6 @@ const card: Card = {
 			damage: "150+",
 
 		},
-		{
-			cost: [
-				"Lightning",
-				"Lightning",
-				"Colorless",
-			],
-			name: {
-				fr: "Tour d’Éclair-GX",
-			},
-			effect: {
-				fr: "Échangez ce Pokémon avec l’un de vos Pokémon de Banc. Si au moins 2 Énergies Lightning supplémentaires sont attachées à ce Pokémon (en plus du coût de cette attaque), cette attaque inflige 100 dégâts supplémentaires. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-			damage: "150+",
-
-		},
 	],
 
 	weaknesses: [

--- a/data/Sun & Moon/Unified Minds/71.ts
+++ b/data/Sun & Moon/Unified Minds/71.ts
@@ -73,21 +73,6 @@ const card: Card = {
 			damage: 200,
 
 		},
-		{
-			cost: [
-				"Psychic",
-				"Psychic",
-				"Colorless",
-			],
-			name: {
-				fr: "Duo Miraculeux-GX",
-			},
-			effect: {
-				fr: "Si au moins une Énergie supplémentaire est attachée à ce Pokémon (en plus du coût de cette attaque), soignez tous les dégâts de vos Pokémon. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
-			damage: 200,
-
-		},
 	],
 
 	weaknesses: [

--- a/data/XY/XY Black Star Promos/XY154.ts
+++ b/data/XY/XY Black Star Promos/XY154.ts
@@ -49,23 +49,6 @@ const card: Card = {
 			damage: 160,
 
 		},
-		{
-			cost: [
-				"Fire",
-				"Fire",
-				"Fire",
-				"Colorless",
-				"Colorless",
-			],
-			name: {
-				fr: "Flamme Brillante",
-			},
-			effect: {
-				fr: "Ce Pokémon ne peut pas utiliser Flamme Brillante pendant votre prochain tour.",
-			},
-			damage: 160,
-
-		},
 	],
 
 	retreat: 0,

--- a/data/XY/XY Black Star Promos/XY63.ts
+++ b/data/XY/XY Black Star Promos/XY63.ts
@@ -42,20 +42,6 @@ const card: Card = {
 			damage: "80＋",
 
 		},
-		{
-			cost: [
-				"Darkness",
-				"Darkness",
-			],
-			name: {
-				fr: "Aile du Désastre",
-			},
-			effect: {
-				fr: "Défaussez la carte du dessus du deck de votre adversaire. Si c'est une carte Dresseur, cette attaque inflige 80 dégâts supplémentaires.",
-			},
-			damage: "80＋",
-
-		},
 	],
 	weaknesses: [
 		{

--- a/data/XY/XY Black Star Promos/XY87.ts
+++ b/data/XY/XY Black Star Promos/XY87.ts
@@ -44,22 +44,6 @@ const card: Card = {
 			damage: "130+",
 
 		},
-		{
-			cost: [
-				"Water",
-				"Water",
-				"Colorless",
-				"Colorless",
-			],
-			name: {
-				fr: "Impact Bras d'Fer",
-			},
-			effect: {
-				fr: "Vous pouvez infliger 30 dégâts supplémentaires. Dans ce cas, défaussez les trois cartes du dessus du deck de chaque joueur.",
-			},
-			damage: "130+",
-
-		},
 	],
 	weaknesses: [
 		{


### PR DESCRIPTION
Forty-five cards carry an extra `attacks` entry that duplicates an attack already on the card, with every language but French stripped out. `data/Sun & Moon/Cosmic Eclipse/210.ts` (Rillaboom & Cinderace & Inteleon-GX):

```ts
{
    cost: ["Colorless", "Colorless", "Colorless"],
    name:   { en: "Solar Plant GX", fr: "Plante Solaire GX", …, de: "Solargewächs GX" },
    effect: { en: "This attack does 50 damage to each of your opponent’s Pokémon. …", … }
},
{
    cost: ["Colorless", "Colorless", "Colorless"],   // ← the same attack again
    name:   { fr: "Plante Solaire-GX" },
    effect: { fr: "Cette attaque inflige 50 dégâts à chacun des Pokémon de votre adversaire. …" }
}
```

Same cost, same damage, same French effect text — and on the GX cards the stub writes `Name-GX` where the real entry writes `Name GX`.

Every stub was required to agree with its twin on **cost and damage**, and on **either** the French name ignoring punctuation **or** the French effect text verbatim, before removal. None is a distinct attack that merely lacks English.

The consequence is that each card declares one more attack than it actually has, so anything that counts attacks, or pairs them against another data source, sees a card whose moves do not line up.

### Affected sets

| set | cards |
|---|---|
| Unified Minds | 13 |
| Cosmic Eclipse | 7 |
| Unbroken Bonds | 6 |
| Ultra Prism | 4 |
| SM Black Star Promos | 4 |
| Forbidden Light | 3 |
| XY Black Star Promos | 3 |
| Lost Thunder | 2 |
| Team Up | 2 |
| Dragon Majesty | 1 |

Deletions only — 660 lines removed, none added — and `bun run validate` (`tsc --noEmit`) passes locally. A re-scan of `data/` after the change finds no duplicate stubs remaining.