### PR TITLE
Add missing German translations for dp5

### DIFF
--- a/data/Diamond & Pearl/Majestic Dawn/1.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/1.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn, when you put Articuno from your hand onto your Bench, you may flip a coin. If heads, choose 1 of the Defending Pokémon. That Pokémon is now Paralyzed.",
 				fr: "Une seule fois lors de votre tour, lorsque vous placez Arktos de votre main sur votre Banc, vous pouvez lancer une pièce. Si c'est face, choisissez 1 des Pokémon Défenseurs. Ce Pokémon est maintenant Paralysé.",
-				de: "Einmal während deines Zuges kannst du, wenn du Arktos von deiner Hand auf deine Bank legst, 1 Münze werfen. Bei \"Kopf\" wähle 1 Verteidigendes Pokémon. Das gewählte Pokémon ist jetzt gelähmt."
+				de: "Einmal während deines Zuges kannst du, wenn du Arktos von deiner Hand auf deine Bank legst, 1 Münze werfen. Bei „Kopf“ wähle 1 Verteidigendes Pokémon. Das gewählte Pokémon ist jetzt gelähmt."
 			},
 		},
 	],
@@ -56,7 +56,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Benched Pokémon. If tails, this attack does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts à chacun des Pokémon de Banc de votre adversaire. Si c'est pile, cette attaque inflige 10 dégâts à chacun de vos Pokémon de Banc. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff jedem Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. Bei \"Zahl\" fügt dieser Angriff jedem Pokémon auf deiner Bank 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff jedem Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. Bei „Zahl“ fügt dieser Angriff jedem Pokémon auf deiner Bank 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 60,
 
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "A legendary bird Pokémon. It can create blizzards by freezing moisture in the air.",
+		de: "Ein Legendäres Vogel-Pokémon. Es kann Blizzards verursachen, indem es Feuchtigkeit gefriert."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/10.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/10.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn, when you put Moltres from your hand onto your Bench, you may flip a coin. If heads, search your discard pile for up to 3 Fire Energy cards and attach them to Moltres.",
 				fr: "Une seule fois lors de votre tour, lorsque vous placez Sulfura de votre main sur votre Banc, vous pouvez lancer une pièce. Si c'est face, choisissez dans votre pile de défausse jusqu'à 3 cartes Énergie Fire et attachez-les à Sulfura.",
-				de: "Einmal während deines Zuges kannst du, wenn du Lavados von deiner Hand auf deine Bank legst, 1 Münze werfen. Bei \"Kopf\" durchsuche deinen Ablagestapel nach bis zu 3 -Energiekarten und lege sie an Lavados an."
+				de: "Einmal während deines Zuges kannst du, wenn du Lavados von deiner Hand auf deine Bank legst, 1 Münze werfen. Bei „Kopf“ durchsuche deinen Ablagestapel nach bis zu 3 {R}-Energiekarten und lege sie an Lavados an."
 			},
 		},
 	],
@@ -56,7 +56,7 @@ const card: Card = {
 			effect: {
 				en: "Discard all Fire Energy attached to Moltres.",
 				fr: "Défaussez toutes les Énergies Fire attachées à Sulfura.",
-				de: "Lege alle an Lavados angelegten -Energien auf deinen Ablagestapel."
+				de: "Lege alle an Lavados angelegten {R}-Energien auf deinen Ablagestapel."
 			},
 			damage: 100,
 
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "One of the legendary bird Pokémon. It is said that its appearance indicates the coming of spring.",
+		de: "Eines der Legendären Vogel-Pokémon. Es wird als Bote des Frühlings angesehen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/100.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/100.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), when you put Porygon-Z LV.X from your hand onto your Active Porygon-Z, you may discard all of your opponent's Special Energy cards in play.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), lorsque vous placez Porygon-Z LV.X de votre main sur votre Porygon-Z Actif, vous pouvez défausser toutes les cartes Énergie Spéciale que votre adversaire a en jeu.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn Porygon-Z LV.X von deiner Hand auf dein aktives Porygon-Z legst, alle Spezial-Energiekarten, die an Pokémondeines Gegners angelegt sind, auf seinen Ablagestapel legen."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn du Porygon-Z LV.X von deiner Hand auf dein aktives Porygon-Z legst, alle Spezial-Energiekarten, die an Pokémon deines Gegners angelegt sind, auf seinen Ablagestapel legen."
 			},
 		},
 	],

--- a/data/Diamond & Pearl/Majestic Dawn/11.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/11.ts
@@ -44,12 +44,12 @@ const card: Card = {
 			name: {
 				en: "Zone Shift",
 				fr: "Changement de zone",
-				de: 'Zonenwechsel'
+				de: "Weiß-Orb"
 			},
 			effect: {
 				en: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon.",
 				fr: "Votre adversaire échange le Défenseur Pokémon avec 1 de ses Pokémon de Banc.",
-				de: 'Dein Gegner tauscht das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus. '
+				de: "Wenn ein Aktives Pokémon eine Schwäche gegen {W}-Pokémon hat, fügen Palkias Angriffe diesem Pokémon 20 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 
 		},
@@ -63,7 +63,7 @@ const card: Card = {
 			name: {
 				en: "Pearl Blast",
 				fr: "Explosion perle",
-				de: 'Perlschuss'
+				de: "Zonenwechsel"
 			},
 			effect: {
 				en: "You may return an Energy card attached to Palkia to your hand. If you do, choose an Energy card attached to the Defending Pokémon and return it to your opponent's hand.",

--- a/data/Diamond & Pearl/Majestic Dawn/12.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/12.ts
@@ -73,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon that lives in warm seas. It inflates the flotation sac on its head to drift and search for food.",
+		de: "Es lebt in warmen Meeren. Geht es auf Nahrungssuche, füllt es den Beutel auf seinem Kopf mit Luft."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/13.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/13.ts
@@ -78,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "Its body is composed of plasma. It is known to infiltrate electronic devices and wreak havoc.",
+		de: "Sein Körper besteht aus Plasma. Mit ihm kann es in elektrische Geräte eindringen und für Chaos sorgen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/14.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/14.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn, when you put Zapdos from your hand onto your Bench, you may flip a coin. If heads, put 1 damage counter on each of your opponent's Pokémon.",
 				fr: "Une seule fois lors de votre tour, lorsque vous placez Electhor de votre main sur votre Banc, vous pouvez lancer une pièce. Si c'est face, placez 1 marqueur de dégât sur chacun des Pokémon de votre adversaire.",
-				de: "Einmal während deines Zuges kannst du, wenn du Zapdos von deiner Hand auf deine Bank legst, 1 Münze werfen. Bei \"Kopf\" lege 1 Schadensmarke auf jedes Pokémon deines Gegners."
+				de: "Einmal während deines Zuges kannst du, wenn du Zapdos von deiner Hand auf deine Bank legst, 1 Münze werfen. Bei „Kopf“ lege 1 Schadensmarke auf jedes Pokémon deines Gegners."
 			},
 		},
 	],
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "A legendary Pokémon that is said to live in thunderclouds. It freely controls lightning bolts.",
+		de: "Ein Legendäres Vogel-Pokémon, das in Gewitterwolken leben soll. Es kontrolliert Blitze."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/15.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/15.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Old Amber",
 		fr: "Vieil Ambre",
+		de: "Altbernstein"
 	},
 
 	stage: "Stage1",
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt verwirrt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: 30,
 
@@ -85,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon that roamed the skies in the dinosaur era. Its teeth are like saw blades.",
+		de: "Dieses PKMN flog zu Zeiten der Dinosaurier am Himmel. Seine Zähne sind wie Sägeblätter."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/16.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/16.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Bronzor",
 		fr: "Archéomire",
+		de: "Bronzel"
 	},
 
 	stage: "Stage1",
@@ -100,6 +101,7 @@ const card: Card = {
 
 	description: {
 		en: "One caused a news sensation when it was dug up at a construction site after a 2,000-year sleep.",
+		de: "Dieses PKMN fand man bei Grabungen auf einer Baustelle, an deren Ort es 2000 Jahre geschlafen hatte."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/17.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/17.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Prinplup",
 		fr: "Prinplouf",
+		de: "Pliprin"
 	},
 
 	stage: "Stage2",
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "Does 50 damage plus 10 more damage for each of your Benched Pokémon. Flip a coin. If tails, this attack does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 50 dégâts plus 10 dégâts supplémentaires pour chaque Pokémon sur votre Banc. Lancez une pièce. Si c'est pile, cette attaque inflige 10 dégâts à chacun des Pokémon de votre Banc. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Dieser Angriff fügt 50 Schadenspunkte plus 10 weitere Schadenspunkte für den Pokémon auf deiner Bank zu. Wirf 1 Münze. Bei \"Zahl\" fügt dieser Angriff allen Pokémon auf deiner Bank 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Dieser Angriff fügt 50 Schadenspunkte plus 10 weitere Schadenspunkte für den Pokémon auf deiner Bank zu. Wirf 1 Münze. Bei „Zahl“ fügt dieser Angriff allen Pokémon auf deiner Bank 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: "50+",
 
@@ -80,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "It swims as fast as a jet boat. The edges of its wings are sharp and can slice apart drifting ice.",
+		de: "Es schwimmt so schnell wie ein Rennboot. Seine Flügel haben scharfe Seiten und können Packeis schneiden."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/18.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/18.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Evoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "You may move an Energy card attached to Espeon to 1 of your Benched Pokémon.",
 				fr: "Vous pouvez déplacer une carte Énergie attachée à Mentali sur 1 des Pokémon de votre Banc.",
-				de: "Du kannst 1 Energiekarte, die an Psiana angelegt ist, entfernen und an ein Pokémon auf deiner Bank anlegen."
+				de: "Du kannst 1 Energiekarte, die an Psiana angelegt ist, entfernen und an 1 Pokémon auf deiner Bank anlegen."
 			},
 			damage: 60,
 
@@ -79,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "Its fur has the look and feel of velvet. The orb on its forehead glows when it uses psycho-power.",
+		de: "Sein Fell ist wie Samt. Setzt es Psycho-Kräfte ein, leuchtet die Kugel in seiner Stirn."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/19.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/19.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Evoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Burned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Brûlé.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt verbrannt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verbrannt."
 			},
 			damage: 30,
 
@@ -80,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "It has a flame sac in its body. Its body temperature tops 1,650 degrees Fahrenheit before battle.",
+		de: "In seinem Körper befindet sich eine Flamme. Seine Körpertemperatur liegt vor dem Kampf bei 900 Grad."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/2.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/2.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "Shiny particles are released from its wings like a veil. It is said to represent the crescent moon.",
+		de: "Seine Flügel geben schimmernde Partikel ab, wie einen Schleier. Man sagt, es stehe für die Mondsichel."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/20.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/20.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Evoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -63,7 +64,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Asleep.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Endormi.",
-				de: "Wirf 1 Münze. Bei 'Kopf' schläft das Verteidigende Pokémon jetzt."
+				de: "Wirf 1 Münze. Bei „Kopf“ schläft das Verteidigende Pokémon jetzt."
 			},
 			damage: 60,
 
@@ -81,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "As a protective technique, it can completely freeze its fur to make its hairs stand like needles.",
+		de: "Will es sich schützen, kann es sein Fell gefrieren, so dass jedes Haar wie eine Nadel absteht."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/21.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/21.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Hippopotas",
 		fr: "Hippopotas",
+		de: "Hippopotas"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Search your discard pile for a Fighting Energy card and attach it to Hippowdon.",
 				fr: "Cherchez dans votre pile de défausse une carte Énergie Fighting et attachez-la à Hippodocus.",
-				de: "Durchsuche deinen Ablagestapel nach 1 -Energiekarte und lege sie an Hippoterus an."
+				de: "Durchsuche deinen Ablagestapel nach 1 {F}-Energiekarte und lege sie an Hippoterus an."
 			},
 			damage: 20,
 
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin for each Fighting Energy attached to Hippowdon. This attack does 50 damage plus 20 more damage for each heads.",
 				fr: "Lancez une pièce pour chaque Énergie Fighting attachée à Hippodocus. Cette attaque inflige 50 dégâts plus 20 dégâts supplémentaires pour chaque face.",
-				de: "Wirf 1 Münze für jede an Hippoterus angelegte -Energie. Dieser Angriff fügt 50 Schadenspunkte plus 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 1 Münze für jede an Hippoterus angelegte {F}-Energie. Dieser Angriff fügt 50 Schadenspunkte plus 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "50+",
 
@@ -78,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "Its huge mouth is almost seven feet across. It has enough power to completely crush a car.",
+		de: "Sein Maul ist fast 2 m breit. Es hat genügend Kraft, um ein Auto zu zermalmen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/22.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/22.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Monferno",
 		fr: "Chimpenfeu",
+		de: "Panpyro"
 	},
 
 	stage: "Stage2",
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Discard all Fire Energy attached to Infernape. This attack does 40 damage times the amount of Fire Energy you discarded.",
 				fr: "Défaussez toutes les Énergies Fire attachées à Simiabraz. Cette attaque inflige 40 dégâts multipliés par le nombre d'Énergies Fire défaussées.",
-				de: "Lege alle an Panferno angelegten -Energien auf deinen Ablagestapel. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl der auf diese Weise auf den Ablagestapel gelegten -Energien zu."
+				de: "Lege alle an Panferno angelegten {R}-Energien auf deinen Ablagestapel. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl der auf diese Weise auf den Ablagestapel gelegten {R}-Energien zu."
 			},
 			damage: "40x",
 
@@ -76,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "Its crown of fire is indicative of its fiery nature. It is beaten by none in terms of quickness.",
+		de: "Seine Krone aus Feuer ist Zeichen seines feurigen Wesens. Niemand ist schneller im Kampf als dieses PKMN."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/23.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/23.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Evoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -85,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "It controls 10,000-volt power and can raise all the furs on its body as if it were sharp needles.",
+		de: "Es kontrolliert 10.000 Volt. Es kann sein Fell so aufstellen, dass es wie scharfe Nadeln wirkt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/24.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/24.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Evoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Remove 1 damage counter from Leafeon.",
 				fr: "Retirez à Phyllali 1 marqueur de dégât.",
-				de: "Entferne 1 Schadenmarke von Folipurba."
+				de: "Entferne 1 Schadensmarke von Folipurba."
 			},
 			damage: 40,
 
@@ -63,7 +64,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 50 damage plus 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 50 dégâts plus 20 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 50 Schadenspunkte plus 20 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 50 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "50+",
 
@@ -88,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "Just like a plant, it uses photosynthesis. As a result, it is always enveloped in clear air.",
+		de: "Genau wie ein Pflanze führt es die Photosynthese aus. Deshalb ist es ständig von reiner Luft umgeben."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/25.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/25.ts
@@ -47,7 +47,7 @@ const card: Card = {
 			name: {
 				en: "(+) Spark",
 				fr: "Étincelle (+)",
-				de: "(+) Funke"
+				de: "⊕ Funke"
 			},
 			effect: {
 				en: "If Plusle is on your Bench, this attack does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
@@ -77,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "It cheers on friends. If its friends are losing, its body lets off more and more sparks.",
+		de: "Es feuert Freunde an. Sind diese im Begriff zu verlieren, gibt sein Körper immer mehr Funken ab."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/26.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/26.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Omanyte",
 		fr: "Amonita",
+		de: "Amonitas"
 	},
 
 	stage: "Stage2",
@@ -78,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "It is thought that this Pokémon became extinct because its spiral shell grew too large.",
+		de: "Man geht davon aus, dass das PKMN ausgestorben ist, weil seine spiralförmige Schale zu groß wurde."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/27.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/27.ts
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy card attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, défaussez une carte Énergie attachée au Pokémon Défenseur.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" lege 1 Energiekarte, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
+				de: "Wirf 1 Münze. Bei „Kopf“ lege 1 Energiekarte, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
 			},
 			damage: 30,
 
@@ -73,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon that lives in warm seas. It inflates the flotation sac on its head to drift and search for food.",
+		de: "Es lebt in warmen Meeren. Geht es auf Nahrungssuche, füllt es den Beutel auf seinem Kopf mit Luft."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/28.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/28.ts
@@ -50,7 +50,7 @@ const card: Card = {
 			name: {
 				en: "(-) Boost",
 				fr: "Boost (-)",
-				de: "(-) Aufladung"
+				de: "⊖ Aufladung"
 			},
 			effect: {
 				en: "If Minun is on your Bench, this attack does 20 damage plus 20 more damage.",
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It cheers on friends with pom-poms made of sparks. It drains power from telephone poles.",
+		de: "Es feuert Freunde mit Pompons an, die aus Funken bestehen. Es holt sich Energie aus Telegrafenmasten."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/29.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/29.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Scyther",
 		fr: "Insécateur",
+		de: "Sichlor"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "If the Defending Pokémon has any Special Energy cards attached to it, this attack does 30 damage plus 50 more damage.",
 				fr: "Si le Pokémon Défenseur possède des cartes Énergie Spéciale, cette attaque inflige 30 dégâts plus 50 dégâts supplémentaires.",
-				de: "Wenn am Verteidigendem Pokémon mindestens 1 Spezialenergiekarte angelegt ist, fügt dieser Angriff 30 Schadenspunkte plus 50 weitere Schadenspunkte zu."
+				de: "Wenn am Verteidigenden Pokémon mindestens 1 Spezialenergiekarte angelegt ist, fügt dieser Angriff 30 Schadenspunkte plus 50 weitere Schadenspunkte zu."
 			},
 			damage: "30+",
 
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 50 damage plus 40 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 50 dégâts plus 40 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei 'Kopf' fügt dieser Angriff 50 Schadenspunkte plus 40 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 50 Schadenspunkte plus 40 weitere Schadenspunkte zu."
 			},
 			damage: "50+",
 
@@ -87,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It has a steel-hard body. It intimidates foes by upraising its eye-patterned pincers.",
+		de: "Sein Körper ist stahlhart. Es bedroht seine Gegner, indem es die Augen auf seinen Scheren zeigt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/3.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/3.ts
@@ -98,6 +98,7 @@ const card: Card = {
 
 	description: {
 		en: "It can lull people to sleep and make them dream. It is active during nights of the new moon.",
+		de: "Es kann andere in Schlaf versetzen und ihnen Träume geben. Es ist nur bei Neumond aktiv."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/30.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/30.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Grotle",
 		fr: "Boskara",
+		de: "Chelcarain"
 	},
 
 	stage: "Stage2",
@@ -82,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "Groups of this Pokémon migrating in search of water have been mistaken for \"moving forests.\"",
+		de: "Gruppen dieser PKMN, die auf der Suche nach Wasser umherlaufen, werden „Wandernder Wald“ genannt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/31.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/31.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Croagunk",
 		fr: "Cradopaud",
+		de: "Glibunkel"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "The Defending Pokémon is now Poisoned. Flip a coin. If heads, the Defending Pokémon is now Paralyzed and Poisoned.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné. Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé et Empoisonné.",
-				de: "Das Verteidigende Pokémon ist jetzt vergiftet. Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt und vegiftet."
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet. Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt und vergiftet."
 			},
 			damage: 20,
 
@@ -76,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "The toxin made in its poison sacs is pumped to the knuckle claws through tubes down its arms.",
+		de: "Das Gift aus seinen Backentaschen wird über zwei Venen in seinen Armen zu den Fingergelenken gepumpt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/32.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/32.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Evoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Each of your Pokémon that evolves from Eevee has no Weakness, and that Pokémon's Retreat Cost is 0.",
 				fr: "Chacun de vos Pokémon évoluant d'Evoli ne possède pas de Faiblesse et a un Coût de retraite de 0.",
-				de: "Jedes deiner Pokémon, das sich aus Evoli entwickelt hat, hat keine Schwäche mehr, und Rückzugskosten 0."
+				de: "Jedes deiner Pokémon, das sich aus Evoli entwickelt, hat keine Schwäche mehr und hat Rückzugskosten 0."
 			},
 		},
 	],
@@ -56,7 +57,7 @@ const card: Card = {
 			name: {
 				en: "Confuse Ray",
 				fr: "Onde folie",
-				de: "Konfusstrahl"
+				de: "Konfustrahl"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Confused.",
@@ -86,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "The light of the moon changed Eevee's genetic structure. It lurks in darkness for prey.",
+		de: "Mondlicht hat die genetische Struktur von EVOLI verändert. Im Dunkeln wartet es auf Beute."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/33.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/33.ts
@@ -50,7 +50,7 @@ const card: Card = {
 			effect: {
 				en: "Each player discards the top card of his or her deck. This attack does 20 damage plus 20 more damage for each Unown discarded in this way.",
 				fr: "Chaque joueur défausse la carte du dessus de son deck. Cette attaque inflige 20 dégâts plus 20 dégâts supplémentaires pour chaque Zarbi défaussée de cette façon.",
-				de: "Jeder Spieler legt die oberste Karte seines Decks auf den Ablagestapel. Dieser Angriff fügt 20 Schadenspunkte plus 20 weitere Schadenspunkte für jede Icognito-Karte, die auf diese Weise abgelegt wurde, zu."
+				de: "Jeder Spieler legt die oberste Karte seines Decks auf seinen Ablagestapel. Dieser Angriff fügt 20 Schadenspunkte plus 20 weitere Schadenspunkte für jede Icognito-Karte, die auf diese Weise auf den Ablagestapel gelegt wurde, zu."
 			},
 			damage: "20+",
 
@@ -67,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "Shaped like ancient writing, it is a huge mystery whether language or Unown came first.",
+		de: "Seine Form sieht aus wie antike Schrift. Was war zuerst da? Die Sprache oder ICOGNITO?"
 	},
 
 	variants: [

--- a/data/Diamond & Pearl/Majestic Dawn/34.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/34.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Evoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin until you get tails. For each heads, discard an Energy card attached to the Defending Pokémon.",
 				fr: "Lancez une pièce jusqu'à ce que vous obteniez pile. Pour chaque face, défaussez une carte Énergie attachée au Pokémon Défenseur.",
-				de: "Wirf so lange 1 Münze, bis zum ersten Mal das Ergebnis \"Zahl\" kommt. Lege pro \"Kopf\" eine an das Verteidigende Pokémon angelegte Energiekarte auf den Ablagestapel deines Gegners."
+				de: "Wirf so lange 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Lege pro „Kopf“ eine an das Verteidigende Pokémon angelegte Energiekarte auf den Ablagestapel deines Gegners."
 			},
 			damage: 60,
 
@@ -80,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "It has evolved to be suitable for aquatic life. It can invisibly melt away into water.",
+		de: "Es hat sich so entwickelt, dass es im Wasser leben kann. Im Wasser selbst wird es unsichtbar."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/35.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/35.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Aipom",
 		fr: "Capumain",
+		de: "Griffel"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Choose 1 card from your opponent's hand without looking. Look at that card you chose, then have your opponent shuffle that card into his or her deck.",
 				fr: "Choisissez sans regarder une carte de la main de votre adversaire. Regardez-la et demandez à votre adversaire de mélanger cette carte à son deck.",
-				de: "Wähle eine Karte deines Gegners (ohne sie vorher anzusehen). Schau dir die Karte an, danach mischt dein Gegner sie in sein Deck."
+				de: "Wähle 1 Karte von der Hand deines Gegners (ohne sie vorher anzusehen). Schau dir die Karte an, danach mischt dein Gegner sie in sein Deck."
 			},
 			damage: 20,
 
@@ -63,7 +64,7 @@ const card: Card = {
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Choisissez 1 des Pokémon de votre adversaire. Cette attaque lui inflige 40 dégâts. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Wähle ein Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 40 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 40 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -80,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "To eat, it deftly shucks nuts with its two tails. It rarely uses its arms now.",
+		de: "Wenn es hungrig ist, knackt es Nüsse mit seinen beiden Schweifen. Nur selten verwendet es die Arme."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/36.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/36.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Spearow",
 		fr: "Piafabec",
+		de: "Habitak"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20x",
 
@@ -81,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It has the stamina to fly all day on its broad wings. It fights by using its sharp beak.",
+		de: "Es hat genügend Ausdauer, den ganzen Tag zu fliegen. Sein scharfer Schnabel dient als Waffe."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/37.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/37.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Turtwig",
 		fr: "Tortipouss",
+		de: "Chelast"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Attach a Grass Energy card from your hand to 1 of your Pokémon.",
 				fr: "Attachez une carte Énergie Grass de votre main à 1 de vos Pokémon.",
-				de: "Lege 1 -Energiekarte von deiner Hand an 1 deiner Pokémon an."
+				de: "Lege 1 {G}-Energiekarte von deiner Hand an 1 deiner Pokémon an."
 			},
 			damage: 20,
 
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 40,
 
@@ -87,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "The shell is hardened soil. Some Pokémon come to peck the berries growing on the trees on its back.",
+		de: "Seine Schale ist harter Lehm. PKMN naschen von den Beeren in den Bäumen auf seinem Rücken."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/38.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/38.ts
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 4 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 4 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 4 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl 'Kopf' zu."
+				de: "Wirf 4 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20x",
 
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "It raises its offspring in its belly pouch. It lets the baby out to play only when it feels safe.",
+		de: "Sein Nachwuchs wächst in seinem Beutel heran. Nur wenn es sicher ist, darf das Junge aus dem Beutel."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/39.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/39.ts
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl 'Kopf' zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20x",
 
@@ -73,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "Instead of hands, it uses its tongue, which is twice its height. Its sticky saliva grips anything.",
+		de: "Es umklammert Dinge mit seiner dehnbaren Zunge. Kommt man ihm zu nahe, wird man eingespeichelt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/4.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/4.ts
@@ -44,7 +44,7 @@ const card: Card = {
 			name: {
 				en: "Time Shift",
 				fr: "Modification temporelle",
-				de: 'Zeitverschiebung'
+				de: "Adamant-Orb"
 			},
 			effect: {
 				en: "Draw cards until you have 6 cards in your hand.",
@@ -63,12 +63,12 @@ const card: Card = {
 			name: {
 				en: "Diamond Blast",
 				fr: "Explosion diamant",
-				de: 'Diamantschuss'
+				de: "Zeitverschiebung"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 60 damage plus 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 60 dégâts plus 20 dégâts supplémentaires.",
-				de: 'Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 60 Schadenspunkte plus 20 weitere Schadenspunkte zu. '
+				de: "Ziehe so viele Karten, bis du 6 Karten auf der Hand hast."
 			},
 			damage: "60+",
 

--- a/data/Diamond & Pearl/Majestic Dawn/40.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/40.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Electrike",
 		fr: "Dynavolt",
+		de: "Frizelbliz"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 30,
 
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy attached to Manectric and this attack does 40 damage plus 30 more damage.",
 				fr: "Lancez une pièce. Si c'est face, défaussez une Énergie attachée à Elecsprint et cette attaque inflige 40 dégâts plus 30 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei 'Kopf' lege 1 Energie, die an Voltenso angelegt ist, auf deinen Ablagestapel und dieser Angriff fügt 40 Schadenpunkte plus 30 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ lege 1 Energie, die an Voltenso angelegt ist, auf deinen Ablagestapel und dieser Angriff fügt 40 Schadenspunkte plus 30 weitere Schadenspunkte zu."
 			},
 			damage: "40+",
 
@@ -84,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "It discharges electricity from its mane. It creates a thundercloud overhead to drop lightning bolts.",
+		de: "Aus seiner Mähne entlädt es Elektrizität. Es generiert eine Gewitterwolke, aus der es Blitze entlädt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/41.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/41.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Chimchar",
 		fr: "Ouisticram",
+		de: "Panflam"
 	},
 
 	stage: "Stage1",
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 damage plus 30 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts plus 30 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 30 Schadenspunkte plus 30 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 Schadenspunkte plus 30 weitere Schadenspunkte zu."
 			},
 			damage: "30+",
 
@@ -77,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "It uses ceilings and walls to launch aerial attacks. Its fiery tail is but one weapon.",
+		de: "Es stürzt sich von Decken und Wänden auf Beute. Sein feuriger Schweif ist nur eine seiner Waffen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/42.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/42.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Burmy",
 		fr: "Cheniti",
+		de: "Burmy"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Any damage done by attacks from your Pokémon to the Defending Pokémon isn't affected by Resistance.",
 				fr: "Tous dégâts infligés par des attaques de vos Pokémon sur le Pokémon Défenseur ne sont pas affectés par la Résistance.",
-				de: "Schaden, der den Verteigigenden Pokémon durch deine Pokémon zugefügt wird, wird nicht durch Resistenz verändert."
+				de: "Schaden, der den Verteidigenden Pokémon durch deine Pokémon zugefügt wird, wird durch Resistenz nicht verändert."
 			},
 		},
 	],
@@ -77,7 +78,7 @@ const card: Card = {
 			effect: {
 				en: "You may switch Mothim with 1 of your Benched Pokémon. If you do, move as many Energy cards attached to Mothim as you like to the new Active Pokémon.",
 				fr: "Vous pouvez échanger Papilord avec 1 des Pokémon de votre Banc. Déplacez alors sur le nouveau Pokémon Actif autant de cartes Énergie attachées à Papilord que vous le voulez.",
-				de: "Du kannst Moterpel gegen 1 Pokémon auf deiner Bank austauschen. Wenn du das machst, kannst du eine belibige Anzahl an Moterpel angelegter Energiekarten entfernen, und an das neue Aktive Pokémon anlegen."
+				de: "Du kannst Moterpel gegen 1 Pokémon auf deiner Bank austauschen. Wenn du das machst, kannst du eine beliebige Anzahl an Moterpel angelegter Energiekarten entfernen und an das neue Aktive Pokémon anlegen."
 			},
 			damage: 40,
 
@@ -100,6 +101,7 @@ const card: Card = {
 
 	description: {
 		en: "It loves the honey of flowers and steals honey collected by Combee.",
+		de: "Es liebt Honig und stiehlt den Honig, der von WADRIBIE gesammelt wurde."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/43.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/43.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Search your discard pile for a Lightning Energy card, show it to your opponent, and put it into your hand.",
 				fr: "Cherchez dans votre pile de défausse une carte Énergie Fighting, montrez-la à votre adversaire et placez-la dans votre main.",
-				de: "Durchsuche deinen Ablagestapel nach 1 -Energiekarte, zeige sie deinem Gegner und nimm sie auf die Hand."
+				de: "Durchsuche deinen Ablagestapel nach 1 {L}-Energiekarte, zeige sie deinem Gegner und nimm sie auf die Hand."
 			},
 
 		},
@@ -53,7 +53,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 30,
 
@@ -78,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "It makes electricity with pouches in its cheeks and shoots charges from its tail. It lives atop trees.",
+		de: "In seinen Backentaschen produziert es Elektrizität und entlädt sie über den Schweif. Es lebt in Baumwipfeln."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/44.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/44.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Piplup",
 		fr: "Tiplouf",
+		de: "Plinfa"
 	},
 
 	stage: "Stage1",
@@ -80,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Its wings deliver wicked blows that snap even the thickest of trees. It searches for prey in icy seas.",
+		de: "Seine Flügel schlagen so kräftig zu, dass es sogar Bäume umknicken kann. Im Eismeer sucht es Beute."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/45.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/45.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pikachu",
 		fr: "Pikachu",
+		de: "Pikachu"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Raichu during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, prévenez tous les effets d'une attaque, dégâts inclus, infligés à Raichu lors du prochain tour de votre adversaire.",
-				de: "Wirf 1 Münze. Bei 'Kopf' verhindere wärend des nächsten Zuges deines Gegners alle Effekte eines Angriffs, einschließlich Schaden, die Raichu zugefügt würden."
+				de: "Wirf 1 Münze. Bei „Kopf“ verhindere während des nächsten Zuges deines Gegners alle Effekte eines Angriffs, einschließlich Schaden, die Raichu zugefügt würden."
 			},
 			damage: 20,
 
@@ -85,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "It can loose 100,000-volt bursts of electricity, instantly downing foes several times its size.",
+		de: "Es kann 100.000 Volt mit einem Schlag freisetzen und so viel größere Gegner besiegen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/46.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/46.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. If 1 of them is heads, this attack does 10 damage plus 10 more damage. If 2 of them are heads, this attack does 10 damage plus 20 more damage. If all of them are heads, this attack does 10 damage plus 40 more damage.",
 				fr: "Lancez 3 pièces. Si l'une est face, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires. Si deux sont faces, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires. Si ce ne sont que des faces, cette attaque inflige 10 dégâts plus 40 dégâts supplémentaires.",
-				de: "Wirf 3 Münzen. Bei 1 Mal \"Kopf\" fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu. Bei 2 Mal \"Kopf\" fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu. Bei 3 Mal \"Kopf\" fügt dieser Angriff 10 Schadenspunkte plus 40 weitere Schadenspunkte zu."
+				de: "Wirf 3 Münzen. Bei 1 Mal „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu. Bei 2 Mal „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu. Bei 3 Mal „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 40 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -77,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "It is nearly impossible to parry its attacking scythes. Its movements are like a ninja's.",
+		de: "Es ist fast unmöglich, seinen Sensen auszuweichen, da es mit der Schnelligkeit eines Ninja zuschlägt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/47.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/47.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Starly",
 		fr: "Étourmi",
+		de: "Staralili"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 30 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 30 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei 'Kopf' fügt dieser Angriff 10 Schadenspunkte plus 30 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 30 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -81,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives in forests and fields. Squabbles over territory occur when flocks collide.",
+		de: "Es lebt in Wäldern und auf Wiesen. Treffen Schwärme aufeinander, streiten sie sich um das Revier."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/48.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/48.ts
@@ -56,7 +56,7 @@ const card: Card = {
 			effect: {
 				en: "Sudowoodo does 30 damage to itself.",
 				fr: "Simularbre s'inflige 30 dégâts.",
-				de: "Mogelbaum fügt sich slebst 30 Schadenspunkte zu."
+				de: "Mogelbaum fügt sich selbst 30 Schadenspunkte zu."
 			},
 			damage: 50,
 
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "It stands along paths pretending to be a tree. If it starts raining, it seems to disappear.",
+		de: "Es steht an Pfaden und tut so, als sei es ein Baum. Im Regen scheint es zu verschwinden."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/49.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/49.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), if Unown Q is on your Bench, you may discard all cards attached to Unown Q and attach Unown Q to 1 of your Pokémon as a Pokémon Tool card. As long as Unown Q is attached to a Pokémon, you pay Colorless less to retreat that Pokémon.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), si Zarbi Q est sur votre Banc, vous pouvez défausser toutes les cartes qui lui sont attachées et attachez Zarbi Q à 1 de vos Pokémon comme carte Outil Pokémon. Tant que Zarbi Q est attachée à 1 Pokémon, vous payez 1 Colorless de moins pour le faire battre en retraite.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn Icignito Q auf deiner Bank ist, alle Karten die an Icognito Q angelegt sind, auf deinen Ablagestapel legen und Icognito Q an 1 deiner Pokémon als Pokémon-Ausrüstung anlegen. Solange Icognito Q an ein Pokémon angelegt ist, bezahlst du  weniger, um dieses Pokémon zurückzuziehen."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn Icognito Q auf deiner Bank ist, alle Karten, die an Icognito Q angelegt sind, auf deinen Ablagestapel legen und Icognito Q an 1 deiner Pokémon als Pokémon-Ausrüstung anlegen. Solange Icognito Q an ein Pokémon angelegt ist, bezahlst du {C} weniger, um dieses Pokémon zurückzuziehen."
 			},
 		},
 	],
@@ -61,6 +61,7 @@ const card: Card = {
 
 	description: {
 		en: "Shaped like ancient writing, it is a huge mystery whether language or Unown came first.",
+		de: "Seine Form sieht aus wie antike Schrift. Was war zuerst da? Die Sprache oder ICOGNITO?"
 	},
 
 	variants: [

--- a/data/Diamond & Pearl/Majestic Dawn/5.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/5.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Evoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Glaceon during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, prévenez tous les effets d'une attaque, dégâts inclus, infligés à Givrali lors du prochain tour de votre adversaire.",
-				de: "Wirf 1 Münze. Bei 'Kopf' verhindere während des nächsten Zuges deines Gegners alle Effekte eines Angriffs, einschließlich Schaden, die Glaziola zugefügt würden."
+				de: "Wirf 1 Münze. Bei „Kopf“ verhindere während des nächsten Zuges deines Gegners alle Effekte eines Angriffs, einschließlich Schaden, die Glaziola zugefügt würden."
 			},
 			damage: 30,
 
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "This attack's damage isn't affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Faiblesse, la Résistance, les Poké-Powers, les Poké-Bodies ou tout autre effet sur le Pokémon Défenseur.",
-				de: "Resistenz, Poké-Power, Poké-Body und alle anderen Effekte auf dem Verteidigendem Pokémon haben keine Auswirkungen auf die Schadenspunkte dieses Angriffs."
+				de: "Resistenz, Poké-Power, Poké-Body und alle anderen Effekte auf dem Verteidigenden Pokémon haben keine Auswirkungen auf die Schadenspunkte dieses Angriffs."
 			},
 			damage: 60,
 
@@ -80,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "As a protective technique, it can completely freeze its fur to make its hairs stand like needles.",
+		de: "Will es sich schützen, kann es sein Fell gefrieren, so dass jedes Haar wie eine Nadel absteht."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/50.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/50.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Draw a card.",
 				fr: "Piochez une carte.",
-				de: "Ziehe eine Karte."
+				de: "Ziehe 1 Karte."
 			},
 
 		},
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Return Aipom and all cards attached to it to your hand. (If you don't have any Benched Pokémon, this attack does nothing.)",
 				fr: "Reprenez Capumain dans votre main ainsi que toutes les cartes qui lui sont attachées. (Si vous ne possédez pas de Pokémon de Banc, cette attaque est sans effet.)",
-				de: "Nimm Griffel und alle an es angelegten Karten zurück auf die Hand. (Dieser Angriff hat keine Auswirkungen, wenn du keine Pokémon auf der Bank hast.)"
+				de: "Nimm Griffel und alle daran angelegten Karten zurück auf die Hand. (Dieser Angriff hat keine Auswirkungen, wenn du keine Pokémon auf deiner Bank hast.)"
 			},
 			damage: 20,
 
@@ -73,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives atop giant trees. It wraps its tail around a branch so it won't fall off while asleep.",
+		de: "Es lebt in den Wipfeln von Riesenbäumen. Es wickelt seinen Schweif um einen Ast, um sich festzuhalten."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/51.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/51.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet.",
-				de: "Wirf 1 Münze. Bei 'Zahl' hat dieser Angriff keine Auswirkungen."
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 30,
 
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "It uses its tail to pluck fruits that are out of reach. Its tail is more adept than its real hands.",
+		de: "Mit seinem Schweif pflückt es hochhängende Früchte. Mit ihm ist es geschickter als mit den Händen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/52.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/52.ts
@@ -49,12 +49,12 @@ const card: Card = {
 			name: {
 				en: "Confuse Ray",
 				fr: "Onde folie",
-				de: "Konfusstrahl"
+				de: "Konfustrahl"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt verwirrt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: 10,
 
@@ -79,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "X-ray photos were taken to check its body structure. Nothing appeared, however.",
+		de: "Man hat Röntgenaufnahmen gemacht, um die Körperstruktur dieses PKMN zu untersuchen. Ohne Ergebnis."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/53.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/53.ts
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "When it senses danger, it perks up its ears. On cold nights, it sleeps with its head tucked into its fur.",
+		de: "Nimmt es Gefahr wahr, richtet es seine Ohren auf. In kalten Nächten vergräbt es den Kopf in seinem Fell."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/54.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/54.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Burmy Sandy Cloak during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, prévenez tous les effets d'une attaque, dégâts inclus, infligés à Cheniti Cape Sable lors du prochain tour de votre adversaire.",
-				de: "Wirf 1 Münze. Bei 'Kopf' verhindere während des nächsten Zuges deines Gegners alle effekte eines Angriffs, einschließlich Schaden, die Burmy Sandumhang zugefügt würden."
+				de: "Wirf 1 Münze. Bei „Kopf“ verhindere während des nächsten Zuges deines Gegners alle Effekte eines Angriffs, einschließlich Schaden, die Burmy Sandumhang zugefügt würden."
 			},
 
 		},
@@ -69,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "If its cloak is broken in battle, it quickly remakes the cloak with materials nearby.",
+		de: "Wird sein Umhang im Kampf zerstört, macht es sich schnell aus dem, was es findet, einen neuen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/55.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/55.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "It can learn and speak human words. If they gather, they all learn the same saying.",
+		de: "Es kann die menschliche Sprache lernen. Versammeln sie sich, bringen sie sich alle dasselbe bei."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/56.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/56.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet.",
-				de: "Wirf 1 Münze. Bei 'Zahl' hat dieser Angriff keine Auswirkungen."
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 40,
 
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "Its fiery rear end is fueled by gas made in its belly. Even rain can't extinguish the fire.",
+		de: "Das Feuer an seinem Hinterteil wird durch Gase im Bauch genährt. Selbst Regen löscht es nicht."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/57.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/57.ts
@@ -44,12 +44,12 @@ const card: Card = {
 			name: {
 				en: "Fury Swipes",
 				fr: "Combo-griffe",
-				de: 'Kratzfurie'
+				de: "Amrenabeere"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl 'Kopf' zu. "
+				de: "Wenn Panflam gelähmt ist, entferne am Ende jedes Zuges den Speziellen Zustand „gelähmt“ von Panflam."
 			},
 			damage: "10x",
 

--- a/data/Diamond & Pearl/Majestic Dawn/58.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/58.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts à chacun des Pokémon de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff allen Pokémon deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff allen Pokémon deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -69,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "It emits cries by agitating an orb at the back of its throat. It moves with flouncing hops.",
+		de: "Es ruft, indem es eine Kugel in seiner Kehle bewegt. Es bewegt sich mit eiligen Hopsern fort."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/59.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/59.ts
@@ -79,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "It collects and delivers honey to its colony. At night, they cluster to form a beehive and sleep.",
+		de: "Es sammelt Honig und bringt ihn in seine Kolonie. Nachts bilden sie einen Bienenstock und schlafen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/6.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/6.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Kabuto",
 		fr: "Kabuto",
+		de: "Kabuto"
 	},
 
 	stage: "Stage2",
@@ -79,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It is thought that this Pokémon came onto land because its prey adapted to life on land.",
+		de: "Man geht davon aus, dass dieses PKMN an Land kam, weil seine Beute ebenfalls irgendwann an Land lebte."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/60.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/60.ts
@@ -51,7 +51,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Empoisonné.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt vergiftet."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet."
 			},
 
 		},
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "Inflating its poison sacs, it makes an eerie blubbering sound for intimidation.",
+		de: "Wenn es seine giftigen Backen aufbläst, hört man ein unheimliches Geräusch, welches Gegner ängstigt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/61.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/61.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, put any 1 card from your discard pile into your hand.",
 				fr: "Lancez une pièce. Si c'est face, placez dans votre main n'importe quelle carte de votre pile de défausse.",
-				de: "Wirf 1 Münze. Bei 'Kopf' wähle 1 Karte aus deinem Ablagestapel und nimm sie auf die Hand."
+				de: "Wirf 1 Münze. Bei „Kopf“ wähle 1 Karte aus deinem Ablagestapel und nimm sie auf deine Hand."
 			},
 
 		},
@@ -47,12 +47,12 @@ const card: Card = {
 			name: {
 				en: "Reaction",
 				fr: "Réagir",
-				de: "Reaction"
+				de: "Reaktion"
 			},
 			effect: {
 				en: "Switch Drifloon with 1 of your Benched Pokémon.",
 				fr: "Échangez Baudrive avec 1 des Pokémon de votre Banc.",
-				de: "Tausche Driftlon gegen 1 Pokémon auf diener Bank aus."
+				de: "Tausche Driftlon gegen 1 Pokémon auf deiner Bank aus."
 			},
 			damage: 20,
 
@@ -77,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "It tugs on the hands of children to steal them away. However, it gets pulled around instead.",
+		de: "Es zieht Kinder an den Händen, um sie mitzunehmen. Doch stets wird es dabei durch die Gegend gezogen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/62.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/62.ts
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet.",
-				de: "Wirf 1 Münze. Bei 'Kopf' hat dieser Angriff keine Auswirkungen"
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 20,
 
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "A rare Pokémon that adapts to harsh environments by taking on different evolutionary forms.",
+		de: "Ein seltenes PKMN, das sich seiner Umgebung anpasst, indem es sich in unterschiedlicher Form entwickelt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/63.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/63.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			effect: {
 				en: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
 				fr: "Si le Pokémon Défenseur essaye d'attaquer lors du prochain tour de votre adversaire, celui-ci lance une pièce. Si c'est pile, cette attaque est sans effet.",
-				de: "Falls das Verteidigende Pokémon während des nächsen Zuges deines Gegners angreift, wirft dein Gegner eine Münze. Bei 'Kopf' hat dieser Angriff keine Auswirkungen."
+				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 
 		},
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "A rare Pokémon that adapts to harsh environments by taking on different evolutionary forms.",
+		de: "Ein seltenes PKMN, das sich seiner Umgebung anpasst, indem es sich in unterschiedlicher Form entwickelt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/64.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/64.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "Using electricity stored in its fur, it stimulates its muscles to heighten its reaction speed.",
+		de: "Die Elektrizität, die es im Fell speichert, nutzt es, um seine Muskeln zu stimulieren."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/65.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/65.ts
@@ -37,6 +37,7 @@ const card: Card = {
 	effect: {
 		en: "Search your deck for a Basic Pokémon and put it onto your Bench. Shuffle your deck afterward.",
 		fr: "Choisissez dans votre deck un Pokémon de base et placez-le sur votre Banc. Ensuite, mélangez votre deck.",
+		de: "Durchsuche dein Deck nach 1 Basis-Pokémon-Karte und lege sie auf deine Bank. Mische dein Deck danach."
 	},
 
 	attacks: [
@@ -72,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "With its sharp glare, it puts foes in a mild hypnotic state. It is a very fickle Pokémon.",
+		de: "Durch seinen scharfen Blick fallen seine Gegner in eine leichte Hypnose. Es ist sehr launenhaft."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/66.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/66.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei 'Kopf' fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "It enshrouds itself with sand to protect itself from germs. It does not enjoy getting wet.",
+		de: "Es bedeckt sich mit Sand, um sich vor Keimen zu schützen. Es mag es gar nicht, wenn es nass wird."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/67.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/67.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Dome Fossil",
 		fr: "Fossile Dôme",
+		de: "Domfossil"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may flip a coin. If heads, search your deck for Helix Fossil, Dome Fossil, or Old Amber and put it onto your Bench. Shuffle your deck afterward. This power can't be used if Kabuto is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez lancer une pièce. Si c'est face, cherchez Fossile Nautile, Fossile Dôme ou Vieil Ambre dans votre deck et placez-la sur votre Banc. Ensuite, mélangez votre deck. Ce pouvoir ne peut pas être utilisé si Kabuto est affecté par un État Spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 Münze werfen. Bei 'Kopf' durchsuche dein Deck nach 1 Helixfossil-, Domfossli- oder Altbernstein-Karte und lege sie auf deine Bank. Mische dein Deck danach. Diese Poké-Power kann nicht benutzt werden, wenn Kabuto von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 Münze werfen. Bei „Kopf“ durchsuche dein Deck nach 1 Helixfossil-, Domfossil- oder Altbernstein-Karte und lege sie auf deine Bank. Mische dein Deck danach. Diese Poké-Power kann nicht benutzt werden, wenn Kabuto von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -73,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "It is thought to have inhabited beaches 300 million years ago. It is protected by a stiff shell.",
+		de: "Man geht davon aus, dass dieses PKMN vor 300 Millionen Jahren die Strände bevölkerte."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/68.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/68.ts
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -73,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "It hides food under its long body hair. However, it forgets it has hidden the food.",
+		de: "Unter seinem langen Fell versteckt es Nahrung. Aber es vergisst, dass es sie dort versteckt hat."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/69.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/69.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Helix Fossil",
 		fr: "Fossile Nautile",
+		de: "Helixfossil"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may flip a coin. If heads, search your discard pile for Helix Fossil, Dome Fossil, or Old Amber and put it onto your Bench. This power can't be used if Omanyte is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez lancer une pièce. Si c'est face, cherchez Fossile Nautile, Fossile Dôme ou Vieil Ambre dans votre deck et placez-la sur votre Banc. Ce pouvoir ne peut pas être utilisé si Amonita est affecté par un État Spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 Münze werfen. Bei \"Kopf\" durchsuche dein Deck nach 1 Helixfossil-, Domfossil- oder Altbernstein-Karte und lege sie auf deine Bank. Mische dein Deck danach. Diese Poké-Power kannst nicht benutzt werden, wenn Amonitas von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 Münze werfen. Bei „Kopf“ durchsuche deinen Ablagestapel nach 1 Helixfossil-, Domfossil- oder Altbernstein-Karte und lege sie auf deine Bank. Diese Poké-Power kann nicht benutzt werden, wenn Amonitas von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -78,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon that was resurrected from a fossil using modern science. It swam in ancient seas.",
+		de: "Dieses PKMN wurde von der modernen Wissenschaft aus einem Fossil geschaffen. Es lebte im urzeitlichen Meer."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/7.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/7.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Evoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -87,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Just like a plant, it uses photosynthesis. As a result, it is always enveloped in clear air.",
+		de: "Genau wie ein Pflanze führt es die Photosynthese aus. Deshalb ist es ständig von reiner Luft umgeben."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/70.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/70.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "If it looses crackling power from the electric pouches on its cheeks, it is being wary.",
+		de: "Ist es angespannt, setzt es knisternd Elektrizität aus seinen Backentaschen frei."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/71.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/71.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei 'Kopf' fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives along shores in northern countries. A skilled swimmer, it dives for over 10 minutes to hunt.",
+		de: "Es lebt an den Küsten der nördlichen Länder. Es kann über 10 Minuten unter Wasser bleiben."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/72.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/72.ts
@@ -45,12 +45,12 @@ const card: Card = {
 			name: {
 				en: "Splatter",
 				fr: "Crépitement",
-				de: 'Verspritzer'
+				de: "Pirsifbeere"
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance.",
 				fr: "Choisissez 1 des Pokémon de votre adversaire. Cette attaque lui inflige 10 dégâts. Les dégâts de cette attaque ne sont pas affectés par la Faiblesse ou la Résistance.",
-				de: 'Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 10 Schadenspunkte zu. Der Schaden dieses angriffs wird durch Schwäche und Resistenz des gewählten Pokémon nicht verändert. '
+				de: "Wenn Plinfa vergiftet ist, entferne am Ende jedes Zuges den Speziellen Zustand „vergiftet“ von Plinfa."
 			},
 
 		}

--- a/data/Diamond & Pearl/Majestic Dawn/73.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/73.ts
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives along bodies of water. Its body shape changed to suit its habitat.",
+		de: "Es lebt in der Nähe von Wasser. Seine Körperform hat sich seiner Umgebung angepasst."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/74.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/74.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet.",
-				de: "Wirf 1 Münze. Bei 'Zahl' hat dieser Angriff keine Auswirkungen."
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 30,
 
@@ -77,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "It flaps its small wings busily to fly. Using its beak, it searches in grass for prey.",
+		de: "Im Flug schlägt es eifrig mit den Flügeln. Mit seinem Schnabel sucht es im Gras nach Beute."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/75.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/75.ts
@@ -77,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "Usually with a large flock, it is barely noticeable when alone. Its cries are very strident.",
+		de: "Normalerweise ist es immer im Schwarm unterwegs. Sein Ruf ist äußerst durchdringend."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/76.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/76.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Empoisonné.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt vergiftet."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet."
 			},
 
 		},
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "It sprays a nose-curling, stinky fluid from its rear to repel attackers.",
+		de: "Es versprüht eine übel stinkende Flüssigkeit aus seinem Hinterleib, um Angreifer zu verjagen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/77.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/77.ts
@@ -73,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "It undertakes photosynthesis with its body, making oxygen. The leaf on its head wilts if it is thirsty.",
+		de: "Sein Körper lebt von der Photosynthese, die Sauerstoff freisetzt. Ist es durstig welkt sein Blatt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/78.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/78.ts
@@ -45,7 +45,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
-				de: 'Biss'
+				de: "Persimbeere"
 			},
 			damage: 30,
 

--- a/data/Diamond & Pearl/Majestic Dawn/79.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/79.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card. Whenever any player attaches an Energy card from his or her hand to Grass Pokémon or Water Pokémon, remove 1 damage counter and all Special Conditions from that Pokémon.",
 		fr: "Lorsqu'un joueur attache une carte Énergie de sa main à un Pokémon Plante ou Eau, retirez à ce Pokémon 1 marqueur de dégât et tous ses États Spéciaux.",
-		de: "Jedes Mal, wenn ein Spieler eine Energiekarte von seiner Hand an ein - oder -Pokémon anlegt, entferne 1 Schadensmarke und alle Speziellen Zustände von diesem Pokémon.",
+		de: "Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadion-Karte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen. Jedes Mal, wenn ein Spieler eine Energiekarte von seiner Hand an ein {G}- oder {W}-Pokémon anlegt, entferne 1 Schadensmarke und alle Speziellen Zustände von diesem Pokémon.",
 	},
 
 	trainerType: "Stadium",

--- a/data/Diamond & Pearl/Majestic Dawn/8.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/8.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "When you attach a Water Energy card from your hand to Manaphy, remove 2 damage counters from Manaphy.",
 				fr: "Lorsque vous attachez une carte Énergie Water de votre main à Manaphy, retirez-lui 2 marqueurs de dégât.",
-				de: "Wenn du 1 -Energiekarte von deiner Hand an Manaphy anlegst, entferne 2 Schadensmarken von Manaphy."
+				de: "Wenn du 1 {W}-Energiekarte von deiner Hand an Manaphy anlegst, entferne 2 Schadensmarken von Manaphy."
 			},
 		},
 	],
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, search your deck for any 1 card and put it into your hand. Shuffle your deck afterward.",
 				fr: "Lancez une pièce. Si c'est face, choisissez 1 carte dans votre deck et placez-la dans votre main. Ensuite, mélangez votre deck.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" durchsuche dein Deck nach 1 Karte und nimm sie auf die Hand. Mische dein Deck danach."
+				de: "Wirf 1 Münze. Bei „Kopf“ durchsuche dein Deck nach 1 Karte und nimm sie auf die Hand. Mische dein Deck danach."
 			},
 
 		},
@@ -71,7 +71,7 @@ const card: Card = {
 			effect: {
 				en: "You may attach up to 2 basic Water Energy cards from your hand to your Benched Pokémon in any way you like.",
 				fr: "Vous pouvez attacher jusqu'à 2 cartes Énergie de base Water de votre main à vos Pokémon de Banc de la façon que vous voulez.",
-				de: "Du kannst bis zu 2 -Basis-Energiekarten von deiner Hand in beliebiger Verteilung an Pokémon auf deiner Bank anlegen."
+				de: "Du kannst bis zu 2 {W}-Basis-Energiekarten von deiner Hand in beliebiger Verteilung an Pokémon auf deiner Bank anlegen."
 			},
 			damage: 30,
 
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "Born on a cold seafloor, it will swim great distances to return to its birthplace.",
+		de: "Geboren auf dem Meeresboden, legt es große Entfernungen zurück, um dorthin zurückzukehren."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/81.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/81.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Flip 3 coins. For each heads, put a Basic Energy card from your discard pile into your hand. If you don't have that many basic Energy cards in your discard pile, put all of them into your hand.",
 		fr: "Lancez 3 pièces. Pour chaque face, placez une carte Énergie de base de votre pile de défausse dans votre main. Si vous ne possédez pas autant de cartes Énergie de base dans votre pile de défausse, placez-les toutes dans votre main.",
-		de: "Wirf 3 Münzen. Nimm für jedes Mal, wenn die Münze \"Kopf\" gezeigt hat, eine Basis-Energiekarte von deinem Ablagestapel auf deine Hand. Falls du nicht genug Basis-Energiekarten in deinem Ablagestapel hast, nimm so viele wie möglich auf die Hand."
+		de: "Wirf 3 Münzen. Nimm für jedes Mal, wenn die Münze „Kopf“ gezeigt hat, eine Basis-Energiekarte von deinem Ablagestapel auf deine Hand. Falls du nicht genug Basis-Energiekarten in deinem Ablagestapel hast, nimm so viele wie möglich auf deine Hand."
 	},
 
 	trainerType: "Item",

--- a/data/Diamond & Pearl/Majestic Dawn/82.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/82.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Search your deck or discard pile for a Trainer card that has Fossil in its name or a Stage 1 or Stage 2 Evolution card that evolves from a Fossil. Show it to your opponent and put it into your hand. If you searched your deck, shuffle your deck afterward.",
 		fr: "Choisissez dans votre deck ou votre pile de défausse une carte Dresseur dont le nom comporte Fossile ou une carte Évolution de Niveau 1 ou 2 qui évolue d'un Fossile. Montrez-la à votre adversaire et placez-la dans votre main. Si vous avez cherché dans votre deck, mélangez-le.",
-		de: "Durchsuche dein Deck oder deinen Ablagestapel nach 1 Trainerkarte mit Fossil im Namen oder einer Evolutionskarte der Phase 1 oder Phase 2, die sich aus einem Fossil entwickelt. Zeige sie deinem Gegner und nimm sie auf die Hand. Falls du dein Deck durchsucht hast, mische es danach.",
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Durchsuche dein Deck oder deinen Ablagestapel nach 1 Trainerkarte mit Fossil im Namen oder 1 Evolutionskarte der Phase 1 oder Phase 2, die sich aus einem Fossil entwickelt. Zeige sie deinem Gegner und nimm sie auf die Hand. Falls du dein Deck durchsucht hast, mische es danach.",
 	},
 
 	trainerType: "Supporter",

--- a/data/Diamond & Pearl/Majestic Dawn/83.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/83.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Draw 2 cards.",
 		fr: "Vous ne pouvez jouer qu'une seule carte Supporter par tour. Lorsque vous la jouez, placez-la à côté de votre Pokémon Actif. À la fin du tour, défaussez-la.",
-		de: "Ziehe 2 Karten."
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Ziehe 2 Karten."
 	},
 
 	trainerType: "Supporter",

--- a/data/Diamond & Pearl/Majestic Dawn/84.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/84.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "Play Old Amber as if it were a Colorless Basic Pokémon. (Old Amber counts as a Trainer card as well, but if Old Amber is Knocked Out, this counts as a Knocked Out Pokémon.) Old Amber can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Old Amber from play. (This doesn't count as a Knocked Out Pokémon.)",
 		fr: "Jouez Vieil Ambre comme si c'était un Pokémon de base Colorless. ( Vieil Ambre compte aussi comme une carte Dresseur mais si  Vieil Ambre est mise K.O, elle compte comme un Pokémon K.O.)  Vieil Ambre ne peut pas être affectée par des États Spéciaux et ne peut pas battre en retraite. N'importe quand lors de votre tour, avant votre attaque, vous pouvez défausser  Vieil Ambre. (Cela ne compte pas comme un Pokémon K.O).",
-		de: "Spiele Altbernstein wie ein -Basis-Pokémon. (Altbernstein zählt gleichzeitig als Trainerkarte, aber wenn Altbernstein kanfunfähig wird, zählt es als kampfunfähiges Pokémon.) Altbernstein kann nicht von Speziellen Zuständen betroffen werden und sich nicht zurückziehen. In deinem Zug (vor deinem Angriff) kannst du Altbernstein auf deinen Ablagestapel legen. (Dies zählt nicht als kampfunfähig gemachtes Pokémon.)"
+		de: "Spiele Altbernstein wie ein {C}-Basis-Pokémon. (Altbernstein zählt gleichzeitig als Trainerkarte, aber wenn Altbernstein kampfunfähig wird, zählt es als kampfunfähiges Pokémon.) Altbernstein kann nicht von Speziellen Zuständen betroffen werden und sich nicht zurückziehen. In deinem Zug (vor deinem Angriff) kannst du Altbernstein auf deinen Ablagestapel legen. (Dies zählt nicht als kampfunfähig gemachtes Pokémon.)"
 	},
 
 	trainerType: "Item",

--- a/data/Diamond & Pearl/Majestic Dawn/85.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/85.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Flip a coin. If heads, search your deck for a Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
 		fr: "Lancez une pièce. Si c'est face, choisissez un Pokémon dans votre deck, montrez-le à votre adversaire et placez-le dans votre main. Ensuite, mélangez votre deck.",
-		de: "Wirf 1 Münze. Bei \"Kopf\" durchsuche dein Deck nach einer Basis-Pokémon-Karte oder einer Evolutionskarte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
+		de: "Wirf 1 Münze. Bei „Kopf“ durchsuche dein Deck nach 1 Pokémon-Karte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 	},
 
 	trainerType: "Item",

--- a/data/Diamond & Pearl/Majestic Dawn/86.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/86.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Reveal cards from your deck until you reveal a Pokémon. Show that Pokémon to your opponent and put it into your hand. Shuffle the other revealed cards back into your deck. (If you don't reveal a Pokémon, shuffle all the revealed cards back into your deck.)",
 		fr: "Retournez des cartes de votre deck jusqu'à ce que vous retourniez un Pokémon. Montrez-le à votre adversaire et placez-le dans votre main. Mélangez les autres cartes à votre deck. (Si vous ne retournez pas de Pokémon, mélangez toutes les cartes retournées à votre deck.)",
-		de: "Decke solange Karten von deinem Deck auf, bis du eine Pokémon-Karte aufdeckst. Zeige die Pokémon-Karte deinem Gegner und nimm sie auf die Hand. Mische die übrigen aufgedeckten Karten zurück in dein Deck. (Falls du kein Pokémon-Karten aufgedeckt hast, mische alle aufgedeckten Karten zurück in dein Deck.)"
+		de: "Decke solange Karten von deinem Deck auf, bis du eine Pokémon-Karte aufdeckst. Zeige die Pokémon-Karte deinem Gegner und nimm sie auf die Hand. Mische die übrigen aufgedeckten Karten zurück in dein Deck. (Falls du keine Pokémon-Karte aufgedeckt hast, mische alle aufgedeckten Karten zurück in dein Deck.)"
 	},
 
 	trainerType: "Item",

--- a/data/Diamond & Pearl/Majestic Dawn/87.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/87.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Flip a coin. If heads, return 1 of your Pokémon and all cards attached to it to your hand.",
 		fr: "Lancez une pièce. Si c'est face, reprenez dans votre main 1 de vos Pokémon ainsi que toutes les cartes qui lui sont attachées.",
-		de: "Wirf 1 Münze. Nimm bei \"Kopf\" 1 deiner Pokémon und alle daran angelegten Karten zurück auf die Hand."
+		de: "Wirf 1 Münze. Nimm bei „Kopf“ 1 deiner Pokémon und alle daran angelegten Karten zurück auf die Hand."
 	},
 
 	trainerType: "Item",

--- a/data/Diamond & Pearl/Majestic Dawn/89.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/89.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "Play Dome Fossil as if it were a Colorless Basic Pokémon. (Dome Fossil counts as a Trainer card as well, but if Dome Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Dome Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Dome Fossil from play. (This doesn't count as a Knocked Out Pokémon.)",
 		fr: "Jouez Fossile Dôme comme si c'était un Pokémon de base Colorless. (Fossile Dôme compte aussi comme une carte Dresseur mais si Fossile Dôme est mise K.O, elle compte comme un Pokémon K.O.) Fossile Dôme ne peut pas être affectée par des États Spéciaux et ne peut pas battre en retraite. N'importe quand lors de votre tour, avant votre attaque, vous pouvez défausser Fossile Dôme. (Cela ne compte pas comme un Pokémon K.O).",
-		de: "Spiele Domfossil wie ein -Basis-Pokémon. (Domfossil zählt gleichzeitig als Trainerkarte, aber wenn Domfossil kampfunfähig wird, zählt es als kampfunfähiges Pokémon.) Domfossil kann nicht von Speziellen Zuständen betroffen werden und sich nicht zurückziehen. In deinem Zug (vor deinem Angriff) kannst du Domfossil auf deinen Ablagestapel legen. (Dies zählt nicht als kampfunfähig gemachtes Pokémon.)"
+		de: "Spiele Domfossil wie ein {C}-Basis-Pokémon. (Domfossil zählt gleichzeitig als Trainerkarte, aber wenn Domfossil kampfunfähig wird, zählt es als kampfunfähiges Pokémon.) Domfossil kann nicht von Speziellen Zuständen betroffen werden und sich nicht zurückziehen. In deinem Zug (vor deinem Angriff) kannst du Domfossil auf deinen Ablagestapel legen. (Dies zählt nicht als kampfunfähig gemachtes Pokémon.)"
 	},
 
 	trainerType: "Item",

--- a/data/Diamond & Pearl/Majestic Dawn/9.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/9.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Discard a Psychic Energy attached to Mewtwo and remove 6 damage counters from Mewtwo.",
 				fr: "Défaussez une Énergie Psychic attachée à Mewtwo et retirez-lui 6 marqueurs de dégât.",
-				de: "Lege 1 an Mewtu angelegte -Energie auf deinen Ablagestapel und entferne 6 Schadensmarken von Mewtu."
+				de: "Lege 1 an Mewtu angelegte {P}-Energie auf deinen Ablagestapel und entferne 6 Schadensmarken von Mewtu."
 			},
 
 		},
@@ -84,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon created by recombining Mew's genes. It's said to have the most savage heart among Pokémon.",
+		de: "Die Gene von MEW wurden neu angeordnet, wodurch dieses PKMN entstand. Es hat ein wildes Herz."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Majestic Dawn/92.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/92.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Call Energy provides Colorless Energy. Once during your turn, if the Pokémon Call Energy is attached to is your Active Pokémon, you may search your deck for up to 2 Basic Pokémon and put them onto your Bench. If you do, shuffle your deck and your turn ends.",
 		fr: "Appel à l'énergie fournit de l'Énergie Colorless. Une seule fois lors de votre tour, si le Pokémon auquel Appel à l'énergie est attachée est votre Pokémon Actif, vous pouvez choisir dans votre deck jusqu'à 2 Pokémon de base et les placer sur votre Banc. Mélangez alors votre deck. Votre tour est terminé.",
-		de: "Ruf-Energie liefert -Energie. Einmal während deines Zuges kannst du, wenn das Pokémon, an das Ruf-Energie angelegt ist, dein Aktives Pokémon ist, dein Deck nach bis zu 2 Basis-Pokémon-Karten durchsuchen und diese auf die Bank legen. Wenn du das machst, mische dein Deck und dein Zug ist beendet."
+		de: "Ruf-Energie liefert {C}-Energie. Einmal während deines Zuges kannst du, wenn das Pokémon, an das Ruf-Energie angelegt ist, dein Aktives Pokémon ist, dein Deck nach bis zu 2 Basis-Pokémon-Karten durchsuchen und diese auf deine Bank legen. Wenn du das machst, mische dein Deck und dein Zug ist beendet."
 	},
 
 	energyType: "Special",

--- a/data/Diamond & Pearl/Majestic Dawn/93.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/93.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect if the Pokémon that Darkness Energy is attached to isn't Darkness. Darkness Energy provides Darkness Energy. (Doesn't count as a basic Energy card.)",
 		fr: "Si le Pokémon auquel Énergie Obscurité est attachée attaque, cette attaque inflige 10 dégâts supplémentaires au Pokémon Actif (avant application de la Faiblesse et de la Résistance). Ignorez cet effet si le Pokémon auquel Énergie Obscurité est attachée n'est pas Darkness. Énergie Obscurité fournit de l'Énergie Darkness. (Elle ne compte pas comme carte Énergie de base).",
-		de: "Falls das Pokémon, an das Finsternis-Energie angelegt ist, angreift, fügt der Angriff den Aktiven Pokémon 10 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden). Dieser Effekt wirkt nur, wenn die Finsternis-Energie an einem Pokémon vom Typ  angelegt ist. Finsternis-Energie liefert -Energie. (Zählt nicht als Basis-Energiekarte.)"
+		de: "Falls das Pokémon, an das Finsternis-Energie angelegt ist, angreift, fügt der Angriff den Aktiven Pokémon 10 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden). Dieser Effekt wirkt nur, wenn die Finsternis-Energie an einem Pokémon vom Typ {D} angelegt ist. Finsternis-Energie liefert {D}-Energie. (Zählt nicht als Basis-Energiekarte.)"
 	},
 
 	energyType: "Special",

--- a/data/Diamond & Pearl/Majestic Dawn/94.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/94.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Health Energy provides Colorless Energy. When you attach this card from your hand to 1 of your Pokémon, remove 1 damage counter from that Pokémon.",
 		fr: "Énergie santé fournit de l'Énergie Colorless. Lorsque vous attachez cette carte de votre main à 1 de vos Pokémon, retirez-lui 1 marqueur de dégât.",
-		de: "Heil-Energie liefert -Energie. Wenn du diese Karte von deiner Hand an 1 deiner Pokémon anlegst, entferne 1 Schadensmarke von diesem Pokémon."
+		de: "Heil-Energie liefert {C}-Energie. Wenn du diese Karte von deiner Hand an 1 deiner Pokémon anlegst, entferne 1 Schadensmarke von diesem Pokémon."
 	},
 
 	energyType: "Special",

--- a/data/Diamond & Pearl/Majestic Dawn/95.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/95.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn't Metal. Metal Energy provides Metal Energy. (Doesn't count as a basic Energy card.)",
 		fr: "Les dégâts infligés par des attaques au Pokémon auquel Énergie Métal est attachée sont réduits de 10 (après application de la Faiblesse et de la Résistance). Ignorez cet effet si le Pokémon auquel Énergie Métal est attachée n'est pas Metal. Énergie Métal fournit de l'Énergie Metal. (Elle ne compte pas comme carte Énergie de base).",
-		de: "Schaden, der dem Pokémon, an das Metall-Energie angelegt ist, durch Angriffe zugefügt wird, wird um 10 reduziert (nachdem Schwäche und Resistenz verrechnet wurden). Dieser Effekt wirkt nur, wenn die Metall-Energie an einem Pokémon vom Typ  angelegt ist. Metall-Energie spendet -Energie. (Zählt nicht als Basis-Energiekarte.)"
+		de: "Schaden, der dem Pokémon, an das Metall-Energie angelegt ist, durch Angriffe zugefügt wird, wird um 10 reduziert (nachdem Schwäche und Resistenz verrechnet wurden). Dieser Effekt wirkt nur, wenn die Metall-Energie an einem Pokémon vom Typ {M} angelegt ist. Metall-Energie liefert {M}-Energie. (Zählt nicht als Basis-Energiekarte.)"
 	},
 
 	energyType: "Special",

--- a/data/Diamond & Pearl/Majestic Dawn/96.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/96.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Recover Energy provides Colorless Energy. When you attach this card from your hand to 1 of your Pokémon, remove all Special Conditions from that Pokémon.",
 		fr: "Énergie guérison fournit de l'Énergie Colorless. Lorsque vous attachez cette carte de votre main à 1 de vos Pokémon, retirez-lui tous ses États Spéciaux.",
-		de: "Erhol-Energie liefert -Energie. Wenn du diese Karte von deiner Hand an 1 deiner Pokémon anlegst, entferne alle Speziellen Zustände von diesem Pokémon."
+		de: "Erhol-Energie liefert {C}-Energie. Wenn du diese Karte von deiner Hand an 1 deiner Pokémon anlegst, entferne alle Speziellen Zustände von diesem Pokémon."
 	},
 
 	energyType: "Special",

--- a/data/Diamond & Pearl/Majestic Dawn/97.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/97.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), when you put Garchomp LV.X from your hand onto your Active Garchomp, you may flip 3 coins. For each heads, put 1 damage counter on each of your opponent's Benched Pokémon.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), lorsque vous placez Carchacrok LV.X  de votre main sur votre Carchacrok Actif, vous pouvez lancer 3 pièces. Pour chaque face, placez 1 marqueur de dégât sur chacun des Pokémon de Banc de votre adversaire.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn du Knakrack LV.X von deiner Hand auf dein aktives Knakrack legst, 3 Münzen werfen. Lege pro \"Kopf\" 1 Schadensmarke auf jedes Pokémon auf der Bank deines Gegners."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn du Knakrack LV.X von deiner Hand auf dein aktives Knakrack legst, 3 Münzen werfen. Lege pro „Kopf“ 1 Schadensmarke auf jedes Pokémon auf der Bank deines Gegners."
 			},
 		},
 	],
@@ -56,7 +56,7 @@ const card: Card = {
 			effect: {
 				en: "Search your discard pile for a Pokémon (excluding Pokémon LV.X) and put it onto your Bench as a Basic Pokémon. Then, you may search your discard pile for up to 3 basic Energy cards and attach them to that Pokémon.",
 				fr: "Choisissez un Pokémon dans votre pile de défausse (Pokémon LV.X exclus) et placez-le sur votre Banc comme un Pokémon de base. Ensuite, vous pouvez choisir dans votre pile de défausse jusqu'à 3 cartes Énergie de base et les attacher à ce Pokémon.",
-				de: "Durchsuche deinen Ablagestapel nach einer Pokémon-Karte (außer Pokémon LV.X) und lege sie als ein Basis-Pokémon auf deine Bank. Danach kannst du deinen Ablagestapel nach bis zu 3 Basis-Energiekarten durchsuchen und sie an dieses Pokémon anlegen."
+				de: "Durchsuche deinen Ablagestapel nach 1 Pokémon-Karte (außer Pokémon LV.X) und lege sie als ein Basis-Pokémon auf deine Bank. Danach kannst du deinen Ablagestapel nach bis zu 3 Basis-Energiekarten durchsuchen und sie an dieses Pokémon anlegen."
 			},
 
 		},

--- a/data/Diamond & Pearl/Majestic Dawn/98.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/98.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "As long as Glaceon is your Active Pokémon, your opponent's Pokémon can't use any Poké-Powers.",
 				fr: "Tant que Givrali est votre Pokémon Actif, les Pokémon de votre adversaire ne peuvent pas utiliser de Poké-Powers.",
-				de: "Solange Glaziola dein Aktives Pokémon ist, können gegneriche Pokémon keine Poké-Power benutzen."
+				de: "Solange Glaziola dein Aktives Pokémon ist, können gegnerische Pokémon keine Poké-Power benutzen."
 			},
 		},
 	],
@@ -56,7 +56,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts à chacun des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff allen Pokémon auf der Bank deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff allen Pokémon auf der Bank deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 70,
 

--- a/data/Diamond & Pearl/Majestic Dawn/99.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/99.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may attach an Energy card from your hand to 1 of your Pokémon. This power can't be used if Leafeon is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez attacher une carte Énergie de votre main à 1 de vos Pokémon. Ce pouvoir ne peut pas être utilisé si Phyllali est affecté par un État Spécial.",
-				de: "Einmal während deines Zuges(vor deinem Angriff) kannst du 1 Energiekarte von deiner Hand an 1 Pokémon anlegen. Diese POké-Power kann nciht benutzt werden, wenn Folipurba von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 Energiekarte von deiner Hand an 1 deiner Pokémon anlegen. Diese Poké-Power kann nicht benutzt werden, wenn Folipurba von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],


### PR DESCRIPTION
## Add missing German translations for dp5

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
