### PR TITLE
(fix) Remove self-referential evolveFrom from four Basic cards

### DIFF
--- a/data/EX/Dragon/37.ts
+++ b/data/EX/Dragon/37.ts
@@ -21,10 +21,6 @@ const card: Card = {
 		"Fighting"
 	],
 
-	evolveFrom: {
-		en: "Meditite",
-	},
-
 	stage: "Basic",
 
 	attacks: [

--- a/data/EX/Team Rocket Returns/62.ts
+++ b/data/EX/Team Rocket Returns/62.ts
@@ -22,10 +22,6 @@ const card: Card = {
 		"Fighting",
 	],
 
-	evolveFrom: {
-		en: "Larvitar",
-	},
-
 	stage: "Basic",
 
 	attacks: [

--- a/data/McDonald's Collection/McDonald's Collection 2021/12.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/12.ts
@@ -22,11 +22,6 @@ const card: Card = {
 		"Fire",
 	],
 
-	evolveFrom: {
-		en: "Chimchar",
-		fr: "Ouisticram",
-	},
-
 	stage: "Basic",
 
 	attacks: [

--- a/data/Scarlet & Violet/My First Battle/29.ts
+++ b/data/Scarlet & Violet/My First Battle/29.ts
@@ -13,9 +13,6 @@ const card: Card = {
 	category: "Pokemon",
 	hp: 30,
 	types: ["Water"],
-	evolveFrom: {
-		en: "Magikarp",
-	},
 	stage: "Basic",
 
 	attacks: [{


### PR DESCRIPTION
Four Basic cards carry an \`evolveFrom\` that names the card itself — a Basic Pokémon does not evolve, least of all from its own species:

| card | set | stage | evolveFrom |
| --- | --- | --- | --- |
| Meditite | EX Dragon 37 | Basic | Meditite |
| Larvitar | EX Team Rocket Returns 62 | Basic | Larvitar |
| Chimchar | McDonald's Collection 2021 12 | Basic | Chimchar |
| Magikarp | My First Battle 29 | Basic | Magikarp |

All four are \`stage: "Basic"\` in their own files, and Basic printings carry no "Evolves from" line. This removes the four blocks; same family as #1973, which these were not part of.