### PR TITLE
feat(card): add explicit Tera classification

### DIFF
--- a/data/Mega Evolution/Ascended Heroes/038.ts
+++ b/data/Mega Evolution/Ascended Heroes/038.ts
@@ -31,6 +31,7 @@ const card: Card = {
 	hp: 320,
 	types: ["Fire"],
 	stage: "Stage2",
+	tera: true,
 
 	attacks: [{
 		cost: ["Fire", "Colorless", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/057.ts
+++ b/data/Mega Evolution/Ascended Heroes/057.ts
@@ -22,6 +22,7 @@ const card: Card = {
 	hp: 200,
 	types: ["Lightning"],
 	stage: "Basic",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Mega Evolution/Ascended Heroes/073.ts
+++ b/data/Mega Evolution/Ascended Heroes/073.ts
@@ -22,6 +22,7 @@ const card: Card = {
 	hp: 220,
 	types: ["Lightning"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Lightning"],

--- a/data/Mega Evolution/Ascended Heroes/121.ts
+++ b/data/Mega Evolution/Ascended Heroes/121.ts
@@ -22,6 +22,7 @@ const card: Card = {
 	hp: 230,
 	types: ["Fighting"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Fighting", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/160.ts
+++ b/data/Mega Evolution/Ascended Heroes/160.ts
@@ -32,6 +32,7 @@ const card: Card = {
 	hp: 320,
 	types: ["Dragon"],
 	stage: "Stage2",
+	tera: true,
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/179.ts
+++ b/data/Mega Evolution/Ascended Heroes/179.ts
@@ -22,6 +22,7 @@ const card: Card = {
 	hp: 230,
 	types: ["Colorless"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Mega Evolution/Ascended Heroes/277.ts
+++ b/data/Mega Evolution/Ascended Heroes/277.ts
@@ -22,6 +22,7 @@ const card: Card = {
 	hp: 200,
 	types: ["Lightning"],
 	stage: "Basic",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Obsidian Flames/042.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/042.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Fire"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Water", "Water", "Water"],

--- a/data/Scarlet & Violet/Obsidian Flames/066.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/066.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Pupitar"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Scarlet & Violet/Obsidian Flames/096.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/096.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Wadribie"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Scarlet & Violet/Obsidian Flames/125.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/125.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Glutexo"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Obsidian Flames/159.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/159.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Dragonir"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Scarlet & Violet/Obsidian Flames/179.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/179.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Raffel"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Scarlet & Violet/Obsidian Flames/210.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/210.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Fire"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Water", "Water", "Water"],

--- a/data/Scarlet & Violet/Obsidian Flames/211.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/211.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Pupitar"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Scarlet & Violet/Obsidian Flames/212.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/212.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Wadribie"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Scarlet & Violet/Obsidian Flames/215.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/215.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Glutexo"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Obsidian Flames/222.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/222.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Fire"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Water", "Water", "Water"],

--- a/data/Scarlet & Violet/Obsidian Flames/223.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/223.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Glutexo"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Obsidian Flames/228.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/228.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Glutexo"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Paldea Evolved/005.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/005.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Tannza"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Paldea Evolved/086.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/086.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Flegmon"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Scarlet & Violet/Paldea Evolved/093.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/093.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 170,
 	types: ["Psychic"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Psychic", "Psychic"],

--- a/data/Scarlet & Violet/Paldea Evolved/230.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/230.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Tannza"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Paldea Evolved/238.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/238.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Flegmon"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Scarlet & Violet/Paldea Evolved/239.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/239.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 170,
 	types: ["Psychic"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Psychic", "Psychic"],

--- a/data/Scarlet & Violet/Paldean Fates/002.ts
+++ b/data/Scarlet & Violet/Paldean Fates/002.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Tannza"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Paldean Fates/006.ts
+++ b/data/Scarlet & Violet/Paldean Fates/006.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Flattutu"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Paldean Fates/054.ts
+++ b/data/Scarlet & Violet/Paldean Fates/054.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Glutexo"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Paldean Fates/212.ts
+++ b/data/Scarlet & Violet/Paldean Fates/212.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Tannza"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Paldean Fates/214.ts
+++ b/data/Scarlet & Violet/Paldean Fates/214.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Flattutu"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Paldean Fates/234.ts
+++ b/data/Scarlet & Violet/Paldean Fates/234.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Glutexo"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Paradox Rift/003.ts
+++ b/data/Scarlet & Violet/Paradox Rift/003.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Schneppke"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Paradox Rift/038.ts
+++ b/data/Scarlet & Violet/Paradox Rift/038.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Knarksel"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Scarlet & Violet/Paradox Rift/046.ts
+++ b/data/Scarlet & Violet/Paradox Rift/046.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Frubaila"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Scarlet & Violet/Paradox Rift/058.ts
+++ b/data/Scarlet & Violet/Paradox Rift/058.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 230,
 	types: ["Lightning"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Psychic"],

--- a/data/Scarlet & Violet/Paradox Rift/098.ts
+++ b/data/Scarlet & Violet/Paradox Rift/098.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 220,
 	types: ["Fighting"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Darkness", "Darkness"],

--- a/data/Scarlet & Violet/Paradox Rift/100.ts
+++ b/data/Scarlet & Violet/Paradox Rift/100.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Toxel"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Lightning", "Lightning"],

--- a/data/Scarlet & Violet/Paradox Rift/137.ts
+++ b/data/Scarlet & Violet/Paradox Rift/137.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Lokroko"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Paradox Rift/217.ts
+++ b/data/Scarlet & Violet/Paradox Rift/217.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Schneppke"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Paradox Rift/219.ts
+++ b/data/Scarlet & Violet/Paradox Rift/219.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Knarksel"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Scarlet & Violet/Paradox Rift/220.ts
+++ b/data/Scarlet & Violet/Paradox Rift/220.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Frubaila"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	attacks: [{
 		cost: ["Grass"],

--- a/data/Scarlet & Violet/Paradox Rift/226.ts
+++ b/data/Scarlet & Violet/Paradox Rift/226.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 220,
 	types: ["Fighting"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Darkness", "Darkness"],

--- a/data/Scarlet & Violet/Paradox Rift/227.ts
+++ b/data/Scarlet & Violet/Paradox Rift/227.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Toxel"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Lightning", "Lightning"],

--- a/data/Scarlet & Violet/Paradox Rift/245.ts
+++ b/data/Scarlet & Violet/Paradox Rift/245.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Knarksel"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Scarlet & Violet/Paradox Rift/260.ts
+++ b/data/Scarlet & Violet/Paradox Rift/260.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Knarksel"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Scarlet & Violet/Prismatic Evolutions/006.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/006.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Evoli"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Grass", "Colorless"],

--- a/data/Scarlet & Violet/Prismatic Evolutions/012.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/012.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Grass"],
 	stage: "Basic",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Prismatic Evolutions/014.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/014.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Evoli"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Fire", "Colorless"],

--- a/data/Scarlet & Violet/Prismatic Evolutions/017.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/017.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Fire"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Fire", "Colorless", "Colorless"],

--- a/data/Scarlet & Violet/Prismatic Evolutions/023.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/023.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Evoli"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Water", "Colorless"],

--- a/data/Scarlet & Violet/Prismatic Evolutions/026.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/026.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Evoli"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Water", "Colorless"],

--- a/data/Scarlet & Violet/Prismatic Evolutions/027.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/027.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Water"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Scarlet & Violet/Prismatic Evolutions/028.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/028.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 190,
 	types: ["Lightning"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Scarlet & Violet/Prismatic Evolutions/030.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/030.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Evoli"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Lightning", "Colorless"],

--- a/data/Scarlet & Violet/Prismatic Evolutions/034.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/034.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Evoli"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Psychic", "Colorless", "Colorless"],

--- a/data/Scarlet & Violet/Prismatic Evolutions/041.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/041.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Evoli"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Psychic", "Colorless", "Colorless"],

--- a/data/Scarlet & Violet/Prismatic Evolutions/058.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/058.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Fighting"],
 	stage: "Basic",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Prismatic Evolutions/060.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/060.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Evoli"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Darkness", "Colorless", "Colorless"],

--- a/data/Scarlet & Violet/Prismatic Evolutions/073.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/073.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Phandra"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Scarlet & Violet/Prismatic Evolutions/075.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/075.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 200,
 	types: ["Colorless"],
 	stage: "Basic",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Prismatic Evolutions/144.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/144.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Evoli"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Grass", "Colorless"],

--- a/data/Scarlet & Violet/Prismatic Evolutions/145.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/145.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Grass"],
 	stage: "Basic",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Prismatic Evolutions/146.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/146.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Evoli"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Fire", "Colorless"],

--- a/data/Scarlet & Violet/Prismatic Evolutions/147.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/147.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Knarbon"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Fire"],

--- a/data/Scarlet & Violet/Prismatic Evolutions/148.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/148.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Fire"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Fire", "Colorless", "Colorless"],

--- a/data/Scarlet & Violet/Prismatic Evolutions/149.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/149.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Evoli"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Water", "Colorless"],

--- a/data/Scarlet & Violet/Prismatic Evolutions/150.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/150.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Evoli"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Water", "Colorless"],

--- a/data/Scarlet & Violet/Prismatic Evolutions/152.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/152.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Water"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Scarlet & Violet/Prismatic Evolutions/153.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/153.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Evoli"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Lightning", "Colorless"],

--- a/data/Scarlet & Violet/Prismatic Evolutions/155.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/155.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Evoli"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Psychic", "Colorless", "Colorless"],

--- a/data/Scarlet & Violet/Prismatic Evolutions/156.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/156.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Evoli"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Psychic", "Colorless", "Colorless"],

--- a/data/Scarlet & Violet/Prismatic Evolutions/160.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/160.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Fighting"],
 	stage: "Basic",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Prismatic Evolutions/161.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/161.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Evoli"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Darkness", "Colorless", "Colorless"],

--- a/data/Scarlet & Violet/Prismatic Evolutions/165.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/165.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Phandra"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Scarlet & Violet/Prismatic Evolutions/167.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/167.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 200,
 	types: ["Colorless"],
 	stage: "Basic",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Prismatic Evolutions/169.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/169.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 230,
 	types: ["Colorless"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Scarlet & Violet/Prismatic Evolutions/177.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/177.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Grass"],
 	stage: "Basic",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Prismatic Evolutions/179.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/179.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 200,
 	types: ["Lightning"],
 	stage: "Basic",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Prismatic Evolutions/180.ts
+++ b/data/Scarlet & Violet/Prismatic Evolutions/180.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 230,
 	types: ["Colorless"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/056.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/056.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Glutexo"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/SVP Black Star Promos/074.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/074.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Glutexo"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/SVP Black Star Promos/163.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/163.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Kickerlo"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	attacks: [{
 		cost: ["Fire", "Colorless", "Colorless"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/164.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/164.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 220,
 	types: ["Water"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Scarlet & Violet/SVP Black Star Promos/165.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/165.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 230,
 	types: ["Colorless"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Scarlet & Violet/Scarlet & Violet/032.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/032.ts
@@ -25,6 +25,7 @@ const card: Card = {
 	},
 
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Fire", "Fire"],

--- a/data/Scarlet & Violet/Scarlet & Violet/045.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/045.ts
@@ -25,6 +25,7 @@ const card: Card = {
 	},
 
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Water", "Water", "Water"],

--- a/data/Scarlet & Violet/Scarlet & Violet/224.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/224.ts
@@ -25,6 +25,7 @@ const card: Card = {
 	},
 
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Fire", "Fire"],

--- a/data/Scarlet & Violet/Scarlet & Violet/225.ts
+++ b/data/Scarlet & Violet/Scarlet & Violet/225.ts
@@ -25,6 +25,7 @@ const card: Card = {
 	},
 
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Water", "Water", "Water"],

--- a/data/Scarlet & Violet/Shrouded Fable/015.ts
+++ b/data/Scarlet & Violet/Shrouded Fable/015.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Knattox"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Metal"],

--- a/data/Scarlet & Violet/Shrouded Fable/081.ts
+++ b/data/Scarlet & Violet/Shrouded Fable/081.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Knattox"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Metal"],

--- a/data/Scarlet & Violet/Stellar Crown/028.ts
+++ b/data/Scarlet & Violet/Stellar Crown/028.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Kickerlo"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	attacks: [{
 		cost: ["Fire", "Colorless", "Colorless"],

--- a/data/Scarlet & Violet/Stellar Crown/032.ts
+++ b/data/Scarlet & Violet/Stellar Crown/032.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 220,
 	types: ["Water"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Scarlet & Violet/Stellar Crown/051.ts
+++ b/data/Scarlet & Violet/Stellar Crown/051.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Wattzapf"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Lightning", "Colorless"],

--- a/data/Scarlet & Violet/Stellar Crown/128.ts
+++ b/data/Scarlet & Violet/Stellar Crown/128.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 230,
 	types: ["Colorless"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Scarlet & Violet/Stellar Crown/157.ts
+++ b/data/Scarlet & Violet/Stellar Crown/157.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Kickerlo"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	attacks: [{
 		cost: ["Fire", "Colorless", "Colorless"],

--- a/data/Scarlet & Violet/Stellar Crown/158.ts
+++ b/data/Scarlet & Violet/Stellar Crown/158.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 220,
 	types: ["Water"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Scarlet & Violet/Stellar Crown/159.ts
+++ b/data/Scarlet & Violet/Stellar Crown/159.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Wattzapf"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Lightning", "Colorless"],

--- a/data/Scarlet & Violet/Stellar Crown/168.ts
+++ b/data/Scarlet & Violet/Stellar Crown/168.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Wattzapf"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Lightning", "Colorless"],

--- a/data/Scarlet & Violet/Stellar Crown/170.ts
+++ b/data/Scarlet & Violet/Stellar Crown/170.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 230,
 	types: ["Colorless"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Scarlet & Violet/Stellar Crown/173.ts
+++ b/data/Scarlet & Violet/Stellar Crown/173.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 230,
 	types: ["Colorless"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Colorless", "Colorless"],

--- a/data/Scarlet & Violet/Surging Sparks/036.ts
+++ b/data/Scarlet & Violet/Surging Sparks/036.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Knarbon"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Fire"],

--- a/data/Scarlet & Violet/Surging Sparks/057.ts
+++ b/data/Scarlet & Violet/Surging Sparks/057.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 200,
 	types: ["Lightning"],
 	stage: "Basic",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Surging Sparks/086.ts
+++ b/data/Scarlet & Violet/Surging Sparks/086.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Evoli"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Psychic", "Colorless", "Colorless"],

--- a/data/Scarlet & Violet/Surging Sparks/091.ts
+++ b/data/Scarlet & Violet/Surging Sparks/091.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Sankabuh"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Colorless", "Colorless", "Colorless"],

--- a/data/Scarlet & Violet/Surging Sparks/106.ts
+++ b/data/Scarlet & Violet/Surging Sparks/106.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Vibrava"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Scarlet & Violet/Surging Sparks/119.ts
+++ b/data/Scarlet & Violet/Surging Sparks/119.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Duodino"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	attacks: [{
 		cost: ["Darkness", "Colorless"],

--- a/data/Scarlet & Violet/Surging Sparks/133.ts
+++ b/data/Scarlet & Violet/Surging Sparks/133.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Owei"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Grass", "Water"],

--- a/data/Scarlet & Violet/Surging Sparks/142.ts
+++ b/data/Scarlet & Violet/Surging Sparks/142.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 160,
 	types: ["Dragon"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Fire", "Water"],

--- a/data/Scarlet & Violet/Surging Sparks/159.ts
+++ b/data/Scarlet & Violet/Surging Sparks/159.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Colorless"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Colorless", "Colorless", "Colorless"],

--- a/data/Scarlet & Violet/Surging Sparks/219.ts
+++ b/data/Scarlet & Violet/Surging Sparks/219.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 200,
 	types: ["Lightning"],
 	stage: "Basic",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Surging Sparks/221.ts
+++ b/data/Scarlet & Violet/Surging Sparks/221.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Sankabuh"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Colorless", "Colorless", "Colorless"],

--- a/data/Scarlet & Violet/Surging Sparks/222.ts
+++ b/data/Scarlet & Violet/Surging Sparks/222.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Vibrava"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	attacks: [{
 		cost: ["Fighting"],

--- a/data/Scarlet & Violet/Surging Sparks/223.ts
+++ b/data/Scarlet & Violet/Surging Sparks/223.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Duodino"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	attacks: [{
 		cost: ["Darkness", "Colorless"],

--- a/data/Scarlet & Violet/Surging Sparks/225.ts
+++ b/data/Scarlet & Violet/Surging Sparks/225.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Owei"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Grass", "Water"],

--- a/data/Scarlet & Violet/Surging Sparks/226.ts
+++ b/data/Scarlet & Violet/Surging Sparks/226.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 160,
 	types: ["Dragon"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Fire", "Water"],

--- a/data/Scarlet & Violet/Surging Sparks/228.ts
+++ b/data/Scarlet & Violet/Surging Sparks/228.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Colorless"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Colorless", "Colorless", "Colorless"],

--- a/data/Scarlet & Violet/Surging Sparks/238.ts
+++ b/data/Scarlet & Violet/Surging Sparks/238.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 200,
 	types: ["Lightning"],
 	stage: "Basic",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Surging Sparks/240.ts
+++ b/data/Scarlet & Violet/Surging Sparks/240.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Duodino"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	attacks: [{
 		cost: ["Darkness", "Colorless"],

--- a/data/Scarlet & Violet/Surging Sparks/242.ts
+++ b/data/Scarlet & Violet/Surging Sparks/242.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Owei"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Grass", "Water"],

--- a/data/Scarlet & Violet/Surging Sparks/247.ts
+++ b/data/Scarlet & Violet/Surging Sparks/247.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 200,
 	types: ["Lightning"],
 	stage: "Basic",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Surging Sparks/248.ts
+++ b/data/Scarlet & Violet/Surging Sparks/248.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Owei"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Grass", "Water"],

--- a/data/Scarlet & Violet/Temporal Forces/060.ts
+++ b/data/Scarlet & Violet/Temporal Forces/060.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Schligda"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Scarlet & Violet/Temporal Forces/108.ts
+++ b/data/Scarlet & Violet/Temporal Forces/108.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Girafarig"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Temporal Forces/190.ts
+++ b/data/Scarlet & Violet/Temporal Forces/190.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Schligda"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Scarlet & Violet/Temporal Forces/194.ts
+++ b/data/Scarlet & Violet/Temporal Forces/194.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Girafarig"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Twilight Masquerade/025.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/025.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Grass"],
 	stage: "Basic",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Twilight Masquerade/029.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/029.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Schneckmag"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Fire", "Colorless"],

--- a/data/Scarlet & Violet/Twilight Masquerade/040.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/040.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Fire"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Fire", "Colorless", "Colorless"],

--- a/data/Scarlet & Violet/Twilight Masquerade/064.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/064.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Water"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Scarlet & Violet/Twilight Masquerade/106.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/106.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Amphizel"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Scarlet & Violet/Twilight Masquerade/112.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/112.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Fighting"],
 	stage: "Basic",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Twilight Masquerade/130.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/130.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Phandra"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Scarlet & Violet/Twilight Masquerade/190.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/190.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Grass"],
 	stage: "Basic",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Twilight Masquerade/191.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/191.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Schneckmag"
 	},
 	stage: "Stage1",
+	tera: true,
 
 	attacks: [{
 		cost: ["Fire", "Colorless"],

--- a/data/Scarlet & Violet/Twilight Masquerade/192.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/192.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Fire"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Fire", "Colorless", "Colorless"],

--- a/data/Scarlet & Violet/Twilight Masquerade/194.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/194.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Water"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Scarlet & Violet/Twilight Masquerade/198.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/198.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Amphizel"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Scarlet & Violet/Twilight Masquerade/199.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/199.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Fighting"],
 	stage: "Basic",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Twilight Masquerade/200.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/200.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Phandra"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Scarlet & Violet/Twilight Masquerade/211.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/211.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Grass"],
 	stage: "Basic",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Twilight Masquerade/212.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/212.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Fire"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Fire", "Colorless", "Colorless"],

--- a/data/Scarlet & Violet/Twilight Masquerade/213.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/213.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Water"],
 	stage: "Basic",
+	tera: true,
 
 	attacks: [{
 		cost: ["Colorless"],

--- a/data/Scarlet & Violet/Twilight Masquerade/214.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/214.ts
@@ -27,6 +27,7 @@ const card: Card = {
 		de: "Amphizel"
 	},
 	stage: "Stage2",
+	tera: true,
 
 	attacks: [{
 		cost: ["Water"],

--- a/data/Scarlet & Violet/Twilight Masquerade/215.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/215.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Fighting"],
 	stage: "Basic",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/data/Scarlet & Violet/Twilight Masquerade/221.ts
+++ b/data/Scarlet & Violet/Twilight Masquerade/221.ts
@@ -19,6 +19,7 @@ const card: Card = {
 	hp: 210,
 	types: ["Grass"],
 	stage: "Basic",
+	tera: true,
 
 	abilities: [{
 		type: "Ability",

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -328,6 +328,14 @@ export interface Card {
 	stage?: 'Basic' | 'BREAK' | 'LEVEL-UP' | 'MEGA' | 'RESTORED' | 'Stage1' | 'Stage2' | 'VMAX' | 'V-UNION' | 'Baby' | 'VSTAR'
 
 	/**
+	 * Printed Tera Pokémon classification.
+	 *
+	 * This assertion is present only when the card is explicitly identified as a
+	 * Tera Pokémon by its printed rule box or an authoritative card listing.
+	 */
+	tera?: true
+
+	/**
 	 * Card Suffix
 	 *
 	 * - EX https://www.tcgdex.net/database/bw/bw4/54

--- a/meta/definitions/api.d.ts
+++ b/meta/definitions/api.d.ts
@@ -260,6 +260,10 @@ export interface Card extends CardResume {
 	 */
 	stage?: string;
 	/**
+	 * Whether this card is explicitly classified as a printed Tera Pokémon.
+	 */
+	tera?: boolean;
+	/**
 	 * Card Suffix
 	 *
 	 * - EX https://www.tcgdex.net/database/ex/ex2/94

--- a/meta/definitions/graphql.gql
+++ b/meta/definitions/graphql.gql
@@ -207,6 +207,9 @@ type Card {
 	"""the Card evolution stage"""
 	stage: String
 
+	"""Whether this card is explicitly classified as a printed Tera Pokémon"""
+	tera: Boolean
+
 	"""the card suffix"""
 	suffix: String
 

--- a/meta/definitions/openapi.yaml
+++ b/meta/definitions/openapi.yaml
@@ -1554,6 +1554,9 @@ components:
           type: [string, null]
           description: Evolution stage (Basic, Stage 1, Stage 2, etc.)
           example: "Stage 2"
+        tera:
+          type: [boolean, null]
+          description: Whether this card is explicitly classified as a printed Tera Pokémon
         suffix:
           type: [string, null]
           description: Special card suffix (EX, GX, V, etc.)

--- a/server/compiler/utils/cardUtil.ts
+++ b/server/compiler/utils/cardUtil.ts
@@ -121,6 +121,7 @@ export async function cardToCardSingle(localId: string, card: Card, lang: Suppor
 		description: card.description ? resolveText(card.description, lang) as string : undefined,
 		level: card.level,
 		stage: translate('stage', card.stage, lang) as any,
+		tera: card.tera,
 		suffix: translate('suffix', card.suffix, lang) as any,
 		item: card.item ? {
 			name: resolveText(card.item.name, lang),


### PR DESCRIPTION
## Summary

- add an optional `tera` field for an explicitly identified printed Tera Pokémon
- pass the field through the compiler and expose it in REST/OpenAPI and GraphQL
- annotate all 146 qualifying international prints currently represented in the database

This is assertion-only provider data. It is never inferred from a Pokémon's name, artwork, `ex` suffix, or text that merely refers to Tera Pokémon. Consumers can therefore distinguish `tera: true` from an older or unreviewed record where the field is absent.

## Data review

The annotated set/collector-number inventory was reconciled exactly against the current structured PokémonTCG `Tera` subtype inventory: 146 expected, 146 annotated, no extras, and no omissions. Ho-Oh `sv8-019` is a representative close negative: its attack mentions Tera Pokémon, but the card itself is not marked.

## Verification

- `git diff --check`
- root TypeScript validation passed in a clean Bun container
- Docker image built successfully from commit `fc513d26f4c7c8981fc7a7c047a759d0f9af144f`

## Scope

No generated files, lockfiles, Docker configuration, filters, special endpoints, or `data-asia` records are changed.
