### PR TITLE
Rename graphicalDescription to visualStyle

### DIFF
--- a/meta/models/database/card.d.ts
+++ b/meta/models/database/card.d.ts
@@ -251,9 +251,9 @@ export interface Card {
 	}
 
 	/**
-	 * TODO: find a better name
+	 * TODO: find a better name -> Name proposed 
 	 */
-	graphicalDescription?: {
+	visualStyle?: {
 		/**
 		 * artwork style of the card
 		 */


### PR DESCRIPTION
Update Card interface in meta/models/database/card.d.ts: rename optional property `graphicalDescription` to `visualStyle` and update the TODO comment to include a proposed name. This clarifies the field's intent (artwork/style metadata).


