### PR TITLE
(fix) Wrong and misspelled English evolveFrom values on 16 cards

### DIFF
--- a/data/Base/Base Set 2/44.ts
+++ b/data/Base/Base Set 2/44.ts
@@ -22,7 +22,7 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Barboach",
+		en: "Bulbasaur",
 	},
 
 	stage: "Stage1",

--- a/data/Base/Base Set 2/58.ts
+++ b/data/Base/Base Set 2/58.ts
@@ -22,7 +22,7 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Poochyena",
+		en: "Rattata",
 	},
 
 	stage: "Stage1",

--- a/data/Base/Team Rocket/24.ts
+++ b/data/Base/Team Rocket/24.ts
@@ -24,7 +24,7 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Weavile",
+		en: "Zubat",
 		fr: "Nosferapti",
 		de: "Zubat"
 	},

--- a/data/Diamond & Pearl/Secret Wonders/57.ts
+++ b/data/Diamond & Pearl/Secret Wonders/57.ts
@@ -24,7 +24,7 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Nidoran?",
+		en: "Nidoran♂",
 		fr: "Nidoran♂",
 	},
 

--- a/data/EX/FireRed & LeafGreen/25.ts
+++ b/data/EX/FireRed & LeafGreen/25.ts
@@ -24,7 +24,7 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Drowsee",
+		en: "Drowzee",
 		fr: "Soporifik"
 	},
 

--- a/data/EX/FireRed & LeafGreen/40.ts
+++ b/data/EX/FireRed & LeafGreen/40.ts
@@ -24,7 +24,7 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Nidoran ♀",
+		en: "Nidoran♀",
 		fr: "Nidoran"
 	},
 

--- a/data/EX/FireRed & LeafGreen/41.ts
+++ b/data/EX/FireRed & LeafGreen/41.ts
@@ -24,7 +24,7 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Nindoran ♂",
+		en: "Nidoran♂",
 		fr: "Nidoran"
 	},
 

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/56.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/56.ts
@@ -22,7 +22,7 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Jiggylypuff",
+		en: "Jigglypuff",
 		fr: "Rondoudou"
 	},
 

--- a/data/Mega Evolution/Chaos Rising/105.ts
+++ b/data/Mega Evolution/Chaos Rising/105.ts
@@ -23,7 +23,7 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Mincinno"
+		en: "Minccino"
 	},
 
 	stage: "Stage1",

--- a/data/Mega Evolution/Chaos Rising/119.ts
+++ b/data/Mega Evolution/Chaos Rising/119.ts
@@ -23,7 +23,7 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Mincinno"
+		en: "Minccino"
 	},
 
 	stage: "Stage1",

--- a/data/Neo/Neo Destiny/2.ts
+++ b/data/Neo/Neo Destiny/2.ts
@@ -24,7 +24,7 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Zubat",
+		en: "Dark Golbat",
 		fr: "Nosferalto obscur"
 	},
 

--- a/data/Neo/Neo Discovery/12.ts
+++ b/data/Neo/Neo Discovery/12.ts
@@ -24,7 +24,7 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Piloswine",
+		en: "Pupitar",
 		fr: "Ymphect",
 		de: "Pupitar"
 	},

--- a/data/POP/POP Series 1/15.ts
+++ b/data/POP/POP Series 1/15.ts
@@ -22,7 +22,7 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Tailow",
+		en: "Taillow",
 		fr: "Nirondelle",
 		de: "Schwalbini"
 	},

--- a/data/POP/POP Series 3/6.ts
+++ b/data/POP/POP Series 3/6.ts
@@ -22,7 +22,7 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Diglett",
+		en: "Eevee",
 		fr: "Evoli",
 		de: "Evoli"
 	},

--- a/data/POP/POP Series 6/5.ts
+++ b/data/POP/POP Series 6/5.ts
@@ -22,7 +22,7 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Cherrim",
+		en: "Cranidos",
 		fr: "Kranidos",
 		de: "Koknodon"
 	},

--- a/data/POP/POP Series 9/9.ts
+++ b/data/POP/POP Series 9/9.ts
@@ -22,7 +22,7 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Bastiodon",
+		en: "Buneary",
 		fr: "Laporeille",
 		de: "Haspiror"
 	},


### PR DESCRIPTION
Grouping every `(name.en, evolveFrom.en)` pair across `data/` and looking at card names that carry more than one parent turns up a set of clear outliers — each a singleton against a majority of 13–48 identical pairings.

Where the card carries other languages, **they agree with the correction and not with the English**, which is what makes these unambiguous:

```ts
// data/POP/POP Series 3/6.ts — Vaporeon
evolveFrom: { en: "Diglett", fr: "Evoli" }          // Evoli = Eevee

// data/Base/Team Rocket/24.ts — Dark Golbat
evolveFrom: { en: "Weavile", fr: "Nosferapti", de: "Zubat" }

// data/Neo/Neo Destiny/2.ts — Dark Crobat
evolveFrom: { en: "Zubat", fr: "Nosferalto obscur" }   // = Dark Golbat
```

### Wrong Pokémon

| card | file | `en` says | should be |
|---|---|---|---|
| Vaporeon | `POP/POP Series 3/6.ts` | Diglett | Eevee |
| Tyranitar | `Neo/Neo Discovery/12.ts` | Piloswine | Pupitar |
| Ivysaur | `Base/Base Set 2/44.ts` | Barboach | Bulbasaur |
| Raticate | `Base/Base Set 2/58.ts` | Poochyena | Rattata |
| Lopunny | `POP/POP Series 9/9.ts` | Bastiodon | Buneary |
| Rampardos | `POP/POP Series 6/5.ts` | Cherrim | Cranidos |
| Dark Golbat | `Base/Team Rocket/24.ts` | Weavile | Zubat |
| Dark Crobat | `Neo/Neo Destiny/2.ts` | Zubat | Dark Golbat |

### Misspellings

| card | `en` says | should be |
|---|---|---|
| Wigglytuff | Jigg**yl**ypuff | Jigglypuff |
| Hypno | Drow**s**ee | Drow**z**ee |
| Swellow | Tai**l**ow | Tai**ll**ow |
| Cinccino ex ×2 | Min**cin**no | Min**ccin**o |
| Nidorino | `Nidoran?` | `Nidoran♂` |
| Nidorino | `N**in**doran ♂` | `Nidoran♂` |
| Nidorina | `Nidoran ♀` (stray space) | `Nidoran♀` |

Deliberately left alone: pairings that look rare but are legitimate — the fossil Trainers (Omanyte from `Helix Fossil` / `Mysterious Fossil` / `Unidentified Fossil`), the Gym-era owned Pokémon (`Erika's Gloom` from both `Oddish` and `Erika's Oddish`), and ex-variants (`Blissey ex` from `Chansey ex`). Those are real distinct cards, not data errors.

16 single-line changes; `bun run validate` (`tsc --noEmit`) passes locally.