### PR TITLE
(fix) Remove wrong Pokédex descriptions from Scarlet & Violet ex cards

### DIFF
--- a/data/Scarlet & Violet/Scarlet & Violet/019.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/019.ts
@@ -90,9 +90,6 @@ const card: Card = {
 	suffix: "ex",
 	illustrator: "takuyoa",
 
-	description: {
-		en: "The thread it secretes from its rear is as strong as wire. The secret behind the thread's strength is the topic of ongoing research.",
-	},
 
 	thirdParty: {
         cardmarket: 702315,

--- a/data/Scarlet & Violet/Scarlet & Violet/032.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/032.ts
@@ -90,9 +90,6 @@ const card: Card = {
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	description: {
-		en: "It's very friendly and faithful to people. It will try to repel enemies by barking and biting.",
-	},
 
 	thirdParty: {
         cardmarket: 702328,

--- a/data/Scarlet & Violet/Scarlet & Violet/045.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/045.ts
@@ -81,9 +81,6 @@ const card: Card = {
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	description: {
-		en: "An underpowered, pathetic Pokémon. It may jump high on rare occasions but never more than seven feet.",
-	},
 
 	thirdParty: {
         cardmarket: 702340,

--- a/data/Scarlet & Violet/Scarlet & Violet/065.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/065.ts
@@ -90,9 +90,6 @@ const card: Card = {
 	suffix: "ex",
 	illustrator: "hncl",
 
-	description: {
-		en: "They're formed by several Magnemite linked together. They frequently appear when sunspots flare up.",
-	},
 
 	thirdParty: {
         cardmarket: 702361,

--- a/data/Scarlet & Violet/Scarlet & Violet/081.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/081.ts
@@ -84,9 +84,6 @@ const card: Card = {
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	description: {
-		en: "Much remains unknown about this creature. It resembles Cyclizar, but it is far more ruthless and powerful.",
-	},
 
 	thirdParty: {
         cardmarket: 689766,

--- a/data/Scarlet & Violet/Scarlet & Violet/086.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/086.ts
@@ -96,9 +96,6 @@ const card: Card = {
 	suffix: "ex",
 	illustrator: "N-DESIGN Inc.",
 
-	description: {
-		en: "It has a psychic power that enables it to distort the space around it and see into the future.",
-	},
 
 	thirdParty: {
         cardmarket: 702382,

--- a/data/Scarlet & Violet/Scarlet & Violet/088.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/088.ts
@@ -96,9 +96,6 @@ const card: Card = {
 	suffix: "ex",
 	illustrator: "PLANETA Mochizuki",
 
-	description: {
-		en: "It feeds on the dark emotions of sadness and hatred, which make it grow steadily stronger.",
-	},
 
 	thirdParty: {
         cardmarket: 702384,

--- a/data/Scarlet & Violet/Scarlet & Violet/123.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/123.ts
@@ -82,9 +82,6 @@ const card: Card = {
 		}
 	],
 
-	description: {
-		en: "Klawf hangs upside-down from cliffs, waiting for prey. But Klawf can't remain in this position for long because its blood rushes to its head.",
-	},
 
 	thirdParty: {
         cardmarket: 702419,

--- a/data/Scarlet & Violet/Scarlet & Violet/125.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/125.ts
@@ -82,9 +82,6 @@ const card: Card = {
 		}
 	],
 
-	description: {
-		en: "This seems to be the Winged King mentioned in an old expedition journal. It was said to have split the land with its bare fists.",
-	},
 
 	thirdParty: {
         cardmarket: 689767,

--- a/data/Scarlet & Violet/Scarlet & Violet/131.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/131.ts
@@ -86,9 +86,6 @@ const card: Card = {
 		}
 	],
 
-	description: {
-		en: "Inflating its poison sacs, it fills the area with an odd sound and hits flinching opponents with a poison jab.",
-	},
 
 	thirdParty: {
         cardmarket: 702426,

--- a/data/Scarlet & Violet/Scarlet & Violet/143.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/143.ts
@@ -88,9 +88,6 @@ const card: Card = {
 	suffix: "ex",
 	illustrator: "5ban Graphics",
 
-	description: {
-		en: "It creates a gas out of poison and minerals from rocks. It then detonates the gas in its cylinders— now numbering eight—to generate energy.",
-	},
 
 	thirdParty: {
         cardmarket: 702439,

--- a/data/Scarlet & Violet/Scarlet & Violet/158.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/158.ts
@@ -90,9 +90,6 @@ const card: Card = {
 	suffix: "ex",
 	illustrator: "aky CG Works",
 
-	description: {
-		en: "Oinkologne is proud of its fine, glossy skin. It emits a concentrated scent from the tip of its tail.",
-	},
 
 	thirdParty: {
         cardmarket: 702454,

--- a/data/Scarlet & Violet/Scarlet & Violet/223.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/223.ts
@@ -90,9 +90,6 @@ const card: Card = {
 	suffix: "ex",
 	illustrator: "takuyoa",
 
-	description: {
-		en: "No matter how much it stuffs its belly with food, it is always anxious about getting hungry again. So, it stashes berries in its cheeks and tail.",
-	},
 
 	thirdParty: {
         cardmarket: 702519,


### PR DESCRIPTION
### How and why?

While filling the German translation gaps in Scarlet & Violet (sv01) I noticed that 13 cards keep an English `description` that can never be translated: they are all Pokémon **ex** cards, and ex cards don't have a Pokédex entry printed on the physical card. That's also why no other language ever had this text — there is no localised source for it.

Since the text isn't on the card, this PR removes the `description` field from those 13 files instead of translating it:

`019` Spidops ex, `032` Arcanine ex, `045` Gyarados ex, `065` Magnezone ex, `081` Miraidon ex, `086` Gardevoir ex, `088` Banette ex, `123` Great Tusk ex, `125` Koraidon ex, `131` Toxicroak ex, `143` Iron Treads ex, `158` Oinkologne ex, `223` Spidops ex

Only the three-line `description` block is removed in each file; every other byte is unchanged, and `tsc --noEmit` still passes.
