### PR TITLE
Add missing German translations for bw6

### DIFF
--- a/data/Black & White/Dragons Exalted/1.ts
+++ b/data/Black & White/Dragons Exalted/1.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Flail Around",
 				fr: "Fléau Bougeant",
+				de: "Rumrudern"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 10,
 
@@ -64,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "It drifts on winds. It is said that when Hoppip gather in fields and mountains, spring is on the way.",
+		de: "Es reitet auf dem Wind. Man sagt, wenn sich Hoppspross versammeln, kommt der Frühling bald."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/10.ts
+++ b/data/Black & White/Dragons Exalted/10.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Dig",
 				fr: "Tunnel",
+				de: "Schaufler"
 			},
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, évitez tous les effets d'attaques (y compris les dégâts) infligés à ce Pokémon pendant le prochain tour de votre adversaire.",
+				de: "Wirf 1 Münze. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die diesem Pokémon zugefügt werden."
 			},
 			damage: 10,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "It grows underground, sensing its surroundings using antennae instead of its virtually blind eyes.",
+		de: "Es wächst unterirdisch heran und nimmt seine Umgebung mit Antennen wahr, da es nahezu blind ist."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/100.ts
+++ b/data/Black & White/Dragons Exalted/100.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Aipom",
 		fr: "Capumain",
+		de: "Griffel"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Double Hit",
 				fr: "Coup Double",
+				de: "Doppelschlag"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Hand Fling",
 				fr: "Catapu-Main",
+				de: "Handwurf"
 			},
 			effect: {
 				en: "Does 10 damage times the number of cards in your hand.",
 				fr: "Inflige 10 dégâts multipliés par le nombre de cartes dans votre main.",
+				de: "Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl der Karten auf deiner Hand zu."
 			},
 			damage: 10,
 
@@ -78,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "Split into two, the tails are so adept at handling and doing things, Ambipom rarely uses its hands.",
+		de: "Es ist mit seinen beiden Schweifen so geschickt, dass es seine Hände nur noch selten gebraucht."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/101.ts
+++ b/data/Black & White/Dragons Exalted/101.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Smack 'n' Slack",
 				fr: "Raclée Dodo",
+				de: "Raufen und Ratzen"
 			},
 			effect: {
 				en: "This Pokémon is now Asleep.",
 				fr: "Ce Pokémon est maintenant Endormi.",
+				de: "Dieses Pokémon schläft jetzt."
 			},
 			damage: 10,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "It spends nearly all its time in a day sprawled out. Just seeing it makes one drowsy.",
+		de: "Es verbringt fast den ganzen Tag mit Faulenzen und Schlafen. Selbst sein Anblick macht bereits müde."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/102.ts
+++ b/data/Black & White/Dragons Exalted/102.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Slakoth",
 		fr: "Parecool",
+		de: "Bummelz"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Ambush",
 				fr: "Embuscade",
+				de: "Hinterhalt"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 40 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 40 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 40 weitere Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -63,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "Its heart beats at a tenfold tempo, so it cannot sit still for even a moment.",
+		de: "Sein Herz schlägt schneller als das anderer Lebewesen. Daher kann es nicht für einen Moment still sitzen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/103.ts
+++ b/data/Black & White/Dragons Exalted/103.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Vigoroth",
 		fr: "Vigoroth",
+		de: "Muntier"
 	},
 
 	stage: "Stage2",
@@ -66,10 +67,12 @@ const card: Card = {
 			name: {
 				en: "Crushing Blow",
 				fr: "Coup Écrasant",
+				de: "Brechschlag"
 			},
 			effect: {
 				en: "Discard an Energy attached to the Defending Pokémon.",
 				fr: "Défaussez une Énergie attachée au Pokémon Défenseur.",
+				de: "Lege 1 an das Verteidigende Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 100,
 
@@ -87,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "The world's laziest Pokémon. When it is lounging, it is actually saving energy for striking back.",
+		de: "Das faulste Pokémon der Welt. Wenn es faulenzt, sammelt es in Wahrheit Energie, um zuzuschlagen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/104.ts
+++ b/data/Black & White/Dragons Exalted/104.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Sing",
 				fr: "Berceuse",
+				de: "Gesang"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 
 		},
@@ -51,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Peck",
 				fr: "Picpic",
+				de: "Schnabel"
 			},
 
 			damage: 20,
@@ -76,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "It can't relax if it or its surroundings are not clean. It wipes of dirt with its wings.",
+		de: "Es kann nicht entspannen, wenn es oder seine Umgebung dreckig ist. Säubert alles mit den Flügeln"
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/105.ts
+++ b/data/Black & White/Dragons Exalted/105.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Peck",
 				fr: "Picpic",
+				de: "Schnabel"
 			},
 
 			damage: 10,
@@ -61,6 +62,7 @@ const card: Card = {
 
 	description: {
 		en: "It can't relax if it or its surroundings are not clean. It wipes of dirt with its wings.",
+		de: "Es kann nicht entspannen, wenn es oder seine Umgebung dreckig ist. Säubert alles mit den Flügeln."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/106.ts
+++ b/data/Black & White/Dragons Exalted/106.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Bang Heads",
 				fr: "Choc Frontal",
+				de: "Prallköpfe"
 			},
 			effect: {
 				en: "Both this Pokémon and the Defending Pokémon are now Confused.",
 				fr: "Ce Pokémon et le Pokémon Défenseur sont maintenant Confus.",
+				de: "Dieses Pokémon und das Verteidigende Pokémon sind jetzt verwirrt."
 			},
 			damage: 20,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "A comparison revealed that Bidoof's front teeth grow at the same rate as Rattata's.",
+		de: "Ein Vergleich zeigte, dass die Vorderzähne von Bidiza und Rattfratz gleich schnell wachsen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/107.ts
+++ b/data/Black & White/Dragons Exalted/107.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Bidoof",
 		fr: "Keunotor",
+		de: "Bidiza"
 	},
 
 	stage: "Stage1",
@@ -43,10 +44,12 @@ const card: Card = {
 			name: {
 				en: "Amnesia",
 				fr: "Amnésie",
+				de: "Amnesie"
 			},
 			effect: {
 				en: "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn.",
 				fr: "Choisissez 1 des attaques du Pokémon Défenseur. Le Pokémon ciblé ne peut pas utiliser l'attaque choisie pendant le prochain tour de votre adversaire.",
+				de: "Wähle 1 Angriff des Verteidigenden Pokémon. Das Pokémon kann den gewählten Angriff während des nächsten Zuges deines Gegners nicht einsetzen."
 			},
 			damage: 40,
 
@@ -61,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Tumbling Tackle",
 				fr: "Tacle Titubant",
+				de: "Taumeltackle"
 			},
 			effect: {
 				en: "Both this Pokémon and the Defending Pokémon are now Asleep.",
 				fr: "Ce Pokémon et le Pokémon Défenseur sont maintenant Endormis.",
+				de: "Dieses Pokémon und das Verteidigende Pokémon schlafen jetzt."
 			},
 			damage: 60,
 
@@ -82,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "A river dammed by Bibarel will never overflow its banks, which is appreciated by the people nearby.",
+		de: "Ein von Bidifas eingedämmter Fluss tritt niemals über seine Ufer. Dafür sind die Anrainer dankbar."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/108.ts
+++ b/data/Black & White/Dragons Exalted/108.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Wake-up Beam",
 				fr: "Rayon Vivifiant",
+				de: "Weckstrahl"
 			},
 			effect: {
 				en: "Remove all Special Conditions from the Defending Pokémon.",
 				fr: "Retirez tous les États Spéciaux du Pokémon Défenseur.",
+				de: "Alle Speziellen Zustände auf dem Verteidigenden Pokémon verlieren ihre Wirkung."
 			},
 			damage: 40,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Drain Slap",
 				fr: "Baffe Sangsue",
+				de: "Watschensauger"
 			},
 			effect: {
 				en: "Heal 30 damage from this Pokémon.",
 				fr: "Soignez 30 dégâts à ce Pokémon.",
+				de: "Heile 30 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 60,
 
@@ -75,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "Its auditory sense is astounding. It has radarlike ability to understand its surroundings through slight sounds.",
+		de: "Hat ein außerordentlich feines Gehör. Es tastet seine Umgebung auf jedes noch so leise Geräusch ab wie ein Radar."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/109.ts
+++ b/data/Black & White/Dragons Exalted/109.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Pound",
 				fr: "Écras'Face",
+				de: "Pfund"
 			},
 
 			damage: 10,
@@ -49,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Reckless Charge",
 				fr: "Attaque Imprudente",
+				de: "Waghalsiger Sturmangriff"
 			},
 			effect: {
 				en: "This Pokémon does 10 damage to itself.",
 				fr: "Ce Pokémon s'inflige 10 dégâts.",
+				de: "Dieses Pokémon fügt sich selbst 10 Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -70,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "They great one another by rubbing each other with their tails, which are always kept well groomed and clean.",
+		de: "Sie sorgen dafür, dass ihre Schweife stets schön sauber sind, da sie diese zur Begrüßung aneinanderreiben."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/11.ts
+++ b/data/Black & White/Dragons Exalted/11.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Nincada",
 		fr: "Ningale",
+		de: "Nincada"
 	},
 
 	stage: "Stage1",
@@ -64,10 +65,12 @@ const card: Card = {
 			name: {
 				en: "Night Slash",
 				fr: "Tranche-Nuit",
+				de: "Nachthieb"
 			},
 			effect: {
 				en: "You may switch this Pokémon with 1 of your Benched Pokémon.",
 				fr: "Vous pouvez échanger ce Pokémon avec 1 de vos Pokémon de Banc.",
+				de: "Du kannst dieses Pokémon gegen 1 Pokémon auf deiner Bank austauschen."
 			},
 			damage: 60,
 
@@ -85,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Because it moves so quickly, it sometimes becomes unseeable. It congregates around tree sap.",
+		de: "Es bewegt sich so schnell, dass es manchmal unsichtbar zu sein scheint. Es liebt Baumsaft."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/110.ts
+++ b/data/Black & White/Dragons Exalted/110.ts
@@ -60,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Gold Breaker",
 				fr: "Goliastruction",
+				de: "Goldbrecher"
 			},
 			effect: {
 				en: "If the Defending Pokémon is a Pokémon-EX, this attack does 60 more damage.",
 				fr: "Si le Pokémon Défenseur est un Pokémon-EX, cette attaque inflige 60 dégâts supplémentaires.",
+				de: "Wenn das Verteidigende Pokémon ein Pokémon-EX ist, fügt dieser Angriff 60 weitere Schadenspunkte zu."
 			},
 			damage: 60,
 
@@ -81,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "They charge wildly and headbutt everything. Their headbutts have enough destructive force to derail a trail.",
+		de: "Rammt seine Gegner ohne Rücksicht auf Verluste mit dem Kopf und vermag damit sogar Züge zum Entgleisen zu bringen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/111.ts
+++ b/data/Black & White/Dragons Exalted/111.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Chirp",
 				fr: "Gazouillis",
+				de: "Zwitscherer"
 			},
 			effect: {
 				en: "Search your deck for 2 Pokémon with Fighting Resistance, reveal them, and put them into your hand. Shuffle your deck afterward.",
 				fr: "Cherchez dans votre deck 2 Pokémon avec une Résistance à Fighting, montrez-les, puis ajoutez-les à votre main. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 2 Pokémon mit {F}-Resistenz, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Sharp Beak",
 				fr: "Bec Aiguisé",
+				de: "Scharfschnabel"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 10,
 
@@ -79,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "They crush berries with their talons. They bravely stand up to any opponent, no matter how strong it is.",
+		de: "Kann mit seinen Füßen Nüsse zermalmen. Es stellt sich jedem noch so starken Gegner tapfer zum Kampf."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/112.ts
+++ b/data/Black & White/Dragons Exalted/112.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Rufflet",
 		fr: "Furaiglon",
+		de: "Geronimatz"
 	},
 
 	stage: "Stage1",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Slash",
 				fr: "Tranche",
+				de: "Schlitzer"
 			},
 
 			damage: 30,
@@ -55,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Fury Attack",
 				fr: "Furie",
+				de: "Furienschlag"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 50 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 50 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 50,
 
@@ -83,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "They fight for their friends without any thought about danger to themselves. One can carry a car while flying.",
+		de: "Für Freunde stürzt es sich selbstlos in den Kampf. Es kann mit seinen Krallen Autos durch die Lüfte tragen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/113.ts
+++ b/data/Black & White/Dragons Exalted/113.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Involuciona a 1 de tus Pokémon evolucionados y pon la carta de Evolución de fase más alta que tenga sobre él en tu mano. (Ese Pokémon no puede evolucionar en este turno.)",
 		it: "Annulla l’evoluzione di uno dei tuoi Pokémon evoluti e riprendi in mano la carta Evoluzione di Fase più alta. Quel Pokémon non può evolversi in questo turno.",
 		pt: "Involui 1 dos seus Pokémon evoluídos e coloca o card de Evolução de Estágio mais alto em sua mão. (Esse Pokémon não pode evoluir desta vez.)",
-		de: "Rückentwickle 1 deiner entwickelten Pokémon und nimm die höchste daraufliegende Evolutionskarte auf deine Hand. (Das Pokémon kann sich während dieses Zuges nicht entwickeln.)"
+		de: "Rückentwickle 1 deiner entwickelten Pokémon und nimm die höchste daraufliegende Evolutionskarte auf deine Hand. (Das Pokémon kann sich während dieses Zuges nicht entwickeln.) Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Dragons Exalted/114.ts
+++ b/data/Black & White/Dragons Exalted/114.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "El Pokémon al que esté unida esta carta obtiene 20 PV más.",
 		it: "Il Pokémon a cui è assegnata questa carta ha 20 PV in più.",
 		pt: "O Pokémon ao qual este card está ligado recebe +20 PS.",
-		de: "Das Pokémon, an das diese Karte angelegt ist, erhält +20 KP."
+		de: "Lege lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Das Pokémon, an das diese Karte angelegt ist, erhält +20 KP. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Black & White/Dragons Exalted/115.ts
+++ b/data/Black & White/Dragons Exalted/115.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Si el Pokémon al que está unida esta carta queda Fuera de Combate por un ataque, pon ese Pokémon en tu mano. (Descarta todas las cartas unidas a ese Pokémon.)",
 		it: "Se il Pokémon a cui è assegnata questa carta viene messo K.O. dal danno di un attacco, riprendi in mano quel Pokémon, ma scarta tutte le carte assegnategli.",
 		pt: "Se o Pokémon ao qual esse card está ligado for Nocauteado por danos de um ataque, coloque esse Pokémon em sua mão. (Descarte todos os cards ligados a esse Pokémon.)",
-		de: "Nimm das Pokémon, an das diese Karte angelegt ist, auf die Hand, wenn es durch Schaden eines Angriffs kampfunfähig wird. (Lege alle an dieses Pokémon angelegten Karten auf deinen Ablagestapel.)"
+		de: "Lege lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Nimm das Pokémon, an das diese Karte angelegt ist, auf die Hand, wenn es durch Schaden eines Angriffs kampfunfähig wird. (Lege alle an dieses Pokémon angelegten Karten auf deinen Ablagestapel.) Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Black & White/Dragons Exalted/116.ts
+++ b/data/Black & White/Dragons Exalted/116.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Elige hasta 2 cartas de Herramienta Pokémon unidas a Pokémon en juego (tuyos o de tu rival) y descártalas.",
 		it: "Scegli fino a due carte Oggetto Pokémon assegnate ai Pokémon in gioco, tuoi o del tuo avversario, e poi scartale.",
 		pt: "Escolha até 2 cards de Ferramenta Pokémon, que estejam ligados aos Pokémon em jogo (seus ou de seu oponente) e descarte-os.",
-		de: "Wähle bis zu 2 Pokémon-Ausrüstungen, die an Pokémon im Spiel angelegt sind (an deine oder die deines Gegners),und lege sie auf den entsprechenden Ablagestapel."
+		de: "Wähle bis zu 2 Pokémon-Ausrüstungen, die an Pokémon im Spiel angelegt sind (an deine oder die deines Gegners),und lege sie auf den entsprechenden Ablagestapel. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Dragons Exalted/119.ts
+++ b/data/Black & White/Dragons Exalted/119.ts
@@ -56,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Rainbow Burn",
 				fr: "Brûlure Arc-en-ciel",
+				de: "Regenbogenfeuer"
 			},
 			effect: {
 				en: "Does 20 more damage for each different type of basic Energy attached to this Pokémon.",
 				fr: "Inflige 20 dégâts supplémentaires pour chaque différent type d'Énergie de base attaché à ce Pokémon.",
+				de: "Dieser Angriff fügt 20 weitere Schadenspunkte für jeden unterschiedlichen, an dieses Pokémon angelegten Basis-Energietyp zu."
 			},
 			damage: 20,
 

--- a/data/Black & White/Dragons Exalted/12.ts
+++ b/data/Black & White/Dragons Exalted/12.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Double Whip",
 				fr: "Double Fouet",
+				de: "Doppelpeitsche"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 10,
 
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Relaxing Fragrance",
 				fr: "Parfum Relaxant",
+				de: "Erholsamer Duft"
 			},
 			effect: {
 				en: "Heal 30 damage and remove all Special Conditions from this Pokémon.",
 				fr: "Soignez 30 dégâts et retirez tous les États Spéciaux de ce Pokémon.",
+				de: "Heile 30 Schadenspunkte bei diesem Pokémon. Alle Speziellen Zustände auf diesem Pokémon verlieren ihre Wirkung."
 			},
 
 		},
@@ -78,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "The more healthy the Roselia, the more pleasant its flowers' aroma. Its scent deeply relaxes people.",
+		de: "Je gesünder das Roselia, desto angenehmer das Aroma seiner Blume, das Menschen so sehr entspannt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/120.ts
+++ b/data/Black & White/Dragons Exalted/120.ts
@@ -54,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Replace",
 				fr: "Repositionnement",
+				de: "Austausch"
 			},
 			effect: {
 				en: "Move as many Energy attached to your Pokémon to your other Pokémon in any way you like.",
 				fr: "Déplacez autant d'Énergies attachées à vos Pokémon que vous voulez vers vos autres Pokémon, de la manière que vous voulez.",
+				de: "Verschiebe beliebig viele an deine Pokémon angelegten Energien nach Belieben auf deine anderen Pokémon."
 			},
 
 		},

--- a/data/Black & White/Dragons Exalted/121.ts
+++ b/data/Black & White/Dragons Exalted/121.ts
@@ -35,10 +35,12 @@ const card: Card = {
 			name: {
 				en: "Rock Tumble",
 				fr: "Roule-Pierre",
+				de: "Rollende Felsen"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by Resistance.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Résistance.",
+				de: "Der Schaden dieses Angriffs wird durch Resistenz nicht verändert."
 			},
 			damage: 50,
 
@@ -52,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Pump-up Smash",
 				fr: "Taurocharge",
+				de: "Aufmöbler"
 			},
 			effect: {
 				en: "Attach 2 basic Energy cards from your hand to your Benched Pokémon in any way you like.",
 				fr: "Attachez 2 cartes Énergie de base de votre main à vos Pokémon de Banc, de la manière que vous voulez.",
+				de: "Lege 2 Basis-Energiekarten von deiner Hand nach Belieben an die Pokémon auf deiner Bank an."
 			},
 			damage: 90,
 

--- a/data/Black & White/Dragons Exalted/122.ts
+++ b/data/Black & White/Dragons Exalted/122.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Triple Laser",
 				fr: "Triple Laser",
+				de: "Dreifachlaser"
 			},
 			effect: {
 				en: "This attack does 30 damage to 3 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige 30 dégâts à 3 des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 3 Pokémon deines Gegners jeweils 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -53,10 +55,12 @@ const card: Card = {
 			name: {
 				en: "Protect Charge",
 				fr: "Recharge Protectrice",
+				de: "Schützender Sturmangriff"
 			},
 			effect: {
 				en: "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, tous les dégâts infligés à ce Pokémon par des attaques sont réduits de 20 (après application de la Faiblesse et de la Résistance).",
+				de: "Während des nächsten Zuges deines Gegners wird Schaden, der diesem Pokémon durch Angriffe zugefügt wird, um 20 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 			damage: 80,
 

--- a/data/Black & White/Dragons Exalted/123.ts
+++ b/data/Black & White/Dragons Exalted/123.ts
@@ -34,10 +34,12 @@ const card: Card = {
 			name: {
 				en: "Celestial Roar",
 				fr: "Cri du Ciel",
+				de: "Himmelsgrollen"
 			},
 			effect: {
 				en: "Discard the top 3 cards of your deck. If any of those cards are Energy cards, attach them to this Pokémon.",
 				fr: "Défaussez les 3 cartes du dessus de votre deck. Si vous y trouvez des cartes Énergie, attachez-les à ce Pokémon.",
+				de: "Lege die obersten 3 Karten deines Decks auf deinen Ablagestapel. Wenn darunter Energiekarten sind, lege sie an dieses Pokémon an."
 			},
 
 		},
@@ -49,10 +51,12 @@ const card: Card = {
 			name: {
 				en: "Dragon Burst",
 				fr: "Fureur du Dragon",
+				de: "Drachensalve"
 			},
 			effect: {
 				en: "Discard all basic Fire Energy or all basic Lightning Energy attached to this Pokémon. This attack does 60 damage times the number of Energy cards you discarded.",
 				fr: "Défaussez toutes les Énergies Fire de base ou toutes les Énergies Lightning de base attachées à ce Pokémon. Cette attaque inflige 60 dégâts multipliés par le nombre de cartes Énergie que vous avez défaussées.",
+				de: "Lege alle an dieses Pokémon angelegten {R}-Basis-Energien oder {L}-Basis-Energien auf deinen Ablagestapel. Dieser Angriff fügt 60 Schadenspunkte mal der Anzahl abgelegter Energiekarten zu."
 			},
 			damage: 60,
 

--- a/data/Black & White/Dragons Exalted/124.ts
+++ b/data/Black & White/Dragons Exalted/124.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Shred",
 				fr: "Déchiquetage",
+				de: "Zerfetzer"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by any effects on the Defending Pokémon.",
 				fr: "Les dégâts de cette attaque ne sont affectés par aucun effet en action sur le Pokémon Défenseur.",
+				de: "Der Schaden dieses Angriffs wird durch Effekte auf dem Verteidigenden Pokémon nicht verändert."
 			},
 			damage: 90,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Dragon Pulse",
 				fr: "Dracochoc",
+				de: "Drachenpuls"
 			},
 			effect: {
 				en: "Discard the top 3 cards of your deck.",
 				fr: "Défaussez les 3 cartes du dessus de votre deck.",
+				de: "Lege die obersten 3 Karten deines Decks auf deinen Ablagestapel."
 			},
 			damage: 130,
 

--- a/data/Black & White/Dragons Exalted/125.ts
+++ b/data/Black & White/Dragons Exalted/125.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Servine",
 		fr: "Lianaja",
+		de: "Efoserp"
 	},
 
 	stage: "Stage2",
@@ -64,10 +65,12 @@ const card: Card = {
 			name: {
 				en: "Leaf Tornado",
 				fr: "Phytomixeur",
+				de: "Grasmixer"
 			},
 			effect: {
 				en: "Move as many Grass Energy attached to your Pokémon to your other Pokémon in any way you like.",
 				fr: "Déplacez autant d'Énergies Grass attachées à vos Pokémon que vous voulez vers vos autres Pokémon, de la manière que vous voulez.",
+				de: "Verschiebe beliebig viele an deine Pokémon angelegten {G}-Energien nach Belieben auf deine anderen Pokémon."
 			},
 			damage: 60,
 
@@ -92,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "This extremely rare Pokémon is a different color than usual. It is very hard to find.",
+		de: "Dieses extrem seltene Pokémon hat eine andere Farbe als üblich. Es ist sehr schwer zu finden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/126.ts
+++ b/data/Black & White/Dragons Exalted/126.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Duosion",
 		fr: "Méios",
+		de: "Mitodos"
 	},
 
 	stage: "Stage2",
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Psywave",
 				fr: "Vague Psy",
+				de: "Psywelle"
 			},
 			effect: {
 				en: "Does 10 more damage for each Energy attached to the Defending Pokémon.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque Énergie attachée au Pokémon Défenseur.",
+				de: "Dieser Angriff fügt 10 weitere Schadenspunkte für jede an das Verteidigende Pokémon angelegte Energie zu."
 			},
 			damage: 30,
 
@@ -86,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "This extremely rare Pokémon is a different color than usual. It is very hard to find.",
+		de: "Dieses sehr seltene Pokémon hat eine andere Farbe als üblich. Es ist sehr schwer zu finden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/127.ts
+++ b/data/Black & White/Dragons Exalted/127.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Krokorok",
 		fr: "Escroco",
+		de: "Rokkaiman"
 	},
 
 	stage: "Stage2",
@@ -43,10 +44,12 @@ const card: Card = {
 			name: {
 				en: "Dark Clamp",
 				fr: "Pince des Ténèbres",
+				de: "Dunkler Klammergriff"
 			},
 			effect: {
 				en: "The Defending Pokémon can't retreat during your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas battre en retraite pendant le prochain tour de votre adversaire.",
+				de: "Das Verteidigende Pokémon kann sich während des nächsten Zuges deines Gegners nicht zurückziehen."
 			},
 			damage: 60,
 
@@ -61,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Bombast",
 				fr: "Arrogance",
+				de: "Prahlerei"
 			},
 			effect: {
 				en: "Does 40 damage times the number of Prize cards you have taken.",
 				fr: "Inflige 40 dégâts multipliés par le nombre de cartes Récompense que vous avez récupérées.",
+				de: "Dieser Angriff fügt 40 Schadenspunkte für jede Preiskarte zu, die du bereits genommen hast."
 			},
 			damage: 40,
 
@@ -89,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "This extremely rare Pokémon is a different color than usual. It is very hard to find.",
+		de: "Dieses sehr seltene Pokémon hat eine andere Farbe als üblich. Es ist sehr schwer zu finden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/128.ts
+++ b/data/Black & White/Dragons Exalted/128.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Dragon Pulse",
 				fr: "Dracochoc",
+				de: "Drachenpuls"
 			},
 			effect: {
 				en: "Discard the top 2 cards of your deck.",
 				fr: "Défaussez les 2 cartes du dessus de votre deck.",
+				de: "Lege die obersten 2 Karten deines Decks auf deinen Ablagestapel."
 			},
 			damage: 40,
 
@@ -53,10 +55,12 @@ const card: Card = {
 			name: {
 				en: "Shred",
 				fr: "Déchiquetage",
+				de: "Zerfetzer"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by any effects on the Defending Pokémon.",
 				fr: "Les dégâts de cette attaque ne sont affectés par aucun effet en action sur le Pokémon Défenseur.",
+				de: "Der Schaden dieses Angriffs wird durch Effekte auf dem Verteidigenden Pokémon nicht verändert."
 			},
 			damage: 90,
 
@@ -74,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "This extremely rare Pokémon is a different color than usual. It is very hard to find.",
+		de: "Dieses sehr seltene Pokémon hat eine andere Farbe als üblich. Es ist schwer zu finden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/13.ts
+++ b/data/Black & White/Dragons Exalted/13.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Needling Sting",
 				fr: "Piqûre Piquante",
+				de: "Nadelstiche"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 10,
 
@@ -65,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "The more healthy the Roselia, the more pleasant its flowers' aroma. Its scent deeply relaxes people.",
+		de: "Je gesünder das Roselia, desto angenehmer das Aroma seiner Blume, das Menschen so sehr entspannt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/14.ts
+++ b/data/Black & White/Dragons Exalted/14.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Roselia",
 		fr: "Rosélia",
+		de: "Roselia"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Crosswise Whip",
 				fr: "Fouets Croisés",
+				de: "Kreuzschlag"
 			},
 			effect: {
 				en: "Flip 4 coins. This attack does 30 damage times the number of heads.",
 				fr: "Lancez 4 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 4 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 30,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Poison Point",
 				fr: "Point Poison",
+				de: "Giftdorn"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné.",
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet."
 			},
 			damage: 60,
 
@@ -86,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "Each of its hands contains different toxins, but both hands can jab with near-fatal power.",
+		de: "Es kann mit beiden Händen verheerend angreifen. Seine Hände enthalten unterschiedliche Gifte."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/15.ts
+++ b/data/Black & White/Dragons Exalted/15.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Roselia",
 		fr: "Rosélia",
+		de: "Roselia"
 	},
 
 	stage: "Stage1",
@@ -64,10 +65,12 @@ const card: Card = {
 			name: {
 				en: "Squeeze",
 				fr: "Compression",
+				de: "Quetschen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage and the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires et le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu und das Verteidigende Pokémon ist jetzt paralysiert."
 			},
 			damage: 30,
 
@@ -92,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "Each of its hands contains different toxins, but both hands can jab with near-fatal power.",
+		de: "Es kann mit beiden Händen verheerend angreifen. Seine Hände enthalten unterschiedliche Gifte."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/16.ts
+++ b/data/Black & White/Dragons Exalted/16.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Stun Needle",
 				fr: "Para-Dard",
+				de: "Betäubungsnadel"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 20,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Reinforced Needle",
 				fr: "Épine Renforcée",
+				de: "Starknadel"
 			},
 			effect: {
 				en: "If this Pokémon has a Pokémon Tool card attached to it, this attack does 40 more damage.",
 				fr: "Si une carte Outil Pokémon est attachée à ce Pokémon, cette attaque inflige 40 dégâts supplémentaires.",
+				de: "Wenn an dieses Pokémon eine Pokémon-Ausrüstung angelegt ist, fügt dieser Angriff 40 weitere Schadenspunkte zu."
 			},
 			damage: 40,
 
@@ -82,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "Arid regions are their habitat. They move rhythmically, making a sound similar to maracas.",
+		de: "Erzeugt durch rhythmische Bewegungen Laute, die dem Klang von Maracas ähneln. Lebt an trockenen Orten."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/17.ts
+++ b/data/Black & White/Dragons Exalted/17.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Double Spin",
 				fr: "Double Tour",
+				de: "Doppeldreher"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 10,
 
@@ -64,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "For some reason, this Pokémon resembles a Poké Ball. They release poison spores to repel those who try to catch them.",
+		de: "Es ähnelt einem Pokéball. Versucht man, es zu fangen, widersetzt es sich, indem es Giftsporen versprüht."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/18.ts
+++ b/data/Black & White/Dragons Exalted/18.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Singe",
 				fr: "Roussi",
+				de: "Versengung"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Burned.",
 				fr: "Le Pokémon Défenseur est maintenant Brûlé.",
+				de: "Das Verteidigende Pokémon ist jetzt verbrannt."
 			},
 
 		},
@@ -56,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "It controls balls of fire. As it grows, its six tails split from their tips to make more tails.",
+		de: "Es beherrscht Feuerbälle. Während es wächst, teilen sich seine sechs Schweife, um weitere zu bilden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/19.ts
+++ b/data/Black & White/Dragons Exalted/19.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Vulpix",
 		fr: "Goupix",
+		de: "Vulpix"
 	},
 
 	stage: "Stage1",
@@ -63,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Hexed Flame",
 				fr: "Flamme Maudite",
+				de: "Flammenfluch"
 			},
 			effect: {
 				en: "Does 50 more damage for each Special Condition affecting the Defending Pokémon.",
 				fr: "Inflige 50 dégâts supplémentaires pour chaque État Spécial affectant le Pokémon Défenseur.",
+				de: "Dieser Angriff fügt 50 weitere Schadenspunkte für jeden Speziellen Zustand zu, von dem das Verteidigende Pokémon betroffen ist."
 			},
 			damage: 20,
 
@@ -84,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "Its nine tails are said to be imbued with a mystic power. It can live for a thousand years.",
+		de: "Seine neun Schweife sollen mystische Kräfte besitzen. Es kann tausend Jahre leben."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/2.ts
+++ b/data/Black & White/Dragons Exalted/2.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Hoppip",
 		fr: "Granivol",
+		de: "Hoppspross"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Bullet Seed",
 				fr: "Balle Graine",
+				de: "Kugelsaat"
 			},
 			effect: {
 				en: "Flip 4 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 4 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 4 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 10,
 
@@ -69,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "It blooms when the weather warms. It floats in the sky to soak up as much sunlight as possible.",
+		de: "Sobald es wärmer wird, blüht es auf. Es schwebt am Himmel und nimmt so viel Sonnenlicht auf wie möglich."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/20.ts
+++ b/data/Black & White/Dragons Exalted/20.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Beat",
 				fr: "Bataille",
+				de: "Verprügler"
 			},
 
 			damage: 10,
@@ -50,6 +51,7 @@ const card: Card = {
 			name: {
 				en: "Magma Punch",
 				fr: "Poing Magma",
+				de: "Magmahieb"
 			},
 
 			damage: 50,
@@ -68,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "When it breathes deeply, heat waves form around its body, making it hard to see clearly.",
+		de: "Atmet es tief ein, bilden sich Hitzewellen um seinen Körper, was wiederum die Sicht beeinträchtigt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/21.ts
+++ b/data/Black & White/Dragons Exalted/21.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Magmar",
 		fr: "Magmar",
+		de: "Magmar"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Flame Screen",
 				fr: "Barrière de Flammes",
+				de: "Flammenschirm"
 			},
 			effect: {
 				en: "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, tous les dégâts infligés à ce Pokémon par des attaques sont réduits de 20 (après application de la Faiblesse et de la Résistance).",
+				de: "Während des nächsten Zuges deines Gegners wird Schaden, der diesem Pokémon durch Angriffe zugefügt wird, um 20 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 			damage: 40,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Flamethrower",
 				fr: "Lance-Flamme",
+				de: "Flammenwurf"
 			},
 			effect: {
 				en: "Discard an Energy attached to this Pokémon.",
 				fr: "Défaussez une Énergie attachée à ce Pokémon.",
+				de: "Lege 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel."
 			},
 			damage: 90,
 
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "When launching 3,600 degrees F fireballs, its body takes on a whitish hue from the intense heat.",
+		de: "Wenn es seine fast 2 000 Grad heißen Feuerbälle abfeuert, nimmt sein Körper eine weißliche Farbe an."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/22.ts
+++ b/data/Black & White/Dragons Exalted/22.ts
@@ -56,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Rainbow Burn",
 				fr: "Brûlure Arc-en-ciel",
+				de: "Regenbogenfeuer"
 			},
 			effect: {
 				en: "Does 20 more damage for each different type of basic Energy attached to this Pokémon.",
 				fr: "Inflige 20 dégâts supplémentaires pour chaque différent type d'Énergie de base attaché à ce Pokémon.",
+				de: "Dieser Angriff fügt 20 weitere Schadenspunkte für jeden unterschiedlichen, an dieses Pokémon angelegten Basis-Energietyp zu."
 			},
 			damage: 20,
 

--- a/data/Black & White/Dragons Exalted/23.ts
+++ b/data/Black & White/Dragons Exalted/23.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Soggy Rush",
 				fr: "Assaut Humide",
+				de: "Nasse Patsche"
 			},
 			effect: {
 				en: "Flip a coin until you get tails. This attack does 10 damage times the number of heads.",
 				fr: "Lancez une pièce jusqu'à ce que vous obteniez un côté pile. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 10,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "A Magikarp living for many years can leap a mountain using Splash. The move remains useless, though.",
+		de: "Ein älteres Karpador kann mit Platscher Berge überspringen. Die Attacke ist trotzdem eher nutzlos."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/24.ts
+++ b/data/Black & White/Dragons Exalted/24.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Magikarp",
 		fr: "Magicarpe",
+		de: "Karpador"
 	},
 
 	stage: "Stage1",
@@ -43,6 +44,7 @@ const card: Card = {
 			name: {
 				en: "Sharp Fang",
 				fr: "Croc Aiguisé",
+				de: "Scharfe Fänge"
 			},
 
 			damage: 60,
@@ -58,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Swing Around",
 				fr: "Balançoire",
+				de: "Gegenschwung"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 30 more damage for each heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts supplémentaires pour chaque côté face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 60,
 
@@ -79,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "Once it begins to rampage, a Gyarados will burn everything down, even in a harsh storm.",
+		de: "Wütet ein Garados, wird es alles niederbrennen. Dies geschieht selbst während eines Sturms."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/25.ts
+++ b/data/Black & White/Dragons Exalted/25.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Lullaby",
 				fr: "Comptine",
+				de: "Wiegenlied"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Asleep.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Endormi.",
+				de: "Wirf 1 Münze. Bei „Kopf“ schläft das Verteidigende Pokémon jetzt."
 			},
 
 		},
@@ -52,6 +54,7 @@ const card: Card = {
 			name: {
 				en: "Water Gun",
 				fr: "Pistolet à O",
+				de: "Aquaknarre"
 			},
 
 			damage: 30,
@@ -70,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "On sunny days, it lands on beaches to bounce like a ball and play. It spouts water from its nose.",
+		de: "An sonnigen Tagen trifft man diese Pokémon an Stränden, wo sie wie Bälle herumhüpfen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/26.ts
+++ b/data/Black & White/Dragons Exalted/26.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Wailmer",
 		fr: "Wailmer",
+		de: "Wailmer"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Water Cannon",
 				fr: "Canon à O",
+				de: "Aquakanone"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 damage times the amount of Water Energy attached to this Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts multipliés par le nombre d'Énergies Water attachées à ce Pokémon.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 Schadenspunkte mal der Anzahl der an dieses Pokémon angelegten {W}-Energien zu."
 			},
 			damage: 30,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Giant Wave",
 				fr: "Vague Géante",
+				de: "Riesenwelle"
 			},
 			effect: {
 				en: "This Pokémon can't use Giant Wave during your next turn.",
 				fr: "Ce Pokémon ne peut pas utiliser Vague Géante pendant votre prochain tour.",
+				de: "Dieses Pokémon kann während deines nächsten Zuges Riesenwelle nicht einsetzen."
 			},
 			damage: 80,
 
@@ -80,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "The biggest of all Pokémon. It can dive to a depth of almost 10,000 feet on only one breath.",
+		de: "Das größte Pokémon. Es kann mit nur einem Atemzug in Tiefen bis 3 000 Meter tauchen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/27.ts
+++ b/data/Black & White/Dragons Exalted/27.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Add-a-Dash",
 				fr: "Rallonge",
+				de: "Noch eine Prise"
 			},
 			effect: {
 				en: "Flip 2 coins. For each heads, draw a card.",
 				fr: "Lancez 2 pièces. Pour chaque côté face, piochez une carte.",
+				de: "Wirf 2 Münzen. Ziehe pro „Kopf“ 1 Karte."
 			},
 
 		},
@@ -56,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "It is a shabby and ugly Pokémon. However, it is very hardy and can survive on little water.",
+		de: "Ein schäbiges, ja sogar hässliches Pokémon. Dafür ist es abgehärtet und überlebt mit wenig Wasser."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/28.ts
+++ b/data/Black & White/Dragons Exalted/28.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Feebas",
 		fr: "Barpau",
+		de: "Barschwa"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Clear Search",
 				fr: "Recherche Libre",
+				de: "Klare Sicht"
 			},
 			effect: {
 				en: "Search your deck for any 3 cards and put them into your hand. Shuffle your deck afterward.",
 				fr: "Cherchez 3 cartes dans votre deck puis ajoutez-les à votre main. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 3 beliebigen Karten und nimm sie auf deine Hand. Mische anschließend dein Deck."
 			},
 
 		},
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Water Pulse",
 				fr: "Vibraqua",
+				de: "Aquawelle"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 			damage: 60,
 
@@ -78,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "Its lovely scales are described as rainbow colored. They change color depending on the viewing angle.",
+		de: "Seine Schuppen sind regenbogenfarben. Die jeweiligen Farben verändern sich je nach Blickwinkel."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/29.ts
+++ b/data/Black & White/Dragons Exalted/29.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Unstoppable Roll",
 				fr: "Roulade Obstinée",
+				de: "Permawalze"
 			},
 			effect: {
 				en: "Flip 2 coins. If both of them are heads, this attack does 30 more damage.",
 				fr: "Lancez 2 pièces. Si vous obtenez 2 côtés face, cette attaque inflige 30 dégâts supplémentaires.",
+				de: "Wirf 2 Münzen. Zeigen beide „Kopf“, fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: 10,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "It rolls across ice floes to reach shore because its body is poorly shaped for swimming.",
+		de: "Es rollt über Eisschollen, um Land zu erreichen, da sein Körper zum Schwimmen nicht geeignet ist."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/3.ts
+++ b/data/Black & White/Dragons Exalted/3.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Skiploom",
 		fr: "Floravol",
+		de: "Hubelupf"
 	},
 
 	stage: "Stage2",
@@ -63,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Acrobatics",
 				fr: "Acrobatie",
+				de: "Akrobatik"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 30 more damage for each heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts supplémentaires pour chaque côté face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -91,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "Blown by the seasonal winds, it circles the globe, scattering cotton spores as it goes.",
+		de: "Es lässt sich von den Winden um den Globus tragen und verteilt auf seinem Flug Baumwollsamen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/30.ts
+++ b/data/Black & White/Dragons Exalted/30.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Spheal",
 		fr: "Obalie",
+		de: "Seemops"
 	},
 
 	stage: "Stage1",
@@ -42,6 +43,7 @@ const card: Card = {
 			name: {
 				en: "Ice Ball",
 				fr: "Ball'Glace",
+				de: "Frostbeule"
 			},
 
 			damage: 30,
@@ -56,6 +58,7 @@ const card: Card = {
 			name: {
 				en: "Aurora Beam",
 				fr: "Onde Boréale",
+				de: "Aurorastrahl"
 			},
 
 			damage: 40,
@@ -74,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "It habitually spins things on its nose. By doing so, it learns textures and odors.",
+		de: "Es balanciert Dinge auf seiner Nase. Dabei lernt es etwas über die Beschaffenheit und den Geruch."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/31.ts
+++ b/data/Black & White/Dragons Exalted/31.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Sealeo",
 		fr: "Phogleur",
+		de: "Seejong"
 	},
 
 	stage: "Stage2",
@@ -43,6 +44,7 @@ const card: Card = {
 			name: {
 				en: "Aurora Beam",
 				fr: "Onde Boréale",
+				de: "Aurorastrahl"
 			},
 
 			damage: 80,
@@ -58,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Ice Entomb",
 				fr: "Cercueil de Glace",
+				de: "Eisiger Kerker"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Paralyzed. This Pokémon can't use Ice Entomb during your next turn.",
 				fr: "Le Pokémon Défenseur est maintenant Paralysé. Ce Pokémon ne peut pas utiliser Cercueil de Glace pendant votre prochain tour.",
+				de: "Das Verteidigende Pokémon ist jetzt paralysiert. Dieses Pokémon kann während deines nächsten Zuges Eisiger Kerker nicht einsetzen."
 			},
 			damage: 60,
 
@@ -79,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "It shatters ice with its big tusks. Its thick blubber repels not only the cold, but also enemy attacks.",
+		de: "Mit seinen Stoßzähnen bricht es durch Eis. Eine Speckschicht schützt es vor Kälte und Angriffen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/32.ts
+++ b/data/Black & White/Dragons Exalted/32.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Wave Splash",
 				fr: "Grosse Vague",
+				de: "Wellenplatscher"
 			},
 
 			damage: 10,
@@ -54,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "It spins its two tails like a screw to propel itself through the water. The tails also slice clinging seaweed.",
+		de: "Dreht seine zwei Schweife wie eine Schraube, um schnell zu schwimmen, und zum Zerschneiden von Algen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/33.ts
+++ b/data/Black & White/Dragons Exalted/33.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Buizel",
 		fr: "Mustébouée",
+		de: "Bamelin"
 	},
 
 	stage: "Stage1",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Wave Splash",
 				fr: "Grosse Vague",
+				de: "Wellenplatscher"
 			},
 
 			damage: 20,
@@ -54,6 +56,7 @@ const card: Card = {
 			name: {
 				en: "Waterfall",
 				fr: "Cascade",
+				de: "Kaskade"
 			},
 
 			damage: 60,
@@ -72,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "It is a common sight around fishing ports. It is known to rescue people and carry off prey.",
+		de: "Man findet es oft in der Nähe von Häfen. Rettet dort Menschen, schleppt aber auch Beute hinfort."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/34.ts
+++ b/data/Black & White/Dragons Exalted/34.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Bubble",
 				fr: "Écume",
+				de: "Blubber"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 10,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "By vibrating its cheeks, it emits sound waves imperceptible to humans. It uses the rhythm of these sounds to talk.",
+		de: "Erzeugt mit seinen Wangen für Menschen unhörbare Schallwellen. Es verständigt sich über den Rhythmus dieser Wellen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/35.ts
+++ b/data/Black & White/Dragons Exalted/35.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Tympole",
 		fr: "Tritonde",
+		de: "Schallquap"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Supersonic",
 				fr: "Ultrason",
+				de: "Superschall"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Confused.",
 				fr: "Le Pokémon Défenseur est maintenant Confus.",
+				de: "Das Verteidigende Pokémon ist jetzt verwirrt."
 			},
 
 		},
@@ -57,6 +60,7 @@ const card: Card = {
 			name: {
 				en: "Hyper Voice",
 				fr: "Mégaphone",
+				de: "Schallwelle"
 			},
 
 			damage: 50,
@@ -75,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "When they vibrate the bumps on their heads, the can make wave in water or earthquake-like vibrations on land.",
+		de: "Wenn es die Beulen auf seinem Kopf zum Schwingen bringt, tobt je nach Umgebung entweder das Wasser oder die Erde bebt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/36.ts
+++ b/data/Black & White/Dragons Exalted/36.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Palpitoad",
 		fr: "Batracné",
+		de: "Mebrana"
 	},
 
 	stage: "Stage2",
@@ -43,10 +44,12 @@ const card: Card = {
 			name: {
 				en: "Echoed Voice",
 				fr: "Écho",
+				de: "Widerhall"
 			},
 			effect: {
 				en: "During your next turn, this Pokémon's Echoed Voice attack does 50 more damage (before applying Weakness and Resistance).",
 				fr: "Pendant votre prochain tour, l'attaque Écho de ce Pokémon inflige 50 dégâts supplémentaires (avant application de la Faiblesse et de la Résistance).",
+				de: "Während deines nächsten Zuges fügt die Attacke Widerhall dieses Pokémon 50 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 			damage: 50,
 
@@ -61,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Drain Punch",
 				fr: "Vampipoing",
+				de: "Ableithieb"
 			},
 			effect: {
 				en: "Heal 20 damage from this Pokémon.",
 				fr: "Soignez 20 dégâts à ce Pokémon.",
+				de: "Heile 20 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 80,
 
@@ -82,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "They shoot paralyzing liquid from their head bumps. They use vibration to hurt their opponents.",
+		de: "Es schießt eine lähmende Flüssigkeit aus den Beulen auf seinem Kopf. Es plagt seine Gegner mit Schallwellen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/37.ts
+++ b/data/Black & White/Dragons Exalted/37.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Mysterious Beam",
 				fr: "Rayon Mystérieux",
+				de: "Seltsamer Strahl"
 			},
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, défaussez une Énergie attachée au Pokémon Défenseur.",
+				de: "Wirf 1 Münze. Lege bei „Kopf“ 1 an das Verteidigende Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 30,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Double Slap",
 				fr: "Torgnoles",
+				de: "Duplexhieb"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 50 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 50 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 50,
 
@@ -75,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "The special membrane enveloping Alomomola has the ability to heal wounds.",
+		de: "Die spezielle Schleimschicht, die seinen Körper umgibt, besitzt heilende Kräfte."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/38.ts
+++ b/data/Black & White/Dragons Exalted/38.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Cotton Guard",
 				fr: "Cotogarde",
+				de: "Watteschild"
 			},
 			effect: {
 				en: "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, tous les dégâts infligés à ce Pokémon par des attaques sont réduits de 20 (après application de la Faiblesse et de la Résistance).",
+				de: "Während des nächsten Zuges deines Gegners wird Schaden, der diesem Pokémon durch Angriffe zugefügt wird, um 20 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Thunder Jolt",
 				fr: "Secousse Tonnerre",
+				de: "Donnerrüttler"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this Pokémon does 10 damage to itself.",
 				fr: "Lancez une pièce. Si c'est pile, ce Pokémon s'inflige 10 dégâts.",
+				de: "Wirf 1 Münze. Bei „Zahl“ fügt sich dieses Pokémon selbst 10 Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -72,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "Its fluffy coat swells to double when static electricity builds up. Touching it can be shocking.",
+		de: "Sein weiches Fell wird doppelt so dick, wenn sich Elektrizität aufbaut."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/39.ts
+++ b/data/Black & White/Dragons Exalted/39.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Mareep",
 		fr: "Wattouat",
+		de: "Voltilamm"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Cotton Guard",
 				fr: "Cotogarde",
+				de: "Watteschild"
 			},
 			effect: {
 				en: "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, tous les dégâts infligés à ce Pokémon par des attaques sont réduits de 20 (après application de la Faiblesse et de la Résistance).",
+				de: "Während des nächsten Zuges deines Gegners wird Schaden, der diesem Pokémon durch Angriffe zugefügt wird, um 20 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 			damage: 20,
 
@@ -58,6 +61,7 @@ const card: Card = {
 			name: {
 				en: "Power Gem",
 				fr: "Rayon Gemme",
+				de: "Juwelenkraft"
 			},
 
 			damage: 40,
@@ -76,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "If its coat becomes fully charged with electricity, its tail lights up. It fires hair that zaps on impact.",
+		de: "Hat es sich mit Elektrizität aufgeladen, leuchtet sein Schweif und es feuert Haare ab, die sich entladen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/4.ts
+++ b/data/Black & White/Dragons Exalted/4.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Whirlwind",
 				fr: "Cyclone",
+				de: "Wirbelwind"
 			},
 			effect: {
 				en: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon.",
 				fr: "Votre adversaire échange le Pokémon Défenseur avec 1 de ses Pokémon de Banc.",
+				de: "Dein Gegner tauscht das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
 			},
 			damage: 20,
 
@@ -65,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "It can hover in one spot by flapping its wings at high speed. It flits about to guard its territory.",
+		de: "Schwebt auf der Stelle durch das schnelle Schlagen seiner Flügel. Hat ein Auge auf sein Territorium."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/40.ts
+++ b/data/Black & White/Dragons Exalted/40.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Flaaffy",
 		fr: "Lainergie",
+		de: "Waaty"
 	},
 
 	stage: "Stage2",
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Electrobullet",
 				fr: "Électrojectile",
+				de: "Elektrokugel"
 			},
 			effect: {
 				en: "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 20 dégâts à 1 des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 1 Pokémon auf der Bank deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 70,
 
@@ -86,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "The tip of its tail shines brightly. In the olden days, people sent signals using the tail's light.",
+		de: "Seine Schweifspitze leuchtet hell. In alten Zeiten hat man mit seiner Hilfe Lichtsignale gegeben."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/41.ts
+++ b/data/Black & White/Dragons Exalted/41.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 10,
@@ -49,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Quick Attack",
 				fr: "Vive-Attaque",
+				de: "Ruckzuckhieb"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 10,
 
@@ -70,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "Using electricity stored in its fur, it stimulates its muscles to heighten its reaction speed.",
+		de: "Die Elektrizität, die es im Fell speichert, nutzt es, um seine Muskeln zu stimulieren."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/42.ts
+++ b/data/Black & White/Dragons Exalted/42.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Quick Turn",
 				fr: "Vif Retournement",
+				de: "Schnelldrehung"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "Using electricity stored in its fur, it stimulates its muscles to heighten its reaction speed.",
+		de: "Die Elektrizität, die es im Fell speichert, nutzt es, um seine Muskeln zu stimulieren."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/43.ts
+++ b/data/Black & White/Dragons Exalted/43.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Electrike",
 		fr: "Dynavolt",
+		de: "Frizelbliz"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Energy Crush",
 				fr: "Écras'Énergie",
+				de: "Zermalmende Energie"
 			},
 			effect: {
 				en: "Does 20 damage times the amount of Energy attached to all of your opponent's Pokémon.",
 				fr: "Inflige 20 dégâts multipliés par le nombre d'Énergies attachées à tous les Pokémon de votre adversaire.",
+				de: "Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl der an allen Pokémon deines Gegners angelegten Energien zu."
 			},
 			damage: 20,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Flash Impact",
 				fr: "Impact-Flash",
+				de: "Blitzeinschlag"
 			},
 			effect: {
 				en: "Does 20 damage to 1 of your Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 20 dégâts à 1 de vos Pokémon. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 1 deiner Pokémon 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 80,
 
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "It discharges electricity from its mane. It creates a thundercloud overhead to drop lightning bolts.",
+		de: "Aus seiner Mähne entlädt es Elektrizität. Es generiert eine Gewitterwolke, aus der es Blitze entlädt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/44.ts
+++ b/data/Black & White/Dragons Exalted/44.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Electrike",
 		fr: "Dynavolt",
+		de: "Frizelbliz"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Energy Assist",
 				fr: "Assistance Énergétique",
+				de: "Energieförderung"
 			},
 			effect: {
 				en: "Attach 2 basic Energy cards from your discard pile to 1 of your Benched Pokémon.",
 				fr: "Attachez 2 cartes Énergie de base de votre pile de défausse à 1 de vos Pokémon de Banc.",
+				de: "Lege 2 Basis-Energiekarten von deinem Ablagestapel an 1 Pokémon auf deiner Bank an."
 			},
 
 		},
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Quick Attack",
 				fr: "Vive-Attaque",
+				de: "Ruckzuckhieb"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -77,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It discharges electricity from its mane. It creates a thundercloud overhead to drop lightning bolts.",
+		de: "Aus seiner Mähne entlädt es Elektrizität. Es generiert eine Gewitterwolke, aus der es Blitze entlädt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/45.ts
+++ b/data/Black & White/Dragons Exalted/45.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Call for Family",
 				fr: "Appel à la Famille",
+				de: "Familienruf"
 			},
 			effect: {
 				en: "Search your deck for 2 Basic Pokémon and put them onto your Bench. Shuffle your deck afterward.",
 				fr: "Cherchez 2 Pokémon de base dans votre deck et placez-les sur votre Banc. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 2 Basis-Pokémon und lege sie auf deine Bank. Mische anschließend dein Deck."
 			},
 
 		},
@@ -50,6 +52,7 @@ const card: Card = {
 			name: {
 				en: "Static Shock",
 				fr: "Choc Statique",
+				de: "Statischer Schock"
 			},
 
 			damage: 20,
@@ -75,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "They live on treetops and glide using the inside of a cape-like membrane while discharging electricity.",
+		de: "Lebt in den Wipfeln der Waldbäume. Während es durch die Lüfte gleitet, entlädt es Strom aus seinen Fluglappen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/46.ts
+++ b/data/Black & White/Dragons Exalted/46.ts
@@ -54,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Replace",
 				fr: "Repositionnement",
+				de: "Austausch"
 			},
 			effect: {
 				en: "Move as many Energy attached to your Pokémon to your other Pokémon in any way you like.",
 				fr: "Déplacez autant d'Énergies attachées à vos Pokémon que vous voulez vers vos autres Pokémon, de la manière que vous voulez.",
+				de: "Verschiebe beliebig viele an deine Pokémon angelegten Energien nach Belieben auf deine anderen Pokémon."
 			},
 
 		},

--- a/data/Black & White/Dragons Exalted/47.ts
+++ b/data/Black & White/Dragons Exalted/47.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cascoon",
 		fr: "Blindalys",
+		de: "Panekon"
 	},
 
 	stage: "Stage2",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Hazardous Scales",
 				fr: "Écailles Fatales",
+				de: "Gefährliche Schuppen"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep, Burned, and Poisoned.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi, Brûlé et Empoisonné.",
+				de: "Das Verteidigende Pokémon schläft jetzt, ist verbrannt und vergiftet."
 			},
 
 		},
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Aerial Ace",
 				fr: "Aéropique",
+				de: "Aero-Ass"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: 50,
 
@@ -78,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "Toxic powder is scattered with each flap. At night, it is known to strip leaves off trees lining boulevards.",
+		de: "Es streut mit jedem Flügelschlag giftiges Pulver. Nachts entfernt es die Blätter von Bäumen an Alleen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/48.ts
+++ b/data/Black & White/Dragons Exalted/48.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Nincada",
 		fr: "Ningale",
+		de: "Nincada"
 	},
 
 	stage: "Stage1",
@@ -63,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Cursed Drop",
 				fr: "Chute Maudite",
+				de: "Verfluchter Fall"
 			},
 			effect: {
 				en: "Put 3 damage counters on your opponent's Pokémon in any way you like.",
 				fr: "Placez 3 marqueurs de dégâts sur les Pokémon de votre adversaire, de la manière que vous voulez.",
+				de: "Verteile 3 Schadensmarken beliebig auf die Pokémon deines Gegners."
 			},
 
 		},
@@ -76,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "A discarded bug shell that came to life. Peering into the crack on its back is said to steal one's spirit.",
+		de: "Ein weggeworfener Käferpanzer, der zum Leben erwachte. Schaut man hinein, stiehlt es einem die Seele."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/49.ts
+++ b/data/Black & White/Dragons Exalted/49.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Sneaky Placement",
 				fr: "Placement Vicieux",
+				de: "Heimlichtuerei"
 			},
 			effect: {
 				en: "Put 1 damage counter on 1 of your opponent's Pokémon.",
 				fr: "Placez 1 marqueur de dégâts sur 1 des Pokémon de votre adversaire.",
+				de: "Lege 1 Schadensmarke auf 1 Pokémon deines Gegners."
 			},
 
 		},
@@ -56,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "Because of the way it floats aimlessly, an old folktale calls it a \"Signpost for Wandering Spirits.\"",
+		de: "Laut einer alten Volkssage nennt man es den „Wegweiser für umherstreifende Geister“."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/5.ts
+++ b/data/Black & White/Dragons Exalted/5.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Yanma",
 		fr: "Yanma",
+		de: "Yanma"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Agility",
 				fr: "Hâte",
+				de: "Agilität"
 			},
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, évitez tous les effets d'attaques (y compris les dégâts) infligés à ce Pokémon pendant le prochain tour de votre adversaire.",
+				de: "Wirf 1 Münze. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die diesem Pokémon zugefügt werden."
 			},
 			damage: 30,
 
@@ -59,6 +62,7 @@ const card: Card = {
 			name: {
 				en: "Cutting Wind",
 				fr: "Vent Glacial",
+				de: "Schneidender Wind"
 			},
 
 			damage: 70,
@@ -84,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Its jaw power is incredible. It is adept at biting apart foes while flying by at high speed.",
+		de: "Die Kraft seines Kiefers ist unglaublich. Es kann daher aus dem Flug heraus hart zubeißen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/50.ts
+++ b/data/Black & White/Dragons Exalted/50.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Beat",
 				fr: "Bataille",
+				de: "Verprügler"
 			},
 
 			damage: 10,
@@ -49,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Gust",
 				fr: "Tornade",
+				de: "Windstoß"
 			},
 
 			damage: 20,
@@ -67,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "Because of the way it floats aimlessly, an old folktale calls it a \"Signpost for Wandering Spirits.\"",
+		de: "Laut einer alten Volkssage nennt man es den „Wegweiser für umherstreifende Geister“."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/51.ts
+++ b/data/Black & White/Dragons Exalted/51.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Drifloon",
 		fr: "Baudrive",
+		de: "Driftlon"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Shadow Steal",
 				fr: "Vol d'Ombre",
+				de: "Schattenklau"
 			},
 			effect: {
 				en: "Does 50 damage times the number of Special Energy cards in your opponent's discard pile.",
 				fr: "Inflige 50 dégâts multipliés par le nombre de cartes Énergie spéciale dans la pile de défausse de votre adversaire.",
+				de: "Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl der Spezial-Energiekarten im Ablagestapel deines Gegners zu."
 			},
 			damage: 50,
 
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Plentiful Placement",
 				fr: "Placement Multiple",
+				de: "Reiche Saat"
 			},
 			effect: {
 				en: "Put 4 damage counters on 1 of your opponent's Pokémon.",
 				fr: "Placez 4 marqueurs de dégâts sur 1 des Pokémon de votre adversaire.",
+				de: "Lege 4 Schadensmarken auf 1 Pokémon deines Gegners."
 			},
 
 		},
@@ -77,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "At dusk, swarms of them are carried aloft on winds. When noticed, they suddenly vanish.",
+		de: "In der Dämmerung steigen ganze Schwärme in die Lüfte, verschwinden aber sofort, wenn man sie bemerkt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/52.ts
+++ b/data/Black & White/Dragons Exalted/52.ts
@@ -60,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Psychic",
 				fr: "Psyko",
+				de: "Psychokinese"
 			},
 			effect: {
 				en: "Does 10 more damage for each Energy attached to the Defending Pokémon.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque Énergie attachée au Pokémon Défenseur.",
+				de: "Dieser Angriff fügt 10 weitere Schadenspunkte für jede an das Verteidigende Pokémon angelegte Energie zu."
 			},
 			damage: 50,
 
@@ -81,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "The guardians of an ancient city, they use their psychic power to attack enemies that invade their territory.",
+		de: "Einst war es der Wächter einer Stadt aus uralten Zeiten. Wer sich in sein Revier wagt, lernt seine Psycho-Kräfte kennen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/53.ts
+++ b/data/Black & White/Dragons Exalted/53.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Pound",
 				fr: "Écras'Face",
+				de: "Pfund"
 			},
 
 			damage: 20,
@@ -51,10 +52,12 @@ const card: Card = {
 			name: {
 				en: "Poison Gas",
 				fr: "Gaz Toxik",
+				de: "Giftwolke"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné.",
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet."
 			},
 			damage: 30,
 
@@ -72,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "Inhaling the gas they belch will make you sleep for a week. They prefer unsanitary places.",
+		de: "Hat ein Faible für schmutzige Orte. Wer das Gas einatmet, das es mit Rülpslauten ausstößt, schläft eine Woche durch."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/54.ts
+++ b/data/Black & White/Dragons Exalted/54.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Trubbish",
 		fr: "Miamiasme",
+		de: "Unratütox"
 	},
 
 	stage: "Stage1",
@@ -65,6 +66,7 @@ const card: Card = {
 			name: {
 				en: "Sludge Toss",
 				fr: "Giclée Vaseuse",
+				de: "Schleimwurf"
 			},
 
 			damage: 60,
@@ -83,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "It clenches opponents with its left arm and finishes them off with foul-smelling poison gas belched from its mouth.",
+		de: "Es nimmt mit dem rechten Arm Gegner in die Mangel und gibt ihnen mit dem giftigen Gas aus seinem Maul den Rest."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/55.ts
+++ b/data/Black & White/Dragons Exalted/55.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Future Sight",
 				fr: "Prescience",
+				de: "Seher"
 			},
 			effect: {
 				en: "Look at the top 5 cards of your deck and put them back on top of your deck in any order.",
 				fr: "Regardez les 5 cartes du dessus de votre deck et replacez-les sur le dessus de votre deck dans l'ordre de votre choix.",
+				de: "Schau dir die obersten 5 Karten deines Decks an und lege sie in beliebiger Reihenfolge zurück auf dein Deck."
 			},
 
 		},
@@ -56,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "They intently observe both Trainers and Pokémon. Apparently, they are looking at something that only Gothita can see.",
+		de: "Beobachtet andere Pokémon und Trainer mit durchdringendem Blick, als könne es etwas erkennen, das keiner sonst sieht."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/56.ts
+++ b/data/Black & White/Dragons Exalted/56.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gothita",
 		fr: "Scrutella",
+		de: "Mollimorba"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Hypnoblast",
 				fr: "Hypnoblast",
+				de: "Hypnoschuss"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 			damage: 10,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Mind Shock",
 				fr: "Choc Cérébral",
+				de: "Verstandesschock"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by Weakness or Resistance.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Faiblesse ou la Résistance.",
+				de: "Der Schaden dieses Angriffs wird durch Schwäche und Resistenz nicht verändert."
 			},
 			damage: 40,
 
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "Starlight is the source of their power. At night, they mark star positions by using psychic power to float stones.",
+		de: "Zieht seine Energie aus dem Sternenlicht. Bei Nacht bringt es Steine zum Schweben und bildet damit Sternzeichen nach."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/57.ts
+++ b/data/Black & White/Dragons Exalted/57.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gothorita",
 		fr: "Mesmérella",
+		de: "Hypnomorba"
 	},
 
 	stage: "Stage2",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Doom Decree",
 				fr: "Verdict Fatal",
+				de: "Urteil"
 			},
 			effect: {
 				en: "Flip 2 coins. If both of them are heads, the Defending Pokémon is Knocked Out.",
 				fr: "Lancez 2 pièces. Si vous obtenez 2 côtés face, le Pokémon Défenseur est mis K.O.",
+				de: "Wirf 2 Münzen. Zeigen beide „Kopf“, wird das Verteidigende Pokémon kampfunfähig."
 			},
 
 		},
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Black Magic",
 				fr: "Magie Noire",
+				de: "Schwarze Magie"
 			},
 			effect: {
 				en: "Does 20 more damage for each of your opponent's Benched Pokémon.",
 				fr: "Inflige 20 dégâts supplémentaires pour chaque Pokémon de Banc de votre adversaire.",
+				de: "Dieser Angriff fügt 20 weitere Schadenspunkte für jedes Pokémon auf der Bank deines Gegners zu."
 			},
 			damage: 40,
 
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "Starry skies thousands of light-years away are visible in the space distorted by their intense psychic power.",
+		de: "Durch seine mächtigen Psycho-Kräfte krümmt sich der Raum und Bilder eines Lichtjahre entfernten Ortes erscheinen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/58.ts
+++ b/data/Black & White/Dragons Exalted/58.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Nap",
 				fr: "Tit'Sieste",
+				de: "Nickerchen"
 			},
 			effect: {
 				en: "Heal 40 damage from this Pokémon.",
 				fr: "Soignez 40 dégâts à ce Pokémon.",
+				de: "Heile 40 Schadenspunkte bei diesem Pokémon."
 			},
 
 		},
@@ -53,6 +55,7 @@ const card: Card = {
 			name: {
 				en: "Pound",
 				fr: "Écras'Face",
+				de: "Pfund"
 			},
 
 			damage: 40,
@@ -71,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "The energy that burns inside it enables it to move, but no one has yet been able to identify this energy.",
+		de: "Es wird durch eine Energie angetrieben, die seinem Körper entspringt. Keiner weiß jedoch, woher diese Energie stammt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/59.ts
+++ b/data/Black & White/Dragons Exalted/59.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Golett",
 		fr: "Gringolem",
+		de: "Golbit"
 	},
 
 	stage: "Stage1",
@@ -43,10 +44,12 @@ const card: Card = {
 			name: {
 				en: "Devolution Punch",
 				fr: "Beigne Dés-évoluante",
+				de: "Rückentwicklungshieb"
 			},
 			effect: {
 				en: "Devolve the Defending Pokémon and put the highest Stage Evolution card on it into your opponent's hand.",
 				fr: "Faites dés-évoluer le Pokémon Défenseur et mettez sa carte Évolution de plus haut Niveau dans la main de votre adversaire.",
+				de: "Rückentwickle das Verteidigende Pokémon. Dein Gegner nimmt die höchste daraufliegende Evolutionskarte auf seine Hand."
 			},
 			damage: 60,
 
@@ -61,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Ghost Hammer",
 				fr: "Spectro Maillet",
+				de: "Geisterhammer"
 			},
 			effect: {
 				en: "During your opponent's next turn, this Pokémon has no Weakness.",
 				fr: "Pendant le prochain tour de votre adversaire, ce Pokémon n'a pas de Faiblesse.",
+				de: "Während des nächsten Zuges deines Gegners hat dieses Pokémon keine Schwäche."
 			},
 			damage: 90,
 
@@ -82,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "It flies around the sky at Mach speeds. Removing the seal on its chest makes its internal energy go out of control.",
+		de: "Es jagt mit Schallgeschwindigkeit durch die Lüfte. Nimmt man das Siegel auf der Brust ab, gerät es außer Kontrolle."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/6.ts
+++ b/data/Black & White/Dragons Exalted/6.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Sleep Poison",
 				fr: "Poison Dodo",
+				de: "Schlafgift"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Asleep and Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Endormi et Empoisonné.",
+				de: "Wirf 1 Münze. Bei „Kopf“ schläft das Verteidigende Pokémon jetzt und ist vergiftet."
 			},
 
 		},
@@ -56,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "Often targeted by bird Pokémon, it desperately resists by releasing poison from its tail spikes.",
+		de: "Es wird oft von Vogel-Pokémon angegriffen, wehrt sich aber mit Gift aus seinen Schwanzspitzen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/60.ts
+++ b/data/Black & White/Dragons Exalted/60.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Headbutt",
 				fr: "Coup d'Boule",
+				de: "Kopfnuss"
 			},
 
 			damage: 10,
@@ -49,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Beat",
 				fr: "Bataille",
+				de: "Verprügler"
 			},
 
 			damage: 20,
@@ -74,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "When it thinks of its dead mother, it cries. Its crying makes the skull it wears rattle hollowly.",
+		de: "Denkt es an seine verstorbene Mutter, weint es, wobei der Schädel auf seinem Kopf hohl klingt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/61.ts
+++ b/data/Black & White/Dragons Exalted/61.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cubone",
 		fr: "Osselait",
+		de: "Tragosso"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Bone Lock",
 				fr: "Piège Osseux",
+				de: "Knochenriegel"
 			},
 			effect: {
 				en: "The Defending Pokémon can't retreat during your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas battre en retraite pendant le prochain tour de votre adversaire.",
+				de: "Das Verteidigende Pokémon kann sich während des nächsten Zuges deines Gegners nicht zurückziehen."
 			},
 			damage: 30,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Vortex Chop",
 				fr: "Coupe-Tourbillon",
+				de: "Wirbelsturm-Schlag"
 			},
 			effect: {
 				en: "If the Defending Pokémon has any Resistance, this attack does 30 more damage.",
 				fr: "Si le Pokémon Défenseur a une Résistance, cette attaque inflige 30 dégâts supplémentaires.",
+				de: "Besitzt das Verteidigende Pokémon eine Resistenz, fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: 60,
 
@@ -86,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "From its birth, this savage Pokémon constantly holds bones. It is skilled in using them as weapons.",
+		de: "Von Geburt an trägt dieses wilde Pokémon Knochen. Es setzt sie talentiert als Waffen ein."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/62.ts
+++ b/data/Black & White/Dragons Exalted/62.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Rock Throw",
 				fr: "Jet-Pierres",
+				de: "Steinwurf"
 			},
 
 			damage: 20,
@@ -55,6 +56,7 @@ const card: Card = {
 
 	description: {
 		en: "When endangered, it may protect itself by raising its magnetism and drawing iron objects to its body.",
+		de: "Es schützt sich bei Gefahr durch Gegenstände aus Eisen, die es mit erhöhtem Magnetismus an sich zieht."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/63.ts
+++ b/data/Black & White/Dragons Exalted/63.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Spinning Attack",
 				fr: "Attaque Tournante",
+				de: "Rundumangriff"
 			},
 
 			damage: 10,
@@ -49,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Reverse Spin",
 				fr: "Vrille Renversante",
+				de: "Gegendreher"
 			},
 			effect: {
 				en: "Your opponent shuffles his or her hand into his or her deck and draws 4 cards.",
 				fr: "Votre adversaire mélange sa main avec son deck et pioche 4 cartes.",
+				de: "Dein Gegner mischt seine Hand zurück in sein Deck und zieht 4 Karten."
 			},
 
 		},
@@ -69,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "It move by spinning on its foot. It is a rare Pokémon that was discovered in ancient ruins.",
+		de: "Es bewegt sich, indem es sich auf seinem Fuß dreht. Ein seltenes Pokémon, das in alten Ruinen lebte."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/64.ts
+++ b/data/Black & White/Dragons Exalted/64.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Baltoy",
 		fr: "Balbuto",
+		de: "Puppance"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Rapid Spin",
 				fr: "Tour Rapide",
+				de: "Turbodreher"
 			},
 			effect: {
 				en: "Switch this Pokémon with 1 of your Benched Pokémon. Then, your opponent switches the Defending Pokémon with 1 of his or her Benched Pok��mon.",
 				fr: "Échangez ce Pokémon avec 1 de vos Pokémon de Banc. Ensuite, votre adversaire échange le Pokémon Défenseur avec 1 de ses Pokémon de Banc.",
+				de: "Tausche dieses Pokémon gegen 1 Pokémon auf deiner Bank aus. Danach tauscht dein Gegner das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
 			},
 			damage: 30,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Rock Smash",
 				fr: "Éclate-Roc",
+				de: "Zertrümmerer"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: 60,
 
@@ -80,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "An ancient clay figurine that came to life as a Pokémon from exposure to a mysterious ray of light.",
+		de: "Eine antike Lehmstatue, die durch ein mysteriöses Licht zum Leben erwacht ist."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/65.ts
+++ b/data/Black & White/Dragons Exalted/65.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Stone Edge",
 				fr: "Lame de Roc",
+				de: "Steinkante"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 10,
 
@@ -54,6 +56,7 @@ const card: Card = {
 			name: {
 				en: "Hammer In",
 				fr: "Enfoncer",
+				de: "Einhämmern"
 			},
 
 			damage: 40,
@@ -72,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "They were discovered a hundred years ago in an earthquake fissure. Inside each one is an energy core.",
+		de: "Wurde vor 100 Jahren nach einem großen Erdbeben in einer Erdspalte entdeckt. Es trägt eine Energiesphäre in sich."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/66.ts
+++ b/data/Black & White/Dragons Exalted/66.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Roggenrola",
 		fr: "Nodulithe",
+		de: "Kiesling"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Rock Cannon",
 				fr: "Canon à Pierres",
+				de: "Felskanone"
 			},
 			effect: {
 				en: "Flip a coin until you get tails. This attack does 30 damage times the number of heads.",
 				fr: "Lancez une pièce jusqu'à ce que vous obteniez un côté pile. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 30,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Earthquake",
 				fr: "Séisme",
+				de: "Erdbeben"
 			},
 			effect: {
 				en: "Does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à chacun de vos Pokémon de Banc. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt jedem Pokémon auf deiner Bank 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 60,
 
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "Because its energy was too great to be contained, the energy leaked and formed orange crystals.",
+		de: "Energie, die ungehindert aus seinem Körper austrat, hat sich an ihm zu orangefarbenen Kristallen verfestigt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/67.ts
+++ b/data/Black & White/Dragons Exalted/67.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Boldore",
 		fr: "Géolithe",
+		de: "Sedimantur"
 	},
 
 	stage: "Stage2",
@@ -43,10 +44,12 @@ const card: Card = {
 			name: {
 				en: "Revenge Cannon",
 				fr: "Canon Talion",
+				de: "Konterkanone"
 			},
 			effect: {
 				en: "Does 10 more damage for each damage counter on each of your Benched Pokémon.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque marqueur de dégâts placé sur chacun de vos Pokémon de Banc.",
+				de: "Dieser Angriff fügt 10 weitere Schadenspunkte für jede Schadensmarke auf den Pokémon auf deiner Bank zu."
 			},
 			damage: 10,
 
@@ -61,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Reckless Charge",
 				fr: "Attaque Imprudente",
+				de: "Waghalsiger Sturmangriff"
 			},
 			effect: {
 				en: "This Pokémon does 40 damage to itself.",
 				fr: "Ce Pokémon s'inflige 40 dégâts.",
+				de: "Dieses Pokémon fügt sich selbst 40 Schadenspunkte zu."
 			},
 			damage: 120,
 
@@ -82,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "The solar energy absorbed by its body's orange crystals is magnified internally are fired from its mouth.",
+		de: "Es absorbiert über seine orangefarbenen Kristalle das Sonnenlicht und schießt die so gewonnene Energie aus seinem Maul."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/68.ts
+++ b/data/Black & White/Dragons Exalted/68.ts
@@ -38,10 +38,12 @@ const card: Card = {
 			name: {
 				en: "Squeeze",
 				fr: "Compression",
+				de: "Quetschen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage and the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires et le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu und das Verteidigende Pokémon ist jetzt paralysiert."
 			},
 			damage: 40,
 
@@ -56,10 +58,12 @@ const card: Card = {
 			name: {
 				en: "Superpower",
 				fr: "Surpuissance",
+				de: "Kraftkoloss"
 			},
 			effect: {
 				en: "You may do 20 more damage. If you do, this Pokémon does 20 damage to itself.",
 				fr: "Vous pouvez infliger 20 dégâts supplémentaires. Dans ce cas, ce Pokémon s'inflige 20 dégâts.",
+				de: "Du kannst mit diesem Angriff 20 weitere Schadenspunkte zufügen. Wenn du das machst, fügt dieses Pokémon sich selbst 20 Schadenspunkte zu."
 			},
 			damage: 70,
 
@@ -77,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "When they encounter foes bigger than themselves, they try to throw them. They always travel in packs of five.",
+		de: "Hat von Natur aus den Drang, Gegner zu werfen, die größer sind als es selbst. Es bildet stets Fünferrudel."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/69.ts
+++ b/data/Black & White/Dragons Exalted/69.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Defensive Stance",
 				fr: "Posture Défensive",
+				de: "Trutzposten"
 			},
 			effect: {
 				en: "Heal 30 damage from this Pokémon. Switch this Pokémon with 1 of your Benched Pokémon.",
 				fr: "Soignez 30 dégâts à ce Pokémon. Échangez ce Pokémon avec 1 de vos Pokémon de Banc.",
+				de: "Heile 30 Schadenspunkte bei diesem Pokémon. Tausche dieses Pokémon gegen 1 Pokémon auf deiner Bank aus."
 			},
 
 		},
@@ -52,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Karate Chop",
 				fr: "Poing-Karaté",
+				de: "Karateschlag"
 			},
 			effect: {
 				en: "Does 70 damage minus 10 damage for each damage counter on this Pokémon.",
 				fr: "Inflige 70 dégâts moins 10 dégâts pour chaque marqueur de dégâts placé sur ce Pokémon.",
+				de: "Dieser Angriff fügt 70 Schadenspunkte minus 10 Schadenspunkte für jede Schadensmarke auf diesem Pokémon zu."
 			},
 			damage: 70,
 
@@ -73,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "Tying their belts gets them pumped and makes their punches more destructive. Disturbing their training angers them.",
+		de: "Zieht es den Gürtel fest, werden seine Hiebe stärker. Kann es gar nicht leiden, wenn man es beim Training stört."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/7.ts
+++ b/data/Black & White/Dragons Exalted/7.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Wurmple",
 		fr: "Chenipotte",
+		de: "Waumpel"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Harden",
 				fr: "Armure",
+				de: "Härtner"
 			},
 			effect: {
 				en: "During your opponent's next turn, if this Pokémon would be damaged by an attack, prevent that attack's damage done to this Pokémon if that damage is 60 or less.",
 				fr: "Pendant le prochain tour de votre adversaire, si ce Pokémon doit subir les dégâts d'une attaque, évitez les dégâts infligés à ce Pokémon si ces dégâts sont de 60 ou moins.",
+				de: "Wenn diesem Pokémon während des nächsten Zuges deines Gegners durch einen Angriff 60 oder weniger Schadenspunkte zugefügt würden, verhindere diesen Schaden."
 			},
 
 		},
@@ -57,6 +60,7 @@ const card: Card = {
 			name: {
 				en: "Bug Bite",
 				fr: "Piqûre",
+				de: "Käferbiss"
 			},
 
 			damage: 40,
@@ -75,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "It wraps silk around the branches of a tree. It drinks rainwater on its silk while awaiting evolution.",
+		de: "Es bindet sich mit Seide an Äste und trinkt Regenwasser, während es starr auf seine Entwicklung wartet."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/70.ts
+++ b/data/Black & White/Dragons Exalted/70.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Muddy Water",
 				fr: "Ocroupi",
+				de: "Lehmbrühe"
 			},
 			effect: {
 				en: "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 20 dégâts à 1 des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 1 Pokémon auf der Bank deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 20,
 
@@ -52,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Rumble",
 				fr: "Bagarre",
+				de: "Grollen"
 			},
 			effect: {
 				en: "The Defending Pokémon can't retreat during your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas battre en retraite pendant le prochain tour de votre adversaire.",
+				de: "Das Verteidigende Pokémon kann sich während des nächsten Zuges deines Gegners nicht zurückziehen."
 			},
 			damage: 40,
 
@@ -80,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "It conceals itself in the mud of the seashore. Then it waits. When prey touch it, it delivers a jolt of electricity.",
+		de: "Es vergräbt sich im Morast am Meeresboden. Wird es von seiner Beute gestreift, lähmt es sie mit Strom."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/71.ts
+++ b/data/Black & White/Dragons Exalted/71.ts
@@ -35,10 +35,12 @@ const card: Card = {
 			name: {
 				en: "Rock Tumble",
 				fr: "Roule-Pierre",
+				de: "Rollende Felsen"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by Resistance.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Résistance.",
+				de: "Der Schaden dieses Angriffs wird durch Resistenz nicht verändert."
 			},
 			damage: 50,
 
@@ -52,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Pump-up Smash",
 				fr: "Taurocharge",
+				de: "Aufmöbler"
 			},
 			effect: {
 				en: "Attach 2 basic Energy cards from your hand to your Benched Pokémon in any way you like.",
 				fr: "Attachez 2 cartes Énergie de base de votre main à vos Pokémon de Banc, de la manière que vous voulez.",
+				de: "Lege 2 Basis-Energiekarten von deiner Hand nach Belieben an die Pokémon auf deiner Bank an."
 			},
 			damage: 90,
 

--- a/data/Black & White/Dragons Exalted/72.ts
+++ b/data/Black & White/Dragons Exalted/72.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Peck",
 				fr: "Picpic",
+				de: "Schnabel"
 			},
 
 			damage: 10,
@@ -49,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Wing Attack",
 				fr: "Cru-Aile",
+				de: "Flügelschlag"
 			},
 
 			damage: 20,
@@ -74,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "If spotted, it will lure an unwary person into chasing it, then lose the pursuer on mountain trails.",
+		de: "Wird es entdeckt, lockt es seinen Verfolger auf eine Jagd in die Berge, wo es ihn dann abschüttelt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/73.ts
+++ b/data/Black & White/Dragons Exalted/73.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Murkrow",
 		fr: "Cornèbre",
+		de: "Kramurx"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Whirlwind",
 				fr: "Cyclone",
+				de: "Wirbelwind"
 			},
 			effect: {
 				en: "You may have your opponent switch the Defending Pokémon with 1 of his or her Benched Pokémon.",
 				fr: "Vous pouvez demander à votre adversaire d'échanger le Pokémon Défenseur avec 1 de ses Pokémon de Banc.",
+				de: "Du kannst deinen Gegner dazu veranlassen, das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank auszutauschen."
 			},
 			damage: 30,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Diving Swipe",
 				fr: "Rafle Plongeante",
+				de: "Sturzklau"
 			},
 			effect: {
 				en: "Discard a random card from your opponent's hand.",
 				fr: "Défaussez au hasard une carte de la main de votre adversaire.",
+				de: "Nimm 1 zufällige Karte aus der verdeckten Hand deines Gegners und lege sie auf dessen Ablagestapel."
 			},
 			damage: 70,
 
@@ -87,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "If one utters a deep cry, many Murkrow gather quickly. For this, it is called \"Summoner of Night.\"",
+		de: "Sein tiefer Ruf lockt andere Kramurx herbei. Man anennt es daher „Beschwörer der Nacht“."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/74.ts
+++ b/data/Black & White/Dragons Exalted/74.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
+				de: "Biss"
 			},
 
 			damage: 10,
@@ -50,6 +51,7 @@ const card: Card = {
 			name: {
 				en: "Darkness Fang",
 				fr: "Croc Obscur",
+				de: "Fänge der Dunkelheit"
 			},
 
 			damage: 30,
@@ -75,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "It is smart enough to hunt in packs. It uses a variety of cries for communicating with others.",
+		de: "Es jagt in Rudeln und kommuniziert über eine ganze Reihe von Rufen mit anderen Hunduster."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/75.ts
+++ b/data/Black & White/Dragons Exalted/75.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Houndour",
 		fr: "Malosse",
+		de: "Hunduster"
 	},
 
 	stage: "Stage1",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
+				de: "Biss"
 			},
 
 			damage: 30,
@@ -55,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Fire Fang",
 				fr: "Crocs Feu",
+				de: "Feuerzahn"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Burned.",
 				fr: "Le Pokémon Défenseur est maintenant Brûlé.",
+				de: "Das Verteidigende Pokémon ist jetzt verbrannt."
 			},
 			damage: 70,
 
@@ -83,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "The flames it breathes when angry contain toxins. If they cause a burn, it will hurt forever.",
+		de: "Ist es wütend, spuckt es giftige Flammen. Die Schmerzen der Verbrennungen dauern ewig an."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/76.ts
+++ b/data/Black & White/Dragons Exalted/76.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Acid Spray",
 				fr: "Bombe Acide",
+				de: "Säurespeier"
 			},
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, défaussez une Énergie attachée au Pokémon Défenseur.",
+				de: "Wirf 1 Münze. Lege bei „Kopf“ 1 an das Verteidigende Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 10,
 
@@ -64,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "It sprays a foul fluid from its rear. Its stench spreads over a mile radius, driving Pokémon away.",
+		de: "Versprüht eine Substanz aus seinem Hinterleib, die in einem großen Radius andere Pokémon fernhält."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/77.ts
+++ b/data/Black & White/Dragons Exalted/77.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Stunky",
 		fr: "Moufouette",
+		de: "Skunkapuh"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Smogscreen",
 				fr: "Brouillard Venimeux",
+				de: "Smogwolke"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned. If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné. Si le Pokémon Défenseur essaie d'attaquer pendant le prochain tour de votre adversaire, ce dernier lance une pièce. Si c'est pile, son attaque ne fait rien.",
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet. Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 20,
 
@@ -58,6 +61,7 @@ const card: Card = {
 			name: {
 				en: "Hammer In",
 				fr: "Enfoncer",
+				de: "Einhämmern"
 			},
 
 			damage: 80,
@@ -83,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "It attacks by spraying a horribly smelly fluid from the tip of its tail. Attacks from above confound it.",
+		de: "Greift mit einer Substanz aus der Spitze seines Schweifs an. Angriffe von oben verblüffen es."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/78.ts
+++ b/data/Black & White/Dragons Exalted/78.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Take Down",
 				fr: "Bélier",
+				de: "Bodycheck"
 			},
 			effect: {
 				en: "This Pokémon does 10 damage to itself.",
 				fr: "Ce Pokémon s'inflige 10 dégâts.",
+				de: "Dieses Pokémon fügt sich selbst 10 Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -65,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "It usually lives deep in mountains. However, hunger may drive it to eat railroad tracks and cars.",
+		de: "Normalerweise lebt es in dunklen Bergen. Ist es hungrig, frisst es auch Eisenbahnschienen und Autos."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/79.ts
+++ b/data/Black & White/Dragons Exalted/79.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Aron",
 		fr: "Galekid",
+		de: "Stollunior"
 	},
 
 	stage: "Stage1",
@@ -42,6 +43,7 @@ const card: Card = {
 			name: {
 				en: "Metal Claw",
 				fr: "Griffe Acier",
+				de: "Metallklaue"
 			},
 
 			damage: 30,
@@ -56,10 +58,12 @@ const card: Card = {
 			name: {
 				en: "Wreak Havoc",
 				fr: "Ravages",
+				de: "Chaos anrichten"
 			},
 			effect: {
 				en: "Flip a coin until you get tails. For each heads, discard the top card of your opponent's deck.",
 				fr: "Lancez une pièce jusqu'à ce que vous obteniez un côté pile. Pour chaque côté face, défaussez la carte du dessus du deck de votre adversaire.",
+				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Lege pro „Kopf“ die oberste Karte vom Deck deines Gegners auf seinen Ablagestapel."
 			},
 			damage: 60,
 
@@ -84,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "For food, it digs up iron ore. It smashes it steely body against others to fight over territory.",
+		de: "Es ernährt sich von Eisenerz. Um sein Revier zu sichern, setzt es seinen harten Körper ein."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/8.ts
+++ b/data/Black & White/Dragons Exalted/8.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Silcoon",
 		fr: "Armulys",
+		de: "Schaloko"
 	},
 
 	stage: "Stage2",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Triple Energy",
 				fr: "Triple Énergie",
+				de: "Dreifach-Energie"
 			},
 			effect: {
 				en: "Search your deck for 3 different types of basic Energy cards and attach them to your Pokémon in any way you like. Shuffle your deck afterward.",
 				fr: "Cherchez dans votre deck 3 différents types de cartes Énergie de base et attachez-les à vos Pokémon de la manière que vous voulez. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 3 vom Typ her unterschiedlichen Basis-Energiekarten und lege sie beliebig an deine Pokémon an. Mische anschließend dein Deck."
 			},
 
 		},
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Drainpour",
 				fr: "Sangsue-Déluge",
+				de: "Gesundgulli"
 			},
 			effect: {
 				en: "Heal 40 damage from each of your Benched Pokémon.",
 				fr: "Soignez 40 dégâts à chacun de vos Pokémon de Banc.",
+				de: "Heile 40 Schadenspunkte bei jedem Pokémon auf deiner Bank."
 			},
 			damage: 40,
 
@@ -78,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "Despite its looks, it is aggressive. It jabs with its long, thin mouth if disturbed while collecting pollen.",
+		de: "Stört man es, während es Pollen sucht, stößt es mit seinem langen, dünnen Mund zu."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/80.ts
+++ b/data/Black & White/Dragons Exalted/80.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Lairon",
 		fr: "Galegon",
+		de: "Stollrak"
 	},
 
 	stage: "Stage2",
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Giga Horn",
 				fr: "Giga Corne",
+				de: "Gigahorn"
 			},
 			effect: {
 				en: "Flip 2 coins. If both of them are tails, this attack does nothing.",
 				fr: "Lancez 2 pièces. Si vous obtenez 2 côtés pile, cette attaque ne fait rien.",
+				de: "Wirf 2 Münzen. Wenn beide „Zahl“ zeigen, hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 90,
 
@@ -93,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "While seeking iron for food, it digs tunnels by breaking through bedrock with its steel horns.",
+		de: "Auf der Suche nach Eisen, seiner Nahrung, gräbt es mit seinen Stahlhörnern sogar Tunnel durch Felsen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/81.ts
+++ b/data/Black & White/Dragons Exalted/81.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Triple Laser",
 				fr: "Triple Laser",
+				de: "Dreifachlaser"
 			},
 			effect: {
 				en: "This attack does 30 damage to 3 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige 30 dégâts à 3 des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 3 Pokémon deines Gegners jeweils 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -53,10 +55,12 @@ const card: Card = {
 			name: {
 				en: "Protect Charge",
 				fr: "Recharge Protectrice",
+				de: "Schützender Sturmangriff"
 			},
 			effect: {
 				en: "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, tous les dégâts infligés à ce Pokémon par des attaques sont réduits de 20 (après application de la Faiblesse et de la Résistance).",
+				de: "Während des nächsten Zuges deines Gegners wird Schaden, der diesem Pokémon durch Angriffe zugefügt wird, um 20 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 			damage: 80,
 

--- a/data/Black & White/Dragons Exalted/82.ts
+++ b/data/Black & White/Dragons Exalted/82.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Nosepass",
 		fr: "Tarinor",
+		de: "Nasgnet"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Magnetic Lines",
 				fr: "Lignes Magnétiques",
+				de: "Magnetische Linien"
 			},
 			effect: {
 				en: "You may move an Energy attached to the Defending Pokémon to 1 of your opponent's Benched Pokémon.",
 				fr: "Vous pouvez déplacer une Énergie attachée au Pokémon Défenseur vers 1 des Pokémon de Banc de votre adversaire.",
+				de: "Du kannst 1 an das Verteidigende Pokémon angelegte Energie auf 1 Pokémon auf der Bank deines Gegners verschieben."
 			},
 			damage: 30,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Heavy Nose",
 				fr: "Pif Paf",
+				de: "Bleierner Zinken"
 			},
 			effect: {
 				en: "If the Defending Pokémon already has any damage counters on it, this attack does 30 more damage.",
 				fr: "Si le Pokémon Défenseur a déjà des marqueurs de dégâts, cette attaque inflige 30 dégâts supplémentaires.",
+				de: "Wenn auf dem Verteidigenden Pokémon bereits mindestens 1 Schadensmarke liegt, fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: 60,
 
@@ -87,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "It freely controls three small units called Mini-Noses using magnetic force.",
+		de: "Es steuert drei kleine Einheiten mithilfe von starkem Magnetismus. Man nennt sie Mininasen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/83.ts
+++ b/data/Black & White/Dragons Exalted/83.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Pull Out",
 				fr: "Déracinement",
+				de: "Herausziehen"
 			},
 			effect: {
 				en: "Put a card from your discard pile on top of your deck.",
 				fr: "Mettez une carte de votre pile de défausse sur le dessus de votre deck.",
+				de: "Lege 1 beliebige Karte von deinem Ablagestapel auf dein Deck."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Iron Head",
 				fr: "Tête de Fer",
+				de: "Eisenschädel"
 			},
 			effect: {
 				en: "Flip a coin until you get tails. This attack does 30 damage times the number of heads.",
 				fr: "Lancez une pièce jusqu'à ce que vous obteniez un côté pile. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 30,
 
@@ -79,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "Durant dig nests in mountains. They build their complicated, interconnected tunnels into mazes.",
+		de: "Es hebt ein komplexes Tunnelsystem im Berginneren aus und nutzt dieses Labyrinth als seinen Bau."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/84.ts
+++ b/data/Black & White/Dragons Exalted/84.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Swablu",
 		fr: "Tylton",
+		de: "Wablu"
 	},
 
 	stage: "Stage1",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Los ataques de tus Pokémon Dragon hacen 20 puntos de daño más a los Pokémon Activos (antes de aplicar Debilidad y Resistencia).",
 				it: "Gli attacchi dei tuoi Pokémon Dragon infliggono 20 danni in più al Pokémon attivo, prima di aver applicato debolezza e resistenza.",
 				pt: "Os ataques do seu Pokémon Dragon causam 20 de danos adicionais ao Pokémon Ativo (antes da aplicação de Fraqueza e Resistência).",
-				de: "Die Angriffe deiner Dragon-Pokémon fügen den Aktiven Pokémon 20 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
+				de: "Die Angriffe deiner {N}-Pokémon fügen den Aktiven Pokémon 20 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 		},
 	],
@@ -65,6 +66,7 @@ const card: Card = {
 			name: {
 				en: "Glide",
 				fr: "Glissement",
+				de: "Gleiten"
 			},
 
 			damage: 40,
@@ -83,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "If it bonds with a person, it will gently envelop the friend with its soft wings, then hum.",
+		de: "Freundet es sich mit jemandem an, hüllt es den Freund sanft mit den Flügeln ein und singt dann."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/85.ts
+++ b/data/Black & White/Dragons Exalted/85.ts
@@ -34,10 +34,12 @@ const card: Card = {
 			name: {
 				en: "Celestial Roar",
 				fr: "Cri du Ciel",
+				de: "Himmelsgrollen"
 			},
 			effect: {
 				en: "Discard the top 3 cards of your deck. If any of those cards are Energy cards, attach them to this Pokémon.",
 				fr: "Défaussez les 3 cartes du dessus de votre deck. Si vous y trouvez des cartes Énergie, attachez-les à ce Pokémon.",
+				de: "Lege die obersten 3 Karten deines Decks auf deinen Ablagestapel. Wenn darunter Energiekarten sind, lege sie an dieses Pokémon an."
 			},
 
 		},
@@ -49,10 +51,12 @@ const card: Card = {
 			name: {
 				en: "Dragon Burst",
 				fr: "Fureur du Dragon",
+				de: "Drachensalve"
 			},
 			effect: {
 				en: "Discard all basic Fire Energy or all basic Lightning Energy attached to this Pokémon. This attack does 60 damage times the number of Energy cards you discarded.",
 				fr: "Défaussez toutes les Énergies Fire de base ou toutes les Énergies Lightning de base attachées à ce Pokémon. Cette attaque inflige 60 dégâts multipliés par le nombre de cartes Énergie que vous avez défaussées.",
+				de: "Lege alle an dieses Pokémon angelegten {R}-Basis-Energien oder {L}-Basis-Energien auf deinen Ablagestapel. Dieser Angriff fügt 60 Schadenspunkte mal der Anzahl abgelegter Energiekarten zu."
 			},
 			damage: 60,
 

--- a/data/Black & White/Dragons Exalted/86.ts
+++ b/data/Black & White/Dragons Exalted/86.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 10,
@@ -49,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Gnaw",
 				fr: "Ronge",
+				de: "Nagen"
 			},
 
 			damage: 20,
@@ -67,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "It attacks using its huge mouth. While its attacks are powerful, it hurts itself out of clumsiness, too.",
+		de: "Greift mit seinem riesigen Maul an. Obwohl seine Angriffe mächtig sind, verletzt es sich dabei auch selbst."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/87.ts
+++ b/data/Black & White/Dragons Exalted/87.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Sand-Attack",
 				fr: "Jet de Sable",
+				de: "Sandwirbel"
 			},
 			effect: {
 				en: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
 				fr: "Si le Pokémon Défenseur essaie d'attaquer pendant le prochain tour de votre adversaire, ce dernier lance une pièce. Si c'est pile, son attaque ne fait rien.",
+				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Knock Away",
 				fr: "Asticotage",
+				de: "Zurückschlagen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 10,
 
@@ -72,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "It attacks using its huge mouth. While its attacks are powerful, it hurts itself out of clumsiness, too.",
+		de: "Greift mit seinem riesigen Maul an. Obwohl seine Angriffe mächtig sind, verletzt es sich dabei auch selbst."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/88.ts
+++ b/data/Black & White/Dragons Exalted/88.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gible",
 		fr: "Griknot",
+		de: "Kaumalat"
 	},
 
 	stage: "Stage1",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 20,
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Shred",
 				fr: "Déchiquetage",
+				de: "Zerfetzer"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by any effects on the Defending Pokémon.",
 				fr: "Les dégâts de cette attaque ne sont affectés par aucun effet en action sur le Pokémon Défenseur.",
+				de: "Der Schaden dieses Angriffs wird durch Effekte auf dem Verteidigenden Pokémon nicht verändert."
 			},
 			damage: 40,
 
@@ -75,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "It loves sparkly things. It seeks treasures in caves and hoards the loot in its nest.",
+		de: "Es liebt funkelnde Dinge und sucht nach Schätzen in Höhlen, die es dann in seinem Nest hortet."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/89.ts
+++ b/data/Black & White/Dragons Exalted/89.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gible",
 		fr: "Griknot",
+		de: "Kaumalat"
 	},
 
 	stage: "Stage1",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Una vez durante tu turno (antes de tu ataque), puedes buscar en tu baraja un Pokémon Dragon, enseñarlo y ponerlo en tu mano. Baraja las cartas de tu baraja después.",
 				it: "Una sola volta durante il tuo turno, prima di attaccare, puoi cercare nel tuo mazzo un Pokémon Dragon, mostrarlo e aggiungerlo alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 				pt: "Uma vez durante sua vez de jogar (antes de atacar), você pode procurar um Pokémon Dragon no seu deck, revelá-lo e colocá-lo na sua mão. Em seguida, embaralhe seus cards.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du dein Deck nach 1 Dragon-Pokémon durchsuchen, es deinem Gegner zeigen und auf deine Hand nehmen. Mische anschließend dein Deck."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du dein Deck nach 1 {N}-Pokémon durchsuchen, es deinem Gegner zeigen und auf deine Hand nehmen. Mische anschließend dein Deck."
 			},
 		},
 	],
@@ -64,6 +65,7 @@ const card: Card = {
 			name: {
 				en: "Dragonslice",
 				fr: "Draco-Tranche",
+				de: "Drachenschnetzler"
 			},
 
 			damage: 20,
@@ -82,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "It loves sparkly things. It seeks treasures in caves and hoards the loot in its nest.",
+		de: "Es liebt funkelnde Dinge und sucht nach Schätzen in Höhlen, die es dann in seinem Nest hortet."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/9.ts
+++ b/data/Black & White/Dragons Exalted/9.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Wurmple",
 		fr: "Chenipotte",
+		de: "Waumpel"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Tangle Drag",
 				fr: "Lasso Piège",
+				de: "Wirrzieher"
 			},
 			effect: {
 				en: "Switch 1 of your opponent's Benched Pokémon with the Defending Pokémon.",
 				fr: "Échangez 1 des Pokémon de Banc de votre adversaire avec le Pokémon Défenseur.",
+				de: "Tausche 1 Pokémon auf der Bank deines Gegners gegen das Verteidigende Pokémon aus."
 			},
 
 		},
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Spiral Drain",
 				fr: "Spirale Épuisante",
+				de: "Spiralsauger"
 			},
 			effect: {
 				en: "Heal 20 damage from this Pokémon.",
 				fr: "Soignez 20 dégâts à ce Pokémon.",
+				de: "Heile 20 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 20,
 
@@ -77,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It never forgets any attack it endured while in the cocoon. After evolution, it seeks payback.",
+		de: "Es vergisst keinen Angriff, den es im Kokon erdulden musste. Nach der Entwicklung sinnt es auf Rache."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/90.ts
+++ b/data/Black & White/Dragons Exalted/90.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gabite",
 		fr: "Carmache",
+		de: "Knarksel"
 	},
 
 	stage: "Stage2",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Mach Cut",
 				fr: "Coupe Vive",
+				de: "Schallschnitt"
 			},
 			effect: {
 				en: "Discard a Special Energy attached to the Defending Pokémon.",
 				fr: "Défaussez une Énergie spéciale attachée au Pokémon Défenseur.",
+				de: "Lege 1 an das Verteidigende Pokémon angelegte Spezial-Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 60,
 
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Dragonblade",
 				fr: "Draco-Lame",
+				de: "Drachenklinge"
 			},
 			effect: {
 				en: "Discard the top 2 cards of your deck.",
 				fr: "Défaussez les 2 cartes du dessus de votre deck.",
+				de: "Lege die obersten 2 Karten deines Decks auf deinen Ablagestapel."
 			},
 			damage: 100,
 
@@ -78,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said that when one runs at high speed, its wings create blades of wind that can fell nearby trees.",
+		de: "Die schnelle Bewegung seiner Flügel erzeugt regelrechte Klingen des Windes, die Bäume fällen können."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/91.ts
+++ b/data/Black & White/Dragons Exalted/91.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gabite",
 		fr: "Carmache",
+		de: "Knarksel"
 	},
 
 	stage: "Stage2",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Jet Headbutt",
 				fr: "Bélier Volant",
+				de: "Flinke Kopfnuss"
 			},
 
 			damage: 40,
@@ -55,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Sand Tomb",
 				fr: "Tourbi-Sable",
+				de: "Sandgrab"
 			},
 			effect: {
 				en: "The Defending Pokémon can't retreat during your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas battre en retraite pendant le prochain tour de votre adversaire.",
+				de: "Das Verteidigende Pokémon kann sich während des nächsten Zuges deines Gegners nicht zurückziehen."
 			},
 			damage: 80,
 
@@ -76,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said that when one runs at high speed, its wings create blades of wind that can fell nearby trees.",
+		de: "Die schnelle Bewegung seiner Flügel erzeugt regelrechte Klingen des Windes, die Bäume fällen können."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/92.ts
+++ b/data/Black & White/Dragons Exalted/92.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Shred",
 				fr: "Déchiquetage",
+				de: "Zerfetzer"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by any effects on the Defending Pokémon.",
 				fr: "Les dégâts de cette attaque ne sont affectés par aucun effet en action sur le Pokémon Défenseur.",
+				de: "Der Schaden dieses Angriffs wird durch Effekte auf dem Verteidigenden Pokémon nicht verändert."
 			},
 			damage: 90,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Dragon Pulse",
 				fr: "Dracochoc",
+				de: "Drachenpuls"
 			},
 			effect: {
 				en: "Discard the top 3 cards of your deck.",
 				fr: "Défaussez les 3 cartes du dessus de votre deck.",
+				de: "Lege die obersten 3 Karten deines Decks auf deinen Ablagestapel."
 			},
 			damage: 130,
 

--- a/data/Black & White/Dragons Exalted/93.ts
+++ b/data/Black & White/Dragons Exalted/93.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Deep Growl",
 				fr: "Rugissement Profond",
+				de: "Kraftvoller Knurrer"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Power Breath",
 				fr: "Souffle Puissant",
+				de: "Kraftvoller Atem"
 			},
 			effect: {
 				en: "Discard an Energy attached to this Pokémon.",
 				fr: "Défaussez une Énergie attachée à ce Pokémon.",
+				de: "Lege 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel."
 			},
 			damage: 30,
 
@@ -72,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "It tends to bit everything, and it is not a picky eater. Approaching it carelessly is dangerous.",
+		de: "Es beißt einfach alles und jeden und frisst, was ihm zwischen die Zähne kommt. Man nähert sich ihm besser mit Bedacht."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/94.ts
+++ b/data/Black & White/Dragons Exalted/94.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Guard Press",
 				fr: "Pression de Garde",
+				de: "Schutzdruck"
 			},
 			effect: {
 				en: "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 10 (after applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, tous les dégâts infligés à ce Pokémon par des attaques sont réduits de 10 (après application de la Faiblesse et de la Résistance).",
+				de: "Während des nächsten Zuges deines Gegners wird Schaden, der diesem Pokémon durch Angriffe zugefügt wird, um 10 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 			damage: 10,
 
@@ -53,6 +55,7 @@ const card: Card = {
 			name: {
 				en: "Headbutt",
 				fr: "Coup d'Boule",
+				de: "Kopfnuss"
 			},
 
 			damage: 30,
@@ -71,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "They cannot see, so they tackle and bite to learn about their surroundings. Their bodies are covered in wounds.",
+		de: "Da es nichts sehen kann, sucht es seine Umgebung mit Rempel- und Bissattacken ab und ist immer mit Wunden übersät."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/95.ts
+++ b/data/Black & White/Dragons Exalted/95.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Deino",
 		fr: "Solochi",
+		de: "Kapuno"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Crunch",
 				fr: "Mâchouille",
+				de: "Knirscher"
 			},
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, défaussez une Énergie attachée au Pokémon Défenseur.",
+				de: "Wirf 1 Münze. Lege bei „Kopf“ 1 an das Verteidigende Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 30,
 
@@ -59,6 +62,7 @@ const card: Card = {
 			name: {
 				en: "Dragon Claw",
 				fr: "Dracogriffe",
+				de: "Drachenklaue"
 			},
 
 			damage: 80,
@@ -77,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "After it has eaten up all the food in its territory, it moves to another area. Its two heads do not get along.",
+		de: "Wenn es sein Revier leergejagt hat, sucht es sich ein neues. Seine beiden Köpfe liegen ständig im Streit."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/96.ts
+++ b/data/Black & White/Dragons Exalted/96.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Deino",
 		fr: "Solochi",
+		de: "Kapuno"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Draw In",
 				fr: "Aspiracartes",
+				de: "Ansaugen"
 			},
 			effect: {
 				en: "Attach 2 Darkness Energy cards from your discard pile to this Pokémon.",
 				fr: "Attachez 2 cartes Énergie Darkness de votre pile de défausse à ce Pokémon.",
+				de: "Lege 2 {D}-Energiekarten von deinem Ablagestapel an dieses Pokémon an."
 			},
 
 		},
@@ -57,6 +60,7 @@ const card: Card = {
 			name: {
 				en: "Dragon Headbutt",
 				fr: "Dracoud'Boule",
+				de: "Drachen-Kopfnuss"
 			},
 
 			damage: 40,
@@ -75,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "Since their two heads do not get along and compete with each other for food, they always eat too much.",
+		de: "Seine zwei Köpfe liegen stets im Streit. So wird jede Mahlzeit ein Wettstreit für sie, bei dem sich beide überfressen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/97.ts
+++ b/data/Black & White/Dragons Exalted/97.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Zweilous",
 		fr: "Diamat",
+		de: "Duodino"
 	},
 
 	stage: "Stage2",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Todas las veces que quieras durante tu turno (antes de tu ataque), puedes mover una Energía Darkness unida a 1 de tus Pokémon a otro de tus Pokémon.",
 				it: "Durante il tuo turno, prima di attaccare, puoi spostare a piacimento una carta Energia Darkness assegnata ai tuoi Pokémon.",
 				pt: "Tantas vezes quanto desejar em sua vez de jogar (antes de atacar), você pode mover uma Energia Darkness ligada a 1 dos seus Pokémon para outro dos seus Pokémon.",
-				de: "Beliebig oft während deines Zuges (vor deinem Angriff) kannst du 1 Darkness-Energie von 1 deiner Pokémon auf 1 anderes deiner Pokémon verschieben."
+				de: "Beliebig oft während deines Zuges (vor deinem Angriff) kannst du 1 {D}-Energie von 1 deiner Pokémon auf 1 anderes deiner Pokémon verschieben."
 			},
 		},
 	],
@@ -66,10 +67,12 @@ const card: Card = {
 			name: {
 				en: "Dragonblast",
 				fr: "Dracoxplosion",
+				de: "Drachenwucht"
 			},
 			effect: {
 				en: "Discard 2 Darkness Energy attached to this Pokémon.",
 				fr: "Défaussez 2 Énergies Darkness attachées à ce Pokémon.",
+				de: "Lege 2 an dieses Pokémon angelegte {D}-Energien auf deinen Ablagestapel."
 			},
 			damage: 140,
 
@@ -87,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "This brutal Pokémon travels the skies on its six wings. Anything that moves seems like a foe to it, triggering its attack.",
+		de: "Es fliegt rastlos durch die Lüfte und greift jeden an, der ihm unter die Augen kommt. Ein äußerst kaltblütiges Pokémon."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/98.ts
+++ b/data/Black & White/Dragons Exalted/98.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Zweilous",
 		fr: "Diamat",
+		de: "Duodino"
 	},
 
 	stage: "Stage2",
@@ -43,10 +44,12 @@ const card: Card = {
 			name: {
 				en: "Consume",
 				fr: "Consumation",
+				de: "Verzehren"
 			},
 			effect: {
 				en: "Heal from this Pokémon the same amount of damage you did to the Defending Pokémon.",
 				fr: "Soignez à ce Pokémon la même quantité de dégâts que vous avez infligée au Pokémon Défenseur.",
+				de: "Heile bei diesem Pokémon genauso viel Schaden, wie du dem Verteidigenden Pokémon zugefügt hast."
 			},
 			damage: 40,
 
@@ -61,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Destructor Beam",
 				fr: "Rayon Destructeur",
+				de: "Zerstörerstrahl"
 			},
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, défaussez une Énergie attachée au Pokémon Défenseur.",
+				de: "Wirf 1 Münze. Lege bei „Kopf“ 1 an das Verteidigende Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 90,
 
@@ -82,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "The heads on their arms do not have brains. They use all three heads to consume and destroy everything.",
+		de: "Die Köpfe an seinen beiden Armen haben kein eigenes Gehirn. Seine drei Mäuler kauen alles radikal kurz und klein."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Dragons Exalted/99.ts
+++ b/data/Black & White/Dragons Exalted/99.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Double Hit",
 				fr: "Coup Double",
+				de: "Doppelschlag"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 10,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives high among the treetops. It can us its tail as freely and cleverly as its hands.",
+		de: "Lebt in den Baumwipfeln. Kann seinen Schweif genauso gut wie seine Hände verwenden."
 	},
 
 	thirdParty: {


### PR DESCRIPTION
## Add missing German translations for bw6

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
