### PR TITLE
[feat]: Add booster image fields to Set interface

### DIFF
--- a/meta/models/database/set.d.ts
+++ b/meta/models/database/set.d.ts
@@ -22,6 +22,9 @@ export interface Set {
 	 */
 	boosters?: Record<string, {
 		name: LanguageSpecific<string>
+		logo?: string
+		artwork_front?: string 
+		artwork_back?: string
 	}>
 
 	/**


### PR DESCRIPTION
Add optional logo, artwork_front, and artwork_back fields to the boosters record in meta/models/database/set.d.ts to align with the Booster schema in openapi.yaml. Fields are typed as string | undefined since no set files currently populate them — this is groundwork ahead of the data backfill step.