### PR TITLE
(fix) the German name of Fusion Strike: Fusionsangriff

### DIFF
--- a/data/Sword & Shield/Fusion Strike.ts
+++ b/data/Sword & Shield/Fusion Strike.ts
@@ -9,7 +9,7 @@ const swsh8: Set = {
 		fr: "Poing de Fusion",
 		es: "Golpe Fusión",
 		it: "Colpo Fusione",
-		de: "Fusions Angriff",
+		de: "Fusionsangriff",
 		pt: "Golpe Fusão"
 	},
 


### PR DESCRIPTION
The German set name is one word, as printed on the boosters and used by PokeWiki and pokemon.com; the space made the set unfindable by its German name.

