### PR TITLE
(fix) Remove invisible zero-width characters from four cards

### DIFF
--- a/data/Mega Evolution/Mega Evolution/066.ts
+++ b/data/Mega Evolution/Mega Evolution/066.ts
@@ -49,8 +49,8 @@ const card: Card = {
 			fr: "Lancez une pièce jusqu'à obtenir un côté pile. Pour chaque côté face, choisissez une carte au hasard dans la main de votre adversaire. Votre adversaire montre ces cartes, puis les mélange avec son deck.",
 			de: "Wirf so lange 1 Münze, bis sie Zahl zeigt. Wähle pro Kopf 1 zufällige Karte aus der Hand deines Gegners. Dein Gegner zeigt dir jene Karten und mischt sie in sein Deck.",
 			it: "Lancia una moneta finché non esce croce. Ogni volta che esce testa, scegli una carta a caso dalla mano del tuo avversario. Il tuo avversario mostra quelle carte e le rimischia nel proprio mazzo.",
-			es: "‌Lanza 1 moneda hasta que salga cruz. Por cada cara, elige 1 carta aleatoria de la mano de tu rival. Tu rival enseña esas cartas, las pone en su baraja y las baraja todas.",
-			pt: "‌Jogue uma moeda até sair coroa. Para cada cara, escolha uma carta aleatória da mão do seu oponente. Seu oponente revela aquelas cartas e as embaralha no baralho dele.",
+			es: "Lanza 1 moneda hasta que salga cruz. Por cada cara, elige 1 carta aleatoria de la mano de tu rival. Tu rival enseña esas cartas, las pone en su baraja y las baraja todas.",
+			pt: "Jogue uma moeda até sair coroa. Para cada cara, escolha uma carta aleatória da mão do seu oponente. Seu oponente revela aquelas cartas e as embaralha no baralho dele.",
 			'es-mx': "Lanza 1 moneda hasta que salga cruz. Por cada cara, elige 1 carta aleatoria de la mano de tu rival. Tu rival muestra esas cartas y las baraja en su mazo."
 		},
 

--- a/data/Mega Evolution/Mega Evolution/145.ts
+++ b/data/Mega Evolution/Mega Evolution/145.ts
@@ -49,8 +49,8 @@ const card: Card = {
 			fr: "Lancez une pièce jusqu'à obtenir un côté pile. Pour chaque côté face, choisissez une carte au hasard dans la main de votre adversaire. Votre adversaire montre ces cartes, puis les mélange avec son deck.",
 			de: "Wirf so lange 1 Münze, bis sie Zahl zeigt. Wähle pro Kopf 1 zufällige Karte aus der Hand deines Gegners. Dein Gegner zeigt dir jene Karten und mischt sie in sein Deck.",
 			it: "Lancia una moneta finché non esce croce. Ogni volta che esce testa, scegli una carta a caso dalla mano del tuo avversario. Il tuo avversario mostra quelle carte e le rimischia nel proprio mazzo.",
-			es: "‌Lanza 1 moneda hasta que salga cruz. Por cada cara, elige 1 carta aleatoria de la mano de tu rival. Tu rival enseña esas cartas, las pone en su baraja y las baraja todas.",
-			pt: "‌Jogue uma moeda até sair coroa. Para cada cara, escolha uma carta aleatória da mão do seu oponente. Seu oponente revela aquelas cartas e as embaralha no baralho dele.",
+			es: "Lanza 1 moneda hasta que salga cruz. Por cada cara, elige 1 carta aleatoria de la mano de tu rival. Tu rival enseña esas cartas, las pone en su baraja y las baraja todas.",
+			pt: "Jogue uma moeda até sair coroa. Para cada cara, escolha uma carta aleatória da mão do seu oponente. Seu oponente revela aquelas cartas e as embaralha no baralho dele.",
 			'es-mx': "Lanza 1 moneda hasta que salga cruz. Por cada cara, elige 1 carta aleatoria de la mano de tu rival. Tu rival muestra esas cartas y las baraja en su mazo."
 		},
 

--- a/data/Scarlet & Violet/Paldean Fates/018.ts
+++ b/data/Scarlet & Violet/Paldean Fates/018.ts
@@ -93,7 +93,7 @@ const card: Card = {
 	illustrator: "OKACHEKE",
 
 	description: {
-		en: "﻿When it is angered, it immediately discharges the energy stored in the pouches in its cheeks.",
+		en: "When it is angered, it immediately discharges the energy stored in the pouches in its cheeks.",
 	},
 
 }

--- a/data/Scarlet & Violet/Paldean Fates/131.ts
+++ b/data/Scarlet & Violet/Paldean Fates/131.ts
@@ -78,7 +78,7 @@ const card: Card = {
 	illustrator: "Yuu Nishida",
 
 	description: {
-		en: "﻿When it is angered, it immediately discharges the energy stored in the pouches in its cheeks.",
+		en: "When it is angered, it immediately discharges the energy stored in the pouches in its cheeks.",
 	},
 
 }


### PR DESCRIPTION
Four card files carry invisible Unicode formatting characters at the start of a text value, directly after the opening quote:

| file | character | field |
| --- | --- | --- |
| Mega Evolution 066 (Houndstone) | U+200C zero width non-joiner | `es` / `pt` attack effect |
| Mega Evolution 145 (Houndstone) | U+200C zero width non-joiner | `es` / `pt` attack effect |
| Paldean Fates 018 (Pikachu) | U+FEFF zero width no-break space | `en` description |
| Paldean Fates 131 (Pikachu) | U+FEFF zero width no-break space | `en` description |

They render as nothing but are real characters in the data — they leak into API responses, break naive string comparison against the printed card text, and can trip parsers that walk grapheme clusters (a quote followed by an extending character fuses into a single cluster that no longer equals `"`). A repository-wide scan for U+200B/U+200C/U+200D/U+FEFF found exactly these six occurrences; this removes them without touching anything else.