### PR TITLE
(fix) 151: the Spanish Fossil abilities are filed as attacks

### DIFF
--- a/data/Scarlet & Violet/151/152.ts
+++ b/data/Scarlet & Violet/151/152.ts
@@ -23,6 +23,7 @@ const card: Card = {
 		name: {
 			fr: "Armure Dôme",
 			en: "Domed Armor",
+			es: "Caparazón Domo",
 			it: "Domocorazza",
 			pt: "Armadura Cupular",
 			de: "Domrüstung"
@@ -31,6 +32,7 @@ const card: Card = {
 		effect: {
 			fr: "Ce Pokémon subit 30 dégâts de moins provenant des attaques (après application de la Faiblesse et de la Résistance).",
 			en: "This Pokémon takes 30 less damage from attacks (after applying Weakness and Resistance).",
+			es: "Los ataques hacen 30 puntos de daño menos a este Pokémon (después de aplicar Debilidad y Resistencia).",
 			it: "Questo Pokémon subisce 30 danni in meno dagli attacchi, dopo aver applicato debolezza e resistenza.",
 			pt: "Este Pokémon recebe 30 pontos de dano a menos de ataques (depois de aplicar Fraqueza e Resistência).",
 			de: "Diesem Pokémon werden durch Attacken 30 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden)."
@@ -48,16 +50,6 @@ const card: Card = {
 
 	trainerType: "Item",
 	regulationMark: "G",
-
-	attacks: [{
-		name: {
-			es: "Caparazón Domo"
-		},
-
-		effect: {
-			es: "Los ataques hacen 30 puntos de daño menos a este Pokémon (después de aplicar Debilidad y Resistencia)."
-		}
-	}],
 
 	variants: [
 		{

--- a/data/Scarlet & Violet/151/153.ts
+++ b/data/Scarlet & Violet/151/153.ts
@@ -23,6 +23,7 @@ const card: Card = {
 		name: {
 			fr: "Houle Nautile",
 			en: "Helical Swell",
+			es: "Oleaje Helicoidal",
 			it: "Helixonda",
 			pt: "Maré Espiralada",
 			de: "Helixschwall"
@@ -31,6 +32,7 @@ const card: Card = {
 		effect: {
 			fr: "Tant que ce Pokémon est sur le Poste Actif, votre adversaire ne peut pas jouer de cartes Stade de sa main.",
 			en: "As long as this Pokémon is in the Active Spot, your opponent can't play any Stadium cards from their hand.",
+			es: "Mientras este Pokémon esté en el Puesto Activo, tu rival no puede jugar ninguna carta de Estadio de su mano.",
 			it: "Fintanto che questo Pokémon è in posizione attiva, il tuo avversario non può giocare le carte Stadio che ha in mano.",
 			pt: "Enquanto este Pokémon estiver no Campo Ativo, seu oponente não poderá jogar nenhuma carta de Estádio da mão dele.",
 			de: "Solange dieses Pokémon in der Aktiven Position ist, kann dein Gegner keine Stadionkarten aus seiner Hand spielen."
@@ -48,16 +50,6 @@ const card: Card = {
 
 	trainerType: "Item",
 	regulationMark: "G",
-
-	attacks: [{
-		name: {
-			es: "Oleaje Helicoidal"
-		},
-
-		effect: {
-			es: "Mientras este Pokémon esté en el Puesto Activo, tu rival no puede jugar ninguna carta de Estadio de su mano."
-		}
-	}],
 
 	variants: [
 		{

--- a/data/Scarlet & Violet/151/154.ts
+++ b/data/Scarlet & Violet/151/154.ts
@@ -23,6 +23,7 @@ const card: Card = {
 		name: {
 			fr: "Protection Ambre",
 			en: "Amber Protection",
+			es: "Protección Ámbar",
 			it: "Ambradifesa",
 			pt: "Proteção Âmbar",
 			de: "Bernsteinschutz"
@@ -31,6 +32,7 @@ const card: Card = {
 		effect: {
 			fr: "Évitez tous les effets des talents des Pokémon de votre adversaire infligés à ce Pokémon.",
 			en: "Prevent all effects of your opponent's Pokémon's Abilities done to this Pokémon.",
+			es: "Se evitan todos los efectos de las habilidades de los Pokémon de tu rival infligidos a este Pokémon.",
 			it: "Previeni tutti gli effetti delle abilità dei Pokémon del tuo avversario inflitti a questo Pokémon.",
 			pt: "Previna todos os efeitos de Habilidades dos Pokémon do seu oponente causados a este Pokémon.",
 			de: "Verhindere alle Effekte von Fähigkeiten der Pokémon deines Gegners, die diesem Pokémon zugefügt werden."
@@ -48,16 +50,6 @@ const card: Card = {
 
 	trainerType: "Item",
 	regulationMark: "G",
-
-	attacks: [{
-		name: {
-			es: "Protección Ámbar"
-		},
-
-		effect: {
-			es: "Se evitan todos los efectos de las habilidades de los Pokémon de tu rival infligidos a este Pokémon."
-		}
-	}],
 
 	variants: [
 		{


### PR DESCRIPTION
On the three Antique Fossil Items in 151 (sv03.5 152–154), the Spanish localisation of the ability is stored as an `attacks` array of its own instead of inside the ability, so every card appears to have an es-only attack and its ability lacks `es`:

| card | ability | stray attack (es only) |
| --- | --- | --- |
| Antique Dome Fossil 152 | Domed Armor | Caparazón Domo |
| Antique Helix Fossil 153 | Helical Swell | Oleaje Helicoidal |
| Antique Old Amber 154 | Amber Protection | Protección Ámbar |

The Spanish names and effects are the straight translations of the ability the other five languages already carry, so this moves them into the ability's `name`/`effect` and removes the phantom `attacks` array. A scan of every card file for attacks lacking an English name against abilities missing exactly that language found no other instance of this shape.