### PR TITLE
[feat]: Attach third-party IDs to pricing objects

### DIFF
--- a/server/src/V2/Components/Card.ts
+++ b/server/src/V2/Components/Card.ts
@@ -125,7 +125,12 @@ async function loadCard(lang: SupportedLanguages, id: string): Promise<SDKCard |
 				getCardMarketPrice(variant),
 				getTCGPlayerPrice(variant),
 			]);
-			variant.pricing = { cardmarket, tcgplayer };
+			const cmId = variant.thirdParty.cardmarket
+			const tcgId = variant.thirdParty.tcgplayer
+			variant.pricing = {
+				cardmarket: cardmarket ? { id: cmId, ...cardmarket } : null,
+				tcgplayer: tcgplayer ? { id: tcgId, ...tcgplayer } : null,
+			};
 		}
 	}
 
@@ -148,11 +153,13 @@ async function loadCard(lang: SupportedLanguages, id: string): Promise<SDKCard |
 
 	// console.timeEnd('loading providers')
 	// console.time('remapping card')
+	const cmId = card.thirdParty?.cardmarket
+	const tcgId = card.thirdParty?.tcgplayer
 	const res = {
 		...deepOmit(card, 'thirdParty'),
 		pricing: {
-			cardmarket: cardmarket,
-			tcgplayer: tcgplayer
+			cardmarket: cardmarket ? { id: cmId, ...cardmarket } : null,
+			tcgplayer: tcgplayer ? { id: tcgId, ...tcgplayer } : null,
 		}
 	} as SDKCard
 	// console.timeEnd('remapping card')


### PR DESCRIPTION
Include the source third-party IDs (`cardmarket` and `tcgplayer`) from `card.thirdParty` / `variant.thirdParty` into the returned pricing objects. Pricing entries are now `{ id, ...providerData }` or `null` if the provider returned no data. `thirdParty` is not exposed directly.

Card-level (`swsh1-1`)

```json
{
  "cardmarket": {
    "id": 427231,
    "unit": "EUR",
    "avg": 1.23,
    "low": 0.75,
    "trend": 1.1
  },
  "tcgplayer": {
    "id": 206047,
    "unit": "USD",
    "holo": { "marketPrice": 1.1 }
  }
}
```

Variant-level (`swsh4-1`)

```json
[
  {
    "type": "normal",
    "variantId": "endfynwn4n10gzq",
    "pricing": {
      "cardmarket": { "id": 511425, "unit": "EUR", "avg": 0.45 },
      "tcgplayer": { "id": 226360, "unit": "USD", "normal": { "marketPrice": 0.22 } }
    }
  },
  {
    "type": "reverse",
    "variantId": "cm4kqul3x1bwlz1f",
    "pricing": {
      "cardmarket": { "id": 511425, "unit": "EUR", "avg": 0.45 },
      "tcgplayer": { "id": 226360, "unit": "USD", "reverse": { "marketPrice": 0.30 } }
    }
  }
]
```