### PR TITLE
Add missing German translations for dp4

### DIFF
--- a/data/Diamond & Pearl/Great Encounters/1.ts
+++ b/data/Diamond & Pearl/Great Encounters/1.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Combusken",
 		fr: "Galifeu",
+		de: "Jungglut"
 	},
 
 	stage: "Stage2",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Search your discard pile for a Fire Energy card and attach it to 1 of your Pokémon.",
 				fr: "Choisissez dans votre pile de défausse une carte Énergie Fire et attachez-la à 1 de vos Pokémon.",
-				de: "Durchsuche deinen Ablagestapel nach einer -Energiekarte und lege sie an 1 deiner Pokémon an."
+				de: "Durchsuche deinen Ablagestapel nach einer {R}-Energiekarte und lege sie an 1 deiner Pokémon an."
 			},
 			damage: 30,
 
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "Discard 2 Fire Energy attached to Blaziken. This attack does 80 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Défaussez 2 Énergies Fire attachées à Brasegali. Cette attaque inflige 80 dégâts à 1 des Pokémon de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse ou la Résistance aux Pokémon de Banc).",
-				de: "Entferne 2 -Energien von Lohgock und lege sie auf deinen Ablagestapel. Dieser Angriff fügt 1 Pokémon deines Gegners 80 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Entferne 2 {R}-Energien von Lohgock und lege sie auf deinen Ablagestapel. Dieser Angriff fügt 1 Pokémon deines Gegners 80 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -79,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "Flames spout from its wrists, enveloping its knuckles. Its punches scorch its foes.",
+		de: "Aus seinen Handgelenken kommt Feuer, das seine Knöchel umhüllt. Schläge verbrennen den Gegner."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/10.ts
+++ b/data/Diamond & Pearl/Great Encounters/10.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Tangela",
 		fr: "Saquedeneu",
+		de: "Tangela"
 	},
 
 	stage: "Stage1",
@@ -87,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It ensnares prey by extending arms made of vines. Losing arms to predators does not trouble it.",
+		de: "Es umwickelt Beute, indem es seine Arme, die aus Ranken bestehen, verlängert."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/100.ts
+++ b/data/Diamond & Pearl/Great Encounters/100.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card. The Retreat Cost for each Psychic and Darkness Pokémon (both yours and your opponent's) is 0.",
 		fr: "Le Coût de retraite de chaque Pokémon Psy et Obscurité (les vôtres et ceux de votre adversaire) est de 0.",
-		de: "Jedes - und jedes -Pokémon im Spiel (deine und die deines Gegners) hat Rückzugskosten 0.",
+		de: "Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadion-Karte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen. Jedes {P}- und jedes {D}-Pokémon im Spiel (deine und die deines Gegners) hat Rückzugskosten 0.",
 	},
 
 	trainerType: "Stadium",

--- a/data/Diamond & Pearl/Great Encounters/104.ts
+++ b/data/Diamond & Pearl/Great Encounters/104.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Each basic Darkness Energy card attached to your Darkness Pokémon now has the effect \"If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance).\" You can't use more than 1 Dark Shadow Poké-Body each turn.",
 				fr: "Chaque carte Énergie Darkness attachée à vos Pokémon Darkness possède maintenant l'effet 'si le Pokémon auquel Énergie Obscurité est attachée attaque, cette attaque inflige 10 dégâts supplémentaires au Pokémon Actif (avant application de la Faiblesse et de la Résistance).' Vous ne pouvez pas utiliser plus d'1 Poké-Body Ombre obscure par tour.",
-				de: "Jede -Basis-Energiekarte, die an deine -Pokémon angelegt ist, hat jetzt den Effekt: \"Wenn das Pokémon, an das Finsternis-Energie angelegt ist, angreift, fügt der Angriff den Aktiven Pokémon 10 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden).\" Du kannst nicht mehr als 1 Finsterer Schatten Poké-Body pro Zug einsetzen."
+				de: "Jede {D}-Basis-Energiekarte, die an deine {D}-Pokémon angelegt ist, hat jetzt den Effekt: \"Wenn das Pokémon, an das Finsternis-Energie angelegt ist, angreift, fügt der Angriff den Aktiven Pokémon 10 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden).\" Du kannst nicht mehr als 1 Finsterer Schatten Poké-Body pro Zug einsetzen."
 			},
 		},
 	],
@@ -60,7 +60,7 @@ const card: Card = {
 			effect: {
 				en: "The Defending Pokémon is now Asleep. Flip 2 coins instead of 1 between turns. If either of them is tails, the Defending Pokémon is still Asleep. If both of them are tails, the Defending Pokémon is Knocked Out.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi. Lancez 2 pièces au lieu d'1 entre deux tours. Si l'une d'elles est pile, le Pokémon Défenseur reste Endormi. Si ce sont deux piles, le Pokémon Défenseur est mis K.O.",
-				de: "Das Verteidigende Pokémon schläft jetzt. Wirf zwischen den Zügen 2 Münzen anstelle von 1 Münze. Wenn eine Münze \"Zahl\" gezeigt hat, schläft das Verteidigende Pokémon weiter. Wenn beide \"Zahl\" gezeigt haben, ist das Verteidigende Pokémon jetzt kampfunfähig."
+				de: "Das Verteidigende Pokémon schläft jetzt. Wirf zwischen den Zügen 2 Münzen anstelle von 1 Münze. Wenn eine Münze „Zahl“ gezeigt hat, schläft das Verteidigende Pokémon weiter. Wenn beide „Zahl“ gezeigt haben, ist das Verteidigende Pokémon jetzt kampfunfähig."
 			},
 			damage: 40,
 

--- a/data/Diamond & Pearl/Great Encounters/105.ts
+++ b/data/Diamond & Pearl/Great Encounters/105.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may have your opponent flip 2 coins. If both of them are heads, your turn ends. If both of them are tails, after your opponent draws a card at the beginning of his or her next turn, his or her turn ends. This power can't be used if Dialga is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez demander à votre adversaire de lancer 2 pièces. Si ce sont 2 faces, votre tour se termine. Si ce sont 2 piles, le tour de votre adversaire se termine une fois qu'il a pioché une carte au début de son tour. Ce pouvoir ne peut pas être utilisé si Dialga est affecté par un État Spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff), kannst du deinen Gegner 2 Münzen werfen lassen. Wenn beide \"Kopf\" gezeigt haben, ist dein Zug jetzt beendet. Wenn beide \"Zahl\" gezeigt haben, endet der nächste Zug deines Gegners, nachdem er zu Beginn seines Zuges eine Karte gezogen hat. Diese Poké-Power kann nicht benutzt werden, wenn Dialga von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff), kannst du deinen Gegner 2 Münzen werfen lassen. Wenn beide „Kopf“ gezeigt haben, ist dein Zug jetzt beendet. Wenn beide „Zahl“ gezeigt haben, endet der nächste Zug deines Gegners, nachdem er zu Beginn seines Zuges eine Karte gezogen hat. Diese Poké-Power kann nicht benutzt werden, wenn Dialga von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],

--- a/data/Diamond & Pearl/Great Encounters/11.ts
+++ b/data/Diamond & Pearl/Great Encounters/11.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Togetic",
 		fr: "Togetic",
+		de: "Togetic"
 	},
 
 	stage: "Stage2",
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 40 damage plus 30 more damage. If tails, remove 3 damage counters from Togekiss.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 40 dégâts plus 30 dégâts supplémentaires. Si c'est pile, retirez à Togekiss 3 marqueurs de dégât.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 40 Schadenspunkte plus 30 weitere Schadenspunkte zu. Bei \"Zahl\" entferne 3 Schadensmarken von Togekiss."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 40 Schadenspunkte plus 30 weitere Schadenspunkte zu. Bei „Zahl“ entferne 3 Schadensmarken von Togekiss."
 			},
 			damage: "40+",
 
@@ -86,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "It will never appear where there is strife. Its sightings have become rare recently.",
+		de: "Es zeigt sich niemals dort, wo es Streitigkeiten gibt. In letzter Zeit wurde es nur selten gesehen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/12.ts
+++ b/data/Diamond & Pearl/Great Encounters/12.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Swablu",
 		fr: "Tylton",
+		de: "Wablu"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 40,
 
@@ -87,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It looks like a fluffy cloud when it is in flight. It hums with its soprano voice.",
+		de: "Im Flug sieht es aus wie eine watteweiche Wolke. Es singt mit einer Sopranstimme."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/13.ts
+++ b/data/Diamond & Pearl/Great Encounters/13.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Kakuna",
 		fr: "Coconfort",
+		de: "Kokuna"
 	},
 
 	stage: "Stage2",
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 50 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 50 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 50,
 
@@ -78,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "Its best attack involves flying around at high speed, striking with poison needles, then flying off.",
+		de: "Sein bester Angriff: Schnell auf den Gegner zufliegen, mit Giftstacheln zustechen und davonfliegen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/14.ts
+++ b/data/Diamond & Pearl/Great Encounters/14.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Metapod",
 		fr: "Chrysacier",
+		de: "Safcon"
 	},
 
 	stage: "Stage2",
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Asleep. If tails, the Defending Pokémon is now Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Endormi. Si c'est pile, le Pokémon Défenseur est maintenant Empoisonné.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" schläft das Verteidigende Pokémon jetzt. Bei \"Zahl\" ist das Verteidigende Pokémon jetzt vergiftet."
+				de: "Wirf 1 Münze. Bei „Kopf“ schläft das Verteidigende Pokémon jetzt. Bei „Zahl“ ist das Verteidigende Pokémon jetzt vergiftet."
 			},
 			damage: 60,
 
@@ -78,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "It loves the honey of flowers and can locate flower patches that have even tiny amounts of pollen.",
+		de: "Es liebt Blütenhonig. Es findet selbst Blumen, die sehr wenig Pollen haben."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/15.ts
+++ b/data/Diamond & Pearl/Great Encounters/15.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Baltoy",
 		fr: "Balbuto",
+		de: "Puppance"
 	},
 
 	stage: "Stage1",
@@ -74,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "An ancient clay figurine that came to life as a Pokémon from exposure to a mysterious ray of light.",
+		de: "Eine antike Lehmstatue, die durch ein mysteriöses Licht zum Leben erwacht ist."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/16.ts
+++ b/data/Diamond & Pearl/Great Encounters/16.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It has the power to control time. It appears in Sinnoh-region myths as an ancient deity.",
+		de: "Es besitzt die Macht, die Zeit zu kontrollieren. In den Mythen von Sinnoh erscheint es als Gottheit."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/17.ts
+++ b/data/Diamond & Pearl/Great Encounters/17.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Loudred",
 		fr: "Ramboum",
+		de: "Krakeelo"
 	},
 
 	stage: "Stage2",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. If the first coin is heads, this attack does 50 damage to the Defending Pokémon. If the first coin is tails, this attack does 20 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) If the second coin is heads, the Defending Pokémon is now Confused. If the second coin is tails, your opponent can't play any Trainer, Supporter, or Stadium cards from his or her hand during your opponent's next turn.",
 				fr: "Lancez 2 pièces. Si la première pièce est face, cette attaque inflige 50 dégâts au Pokémon Défenseur. Si la première pièce est pile, cette attaque inflige 20 dégâts à chacun des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse ou la Résistance aux Pokémon de Banc). Si la seconde pièce est face, le Pokémon Défenseur est maintenant Confus. Si la seconde pièce est pile, votre adversaire ne peut pas jouer de cartes Dresseur, Supporter ou Stade de sa main lors de son prochain tour.",
-				de: "Wirf 2 Münzen. Wenn die erste Münze \"Kopf\" gezeigt hat, fügt dieser Angriff dem Verteidigenden Pokémon 50 Schadenspunkte zu. Wenn die erste Münze \"Zahl\" gezeigt hat, fügt dieser Angriff allen Pokémon auf der Bank deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.) Wenn die zweite Münze \"Kopf\" gezeigt hat, ist das Verteidigende Pokémon jetzt verwirrt. Wenn die zweite Münze \"Zahl\" gezeigt hat, kann dein Gegner in seinem nächsten Zug keine Trainer-, Unterstützer- und Stadion-Karten von seiner Hand spielen."
+				de: "Wirf 2 Münzen. Wenn die erste Münze „Kopf“ gezeigt hat, fügt dieser Angriff dem Verteidigenden Pokémon 50 Schadenspunkte zu. Wenn die erste Münze „Zahl“ gezeigt hat, fügt dieser Angriff allen Pokémon auf der Bank deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.) Wenn die zweite Münze „Kopf“ gezeigt hat, ist das Verteidigende Pokémon jetzt verwirrt. Wenn die zweite Münze „Zahl“ gezeigt hat, kann dein Gegner in seinem nächsten Zug keine Trainer-, Unterstützer- und Stadion-Karten von seiner Hand spielen."
 			},
 
 		},
@@ -77,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "Its howls can be heard over six miles away. It emits all sorts of noises from the ports on its body.",
+		de: "Sein Heulen hört man in 10 km Entfernung. Es gibt alle Arten von Geräuschen von sich."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/18.ts
+++ b/data/Diamond & Pearl/Great Encounters/18.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Houndour",
 		fr: "Malosse",
+		de: "Hunduster"
 	},
 
 	stage: "Stage1",
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "You may discard a Fire or Darkness Energy attached to Houndoom. If you discard a Fire Energy, the Defending Pokémon is now Burned. If you discard a Darkness Energy, this attack does 40 damage plus 30 more damage.",
 				fr: "Vous pouvez défausser une Énergie Fire ou Darkness attachée à Demolosse. Si vous défaussez une Énergie Fire, le Pokémon Défenseur est maintenant Brûlé. Si vous défaussez une Énergie (D), cette attaque inflige 40 dégâts plus 30 dégâts supplémentaires.",
-				de: "Du kannst 1 an Hundemon angelegte - oder -Energie auf deinen Ablagestapel legen. Wenn du 1 -Energie auf deinen Ablagestapel legst, ist das Verteidigende Pokémon jetzt verbrannt. Wenn du 1 -Energie auf deinen Ablagestapel legst, fügt dieser Angriff 40 Schadenspunkte plus 30 weitere Schadenspunkte zu."
+				de: "Du kannst 1 an Hundemon angelegte {R}- oder {D}-Energie auf deinen Ablagestapel legen. Wenn du 1 {R}-Energie auf deinen Ablagestapel legst, ist das Verteidigende Pokémon jetzt verbrannt. Wenn du 1 {D}-Energie auf deinen Ablagestapel legst, fügt dieser Angriff 40 Schadenspunkte plus 30 weitere Schadenspunkte zu."
 			},
 			damage: "40+",
 
@@ -86,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "Long ago, people imagined its eerie howls to be the call of the grim reaper.",
+		de: "In alten Zeiten glaubte man, das Heulen dieses PKMN sei der Ruf des Todes."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/19.ts
+++ b/data/Diamond & Pearl/Great Encounters/19.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Drowzee",
 		fr: "Soporifik",
+		de: "Traumato"
 	},
 
 	stage: "Stage1",
@@ -80,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Seeing its swinging pendulum can induce sleep in three seconds, even if someone just woke up.",
+		de: "Ein Blick auf das Pendel versetzt einen in 3 Sekunden in Schlaf, selbst wenn man gar nicht müde ist."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/2.ts
+++ b/data/Diamond & Pearl/Great Encounters/2.ts
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "Shiny particles are released from its wings like a veil. It is said to represent the crescent moon.",
+		de: "Seine Flügel geben schimmernde Partikel ab, wie einen Schleier. Man sagt, es steht für die Mondsichel."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/20.ts
+++ b/data/Diamond & Pearl/Great Encounters/20.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Krabby",
 		fr: "Krabby",
+		de: "Krabby"
 	},
 
 	stage: "Stage1",
@@ -77,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "The larger pincer has 10,000-horsepower strength. However, it is so heavy, it is difficult to aim.",
+		de: "Die großen Scheren haben eine Stärke von 10 000 PS. Aber sie sind schwer und kaum zu handhaben."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/21.ts
+++ b/data/Diamond & Pearl/Great Encounters/21.ts
@@ -69,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "It loves crossing the sea with people and Pokémon on its back. It understands human speech.",
+		de: "Es liebt es, das Meer mit PKMN und Menschen auf dem Rücken zu überqueren. Es versteht die Menschen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/22.ts
+++ b/data/Diamond & Pearl/Great Encounters/22.ts
@@ -57,7 +57,7 @@ const card: Card = {
 			effect: {
 				en: "Discard a Fire Energy and a Water Energy attached to Latias.",
 				fr: "Défaussez une Énergie Fire et une Énergie Water attachées à Latias.",
-				de: "Lege 1 -Energie und 1 -Energie, die an Latias angelegt sind, auf deinen Ablagestapel."
+				de: "Lege 1 {R}-Energie und 1 {W}-Energie, die an Latias angelegt sind, auf deinen Ablagestapel."
 			},
 			damage: 80,
 
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "Its body is covered with a down that can refract light in such a way that it becomes invisible.",
+		de: "Sein Körper ist mit Daunen bedeckt, die das Licht so brechen, dass das PKMN unsichtbar wird."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/23.ts
+++ b/data/Diamond & Pearl/Great Encounters/23.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, search your deck for a basic Energy card and attach it to Latios. Shuffle your deck afterward.",
 				fr: "Lancez une pièce. Si c'est face, choisissez dans votre deck une carte Énergie de base et attachez-la à Latios. Ensuite, mélangez votre deck.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" durchsuche dein Deck nach 1 Basis-Energiekarte und lege sie an Latios an. Mische dein Deck danach."
+				de: "Wirf 1 Münze. Bei „Kopf“ durchsuche dein Deck nach 1 Basis-Energiekarte und lege sie an Latios an. Mische dein Deck danach."
 			},
 			damage: 10,
 
@@ -83,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "A highly intelligent Pokémon. By folding back its wings in flight, it can overtake jet planes.",
+		de: "Ein hochintelligentes PKMN. Wenn es im Flug seine Flügel nach hinten legt, ist es schneller als ein Jet."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/24.ts
+++ b/data/Diamond & Pearl/Great Encounters/24.ts
@@ -78,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "Attached to its head is a huge set of jaws formed by horns. It can chew through iron beams.",
+		de: "Auf seinem Kopf befindet sich ein riesiger Kiefer, der aus Hörnern besteht. Er kann Eisen zermalmen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/25.ts
+++ b/data/Diamond & Pearl/Great Encounters/25.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Feebas",
 		fr: "Barpau",
+		de: "Barschwa"
 	},
 
 	stage: "Stage1",
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. If both are tails, this attack does nothing. For each heads, discard an Energy attached to the Defending Pokémon.",
 				fr: "Lancez 2 pièces. Si ce sont 2 piles, cette attaque est sans effet. Pour chaque face, défaussez une Énergie attachée au Pokémon Défenseur.",
-				de: "Wirf 2 Münzen. Wenn beide \"Zahl\" zeigen, hat dieser Angriff keine Auswirkungen. Lege pro \"Kopf\" eine an das Verteidigende Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
+				de: "Wirf 2 Münzen. Wenn beide „Zahl“ zeigen, hat dieser Angriff keine Auswirkungen. Lege pro „Kopf“ eine an das Verteidigende Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 50,
 
@@ -79,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "When people bicker, it is said to arise from the depths of lakes to becalm violent hearts.",
+		de: "Wenn sich jemand streitet, steigt es aus den Tiefen des Sees empor, um die Streitenden zu beruhigen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/26.ts
+++ b/data/Diamond & Pearl/Great Encounters/26.ts
@@ -57,7 +57,7 @@ const card: Card = {
 			effect: {
 				en: "You may flip a coin. If heads, discard all Energy attached to Palkia and put the Defending Pokémon and all cards attached to it on top of your opponent's deck. Your opponent shuffles his or her deck afterward.",
 				fr: "Vous pouvez lancer une pièce. Si c'est face, défaussez toutes les Énergies attachées à Palkia et placez le Pokémon Défenseur et toutes les cartes qui lui sont attachées au dessus du deck de votre adversaire. Ensuite, votre adversaire mélange son deck.",
-				de: "Du kannst 1 Münze werfen. Bei \"Kopf\" lege alle Energien, die an Palkia angelegt sind, auf deinen Ablagestapel. Danach lege das Verteidigende Pokémon und alle an es angelegten Karten auf das Deck deines Gegners. Dein Gegner mischt sein Deck danach."
+				de: "Du kannst 1 Münze werfen. Bei „Kopf“ lege alle Energien, die an Palkia angelegt sind, auf deinen Ablagestapel. Danach lege das Verteidigende Pokémon und alle an es angelegten Karten auf das Deck deines Gegners. Dein Gegner mischt sein Deck danach."
 			},
 			damage: 40,
 
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "It has the ability to distort space. It is described as a deity in Sinnoh-region mythology.",
+		de: "Es hat die Macht, den Raum zu krümmen. In den Mythen von Sinnoh erscheint es als Gottheit."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/27.ts
+++ b/data/Diamond & Pearl/Great Encounters/27.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Mankey",
 		fr: "Férosinge",
+		de: "Menki"
 	},
 
 	stage: "Stage1",
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Primeape is now Confused. Flip a coin. If heads, the Defending Pokémon can't attack during your opponent's next turn.",
 				fr: "Colosinge est maintenant Confus. Lancez une pièce. Si c'est face, le Pokémon Défenseur ne peut pas attaquer lors du prochain tour de votre adversaire.",
-				de: "Rasaff ist jetzt verwirrt. Wirf 1 Münze. Bei \"Kopf\" kann das Verteidigende Pokémon im nächsten Zug deines Gegners nicht angreifen."
+				de: "Rasaff ist jetzt verwirrt. Wirf 1 Münze. Bei „Kopf“ kann das Verteidigende Pokémon im nächsten Zug deines Gegners nicht angreifen."
 			},
 			damage: 50,
 
@@ -79,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It grows angry if you see its eyes and gets angrier if you run. If you beat it, it gets even madder.",
+		de: "Siehst du ihm in die Augen, wird es wütend. Rennst du weg, wird es noch wütender. Ärgerst du es..."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/28.ts
+++ b/data/Diamond & Pearl/Great Encounters/28.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Slowpoke",
 		fr: "Ramoloss",
+		de: "Flegmon"
 	},
 
 	stage: "Stage1",
@@ -78,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "Being bitten by Shellder gave it intelligence comparable to that of award-winning scientists.",
+		de: "Wird es von MUSCHAS gebissen, wird es so intelligent, dass es sich mit Nobelpreisträgern messen kann."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/29.ts
+++ b/data/Diamond & Pearl/Great Encounters/29.ts
@@ -67,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "Shaped like ancient writing, it is a huge mystery whether language or UNOWN came first.",
+		de: "Seine Form sieht aus wie antike Schrift. Was war zuerst da? Die Sprache oder ICOGNITO?"
 	},
 
 	variants: [

--- a/data/Diamond & Pearl/Great Encounters/3.ts
+++ b/data/Diamond & Pearl/Great Encounters/3.ts
@@ -79,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "It can lull people to sleep and make them dream. It is active during nights of the new moon.",
+		de: "Es kann andere in Schlaf versetzen und ihnen Träume geben. Es ist nur bei Neumond aktiv."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/30.ts
+++ b/data/Diamond & Pearl/Great Encounters/30.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Wailmer",
 		fr: "Wailmer",
+		de: "Wailmer"
 	},
 
 	stage: "Stage1",
@@ -80,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "The biggest of all Pokémon. It can dive to a depth of almost 10,000 feet on only one breath.",
+		de: "Das größte PKMN. Es kann mit nur einem Atemzug in Tiefen bis 3.000 Meter tauchen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/31.ts
+++ b/data/Diamond & Pearl/Great Encounters/31.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Koffing",
 		fr: "Smogo",
+		de: "Smogon"
 	},
 
 	stage: "Stage1",
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused and Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus et Empoisonné.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt vergiftet und verwirrt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet und verwirrt."
 			},
 			damage: 30,
 
@@ -78,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "It grows by feeding on gases released by garbage. Though very rare, triplets have been found.",
+		de: "Es wächst, indem es Gase aufnimmt, die aus dem Müll aufsteigen. Selten kann man Drillinge von ihnen finden."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/32.ts
+++ b/data/Diamond & Pearl/Great Encounters/32.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Jigglypuff",
 		fr: "Rondoudou",
+		de: "Pummeluff"
 	},
 
 	stage: "Stage1",
@@ -78,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "Its fine fur feels sublime to the touch. It can expand its body by inhaling air.",
+		de: "Sein feines Fell fühlt sich herrlich an. Es kann sich größer machen, indem es Luft einatmet."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/33.ts
+++ b/data/Diamond & Pearl/Great Encounters/33.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Ekans",
 		fr: "Abo",
+		de: "Rettan"
 	},
 
 	stage: "Stage1",
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 50,
 
@@ -80,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "The pattern on its belly is for intimidation. It constricts foes while they are frozen in fear.",
+		de: "Das Muster auf seinem Bauch schüchtert Gegner ein. Sind sie vor Angst erstarrt, umklammert es sie."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/34.ts
+++ b/data/Diamond & Pearl/Great Encounters/34.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cacnea",
 		fr: "Cacnea",
+		de: "Tuska"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20x",
 
@@ -88,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It becomes active at night, seeking prey that is exhausted from the day's desert heat.",
+		de: "Ein nachtaktives PKMN, das Beute sucht, die durch die Tageshitze der Wüste bereits erschöpft ist."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/35.ts
+++ b/data/Diamond & Pearl/Great Encounters/35.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Torchic",
 		fr: "Poussifeu",
+		de: "Flemmli"
 	},
 
 	stage: "Stage1",
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 50 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 50 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "50x",
 
@@ -80,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Its kicking mastery lets it loose 10 kicks per second. It emits sharp cries to intimidate foes.",
+		de: "Es kann 10 Tritte pro Sekunde austeilen. Es gibt schrille Schreie von sich, um Gegner einzuschüchtern."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/36.ts
+++ b/data/Diamond & Pearl/Great Encounters/36.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, search your deck for any 1 card and put it into your hand. Shuffle your deck afterward.",
 				fr: "Lancez une pièce. Si c'est face, choisissez 1 carte dans votre deck et placez-la dans votre main. Ensuite, mélangez votre deck.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" durchsuche dein Deck nach 1 Karte und nimm sie auf die Hand. Mische dein Deck danach."
+				de: "Wirf 1 Münze. Bei „Kopf“ durchsuche dein Deck nach 1 Karte und nimm sie auf die Hand. Mische dein Deck danach."
 			},
 
 		},
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "It carries food rolled up in its tail. It has the habit of sharing food with people lost in mountains.",
+		de: "Im eingerollten Schweif transportiert es Futter, das es mit denen teilt, die sich verlaufen haben."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/37.ts
+++ b/data/Diamond & Pearl/Great Encounters/37.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Buizel",
 		fr: "Mustébouée",
+		de: "Bamelin"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Floatzel during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, prévenez tous les effets d'une attaque, dégâts inclus, infligés à Mustéflott lors du prochain tour de votre adversaire.",
-				de: "Wirf 1 Münze. Bei 'Kopf' verhindere während des nächsten Zuges deines Gegners alle Effekte eines Angriffs, einschließlich Schaden, die Bojelin zugefügt würden."
+				de: "Wirf 1 Münze. Bei „Kopf“ verhindere während des nächsten Zuges deines Gegners alle Effekte eines Angriffs, einschließlich Schaden, die Bojelin zugefügt würden."
 			},
 			damage: 20,
 
@@ -63,7 +64,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts à 1 des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse ou la Résistance aux Pokémon de Banc).",
-				de: "Wirf 1 Münze. Bei 'Kopf' fügt dieser Angriff einem Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz für Pokémon auf der Bank nicht an.)"
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 1 Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 60,
 
@@ -81,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It floats using its well-developed floatation sac. It assists in the rescues of drowning people.",
+		de: "Es treibt mithilfe einer Art Rettungsring auf dem Wasser und hilft dem, der zu ertrinken droht."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/38.ts
+++ b/data/Diamond & Pearl/Great Encounters/38.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Clamperl",
 		fr: "Coquiperl",
+		de: "Perlu"
 	},
 
 	stage: "Stage1",
@@ -58,7 +59,7 @@ const card: Card = {
 			effect: {
 				en: "If Gorebyss has any Psychic Energy attached to it, this attack does 30 damage plus 20 more damage and the Defending Pokémon is now Confused.",
 				fr: "Si Rosabyss possède de l'Énergie Psychic, cette attaque inflige 30 dégâts plus 20 dégâts supplémentaires et le Pokémon Défenseur est maintenant Confus.",
-				de: "Wenn an Saganabyss mindestens 1 -Energie angelegt ist, fügt dieser Angriff 30 Schadenspunkte plus 20 weitere Schadenspunkte zu und das Verteidigende Pokémon ist jetzt verwirrt."
+				de: "Wenn an Saganabyss mindestens 1 {P}-Energie angelegt ist, fügt dieser Angriff 30 Schadenspunkte plus 20 weitere Schadenspunkte zu und das Verteidigende Pokémon ist jetzt verwirrt."
 			},
 			damage: "30+",
 
@@ -74,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives at the bottom of the sea. In the springtime, its pink body turns more vivid for some reason.",
+		de: "Es lebt auf dem Grund des Meeres. Im Frühling wirkt die Farbe seines Körpers viel kräftiger."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/39.ts
+++ b/data/Diamond & Pearl/Great Encounters/39.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Snubbull",
 		fr: "Snubbull",
+		de: "Snubbull"
 	},
 
 	stage: "Stage1",
@@ -82,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "It is timid in spite of its looks. If it becomes enraged, however, it will strike with its huge fangs.",
+		de: "Es ist trotz seines Äußeren schüchtern. Wird es wütend, schnappt es mit seinen Fängen zu."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/4.ts
+++ b/data/Diamond & Pearl/Great Encounters/4.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It can lull people to sleep and make them dream. It is active during nights of the new moon.",
+		de: "Es kann andere in Schlaf versetzen und ihnen Träume geben. Es ist nur bei Neumond aktiv."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/40.ts
+++ b/data/Diamond & Pearl/Great Encounters/40.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Treecko",
 		fr: "Arcko",
+		de: "Geckarbor"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Search your deck for up to 2 Grass Energy cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward.",
 				fr: "Choisissez dans votre deck jusqu'à 2 cartes Énergie Grass, montrez-les à votre adversaire et placez-les dans votre main. Ensuite, mélangez votre deck.",
-				de: "Durchsuche dein Deck nach bis zu 2 -Energiekarten, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
+				de: "Durchsuche dein Deck nach bis zu 2 {G}-Energiekarten, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 			},
 
 		},
@@ -83,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives in dense jungles. While closing in on its prey, it leaps from branch to branch.",
+		de: "Es lebt im dichten Dschungel. Es springt von Ast zu Ast, wenn es sich einer Beute nähert."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/41.ts
+++ b/data/Diamond & Pearl/Great Encounters/41.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Makuhita",
 		fr: "Makuhita",
+		de: "Makuhita"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 40 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts plus 40 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 20 Schadenspunkte plus 40 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 40 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -81,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It loves to match power with big-bodied Pokémon. It can knock a truck flying with its arm thrusts.",
+		de: "Es liebt das Kräftemessen mit großen PKMN. Mit seinem Armwurf kann es LKW durch die Luft werfen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/42.ts
+++ b/data/Diamond & Pearl/Great Encounters/42.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Clamperl",
 		fr: "Coquiperl",
+		de: "Perlu"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon can't attack or retreat during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur ne peut pas attaquer ou battre en retraite lors du prochain tour de votre adversaire.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" kann das Verteidigende Pokémon im nächsten Zug deines Gegners weder angreifen noch sich zurückziehen."
+				de: "Wirf 1 Münze. Bei „Kopf“ kann das Verteidigende Pokémon im nächsten Zug deines Gegners weder angreifen noch sich zurückziehen."
 			},
 
 		},
@@ -58,7 +59,7 @@ const card: Card = {
 			effect: {
 				en: "If Huntail has any Darkness Energy attached to it, this attack does 30 damage plus 20 more damage and discard a Special Energy card, if any, attached to the Defending Pokémon.",
 				fr: "Si Serpang possède de l'Énergie Darkness, cette attaque inflige 30 dégâts plus 20 dégâts supplémentaires. Défaussez une carte Énergie spéciale attachée au Pokémon Défenseur, s'il en a.",
-				de: "Wenn an Aalabyss mindestens 1 -Energie angelegt ist, fügt dieser Angriff 30 Schadenspunkte plus 20 weitere Schadenspunkte zu und lege, falls am Verteidigenden Pokémon eine Spezialenergiekarte angelegt ist, diese auf den Ablagestapel deines Gegners."
+				de: "Wenn an Aalabyss mindestens 1 {D}-Energie angelegt ist, fügt dieser Angriff 30 Schadenspunkte plus 20 weitere Schadenspunkte zu und lege, falls am Verteidigenden Pokémon eine Spezialenergiekarte angelegt ist, diese auf den Ablagestapel deines Gegners."
 			},
 			damage: "30+",
 
@@ -76,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives deep in the sea. With a tail shaped like a small fish, it attracts unsuspecting prey.",
+		de: "Es lebt tief im Meer. Sein Schweif ist wie ein kleiner Fisch geformt. Mit ihm lockt es Beute an."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/43.ts
+++ b/data/Diamond & Pearl/Great Encounters/43.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Zigzagoon",
 		fr: "Zigzaton",
+		de: "Zigzachs"
 	},
 
 	stage: "Stage1",
@@ -75,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "It charges prey at speeds over 60 mph. However, because it can only run straight, it often fails.",
+		de: "Es stürzt sich mit 100 km/h auf Beute. Aber es kann nur geradeaus laufen und die Jagd misslingt oft."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/44.ts
+++ b/data/Diamond & Pearl/Great Encounters/44.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Whismur",
 		fr: "Chuchmur",
+		de: "Flurmel"
 	},
 
 	stage: "Stage1",
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 40 damage plus 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 40 dégâts plus 20 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 40 Schadenspunkte plus 20 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 40 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "40+",
 
@@ -80,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "The shock waves from its cries can tip over trucks. It stamps its feet to power up.",
+		de: "Die Schockwellen, die durch sein Rufen entstehen, können einen LKW umkippen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/45.ts
+++ b/data/Diamond & Pearl/Great Encounters/45.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Slugma",
 		fr: "Limagma",
+		de: "Schneckmag"
 	},
 
 	stage: "Stage1",
@@ -79,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "Its body temperature is roughly 18,000 degrees F. Flames spout from gaps in its hardened shell.",
+		de: "Seine Körpertemperatur beträgt etwa 10 000 Grad. Aus seiner Schale treten immer wieder Flammen aus."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/46.ts
+++ b/data/Diamond & Pearl/Great Encounters/46.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Mudkip",
 		fr: "Gobou",
+		de: "Hydropi"
 	},
 
 	stage: "Stage1",
@@ -76,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "Its sturdy legs give it sure footing, even in mud. It burrows into dirt to sleep.",
+		de: "Seine kräftigen Beine geben ihm sicheren Halt. Es gräbt sich in Dreck ein, wenn es schlafen will."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/47.ts
+++ b/data/Diamond & Pearl/Great Encounters/47.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Caterpie",
 		fr: "Chenipan",
+		de: "Raupy"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), if Metapod is your Active Pokémon, you may flip a coin. If heads, search your deck for a card that evolves from Metapod and put it onto Metapod. (This counts as evolving Metapod.) Shuffle your deck afterward. This power can't be used if Metapod is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), si Chrysacier est votre Pokémon Actif, vous pouvez lancer une pièce. Si c'est face, cherchez dans votre deck une carte qui évolue de Chrysacier et placez-la sur Chrysacier. (Vous le faites ainsi évoluer.) Ensuite, mélangez votre deck. Ce pouvoir ne peut pas être utilisé si Chrysacier est affecté par un État Spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff), wenn Safcon dein Aktives Pokémon ist, kannst du 1 Münze werfen. Bei \"Kopf\" durchsuche dein Deck nach einer Karte, die sich aus Safcon entwickelt, und lege diese auf Safcon. (Dies zählt als Entwickeln von Safcon.) Mische dein Deck danach. Diese Poké-Power kann nicht benutzt werden, wenn Safcon von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff), wenn Safcon dein Aktives Pokémon ist, kannst du 1 Münze werfen. Bei „Kopf“ durchsuche dein Deck nach einer Karte, die sich aus Safcon entwickelt, und lege diese auf Safcon. (Dies zählt als Entwickeln von Safcon.) Mische dein Deck danach. Diese Poké-Power kann nicht benutzt werden, wenn Safcon von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -74,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "A steel-hard shell protects its tender body. It quietly endures hardships while awaiting evolution.",
+		de: "Der stahlharte Panzer schützt seinen zarten Körper. Es wartet geduldig auf seine Entwicklung."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/48.ts
+++ b/data/Diamond & Pearl/Great Encounters/48.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Wingull",
 		fr: "Goelise",
+		de: "Wingull"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Choose up to 2 basic Water Energy cards from your hand and attach them to Pelipper. Remove 2 damage counters for each Energy card attached in this way.",
 				fr: "Choisissez jusqu'à 2 cartes Énergie de base (W) de votre main et attachez-les à Bekipan. Retirez 2 marqueurs de dégât pour chaque carte Énergie attachée de cette façon.",
-				de: "Wähle bis zu 2 -Basis-Energiekarten von deiner Hand und lege sie an Pelipper an. Entferne für jede so angelegte Energiekarte 2 Schadensmarken von Pelipper."
+				de: "Wähle bis zu 2 {W}-Basis-Energiekarten von deiner Hand und lege sie an Pelipper an. Entferne für jede so angelegte Energiekarte 2 Schadensmarken von Pelipper."
 			},
 
 		},
@@ -84,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "It dips its large bill in the sea, then scoops up numerous prey along with water.",
+		de: "Es taucht seinen großen Schnabel ins Wasser und fängt so eine Menge Beute."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/49.ts
+++ b/data/Diamond & Pearl/Great Encounters/49.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Porygon",
 		fr: "Porygon",
+		de: "Porygon"
 	},
 
 	stage: "Stage1",
@@ -74,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "With planetary development software installed, it became capable of working in space.",
+		de: "Interstellare Software wurde installiert, so dass dieses PKMN sich auch im All bewegen kann."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/5.ts
+++ b/data/Diamond & Pearl/Great Encounters/5.ts
@@ -79,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "It makes fur balls that crackle with static electricity. It stores them with berries in tree holes.",
+		de: "Es bildet ein Fellknäuel, der vor statischer Energie knistert. Es speichert die Energie in Bäumen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/50.ts
+++ b/data/Diamond & Pearl/Great Encounters/50.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Glameow",
 		fr: "Chaglam",
+		de: "Charmian"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, défaussez une Énergie attachée au Pokémon Défenseur.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" lege eine Energie, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
+				de: "Wirf 1 Münze. Bei „Kopf“ lege eine Energie, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
 			},
 			damage: 20,
 
@@ -63,7 +64,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 40 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 40 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "40x",
 
@@ -81,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It is a brazen brute that barges its way into another Pokémon's nest and claims it as its own.",
+		de: "Dieses PKMN ist ein Grobian, der sich in die Nester anderer PKMN einnistet und sie sich damit aneignet."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/51.ts
+++ b/data/Diamond & Pearl/Great Encounters/51.ts
@@ -71,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "A rare Pokémon discovered during a deep-sea exploration. It has not changed in over 100 million years.",
+		de: "Tiefseeforscher fanden dieses seltene PKMN, das sich in 100 Mio. Jahren nicht verändert hat."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/52.ts
+++ b/data/Diamond & Pearl/Great Encounters/52.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, your opponent can't play any Trainer cards from his or her hand during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, votre adversaire ne peut pas jouer de cartes Dresseur de sa main lors de son prochain tour.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" kann dein Gegner in seinem nächsten Zug keine Trainerkarten von seiner Hand spielen."
+				de: "Wirf 1 Münze. Bei „Kopf“ kann dein Gegner in seinem nächsten Zug keine Trainerkarten von seiner Hand spielen."
 			},
 			damage: 20,
 
@@ -57,7 +57,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 damage plus 30 more damage and the Defending Pokémon is now Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts plus 30 dégâts supplémentaires et le Pokémon Défenseur est maintenant Empoisonné.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 30 Schadenspunkte plus 30 weitere Schadenspunkte zu und das Verteidigende Pokémon ist jetzt vergiftet."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 Schadenspunkte plus 30 weitere Schadenspunkte zu und das Verteidigende Pokémon ist jetzt vergiftet."
 			},
 			damage: "30+",
 
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "For many generations, it has feuded with ZANGOOSE. It whets its bladed tail on rocks for battle.",
+		de: "Seit Generationen ist es mit SENGO verfeindet. Es wetzt seinen scharfen Schweif an Felsen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/53.ts
+++ b/data/Diamond & Pearl/Great Encounters/53.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, défaussez une Énergie attachée au Pokémon Défenseur.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" lege eine Energie, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
+				de: "Wirf 1 Münze. Bei „Kopf“ lege eine Energie, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
 			},
 			damage: 20,
 
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "Despite being clad entirely in iron-hard armor, it flies at speeds over 180 mph.",
+		de: "Es wird komplett von einer eisenharten Rüstung geschützt. Wenn es fliegt, erreicht es bis zu 300 km/h."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/54.ts
+++ b/data/Diamond & Pearl/Great Encounters/54.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Slowpoke",
 		fr: "Ramoloss",
+		de: "Flegmon"
 	},
 
 	stage: "Stage1",
@@ -77,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "Though usually dim witted, it seems to become inspired if the SHELLDER on its tail bites down.",
+		de: "Ein begriffsstutziges Pokémon. Beißt das MUSCHAS am Schweif zu, scheint es Intelligenz zu gewinnen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/55.ts
+++ b/data/Diamond & Pearl/Great Encounters/55.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Togepi",
 		fr: "Togepi",
+		de: "Togepi"
 	},
 
 	stage: "Stage1",
@@ -84,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said to appear in front of kindly people to scatter a glowing down called \"joy dust.\"",
+		de: "Man sagt, es erscheint vor denen, die gutherzig sind, und verteilt glänzenden „Glücksstaub“."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/56.ts
+++ b/data/Diamond & Pearl/Great Encounters/56.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), if Unown F is on your Bench, you may use this power. Put a coin next to your Active Pokémon without showing your opponent and cover it with your hand. Your opponent guesses if the coin is heads or tails. If he or she is wrong, draw a card.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), si Zarbi F est sur votre Banc, vous pouvez utiliser ce pouvoir. Placez une pièce à côté de votre Pokémon Actif. Ne la montrez pas à votre adversaire et cachez-la avec votre main. Votre adversaire doit deviner si c'est pile ou face. S'il ou elle a tort, piochez une carte.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn Icognito F auf deiner Bank ist, diese Poké-Power benutzen. Lege 1 Münze verdeckt neben dein Aktives Pokémon. Dein Gegner muss erraten, ob die Münze \"Kopf\" oder \"Zahl\" zeigt. Wenn er falsch rät, ziehe 1 Karte."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn Icognito F auf deiner Bank ist, diese Poké-Power benutzen. Lege 1 Münze verdeckt neben dein Aktives Pokémon. Dein Gegner muss erraten, ob die Münze „Kopf“ oder „Zahl“ zeigt. Wenn er falsch rät, ziehe 1 Karte."
 			},
 		},
 	],
@@ -50,7 +50,7 @@ const card: Card = {
 			effect: {
 				en: "You may flip a coin. If tails, this attack does nothing. If heads, this attack's base damage is 30.",
 				fr: "Vous pouvez lancer une pièce. Si c'est pile, cette attaque est sans effet. Si c'est face, les dégâts de base de cette attaque sont de 30.",
-				de: "Du kannst 1 Münze werfen. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen. Bei \"Kopf\" beträgt der Grundschaden dieses Angriffs 30 Schadenspunkte."
+				de: "Du kannst 1 Münze werfen. Bei „Zahl“ hat dieser Angriff keine Auswirkungen. Bei „Kopf“ beträgt der Grundschaden dieses Angriffs 30 Schadenspunkte."
 			},
 			damage: 10,
 
@@ -67,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "Shaped like ancient writing, it is a huge mystery whether language or UNOWN came first.",
+		de: "Seine Form sieht aus wie antike Schrift. Was war zuerst da? Die Sprache oder ICOGNITO?"
 	},
 
 	variants: [

--- a/data/Diamond & Pearl/Great Encounters/57.ts
+++ b/data/Diamond & Pearl/Great Encounters/57.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "Shaped like ancient writing, it is a huge mystery whether language or UNOWN came first.",
+		de: "Seine Form sieht aus wie antike Schrift. Was war zuerst da? Die Sprache oder ICOGNITO?"
 	},
 
 	variants: [

--- a/data/Diamond & Pearl/Great Encounters/58.ts
+++ b/data/Diamond & Pearl/Great Encounters/58.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts à chacun des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse ou la Résistance aux Pokémon de Banc).",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff allen Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff allen Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 10,
 
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "On sunny days, it lands on beaches to bounce like a ball and play. It spouts water from its nose.",
+		de: "An sonnigen Tagen trifft man diese Pokémon an Stränden, wo sie wie Bälle herumhüpfen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/59.ts
+++ b/data/Diamond & Pearl/Great Encounters/59.ts
@@ -71,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "It has feuded with SEVIPER for many generations. Its sharp claws are its biggest weapons.",
+		de: "Seit Generationen ist es mit VIPITIS verfeindet. Seine scharfen Klauen sind seine stärksten Waffen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/6.ts
+++ b/data/Diamond & Pearl/Great Encounters/6.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Porygon2",
 		fr: "Porygon2",
+		de: "Porygon2"
 	},
 
 	stage: "Stage2",
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 40 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 40 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "40x",
 
@@ -78,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "Additional software was installed to make it a better Pokémon. It began acting oddly, however.",
+		de: "Zusätzliche Software wurde installiert, um das PKMN zu verbessern. Seitdem benimmt es sich seltsam."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/60.ts
+++ b/data/Diamond & Pearl/Great Encounters/60.ts
@@ -73,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "It moves by spinning on its foot. It is a rare Pokémon that was discovered in ancient ruins.",
+		de: "Es bewegt sich, indem es sich auf seinem Fuß dreht. Ein seltenes PKMN, das in alten Ruinen lebte."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/61.ts
+++ b/data/Diamond & Pearl/Great Encounters/61.ts
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "It has a flotation sac that is like an inflatable collar. It floats on water with its head out.",
+		de: "Es hat eine Art Rettungsring um den Hals. Wenn es schwimmt, gerät sein Kopf niemals unter Wasser."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/62.ts
+++ b/data/Diamond & Pearl/Great Encounters/62.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
 				fr: "Si le Pokémon Défenseur essaye d'attaquer lors du prochain tour de votre adversaire, celui-ci lance une pièce. Si c'est pile, cette attaque est sans effet.",
-				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 
 		},
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "By storing water in its body, this desert dweller can survive 30 days without water.",
+		de: "Dieser Wüstenbewohner speichert Wasser in seinem Körper. So kann er 30 Tage ohne Wasser überleben."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/63.ts
+++ b/data/Diamond & Pearl/Great Encounters/63.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), if Caterpie is your Active Pokémon, you may flip a coin. If heads, search your deck for a card that evolves from Caterpie and put it onto Caterpie. (This counts as evolving Caterpie.) Shuffle your deck afterward. This power can't be used if Caterpie is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), si Chenipan est votre Pokémon Actif, vous pouvez lancer une pièce. Si c'est face, cherchez dans votre deck une carte qui évolue de Chenipan et placez-la sur Chenipan. (Vous le faites ainsi évoluer.) Ensuite, mélangez votre deck. Ce pouvoir ne peut pas être utilisé si Chenipan est affecté par un État Spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff), wenn Raupy dein Aktives Pokémon ist, kannst du 1 Münze werfen. Bei \"Kopf\" durchsuche dein Deck nach einer Karte, die sich aus Raupy entwickelt, und lege diese auf Raupy. (Dies zählt als Entwickeln von Raupy.) Mische dein Deck danach. Diese Poké-Power kann nicht benutzt werden, wenn Raupy von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff), wenn Raupy dein Aktives Pokémon ist, kannst du 1 Münze werfen. Bei „Kopf“ durchsuche dein Deck nach einer Karte, die sich aus Raupy entwickelt, und lege diese auf Raupy. (Dies zählt als Entwickeln von Raupy.) Mische dein Deck danach. Diese Poké-Power kann nicht benutzt werden, wenn Raupy von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "It releases a stench from its red antenna to repel enemies. It grows by molting repeatedly.",
+		de: "Seine roten Antennen sondern einen Gestank ab, der Feinde verjagt. Es wächst, indem es sich häutet."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/64.ts
+++ b/data/Diamond & Pearl/Great Encounters/64.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "It makes a single pearl during its lifetime. The pearl is said to amplify psychic power.",
+		de: "In seinem Leben erschafft es eine einzige Perle. Diese soll Psycho-Kräfte verstärken."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/65.ts
+++ b/data/Diamond & Pearl/Great Encounters/65.ts
@@ -69,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "It can tell what people are dreaming by sniffing with its big nose. It loves fun dreams.",
+		de: "Mit seiner großen Nase kann es die Träume anderer erkennen. Es liebt lustige Träume."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/66.ts
+++ b/data/Diamond & Pearl/Great Encounters/66.ts
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Empoisonné,",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt vergiftet."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet."
 			},
 			damage: 10,
 
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "It sneaks through grass without making a sound and strikes unsuspecting prey from behind.",
+		de: "Es bewegt sich ohne einen Laut durch das Gras und greift seine ahnungslose Beute von hinten an."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/67.ts
+++ b/data/Diamond & Pearl/Great Encounters/67.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "It is famous for its shabby appearance. While populous, they tend to cluster in set locations.",
+		de: "Seine lumpige Gestalt ist berühmt. Es lebt mit anderen in Gruppen an bestimmten Orten."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/68.ts
+++ b/data/Diamond & Pearl/Great Encounters/68.ts
@@ -69,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "It claws if displeased and purrs when affectionate. Its fickleness is very popular among some.",
+		de: "Es schlägt mit Krallen zu oder schnurrt, je nachdem, ob es gerade wütend oder zutraulich ist."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/69.ts
+++ b/data/Diamond & Pearl/Great Encounters/69.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, discard a Fire Energy attached to Houndour.",
 				fr: "Lancez une pièce. Si c'est pile, défaussez une Énergie Fire attachée à Malosse.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" entferne 1 -Energie, die an Hunduster angelegt ist, und lege sie auf deinen Ablagestapel."
+				de: "Wirf 1 Münze. Bei „Zahl“ entferne 1 {R}-Energie, die an Hunduster angelegt ist, und lege sie auf deinen Ablagestapel."
 			},
 			damage: 20,
 
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "It conveys its feelings using different cries. It works in a pack to cleverly take down prey.",
+		de: "Durch unterschiedliche Schreie drückt es seine Gefühle aus. Diese PKMN jagen im Verbund nach Beute."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/7.ts
+++ b/data/Diamond & Pearl/Great Encounters/7.ts
@@ -57,7 +57,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 damage plus 30 more damage and the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts plus 30 dégâts supplémentaires et le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 30 Schadenspunkte plus 30 weitere Schadenspunkte zu und das Verteidigende Pokémon ist jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 Schadenspunkte plus 30 weitere Schadenspunkte zu und das Verteidigende Pokémon ist jetzt gelähmt."
 			},
 			damage: "30+",
 
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "Its body is composed of plasma. It is known to infiltrate electronic devices and wreak havoc.",
+		de: "Sein Körper besteht aus Plasma. Mit ihm kann es in elektrische Geräte eindringen und für Chaos sorgen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/70.ts
+++ b/data/Diamond & Pearl/Great Encounters/70.ts
@@ -69,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "It has a soft and bouncy body. Once it starts bouncing, it becomes impossible to stop.",
+		de: "Es hat einen weichen, elastischen Körper. Hat es einmal angefangen zu hüpfen, ist es nicht zu stoppen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/71.ts
+++ b/data/Diamond & Pearl/Great Encounters/71.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may flip a coin. If heads, search your deck for a Grass Basic Pokémon and put it onto your Bench. Shuffle your deck afterward. This power can't be used if Illumise is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez lancer une pièce. Si c'est face, cherchez dans votre deck un Pokémon de base Grass et placez-le sur votre Banc. Ensuite, mélangez votre deck. Ce pouvoir ne peut pas être utilisé si Lumivole est affecté par un État Spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 Münze werfen. Bei \"Kopf\" durchsuche dein Deck nach 1 -Basis-Pokémon-Karte und lege sie auf deine Bank. Mische dein Deck danach. Diese Poké-Power kann nicht benutzt werden, wenn Illumise von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 Münze werfen. Bei „Kopf“ durchsuche dein Deck nach 1 {G}-Basis-Pokémon-Karte und lege sie auf deine Bank. Mische dein Deck danach. Diese Poké-Power kann nicht benutzt werden, wenn Illumise von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -73,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "With its sweet aroma, it guides VOLBEAT to draw signs with light in the night sky.",
+		de: "Sein süßer Duft leitet VOLBEAT an, Zeichen aus Licht an den Nachthimmel zu malen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/72.ts
+++ b/data/Diamond & Pearl/Great Encounters/72.ts
@@ -73,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "When it wavers its big, round eyes, it begins singing a lullaby that makes everyone drowsy.",
+		de: "Sobald es mit seinen großen, runden Augen rollt, fängt es an, ein Lied zu singen und jeder schläft ein."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/73.ts
+++ b/data/Diamond & Pearl/Great Encounters/73.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Weedle",
 		fr: "Aspicot",
+		de: "Hornliu"
 	},
 
 	stage: "Stage1",
@@ -75,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "While awaiting evolution, it hides from predators under leaves and in nooks of branches.",
+		de: "Während es auf seine Entwicklung wartet, versteckt es sich unter Blättern und zwischen Ästen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/74.ts
+++ b/data/Diamond & Pearl/Great Encounters/74.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "The Defending Pokémon is now Poisoned. If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné. S'il essaye d'attaquer lors du prochain tour de votre adversaire, celui-ci lance une pièce. Si c'est pile, cette attaque est sans effet.",
-				de: "Das Verteidigende Pokémon ist jetzt vergiftet. Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet. Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 10,
 
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "Lighter-than-air gases in its body keep it aloft. The gases not only smell, they are also explosive.",
+		de: "Gase, die leichter als Luft sind, lassen es schweben. Diese Gase stinken und sind explosiv."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/75.ts
+++ b/data/Diamond & Pearl/Great Encounters/75.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives in burrows dug on sandy beaches. Its pincers fully grow back if they are broken in battle.",
+		de: "Es lebt in Höhlen am Strand. Seine Scheren wachsen nach, wenn es sie im Kampf verliert."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/76.ts
+++ b/data/Diamond & Pearl/Great Encounters/76.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "Because it turns active on nights of the full moon, it is said to have some link to the lunar phases.",
+		de: "Da es in Vollmondnächten aktiv wird, sagt man ihm nach, mit den Mondphasen in Verbindung zu stehen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/77.ts
+++ b/data/Diamond & Pearl/Great Encounters/77.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives in warm seas. It is said that a couple finding this Pokémon will be blessed with eternal love.",
+		de: "Es lebt in warmen Meeren. Man sagt, dass Verliebte, die es sehen, mit ewiger Liebe gesegnet sind."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/78.ts
+++ b/data/Diamond & Pearl/Great Encounters/78.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing. If heads, discard an Energy card attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet. Si c'est face, défaussez une carte Énergie attachée au Pokémon Défenseur.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen. Bei \"Kopf\" entferne 1 Energiekarte, die an das Verteidigende Pokémon angelegt ist, und lege sie auf den Ablagestapel deines Gegners."
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen. Bei „Kopf“ entferne 1 Energiekarte, die an das Verteidigende Pokémon angelegt ist, und lege sie auf den Ablagestapel deines Gegners."
 			},
 			damage: 40,
 
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "It toughens its body by slamming into thick trees. Many snapped trees can be found near its nest.",
+		de: "Es stärkt seinen Körper, indem es gegen Bäume rennt. In seiner Nähe finden sich viele umgekippte Bäume."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/79.ts
+++ b/data/Diamond & Pearl/Great Encounters/79.ts
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives in treetop colonies. If one becomes enraged, the whole colony rampages for no reason.",
+		de: "Es lebt mit anderen in Baumkronen. Wird eines von ihnen wütend, werden alle anderen auch wütend."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/8.ts
+++ b/data/Diamond & Pearl/Great Encounters/8.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Grovyle",
 		fr: "Massko",
+		de: "Reptain"
 	},
 
 	stage: "Stage2",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Each basic Grass Energy card attached to your Grass Pokémon provides Grass Grass Energy instead. You can't use more than 1 Wild Growth Poké-Body each turn.",
 				fr: "Chaque carte Énergie Grass attachée à vos Pokémon Grass fournit maintenant de l'Énergie Grass Grass. Vous ne pouvez pas utiliser plus d'1 Poké-Body Luxuriance par tour.",
-				de: "Jede -Basis-Energiekarte, die an deine -Pokémon angelegt ist, liefert -Energie. Du kannst nicht mehr als 1 Wildes Wachstum Poké-Body pro Zug einsetzen."
+				de: "Jede {G}-Basis-Energiekarte, die an deine {G}-Pokémon angelegt ist, liefert {G}{G}-Energie. Du kannst nicht mehr als 1 Wildes Wachstum Poké-Body pro Zug einsetzen."
 			},
 		},
 	],
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 50 damage plus 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 50 dégâts plus 20 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 50 Schadenspunkte plus 20 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 50 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "50+",
 
@@ -87,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "The leaves that grow on its arms can slice down thick trees. It is without peer in jungle combat.",
+		de: "Die Blätter an seinen Armen können dicke Bäume fällen. Im Dschungelkampf gibt es kein stärkeres PKMN."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/80.ts
+++ b/data/Diamond & Pearl/Great Encounters/80.ts
@@ -53,7 +53,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 30 damage plus 20 more damage for each heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts plus 20 dégâts supplémentaires pour chaque face.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte plus 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte plus 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "30+",
 
@@ -71,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "To alert it, the fin on its head senses the flow of water. It has the strength to heft boulders.",
+		de: "Die Flosse auf seinem Kopf prüft die Strömung des Wassers. Dieses PKMN kann Felsen heben."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/81.ts
+++ b/data/Diamond & Pearl/Great Encounters/81.ts
@@ -69,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "The world's first artificially created Pokémon. It can travel through electronic space.",
+		de: "Das erste künstlich erzeugte PKMN der Welt. Es kann durch elektronischen Raum reisen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/82.ts
+++ b/data/Diamond & Pearl/Great Encounters/82.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "Although slow, it is skilled at fishing with its tail. It does not feel pain if its tail is bitten.",
+		de: "Es ist langsam, hat aber ein Talent, mit seinem Schweif zu fischen. Beißt etwas an, tut es ihm nicht weh."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/83.ts
+++ b/data/Diamond & Pearl/Great Encounters/83.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "Its body is made of magma. If it doesn't keep moving, its body will cool and harden.",
+		de: "Sein Körper besteht aus Magma. Bleibt es nicht ständig in Bewegung, kühlt es aus und verhärtet sich."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/84.ts
+++ b/data/Diamond & Pearl/Great Encounters/84.ts
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "Small Pokémon flee from its scary face. It is, however, considered by women to be cute.",
+		de: "Kleine PKMN fliehen beim Anblick seines Gesichts. Frauen aber finden es niedlich."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/85.ts
+++ b/data/Diamond & Pearl/Great Encounters/85.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "If you have Lunatone in play, damage done to your opponent's Pokémon by your Psychic or Fighting Pokémon isn't affected by Resistance.",
 				fr: "Si vous avez Seleroc en jeu, les dégâts infligés aux Pokémon de votre adversaire par vos Pokémon Psychic ou Fighting ne sont pas affectés par la Résistance.",
-				de: "Wenn du Lunastein im Spiel hast, wird Schaden, der gegnerischen Pokémon durch deine - oder -Pokémon zugefügt wird, durch Resistenz nicht verändert."
+				de: "Wenn du Lunastein im Spiel hast, wird Schaden, der gegnerischen Pokémon durch deine {P}- oder {F}-Pokémon zugefügt wird, durch Resistenz nicht verändert."
 			},
 		},
 	],
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "A new Pokémon species, rumored to be from the sun. It gives off light while spinning.",
+		de: "Eine neue PKMN-Spezies, von der man annimmt, sie käme von der Sonne. Sie strahlt Licht ab."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/86.ts
+++ b/data/Diamond & Pearl/Great Encounters/86.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Swablu during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, prévenez tous les effets d'une attaque, dégâts inclus, infligés à Tylton lors du prochain tour de votre adversaire.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" verhindere während des nächsten Zuges deines Gegners alle Effekte eines Angriffs, einschließlich Schaden, die Wablu zugefügt würden."
+				de: "Wirf 1 Münze. Bei „Kopf“ verhindere während des nächsten Zuges deines Gegners alle Effekte eines Angriffs, einschließlich Schaden, die Wablu zugefügt würden."
 			},
 
 		},
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "Its wings are like cotton tufts. If it perches on someone's head, it looks like a cotton hat.",
+		de: "Seine Flügel sehen aus wie Baumwolle. Legt es sie jemandem auf den Kopf, sehen sie wie ein Wollhut aus."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/87.ts
+++ b/data/Diamond & Pearl/Great Encounters/87.ts
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Does 20 damage plus 10 more damage for each Colorless Energy in the Defending Pokémon's Retreat Cost (after applying effects to the Retreat Cost).",
 				fr: "Inflige 20 dégâts plus 10 dégâts supplémentaires pour chaque Énergie Colorless dans le Coût de retraite du Pokémon Défenseur (après application des effets sur le Coût de retraite).",
-				de: "Dieser Angriff fügt 20 Schadenspunkte plus 10 weitere Schadenspunkte für jede -Energie in den Rückzugskosten des Verteidigenden Pokémon zu (nachdem Effekte auf die Rückzugskosten verrechnet wurden)."
+				de: "Dieser Angriff fügt 20 Schadenspunkte plus 10 weitere Schadenspunkte für jede {C}-Energie in den Rückzugskosten des Verteidigenden Pokémon zu (nachdem Effekte auf die Rückzugskosten verrechnet wurden)."
 			},
 			damage: "20+",
 
@@ -73,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "It is shrouded by blue vines. No one has seen the face hidden behind this growth of vines.",
+		de: "Es ist von blauen Ranken umgeben. Niemand hat jemals das Gesicht dieses Pokémon gesehen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/88.ts
+++ b/data/Diamond & Pearl/Great Encounters/88.ts
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, search your deck for a Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
 				fr: "Lancez une pièce. Si c'est face, choisissez un Pokémon dans votre deck, montrez-le à votre adversaire et placez-le dans votre main. Ensuite, mélangez votre deck.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" durchsuche dein Deck nach einer Pokémon-Karte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
+				de: "Wirf 1 Münze. Bei „Kopf“ durchsuche dein Deck nach einer Pokémon-Karte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 			},
 
 		},
@@ -71,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "Its shell is said to be stuffed with happiness that it shares with kindhearted people.",
+		de: "Seine Schale ist mit Glücksgefühlen gefüllt, die es mit gutherzigen Lebewesen teilt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/89.ts
+++ b/data/Diamond & Pearl/Great Encounters/89.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "A fire burns inside, so it feels very warm to hug. It launches fireballs of 1,800 degrees F.",
+		de: "In seinem Inneren lodert ein Feuer. Es schleudert 1 000 Grad heiße Feuerbälle."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/9.ts
+++ b/data/Diamond & Pearl/Great Encounters/9.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Marshtomp",
 		fr: "Flobio",
+		de: "Moorabbel"
 	},
 
 	stage: "Stage2",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "As often as you like during your turn (before your attack), you may move a Water or Fighting Energy attached to 1 of your Benched Pokémon to your Active Pokémon. This power can't be used if Swampert is affected by a Special Condition.",
 				fr: "Autant de fois que vous le voulez lors de votre tour (avant votre attaque), vous pouvez déplacer une Énergie Water ou Fighting attachée à 1 des Pokémon de votre Banc sur votre Pokémon Actif. Ce pouvoir ne peut pas être utilisé si Laggron est affecté par un État Spécial.",
-				de: "Beliebig oft während deines Zuges (vor deinem Angriff) kannst du 1 - oder -Energie, die an 1 Pokémon auf deiner Bank angelegt ist, an dein Aktives Pokémon anlegen. Diese Poké-Power kann nicht benutzt werden, wenn Sumpex von einem Speziellen Zustand betroffen ist."
+				de: "Beliebig oft während deines Zuges (vor deinem Angriff) kannst du 1 {W}- oder {F}-Energie, die an 1 Pokémon auf deiner Bank angelegt ist, an dein Aktives Pokémon anlegen. Diese Poké-Power kann nicht benutzt werden, wenn Sumpex von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -80,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "It can swim while towing a large ship. It bashes down foes with a swing of its thick arms.",
+		de: "Es kann im Schwimmen ein großes Schiff ziehen. Seine Gegner schlägt es mit Schlägen seiner Arme zurück."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/90.ts
+++ b/data/Diamond & Pearl/Great Encounters/90.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "The soles of its feet are covered by countless tiny spikes, enabling it to walk on walls and ceilings.",
+		de: "Seine Fußsohlen sind mit kleinen Stacheln bedeckt, so dass es an Wänden und Decken Halt findet."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/91.ts
+++ b/data/Diamond & Pearl/Great Encounters/91.ts
@@ -67,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "Shaped like ancient writing, it is a huge mystery whether language or UNOWN came first.",
+		de: "Seine Form sieht aus wie antike Schrift. Was war zuerst da? Die Sprache oder ICOGNITO?"
 	},
 
 	variants: [

--- a/data/Diamond & Pearl/Great Encounters/92.ts
+++ b/data/Diamond & Pearl/Great Encounters/92.ts
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt verwirrt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: 20,
 
@@ -73,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "It communicates with others by lighting up its rear at night. It loves ILLUMISE's sweet aroma.",
+		de: "Es kommuniziert mit anderen, indem es sein Hinterteil zum Leuchten bringt. Es liebt ILLUMISEs Duft."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/93.ts
+++ b/data/Diamond & Pearl/Great Encounters/93.ts
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 
 		},
@@ -71,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "It eats its weight in leaves every day. It fends off attackers with the needle on its head.",
+		de: "Es frisst täglich sein Gewicht in Blättern. Die Nadel auf seinem Kopf dient der Verteidigung."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/94.ts
+++ b/data/Diamond & Pearl/Great Encounters/94.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts à chacun des Pokémon de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse ou la Résistance aux Pokémon de Banc).",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff allen Pokémon deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff allen Pokémon deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "Usually, its cries are like quiet murmurs.  If frightened, it shrieks at the same volume as a jet plane.",
+		de: "Normalerweise klingen seine Rufe wie Gemurmel. Hat es aber Angst, ist es so laut wie ein Flugzeug."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/95.ts
+++ b/data/Diamond & Pearl/Great Encounters/95.ts
@@ -73,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "It makes its nest on steep sea cliffs. Riding updrafts, it soars to great heights.",
+		de: "Es baut sein Nest auf steilen Klippen. Es nutzt die Aufwinde, um in größerer Höhe fliegen zu können."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/96.ts
+++ b/data/Diamond & Pearl/Great Encounters/96.ts
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10x",
 
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "It walks in zigzag fashion. It is good at finding items in the grass and even in the ground.",
+		de: "Es läuft im Zickzack. Es hat das Talent, Items im Gras, aber auch im Boden, zu finden."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Great Encounters/97.ts
+++ b/data/Diamond & Pearl/Great Encounters/97.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Attach Amulet Coin to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card. If the Pokémon Amulet Coin is attached to is your Active Pokémon at the end of your turn, draw a card.",
 		fr: "Attachez Pièce rune à 1 de vos Pokémon qui ne posséde pas déjà d'Outil Pokémon. Si ce Pokémon est mis K.O, défaussez cette carte.",
-		de: "Wenn das Pokémon, an das Münzamulett angelegt ist, am Ende deines Zuges dein Aktives Pokémon ist, ziehe 1 Karte."
+		de: "Lege Münzamulett an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn dieses Pokémon kampfunfähig wird, lege Münzamulett auf den Ablagestapel. Wenn das Pokémon, an dem Münzamulett angelegt ist, am Ende deines Zuges dein Aktives Pokémon ist, ziehe 1 Karte."
 	},
 
 	trainerType: "Tool",

--- a/data/Diamond & Pearl/Great Encounters/98.ts
+++ b/data/Diamond & Pearl/Great Encounters/98.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Discard up to 2 cards from your hand. If you discard 1 card, draw 3 cards. If you discard 2 cards, draw 4 cards.",
 		fr: "Défaussez jusqu'à 2 cartes de votre main. Si vous défaussez 1 carte, piochez 3 cartes. Si vous défaussez 2 cartes, piochez 4 cartes.",
-		de: "Lege bis zu 2 Karten von deiner Hand auf deinen Ablagestapel. Wenn du auf diese Weise 1 Karte auf deinen Ablagestapel gelegt hast, ziehe 3 Karten. Wenn du auf diese Weise 2 Karte auf deinen Ablagestapel gelegt hast, ziehe 4 Karten.",
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Lege bis zu 2 Karten von deiner Hand auf deinen Ablagestapel. Wenn du auf diese Weise 1 Karte auf deinen Ablagestapel gelegt hast, ziehe 3 Karten. Wenn du auf diese Weise 2 Karten auf deinen Ablagestapel gelegt hast, ziehe 4 Karten.",
 	},
 
 	trainerType: "Supporter",

--- a/data/Diamond & Pearl/Great Encounters/99.ts
+++ b/data/Diamond & Pearl/Great Encounters/99.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Attach Leftovers to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card. If the Pokémon Leftovers is attached to is your Active Pokémon at the end of your turn, remove 1 damage counter from the Pokémon.",
 		fr: "Attachez Pièce rune à 1 de vos Pokémon qui ne posséde pas déjà d'Outil Pokémon. Si ce Pokémon est mis K.O, défaussez cette carte.",
-		de: "Wenn das Pokémon, an das Überreste angelegt ist, am Ende deines Zuges dein Aktives Pokémon ist, entferne 1 Schadensmarke von diesem Pokémon."
+		de: "Lege Überreste an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn dieses Pokémon kampfunfähig wird, lege Überreste auf den Ablagestapel. Wenn das Pokémon, an dem Überreste angelegt ist, am Ende deines Zuges dein Aktives Pokémon ist, entferne 1 Schadensmarke von diesem Pokémon."
 	},
 
 	trainerType: "Tool",


### PR DESCRIPTION
## Add missing German translations for dp4

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
