### PR TITLE
Add missing German translations for dp2

### DIFF
--- a/data/Diamond & Pearl/Mysterious Treasures/1.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/1.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Lairon",
-		fr: "Galegon"
+		fr: "Galegon",
+		de: "Stollrak"
 	},
 
 	stage: "Stage2",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Search your discard pile for all Energy cards and show them to your opponent. If you find any Metal Special Energy cards there, this attack does 40 damage plus 30 more damage. Put all of those Energy cards on top of your deck. Shuffle your deck afterward.",
 				fr: "Cherchez dans votre pile de défausse toutes les cartes Énergie et montrez-les à votre adversaire. Si vous y trouvez des cartes Énergie Spéciale Metal, cette attaque inflige 40 dégâts plus 30 dégâts supplémentaires. Placez toutes ces cartes au dessus de votre deck. Ensuite, mélangez votre deck.",
-				de: "Durchsuche deinen Ablagestapel nach allen Energiekarten und zeige sie deinem Gegner. Wenn mindestens 1 dieser Energiekarten eine -Spezialenergiekarte ist, fügt dieser Angriff 40 Schadenspunkte plus 30 weitere Schadenspunkte zu. Lege alle diese Energiekarten auf dein Deck. Mische dein Deck danach."
+				de: "Durchsuche deinen Ablagestapel nach allen Energiekarten und zeige sie deinem Gegner. Wenn mindestens 1 dieser Energiekarten eine {M}-Spezialenergiekarte ist, fügt dieser Angriff 40 Schadenspunkte plus 30 weitere Schadenspunkte zu. Lege alle diese Energiekarten auf dein Deck. Mische dein Deck danach."
 			},
 			damage: "40+",
 
@@ -64,7 +65,7 @@ const card: Card = {
 			effect: {
 				en: "You may do 60 damage plus 40 more damage. If you do, Aggron does 40 damage to itself.",
 				fr: "Vous pouvez infliger 60 dégâts plus 40 dégâts supplémentaires. Galeking s'inflige alors 40 dégâts.",
-				de: "Du kannst mit diesem Angriff 60 Schadenspunkte plus weitere 40 Schadenspunkte zufügen. Wenn du das machst, fügt sich Stolloss selbst 40 Schadenspunkte zu."
+				de: "Du kannst mit diesem Angriff 60 Schadenspunkte plus 40 weitere Schadenspunkte zufügen. Wenn du das machst, fügt sich Stolloss selbst 40 Schadenspunkte zu."
 			},
 			damage: "60+",
 
@@ -89,7 +90,8 @@ const card: Card = {
 
 	description: {
 		en: "While seeking iron for food, it digs tunnels by breaking through bedrock with its steel horns.",
-		fr: "Il creuse des galeries à travers la pierre avec ses cornes d'acier pour trouver le fer qu'il apprécie."
+		fr: "Il creuse des galeries à travers la pierre avec ses cornes d'acier pour trouver le fer qu'il apprécie.",
+		de: "Auf der Suche nach Eisen, seiner Nahrung, gräbt es mit seinen Stahlhörnern sogar Tunnel durch Felsen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/10.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/10.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Murkrow",
-		fr: "Cornèbre"
+		fr: "Cornèbre",
+		de: "Kramurx"
 	},
 
 	stage: "Stage1",
@@ -86,7 +87,8 @@ const card: Card = {
 
 	description: {
 		en: "Becoming active at night, it is known to swarm with numerous MURKROW in tow.",
-		fr: ": Ce Pokémon nocturne évolue en grandes volées escortées par des Cornèbre."
+		fr: ": Ce Pokémon nocturne évolue en grandes volées escortées par des Cornèbre.",
+		de: "Ein nachtaktives PKMN, das sich in Schwärmen mit KRAMURX durch die Nacht bewegt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/100.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/100.ts
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 20,
 
@@ -72,7 +72,8 @@ const card: Card = {
 
 	description: {
 		en: "In the snow country, certain folklore says a house will prosper if a SNORUNT lives there.",
-		fr: "Selon un vieux dicton des régions enneigées : \"Stalgamin dans la maison, richesse à l'horizon\"."
+		fr: "Selon un vieux dicton des régions enneigées : \"Stalgamin dans la maison, richesse à l'horizon\".",
+		de: "Im Land des Schnees sagt eine Legende, dass in ein Haus Wohlstand einzieht, wenn es darin lebt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/101.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/101.ts
@@ -53,7 +53,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, Snover does 10 damage to itself.",
 				fr: "Lancez une pièce. Si c'est pile, Blizzi s'inflige 10 dégâts.",
-				de: "Wirf 1 Münze. Bei 'Zahl' fügt sich Shnebedeck selbst 10 Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Zahl“ fügt sich Shnebedeck selbst 10 Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -71,7 +71,8 @@ const card: Card = {
 
 	description: {
 		en: "It lives on snowy mountains. Having had little contact with humans, it is boldly inquisitive.",
-		fr: "Il vit sur les monts enneigés. Ignorant des coutumes humaines, il lui arrive d'être très indiscret."
+		fr: "Il vit sur les monts enneigés. Ignorant des coutumes humaines, il lui arrive d'être très indiscret.",
+		de: "Es lebt im Schnee der Berge. Es hatte bisher kaum Kontakt zu Menschen und ist daher sehr neugierig."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/102.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/102.ts
@@ -51,7 +51,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, during your next turn, Spheal's Rollout attack's base damage is 40.",
 				fr: "Lancez une pièce. Si c'est face, les dégâts de base de l'attaque Roulade d'Obalie sont de 40 lors de votre prochain tour.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" beträgt in deinem nächsten Zug der Grundschaden von Seemops' Angriff Walzer 40 Schadenspunkte."
+				de: "Wirf 1 Münze. Bei „Kopf“ beträgt in deinem nächsten Zug der Grundschaden des von Seemops' Angriff Walzer 40 Schadenspunkte."
 			},
 
 		},
@@ -68,7 +68,8 @@ const card: Card = {
 
 	description: {
 		en: "It rolls across ice floes to reach shore because its body is poorly shaped for swimming.",
-		fr: "Il gagne la côte en roulant sur les blocs de glace car sa morphologie n'est pas adaptée à la nage."
+		fr: "Il gagne la côte en roulant sur les blocs de glace car sa morphologie n'est pas adaptée à la nage.",
+		de: "Es rollt über Eisschollen, um Land zu erreichen, da sein Körper zum Schwimmen nicht geeignet ist."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/103.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/103.ts
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20x",
 
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "It sets a trap by spinning a web with thin but strong silk. It waits motionlessly for prey to arrive.",
-		fr: "Il tisse une toile fine mais solide pour poser des pièges et se poste dans l'attente d'une proie."
+		fr: "Il tisse une toile fine mais solide pour poser des pièges et se poste dans l'attente d'une proie.",
+		de: "Es baut eine Falle, indem es ein Netz mit dünner, starker Seide spinnt. Es wartet still auf Beute."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/104.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/104.ts
@@ -55,7 +55,8 @@ const card: Card = {
 
 	description: {
 		en: "It appears as if it is skating on water. It draws prey with a sweet scent from the tip of its head.",
-		fr: "Il semble patiner sur l'eau. Le parfum diffusé par le sommet de sa tête sert à attirer ses proies."
+		fr: "Il semble patiner sur l'eau. Le parfum diffusé par le sommet de sa tête sert à attirer ses proies.",
+		de: "Scheinbar reitet es auf dem Wasser. Es lockt seine Beute mit einem süßen Duft an."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/105.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/105.ts
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "It lets honey soak into its paws so it can lick them all the time. Every sets of paws tastes unique.",
-		fr: "Il baigne ses griffes dans le miel pour les lécher. Chaque paire de pattes a un goût unique."
+		fr: "Il baigne ses griffes dans le miel pour les lécher. Chaque paire de pattes a un goût unique.",
+		de: "Es lässt Honig in seine Pranken eindringen, so dass es immer welchen dabeihat."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/106.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/106.ts
@@ -67,7 +67,8 @@ const card: Card = {
 
 	description: {
 		en: "It has the habit of biting anything with its developed jaws. Even its Trainer need to be careful.",
-		fr: "Il broie tout ce qu'il trouve avec ses mâchoires puissantes. Même son dresseur doit s'en méfier."
+		fr: "Il broie tout ce qu'il trouve avec ses mâchoires puissantes. Même son dresseur doit s'en méfier.",
+		de: "Es hat die Angewohnheit, nach allem zu schnappen, was es sieht. Selbst seine Trainer müssen aufpassen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/107.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/107.ts
@@ -57,7 +57,8 @@ const card: Card = {
 
 	description: {
 		en: "It controls balls of fire. As it grows, its six tails split from their tips to make more tails.",
-		fr: "Il envoie des boules de feu. Avec l'âge, ses six queues en forment de nouvelles."
+		fr: "Il envoie des boules de feu. Avec l'âge, ses six queues en forment de nouvelles.",
+		de: "Es beherrscht Feuerbälle. Während es wächst, teilen sich seine sechs Schweife, um weitere zu bilden."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/108.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/108.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt verwirrt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 
 		},
@@ -76,7 +76,8 @@ const card: Card = {
 
 	description: {
 		en: "Even though it has no eyes, it can sense obstacles using ultrasonic waves it emits from its mouth.",
-		fr: "Bien que dépourvu d'yeux, il repère les obstacles grâce aux ultrasons émis par sa gueule."
+		fr: "Bien que dépourvu d'yeux, il repère les obstacles grâce aux ultrasons émis par sa gueule.",
+		de: "Obwohl es keine Augen hat, kann es Hindernisse mithilfe von Ultraschallwellen wahrnehmen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/109.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/109.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Choose a card from your hand and put it on top of your deck. Search your deck for a Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward. (If this is the only card in your hand, you can't play this card.)",
 		fr: "Choisissez une carte de votre main et placez-la au dessus de votre deck. Choisissez dans votre deck un Pokémon, montrez-le à votre adversaire et placez-le dans votre main. Ensuite, mélangez votre deck. (Si c'est la seule carte que vous ayez en main, vous ne pouvez pas jouer cette carte.)",
-		de: "Wähle 1 Karte von deiner Hand und lege sie auf dein Deck. Durchsuche dein Deck nach einer Pokémon-Karte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach. (Wenn diese Karte die einzige Karte auf deiner Hand ist, kannst du sie nicht spielen.)",
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Wähle 1 Karte von deiner Hand und lege sie auf dein Deck. Durchsuche dein Deck nach einer Pokémon-Karte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach. (Wenn diese Karte die einzige Karte auf deiner Hand ist, kannst du sie nicht spielen.)",
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/11.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/11.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Finneon",
-		fr: "Écayon"
+		fr: "Écayon",
+		de: "Finneon"
 	},
 
 	stage: "Stage1",
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Does 30 damage plus 10 more damage for each Water Energy attached to Lumineon. Then, return all Water Energy attached to Lumineon to your hand.",
 				fr: "Inflige 30 dégâts plus 10 dégâts supplémentaires pour chaque Énergie Water attachée à Luminéon. Ensuite, reprenez dans votre main toutes les Énergies Water attachées à Luminéon.",
-				de: "Dieser Angriff fügt 30 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Lumineon angelegte -Energie zu. Danach nimm alle an Lumineon angelegte -Energie zurück auf deine Hand."
+				de: "Dieser Angriff fügt 30 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Lumineon angelegte {W}-Energie zu. Danach nimm alle an Lumineon angelegte {W}-Energie zurück auf deine Hand."
 			},
 			damage: "30+",
 
@@ -78,7 +79,8 @@ const card: Card = {
 
 	description: {
 		en: "It lives on the deep-sea floor. It attracts prey by flashing the patterns on its four tail fins.",
-		fr: "Il vit au plus profond de l'océan. Il attire sa proie en illuminant les motifs de ses 4 nageoires."
+		fr: "Il vit au plus profond de l'océan. Il attire sa proie en illuminant les motifs de ses 4 nageoires.",
+		de: "Es lebt tief auf dem Meeresboden. Das blinkende Muster auf seinen vier Rückenflossen zieht Beute an."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/111.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/111.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Search your deck or discard pile for a Trainer card that has Fossil in its name or a Stage 1 or Stage 2 Evolution card that evolves from a Fossil. Show it to your opponent and put it into your hand. If you searched your deck, shuffle your deck afterward.",
 		fr: "Choisissez dans votre deck ou votre pile de défausse une carte Dresseur dont le nom comporte Fossile ou une carte Évolution de Niveau 1 ou 2 qui évolue d'un Fossile. Montrez-la à votre adversaire et placez-la dans votre main. Si vous avez cherché dans votre deck, mélangez-le.",
-		de: "Durchsuche dein Deck oder deinen Ablagestapel nach 1 Trainerkarte mit Fossil im Namen oder einer Evolutionskarte der Phase 1 oder Phase 2, die sich aus einem Fossil entwickelt. Zeige sie deinem Gegner und nimm sie auf die Hand. Falls du dein Deck durchsucht hast, mische es danach.",
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Durchsuche dein Deck oder deinen Ablagestapel nach 1 Trainerkarte mit Fossil im Namen oder einer Evolutionskarte der Phase 1 oder Phase 2, die sich aus einem Fossil entwickelt. Zeige sie deinem Gegner und nimm sie auf die Hand. Falls du dein Deck durchsucht hast, mische es danach.",
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/112.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/112.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card. Apply Weakness for each Pokémon (both yours and your opponent's) as ×2 instead.",
 		fr: "Multipliez la Faiblesse de chaque Pokémon par 2 (les vôtres et ceux de votre adversaire).",
-		de: "Wenn Pokémon (deine und die deines Gegners) eine Schwäche haben, dann wird der entsprechende Schaden nicht um den Schwäche-Wert dieses Pokémon erhöht, sondern verdoppelt.",
+		de: "Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadion-Karte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen. Wenn Pokémon (deine und die deines Gegners) eine Schwäche haben, dann wird der entsprechende Schaden nicht um den Schwäche-Wert dieses Pokémon erhöht, sondern verdoppelt.",
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/115.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/115.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Each player shuffles his or her hand into his or her deck, and you and your opponent play \"Rock-Paper-Scissors.\" The player who wins draws up to 6 cards. The player who loses draws up to 3 cards. (You draw your cards first.)",
 		fr: "Chaque joueur mélange sa main à son deck et vous et votre adversaire jouez au jeu 'pierre-papier-ciseaux '. Le gagnant pioche jusqu'à 6 cartes. Le perdant pioche jusqu'à 3 cartes. (Vous piochez vos cartes en premier.)",
-		de: "Jeder Spieler mischt seine Handkarten zurück in sein Deck. Du und dein Gegner spielen \"Schere-Stein-Papier\". Der Gewinner zieht bis zu 6 Karten, der Verlierer bis zu 3 Karten. (Du ziehst zuerst.)",
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Jeder Spieler mischt seine Handkarten zurück in sein Deck. Du und dein Gegner spielen „Stein-Schere-Papier“. Der Gewinner zieht bis zu 6 Karten, der Verlierer bis zu 3 Karten. (Du ziehst zuerst.)",
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/116.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/116.ts
@@ -18,7 +18,7 @@ const card: Card = {
 	effect: {
 		en: "Play Armor Fossil as if it were a Colorless Basic Pokémon. (Armor Fossil counts as a Trainer card as well, but if Armor Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Armor Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Armor Fossil from play. (This doesn't count as a Knocked Out Pokémon.)",
 		fr: "Jouez Fossile armure comme si c'était un Pokémon de base . (Fossile armure compte aussi comme une carte Dresseur mais si Fossile armure est mise K.O. elle compte comme un Pokémon K.O.) Fossile armure ne peut pas être affectée par des États Spéciaux et ne peut pas battre en retraite. N'importe quand lors de votre tour, avant votre attaque, vous pouvez défausser Fossile armure. (Cela ne compte pas comme un Pokémon K.O.)",
-		de: "Spiele Panzerfossil wie ein -Basis-Pokémon. (Panzerfossil zählt gleichzeitig als Trainerkarte, aber wenn Panzerfossil kampfunfähig wird, zählt es als kampfunfähiges Pokémon.) Panzerfossil kann nicht von Speziellen Zuständen betroffen werden und sich nicht zurückziehen. In deinem Zug (vor deinem Angriff) kannst du Panzerfossil auf deinen Ablagestapel legen. (Dies zählt nicht als kampfunfähig gemachtes Pokémon.)"
+		de: "Spiele Panzerfossil wie ein {C}-Basis-Pokémon. (Panzerfossil zählt gleichzeitig als Trainerkarte, aber wenn Panzerfossil kampfunfähig wird, zählt es als kampfunfähiges Pokémon.) Panzerfossil kann nicht von Speziellen Zuständen betroffen werden und sich nicht zurückziehen. In deinem Zug (vor deinem Angriff) kannst du Panzerfossil auf deinen Ablagestapel legen. (Dies zählt nicht als kampfunfähig gemachtes Pokémon.)"
 	},
 
 	abilities: [

--- a/data/Diamond & Pearl/Mysterious Treasures/117.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/117.ts
@@ -18,7 +18,7 @@ const card: Card = {
 	effect: {
 		en: "Play Skull Fossil as if it were a Colorless Basic Pokémon. (Skull Fossil counts as a Trainer card as well, but if Skull Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Skull Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Skull Fossil from play. (This doesn't count as a Knocked Out Pokémon.)",
 		fr: "Jouez Fossile crâne comme si c'était un Pokémon de base . (Fossile crâne compte aussi comme une carte Dresseur mais si Fossile crâne est mise K.O. elle compte comme un Pokémon K.O.) Fossile crâne ne peut pas être affectée par des États Spéciaux et ne peut pas battre en retraite. N'importe quand lors de votre tour, avant votre attaque, vous pouvez défausser Fossile crâne. (Cela ne compte pas comme un Pokémon K.O.)",
-		de: "Spiele Kopffossil wie ein -Basis-Pokémon. (Kopffossil zählt gleichzeitig als Trainerkarte, aber wenn Kopffossil kampfunfähig wird, zählt es als kampfunfähiges Pokémon.) Kopffossil kann nicht von Speziellen Zuständen betroffen werden und sich nicht zurückziehen. In deinem Zug (vor deinem Angriff) kannst du Kopffossil auf deinen Ablagestapel legen. (Dies zählt nicht als kampfunfähig gemachtes Pokémon.)"
+		de: "Spiele Kopffossil wie ein {C}-Basis-Pokémon. (Kopffossil zählt gleichzeitig als Trainerkarte, aber wenn Kopffossil kampfunfähig wird, zählt es als kampfunfähiges Pokémon.) Kopffossil kann nicht von Speziellen Zuständen betroffen werden und sich nicht zurückziehen. In deinem Zug (vor deinem Angriff) kannst du Kopffossil auf deinen Ablagestapel legen. (Dies zählt nicht als kampfunfähig gemachtes Pokémon.)"
 	},
 
 	abilities: [

--- a/data/Diamond & Pearl/Mysterious Treasures/118.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/118.ts
@@ -16,7 +16,7 @@ const card: Card = {
 
 	effect: {
 		en: "Attach Multi Energy to 1 of your Pokémon. While in play, Multi Energy provides every type of Energy but provides only 1 Energy at a time. (Has no effect other than providing Energy.) Multi Energy provides Colorless Energy when attached to a Pokémon that already has Special Energy cards attached to it.",
-		de: "Lege Multi-Energie an 1 deiner Pokémon an. Während Multi-Energie im Spiel ist, zählt sie als jeder beliebige Basis-Energietyp, spendet aber immer nur eine Energie auf einmal. (Sie hat keinen Effekt, außer dass sie Energie spendet.) Multi-Energie zählt als -Energie, falls sie an ein Pokémon angelegt wird, an dem bereits eine Spezialenergiekarte angelegt ist.",
+		de: "Lege Multi-Energie an 1 deiner Pokémon an. Während Multi-Energie im Spiel ist, zählt sie als jeder beliebige Basis-Energietyp, spendet aber immer nur 1 Energie auf einmal. (Sie hat keinen Effekt, außer dass sie Energie spendet.) Multi-Energie zählt als {C}-Energie, falls sie an ein Pokémon angelegt wird, an dem bereits eine Spezialenergiekarte angelegt ist.",
 		fr: "Attachez Énergies multiples à 1 de vos Pokémon. Lorsqu'elle est en jeu, Énergies multiples fournit tous les types d'énergie (mais seulement un à la fois). (Elle n'a pas d'autre effet que de fournir de l'Énergie.) Énergies multiples fournit une Énergie Incolore lorsqu'elle est attachée à un Pokémon qui possède déjà des cartes Énergie Spéciale.",
 	},
 

--- a/data/Diamond & Pearl/Mysterious Treasures/119.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/119.ts
@@ -16,7 +16,7 @@ const card: Card = {
 
 	effect: {
 		en: "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect if the Pokémon that Darkness Energy is attached to isn't Darkness. Darkness Energy provides Darkness Energy. (Doesn't count as a basic Energy card.)",
-		de: "Falls das Pokémon, an das Finsternis-Energie angelegt ist, angreift, fügt der Angriff den Aktiven Pokémon 10 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden). Dieser Effekt wirkt nur, wenn die Finsternis-Energie an einem Pokémon vom Typ  angelegt ist. Finsternis-Energie liefert -Energie. (Zählt nicht als Basis-Energiekarte.)",
+		de: "Falls das Pokémon, an das Finsternis-Energie angelegt ist, angreift, fügt der Angriff den Aktiven Pokémon 10 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden). Dieser Effekt wirkt nur, wenn die Finsternis-Energie an einem Pokémon vom Typ {D} angelegt ist. Finsternis-Energie liefert {D}-Energie. (Zählt nicht als Basis-Energiekarte.)",
 		fr: "Si le Pokémon Énergie Obscurité est attaché à des attaques, l'attaque inflige 10 dégâts supplémentaires au Pokémon Actif (avant application de la Faiblesse et de la Résistance). Ignorez cet effet si le Pokémon auquel Énergie Obscurité est attachée n'est pas de type Obscurité. Énergie Obscurité fournit de l'Énergie Obscurité. (Elle ne compte pas comme carte Énergie de base.)",
 	},
 

--- a/data/Diamond & Pearl/Mysterious Treasures/12.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/12.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Magmar",
-		fr: "Magmar"
+		fr: "Magmar",
+		de: "Magmar"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
 				fr: "Si le Pokémon Défenseur essaye d'attaquer lors du prochain tour de votre adversaire, celui-ci lance une pièce. Si c'est pile, cette attaque est sans effet.",
-				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 30,
 
@@ -81,7 +82,8 @@ const card: Card = {
 
 	description: {
 		en: "It blasts fireballs of over 3,600 degrees F from the ends of its arms. It lives in volcanic craters.",
-		fr: "Il projette des boules de feu de 2000°C à bout de bras. Il vit dans les cratères volcaniques."
+		fr: "Il projette des boules de feu de 2000°C à bout de bras. Il vit dans les cratères volcaniques.",
+		de: "Aus den Enden seiner Arme schießen Feuerbälle mit 2000 Grad. Es lebt in Vulkankratern."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/120.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/120.ts
@@ -16,7 +16,7 @@ const card: Card = {
 
 	effect: {
 		en: "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn't Metal. Metal Energy provides Metal Energy. (Doesn't count as a basic Energy card.)",
-		de: "Schaden, der dem Pokémon, an das Metall-Energie angelegt ist, durch Angriffe zugefügt wird, wird um 10 reduziert (nachdem Schwäche und Resistenz verrechnet wurden). Dieser Effekt wirkt nur, wenn die Metall-Energie an einem Pokémon vom Typ  angelegt ist. Metall-Energie spendet -Energie. (Zählt nicht als Basis-Energiekarte.)",
+		de: "Schaden, der dem Pokémon, an das Metall-Energie angelegt ist, durch Angriffe zugefügt wird, wird um 10 reduziert (nachdem Schwäche und Resistenz verrechnet wurden). Dieser Effekt wirkt nur, wenn die Metall-Energie an einem Pokémon vom Typ {M} angelegt ist. Metall-Energie spendet {M}-Energie. (Zählt nicht als Basis-Energiekarte.)",
 		fr: "Les dégâts infligés par des attaques au Pokémon auquel Énergie Métal est attachée sont réduits de 10 (après application de la Faiblesse et la Résistance) Ignorez cet effet si le Pokémon auquel Énergie Métal est attachée n'est pas de type Métal. Énergie Métal fournit de l'Énergie Métal. (Elle ne compte pas comme carte Énergie de base.)",
 	},
 

--- a/data/Diamond & Pearl/Mysterious Treasures/122.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/122.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), when you put Lucario LV. X from your hand onto your Active Lucario, you may use this power. Prevent all effects of an attack, including damage, done to Lucario during your opponent's next turn. (If Lucario is no longer your Active Pokémon, this effect ends.)",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), lorsque vous placez Lucario NIV.X de votre main sur votre Lucario Actif, vous pouvez utiliser ce pouvoir. Prévenez tous les effets d'une attaque, dégâts inclus infligés à Lucario lors du prochain tour de votre adversaire. (Si Lucario n'est plus votre Pokémon Actif, cet effet se termine.)",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn du Lucario LV.X auf dein aktives Lucario legst, diese Poke-Power benutzen. Verhindere während des nächsten zuges deines Gegners alle Effekte eines Angriffs, einschließlich Schaden, die Lucario zugefügt werden. (Wenn Lucario nicht mehr dein Aktives Pokémon ist, endet dieser Effekt.)"
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn du Lucario LV.X auf dein aktives Lucario legst, diese Poké-Power benutzen. Verhindere während des nächsten Zuges deines Gegners alle Effekte eines Angriffs, einschließlich Schaden, die Lucario zugefügt werden. (Wenn Lucario nicht mehr dein Aktives Pokémon ist, endet dieser Effekt.)"
 			},
 		},
 	],

--- a/data/Diamond & Pearl/Mysterious Treasures/123.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/123.ts
@@ -57,7 +57,7 @@ const card: Card = {
 			effect: {
 				en: "Discard 2 Fire Energy attached to Magmortar. Choose 1 of your opponent's Pokémon. This attack does 100 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) During your next turn, Magmortar can't use Flame Bluster.",
 				fr: "Défaussez 2 Énergies Fire attachées à Maganon. Choisissez 1 des Pokémon de votre adversaire. Cette attaque lui inflige 100 dégâts. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.) Lors de votre prochain tour, Maganon ne peut pas utiliser Rafale de flammes.",
-				de: "Lege 2 an Magbrant angelegte -Energien auf deinen Ablagestapel. Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 100 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.) Magbrant kann Flammengetöse in deinem nächsten Zug nicht einsetzen."
+				de: "Lege 2 an Magbrant angelegte {R}-Energien auf deinen Ablagestapel. Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 100 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.) Magbrant kann Flammengetöse in deinem nächsten Zug nicht einsetzen."
 			},
 
 		},

--- a/data/Diamond & Pearl/Mysterious Treasures/124.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/124.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "Flip 3 coins. For each heads, search your discard pile for a Pokémon, show it to your opponent, and put it into your hand.",
 		fr: "Lancez 3 pièces. Pour chaque face, choisissez un Pokémon dans votre pile de défausse, montrez-la à votre adversaire et placez-le dans votre main.",
-		de: "Wirf 3 Münzen. Durchsuche für jedes Mal, wenn die Münze \"Kopf\" gezeigt hat, deinen Ablagestapel nach 1 Pokémon-Karte, zeige sie deinem Gegner und nimm sie auf die Hand."
+		de: "Wirf 3 Münzen. Durchsuche für jedes Mal, wenn die Münze „Kopf“ gezeigt hat, deinen Ablagestapel nach 1 Pokémon-Karte, zeige sie deinem Gegner und nimm sie auf die Hand."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/13.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/13.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Bayleef",
-		fr: "Macronium"
+		fr: "Macronium",
+		de: "Lorblatt"
 	},
 
 	stage: "Stage2",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. If the first coin is heads, the Defending Pokémon is now Poisoned. If the second coin is heads, the Defending Pokémon is now Burned. If the third coin is heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez 3 pièces. Si la première pièce est face, le Pokémon Défenseur est maintenant Empoisonné. Si la deuxième pièce est face, le Pokémon Défenseur est maintenant Brûlé. Si la troisième pièce est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 3 Münzen. Wenn der erste Wurf \"Kopf\" zeigt, ist das Verteidigende Pokémon jetzt vergiftet. Wenn der zweite Wurf \"Kopf\" zeigt, ist das Verteidigende Pokémon jetzt verbrannt. Wenn der dritte Wurf \"Kopf\" zeigt, ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 3 Münzen. Wenn der erste Wurf „Kopf“ zeigt, ist das Verteidigende Pokémon jetzt vergiftet. Wenn der zweite Wurf „Kopf“ zeigt, ist das Verteidigende Pokémon jetzt verbrannt. Wenn der dritte Wurf „Kopf“ zeigt, ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "If your opponent has any Fire Pokémon in play, this attack does 60 damage plus 30 more damage.",
 				fr: "Si votre adversaire possède des Pokémon Fire en jeu, cette attaque inflige 60 dégâts plus 30 dégâts supplémentaires.",
-				de: "Wenn dein Gegner mindestens 1 -Pokémon im Spiel hat, fügt dieser Angriff 60 Schadenspunkte plus 30 weitere Schadenspunkte zu."
+				de: "Wenn dein Gegner mindestens 1 {R}-Pokémon im Spiel hat, fügt dieser Angriff 60 Schadenspunkte plus 30 weitere Schadenspunkte zu."
 			},
 			damage: "60+",
 
@@ -87,7 +88,8 @@ const card: Card = {
 
 	description: {
 		en: "Its breath has the fantastic ability to revive dead plants and flowers.",
-		fr: "Son souffle a l'incroyable capacité de ranimer les plantes et les fleurs flétries."
+		fr: "Son souffle a l'incroyable capacité de ranimer les plantes et les fleurs flétries.",
+		de: "Mit seinem Atem kann es tote Pflanzen und Blumen zu neuem Leben erwecken."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/14.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/14.ts
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "Known as \"The Being of Emotion.\" It taught humans the nobility of sorrow, pain, and joy.",
-		fr: "On l'appelle \"être de l'émotion\". Il enseigne aux hommes la beauté de la tristesse, la douleur et la joie."
+		fr: "On l'appelle \"être de l'émotion\". Il enseigne aux hommes la beauté de la tristesse, la douleur et la joie.",
+		de: "„Das fühlende Wesen“. Es lehrt die Menschen die Ideale von Trauer, Schmerz und Freude."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/15.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/15.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pikachu",
-		fr: "Pikachu"
+		fr: "Pikachu",
+		de: "Pikachu"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Search your deck for up to 2 Lightning Energy cards and attach them to 1 of your Pokémon. Shuffle your deck afterward.",
 				fr: "Choisissez dans votre deck jusqu'à 2 cartes Énergie Lightning et attachez-les à 1 de vos Pokémon. Ensuite, mélangez votre deck.",
-				de: "Durchsuche dein Deck nach bis zu 2 -Energiekarten und lege sie an 1 deiner Pokémon an. Mische dein Deck danach."
+				de: "Durchsuche dein Deck nach bis zu 2 {L}-Energiekarten und lege sie an 1 deiner Pokémon an. Mische dein Deck danach."
 			},
 
 		},
@@ -58,7 +59,7 @@ const card: Card = {
 			effect: {
 				en: "Discard all basic Lightning Energy cards attached to Raichu. This attack does 30 damage times the number of Lightning Energy cards you discarded.",
 				fr: "Défaussez toutes les cartes Énergie Lightning attachées à Raichu. Cette attaque inflige 30 dégâts multipliés par le nombre de cartes Énergie défaussées.",
-				de: "Lege alle an Raichu angelegten -Basis-Energiekarten auf deinen Ablagestapel. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl der auf diese Weise auf den Ablagestapel gelegten -Energiekarten zu."
+				de: "Lege alle an Raichu angelegten {L}-Basis-Energiekarten auf deinen Ablagestapel. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl der auf diese Weise auf den Ablagestapel gelegten {L}-Energiekarten zu."
 			},
 			damage: "30x",
 
@@ -83,7 +84,8 @@ const card: Card = {
 
 	description: {
 		en: "It turns aggressive if it has too much electricity in its body. It discharges power through its tail.",
-		fr: "Il devient agressif lorsque son corps contient trop d'électricité. Il la décharge par sa queue."
+		fr: "Il devient agressif lorsque son corps contient trop d'électricité. Il la décharge par sa queue.",
+		de: "Bei zu viel Elektrizität im Körper wird es aggressiv. Es entlädt sich über seinen Schweif."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/16.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/16.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Quilava",
-		fr: "Feurisson"
+		fr: "Feurisson",
+		de: "Igelavar"
 	},
 
 	stage: "Stage2",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may attach a Fire Energy card from your discard pile to 1 of your Benched Pokémon. This power can't be used if Typhlosion is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez attacher une carte Énergie Fire de votre pile de défausse à 1 des Pokémon de votre Banc. Ce pouvoir ne peut pas être utilisé si Typhlosion est affecté par un État Spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du eine -Energiekarte von deinem Ablagestapel nehmen und an 1 Pokémon auf deiner Bank anlegen. Diese Poké-Power kann nicht benutzt werden, wenn Tornupto von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du eine {R}-Energiekarte von deinem Ablagestapel nehmen und an 1 Pokémon auf deiner Bank anlegen. Diese Poké-Power kann nicht benutzt werden, wenn Tornupto von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Discard a Water Energy attached to the Defending Pokémon.",
 				fr: "Défaussez une Énergie Water attachée au Pokémon Défenseur.",
-				de: "Lege 1 -Energie, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
+				de: "Lege 1 {W}-Energie, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
 			},
 			damage: 60,
 
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "It attacks using blasts of fire. It creates heat shimmers with intense fire to hide itself.",
-		fr: "Il attaque en projetant des flammes. Il se dissimule derrière les vagues de chaleur qu'il produit."
+		fr: "Il attaque en projetant des flammes. Il se dissimule derrière les vagues de chaleur qu'il produit.",
+		de: "Es greift seine Gegner mit Feuer an. Dabei entsteht ein Hitzeflimmern, in dem es sich versteckt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/17.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/17.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pupitar",
-		fr: "Ymphect"
+		fr: "Ymphect",
+		de: "Pupitar"
 	},
 
 	stage: "Stage2",
@@ -89,7 +90,8 @@ const card: Card = {
 
 	description: {
 		en: "If it rampages, it knocks down mountains and buries rivers. Maps must be redrawn afterward.",
-		fr: "Lorsqu'il est en colère, il abat des montagnes et enterre des fleuves. On doit alors modifier les cartes."
+		fr: "Lorsqu'il est en colère, il abat des montagnes et enterre des fleuves. On doit alors modifier les cartes.",
+		de: "Bei einem Tobsuchtsanfall zerstört es ganze Gebirge und legt Flüsse trocken."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/18.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/18.ts
@@ -72,7 +72,8 @@ const card: Card = {
 
 	description: {
 		en: "Known as \"The Being of Knowledge.\" It is said that it can wipe out the memory of those who see its eyes.",
-		fr: "On l'appelle \"être du savoir\". On raconte que son regard a le pouvoir d'effacer la mémoire."
+		fr: "On l'appelle \"être du savoir\". On raconte que son regard a le pouvoir d'effacer la mémoire.",
+		de: "„Das wissende Wesen“. Es soll die Erinnerungen derer löschen, die ihm in die Augen sehen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/19.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/19.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Snover",
-		fr: "Blizzi"
+		fr: "Blizzi",
+		de: "Shnebedeck"
 	},
 
 	stage: "Stage1",
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, put 1 damage counter on each of your opponent's Benched Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, placez 1 marqueur de dégât sur chaque Pokémon de Banc de votre adversaire.",
-				de: "Wirf 1 Münze. Bei 'Kopf' lege 1 Schadensmarke auf jedes Pokémon auf der Bank deines Gegners."
+				de: "Wirf 1 Münze. Bei „Kopf“ lege 1 Schadensmarke auf jedes Pokémon auf der Bank deines Gegners."
 			},
 			damage: 60,
 
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "It whips up blizzards in mountains that are always buried in snow. It is the abominable snowman.",
-		fr: "C'est l'abominable homme des neiges. Il ensevelit les montagnes sous ses blizzards."
+		fr: "C'est l'abominable homme des neiges. Il ensevelit les montagnes sous ses blizzards.",
+		de: "Es löst in den Bergen, wo ewiger Schnee liegt, Blizzards aus. Es ist ein scheußlicher Schneemann."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/2.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/2.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Kadabra",
-		fr: "Kadabra"
+		fr: "Kadabra",
+		de: "Kadabra"
 	},
 
 	stage: "Stage2",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Power Cancel",
 				fr: "Annulation de pouvoir",
-				de: "Power Ausschalten"
+				de: "Power ausschalten"
 			},
 			effect: {
 				en: "Once during your opponent's turn, when your opponent's Pokémon uses any Poké-Power, you may discard 2 cards from your hand and prevent all effects of that Poké-Power. (This counts as that Pokémon using its Poké-Power.) This power can't be used if Alakazam is affected by a Special Condition.",
 				fr: "Une seule fois lors du tour de votre adversaire, lorsque celui-ci utilise un Poké-Power, vous pouvez défausser 2 cartes de votre main et prévenir les effets de ce Poké-Power. (C'est ce Pokémon qui utilise ce Poké-Power.) Ce pouvoir ne peut pas être utilisé si Alakazam possède un État Spécial.",
-				de: "Einmal während des Zuges deines Gegners kannst du, wenn 1 Pokémon deines Gegners eine Poké-Power benutzt, 2 Karten von der Hand auf deinen Ablagestapel legen. Wenn du das machst, verhindere alle Effekte dieser Poké-Power. (Die Poké-Power gilt dennoch als benutzt.) Diese Poké-Power kann nicht benutzt werden, wenn Simsala von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während des Zuges deines Gegners kannst du, wenn 1 Pokémon deines Gegners eine Poké-Power benutzt, 2 Karten von deiner Hand auf deinen Ablagestapel legen. Wenn du das machst, verhindere alle Effekte dieser Poké-Power. (Die Poké-Power gilt dennoch als benutzt.) Diese Poké-Power kann nicht benutzt werden, wenn Simsala von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "Its superb memory lets it recall everything it has experienced from birth. Its IQ exceeds 5,000.",
-		fr: "Grâce à sa mémoire exceptionnelle, il n'a rien oublié depuis sa naissance. Il a un Q.I. de 5 000."
+		fr: "Grâce à sa mémoire exceptionnelle, il n'a rien oublié depuis sa naissance. Il a un Q.I. de 5 000.",
+		de: "Es besitzt ein fantastisches Gedächtnis und erinnert sich an alles seit seiner Geburt. IQ: Über 5 000."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/20.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/20.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Spinarak",
-		fr: "Mimigal"
+		fr: "Mimigal",
+		de: "Webarak"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "The Retreat Cost for each player's Pokémon (excluding Ariados) is Colorless more.",
 				fr: "Le Coût de retraite des Pokémon de chaque joueur (Migalos exclu) est de Colorless de plus.",
-				de: "Die Rückzugskosten aller Pokémon (außer Ariados) sind um  erhöht."
+				de: "Die Rückzugskosten aller Pokémon (außer Ariados) sind um {C} erhöht."
 			},
 		},
 	],
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned. If tails, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Empoisonné. Si c'est pile, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt vergiftet. Bei \"Zahl\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet. Bei „Zahl“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -78,7 +79,8 @@ const card: Card = {
 
 	description: {
 		en: "It attaches silk to its prey and sets it free. Later, it tracks the silk to the prey and its friends.",
-		fr: "Il attache un fil à sa proie avant de la libérer. Il s'en servira pour la retrouver, elle et ses amis."
+		fr: "Il attache un fil à sa proie avant de la libérer. Il s'en servira pour la retrouver, elle et ses amis.",
+		de: "Es befestigt Seide an der Beute und lässt sie frei. Es folgt dem Seidenfaden zur Beute u. ihren Freunden."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/21.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/21.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Shieldon",
-		fr: "Dinoclier"
+		fr: "Dinoclier",
+		de: "Schilterus"
 	},
 
 	stage: "Stage2",
@@ -86,7 +87,8 @@ const card: Card = {
 
 	description: {
 		en: "Any frontal attack is repulsed. It is a docile Pokémon that feeds on grass and berries.",
-		fr: "Il résiste à toute attaque frontale. C'est un Pokémon docile qui se nourrit d'herbe et de Baies."
+		fr: "Il résiste à toute attaque frontale. C'est un Pokémon docile qui se nourrit d'herbe et de Baies.",
+		de: "Jeder Frontalangriff wird abgeschmettert. Dieses friedliche PKMN ernährt sich von Gras und Beeren."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/22.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/22.ts
@@ -72,7 +72,8 @@ const card: Card = {
 
 	description: {
 		en: "To knock foes flying, it makes the air shudder with its cries. It converses using seven cries.",
-		fr: "Son langage comporte sept cris. Il les utilise pour faire vibrer l'air et projeter son ennemi."
+		fr: "Son langage comporte sept cris. Il les utilise pour faire vibrer l'air et projeter son ennemi.",
+		de: "Um die Gegner fortzuwehen, setzt es die Luft mit Schreien in Bewegung."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/23.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/23.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Golbat",
-		fr: "Nosferalto"
+		fr: "Nosferalto",
+		de: "Golbat"
 	},
 
 	stage: "Stage2",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn, when you play Crobat from your hand to evolve 1 of your Pokémon, you may choose 1 of the Defending Pokémon. That Pokémon is now Poisoned. Put 2 damage counters instead of 1 on that Pokémon between turns.",
 				fr: "Une seule fois lors de votre tour, lorsque vous jouez Nostenfer de votre main pour faire évoluer 1 de vos Pokémon, vous pouvez choisir 1 des Pokémon Défenseurs. Ce Pokémon est maintenant Empoisonné. Placez 2 marqueurs de dégâts au lieu d'1 sur ce Pokémon entre deux tours.",
-				de: "Einmal während deines Zuges kannst du, wenn du Iksbat von deiner Hand spielst, um 1 deiner Pokémon weiter zu entwickeln, 1 Verteidigendes Pokémon wählen. Das gewählte Pokémon ist jetzt vergiftet. Lege zwischen den Zügen 2 Schadensmarken anstelle von 1 Schadensmarke auf das gewählte Pokémon."
+				de: "Einmal während deines Zuges kannst du, wenn du Iksbat von deiner Hand spielst, um 1 deiner Pokémon zu entwickeln, 1 Verteidigendes Pokémon wählen. Das gewählte Pokémon ist jetzt vergiftet. Lege zwischen den Zügen 2 Schadensmarken anstelle von 1 Schadensmarke auf das gewählte Pokémon."
 			},
 		},
 	],
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon. This attack does 50 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Flip a coin. If tails, shuffle Crobat and all cards attached to it back into your deck.",
 				fr: "Choisissez 1 des Pokémon de votre adversaire. Cette attaque lui inflige 50 dégâts. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.) Lancez une pièce. Si c'est pile, mélangez Nostenfer et toutes les cartes qui lui sont attachées à votre deck.",
-				de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 50 Schadenspunkte zu. (Wende Schwäche und Resistenz für Pokémon auf der Bank nicht an.) Wirf 1 Münze. Bei \"Zahl\" mische Iksbat und alle Karten, die an es angelegt sind, zurück in dein Deck."
+				de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 50 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.) Wirf 1 Münze. Bei „Zahl“ mische Iksbat und alle Karten, die an es angelegt sind, zurück in dein Deck."
 			},
 
 		},
@@ -82,7 +83,8 @@ const card: Card = {
 
 	description: {
 		en: "Having four wings enables it to fly faster and more quietly. It turns active when the night comes.",
-		fr: "Il vole rapidement et sans faire de bruit grâce à ses quatre ailes. C'est un Pokémon nocturne."
+		fr: "Il vole rapidement et sans faire de bruit grâce à ses quatre ailes. C'est un Pokémon nocturne.",
+		de: "Seine vier Flügel erlauben es dem PKMN, schneller und leiser zu fliegen. Es ist nachtaktiv."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/24.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/24.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Exeggcute",
-		fr: "Noeunoeuf"
+		fr: "Noeunoeuf",
+		de: "Owei"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin for each basic Energy card attached to Exeggutor and to the Defending Pokémon. This attack does 30 damage times the number of heads.",
 				fr: "Lancez une pièce pour chaque Carte Énergie de base attachée à Noadkoko et au Pokémon Défenseur. Cette attaque inflige 30 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 1 Münze für jede an Kokowei und das Verteidigende Pokémon angelegte Basis-Energiekarte. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 1 Münze für jede an Kokowei und das Verteidigende Pokémon angelegte Basis-Energiekarte. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "30x",
 
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Search your deck for up to 2 Grass Energy cards and attach them to any of your Pokémon in any way you like. Shuffle your deck afterward.",
 				fr: "Choisissez dans votre deck jusqu'à 2 cartes Énergie Grass et attachez-les à vos Pokémon de la façon que vous voulez. Ensuite, mélangez votre deck.",
-				de: "Durchsuche dein Deck nach bis zu 2 -Energiekarten und lege sie in beliebiger Verteilung an deine Pokémon an. Mische dein Deck danach."
+				de: "Durchsuche dein Deck nach bis zu 2 {G}-Energiekarten und lege sie in beliebiger Verteilung an deine Pokémon an. Mische dein Deck danach."
 			},
 
 		},
@@ -77,7 +78,8 @@ const card: Card = {
 
 	description: {
 		en: "It is called \"The Walking Jungle.\" If a head grows too big, it falls off and becomes an EXEGGCUTE.",
-		fr: "On l'appelle \" jungle sur pattes \". Si une tête devient trop grosse, elle tombe et produit un Noeunoeuf"
+		fr: "On l'appelle \" jungle sur pattes \". Si une tête devient trop grosse, elle tombe et produit un Noeunoeuf",
+		de: "Man nennt es den „Laufenden Dschungel“. Wird ein Kopf zu groß, fällt er ab und wird zu einem OWEI."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/25.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/25.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Snorunt",
-		fr: "Stalgamin"
+		fr: "Stalgamin",
+		de: "Schneppke"
 	},
 
 	stage: "Stage1",
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, your opponent can't play any Trainer cards or Supporter cards from his or her hand during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, votre adversaire ne peut pas jouer de cartes Dresseur ou de cartes Supporter de sa main lors de son prochain tour.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" kann dein Gegner in seinem nächsten Zug keine Trainer- oder Unterstützerkarten von seiner Hand spielen."
+				de: "Wirf 1 Münze. Bei „Kopf“ kann dein Gegner in seinem nächsten Zug keine Trainer- oder Unterstützerkarten von seiner Hand spielen."
 			},
 			damage: 50,
 
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "To protect itself, it clads its body in an armor of ice, made by freezing moisture in the air.",
-		fr: "Il gèle l'humidité de l'air pour former une armure de glace protectrice autour de son corps."
+		fr: "Il gèle l'humidité de l'air pour former une armure de glace protectrice autour de son corps.",
+		de: "Um sich zu schützen, umgibt es seinen Körper mit einer Rüstung aus Eis."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/26.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/26.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Magikarp",
-		fr: "Magicarpe"
+		fr: "Magicarpe",
+		de: "Karpador"
 	},
 
 	stage: "Stage1",
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin until you get tails. For each heads, choose 1 card from your opponent's hand without looking and discard it. If the first coin is tails, Gyarados is now Confused.",
 				fr: "Lancez une pièce jusqu'à ce que vous obteniez pile. Pour chaque face, choisissez sans regarder 1 carte de la main de votre adversaire et défaussez-la. Si la première pièce est pile, Leviator est maintenant Confus.",
-				de: "Wirf so lange 1 Münze, bis zum ersten Mal das Ergebnis \"Zahl\" kommt. Wähle für jedes Mal, wenn die Münze \"Kopf\" gezeigt hat, eine Karte von der Hand deines Gegners (ohne sie vorher anzusehen). Dein Gegner legt die gewählte Karte auf seinen Ablagestapel. Wenn der allererste Wurf \"Zahl\" gezeigt hat, ist Garados jetzt verwirrt."
+				de: "Wirf so lange 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Wähle für jedes Mal, wenn die Münze „Kopf“ gezeigt hat, eine Karte von der Hand deines Gegners (ohne sie vorher anzusehen). Dein Gegner legt die gewählte Karte auf seinen Ablagestapel. Wenn der allererste Wurf „Zahl“ gezeigt hat, ist Garados jetzt verwirrt."
 			},
 			damage: 80,
 
@@ -87,7 +88,8 @@ const card: Card = {
 
 	description: {
 		en: "Once it appears, its rage never settles until it has razed the fields and mountains around it.",
-		fr: "Lorsqu'il apparaît, sa rage ne cesse qu'après qu'il a rasé les plaines et montagnes alentour."
+		fr: "Lorsqu'il apparaît, sa rage ne cesse qu'après qu'il a rasé les plaines et montagnes alentour.",
+		de: "Sobald es erscheint, nimmt seine Wut nicht eher ab, bis es die Felder und Berge ringsum zerstört hat."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/27.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/27.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Kricketot",
-		fr: "Crikzik"
+		fr: "Crikzik",
+		de: "Zirpurze"
 	},
 
 	stage: "Stage1",
@@ -80,7 +81,8 @@ const card: Card = {
 
 	description: {
 		en: "It crosses its knifelike arms in front of its chest when it cries. It can compose melodies ad lib.",
-		fr: "Il croise ses bras affûtés devant son torse pour crier. Il compose tout un tas de mélodies."
+		fr: "Il croise ses bras affûtés devant son torse pour crier. Il compose tout un tas de mélodies.",
+		de: "Wenn es ruft, verschränkt es seine messerartigen Arme vor der Brust. Es komponiert aus dem Stegreif."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/28.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/28.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Electrike",
-		fr: "Dynavolt"
+		fr: "Dynavolt",
+		de: "Frizelbliz"
 	},
 
 	stage: "Stage1",
@@ -85,7 +86,8 @@ const card: Card = {
 
 	description: {
 		en: "It discharges electricity from its mane. It creates a thundercloud overhead to drop lightning bolts.",
-		fr: "Il libère l'électricité par sa crinière. Il crée un nuage d'orage pour appeler la foudre."
+		fr: "Il libère l'électricité par sa crinière. Il crée un nuage d'orage pour appeler la foudre.",
+		de: "Aus seiner Mähne entlädt es Elektrizität. Es generiert eine Gewitterwolke, aus der es Blitze entlädt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/29.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/29.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "If Mantyke is anywhere under Mantine, the Retreat Cost for each of your Water Pokémon is ColorlessColorless less.",
 				fr: "Si Babimanta se trouve sous Demanta, le coût de retraite de chacun de vos Pokémon Water est ColorlessColorless de moins.",
-				de: "Wenn Mantirps sich an beliebiger Stelle unter Mantax befindet, sind die Rückzugskosten deiner -Pokémon um   reduziert."
+				de: "Wenn Mantirps sich an beliebiger Stelle unter Mantax befindet, sind die Rückzugskosten deiner {W}-Pokémon um {C} {C} reduziert."
 			},
 		},
 	],
@@ -80,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "When the waves are calm, one may encounter a swarm of Mantine swimming as if they are in flight.",
-		fr: "Lorsque la mer est calme, il arrive de croiser un banc de Démanta nageant comme s'il volaient."
+		fr: "Lorsque la mer est calme, il arrive de croiser un banc de Démanta nageant comme s'il volaient.",
+		de: "Wenn das Meer ruhig ist, kann man vielleicht einen Schwarm MANTAX sehen, die schnell vorbeischwimmen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/3.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/3.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Aipom",
-		fr: "Capumain"
+		fr: "Capumain",
+		de: "Griffel"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Your opponent flips a coin until he or she gets heads. For each tails, remove an Energy card attached to the Defending Pokémon and put it on the bottom of your opponent's deck.",
 				fr: "Votre adversaire lance une pièce jusqu'à ce qu'il ou elle obtienne face. Pour chaque pile, retirez une carte Énergie attachée au Pokémon Défenseur et placez-la au dessous du deck de votre adversaire.",
-				de: "Dein Gegner wirft so lange 1 Münze, bis zum ersten Mal das Ergebnis \"Kopf\" kommt. Für jedes Mal, wenn die Münze \"Zahl\" gezeigt hat, lege eine Energiekarte, die am Verteidigenden Pokémon angelegt ist, unter das Deck deines Gegners."
+				de: "Dein Gegner wirft so lange 1 Münze, bis zum ersten Mal das Ergebnis „Kopf“ kommt. Für jedes Mal, wenn die Münze „Zahl“ gezeigt hat, lege eine Energiekarte, die am Verteidigenden Pokémon angelegt ist, unter das Deck deines Gegners."
 			},
 			damage: 30,
 
@@ -80,7 +81,8 @@ const card: Card = {
 
 	description: {
 		en: "To eat, it deftly shucks nuts with its two tails. It rarely uses its arms now.",
-		fr: "Il se nourrit de noix qu'il épluche avec ses deux queues habiles. Il utilise de moins en moins ses bras."
+		fr: "Il se nourrit de noix qu'il épluche avec ses deux queues habiles. Il utilise de moins en moins ses bras.",
+		de: "Wenn es hungrig ist, knackt es Nüsse mit seinen beiden Schweifen. Nur selten verwendet es die Arme."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/30.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/30.ts
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Put a coin next to your Active Pokémon without showing your opponent and cover it with your hand. Your opponent guesses if the coin is heads or tails. If he or she is wrong, this attack does 50 damage to the Defending Pokémon. If he or she is right, Mr. Mime does 20 damage to itself, and this attack's damage isn't affected by Weakness or Resistance.",
 				fr: "Placez une pièce à côté de votre Pokémon Actif. Ne la montrez pas à votre adversaire et cachez-la avec votre main. Votre adversaire doit deviner si c'est pile ou face. S'il ou elle a tort, cette attaque inflige 50 dégâts au Pokémon Défenseur. S'il ou elle a raison, M. Mime s'inflige 20 dégâts et les dégâts de cette attaque ne sont pas affectés par la Faiblesse ou la Résistance.",
-				de: "Lege 1 Münze verdeckt neben dein Aktives Pokémon. Dein Gegner muss erraten, ob die Münze \"Kopf\" oder \"Zahl\" zeigt. Wenn er falsch rät, fügt dieser Angriff dem Verteidigenden Pokémon 50 Schadenspunkte zu. Wenn er richtig rät, fügt sich Pantimos selbst 20 Schadenspunkte, die durch Schwäche und Resistenz nicht verändert werden, zu."
+				de: "Lege 1 Münze verdeckt neben dein Aktives Pokémon. Dein Gegner muss erraten, ob die Münze „Kopf“ oder „Zahl“ zeigt. Wenn er falsch rät, fügt dieser Angriff dem Verteidigenden Pokémon 50 Schadenspunkte zu. Wenn er richtig rät, fügt sich Pantimos selbst 20 Schadenspunkte, die durch Schwäche und Resistenz nicht verändert werden, zu."
 			},
 
 		},
@@ -72,7 +72,8 @@ const card: Card = {
 
 	description: {
 		en: "It is a pantomime expert that can create invisible but solid walls using miming gestures.",
-		fr: "Un expert de la pantomime dont les gestes façonnent de solides murs invisibles."
+		fr: "Un expert de la pantomime dont les gestes façonnent de solides murs invisibles.",
+		de: "Ein Experte der Pantomime. Es kann unsichtbare, aber solide Wände allein durch Gesten erzeugen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/31.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/31.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Nidorina",
-		fr: "Nidorina"
+		fr: "Nidorina",
+		de: "Nidorina"
 	},
 
 	stage: "Stage2",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "The attack cost of your Nidoran ♀, Nidorina, Nidoran ♂, Nidorino, and Nidoking's attack is Colorless less.",
 				fr: "Le Coût d'attaque de l'attaque de votre Nidoran♀, Nidorina, Nidoran♂, Nidorino, Nidoking est Colorless de moins.",
-				de: "Die Angriffe deiner Nidoran ♀, Nidorina, Nidoran ♂, Nidorino und Nidoking kosten  weniger."
+				de: "Die Angriffe deiner Nidoran ♀, Nidorina, Nidoran ♂, Nidorino und Nidoking kosten {C} weniger."
 			},
 		},
 	],
@@ -86,7 +87,8 @@ const card: Card = {
 
 	description: {
 		en: "Its entire body is armored with hard scales. It will protect the young in its burrow with its life.",
-		fr: "Son corps est recouvert d'écailles solides. Il donnera sa vie pour secourir les petits de son terrier."
+		fr: "Son corps est recouvert d'écailles solides. Il donnera sa vie pour secourir les petits de son terrier.",
+		de: "Sein ganzer Körper ist mit harten Schuppen bedeckt. Es beschützt sein Junges mit seinem Leben."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/32.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/32.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Vulpix",
-		fr: "Goupix"
+		fr: "Goupix",
+		de: "Vulpix"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may choose 1 of your opponent's Pokémon. Ninetales is the same type as that Pokémon (all if that Pokémon is more than 1 type) until the end of your turn. This power can't be used if Ninetales is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez choisir 1 des Pokémon de votre adversaire. Feunard est du même type que ce Pokémon (de tous ses types si ce Pokémon est de plus d'un type) jusqu'à la fin du tour. Ce pouvoir ne peut pas être utilisé si Feunard est affecté par un État Spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 Pokémon deines Gegners wählen. Vulnona ist bis zum Ende deines Zuges ein Pokémon desselben Typs (oder Typen, wenn das gewählte Pokémon mehr als 1 Typ hat) wie das gewählte Pokémon. Diese Poké-Power kann nicht benutzt werden, wenn Vulnona von einem Speziellen Zustand bestroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 Pokémon deines Gegners wählen. Vulnona ist bis zum Ende deines Zuges ein Pokémon desselben Typs (oder Typen, wenn das gewählte Pokémon mehr als 1 Typ hat) wie das gewählte Pokémon. Diese Poké-Power kann nicht benutzt werden, wenn Vulnona von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Discard a Fire Energy attached to Ninetales.",
 				fr: "Défaussez une Énergie Fire attachée à Feunard.",
-				de: "Lege 1 an Vulnona angelegte -Energie auf deinen Ablagestapel."
+				de: "Lege 1 an Vulnona angelegte {R}-Energie auf deinen Ablagestapel."
 			},
 			damage: 60,
 
@@ -78,7 +79,8 @@ const card: Card = {
 
 	description: {
 		en: "Its nine tails are said to be imbued with a mystic power. It can live for a thousand years.",
-		fr: "On raconte que ses neuf queues détiennent un pouvoir mystique. Il peut vivre pendant mille ans."
+		fr: "On raconte que ses neuf queues détiennent un pouvoir mystique. Il peut vivre pendant mille ans.",
+		de: "Seine neun Schweife sollen mystische Kräfte besitzen. Es kann tausende Jahre leben."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/33.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/33.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Cranidos",
-		fr: "Kranidos"
+		fr: "Kranidos",
+		de: "Koknodon"
 	},
 
 	stage: "Stage2",
@@ -81,7 +82,8 @@ const card: Card = {
 
 	description: {
 		en: "Its powerful head butt has enough power to shatter even the most durable things upon impact.",
-		fr: "Son violent coup de tête est assez puissant pour pulvériser les matériaux les plus résistants"
+		fr: "Son violent coup de tête est assez puissant pour pulvériser les matériaux les plus résistants",
+		de: "Sein kräftiger Kopfstoß hat genug Kraft, um selbst die stabilsten Dinge zu zerschmettern."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/34.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/34.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Vigoroth",
-		fr: "Vigoroth"
+		fr: "Vigoroth",
+		de: "Muntier"
 	},
 
 	stage: "Stage2",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), if Slaking is your Active Pokémon, you may flip a coin. If heads, Slaking's Lazy Blow attack's base damage is 130 during this turn. If tails, Slaking can't attack or retreat during this turn. (If Slaking is no longer your Active Pokémon, this effect ends.)",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), si Monaflemit est votre Pokémon Actif, vous pouvez lancer une pièce. Si c'est face, les dégâts de base de l'attaque Coup mou de Monaflemit sont de 130 lors de ce tour. Si c'est pile, Monaflemit ne peut pas attaquer ou battre en retraite lors de ce tour. (Si Monaflemit n'est plus votre Pokémon Actif, cet effet se termine.)",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn Letarking dein Aktives Pokémon ist, 1 Münze werfen. Bei \"Kopf\" beträgt der Grundschaden von Letarkings Angriff Lahmer Schlag in diesem Zug 130 Schadenspunkte. Bei \"Zahl\" kann Letarking in diesem Zug weder angreifen noch sich zurückziehen. (Wenn Letarking nicht mehr dein Aktives Pokémon ist, endet dieser Effekt.)"
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn Letarking dein Aktives Pokémon ist, 1 Münze werfen. Bei „Kopf“ beträgt der Grundschaden von Letarkings Angriff Lahmer Schlag in diesem Zug 130 Schadenspunkte. Bei „Zahl“ kann Letarking in diesem Zug weder angreifen noch sich zurückziehen. (Wenn Letarking nicht mehr dein Aktives Pokémon ist, endet dieser Effekt.)"
 			},
 		},
 	],
@@ -76,7 +77,8 @@ const card: Card = {
 
 	description: {
 		en: "The world's laziest Pokémon. When it is lounging, it is actually saving energy for striking back.",
-		fr: "Le Pokémon le plus fainéant du monde. Il s'allonge pour économiser ses forces et contre-attaquer."
+		fr: "Le Pokémon le plus fainéant du monde. Il s'allonge pour économiser ses forces et contre-attaquer.",
+		de: "Das faulste PKMN der Welt. Wenn es faulenzt, sammelt es in Wahrheit Energie, um zuzuschlagen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/35.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/35.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "If Bonsly is anywhere under Sudowoodo, flip a coin. If heads, prevent all effects of an attack, including damage, done to Sudowoodo during your opponent's next turn.",
 				fr: "Si Manzaï se trouve en dessous de Simularbre, lancez une pièce. Si c'est face, prévenez tous les effets d'une attaque, dégâts inclus, infligés à Simularbre lors du prochain tour de votre adversaire.",
-				de: "Wenn Mobai sich an beliebiger Stelle unter Mogelbaum befindet, wirf 1 Münze. Verhindere bei \"Kopf\" während des nächsten Zuges deines Gegners alle Effekte eines Angriffs, einschließlich Schaden, die Mogelbaum zugefügt werden."
+				de: "Wenn Mobai sich an beliebiger Stelle unter Mogelbaum befindet, wirf 1 Münze. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte eines Angriffs, einschließlich Schaden, die Mogelbaum zugefügt werden."
 			},
 			damage: 20,
 
@@ -74,7 +74,8 @@ const card: Card = {
 
 	description: {
 		en: "Despite appearing to be a tree, its body is closer to rocks and stones. It is very weak to water.",
-		fr: "On pourrait le prendre pour un arbre, mais il est plus proche d'une pierre. L'eau est son point faible."
+		fr: "On pourrait le prendre pour un arbre, mais il est plus proche d'une pierre. L'eau est son point faible.",
+		de: "Auch wenn es wie ein Baum aussieht, ist es eher wie ein Stein o. Fels. Es ist schwach gegenüber Wasser."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/36.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/36.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Croagunk",
-		fr: "Cradopaud"
+		fr: "Cradopaud",
+		de: "Glibunkel"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Your opponent can't remove the Special Condition Poisoned by evolving or devolving his or her Poisoned Pokémon. (This also includes putting a Pokémon Level-Up card onto the Poisoned Pokémon.)",
 				fr: "Votre adversaire ne peut pas retirer l'État Spécial Empoisonné en faisant évoluer ou en désévoluant ses Pokémon Empoisonnés. (Placer une carte Pokémon Niveau Sup sur le Pokémon Empoisonné inclus.)",
-				de: "Dein Gegner kann den Speziellen Zustand \"vergiftet\" von seinen Pokémon nicht durch Entwickeln oder Rückentwickeln entfernen. (Dies gilt auch für das Spielen einer Pokémon Level-Up-Karte auf das vergiftete Pokémon.)"
+				de: "Dein Gegner kann den Speziellen Zustand „vergiftet“ von seinen Pokémon nicht durch Entwickeln oder Rückentwickeln entfernen. (Dies gilt auch für das Spielen einer Pokémon Level-Up-Karte auf das vergiftete Pokémon.)"
 			},
 		},
 	],
@@ -78,7 +79,8 @@ const card: Card = {
 
 	description: {
 		en: "Its knuckle claws secrete a toxin so vile that even a scratch could prove fatal.",
-		fr: "Les griffes de ses poings sécrètent une toxine si atroce qu'une simple égratignure peut s'avérer fatale."
+		fr: "Les griffes de ses poings sécrètent une toxine si atroce qu'une simple égratignure peut s'avérer fatale.",
+		de: "Die Gelenke an seinen Klauen geben ein so starkes Gift ab, dass selbst ein kleiner Kratzer fatal ist."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/37.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/37.ts
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "Choose an Energy card attached to the Defending Pokémon and put it face down. Treat that card as a Special Energy card that provides Colorless Energy and doesn't have any effect other than providing Energy. Put that card face up at the end of your opponent's next turn.",
 				fr: "Choisissez une carte Énergie attachée au Pokémon Défenseur et placez-la face cachée. Traitez cette carte comme une carte Énergie Spéciale qui fournit de l'Énergie Colorless et qui n'a pas d'autre effet que de fournir de l'Énergie. Retournez cette carte à la fin du prochain tour de votre adversaire.",
-				de: "Wähle eine Energiekarte, die am Verteidigenden Pokémon angelegt ist, und verdecke sie. Behandle diese Karte wie eine Spezialenergiekarte, die -Energie liefert und keinen anderen Effekt hat, als Energie zu liefern. Decke die Karte am Ende des nächsten Zuges deines Gegners wieder auf."
+				de: "Wähle eine Energiekarte, die am Verteidigenden Pokémon angelegt ist, und verdecke sie. Behandle diese Karte wie eine Spezialenergiekarte, die {C}-Energie liefert und keinen anderen Effekt hat, als Energie zu liefern. Decke die Karte am Ende des nächsten Zuges deines Gegners wieder auf."
 			},
 
 		},
@@ -71,7 +71,8 @@ const card: Card = {
 
 	description: {
 		en: "Shaped like ancient writing, it is a huge mystery whether language or UNOWN came first.",
-		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou du Zarbi est apparu en premier."
+		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou du Zarbi est apparu en premier.",
+		de: "Seine Form sieht aus wie antike Schrift. Was war zuerst da? Die Sprache oder ICOGNITO?"
 	},
 
 	variants: [

--- a/data/Diamond & Pearl/Mysterious Treasures/38.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/38.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Teddiursa",
-		fr: "Teddiursa"
+		fr: "Teddiursa",
+		de: "Teddiursa"
 	},
 
 	stage: "Stage1",
@@ -82,7 +83,8 @@ const card: Card = {
 
 	description: {
 		en: "In its territory, it leaves scratches on trees that bear delicious berries or fruits.",
-		fr: "Il marque de ses griffes les arbres de son territoire qui portent des Baies ou des fruits."
+		fr: "Il marque de ses griffes les arbres de son territoire qui portent des Baies ou des fruits.",
+		de: "Es durchstreift sein Revier und markiert Bäume, die Früchte oder Beeren tragen, mit Kratzern."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/39.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/39.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Sealeo",
-		fr: "Phogleur"
+		fr: "Phogleur",
+		de: "Seejong"
 	},
 
 	stage: "Stage2",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn, when you play Walrein from your hand to evolve 1 of your Pokémon, you may flip 2 coins. If both are heads, discard 1 of the Defending Pokémon and all cards attached to it. (This doesn't count as a Knocked Out Pokémon.)",
 				fr: "Une seule fois lors de votre tour, lorsque vous jouez Kaimorse de votre main pour faire évoluer 1 de vos Pokémon, vous pouvez lancer 2 pièces. Si ce sont deux fois faces, défaussez 1 des Pokémon Défenseurs ainsi que toutes les cartes qui lui sont attachées. (Le Pokémon n'est pas mis K.O.)",
-				de: "Einmal während deines Zuges kannst du, wenn du Walraisa von deiner Hand spielst, um 1 deiner Pokémon zu entwickeln, 2 Münzen werfen. Wenn beide Münzen \"Kopf\" gezeigt haben, lege 1 Verteidigendes Pokémon mit allen Karten, die an es angelegt sind, auf den Ablagestapel deines Gegners. (Dieses Pokémon zählt nicht als kampfunfähig gemachtes Pokémon.)"
+				de: "Einmal während deines Zuges kannst du, wenn du Walraisa von deiner Hand spielst, um 1 deiner Pokémon zu entwickeln, 2 Münzen werfen. Wenn beide Münzen „Kopf“ gezeigt haben, lege 1 Verteidigendes Pokémon mit allen Karten, die an es angelegt sind, auf den Ablagestapel deines Gegners. (Dieses Pokémon zählt nicht als kampfunfähig gemachtes Pokémon.)"
 			},
 		},
 	],
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "It shatters ice with its big tusks. Its thick blubber repels not only the cold, but also enemy attacks.",
-		fr: "Il brise la glace avec ses grosses défenses. Sa graisse le protège du froid, mais aussi des attaques."
+		fr: "Il brise la glace avec ses grosses défenses. Sa graisse le protège du froid, mais aussi des attaques.",
+		de: "Mit seinen Stoßzähnen bricht es durch Eis. Eine Speckschicht schützt es vor Kälte und Angriffen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/4.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/4.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "If you have Uxie and Mesprit in play, the attack cost of each of your opponent's Basic Pokémon's attack is Colorless more. You can't use more than 1 Downer Material Poké-Body each turn.",
 				fr: "Si vous avez Créhelf ou Créfollet en jeu, le Coût d'attaque de l'attaque de chacun des Pokémon de base de votre adversaire est de Colorless de plus. Vous ne pouvez pas utiliser plus d'1 Poké-Body Matériel immobilisateur par tour.",
-				de: "Wenn du Selfe und Vesprit im Spiel hast, kosten die Angriffe der Basis-Pokémon deines Gegners 1 zusätzliche . Du kannst nicht mehr als 1 Beruhigungsmittel Poké-Body pro Zug einsetzen."
+				de: "Wenn du Selfe und Vesprit im Spiel hast, kosten die Angriffe der Basis-Pokémon deines Gegners 1 zusätzliche {C}. Du kannst nicht mehr als 1 Beruhigungsmittel Poké-Body pro Zug einsetzen."
 			},
 		},
 	],
@@ -72,7 +72,8 @@ const card: Card = {
 
 	description: {
 		en: "Known as \"The Being of Willpower.\" It sleeps at the bottom of a lake to keep the world in balance.",
-		fr: "On l'appelle \"être de la volonté\". Il dort au fond d'un lac pour maintenir l'équilibre du monde."
+		fr: "On l'appelle \"être de la volonté\". Il dort au fond d'un lac pour maintenir l'équilibre du monde.",
+		de: "„Das starke Wesen“. Es schläft auf dem Grund eines Sees und hält so die Welt in Balance."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/40.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/40.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Barboach",
-		fr: "Barloche"
+		fr: "Barloche",
+		de: "Schmerbe"
 	},
 
 	stage: "Stage1",
@@ -65,7 +66,7 @@ const card: Card = {
 			effect: {
 				en: "Does 20 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 20 dégâts à chaque Pokémon de Banc (les vôtres et ceux de votre adversaire). (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc).",
-				de: "Dieser Angriff fügt jedem Pokémon auf der Bank (deinen und denen deines Gegners) 20 Schadenspunkte zu. (Wende Schwäche und Resistenz für Pokémon auf der Bank nicht an.)"
+				de: "Dieser Angriff fügt jedem Pokémon auf der Bank (deinen und denen deines Gegners) 20 Schadenpunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 60,
 
@@ -90,7 +91,8 @@ const card: Card = {
 
 	description: {
 		en: "It is very territorial. It repels foes by setting of tremors that extend over a three-mile radius.",
-		fr: "Il est attaché à son territoire. Il repousse l'ennemi en provoquant des secousses qui portent à 5 Km."
+		fr: "Il est attaché à son territoire. Il repousse l'ennemi en provoquant des secousses qui portent à 5 Km.",
+		de: "Es verteidigt sein Revier, indem es Erschütterungen auslöst, die noch in 5 km Entfernung zu spüren sind."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/41.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/41.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Chikorita",
-		fr: "Germignon"
+		fr: "Germignon",
+		de: "Endivie"
 	},
 
 	stage: "Stage1",
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 30 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "30x",
 
@@ -85,7 +86,8 @@ const card: Card = {
 
 	description: {
 		en: "The buds that ring its neck give off a spicy aroma that perks people up.",
-		fr: "Le collier de bourgeons à son cou répand un arôme épicé qui vous donne du tonus."
+		fr: "Le collier de bourgeons à son cou répand un arôme épicé qui vous donne du tonus.",
+		de: "Die Knospen an seinem Hals geben ein würziges Aroma ab, das andere aufheitert."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/42.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/42.ts
@@ -69,7 +69,8 @@ const card: Card = {
 
 	description: {
 		en: "It emits cries by agitating an orb at the back of its throat. It moves with flouncing hops.",
-		fr: "Il émet des cris en agitant l'orbe à l'arrière de sa gorge. Il avance par bonds désordonnés."
+		fr: "Il émet des cris en agitant l'orbe à l'arrière de sa gorge. Il avance par bonds désordonnés.",
+		de: "Es ruft, indem es eine Kugel in seiner Kehle bewegt. Es bewegt sich mit eiligen Hopsern fort."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/43.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/43.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Skull Fossil",
-		fr: "Fossile crâne"
+		fr: "Fossile crâne",
+		de: "Kopffossil"
 	},
 
 	stage: "Stage1",
@@ -75,7 +76,8 @@ const card: Card = {
 
 	description: {
 		en: "It lived in jungles around 100 million years ago. Its skull is as hard as iron.",
-		fr: "Il vivait dans la jungle il y a environ 100 millions d'années. Son crâne est dur comme du fer."
+		fr: "Il vivait dans la jungle il y a environ 100 millions d'années. Son crâne est dur comme du fer.",
+		de: "Vor über 100 Millionen Jahren lebte es in den Dschungeln. Sein Schädel ist hart wie Eisen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/44.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/44.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Totodile",
-		fr: "Kaiminus"
+		fr: "Kaiminus",
+		de: "Karnimani"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn, when you play Croconaw from your hand to evolve 1 of your Pokémon, you may look at the top 5 cards of your deck. Choose all Energy cards you find there, show them to your opponent, and put them into your hand. Put the other cards back on top of your deck. Shuffle your deck afterward.",
 				fr: "Une seule fois lors de votre tour, lorsque vous jouez Crocrodil de votre main pour faire évoluer 1 de vos Pokémon, vous pouvez regarder les 5 du dessus de votre deck. Choisissez-y toutes les cartes Énergie, montrez-les à votre adversaire et placez-les dans votre main. Replacez les autres cartes au dessus de votre deck. Ensuite, mélangez votre deck.",
-				de: "Einmal während deines Zuges kannst du, wenn du Tyracroc von deiner Hand spielst, um 1 deiner Pokémon zu entwickeln, dir die obersten 5 Karten deines Decks anschauen. Wähle alle Energiekarten, die du dort gefunden hast, zeige sie deinem Gegner und nimm sie auf die Hand. Lege die anderen Karten zurück auf dein Deck. Mische dein Deck danach"
+				de: "Einmal während deines Zuges kannst du, wenn du Tyracroc von deiner Hand spielst, um 1 deiner Pokémon zu entwickeln, dir die obersten 5 Karten deines Decks anschauen. Wähle alle Energiekarten, die du dort gefunden hast, zeige sie deinem Gegner und nimm sie auf die Hand. Lege die anderen Karten zurück auf dein Deck. Mische dein Deck danach."
 			},
 		},
 	],
@@ -78,7 +79,8 @@ const card: Card = {
 
 	description: {
 		en: "Once it bites down, it won't let go until it loses its fangs. New fangs quickly grow into place.",
-		fr: "Quand il mord, il ne lâche pas prise avant que ses crocs se brisent. Ils repoussent par la suite."
+		fr: "Quand il mord, il ne lâche pas prise avant que ses crocs se brisent. Ils repoussent par la suite.",
+		de: "Hat es einmal zugebissenn, lässt es erst los, wenn es seine Zähne verliert, die schnell nachwachsen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/45.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/45.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Seel",
-		fr: "Otaria"
+		fr: "Otaria",
+		de: "Jurob"
 	},
 
 	stage: "Stage1",
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "In snow, the pure white coat covering its body obscures it from predators.",
-		fr: "Son corps est couvert d'un grand manteau blanc qui, dans la neige, le dissimule aux yeux des prédateurs."
+		fr: "Son corps est couvert d'un grand manteau blanc qui, dans la neige, le dissimule aux yeux des prédateurs.",
+		de: "Sein Körper ist mit einem weißen Fell bedeckt, das es im Schnee fast unsichtbar für Gegner macht."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/46.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/46.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Doduo",
-		fr: "Dodrio"
+		fr: "Dodrio",
+		de: "Dodu"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10x",
 
@@ -84,7 +85,8 @@ const card: Card = {
 
 	description: {
 		en: "When DODUO evolves into this odd breed, one of its heads splits into two. It runs at nearly 40 mph.",
-		fr: "Quand Doduo connait cette étrange évolution, l'une de ses têtes se dédouble. Il atteint les 60 km/h."
+		fr: "Quand Doduo connait cette étrange évolution, l'une de ses têtes se dédouble. Il atteint les 60 km/h.",
+		de: "Entwickelt sich DODU, teilt sich einer der Köpfe in zwei. Es kann sich mit 60 km/h fortbewegen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/47.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/47.ts
@@ -68,7 +68,8 @@ const card: Card = {
 
 	description: {
 		en: "It digs into the ground with its tail and makes a mazelike nest. It can fly just a little.",
-		fr: "Son nid est un véritable labyrinthe qu'il creuse à l'aide de sa queue. Il sait à peine voler."
+		fr: "Son nid est un véritable labyrinthe qu'il creuse à l'aide de sa queue. Il sait à peine voler.",
+		de: "Es gräbt sich mit seinem Schweif in die Erde und baut ein labyrinthartiges Nest. Es kann kaum fliegen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/48.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/48.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Gible",
-		fr: "Griknot"
+		fr: "Griknot",
+		de: "Kaumalat"
 	},
 
 	stage: "Stage1",
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, put 4 damage counters on 1 of your opponent's Pokémon. If tails, remove 4 damage counters from 1 of your Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, placez 4 marqueurs de dégât sur 1 des Pokémon de votre adversaire. Si c'est pile, retirez 4 marqueurs de dégât à 1 de vos Pokémon.",
-				de: "Wirf 1 Münze. Bei 'Kopf' lege 4 Schadensmarken auf 1 Pokémon deines Gegners. Bei 'Zahl' entferne 4 Schadensmarken von 1 deiner Pokémon."
+				de: "Wirf 1 Münze. Bei „Kopf“ lege 4 Schadensmarken auf 1 Pokémon deines Gegners. Bei „Zahl“ entferne 4 Schadensmarken von 1 deiner Pokémon."
 			},
 
 		},
@@ -77,7 +78,8 @@ const card: Card = {
 
 	description: {
 		en: "There is a long-held belief that medicine made from its scale will heal even incurable illnesses.",
-		fr: "Selon une croyance ancienne, on peut utiliser ses écailles pour guérir les maladies incurables."
+		fr: "Selon une croyance ancienne, on peut utiliser ses écailles pour guérir les maladies incurables.",
+		de: "Es gibt einen uralten Glauben, dass Medizin, die aus seinen Schuppen gewonnen wird, alles heilen kann."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/49.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/49.ts
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face le Pokémon Défenseur est maintenant Confus.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt verwirrt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: 20,
 
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "Its tail also has a small brain. It bites to repel any foe trying to sneak up on it from behind.",
-		fr: "Sa queue contient un minuscule cerveau. Elle mord l'ennemi qui essaie de le frapper dans le dos."
+		fr: "Sa queue contient un minuscule cerveau. Elle mord l'ennemi qui essaie de le frapper dans le dos.",
+		de: "Sein Schweif besitzt ebenfalls ein Gehirn. Er beißt jeden Gegner, der sich von hinten heranschleicht."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/5.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/5.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Chansey",
-		fr: "Leveinard"
+		fr: "Leveinard",
+		de: "Chaneira"
 	},
 
 	stage: "Stage1",
@@ -77,7 +78,8 @@ const card: Card = {
 
 	description: {
 		en: "This kindhearted Pokémon nurses sick Pokémon to health. It senses feelings of sadness.",
-		fr: "Ce Pokémon au cœur d'or soigne les Pokémon malades. Il ressent la tristesse d'autrui."
+		fr: "Ce Pokémon au cœur d'or soigne les Pokémon malades. Il ressent la tristesse d'autrui.",
+		de: "Dieses gutherzige PKMN pflegt kranke PKMN gesund. Es spürt die Traurigkeit anderer Lebewesen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/50.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/50.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Zubat",
-		fr: "Nosferapti"
+		fr: "Nosferapti",
+		de: "Zubat"
 	},
 
 	stage: "Stage1",
@@ -66,7 +67,8 @@ const card: Card = {
 
 	description: {
 		en: "It loves the blood of humans and Pokémon. It flies around at night in search of neck veins.",
-		fr: "Il aime le sang des humains et des Pokémon. Il erre la nuit en quête d'un cou où planter ses crocs."
+		fr: "Il aime le sang des humains et des Pokémon. Il erre la nuit en quête d'un cou où planter ses crocs.",
+		de: "Es liebt das Blut von Menschen und Pokémon. Nachts fliegt es umher auf der Suche nach Halsvenen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/51.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/51.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Geodude",
-		fr: "Racaillou"
+		fr: "Racaillou",
+		de: "Kleinstein"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin until you get tails. This attack does 30 damage times the number of heads.",
 				fr: "Lancez une pièce jusqu'à ce que vous obteniez pile. Cette attaque inflige 30 dégâts multipliés par le nombre de faces.",
-				de: "Wirf so lange 1 Münze, bis zum ersten Mal das Ergebnis 'Zahl' kommt. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl 'Kopf' zu."
+				de: "Wirf so lange 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "30x",
 
@@ -88,7 +89,8 @@ const card: Card = {
 
 	description: {
 		en: "GRAVELER make their homes on sheer cliff faces by gouging out numerous horizontal holes.",
-		fr: "Gravalanch creuse son terrier à flanc de montagne en perçant des galeries horizontales."
+		fr: "Gravalanch creuse son terrier à flanc de montagne en perçant des galeries horizontales.",
+		de: "GEOROK leben an steilen Felsvorsprüngen. Sie graben dazu viele Löcher aus."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/52.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/52.ts
@@ -69,7 +69,8 @@ const card: Card = {
 
 	description: {
 		en: "It loves round white things. It carries and egg-shaped rock in imitation of CHANSEY.",
-		fr: "Ce Pokémon aime ce qui est rond et blanc et transporte un caillou en forme d'œuf pour imiter Leveinard."
+		fr: "Ce Pokémon aime ce qui est rond et blanc et transporte un caillou en forme d'œuf pour imiter Leveinard.",
+		de: "Es liebt runde, weiße Dinge. Es trägt einen eiförmigen Stein bei sich, und imitiert damit CHANEIRA."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/53.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/53.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Aron",
-		fr: "Galekid"
+		fr: "Galekid",
+		de: "Stollunior"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Search your discard pile for a Metal Energy card and attach it to Lairon. If you do, remove 2 damage counters from Lairon.",
 				fr: "Choisissez dans votre pile de défausse une carte Énergie Metal et attachez-la à Galegon. Retirez-lui alors 2 marqueurs de dégât.",
-				de: "Durchsuche deinen Ablagestapel nach 1 -Energiekarte und lege sie an Stollrak an. Wenn du das machst, entferne 2 Schadensmarken von Stollrak."
+				de: "Durchsuche deinen Ablagestapel nach 1 {M}-Energiekarte und lege sie an Stollrak an. Wenn du das machst, entferne 2 Schadensmarken von Stollrak."
 			},
 
 		},
@@ -82,7 +83,8 @@ const card: Card = {
 
 	description: {
 		en: "For food, it digs up iron ore. It smashes its steely body against others to fight over territory.",
-		fr: "Il se nourrit du minéral de fer qu'il fore. Il défend son territoire en chargeant avec son corps d'acier."
+		fr: "Il se nourrit du minéral de fer qu'il fore. Il défend son territoire en chargeant avec son corps d'acier.",
+		de: "Es ernährt sich von Eisenerz. Um sein Revier zu sichern, setzt es seinen harten Körper ein."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/54.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/54.ts
@@ -71,7 +71,8 @@ const card: Card = {
 
 	description: {
 		en: "Born in the spout of a volcano, its body is covered by flames that shimmer like the sun.",
-		fr: "Il est né au milieu d'un volcan. Son corps est couvert de flammes qui flambent comme un soleil."
+		fr: "Il est né au milieu d'un volcan. Son corps est couvert de flammes qui flambent comme un soleil.",
+		de: "Es wurde bei einem Vulkanausbruch geboren. Sein Körper ist von hellen Flammen umgeben."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/55.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/55.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Surskit",
-		fr: "Arakdo"
+		fr: "Arakdo",
+		de: "Gehweiher"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Does 20 damage times the number of Colorless Energy in the Defending Pokémon's Retreat Cost (after applying effects to the Retreat Cost).",
 				fr: "Inflige 20 dégâts multipliés par le nombre d'Énergie Colorless dans le Coût de retraite du Pokémon Défenseur (après application des effets du Coût de retraite).",
-				de: "Dieser Angriff fügt 20 Schadenspunkte für jede -Energie in den Rückzugskosten des Verteidigenden Pokémon zu (nachdem Effekte auf die Rückzugskosten verrechnet wurden)."
+				de: "Dieser Angriff fügt 20 Schadenspunkte für jede {C}-Energie in den Rückzugskosten des Verteidigenden Pokémon zu (nachdem Effekte auf die Rückzugskosten verrechnet wurden)."
 			},
 			damage: "20x",
 
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "If your opponent has any Water Pokémon in play, this attack does 30 damage plus 30 more damage and the Defending Pokémon is now Confused.",
 				fr: "Si votre adversaire possède des Pokémon Water en jeu, cette attaque inflige 30 dégâts plus 30 dégâts supplémentaires et le Pokémon Défenseur est maintenant Confus.",
-				de: "Wenn dein Gegner mindestens 1 -Pokémon im Spiel hat, fügt dieser Angriff 30 Schadenspunkte plus 30 weitere Schadenspunkte zu und das Verteidigende Pokémon ist jetzt verwirrt."
+				de: "Wenn dein Gegner mindestens 1 {W}-Pokémon im Spiel hat, fügt dieser Angriff 30 Schadenspunkte plus 30 weitere Schadenspunkte zu und das Verteidigende Pokémon ist jetzt verwirrt."
 			},
 			damage: "30+",
 
@@ -85,7 +86,8 @@ const card: Card = {
 
 	description: {
 		en: "Its antennae have eye patterns on them. Its four wings enable it to hover and fly in any direction.",
-		fr: "Des motifs en forme d'yeux ornent ses antennes. Ses 4 ailes l'aident à voler dans toutes les directions."
+		fr: "Des motifs en forme d'yeux ornent ses antennes. Ses 4 ailes l'aident à voler dans toutes les directions.",
+		de: "Seine Antenne besitzt ein Augenmuster. Seine vier Flügel erlauben es, in alle Richtungen zu fliegen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/56.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/56.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Nidoran♀",
-		fr: "Nidoran"
+		fr: "Nidoran",
+		de: "Nidoran♀"
 	},
 
 	stage: "Stage1",
@@ -74,7 +75,8 @@ const card: Card = {
 
 	description: {
 		en: "When it senses danger, it raises all the barbs on its body. These barbs grow slower than NIDORINO's.",
-		fr: ":Ce Pokémon dresse ses piquants en cas de danger. Ils poussent moins vite que ceux de Nidorino."
+		fr: ":Ce Pokémon dresse ses piquants en cas de danger. Ils poussent moins vite que ceux de Nidorino.",
+		de: "Bei Gefahr fährt es die Widerhaken am Körper aus. Diese wachsen langsamer als die von NIDORINO."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/57.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/57.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Remoraid",
-		fr: "Rémoraid"
+		fr: "Rémoraid",
+		de: "Remoraid"
 	},
 
 	stage: "Stage1",
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "It lives in the gaps of boulders and in holes on the seafloor. Its suction cups grip prey tightly.",
-		fr: "Il hante les fissures dans la roche et les trous au fond de la mer. Ses ventouses ne lâchent jamais prise."
+		fr: "Il hante les fissures dans la roche et les trous au fond de la mer. Ses ventouses ne lâchent jamais prise.",
+		de: "Es lebt in Gesteinsritzen und Löchern auf dem Meeresboden. Mit Saugnäpfen hält es Beute fest."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/58.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/58.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Paras",
-		fr: "Paras"
+		fr: "Paras",
+		de: "Paras"
 	},
 
 	stage: "Stage1",
@@ -80,7 +81,8 @@ const card: Card = {
 
 	description: {
 		en: "A mushroom grown larger than the host's body controls PARASECT. It scatters poisonous spores.",
-		fr: "Un champignon parasite plus gros que Parasect contrôle son corps. Il répand des spores empoisonnées."
+		fr: "Un champignon parasite plus gros que Parasect contrôle son corps. Il répand des spores empoisonnées.",
+		de: "PARASEK wird von einem Pilz, der größer als das Pokémon ist, kontrolliert. Er gibt Giftsporen ab."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/59.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/59.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Larvitar",
-		fr: "Embrylex"
+		fr: "Embrylex",
+		de: "Larvitar"
 	},
 
 	stage: "Stage1",
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "Pupitar does 10 damage to itself. Flip a coin. If heads, prevent all damage done to Pupitar by attacks during your opponent's next turn.",
 				fr: "Ymphect s'inflige 10 dégâts. Lancez une pièce. Si c'est face, prévenez tous les effets infligés à Ymphect par des attaques lors du prochain tour de votre adversaire.",
-				de: "Pupitar fügt sich selbst 10 Schadenspunkte zu. Wirf 1 Münze. Bei \"Kopf\" verhindere allen Schaden, der Pupitar im nächsten Zug deines Gegners durch Angriffe zugefügt wird."
+				de: "Pupitar fügt sich selbst 10 Schadenspunkte zu. Wirf 1 Münze. Bei „Kopf“ verhindere allen Schaden, der Pupitar im nächsten Zug deines Gegners durch Angriffe zugefügt wird."
 			},
 			damage: 50,
 
@@ -85,7 +86,8 @@ const card: Card = {
 
 	description: {
 		en: "Its body is as hard as bedrock. By venting pressurized gas, it can launch itself like a rocket.",
-		fr: "Son corps est dur comme la pierre souterraine. Il file comme une fusée en expulsant des gaz."
+		fr: "Son corps est dur comme la pierre souterraine. Il file comme une fusée en expulsant des gaz.",
+		de: "Sein Körper ist hart wie Fels. Es lässt mit Hochdruck Gas ab, um wie eine Rakete nach oben zu schießen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/6.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/6.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Bronzor",
-		fr: "Archéomire"
+		fr: "Archéomire",
+		de: "Bronzel"
 	},
 
 	stage: "Stage1",
@@ -86,7 +87,8 @@ const card: Card = {
 
 	description: {
 		en: "One caused a news sensation when it was dug up at a construction site after a 2,000-year sleep.",
-		fr: "La découverte d'un de ces Pokémon sur un site de fouilles après 2 000 ans de sommeil a fait sensation."
+		fr: "La découverte d'un de ces Pokémon sur un site de fouilles après 2 000 ans de sommeil a fait sensation.",
+		de: "Dieses PKMN fand man bei Grabungen auf einer Baustelle, an deren Ort es 2 000 Jahre geschlafen hatte."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/60.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/60.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Cyndaquil",
-		fr: "Héricendre"
+		fr: "Héricendre",
+		de: "Feurigel"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, discard a Fire Energy attached to Quilava.",
 				fr: "Lancez une pièce. Si c'est pile, défaussez une Énergie Fire attachée à Feurisson.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" lege 1 an Igelavar angelegte -Energie auf deinen Ablagestapel."
+				de: "Wirf 1 Münze. Bei „Zahl“ lege 1 an Igelavar angelegte {R}-Energie auf deinen Ablagestapel."
 			},
 			damage: 40,
 
@@ -62,7 +63,8 @@ const card: Card = {
 
 	description: {
 		en: "It intimidates foes with the heat of its flames. The fire burn more strongly when it readies to fight.",
-		fr: "La chaleur de ses flammes intimide l'ennemi. Elles s'intensifient lorsqu'il se prépare à combattre."
+		fr: "La chaleur de ses flammes intimide l'ennemi. Elles s'intensifient lorsqu'il se prépare à combattre.",
+		de: "Es bedroht seine Gegner mit der Hitze seiner Flammen. Ist es kampfbereit, lodern sie stärker."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/61.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/61.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Sandshrew",
-		fr: "Sabelette"
+		fr: "Sabelette",
+		de: "Sandan"
 	},
 
 	stage: "Stage1",
@@ -86,7 +87,8 @@ const card: Card = {
 
 	description: {
 		en: "It curls up, then rolls into foes with its back. Its sharp spines inflict severe damage.",
-		fr: "Il se met en boule pour percuter l'ennemi. Ses épines aiguisées font beaucoup de dégâts."
+		fr: "Il se met en boule pour percuter l'ennemi. Ses épines aiguisées font beaucoup de dégâts.",
+		de: "Es rollt sich zusammen und rollt dann auf Gegner zu, die durch seine Stacheln Schaden nehmen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/62.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/62.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Spheal",
-		fr: "Obalie"
+		fr: "Obalie",
+		de: "Seemops"
 	},
 
 	stage: "Stage1",
@@ -61,7 +62,8 @@ const card: Card = {
 
 	description: {
 		en: "It habitually spins things on its nose. By doing so, it learns textures and odors.",
-		fr: "Il fait souvent tourner des objets sur son museau pour connaitre leur odeur et leur texture."
+		fr: "Il fait souvent tourner des objets sur son museau pour connaitre leur odeur et leur texture.",
+		de: "Es balanciert Dinge auf seiner Nase. Dabei lernt es etwas über die Beschaffenheit und den Geruch."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/63.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/63.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Armor Fossil",
-		fr: "Fossile armure"
+		fr: "Fossile armure",
+		de: "Panzerfossil"
 	},
 
 	stage: "Stage1",
@@ -63,7 +64,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 40 damage plus 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 40 dégâts plus 20 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei 'Kopf' fügt dieser Angriff 40 Schadenspunkte plus 20 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 40 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "40+",
 
@@ -88,7 +89,8 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon that lived in jungles around 100 million years ago. Its facial hide is extremely hard.",
-		fr: "Un Pokémon qui vivait dans la jungle il y a 100 millions d'années. Son visage est très dur."
+		fr: "Un Pokémon qui vivait dans la jungle il y a 100 millions d'années. Son visage est très dur.",
+		de: "Vor über 100 Millionen Jahren lebte es in den Dschungeln. Seine Gesichtshaut ist extrem hart."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/64.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/64.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Remove 3 damage counters from each of your Benched Pokémon that has any Grass Energy attached to it.",
 				fr: "Retirez 3 marqueurs de dégât à chacun de vos Pokémon de Banc possédant une Énergie Grass.",
-				de: "Entferne 3 Schadensmarken von jedem Pokémon auf deiner Bank, an dem mindestens 1 -Energie angelegt ist."
+				de: "Entferne 3 Schadensmarken von jedem Pokémon auf deiner Bank, an dem mindestens 1 {G}-Energie angelegt ist."
 			},
 
 		},
@@ -80,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "Because it continually ate only its favorite fruit, the fruit started growing around its neck.",
-		fr: "À force de manger son fruit préféré, il a fini par pousser autour de son cou."
+		fr: "À force de manger son fruit préféré, il a fini par pousser autour de son cou.",
+		de: "Da es ausschließlich seine Lieblingsfrucht frisst, begann diese, um seinen Hals herumzuwachsen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/65.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/65.ts
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "During your opponent's next turn, whenever your opponent flips a coin, treat it as tails.",
 				fr: "Lors du prochain tour de votre adversaire, lorsque votre adversaire lance une pièce, considérez que c'est pile.",
-				de: "Im nächsten Zug deines Gegners zählen alle Ergebnisse von Münzwürfen deines Gegners als \"Zahl\"."
+				de: "Im nächsten Zug deines Gegners zählen alle Ergebnisse von Münzwürfen deines Gegners als „Zahl“."
 			},
 
 		},
@@ -72,7 +72,8 @@ const card: Card = {
 
 	description: {
 		en: "Shaped like ancient writing, it is a huge mystery whether language or UNOWN came first.",
-		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou du Zarbi est apparu en premier."
+		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou du Zarbi est apparu en premier.",
+		de: "Seine Form sieht aus wie antike Schrift. Was war zuerst da? Die Sprache oder ICOGNITO?"
 	},
 
 	variants: [

--- a/data/Diamond & Pearl/Mysterious Treasures/66.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/66.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), if Unown M is your Active Pokémon, you may flip a coin. If heads, switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. This power can't be used if Unown M is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), si Zarbi M est votre Pokémon Actif, vous pouvez lancer une pièce. Si c'est face, échangez 1 des Pokémon de Banc de votre adversaire avec 1 des Pokémon Défenseurs. Ce pouvoir ne peut pas être utilisé si Zarbi M est affecté par un État Spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn Icognito M dein Aktives Pokémon ist, 1 Münze werfen. Bei \"Kopf\" tausche 1 Verteidigendes Pokémon deines Gegners gegen 1 Pokémon auf der Bank deines Gegners aus. Diese Poké-Power kann nicht benutzt werden, wenn Icognito M von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn Icognito M dein Aktives Pokémon ist, 1 Münze werfen. Bei „Kopf“ tausche 1 Verteidigendes Pokémon deines Gegners gegen 1 Pokémon auf der Bank deines Gegners aus. Diese Poké-Power kann nicht benutzt werden, wenn Icognito M von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 damage. If tails, this attack does 30 damage to 1 of your Pokémon, and this attack's damage isn't affected by Weakness or Resistance.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts. Si c'est pile, cette attaque inflige 30 dégâts à 1 de vos Pokémon et les dégâts de cette attaque ne sont pas affectés par la Faiblesse et la Résistance.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 30 Schadenspunkte zu. Bei \"Zahl\" fügt dieser Angriff 1 deiner Pokémon 30 Schadenspunkte zu und der Schaden dieses Angriffs wird durch Schwäche und Resistenz nicht verändert."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 Schadenspunkte zu. Bei „Zahl“ fügt dieser Angriff 1 deiner Pokémon 30 Schadenspunkte zu und der Schaden dieses Angriffs wird durch Schwäche und Resistenz nicht verändert."
 			},
 
 		},
@@ -71,7 +71,8 @@ const card: Card = {
 
 	description: {
 		en: "Shaped like ancient writing, it is a huge mystery whether language or UNOWN came first.",
-		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou de Zarbi est apparu en premier."
+		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou de Zarbi est apparu en premier.",
+		de: "Seine Form sieht aus wie antike Schrift. Was war zuerst da? Die Sprache oder ICOGNITO?"
 	},
 
 	variants: [

--- a/data/Diamond & Pearl/Mysterious Treasures/67.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/67.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), if Unown T is your Active Pokémon, you may discard a card from your hand. Then, flip a coin. If heads, put 2 damage counters on 1 of your opponent's Benched Pokémon. This power can't be used if Unown T is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), si Zarbi T est votre Pokémon Actif, vous pouvez défausser une carte de votre main. Ensuite, lancez une pièce. Si c'est face, placez 2 marqueurs de dégât sur 1 des Pokémon de Banc de votre adversaire. Ce pouvoir ne peut pas être utilisé si Zarbi T est affecté par un État Spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn Icognito T dein Aktives Pokémon ist, 1 Karte von deiner Hand auf deinen Ablagestapel legen. Danach wirf 1 Münze. Bei 'Kopf' lege 2 Schadensmarken auf 1 Pokémon auf der Bank deines Gegners. Diese Poké-Power kann nicht benutzt werden, wenn Icognito T von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn Icognito T dein Aktives Pokémon ist, 1 Karte von deiner Hand auf deinen Ablagestapel legen. Danach wirf 1 Münze. Bei „Kopf“ lege 2 Schadensmarken auf 1 Pokémon auf der Bank deines Gegners. Diese Poké-Power kann nicht benutzt werden, wenn Icognito T von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -71,7 +71,8 @@ const card: Card = {
 
 	description: {
 		en: "Shaped like ancient writing, it is a huge mystery whether language or UNOWN came first.",
-		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou de Zarbi est apparu en premier."
+		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou de Zarbi est apparu en premier.",
+		de: "Seine Form sieht aus wie antike Schrift. Was war zuerst da? Die Sprache oder ICOGNITO?"
 	},
 
 	variants: [

--- a/data/Diamond & Pearl/Mysterious Treasures/68.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/68.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Slakoth",
-		fr: "Parecool"
+		fr: "Parecool",
+		de: "Bummelz"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "If Vigoroth evolved from Slakoth during this turn and Slakoth was Asleep, this attack's base damage is 60 instead of 10.",
 				fr: "Si Vigoroth a évolué de Parecool lors de ce tour et que Parecool est Endormi, les dégâts de base de cette attaque sont de 60 au lieu de 10.",
-				de: "Wenn Muntier sich in diesem Zug aus Bummelz entwickelt hat, während Bummelz den Speziellen Zustand \"schlafend\" hatte, beträgt der Grundschaden dieses Angriffs 60 Schadenspunkte anstelle von 10 Schadenspunkten."
+				de: "Wenn Muntier sich in diesem Zug aus Bummelz entwickelt hat, während Bummelz den Speziellen Zustand „schlafend“ hatte, beträgt der Grundschaden dieses Angriffs 60 Schadenspunkte anstelle von 10 Schadenspunkten."
 			},
 			damage: 10,
 
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 30 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "30x",
 
@@ -80,7 +81,8 @@ const card: Card = {
 
 	description: {
 		en: "Its heart beats at a tenfold tempo, so it cannot sit still even for a moment.",
-		fr: "Son cœur bat dix fois plus vite que la normale, c'est pourquoi il ne tient pas en place."
+		fr: "Son cœur bat dix fois plus vite que la normale, c'est pourquoi il ne tient pas en place.",
+		de: "Sein Herz schlägt schneller als das anderer Lebewesen. Daher kann es nicht für einen Moment still sitzen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/69.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/69.ts
@@ -72,7 +72,8 @@ const card: Card = {
 
 	description: {
 		en: "It sleeps for 18 hours a day. Even when awake, it teleports itself while remaining seated.",
-		fr: "Il dort 18 heures par jour. Même éveillé, il ne prend pas la peine de se lever pour se téléporter."
+		fr: "Il dort 18 heures par jour. Même éveillé, il ne prend pas la peine de se lever pour se téléporter.",
+		de: "18 Stunden am Tag schläft es. Und wenn es wach ist, teleportiert es sich, während es sitzen bleibt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/7.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/7.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Search your deck for a Grass Energy card and attach it to Celebi. Shuffle your deck afterward.",
 				fr: "Cherchez dans votre deck une carte Énergie Grass et attachez-la à Celebi. Ensuite, mélangez votre deck.",
-				de: "Durchsuche dein Deck nach einer -Energiekarte und lege sie an Celebi an. Mische dein Deck danach."
+				de: "Durchsuche dein Deck nach einer {G}-Energiekarte und lege sie an Celebi an. Mische dein Deck danach."
 			},
 
 		},
@@ -53,7 +53,7 @@ const card: Card = {
 			effect: {
 				en: "You may move any number of basic Grass Energy cards attached to your Pokémon to your other Pokémon in any way you like.",
 				fr: "Vous pouvez déplacer autant de cartes Énergie de base Grass attachées à vos Pokémon que vous voulez sur vos autres Pokémon de la façon que vous voulez.",
-				de: "Du kannst beliebig viele -Basis-Energiekarten, die an deinen Pokémon angelegt sind, in beliebiger Verteilung an deine anderen Pokémon anlegen."
+				de: "Du kannst beliebig viele {G}-Basis-Energiekarten, die an deinen Pokémon angelegt sind, in beliebiger Verteilung an deine anderen Pokémon anlegen."
 			},
 			damage: 30,
 
@@ -71,7 +71,8 @@ const card: Card = {
 
 	description: {
 		en: "It has the power to travel across time, but is is said to appear only in peaceful times.",
-		fr: "Il a le pouvoir de voyager dans le temps. Cependant, on dit qu'il n'apparaît qu'en temps de paix."
+		fr: "Il a le pouvoir de voyager dans le temps. Cependant, on dit qu'il n'apparaît qu'en temps de paix.",
+		de: "Es kann durch die Zeit reisen, aber es erscheint nur zu friedlichen Zeiten."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/70.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/70.ts
@@ -69,7 +69,8 @@ const card: Card = {
 
 	description: {
 		en: "It uses its tail to pluck fruits that are out of reach. Its tail is more adept than its real hands.",
-		fr: "Il utilise sa queue pour cueillir les fruits inaccessibles. Elle est plus agile que ses mains."
+		fr: "Il utilise sa queue pour cueillir les fruits inaccessibles. Elle est plus agile que ses mains.",
+		de: "Mit dem Schweif pflückt es hochhängende Früchte. Mit ihm ist es geschickter als mit den Händen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/71.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/71.ts
@@ -64,7 +64,8 @@ const card: Card = {
 
 	description: {
 		en: "It usually lives deep in mountains. However, hunger may drive it to eat railroad tracks and cars.",
-		fr: "Il vit habituellement au cœur des montagnes. Affamé, il dévore parfois des rails et des voitures."
+		fr: "Il vit habituellement au cœur des montagnes. Affamé, il dévore parfois des rails et des voitures.",
+		de: "Normalerweise lebt es in dunklen Bergen. Ist es hungrig, frisst es auch Eisenbahnschienen und Autos."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/72.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/72.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts à chacun des Pokémon de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff jedem Pokémon deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff jedem Pokémon deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -62,7 +62,8 @@ const card: Card = {
 
 	description: {
 		en: "It coats its entire body with a slimy fluid so it can squirm and slip away if grabbed.",
-		fr: "Il enduit son corps d'une substance visqueuse pour glisser et se libérer quand on l'agrippe."
+		fr: "Il enduit son corps d'une substance visqueuse pour glisser et se libérer quand on l'agrippe.",
+		de: "Es bedeckt seinen Körper mit einer schleimigen Substanz und kann sich so aus Umklammerungen winden."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/73.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/73.ts
@@ -34,7 +34,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
-				de: "Tackle"
+				de: "Kerzalbeere"
 			},
 
 			damage: 30,

--- a/data/Diamond & Pearl/Mysterious Treasures/74.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/74.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt verwirrt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: 20,
 
@@ -64,7 +64,8 @@ const card: Card = {
 
 	description: {
 		en: "Implements shaped like it were discovered in ancient tombs. It is unknown if they are related.",
-		fr: "Il rappelle des objets trouvés dans des sépultures anciennes. Nul ne sait qu'ils sont liés."
+		fr: "Il rappelle des objets trouvés dans des sépultures anciennes. Nul ne sait qu'ils sont liés.",
+		de: "Sein Körper sieht aus, als seien Teile davon in alten Gräbern gefunden worden."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/75.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/75.ts
@@ -34,12 +34,12 @@ const card: Card = {
 			name: {
 				en: "Quick Attack",
 				fr: "Vive-attaque",
-				de: "Ruckzuckhieb"
+				de: "Maronbeere"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 30 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 30 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 10 Schadenspunkte plus 30 weitere Schadenspunkte zu."
+				de: "Wenn Bamelin schläft, entferne am Ende jedes Zuges den Speziellen Zustand „schlafend“ von Bamelin."
 			},
 			damage: "10+",
 

--- a/data/Diamond & Pearl/Mysterious Treasures/76.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/76.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, prevent all damage done to Chansey by attacks during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, prévenez tous dégâts infligés à Leveinard par des attaques lors du prochain tour de votre adversaire.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" verhindere alle Schadenspunkte, die Chaneira während des nächsten Zuges deines Gegners durch Angriffe zugefügt werden."
+				de: "Wirf 1 Münze. Bei „Kopf“ verhindere alle Schadenspunkte, die Chaneira während des nächsten Zuges deines Gegners durch Angriffe zugefügt werden."
 			},
 
 		},
@@ -76,7 +76,8 @@ const card: Card = {
 
 	description: {
 		en: "It is said to deliver happiness. Being compassionate, it shares its eggs with injured people.",
-		fr: "Il est censé apporter la joie. Ce Pokémon charitable offre ses œufs aux blessés."
+		fr: "Il est censé apporter la joie. Ce Pokémon charitable offre ses œufs aux blessés.",
+		de: "Man sagt, es bringe Glück. Es ist sehr mitfühlend und teilt seine Eier mit Verletzten."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/77.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/77.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Asleep.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Endormi.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" schläft das Verteidigende Pokémon jetzt."
+				de: "Wirf 1 Münze. Bei „Kopf“ schläft das Verteidigende Pokémon jetzt."
 			},
 
 		},
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -77,7 +77,8 @@ const card: Card = {
 
 	description: {
 		en: "It uses the leaf on its head to determine the temperature and humidity. It loves to sunbathe.",
-		fr: "Il jauge la température et l'humidité grâce à la feuille sur sa tête. Il raffole des bains de soleil."
+		fr: "Il jauge la température et l'humidité grâce à la feuille sur sa tête. Il raffole des bains de soleil.",
+		de: "Mit dem Blatt auf seinem Kopf bestimmt es die Temperatur und Feuchtigkeit. Es liebt Sonnenbäder."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/78.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/78.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, your opponent can't play any Supporter cards from his or her hand during his or her next turn.",
 				fr: "Lancez une pièce. Si c'est face, votre adversaire ne peut pas jouer de cartes Supporter de sa main lors de son prochain tour.",
-				de: "Wirf 1 Münze. Bei 'Kopf' kann dein Gegner in seinem nächsten Zug keine Unterstützerkarten von seiner Hand spielen."
+				de: "Wirf 1 Münze. Bei „Kopf“ kann dein Gegner in seinem nächsten Zug keine Unterstützerkarten von seiner Hand spielen."
 			},
 
 		},
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Empoisonné.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt vergiftet."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet."
 			},
 			damage: 20,
 
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "Its cheeks hold poison sacs. It tries to catch foes off guard to jab them with toxic fingers.",
-		fr: "Ses joues contiennent des glandes toxiques. Il attaque par surprise et utilise son toucher empoisonné."
+		fr: "Ses joues contiennent des glandes toxiques. Il attaque par surprise et utilise son toucher empoisonné.",
+		de: "In seinen Backen sammelt sich Gift. Es versucht, Beute zu überraschen und mit Giftfingern zu schnappen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/79.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/79.ts
@@ -64,7 +64,8 @@ const card: Card = {
 
 	description: {
 		en: "It has a timid nature. If it is startled, the flames on its back burn more vigorously.",
-		fr: "Ce Pokémon est un grand timide. Les flammes sur son dos s'intensifient lorsqu'il prend peur."
+		fr: "Ce Pokémon est un grand timide. Les flammes sur son dos s'intensifient lorsqu'il prend peur.",
+		de: "Erschrickt sich dieses scheue PKMN, lodern die Flammen auf seinem Rücken kräftiger."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/8.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/8.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Croconaw",
-		fr: "Crocrodil"
+		fr: "Crocrodil",
+		de: "Tyracroc"
 	},
 
 	stage: "Stage2",
@@ -81,7 +82,8 @@ const card: Card = {
 
 	description: {
 		en: "It usually moves slowly, but it goes at blinding speed when it attacks and bites prey.",
-		fr: "Ce Pokémon à l'air pataud est capable d'attaquer à la vitesse de l'éclair pour mordre sa proie."
+		fr: "Ce Pokémon à l'air pataud est capable d'attaquer à la vitesse de l'éclair pour mordre sa proie.",
+		de: "Eigentlich bewegt es sich langsam, doch seine Beute greift es blitzschnell an."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/80.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/80.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10x",
 
@@ -81,7 +81,8 @@ const card: Card = {
 
 	description: {
 		en: "The brains in its two heads appear to communicate emotions to each other with a telepathic power.",
-		fr: "Ses deux cerveaux semblent communiquer leurs émotions grâce à un lien télépathique."
+		fr: "Ses deux cerveaux semblent communiquer leurs émotions grâce à un lien télépathique.",
+		de: "Die Gehirne der beiden Köpfe kommunizieren ihre Gefühle über Telepathie."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/81.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/81.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, your opponent can't attach any Energy cards from his or her hand to the Active Pokémon during his or her next turn.",
 				fr: "Lancez une pièce. Si c'est face, votre adversaire ne peut pas attacher de cartes Énergie de sa main à son Pokémon Actif lors de son prochain tour.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" kann dein Gegner in seinem nächsten Zug keine Energiekarten von seiner Hand an die Aktiven Pokémon anlegen."
+				de: "Wirf 1 Münze. Bei „Kopf“ kann dein Gegner in seinem nächsten Zug keine Energiekarten von seiner Hand an die Aktiven Pokémon anlegen."
 			},
 			damage: 10,
 
@@ -63,7 +63,8 @@ const card: Card = {
 
 	description: {
 		en: "Using electricity stored in its fur, it stimulates its muscles to heighten its reaction speed.",
-		fr: "Il améliore ses réflexes en stimulant ses muscles grâce à l'électricité dans sa fourrure."
+		fr: "Il améliore ses réflexes en stimulant ses muscles grâce à l'électricité dans sa fourrure.",
+		de: "Die Elektrizität, die es im Fell speichert, nutzt es, um seine Muskeln zu stimulieren."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/82.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/82.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin for each Energy attached to Exeggcute. Choose 1 of your opponent's Pokémon. For each heads, this attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Lancez une pièce pour chaque Énergie attachée à Noeunoeuf. Choisissez un des Pokémon de votre adversaire. Pour chaque face, cette attaque lui inflige 10 dégâts. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Wirf 1 Münze für jede an Owei angelegte Energie. Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 10 Schadenspunkte mal der Anzahl \"Kopf\" zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Wirf 1 Münze für jede an Owei angelegte Energie. Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 10 Schadenspunkte mal der Anzahl „Kopf“ zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -55,7 +55,8 @@ const card: Card = {
 
 	description: {
 		en: "Its six eggs converse using telepathy. They can quickly gather if they become separated.",
-		fr: "Ces six œufs communiquent par télépathie. Ils peuvent se réunir rapidement si on les sépare."
+		fr: "Ces six œufs communiquent par télépathie. Ils peuvent se réunir rapidement si on les sépare.",
+		de: "Die sechs Eier kommunizieren telepathisch. Werden sie getrennt, finden sie sich schnell wieder."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/83.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/83.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Finneon during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, prévenez tous les effets d'une attaque, dégâts inclus, infligés à Ecayon lors du prochain tour de votre adversaire.",
-				de: "Wirf 1 Münze. Verhindere bei \"Kopf\" während des nächsten Zuges deines Gegners alle Effekte eines Angriffs, einschließlich Schaden, die Finneon zugefügt werden."
+				de: "Wirf 1 Münze. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte eines Angriffs, einschließlich Schaden, die Finneon zugefügt werden."
 			},
 
 		},
@@ -69,7 +69,8 @@ const card: Card = {
 
 	description: {
 		en: "After long exposure to sunlight, the patterns on its tail fins shine vividly when darkness arrives.",
-		fr: "Après une longue exposition au soleil, les motifs de ses nageoires caudales luisent à la nuit tombée."
+		fr: "Après une longue exposition au soleil, les motifs de ses nageoires caudales luisent à la nuit tombée.",
+		de: "Wurden die Flossen lange dem Sonnenlicht ausgesetzt, leuchten sie in der Dunkelheit."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/84.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/84.ts
@@ -62,7 +62,8 @@ const card: Card = {
 
 	description: {
 		en: "Many live on mountain trails and remain half buried while keeping an eye on climbers.",
-		fr: "Nombre d'entre eux vivent sur des chemins montagneux où ils restent enfouis à épier les alpinistes."
+		fr: "Nombre d'entre eux vivent sur des chemins montagneux où ils restent enfouis à épier les alpinistes.",
+		de: "Viele von ihnen leben auf Bergpfaden, halb vergraben und Bergsteiger beobachtend."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/85.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/85.ts
@@ -56,7 +56,8 @@ const card: Card = {
 
 	description: {
 		en: "It nests in small, horizontal holes in cave walls. It pounces to catch prey that stray too close.",
-		fr: "Il niche dans les petits trous horizontaux des murs des grottes. Il bondit pour saisir sa proie."
+		fr: "Il niche dans les petits trous horizontaux des murs des grottes. Il bondit pour saisir sa proie.",
+		de: "Es nistet in kleinen Löchern in Höhlenwänden. Es springt Beute, die sich zu nah heranwagt, an."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/86.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/86.ts
@@ -68,7 +68,8 @@ const card: Card = {
 
 	description: {
 		en: "It shakes its head back to front, causing its antennae to hit each other and sound like a xylophone.",
-		fr: "Quand il bascule sa tête d'avant en arrière, ses antennes se heurtent dans un son de xylophone."
+		fr: "Quand il bascule sa tête d'avant en arrière, ses antennes se heurtent dans un son de xylophone.",
+		de: "Es schüttelt seinen Kopf, so dass die beiden Antennen sich berühren und wie ein Xylophon klingen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/87.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/87.ts
@@ -77,7 +77,8 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon that eats soil. Once it has eaten a large mountain, it goes to sleep so it can grow.",
-		fr: "Un Pokémon qui se nourrit de terre. Après avoir dévoré une montagne, il s'endort pour grandir."
+		fr: "Un Pokémon qui se nourrit de terre. Après avoir dévoré une montagne, il s'endort pour grandir.",
+		de: "Dieses PKMN frisst das Erdreich. Hat es einen Berg verspeist, schläft es ein, um zu wachsen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/88.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/88.ts
@@ -31,7 +31,7 @@ const card: Card = {
 			name: {
 				en: "Baby Evolution",
 				fr: "Évolution bébé",
-				de: "Baby-Evolution"
+				de: "Baby Evolution"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may put Magmar from your hand onto Magby (this counts as evolving Magby) and remove all damage counters from Magby.",
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Burned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Brûlé.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt verbrannt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verbrannt."
 			},
 
 		},
@@ -69,7 +69,8 @@ const card: Card = {
 
 	description: {
 		en: "Its body temperature is around 1,100 degrees F. It is healthy if it is breathing yellow flames.",
-		fr: "Sa température corporelle avoisine les 600°C. Son souffle est jaune quand il est en bonne santé."
+		fr: "Sa température corporelle avoisine les 600°C. Son souffle est jaune quand il est en bonne santé.",
+		de: "Seine Körpertemperatur liegt bei etwa 600 Grad. Ist es gesund, atmet es gelbe Flammen aus."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/89.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/89.ts
@@ -56,7 +56,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. If either of them is tails, this attack does nothing.",
 				fr: "Lancez 2 pièces. Si vous obtenez une pile, cette attaque est sans effet.",
-				de: "Wirf 2 Münzen. Wenn eine oder beide Münzen 'Zahl' gezeigt haben, hat dieser Angriff keine Auswirkungen."
+				de: "Wirf 2 Münzen. Wenn eine oder beide Münzen „Zahl“ gezeigt haben, hat dieser Angriff keine Auswirklungen."
 			},
 			damage: 60,
 
@@ -74,7 +74,8 @@ const card: Card = {
 
 	description: {
 		en: "It is said to be the world's weakest Pokémon. No one knows why it has managed to survive.",
-		fr: "Ce Pokémon est réputé pour être le plus faible au monde. Nul ne sait comment son espèce perdure."
+		fr: "Ce Pokémon est réputé pour être le plus faible au monde. Nul ne sait comment son espèce perdure.",
+		de: "Man sagt, es sei das schwächste PKMN der Welt. Niemand weiß, wie es bisher überleben konnte."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/9.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/9.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Gabite",
-		fr: "Carmache"
+		fr: "Carmache",
+		de: "Knarksel"
 	},
 
 	stage: "Stage2",
@@ -73,7 +74,8 @@ const card: Card = {
 
 	description: {
 		en: "When it folds up its body and extends its wings, it looks like a jet plane. It flies at sonic speed.",
-		fr: "Quand il se recroqueville et étend ses ailes, on dirait un chasseur. Sa vitesse est supersonique."
+		fr: "Quand il se recroqueville et étend ses ailes, on dirait un chasseur. Sa vitesse est supersonique.",
+		de: "Spannt es seinen Körper und seine Flügel, sieht es aus wie ein Jet. Es fliegt mit Schallgeschwindigkeit."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/90.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/90.ts
@@ -78,7 +78,8 @@ const card: Card = {
 
 	description: {
 		en: "It is believed that seeing this Pokémon at night will bring about ominous occurrences.",
-		fr: "On dit que rencontrer un Cornèbre la nuit est signe de mauvais augure."
+		fr: "On dit que rencontrer un Cornèbre la nuit est signe de mauvais augure.",
+		de: "Sieht man dieses PKMN bei Nacht, sollen merkwürdige Dinge passieren."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/91.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/91.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Search your deck for Nidoran♂ or Nidoran♀ and put it onto your Bench. Shuffle your deck afterward.",
 				fr: "Cherchez dans votre deck Nidoran♂ ou Nidoran♀ et placez-le sur votre Banc. Ensuite, mélangez votre deck.",
-				de: "Durchsuche dein Deck nach einer Nidoran ♂- oder Nidoran ♀-Karte und lege sie auf deine Bank. Mische dein Deck danach."
+				de: "Durchsuche dein Deck nach einer Nidoran ♀- oder Nidoran ♂-Karte und lege sie auf deine Bank. Mische dein Deck danach."
 			},
 
 		},
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Empoisonné.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt vergiftet."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet."
 			},
 			damage: 20,
 
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "While it does not prefer to fight, even one drop of the poison it secretes from barbs can be fatal.",
-		fr: "Bien qu'il rechigne à se battre, une goutte du poison sécrété par ses piquants peut s'avérer fatale."
+		fr: "Bien qu'il rechigne à se battre, une goutte du poison sécrété par ses piquants peut s'avérer fatale.",
+		de: "Es mag keine Kämpfe. Ein einziger Tropfen des Gifts aus seinen Widerhaken hat eine fatale Wirkung."
 	},
 
 	variants: [

--- a/data/Diamond & Pearl/Mysterious Treasures/92.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/92.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -70,7 +70,8 @@ const card: Card = {
 
 	description: {
 		en: "Mushrooms named tochukaso grow on its back. They grow along with the host PARAS.",
-		fr: "Des champignons appelés \"tochukaso\" poussent sur son dos. Ils évoluent avec le Paras hôte."
+		fr: "Des champignons appelés \"tochukaso\" poussent sur son dos. Ils évoluent avec le Paras hôte.",
+		de: "Auf seinem Rücken wachsen Pilze, die Tochukaso. Sie nehmen an Größe zu, wenn PARAS wächst."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/93.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/93.ts
@@ -31,7 +31,7 @@ const card: Card = {
 			name: {
 				en: "Baby Evolution",
 				fr: "Évolution bébé",
-				de: "Baby-Evolution"
+				de: "Baby Evolution"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may put Pikachu from your hand onto Pichu (this counts as evolving Pichu) and remove all damage counters from Pichu.",
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 20,
 
@@ -77,7 +77,8 @@ const card: Card = {
 
 	description: {
 		en: "The electric pouches on its cheeks are still small. They cannot store much electricity yet.",
-		fr: "Les poches sur ses joues sont encore trop petites pour accumuler beaucoup d'électricité."
+		fr: "Les poches sur ses joues sont encore trop petites pour accumuler beaucoup d'électricité.",
+		de: "Seine Backentaschen sind noch recht klein. Daher kann es nicht allzu viel Elektrizität speichern."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/94.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/94.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), if Pichu is anywhere under Pikachu, you may search your discard pile for a Lightning Energy card, show it to your opponent, and put it into your hand. This power can't be used if Pikachu is affected by a Special Condition.",
 				fr: "Une seule fois lors votre tour (avant votre attaque), si Pichu se trouve sous Pikachu, vous pouvez chercher une carte Énergie Lightning dans votre pile de défausse. Montrez-la à votre adversaire et placez-la dans votre main. Ce pouvoir ne peut pas être utilisé si Pikachu est affecté par un État Spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn Pichu sich an beliebiger Stelle unter Pikachu befindet, deinen Ablagestapel nach einer -Energiekarte durchsuchen. Zeige sie deinem Gegner und nimm sie auf die Hand. Diese Poké-Power kann nicht benutzt werden, wenn Pikachu von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn Pichu sich an beliebiger Stelle unter Pikachu befindet, deinen Ablagestapel nach einer {L}-Energiekarte durchsuchen. Zeige sie deinem Gegner und nimm sie auf die Hand. Diese Poké-Power kann nicht benutzt werden, wenn Pikachu von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -80,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "It lives in forests with others. It stores electricity in the pouches on its cheeks.",
-		fr: "Il vit en forêt avec ses pairs. Il accumule l'électricité dans les poches de ses joues."
+		fr: "Il vit en forêt avec ses pairs. Il accumule l'électricité dans les poches de ses joues.",
+		de: "Es lebt zusammen mit anderen in Wäldern. In seinen Backentaschen speichert es Elektrizität."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/95.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/95.ts
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "It squirts water forcefully from its mouth to shoot down flying prey.",
-		fr: "Il crache un puissant jet d'eau pour abattre les proies volantes."
+		fr: "Il crache un puissant jet d'eau pour abattre les proies volantes.",
+		de: "Es spritzt Wasser mit Hochdruck aus seinem Maul und schießt damit auf fliegende Beute."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/96.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/96.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
 				fr: "Si le Pokémon Défenseur essaye d'attaquer lors du prochain tour de votre adversaire, celui-ci lance une pièce. Si c'est pile, cette attaque est sans effet.",
-				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 
 		},
@@ -76,7 +76,8 @@ const card: Card = {
 
 	description: {
 		en: "To protect itself from attackers, it curls up into a ball. It lives in arid regions with minimal rainfall.",
-		fr: "Il vit sur des terres arides épargnées par la pluie. Il se roule en boule pour se protéger."
+		fr: "Il vit sur des terres arides épargnées par la pluie. Il se roule en boule pour se protéger.",
+		de: "Es lebt in trockenen Regionen mit wenig Regen. Es rollt sich ein, um sich vor Gegnern zu schützen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/97.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/97.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 
@@ -57,7 +57,8 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon that lives on icebergs. It swims in the sea using the point on its head to break up ice.",
-		fr: "Un habitant des icebergs. En mer, il utilise la corne sur sa tête pour briser la banquise."
+		fr: "Un habitant des icebergs. En mer, il utilise la corne sur sa tête pour briser la banquise.",
+		de: "Dieses Pokémon lebt auf Eisbergen. Es schwimmt im Eiswasser und bricht das Eis mithilfe seines Horns."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Mysterious Treasures/98.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/98.ts
@@ -33,12 +33,12 @@ const card: Card = {
 			name: {
 				en: "Plasma",
 				fr: "Plasma",
-				de: "Plasma"
+				de: "Fragiabeere"
 			},
 			effect: {
 				en: "Flip a coin. If heads, search your discard pile for a Lightning Energy card and attach it to Shinx.",
 				fr: "Lancez une pièce. Si c'est face, choisissez dans votre pile de défausse une carte Énergie Lightning et attachez-la à Lixy.",
-				de: "Wirf 1 Münze. bei 'Kopf' durchsuche deinen Ablagestapel nach einer -Energiekarte und lege sie an Sheinux an."
+				de: "Wenn Sheinux verbrannt ist, entferne am Ende jedes Zuges den Speziellen Zustand „verbrannt“ von Sheinux."
 			},
 			damage: 10,
 

--- a/data/Diamond & Pearl/Mysterious Treasures/99.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/99.ts
@@ -55,7 +55,8 @@ const card: Card = {
 
 	description: {
 		en: "It spends nearly all its time in a day sprawled out. Just seeing it makes one drowsy.",
-		fr: "Il passe le plus clair de son temps affalé. Rien qu'à le voir, on a envie de bâiller."
+		fr: "Il passe le plus clair de son temps affalé. Rien qu'à le voir, on a envie de bâiller.",
+		de: "Es verbringt fast den ganzen Tag mit Faulenzen und Schlafen. Selbst sein Anblick macht bereits müde."
 	},
 
 	thirdParty: {


### PR DESCRIPTION
## Add missing German translations for dp2

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
