### PR TITLE
(fix) Expedition Base Set: remove Aquapolis data bleed from 20 cards

### DIFF
--- a/data/E-Card/Expedition Base Set/10.ts
+++ b/data/E-Card/Expedition Base Set/10.ts
@@ -26,17 +26,6 @@ const card: Card = {
 		fr: "Taupiqueur"
 	},
 
-	abilities: [
-		{
-			type: "Poke-BODY",
-			name: {
-				en: "Pure Body",
-			},
-			effect: {
-				en: "To attach a Fire Energy card from your hand to Entei, you must discard an Energy card attached to Entei. (Attach the Fire Energy, and then discard an Energy from Entei.)",
-			},
-		},
-	],
 	stage: "Stage1",
 
 	attacks: [

--- a/data/E-Card/Expedition Base Set/11.ts
+++ b/data/E-Card/Expedition Base Set/11.ts
@@ -26,17 +26,6 @@ const card: Card = {
 		fr: "Piafabec"
 	},
 
-	abilities: [
-		{
-			type: "Poke-POWER",
-			name: {
-				en: "Energy Return",
-			},
-			effect: {
-				en: "As often as you like during your turn (before your attack), choose an Energy card attached to 1 of your Pokémon and return it to your hand. This power can't be used if Espeon is affected by a Special Condition.",
-			},
-		},
-	],
 	stage: "Stage1",
 
 	attacks: [

--- a/data/E-Card/Expedition Base Set/140.ts
+++ b/data/E-Card/Expedition Base Set/140.ts
@@ -35,19 +35,6 @@ const card: Card = {
 			},
 		},
 	],
-	attacks: [
-		{
-			cost: [
-				"Water",
-			],
-			name: {
-				en: "Splatter",
-			},
-			effect: {
-				en: "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. Don't apply Weakness or Resistance.",
-			},
-		},
-	],
 }
 
 export default card

--- a/data/E-Card/Expedition Base Set/148.ts
+++ b/data/E-Card/Expedition Base Set/148.ts
@@ -11,60 +11,6 @@ const card: Card = {
 	illustrator: "Ken Sugimori",
 	rarity: "Uncommon",
 	category: "Trainer",
-	abilities: [
-		{
-			type: "Poke-BODY",
-			name: {
-				en: "Crystal Type",
-			},
-			effect: {
-				en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Search your deck for an Evolution card, show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
-			},
-		},
-	],
-	weaknesses: [
-		{
-			type: "Lightning",
-			value: "x2"
-		},
-	],
-	attacks: [
-		{
-			cost: [
-				"Water",
-				"Water",
-				"Lightning",
-			],
-			name: {
-				en: "Aquabomb",
-			},
-			effect: {
-				en: "Kindra does 10 damage to itself. (Don't apply Weakness or Resistance when Kingdra damages itself with this attack.)",
-			},
-			damage: 40,
-		},
-		{
-			cost: [
-				"Psychic",
-				"Psychic",
-				"Lightning",
-				"Colorless",
-			],
-			name: {
-				en: "Dual Burn",
-			},
-			effect: {
-				en: "Flip 2 coins. For each tails, discard 1 Energy card attached to Kingdra.",
-			},
-			damage: 60,
-		},
-	],
-	stage: "Stage2",
-	types: [
-		"Colorless"
-	],
-	hp: 110,
-	dexId: [230],
 	trainerType: "Supporter",
 	set: Set,
 
@@ -114,7 +60,6 @@ const card: Card = {
 			},
 		}
 	],
-	retreat: 3,
 }
 
 export default card

--- a/data/E-Card/Expedition Base Set/149.ts
+++ b/data/E-Card/Expedition Base Set/149.ts
@@ -11,59 +11,6 @@ const card: Card = {
 	illustrator: "Ken Sugimori",
 	rarity: "Uncommon",
 	category: "Trainer",
-	abilities: [
-		{
-			type: "Poke-BODY",
-			name: {
-				en: "Crystal Type",
-			},
-			effect: {
-				en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Shuffle your hand into your deck, then draw 5 cards.",
-			},
-		},
-	],
-	weaknesses: [
-		{
-			type: "Psychic",
-			value: "x2"
-		},
-	],
-	attacks: [
-		{
-			cost: [
-				"Psychic",
-				"Fire",
-			],
-			name: {
-				en: "Psychic",
-			},
-			effect: {
-				en: "This attack does 10 damage times the number of Energy cards attached to the Defending Pokémon.",
-			},
-			damage: "10×",
-		},
-		{
-			cost: [
-				"Water",
-				"Water",
-				"Fire",
-				"Colorless",
-			],
-			name: {
-				en: "Steam Blast",
-			},
-			effect: {
-				en: "Discard an Energy card attached to Lugia.",
-			},
-			damage: 50,
-		},
-	],
-	stage: "Basic",
-	types: [
-		"Colorless"
-	],
-	hp: 80,
-	dexId: [249],
 	trainerType: "Supporter",
 	set: Set,
 
@@ -96,7 +43,6 @@ const card: Card = {
 			}
 		}
 	],
-	retreat: 3,
 }
 
 export default card

--- a/data/E-Card/Expedition Base Set/150.ts
+++ b/data/E-Card/Expedition Base Set/150.ts
@@ -11,60 +11,6 @@ const card: Card = {
 	illustrator: "Keiji Kinebuchi",
 	rarity: "Uncommon",
 	category: "Trainer",
-	abilities: [
-		{
-			type: "Poke-BODY",
-			name: {
-				en: "Crystal Type",
-			},
-			effect: {
-				en: "Attach Strength Charm to 1 of your Pokémon that doesn't have a Pokémon Tool attached to it. Whenever an attack from the Pokémon that Strength Charm is attached to does damage (after applying Weakness and Resistance), the attack does 10 more damage. At the end of your turn in which this happens, discard Strength Charm.",
-			},
-		},
-	],
-	weaknesses: [
-		{
-			type: "Grass",
-			value: "x2"
-		},
-	],
-	attacks: [
-		{
-			cost: [
-				"Grass",
-				"Grass",
-				"Colorless",
-			],
-			name: {
-				en: "Poison Horn",
-			},
-			effect: {
-				en: "The Defending Pokémon is now Poisoned.",
-			},
-			damage: 20,
-		},
-		{
-			cost: [
-				"Lightning",
-				"Lightning",
-				"Fighting",
-				"Fighting",
-			],
-			name: {
-				en: "Rolling Thunder",
-			},
-			effect: {
-				en: "Flip a coin, If heads, this attack does 10 damage to each of your opponent's Benched Pokémon. If tails, this attack does 10 damage to each of your Benched Pokémon. (Don't apply Weakness or Resistance for Benched Pokémon.)",
-			},
-			damage: 50,
-		},
-	],
-	stage: "Stage2",
-	types: [
-		"Colorless"
-	],
-	hp: 100,
-	dexId: [34],
 	trainerType: "Tool",
 	set: Set,
 
@@ -90,7 +36,6 @@ const card: Card = {
 			},
 		},
 	],
-	retreat: 3,
 }
 
 export default card

--- a/data/E-Card/Expedition Base Set/17.ts
+++ b/data/E-Card/Expedition Base Set/17.ts
@@ -21,17 +21,6 @@ const card: Card = {
 		"Fire"
 	],
 
-	abilities: [
-		{
-			type: "Poke-BODY",
-			name: {
-				en: "Fluff",
-			},
-			effect: {
-				en: "During your opponent's turn, if Jumpluff would be damaged or affected by an opponent's attack and it already has at least 1 damage counter on it, flip a coin. If heads, prevent all effects of that attack (including damage).",
-			},
-		},
-	],
 	stage: "Baby",
 
 	resistances: [

--- a/data/E-Card/Expedition Base Set/19.ts
+++ b/data/E-Card/Expedition Base Set/19.ts
@@ -21,17 +21,6 @@ const card: Card = {
 		"Psychic"
 	],
 
-	abilities: [
-		{
-			type: "Poke-POWER",
-			name: {
-				en: "Water Cyclone",
-			},
-			effect: {
-				en: "As often as you like during your turn (before your attack), you may move a Water Energy card from your Active Pokémon to 1 of your Benched Pokémon. This power can't be used if Kingdra is affected by a Special Condition.",
-			},
-		},
-	],
 	stage: "Basic",
 
 	attacks: [

--- a/data/E-Card/Expedition Base Set/21.ts
+++ b/data/E-Card/Expedition Base Set/21.ts
@@ -26,17 +26,6 @@ const card: Card = {
 		fr: "Goupix"
 	},
 
-	abilities: [
-		{
-			type: "Poke-POWER",
-			name: {
-				en: "Ion Coating",
-			},
-			effect: {
-				en: "You may use this power once during each of your turns (before your attack). All Lightning Energy attached to your Active Pokémon becomes Water Energy for the rest of the turn. (This effect ends if your Active Pokémon retreats or is returned to your hand.) This power can't be used if Lanturn is affected by a Special Condition.",
-			},
-		},
-	],
 	stage: "Stage1",
 
 	attacks: [

--- a/data/E-Card/Expedition Base Set/22.ts
+++ b/data/E-Card/Expedition Base Set/22.ts
@@ -21,17 +21,6 @@ const card: Card = {
 		"Lightning"
 	],
 
-	abilities: [
-		{
-			type: "Poke-POWER",
-			name: {
-				en: "Magnetic Flow",
-			},
-			effect: {
-				en: "Once during your turn (before your attack), if Magneton is your Active Pokémon, you may flip a coin. If heads, choose 2 of your opponent's Pokémon that have Energy cards attached to them. Choose 1 of the Energy cards attached to each of those Pokémon and switch them between the Pokémon. This power can't be used if Magneton is affected by a Special Condition.",
-			},
-		},
-	],
 	stage: "Baby",
 
 	resistances: [

--- a/data/E-Card/Expedition Base Set/26.ts
+++ b/data/E-Card/Expedition Base Set/26.ts
@@ -26,17 +26,6 @@ const card: Card = {
 		fr: "Ponyta"
 	},
 
-	abilities: [
-		{
-			type: "Poke-BODY",
-			name: {
-				en: "Suction Cups",
-			},
-			effect: {
-				en: "As long as Octillery is your Active Pokémon, whenever the Defending Pokémon retreats, discard all Energy cards attached to the Defending Pokémon when it goes to the Bench.",
-			},
-		},
-	],
 	stage: "Stage1",
 
 	attacks: [

--- a/data/E-Card/Expedition Base Set/3.ts
+++ b/data/E-Card/Expedition Base Set/3.ts
@@ -26,17 +26,6 @@ const card: Card = {
 		fr: "Abo"
 	},
 
-	abilities: [
-		{
-			type: "Poke-BODY",
-			name: {
-				en: "Gluey Slime",
-			},
-			effect: {
-				en: "As long as Ariados is in play, each player must pay an additional Colorless to retreat his or her Active Pokémon. Gluey Slime can't make a player pay more than an additional Colorless to retreat a Pokémon, even if there is more than 1 Ariados in play.",
-			},
-		},
-	],
 	stage: "Stage1",
 
 	attacks: [

--- a/data/E-Card/Expedition Base Set/32.ts
+++ b/data/E-Card/Expedition Base Set/32.ts
@@ -26,17 +26,6 @@ const card: Card = {
 		fr: "Smogo"
 	},
 
-	abilities: [
-		{
-			type: "Poke-BODY",
-			name: {
-				en: "Poison Resistance",
-			},
-			effect: {
-				en: "Scizor can't be Poisoned.",
-			},
-		},
-	],
 	stage: "Stage1",
 
 	attacks: [

--- a/data/E-Card/Expedition Base Set/39.ts
+++ b/data/E-Card/Expedition Base Set/39.ts
@@ -26,17 +26,6 @@ const card: Card = {
 		fr: "Reptincel"
 	},
 
-	abilities: [
-		{
-			type: "Poke-POWER",
-			name: {
-				en: "Miracle Shift",
-			},
-			effect: {
-				en: "Once during your turn (before your attack), discard a basic Energy card attached to 1 of your Pokémon. Then, choose a basic Energy card from your discard pile and attach it to that Pokémon. This power can't be used if Togetic is affected by a Special Condition.",
-			},
-		},
-	],
 	stage: "Stage2",
 
 	attacks: [

--- a/data/E-Card/Expedition Base Set/42.ts
+++ b/data/E-Card/Expedition Base Set/42.ts
@@ -26,17 +26,6 @@ const card: Card = {
 		fr: "Kokiyas"
 	},
 
-	abilities: [
-		{
-			type: "Poke-POWER",
-			name: {
-				en: "Fragrance Trap",
-			},
-			effect: {
-				en: "Once during your turn (before your attack), you may flip a coin. If heads, choose 1 of your opponent's Benched Pokémon and switch the Defending Pokémon with it. This Power can't be used if Victreebel is affected by a Special Condition.",
-			},
-		},
-	],
 	stage: "Stage1",
 
 	attacks: [

--- a/data/E-Card/Expedition Base Set/44.ts
+++ b/data/E-Card/Expedition Base Set/44.ts
@@ -26,17 +26,6 @@ const card: Card = {
 		fr: "Taupiqueur"
 	},
 
-	abilities: [
-		{
-			type: "Poke-BODY",
-			name: {
-				en: "Anti-Lightning",
-			},
-			effect: {
-				en: "You can't attach Lightning Energy cards from your hand to Zapdos.",
-			},
-		},
-	],
 	stage: "Stage1",
 
 	attacks: [

--- a/data/E-Card/Expedition Base Set/8.ts
+++ b/data/E-Card/Expedition Base Set/8.ts
@@ -26,17 +26,6 @@ const card: Card = {
 		fr: "Kokiyas"
 	},
 
-	abilities: [
-		{
-			type: "Poke-POWER",
-			name: {
-				en: "Super Dynamo",
-			},
-			effect: {
-				en: "Once during your turn (before your attack), if Electrode is your Active Pokémon, you may flip a coin. If heads, choose a Lightning Energy card from your discard pile and attach it to 1 of your Pokémon. This power can't be used if Electrode is affected by a Special Condition.",
-			},
-		},
-	],
 	stage: "Stage1",
 
 	attacks: [

--- a/data/E-Card/Expedition Base Set/83.ts
+++ b/data/E-Card/Expedition Base Set/83.ts
@@ -21,17 +21,6 @@ const card: Card = {
 		"Water"
 	],
 
-	abilities: [
-		{
-			type: "Poke-BODY",
-			name: {
-				en: "Lightweight",
-			},
-			effect: {
-				en: "You pay Colorless less to retreat Hoppip for each Grass Energy attached to it.",
-			},
-		},
-	],
 	stage: "Basic",
 
 	attacks: [

--- a/data/E-Card/Expedition Base Set/91.ts
+++ b/data/E-Card/Expedition Base Set/91.ts
@@ -26,17 +26,6 @@ const card: Card = {
 		fr: "Héricendre"
 	},
 
-	abilities: [
-		{
-			type: "Poke-BODY",
-			name: {
-				en: "Conductive Body",
-			},
-			effect: {
-				en: "You pay Colorless less to retreat Magnemite for each Magnemite on your Bench.",
-			},
-		},
-	],
 	stage: "Stage1",
 
 	attacks: [

--- a/data/E-Card/Expedition Base Set/95.ts
+++ b/data/E-Card/Expedition Base Set/95.ts
@@ -21,17 +21,6 @@ const card: Card = {
 		"Grass"
 	],
 
-	abilities: [
-		{
-			type: "Poke-BODY",
-			name: {
-				en: "Energy Barrier",
-			},
-			effect: {
-				en: "If Mr. Mime would be damaged by an attack, reduce that damage by 10 for each basic Energy card attached to Mr. Mime. The maximum amount of damage that can be reduced by Energy Barrier is 20.",
-			},
-		},
-	],
 	stage: "Basic",
 
 	attacks: [


### PR DESCRIPTION
Twenty `Expedition Base Set` files carry fields copied from the **Aquapolis card of the same collector number**. Sixteen Pokémon gained a Poké-POWER/Poké-BODY the printed card does not have, three Trainers gained an entire Pokémon stat block, and one Trainer gained an attack.

The giveaway is that the ability effect text still names the Aquapolis Pokémon it was written for, and none of those Pokémon exist in Expedition at all:

| Expedition | card | spurious ability | written for (Aquapolis, same number) |
|---|---|---|---|
| 3 | Arbok | Gluey Slime | Ariados |
| 8 | Cloyster | Super Dynamo | Electrode |
| 10 | Dugtrio | Pure Body | Entei |
| 11 | Fearow | Energy Return | Espeon |
| 17 | Magby | Fluff | Jumpluff |
| 19 | Mew | Water Cyclone | Kingdra |
| 21 | Ninetales | Ion Coating | Lanturn |
| 22 | Pichu | Magnetic Flow | Magneton |
| 26 | Rapidash | Suction Cups | Octillery |
| 32 | Weezing | Poison Resistance | Scizor |
| 39 | Charizard | Miracle Shift | Togetic |
| 42 | Cloyster | Fragrance Trap | Victreebel |
| 44 | Dugtrio | Anti-Lightning | Zapdos |
| 83 | Jynx | Lightweight | Hoppip |
| 91 | Quilava | Conductive Body | Magnemite |
| 95 | Bulbasaur | Energy Barrier | Mr. Mime (95a/95b) |

Each block is byte-identical to `data/E-Card/Aquapolis/<same number>.ts`. Arbok's reads *"As long as **Ariados** is in play…"*; Mew's *"…if **Kingdra** is affected by a Special Condition"*; Bulbasaur's *"If **Mr. Mime** would be damaged by an attack…"*.

### Trainers carrying a whole Pokémon stat block

`abilities`, `attacks`, `weaknesses`, `stage`, `types`, `hp`, `dexId` and `retreat` removed; their own `name`, `effect` and `trainerType` are untouched.

- **148** Professor Elm's Training Method — Kingdra's block, down to `hp: 110` and `dexId: [230]`
- **149** Professor Oak's Research — Lugia's block
- **150** Strength Charm — Nidoking's block

### Trainer carrying a spurious attack

- **140** Energy Removal 2 — held Water Cube 01's `Splatter`

`144` Multi Technical Machine 01 keeps its attack: TM cards really do grant one, so that one is correct.

### Verification

- Every removed ability was cross-checked against a German scan of the card; none of the 20 shows a Poké-POWER or Poké-BODY.
- Deletions only (0 additions, 353 deletions). `npx tsc --noEmit --project tsconfig.json` passes.

Same class of error as #1965 (Poliwag carrying Healing Berry's `effect` and `trainerType`, also from Aquapolis 125).
