### PR TITLE
Add missing German translations for hgss3

### DIFF
--- a/data/HeartGold & SoulSilver/Undaunted/29.ts
+++ b/data/HeartGold & SoulSilver/Undaunted/29.ts
@@ -42,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, search your discard pile for a Metal Energy card and attach it to Lairon.",
 				fr: "Lancez une pièce. Si c’est face, récupérez une carte Énergie Metal dans votre pile de défausse et attachez-la à Galegon.",
-				de: "Wirf eine Münze. Durchsuche bei \"Kopf\" deinen Ablagestapel nach einer -Energiekarte und lege sie an Stollrak an."
+				de: "Wirf eine Münze. Durchsuche bei „Kopf“ deinen Ablagestapel nach einer {M}-Energiekarte und lege sie an Stollrak an."
 			},
 			damage: 20,
 


### PR DESCRIPTION
## Add missing German translations for hgss3

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
