### PR TITLE
Add missing German translations for neo4

### DIFF
--- a/data/Neo/Neo Destiny/1.ts
+++ b/data/Neo/Neo Destiny/1.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Flaaffy",
-		fr: "Lainergie obscur"
+		fr: "Lainergie obscur",
+		de: "Dunkles Waaty"
 	},
 
 	stage: "Stage2",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Conductivity",
 				fr: "Conductivité",
-				de: "Conductivity"
+				de: "Leitfähigkeit"
 			},
 			effect: {
 				en: "Whenever your opponent attaches an Energy card to a Pokémon from his or her hand, this Power does 10 damage to that Pokémon. (Don't apply Weakness and Resistance) This power stops working if you have more than 1 Dark Ampharos in play or while Dark Ampharos is Asleep, Confused or Paralysed.",
 				fr: "Lorsque votre adversaire attache une carte Énergie de sa main à son Pokémon, ce pouvoir inflige 10 dégâts à ce Pokémon. (N'appliquez ni la Faiblesse ni la Résistance.) Ce pouvoir cesse de fonctionner si vous avez plus d'un Pharamp obscur en jeu ou si Pharamp obscur est Endormi, Confus ou Paralysé.",
-				de: "Whenever your opponent attaches an Energy card from his or her hand to a Pokémon, this power does 10 damage to that Pokémon. (Don't apply Weakness and Resistance.) This power stops working if you have more than 1 Dark Ampharos in play or while Dark Ampharos is Asleep, Confused, or Paralyzed."
+				de: "Immer wenn dein Gegner eine Energiekarte aus seiner Hand an ein Pokémon anlegt, fügt diese Power diesem Pokémon 10 Schadenspunkte zu. (Wende Schwäche und Resistenz nicht an.) Diese Fähigkeit verliert ihre Wirkung, solange du mehr als 1 Dunkles Ampharos im Spiel hast oder während Dunkles Ampharos schläft, verwirrt oder gelähmt ist."
 			},
 		},
 	],
@@ -56,12 +57,12 @@ const card: Card = {
 			name: {
 				en: "Shock Bolt",
 				fr: "Choc'éclair",
-				de: "Shock Bolt"
+				de: "Schock-Blitz"
 			},
 			effect: {
 				en: "Discard all Energy cards attached to this Pokémon in order to use this attack.",
 				fr: "Défaussez-vous de toutes les cartes Énergie  attachées à Pharamp obscur ou cette attaque ne fait rien.",
-				de: "Discard all  Energy cards attached to Dark Ampharos or this attack does nothing."
+				de: "Lege alle an Dunkles Ampharos angelegten {L}-Energiekarten auf deinen Ablagestapel, oder dieser Angriff hat keine Auswirkungen."
 			},
 			damage: 50,
 
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "Its brightly lit tail can be seen for miles in the dark, even by ships on the sea.",
-		fr: "La nuit, la pointe de sa queue est visible à des kilomètres à la ronde, même pour les bateaux qui naviguent au large."
+		fr: "La nuit, la pointe de sa queue est visible à des kilomètres à la ronde, même pour les bateaux qui naviguent au large.",
+		de: "Sein hell leuchtender Schwanz kann in der Dunkelheit meilenweit gesehen werden, selbst von Schiffen auf hoher See."
 	},
 
 

--- a/data/Neo/Neo Destiny/10.ts
+++ b/data/Neo/Neo Destiny/10.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Quilava",
-		fr: "Feurisson obscur"
+		fr: "Feurisson obscur",
+		de: "Igelavar"
 	},
 
 	stage: "Stage2",
@@ -56,7 +57,7 @@ const card: Card = {
 			effect: {
 				en: "You may discard any number of Energy cards attached to your Pokémon. Flip a coin for each Energy card discarded in this way. This attack does 40 damage times the number of heads.",
 				fr: "Vous pouvez vous défausser de n'importe quel nombre de cartes Énergie  attachées à votre Pokémon. Lancez une pièce pour chaque carte Énergie  défaussée de cette manière. Cette attaque fait 40 dégâts multipliés par le nombre de faces.",
-				de: "Du kannst eine beliebige Anzahl an dein Pokémon angelegte -Energiekarten auf deinen Ablagestapel legen. Wirf für jede -Energiekarte, die du auf diese Weise auf deinen Ablagestapel gelegt hast, eine Münze. Dieser angriff fügt 40 Schadenspunkte mal der Anzahl 'Kopf' zu."
+				de: "Du kannst eine beliebige Anzahl an dein Pokémon angelegte {R}-Energiekarten auf deinen Ablagestapel legen. Wirf für jede {R}-Energiekarte, die du auf diese Weise auf deinen Ablagestapel gelegt hast, eine Münze. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "40x",
 
@@ -74,7 +75,8 @@ const card: Card = {
 
 	description: {
 		en: "When it's in combat, the air around it shimmers and warps from the intense heat it produces.",
-		fr: "Quand il se bat, l'air autour de lui scintille et semble s'enflammer à cause de l'intense chaleur émanant de lui."
+		fr: "Quand il se bat, l'air autour de lui scintille et semble s'enflammer à cause de l'intense chaleur émanant de lui.",
+		de: "Wenn es kämpft, schimmert und krümmt sich die Luft durch die Hitze, die es produziert."
 	},
 
 

--- a/data/Neo/Neo Destiny/100.ts
+++ b/data/Neo/Neo Destiny/100.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. Once during each player's turn (before attacking), that player may flip a coin. If heads, that player draws a card.",
 		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez-vous de cette carte si une autre carte Stade arrive en jeu.\n\nUne fois durant le tour de chaque joueur (avant son attaque), ce joueur peut lancer une pièce. Si c'est face, ce joueur pioche une carte.",
-		de: "Once during each player's turn, that player may flip a coin. If heads, the player draws a card."
+		de: "Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadion-Karte ins Spiel kommt. Einmal in jedem eigenen Zug (vor dem Angriff) darf jeder Spieler eine Münze werfen. Bei „Kopf“ zieht dieser Spieler eine Karte."
 	},
 
 

--- a/data/Neo/Neo Destiny/101.ts
+++ b/data/Neo/Neo Destiny/101.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Attach Magnifier to 1 of your Pokémon. At the end of your turn, discard Magnifier. If the Pokémon Magnifier is attached to attacks, don't apply Resistance for that attack.",
 		fr: "Attachez Loupe à un de vos Pokémon. A la fin de votre tour, défaussez-vous de Loupe. Si le Pokémon auquel Loupe est attachée attaque, n'appliquez pas la Résistance pour cette attaque.",
-		de: "Attach Magnifier to 1 of your Pokémon. At he end of your turn, discard Magnifier. If the Pokémon Magnifier is attached to attcks, don't apply Resistance for this attack."
+		de: "Lege Vergrößerungsglas an eines deiner Pokémon an. Lege am Ende deines Zuges auf deinen Ablagestapel. Wenn das Pokémon, an das das Vergrößerungsglas angelegt ist, angreift, wende Resistenz für diesen Angriff nicht an."
 	},
 
 

--- a/data/Neo/Neo Destiny/102.ts
+++ b/data/Neo/Neo Destiny/102.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Put an Evolution card from your hand face down in front of you. Your opponent guesses whether it is a Pokémon card with Light in its name, a Pokémon card with Dark in its name, or neither one. Flip the card over. If your opponent guessed right, he or she draws 3 cards. If your opponent guessed wrong, you draw 3 cards. Either way, return the card to your hand.",
 		fr: "Placez une carte Évolution de votre main devant vous, face cachée. Votre adversaire doit deviner s'il s'agit d'une carte Pokémon lumineux, Pokémon obscur ou ni l'une ni l'autre. Retournez la carte. Si votre adversaire a vu juste, il pioche 3 cartes. S'il s'est trompé, vous piochez 3 cartes. Dans tous les cas, replacez la carte dans votre main.",
-		de: "Put an Evoloution card from your hand face down in front of you. Your opponent guesses whether it is a Pokémon card with Light in its name, a Pokémon card with Dark in its name, or neither one. Flip the card over. If your opponent guessed right, he or she draw 3 cards. If your oppnent guessed wrong, you draw 3 cards. Either way, return the card to your hand."
+		de: "Lege eine Entwicklungskarte aus deiner Hand verdeckt vor dich hin. Dein Gegner muss raten, ob es eine Pokémonkarte mit „Helles“ im Namen, eine Pokémonkarte mit „Dunkles“ im Namen oder weder noch ist. Deck die Karte dann auf. Wenn dein Gegner richtig geraten hat, zieht er drei Karten. Wenn dein Gegner falsch geraten hat, ziehst du drei Karten. Nimm auf jeden Fall die Karte zurück auf deine Hand."
 	},
 
 

--- a/data/Neo/Neo Destiny/103.ts
+++ b/data/Neo/Neo Destiny/103.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Look at your opponent's hand and choose a card there. Your opponent shuffles that card into his or her deck. Then, your opponent may draw up to 2 cards.",
 		fr: "Regardez la main de votre adversaire et choisissez-y une carte. Votre adversaire mélange cette carte à son deck. Il peut ensuite piocher jusqu'à 2 cartes.",
-		de: "Schaue dir die Karte auf der Hand deines Gegners an und wähle eine Karte davon. Dein Gegner mischt diese Karte in sein Deck. Dann darf er bis zu zwei Karten ziehen."
+		de: "Schaue dir die Karten auf der Hand deines Gegners an und wähle eine Karte davon. Dein Gegner mischt diese Karte in sein Deck. Dann darf er bis zu zwei Karten ziehen."
 	},
 
 

--- a/data/Neo/Neo Destiny/104.ts
+++ b/data/Neo/Neo Destiny/104.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Flip a coin. If heads, your Active Pokémon is no longer Asleep, Confused, Paralyzed, or Poisoned and remove 2 damage counters from it. If your Active Pokémon has fewer damage counters than that, remove all of them.",
 		fr: "Lancez une pièce. Si c'est face, votre Pokémon Actif n'est plus Endormi, Confus, Paralysé ou Empoisonné, retirez 2 marqueurs de dégâts de votre Pokémon Actif. Si votre Pokémon Actif a moins de marqueurs de dégâts, retirez-les tous.",
-		de: "Wirf eine Münze. Bei 'Kopf' schläft dein Aktives Pokémon nicht mehr und ist nicht länger verwirrt, gelähmt oder vergiftet. Entferne zwei Schadensmarken von deinem aktiven Pokémon. Hat es weniger als zwei Schadensmarken, entferne alle."
+		de: "Wirf eine Münze. Bei „Kopf“ schläft dein aktives Pokémon nicht mehr und ist nicht länger verwirrt, gelähmt oder vergiftet. Entferne zwei Schadensmarken von deinem aktiven Pokémon. Hat es weniger als zwei Schadensmarken, entferne alle."
 	},
 
 

--- a/data/Neo/Neo Destiny/105.ts
+++ b/data/Neo/Neo Destiny/105.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "You can't play this card if you have 5 or more cards in your hand (including this one). Draw cards until you have exactly 4 cards in your hand.",
 		fr: "Vous ne pouvez pas jouer cette carte si vous avez 5 cartes ou plus dans votre main (y compris celle-ci). Piochez des cartes jusqu'à ce que votre main soit de 4 cartes.",
-		de: "You can´t play this card if you have 5 or more cards in your hand (including this one). Draw cards until you have exactly 4 cards in your hand."
+		de: "Du kannst diese Karte nicht spielen, wenn du fünf oder mehr Karten auf deiner Hand hast (einschließlich dieser hier). Ziehe so viele Karten, bis du genau vier Karten auf deiner Hand hast."
 	},
 
 

--- a/data/Neo/Neo Destiny/106.ts
+++ b/data/Neo/Neo Destiny/106.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Remove a number of damage counters from 1 of your Benched Pokémon equal to the number of Energy cards attached to Shining Celebi. If the Pokémon has fewer damage counters than that, remove all of them.",
 				fr: "Retirez un nombre de marqueurs de dégâts sur un des Pokémon de votre Banc égal au nombre d'Énergies  attachées à Celebi brillant. Si le Pokémon a moins de marqueurs de dégâts, retirez-les tous.",
-				de: "Entferne so viele Schadensmarken von einem deiner Pokémon auf deiner Bank, wie -Energie an Schimmerndes Celebi angelegt sind. Wenn dieses Pokémon weniger Schadensmarken hat, entferne alle."
+				de: "Entferne so viele Schadensmarken von einem deiner Pokémon, wie {W}-Energie an Schimmerndes Celebi angelegt sind. Wenn dieses Pokémon weniger Schadensmarken hat, entferne alle."
 			},
 
 		},
@@ -57,7 +57,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a number of coins equal to the number of Energy attached to the Defending Pokémon. If you get 1 or more heads, the Defending Pokémon is now Asleep, Confused, or Poisoned (your choice).",
 				fr: "Lancez un nombre de pièces égal au nombre de cartes Énergie attachées au Pokémon Défenseur. Si vous obtenez au moins une face, le Pokémon Défenseur est maintenant Endormi, Confus ou Empoisonné (selon votre choix).",
-				de: "Wirf so viele Münzen, wie Energiekarten an das verteidigende Pokémon angelegt sind. Wenn mindestens einmal 'Kopf' fällt, wählst du, ob das verteidigende Pokémon jetzt verwirrt oder vergiftet ist oder schläft."
+				de: "Wirf so viele Münzen, wie Energiekarten an das verteidigende Pokémon angelegt sind. Wenn mindestens einmal „Kopf“ fällt, wählst du, ob das verteidigende Pokémon jetzt verwirrt oder vergiftet ist oder schläft."
 			},
 
 			damage: 10
@@ -75,7 +75,8 @@ const card: Card = {
 
 	description: {
 		en: "It is worshipped as a god of the forest. It appears only in undisturbed old-growth forests.",
-		fr: "Il est adoré comme un dieu de la forêt. Il n'apparaît que dans des forêts anciennes et paisibles."
+		fr: "Il est adoré comme un dieu de la forêt. Il n'apparaît que dans des forêts anciennes et paisibles.",
+		de: "Es wird als Waldgottheit verehrt. Es erscheint nur in unberührten uralten Wäldern."
 	},
 
 

--- a/data/Neo/Neo Destiny/107.ts
+++ b/data/Neo/Neo Destiny/107.ts
@@ -42,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Discard 1 Energy card and 1 Energy card attached to Shining Charizard or this attack does nothing. Flip a coin. If tails, Shining Charizard does 30 damage to itself.",
 				fr: "Défaussez-vous d'une carte Énergie  et d'une carte Énergie  attachées à Dracaufeu brillant ou cette attaque ne fait rien. Lancez une pièce. Si c'est pile, Dracaufeu brillant s'inflige 30 dégâts.",
-				de: "Lege eine jeweils an Schimmerndes Glurak angelegte -Energiekarte und -Energiekarte auf deinen Ablagestapel, oder dieser Angriff hat keine Auswirkungen. Wirf eine Münze. Bei \"Zahl\" fügt sich Schimmerndes Glurak selbst 30 Schadenspunkte zu."
+				de: "Lege eine jeweils an Glurak angelegte {R}-Energiekarte und {L}-Energiekarte auf deinen Ablagestapel, oder dieser Angriff hat keine Auswirkungen. Wirf eine Münze. Bei „Zahl“ fügt sich Schimmerndes Glurak selber 30 Schadenspunkte zu."
 			},
 			damage: 100,
 
@@ -67,7 +67,8 @@ const card: Card = {
 
 	description: {
 		en: "The flames it breathes are so hot that they can melt anything.",
-		fr: "Les flammes qu'il souffle sont si chaudes qu'elles peuvent faire fondre n'importe quoi."
+		fr: "Les flammes qu'il souffle sont si chaudes qu'elles peuvent faire fondre n'importe quoi.",
+		de: "Die Flammen, die es ausatmet, sind so heiß, dass sie alles zum Schmelzen bringen können."
 	},
 
 

--- a/data/Neo/Neo Destiny/108.ts
+++ b/data/Neo/Neo Destiny/108.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 damage plus 10 more damage and does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) If tails, this attack does 30 damage and Shining Kabutops does 10 damage to itself.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts plus 10 dégâts supplémentaires et inflige 10 dégâts à chaque Pokémon du Banc de votre adversaire. (N'appliquez ni la Faiblesse, ni la Résistance aux Pokémon du Banc.) Si c'est pile, cette attaque inflige 30 dégâts et Kabutops brillant s'inflige 10 dégâts.",
-				de: "Wirf eine Münze. Bei 'Kopf' fügt dieser Angriff 30 Schadenspunkte plus 10 weitere Schadenpunkte zu und außerdem jedem Pokémon auf der Bank deines gegners 10 Schadenspunkte. (Wende Schwäche und resistenz bei Pokémon auf der Bank nicht an.) Bei 'Zahl' fügt dieser Angriff 30 Schadenpunkte zu, und Schimmerndes Kabutops fügt sich selbst 10 Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 30 Schadenspunkte plus 10 weitere Schadenspunkte zu und außerdem jedem Pokémon auf der Bank deines Gegners 10 Schadenspunkte. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.) Bei „Zahl“ fügt dieser Angriff 30 Schadenspunkte zu und Schimmerndes Kabutops fügt sich selber 30 Schadenspunkte zu."
 			},
 			damage: "30+",
 
@@ -60,7 +60,7 @@ const card: Card = {
 			effect: {
 				en: "Does 50 damage plus 10 more damage for each Energy attached to Shining Kabutops but not used to pay for this attack's Energy cost. Don't apply Resistance.",
 				fr: "Inflige 50 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  attachée à Kabutops brillant mais non utilisée pour payer le coût d'Énergie de cette attaque. N'appliquez pas la Résistance.",
-				de: "Fügt 40 Schadenspunkte plus 10 weitere Schadenpunkte für jede an Schimmerndes Kabutops angelegte -Energie, die nicht zum Zahlen der Angriffskosten verwendet wird, zu. Wende Resistenz nicht an."
+				de: "Fügt 50 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Schimmerndes Kabutops angelegte {W}-Energie, die nicht zum Zahlen der Angriffskosten verwendet wird, zu. Wende Resistenz nicht an."
 			},
 			damage: "50+",
 
@@ -78,7 +78,8 @@ const card: Card = {
 
 	description: {
 		en: "This ancient Pokémon uses its razor-sharp claws to cut open its prey and gain access to its blood.",
-		fr: "Ce Pokémon antique utilise ses griffes acérées pour trancher ses proies et récupérer leur sang."
+		fr: "Ce Pokémon antique utilise ses griffes acérées pour trancher ses proies et récupérer leur sang.",
+		de: "Dieses uralte Pokémon verwendet seine rasiermesserscharfen Klauen, um seine Opfer aufzuschlitzen und an ihr Blut heranzukommen."
 	},
 
 

--- a/data/Neo/Neo Destiny/109.ts
+++ b/data/Neo/Neo Destiny/109.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			effect: {
 				en: "If an attack does damage to Shining Mewtwo during your opponent's next turn (even if Shining Mewtwo is Knocked Out), flip a coin. If heads, prevent all damage done to Shining Mewtwo from that attack (any other effects of attacks still happen) and do 20 damage to the attacking Pokémon.",
 				fr: "Si une attaque inflige des dégâts à Mewtwo brillant pendant le prochain tour de votre adversaire (même si Mewtwo brillant est mis K.O.), lancez une pièce. Si c'est face, prévenez tous les dégâts infligés à Mewtwo brillant par cette attaque (Tous les autres effets dus à des attaques subsistent) et infligez 20 dégâts au Pokémon attaquant.",
-				de: "Wirf eine Münze, wenn ein Angriff im nächsten Zug deines gegners Schimmerndes Mewtu Schaden zufügt (selbst wenn Schimmerndes Mewtu kampfunfähig wird). Verhindere bei 'Kopf' allen Schaden, der Schimmerndes Mewtu von diesem Angriff zugefügt wird (alle anderen Effekte von Angriffen behalten ihre Wirkung) und füge dem angreifenden Pokémon 20 Schadenspunkte zu."
+				de: "Wirf eine Münze, wenn ein Angriff im nächsten Zug deines Gegners Schimmerndes Mewtu Schaden zufügt (selbst wenn Schimmerndes Mewtu kampfunfähig wird). Verhindere bei „Kopf“ allen Schaden, der Schimmerndes Mewtu von diesem Angriff zugefügt wird (alle anderen Effekte von Angriffen behalten ihre Wirkung) und füge dann dem angreifenden Pokémon 20 Schadenspunkte zu."
 			},
 
 		},
@@ -57,7 +57,7 @@ const card: Card = {
 			effect: {
 				en: "Discard a Energy card attached to Shining Mewtwo or this attack does nothing. This attack does 40 damage plus 10 damage for each Energy attached to the Defending Pokémon.",
 				fr: "Défaussez-vous d'une carte Énergie  attachée à Mewtwo brillant ou cette attaque ne fait rien. Cette attaque inflige 40 dégâts plus 10 dégâts pour chaque Énergie attachée au Pokémon Défenseur.",
-				de: "Lege eine an Schimmerndes Mewtu angelegte -Energiekarte auf deinen Ablagestapel, oder dieser Angriff hat keine Auswirkungen. Dieser Angriff fügt 40 Schadenspunkte plus weitere 10 Schadenspunkte für jede an das verteidigende Pokémon angelegte Energie zu."
+				de: "Lege eine an Schimmerndes Mewtu angelegte {R}-Energiekarte auf deinen Ablagestapel, oder dieser Angriff hat keine Auswirkungen. Dieser Angriff fügt 40 Schadenspunkte plus weitere 10 Schadenspunkte für jede an das verteidigende Pokémon angelegte Energie zu."
 			},
 			damage: "40+",
 
@@ -75,7 +75,8 @@ const card: Card = {
 
 	description: {
 		en: "It uses its highly developed psychic powers to defeat its enemies before they even have time to think.",
-		fr: "Il utilise ses pouvoirs psychiques surdéveloppés pour vaincre ses ennemis avant qu'ils n'aient le temps de réfléchir."
+		fr: "Il utilise ses pouvoirs psychiques surdéveloppés pour vaincre ses ennemis avant qu'ils n'aient le temps de réfléchir.",
+		de: "Es verwendet seine hoch entwickelten psychischen Kräfte, um seine Gegner zu besiegen, bevor diese überhaupt Zeit zum Denken haben."
 	},
 
 

--- a/data/Neo/Neo Destiny/11.ts
+++ b/data/Neo/Neo Destiny/11.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pupitar",
-		fr: "Ymphect obscur"
+		fr: "Ymphect obscur",
+		de: "Pupitar"
 	},
 
 	stage: "Stage2",
@@ -38,12 +39,12 @@ const card: Card = {
 			name: {
 				en: "Mountain Smasher",
 				fr: "Casse-montagne",
-				de: "Mountain Smasher"
+				de: "Bergzertrümmerer"
 			},
 			effect: {
 				en: "Flip a number of coins equal to the number of Energy cards attached to Dark Tyranitar. This attack does 20 damage times the number of heads. Then, for each heads, discard the top card from your opponent's deck.",
 				fr: "Lancez un nombre de pièces égal au nombre de cartes Énergie  attachées à Tyranocif obscur. Cette attaque inflige 20 dégâts multipliés par le nombre de faces. Puis, pour chaque face, défaussez-vous de la carte du dessus du deck de votre adversaire.",
-				de: "Flip a number of coins equal to the number of  Energy cards attached to Dark Tyranitar. This attack does 20 damage times the number of heads. Then, for each heads, discard the top card from your opponent's deck."
+				de: "Wirf so viele Münzen, wie an Dunkles Despotar {F}-Energiekarten angelegt sind. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu. Lege dann für jedes Mal „Kopf“ die oberste Karte vom Deck deines Gegners auf den Ablagestapel."
 			},
 			damage: "20x",
 
@@ -59,13 +60,13 @@ const card: Card = {
 			name: {
 				en: "Fling Away",
 				fr: "Catapulte",
-				de: "Fling Away"
+				de: "Wegschleudern"
 			},
 
 			effect: {
 				en: "If your opponent has any Benched Pokémon, this attack does 30 damage instead of 50 and choose 1 of those Benched Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Si votre adversaire a des Pokémon sur son Banc, cette attaque inflige 30 dégâts au lieu de 50 et vous choisissez un des Pokémon de son Banc. Cette attaque inflige 30 dégâts à ce Pokémon. (N'appliquez pas la Faiblesse et la Résistance pour les Pokémon du Banc.)",
-				de: "If your opponent has any Benched Pokémon, this attack does 30 damage instead of 50 and choose 1 of those Benched Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Falls dein Gegner mindestens ein Pokémon auf der Bank hat, fügt dieser Angriff 30 Schadenspunkte statt 50 zu und du bestimmst ein Pokémon auf der Bank deines Gegners. Dieser Angriff fügt diesem Pokémon 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 			damage: 50
@@ -90,7 +91,8 @@ const card: Card = {
 
 	description: {
 		en: "Its power is such that not even mountains can stand in its way.",
-		fr: "Sa puissance est telle que même les montagnes ne lui résistent pas."
+		fr: "Sa puissance est telle que même les montagnes ne lui résistent pas.",
+		de: "Seine Kraft ist so groß, dass selbst Berge für ihn kein Hindernis darstellen."
 	},
 
 

--- a/data/Neo/Neo Destiny/110.ts
+++ b/data/Neo/Neo Destiny/110.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. If exactly 1 is heads, the Defending Pokémon is now Asleep. If exactly 2 are heads, the Defending Pokémon is now Confused. If all 3 are heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez 3 pièces. S'il y a une face, le Pokémon Défenseur est maintenant Endormi. S'il y a 2 faces, le Pokémon Défenseur est maintenant Confus. S'il y a 3 faces, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf drei Münzen. Wenn genau einmal 'Kopf' fällt, schläft das verteidigende Pokémon jetzt. Wenn genau zweimal 'Kopf' fällt, ist das verteidigende Pokémon jetzt verwirrt. Wenn jedes Mal 'KopfÄ fällt, ist das verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf drei Münzen. Wenn genau einmal „Kopf“ fällt, schläft das verteidigende Pokémon jetzt. Wenn genau zweimal „Kopf“ fällt, ist das verteidigende Pokémon jetzt verwirrt. Wenn jedes Mal „Kopf“ fällt, ist das verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 30,
 
@@ -65,7 +65,8 @@ const card: Card = {
 
 	description: {
 		en: "It speeds up its thought processes by turning its head around 180 degrees.",
-		fr: "Il accélère la vitesse à laquelle il pense en tournant sa tête à 180 degrés."
+		fr: "Il accélère la vitesse à laquelle il pense en tournant sa tête à 180 degrés.",
+		de: "Es beschleunigt seine Denkprozesse, indem es seinen Kopf um 180 Grad dreht."
 	},
 
 

--- a/data/Neo/Neo Destiny/111.ts
+++ b/data/Neo/Neo Destiny/111.ts
@@ -43,7 +43,7 @@ const card: Card = {
 			effect: {
 				en: "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to that Pokémon for each Energy attached to Shining Raichu. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Si votre adversaire a des Pokémon sur son Banc, choisissez l'un d'eux et cette attaque inflige 10 dégâts à ce Pokémon pour chaque Énergie  attachée à Raichu brillant. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon du Banc.)",
-				de: "Wenn dein gegner mindestens ein Pokémon auf seiner Bank hat, wählt eines von diesen, und dieser Angriff fügt diesem Pokémon 10 Schadenspunkte für jede an Schimmerndes Raichu angelegte -Energie zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Wenn dein Gegner mindestens ein Pokémon auf seiner Bank hat, wähle eines von diesen und dieser Angriff fügt diesem Pokémon 10 Schadenspunkte für jede an Schimmerndes Raichu angelegte {W}-Energie zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 			damage: 40
@@ -61,7 +61,8 @@ const card: Card = {
 
 	description: {
 		en: "If the electricity in its cheeks runs out, it sticks its tail straight up and uses it to collect energy from the air.",
-		fr: "S'il vient à court d'électricité au niveau de ses joues, il dresse sa queue pour collecter l'énergie dans l'air ambiant."
+		fr: "S'il vient à court d'électricité au niveau de ses joues, il dresse sa queue pour collecter l'énergie dans l'air ambiant.",
+		de: "Wenn die Elektrizität in seinen Backen zu stark abnimmt, streckt es seinen Schwanz steil in die Luft, um Energie aus der Luft aufzunehmen."
 	},
 
 

--- a/data/Neo/Neo Destiny/112.ts
+++ b/data/Neo/Neo Destiny/112.ts
@@ -43,7 +43,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage to each Benched Pokémon (yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.) If tails, this attack does nothing. Either way, Shining Steelix can't attack during your next turn.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts à chaque Pokémon du Banc (le vôtre et celui de votre adversaire). (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon du Banc.) Si c'est pile, cette attaque ne fait rien. Dans tous les cas, Steelix brillant ne peut pas attaquer pendant votre prochain tour.",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff allen Pokémon auf der Bank 10 Schadenspunkte zu (deinen und denen deines Gegners). (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.) Bei \"Zahl\" hat dieser Angriff keine Auswirkungen. Unabhängig davon, kann Schimmerndes Stahlos während deines nächsten Zuges nicht angreifen."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff allen Pokémon auf der Bank 10 Schadenspunkte zu (deinen und denen deines Gegners). (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.) Bei „Zahl“ hat dieser Angriff keine Auswirkungen. Unabhängig davon kann Schimmerndes Stahlos während deines nächsten Zuges nicht angreifen."
 			},
 
 			damage: 80
@@ -68,7 +68,8 @@ const card: Card = {
 
 	description: {
 		en: "If an Onix lives 100 years or more, its skin hardens, eventually becoming even harder than a diamond.",
-		fr: "Si un Onix vit au moins 100 ans, sa peau durcit et devient peu à peu plus dure que le diamant."
+		fr: "Si un Onix vit au moins 100 ans, sa peau durcit et devient peu à peu plus dure que le diamant.",
+		de: "Wenn ein Onix 100 Jahre oder länger lebt, wird seine Haut immer härter, manchmal sogar härter als Diamanten."
 	},
 
 

--- a/data/Neo/Neo Destiny/113.ts
+++ b/data/Neo/Neo Destiny/113.ts
@@ -36,7 +36,8 @@ const card: Card = {
 
 	description: {
 		en: "It is so powerful, it can knock down a mountain with hust one arm.",
-		fr: "Il est si puissant qu'il peut renverser une montagne d'un coup de coude."
+		fr: "Il est si puissant qu'il peut renverser une montagne d'un coup de coude.",
+		de: "Es ist so kräftig, dass es einen Berg mit nur einer Hand umwerfen kann."
 	},
 
 	attacks: [{

--- a/data/Neo/Neo Destiny/12.ts
+++ b/data/Neo/Neo Destiny/12.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Growlithe",
-		fr: "Caninos"
+		fr: "Caninos",
+		de: "Fukano"
 	},
 
 	stage: "Stage1",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Drive Off",
 				fr: "Déroute",
-				de: "Drive Off"
+				de: "Wegtreiben"
 			},
 			effect: {
 				en: "As long as Light Arcanine is your Active Pokémon, once during your turn (before your attack), if your opponent has any Benched Pokémon, he or she chooses 1 of them and switches it with the Defending Pokémon. This power can't be used while Light Arcanine is Asleep, Confused, or Paralyzed.",
 				fr: "Tant qu'Arcanin lumineux est votre Pokémon Actif, une fois pendant votre tour (avant votre attaque), si votre adversaire a des Pokémon sur son Banc, il en choisit un et l'échange contre le Pokémon Défenseur. Ce pouvoir ne fonctionne pas si Arcanin lumineux est Endormi, Confus ou Paralysé.",
-				de: "As long as Light Arcanine is your Active Pokémon, once during your turn (before your attack), if your opponent has any Benched Pokémon, he or she chooses 1 of them and switches it with the Defending Pokémon. This power can't be used while Light Arcanine is Asleep, Confused, or Paralayzed."
+				de: "Solange Helles Arkani dein aktives Pokémon ist, und falls dein Gegner mindestens ein Pokémon auf der Bank hat, wählt dein Gegner einmal in deinem Zug (vor deinem Angriff) eines von ihnen und tauscht es mit dem verteidigenden Pokémon. Diese Fähigkeit kann nicht verwendet werden, falls Helles Arkani schläft, verwirrt oder gelähmt ist."
 			},
 		},
 	],
@@ -57,13 +58,13 @@ const card: Card = {
 			name: {
 				en: "Gentle Flames",
 				fr: "Douces flammes",
-				de: "Gentle Flames"
+				de: "Sanfte Flammen"
 			},
 
 			effect: {
 				en: "If the Defending Pokémon is a Baby Pokémon, this attack does 10 damage instead of 50. If the Defending Pokémon is a Basic Pokémon, this attack does 30 damage instead of 50.",
 				fr: "Si le Pokémon Défenseur est un Bébé Pokémon, cette attaque inflige 10 dégâts au lieu de 50. Si le Pokémon Défenseur est un Pokémon de base, cette attaque inflige 30 dégâts au lieu de 50.",
-				de: "If the Defending Pokémon is a Baby Pokémon, this attack does 10 damage instead of 50. If the Defending Pokémon is a Basic Pokémon, this attack does 30 damage instead of 50."
+				de: "Wenn das verteidigende Pokémon ein Baby-Pokémon ist, fügt dieser Angriff 10 Schadenspunkte statt 50 zu. Wenn das verteidigende Pokémon ein Basis-Pokémon ist, fügt dieser Angriff 30 Schadenspunkte statt 50 zu."
 			},
 
 			damage: 50
@@ -81,7 +82,8 @@ const card: Card = {
 
 	description: {
 		en: "This legendary Chinese Pokémon is easily recognized by its large flowing mane.",
-		fr: "Ce légendaire Pokémon chinois est facilement reconnaissable de par sa grande crinière."
+		fr: "Ce légendaire Pokémon chinois est facilement reconnaissable de par sa grande crinière.",
+		de: "Dieses legendäre chinesische Pokémon kann leicht an seiner riesigen wuscheligen Mähne erkannt werden."
 	},
 
 

--- a/data/Neo/Neo Destiny/13.ts
+++ b/data/Neo/Neo Destiny/13.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Marill",
-		fr: "Marill"
+		fr: "Marill",
+		de: "Marill"
 	},
 
 	stage: "Stage1",
@@ -38,12 +39,12 @@ const card: Card = {
 			name: {
 				en: "Bubble",
 				fr: "Écume",
-				de: "Bubble"
+				de: "Blubber"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 
@@ -57,12 +58,12 @@ const card: Card = {
 			name: {
 				en: "Bubble Jump",
 				fr: "Saute bulle",
-				de: "Bubble Jump"
+				de: "Blubbsprung"
 			},
 			effect: {
 				en: "If you have any Benched Pokémon, flip a coin. If heads, take 2 Energy cards attached to Light Azumarill and attach them to 1 of your Benched Pokémon. Then return Light Azumarill and all cards attached to it to your hand.",
 				fr: "Si vous avez des Pokémon sur votre Banc, lancez une pièce. Si c'est face, prenez 2 cartes Énergie attachées à Azumarill lumineux et attachez-les à l'un des Pokémon de votre Banc. Puis renvoyez Azumarill lumineux et toutes les cartes qui y sont attachées dans votre main.",
-				de: "If you have any Benched Pokémon, flip a coin. If heads, take 2 Energy cards attached to Light Azumarill and attach them to 1 of your Benched Pokémon. Then return Light Azumarill and all cards attached to it to your head."
+				de: "Wirf eine Münze, wenn du mindestens ein Pokémon auf der Bank hast. Nimm bei „Kopf“ zwei an Helles Azumarill angelegte Energiekarten und lege sie an eines deiner Pokémon auf der Bank an. Bringe dann Helles Azumarill und alle darin angelegten Karten auf deine Hand zurück."
 			},
 			damage: 30,
 
@@ -80,7 +81,8 @@ const card: Card = {
 
 	description: {
 		en: "It curls up its long ears when swimming to prevent water from entering them.",
-		fr: "Il replie ses longues oreilles quand il nage pour éviter que l'eau y entre."
+		fr: "Il replie ses longues oreilles quand il nage pour éviter que l'eau y entre.",
+		de: "Es rollt beim Schwimmen seine langen Ohren ein, damit kein Wasser hineinkommt."
 	},
 
 

--- a/data/Neo/Neo Destiny/14.ts
+++ b/data/Neo/Neo Destiny/14.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Dragonair",
-		fr: "Draco lumineux"
+		fr: "Draco lumineux",
+		de: "Dragonir"
 	},
 
 	stage: "Stage2",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Miraculous Wind",
 				fr: "Vent miraculeux",
-				de: "Miraculous Wind"
+				de: "Wundersamer Wind"
 			},
 			effect: {
 				en: "As long as Light Dragonite is your Active Pokémon, each Special Energy card provides Colorless Energy instead of its usual type and its other effects stop working. This power stops working while Light Dragonite is Asleep, Confused, or Paralyzed.",
 				fr: "Tant que Dracolosse lumineux est votre Pokémon Actif, toutes les cartes Énergie spéciale fournissent de l'Énergie  au lieu de leur type d'Énergie habituel et leurs autres effets cessent de fonctionner. Ce pouvoir cesse de fonctionner si Dracolosse lumineux est Endormi, Confus ou Paralysé.",
-				de: "As long as Light Dragonite is your Active Pokémon, each Special Energy card provides  Energy instead of its usual type and its other effects stop working. This power stops working while Light Dragonite is Asleep, Confused, or Paralyzed."
+				de: "Solange Helles Dragoran dein aktives Pokémon ist, erzeugt jede Spezialenergiekarte {C}-Energie statt ihres normalen Typs, und alle ihre anderen Effekte funktionieren nicht. Diese Fähigkeit verliert ihre Wirkung, solange Helles Dragoran schläft, verwirrt oder gelähmt ist."
 			},
 		},
 	],
@@ -56,12 +57,12 @@ const card: Card = {
 			name: {
 				en: "Light Wave",
 				fr: "Vague lumineuse",
-				de: "Light Wave"
+				de: "Leichte Wellen"
 			},
 			effect: {
 				en: "During your opponent's next turn, prevent all effects of attacks that are not damage done to this Pokémon.",
 				fr: "Prévenez tous les effets d'attaques, excepté les dégâts, infligés lors d'attaques contre Dracolosse lumineux pendant le prochain tour de votre adversaire.",
-				de: "Prevent all effects of attacks, other than damge, done to Light Dragonite during your opponent's next turn."
+				de: "Verhindere alle Auswirkungen von Angriffen (außer Schaden), der Helles Dragoran während des nächsten Zuges deines Gegners zugefügt wird."
 			},
 			damage: 40,
 
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "It is said to fly constantly over the sea, looking for people in need of aid.",
-		fr: "On raconte qu'il vole constamment au-dessus des mers, à la recherche de personnes ayant besoin d'aide."
+		fr: "On raconte qu'il vole constamment au-dessus des mers, à la recherche de personnes ayant besoin d'aide.",
+		de: "Man sagt ihm nach, ständig über die Meere zu fliegen und nach Leuten in Not Ausschau zu halten."
 	},
 
 

--- a/data/Neo/Neo Destiny/15.ts
+++ b/data/Neo/Neo Destiny/15.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Togepi",
-		fr: "Togepi"
+		fr: "Togepi",
+		de: "Togepi"
 	},
 
 	stage: "Stage1",
@@ -76,7 +77,8 @@ const card: Card = {
 
 	description: {
 		en: "It becomes depressed if it is not near kind-hearted people. Is is able to float in the air without moving its wings.",
-		fr: "Il devient rapidement déprimé s'il n'est pas près de personnes au grand cœur. Il peut flotter dans les airs sans bouger ses ailes."
+		fr: "Il devient rapidement déprimé s'il n'est pas près de personnes au grand cœur. Il peut flotter dans les airs sans bouger ses ailes.",
+		de: "Es wird traurig, wenn es nicht in der Nähe von netten Menschen ist. Es kann in der Luft schweben, ohne seine Flügel zu bewegen."
 	},
 
 

--- a/data/Neo/Neo Destiny/17.ts
+++ b/data/Neo/Neo Destiny/17.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Spinarak",
-		fr: "Mimigal"
+		fr: "Mimigal",
+		de: "Webarak"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "If your opponent has any Benched Pokémon, choose 1 of them and switch it with the Defending Pokémon, then flip a coin. If heads, the new Defending Pokémon is now Paralyzed.",
 				fr: "Si votre adversaire a des Pokémon sur son Banc, choisissez l'un d'eux et échangez-le contre le Pokémon Défenseur, puis lancez une pièce. Si c'est face, le nouveau Pokémon Défenseur est maintenant Paralysé.",
-				de: "Falls dein Gegner mindestens ein Pokémon auf der Bank hat, wähle eines von diesen und tausche es mit dem verteidigenden Pokémon aus. Wirf dann eine Münze. Bei 'Kopf' ist das neue verteidigende Pokémon jetzt gelähmt."
+				de: "Falls dein Gegner mindestens ein Pokémon auf der Bank hat, wähle eines von diesen und tausche es mit dem verteidigenden Pokémon aus. Wirf dann eine Münze. Bei „Kopf“ ist das neue verteidigende Pokémon jetzt gelähmt."
 			},
 
 		},
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "The Defending Pokémon is now Poisoned. Flip a coin. If heads, the Defending Pokémon can't retreat until the end of your opponent's next turn and if the effect of an attack, Pokémon Power, or Trainer card would change that player's Active Pokémon, that part of the effect does nothing.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné. Lancez une pièce. Si c'est face, le Pokémon Défenseur ne peut pas battre en retraite avant la fin du prochain tour de votre adversaire et si l'effet d'une attaque, Pouvoir Pokémon ou carte Dresseur vient à changer le Pokémon Actif, cette partie de l'attaque ne fait rien.",
-				de: "Das verteidigende Pokémon ist jetzt vergiftet. Wirf eine Münze. Bei 'Kopf' kann sich das verteidigende Pokémon bis zum Ende des nächsten Zuges deines Gegners nicht zurückziehen, und wenn der Effekt eines Angriffs, einer Pokémon-Power oder Trainerkarte das aktive Pokémon dieses Spielers ändern würde, hat dieser Teil des Effekts dann keine Wirkung."
+				de: "Das verteidigende Pokémon ist jetzt vergiftet. Wirf eine Münze. Bei „Kopf“ kann sich das verteidigende Pokémon bis zum Ende des nächsten Zuges deines Gegners nicht zurückziehen, und wenn der Effekt eines Angriffs, einer Pokémon-Power oder Trainerkarte das aktive Pokémon dieses Spielers ändern würde, hat dieser Teil des Effekts dann keine Wirkung."
 			},
 			damage: 30,
 
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "Wherever it goes, it spins a thread that always leads back to its web.",
-		fr: "Où qu'il aille, il tisse un fil qui le ramène à sa toile."
+		fr: "Où qu'il aille, il tisse un fil qui le ramène à sa toile.",
+		de: "Wo auch immer es hingeht, spinnt es einen Faden, der zurück zu seinem Nest führt."
 	},
 
 

--- a/data/Neo/Neo Destiny/18.ts
+++ b/data/Neo/Neo Destiny/18.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Slugma",
-		fr: "Limagma"
+		fr: "Limagma",
+		de: "Schneckmag"
 	},
 
 	stage: "Stage1",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Hot Plate",
 				fr: "Assiette chaude",
-				de: "Hot Plate"
+				de: "Heißer Boden"
 			},
 			effect: {
 				en: "As long as Dark Magcargo is your Active Pokémon, whenever a player puts a Baby Pokémon or Basic Pokémon onto his or her Bench from his or her hand, this power does 10 damage to that Pokémon. (Don't apply Weakness and Resistance.) This power stops working if Dark Magcargo is Asleep, Confused, or Paralyzed.",
 				fr: "Tant que Volcaropod obscur est votre Pokémon Actif, quand un joueur place un Bébé Pokémon ou un Pokémon de base sur son Banc depuis sa main, ce pouvoir inflige 10 dégâts à ce Pokémon. (N'appliquez ni la Faiblesse ni la Résistance.) Ce pouvoir cesse de fonctionner si Volcaropod obscur est Endormi, Confus ou Paralysé.",
-				de: "As long as Dark Magkargo is your Active Pokémon, whenever a player puts a Baby Pokémon or a Basic-Pokémon onto his or her Bench from his or her hand, this power does 10 damage to that Pokémon. (Don´t apply Weakness and Resistance.) This power stops working Dark Magcargo is Asleep, Confused, or Paralyzed."
+				de: "Solange Dunkles Magcargo dein aktives Pokémon ist, fügt diese Fähigkeit immer, wenn ein Spieler ein Baby-Pokémon oder ein Basis-Pokémon aus seiner Hand auf seine Bank legt, diesem Pokémon 10 Schadenspunkte zu. (Wende Schwäche und Resistenz nicht an.) Diese Fähigkeit verliert ihre Wirkung, solange Dunkles Magcargo schläft, verwirrt oder gelähmt ist."
 			},
 		},
 	],
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Ball of Flame",
 				fr: "Boule de flammes",
-				de: "Ball of Flame"
+				de: "Flammenball"
 			},
 			effect: {
 				en: "You may discard a Energy card attached to Dark Magcargo when you use this attack. If you do and if your opponent has any Benched Pokémon, choose 1 of them and this attack does 20 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Vous pouvez vous défausser d'une carte Énergie  attachée à Volcaropod obscur quand vous utilisez cette attaque. Si vous le faites, et si votre adversaire a des Pokémon sur son Banc, choisissez l'un d'eux et cette attaque lui inflige 20 dégâts (Ne pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc.)",
-				de: "You may discard a  Energy card attached to Dark Magcargo when you use this attack. If you do and if your opponent has any Benched Pokémon, choose 1 of them and this attack does 20 damage to it. (Don´t apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Du kannst eine an Dunkles Magcargo angelegte {R}-Energiekarte auf deinen Ablagestapel legen, wenn du diesen Angriff verwendest. Falls du dies tust und falls dein Gegner mindestens ein Pokémon auf der Bank hat, bestimmme eines von diesen. Dieser Angriff fügt diesem Pokémon 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 20,
 
@@ -78,7 +79,8 @@ const card: Card = {
 
 	description: {
 		en: "The shell on its back comes off easily, exposing the flames running through its body.",
-		fr: "La carapace qui couvre son dos s'enlève facilement, exposant à l'air son corps enflammé."
+		fr: "La carapace qui couvre son dos s'enlève facilement, exposant à l'air son corps enflammé.",
+		de: "Die Muschel auf seinem Rücken lässt sich leicht entfernen und legt die Flammen frei, die durch den Körper jagen."
 	},
 
 

--- a/data/Neo/Neo Destiny/19.ts
+++ b/data/Neo/Neo Destiny/19.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Omanyte",
-		fr: "Amonita obscur"
+		fr: "Amonita obscur",
+		de: "Amonitas"
 	},
 
 	stage: "Stage2",
@@ -38,12 +39,12 @@ const card: Card = {
 			name: {
 				en: "Prehistoric Water",
 				fr: "Eau préhistorique",
-				de: "Prehistoric Water"
+				de: "Urzeitwasser"
 			},
 			effect: {
 				en: "If your opponent has any evolved Pokémon in play, choose 1 of them and flip a coin. If heads, your opponent takes the highest Stage Evolution card on that Pokémon and shuffles it into his or her deck.",
 				fr: "Si votre adversaire a des Pokémon évolués, choisissez l'un d'eux et lancez une pièce. Si c'est face, votre adversaire prend la carte Évolution de niveau le plus élevé de ce Pokémon et la mélange à son deck.",
-				de: "If your opponent has any evolved Pokémon in play, choose 1 of them and flip a coin. If heads, your opponent takes the highest Stage Evolution card on that Pokémon and shuffles it into his or her deck."
+				de: "Wenn dein Gegner mindestens ein entwickeltes Pokémon im Spiel hat, wähle eines von diesen und wirf eine Münze. Bei „Kopf“ nimmt dein Gegner die Entwicklungskarte der höchsten Phase von diesem Pokémon und mischt sie in sein Deck."
 			},
 
 		},
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Dark Tentacle",
 				fr: "Sombre tentacule",
-				de: "Dark Tentacle"
+				de: "Finsteres Tentakel"
 			},
 			effect: {
 				en: "During your opponent's next turn, the Defending Pokémon can't evolve except from effects of attacks or Pokémon Powers. (Benching that Pokémon ends this effect.)",
 				fr: "Pendant le prochain tour de votre adversaire, le Pokémon Défenseur ne peut pas évoluer excepté par l'effet d'une attaque ou d'un Pouvoir Pokémon. (Envoyer ce Pokémon sur le Banc met fin à cet effet.)",
-				de: "During your opponent's next turn, the Defending Pokémon can't evolve except from effects of attacks or Pokémon Powers. (Benching that Pokémon ends this effect.)"
+				de: "Während des nächsten Zuges deines Gegners kann sich das verteidigende Pokémon nicht entwickeln, außer durch Effekte von Angriffen und Pokémon-Powers. (Wenn das Pokémon auf die Bank kommt, endet dadurch dieser Effekt.)"
 			},
 			damage: 30,
 
@@ -78,7 +79,8 @@ const card: Card = {
 
 	description: {
 		en: "Nothing can escape once wrapped in its tentacles, which it uses for self-defense as well as to catch food.",
-		fr: "Rien ne peut lui échapper une fois dans ses tentacules, qu'il utilise pour se défendre, mais aussi pour se nourrir."
+		fr: "Rien ne peut lui échapper une fois dans ses tentacules, qu'il utilise pour se défendre, mais aussi pour se nourrir.",
+		de: "Nichts, was es einmal in seine Tentakel gewickelt hat kann entkommen - sowohl in der Selbstverteidigung als auch beim Fangen von Nahrung."
 	},
 
 

--- a/data/Neo/Neo Destiny/2.ts
+++ b/data/Neo/Neo Destiny/2.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Dark Golbat",
-		fr: "Nosferalto obscur"
+		fr: "Nosferalto obscur",
+		de: "Dunkles Golbat"
 	},
 
 	stage: "Stage2",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Surprise Bite",
 				fr: "Morsure surprise",
-				de: "Surprise Bite"
+				de: "Überraschungsbiss"
 			},
 			effect: {
 				en: "When you play Dark Crobat from your hand, you may choose 1 of your opponent's Pokémon. This power does 20 damage do that Pokémon. (Don't apply Weakness and Resistance.)",
 				fr: "Quand vous jouez Nostenfer obscur depuis votre main, vous pouvez choisir un des Pokémon de votre adversaire. Ce pouvoir inflige 20 dégâts à ce Pokémon. (N'appliquez ni la Faiblesse, ni la Résistance.)",
-				de: "When you play Dark Crobat from your hand, you may choose 1 of your opponent's Pokémon. This power does 20 damage to that Pokémon. (Don't apply Weakness and Resistance.)"
+				de: "Wenn du Dunkles Iksbat aus deiner Hand spielst, kannst du 1 der Pokémon deines Gegners wählen. Diese Power fügt diesem Pokémon 20 Schadenspunkte zu. (Wende Schwäche und Resistenz nicht an.)"
 			},
 		},
 	],
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Dark Drain",
 				fr: "Sombre saignée",
-				de: "Dark Drain"
+				de: "Finsteres Aussaugen"
 			},
 			effect: {
 				en: "Flip a coin for each of your opponent's Pokémon. For each heads, this attack does 10 damage to that Pokémon. Don't apply Weakness and Resistance. Remove a number of damage counters from Dark Crobat equal to the damage dealt. If Dark Crobat has fewer damage counters than that, remove all of them.",
 				fr: "Lancez une pièce pour chaque Pokémon de votre adversaire. Pour chaque face, cette attaque inflige 10 dégâts à ce Pokémon. N'appliquez ni la Faiblesse, ni la Résistance. Retirez un nombre de marqueurs de dégâts sur Nostenfer obscur égal aux dégâts infligés. Si Nostenfer obscur a moins de marqueurs de dégâts, retirez-les tous.",
-				de: "Flip a coin for each of your opponent's Pokémon. For each heads, this attack does 10 damage to that Pokémon. Don't apply Weakness and Resistance. Remove a number of damage counters from Dark Crobat equal to the damage dealt. If Dark Crobat has fewer damage counters than that, remove all of them."
+				de: "Wirf für jedes Pokémon deines Gegners eine Münze. Immer wenn „Kopf“ fällt, fügt dieser Angriff dem entsprechenden Pokémon 10 Schadenspunkte zu. Wende Schwäche und Resistenz nicht an. Zähle, wie oft du insgesamt „Kopf“ geworfen hast, und entferne so viele Schadensmarken von Dunkles Iksbat. Falls Dunkles Iksbat weniger Schadensmarken hat, entferne alle."
 			},
 
 		},
@@ -82,7 +83,8 @@ const card: Card = {
 
 	description: {
 		en: "Although the wings it has evolved on its feet allow it to fly at high speeds, they unfortunately make it difficult to perch.",
-		fr: "Les ailes supplémentaires qui ornent ses pattes lui permettent de voler très vite, mais elles lui compliquent la vie quand il veut se percher."
+		fr: "Les ailes supplémentaires qui ornent ses pattes lui permettent de voler très vite, mais elles lui compliquent la vie quand il veut se percher.",
+		de: "Seine Flügel, die sich im Beinbereich entwickelt haben, erlauben ihm zwar, mit hoher Geschwindigkeit zu fliegen, aber machen es kompliziert, gescheit zu sitzen."
 	},
 
 

--- a/data/Neo/Neo Destiny/20.ts
+++ b/data/Neo/Neo Destiny/20.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Slowpoke",
-		fr: "Ramoloss"
+		fr: "Ramoloss",
+		de: "Flegmon"
 	},
 
 	stage: "Stage1",
@@ -78,7 +79,8 @@ const card: Card = {
 
 	description: {
 		en: "Each time it yawns, the Shellder on its head releases an enzyme that makes it grow even smarter.",
-		fr: "À chaque fois qu'il baille, le Kokiyas qu'il porte sur la tête projette une enzyme qui le rend encore plus intelligent."
+		fr: "À chaque fois qu'il baille, le Kokiyas qu'il porte sur la tête projette une enzyme qui le rend encore plus intelligent.",
+		de: "Immer wenn es gähnt, gibt das Muschas auf seinem Kopf ein Enzym frei, das es sofort klüger macht."
 	},
 
 

--- a/data/Neo/Neo Destiny/21.ts
+++ b/data/Neo/Neo Destiny/21.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Teddiursa",
-		fr: "Teddiursa"
+		fr: "Teddiursa",
+		de: "Teddiursa"
 	},
 
 	stage: "Stage1",
@@ -38,12 +39,12 @@ const card: Card = {
 			name: {
 				en: "Provoke",
 				fr: "Provocation",
-				de: "Provoke"
+				de: "Provozieren"
 			},
 			effect: {
 				en: "Look at your opponent's hand. If he or she has any Baby Pokémon and/or Basic Pokémon there, you may put any number of them onto your opponent's Bench (as long as there's room). Then, your opponent looks at your hand. If you have any Baby Pokémon and/or Basic Pokémon there, your opponent may put any number of them onto your Bench (as long as there's room).",
 				fr: "Regardez la main de votre adversaire. Si vous y trouvez des Bébés Pokémon et/ou des Pokémon de base, vous pouvez placer n'importe quel nombre d'entre eux sur le Banc de votre adversaire (tant qu'il n'est pas plein). Puis votre adversaire regarde votre main. S'il y trouve des Bébés Pokémon et/ou des Pokémon de base, votre adversaire peut placer n'importe quel nombre d'entre eux sur votre Banc (tant qu'il n'est pas plein).",
-				de: "Look at your opponent's hand. If he or she has any Baby Pokémon and/or Basic Pokémon there, you may put any number of them onto your opponent's Bench (as long as there's room). Then, your opponent looks at your hand. If you have any Baby Pokémon and/or Basic Pokémon there, your opponent may put any number of them onto your Bench (as long as there's room)."
+				de: "Schau dir die Karten auf der Hand deines Gegners an. Wenn er mindestens ein Baby-Pokémon und/oder Basis-Pokémon darunter hat, kannst du eine beliebige Anzahl davon auf die Bank deines Gegners legen (solange dort Platz ist). Dann schaut sich dein Gegner die Karten auf deiner Hand an. Wenn du mindestens ein Baby-Pokémon und/oder Basis-Pokémon auf der Hand hast, kann dein Gegner eine beliebige Anzahl davon auf deine Bank legen (solange dort Platz ist)."
 			},
 
 		},
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Battle Frenzy",
 				fr: "Frénésie du combat",
-				de: "Battle Frenzy"
+				de: "Kampfrausch"
 			},
 			effect: {
 				en: "For each Pokémon in play (yours and your opponent's), flip a coin. For each heads, this attack does 20 damage to that Pokémon. Don't apply Weakness and Resistance for this attack.",
 				fr: "Pour chaque Pokémon en jeu (ceux de votre adversaire et les vôtres), lancez une pièce. Pour chaque face, cette attaque inflige 20 dégâts à ce Pokémon. N'appliquez ni la Faiblesse ni la Résistance pour cette attaque.",
-				de: "For each Pokémon in play (yours and your opponent's), flip a coin. For each heads, this attack does 20 damage to that Pokémon. Don't apply Weakness and Resistance for this attack."
+				de: "Wirf für jedes Pokémon im Spiel (deine und die deines Gegners) eine Münze. Für jedes Mal „Kopf“ fügt dieser Angriff dem entsprechenden Pokémon 20 Schadenspunkte zu. Wende Schwäche und Resistenz bei diesem Angriff nicht an."
 			},
 
 		},
@@ -84,7 +85,8 @@ const card: Card = {
 
 	description: {
 		en: "Its keen nose can pick out any scent, even that of food buried deep underground.",
-		fr: "Son sens aiguisé de l'odorat détecte la moindre odeur, même celle de la nourriture quand elle est enfouie profondément."
+		fr: "Son sens aiguisé de l'odorat détecte la moindre odeur, même celle de la nourriture quand elle est enfouie profondément.",
+		de: "Seine feine Nase kann jeden Geruch erkennen, selbst den von Essen, das tief vergraben ist."
 	},
 
 

--- a/data/Neo/Neo Destiny/22.ts
+++ b/data/Neo/Neo Destiny/22.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Dratini",
-		fr: "Minidraco"
+		fr: "Minidraco",
+		de: "Dratini"
 	},
 
 	stage: "Stage1",
@@ -39,12 +40,12 @@ const card: Card = {
 			name: {
 				en: "Healing Light",
 				fr: "Lumière soignante",
-				de: "Healing Light"
+				de: "Heilendes Licht"
 			},
 			effect: {
 				en: "Remove 1 damage counter from each of your Pokémon that has any damage counters on it.",
 				fr: "Retirez un marqueur de dégât de chacun de vos Pokémon ayant des marqueurs de dégâts.",
-				de: "Remove 1 damage counter from each of you Pokémon that has any damage counters on it."
+				de: "Entferne von jedem deiner Pokémon, auf dem Schadensmarken liegen, eine der Schadensmarken."
 			},
 
 		},
@@ -58,13 +59,13 @@ const card: Card = {
 			name: {
 				en: "Protective Wave",
 				fr: "Onde protectrice",
-				de: "Protective Wave"
+				de: "Schützende Welle"
 			},
 
 			effect: {
 				en: "Flip a coin. If heads, during your opponent's next turn, prevent all effects of attacks, including damage, done to Light Dragonair.",
 				fr: "Lancez une pièce. Si c'est face, pendant le prochain tour de votre adversaire, prévenez tous les effets d'attaques, y compris les dégâts, infligés à Draco lumineux.",
-				de: "Flip a coin. If heads, during your opponent's turn, prevent all effects of attacks, including damage, done to Light Dragonair."
+				de: "Wirf eine Münze. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die Helles Dragonir zugefügt werden."
 			},
 
 			damage: 20
@@ -82,7 +83,8 @@ const card: Card = {
 
 	description: {
 		en: "The aura it projects from its body has an effect on the surrounding climate and weather.",
-		fr: "L'aura qui enveloppe son corps a un effet sur la météo et le climat environnants."
+		fr: "L'aura qui enveloppe son corps a un effet sur la météo et le climat environnants.",
+		de: "Die Aura, die sein Körper ausstrahlt, beeinflusst das Klima und Wetter seiner Umgebung."
 	},
 
 

--- a/data/Neo/Neo Destiny/23.ts
+++ b/data/Neo/Neo Destiny/23.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Chinchou",
-		fr: "Loupio"
+		fr: "Loupio",
+		de: "Lampi"
 	},
 
 	stage: "Stage1",
@@ -38,12 +39,12 @@ const card: Card = {
 			name: {
 				en: "Searchlight",
 				fr: "Phare",
-				de: "Searchlight"
+				de: "Scheinwerfer"
 			},
 			effect: {
 				en: "Flip a coin. If heads, each player may choose a card from his or her discard pile and put it into his or her hand.",
 				fr: "Lancez une pièce. Si c'est face, chaque joueur peut choisir une carte de sa pile de défausse et la placer dans sa main.",
-				de: "Flip a coin. If heads, each player may choose a card from his or her discard pile and put it into his or her hand."
+				de: "Wirf eine Münze. Bei „Kopf“ darf jeder Spieler eine Karte von seinem Ablagestapel auswählen und auf seine Hand nehmen."
 			},
 
 		},
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Spark",
 				fr: "Étincelle",
-				de: "Spark"
+				de: "Funkensprung"
 			},
 			effect: {
 				en: "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Si votre adversaire a des Pokémon sur son Banc, choisissez l'un d'eux et cette attaque lui inflige 10 dégâts. (Ne pas appliquer la Résistance et la Faiblesse au Pokémon du Banc.)",
-				de: "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon)"
+				de: "Falls dein Gegner mindestens ein Pokémon auf der Bank hat, wähle eines von diesen, und dieser Angriff fügt ihm 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 30,
 
@@ -78,7 +79,8 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon has evolved its dorsal fin to emit light, which attracts the fish it feeds on.",
-		fr: "La nageoire dorsale de ce Pokémon a évolué pour émettre de la lumière, ce qui attire les poissons dont il se nourrit."
+		fr: "La nageoire dorsale de ce Pokémon a évolué pour émettre de la lumière, ce qui attire les poissons dont il se nourrit.",
+		de: "Dieses Pokémon hat sich so entwickelt, dass seine Rückenflosse Licht ausstrahlt, das Fische anlockt, von denen es sich ernährt."
 	},
 
 

--- a/data/Neo/Neo Destiny/24.ts
+++ b/data/Neo/Neo Destiny/24.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Ledyba",
-		fr: "Coxy"
+		fr: "Coxy",
+		de: "Ledyba"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "If you have any Benched Pokémon, switch 1 of them with Light Ledian. As long as that Pokémon is your Active Pokémon, it can't become Asleep, Confused, Paralyzed, or Poisoned. (All other effects of attacks, Pokémon Powers, and Trainer cards still happen.)",
 				fr: "Si vous avez des Pokémon sur votre Banc, échangez l'un d'eux contre Coxyclaque lumineux. Tant que ce Pokémon est votre Pokémon Actif, il ne peut pas devenir Endormi, Confus, Paralysé ou Empoisonné. (Tous les autres effets d'attaques, Pouvoir Pokémon et cartes Dresseur sont toujours actifs.)",
-				de: "Falls du mindestens ein Pokémon auf deiner Bank hast, tausche eines von diesen mit Helles Ledian. Solange dieses Pokémon dein Aktives Pokémon ist, kann es nicht schlafen, verwirrt, gelähmt oder vergiftet sein. (Alle anderen Effekte von Angriffen, Pokémon-Powers und Trainerkarten finden immer noch statt.)"
+				de: "Falls du mindestens ein Pokémon auf deiner Bank hast, tausche eines von diesen mit Helles Ledian. Solange dieses Pokémon dein aktives Pokémon ist, kann es nicht schlafen, verwirrt, gelähmt oder vergiftet sein. (Alle anderen Effekte von Angriffen, Pokémon-Powers und Trainerkarten finden immer noch statt.)"
 			},
 
 		},
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 4 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 4 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 4 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl 'Kopf' zu."
+				de: "Wirf 4 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20x",
 
@@ -84,7 +85,8 @@ const card: Card = {
 
 	description: {
 		en: "The number of spots on its back increase or decrease depending on the number of stars visible in the night sky.",
-		fr: "Le nombre de taches sur son dos augmente ou diminue en fonction du nombre d'étoiles visibles dans le ciel nocturne."
+		fr: "Le nombre de taches sur son dos augmente ou diminue en fonction du nombre d'étoiles visibles dans le ciel nocturne.",
+		de: "Die Anzahl der Punkte auf seinem Rücken steigt und sinkt mit der Anzahl Sterne, die am Nachthimmel zu sehen sind."
 	},
 
 

--- a/data/Neo/Neo Destiny/25.ts
+++ b/data/Neo/Neo Destiny/25.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Machoke",
-		fr: "Machopeur lumineux"
+		fr: "Machopeur lumineux",
+		de: "Maschock"
 	},
 
 	stage: "Stage2",
@@ -41,13 +42,13 @@ const card: Card = {
 			name: {
 				en: "Beatdown",
 				fr: "Combat",
-				de: "Beatdown"
+				de: "Niederprügler"
 			},
 
 			effect: {
 				en: "If the Defending Pokémon has Dark in its name or is a Pokémon, flip a coin. If heads, this attack does 100 damage instead of 50.",
 				fr: "Si le Pokémon Défenseur est un Pokémon obscur ou si c'est un Pokémon , lancez une pièce. Si c'est face, cette attaque inflige 100 dégâts au lieu de 50.",
-				de: "If the Defending Pokémon has Dark in its name or is a  Pokémon, flip a coin. If heads, this attack does 100 damage instead of 50."
+				de: "Wirf eine Münze, wenn das verteidigende Pokémon „Dunkles“ in seinem Namen hat oder ein {D}-Pokémon ist. Bei „Kopf“ fügt dieser Angriff 100 Schadenspunkte statt 50 zu."
 			},
 
 			damage: 50
@@ -65,20 +66,21 @@ const card: Card = {
 
 	description: {
 		en: "It uses its four arms in combat to unleash a ceaseless flurry of punches.",
-		fr: "Il utilise ses quatre bras au combat pour délivrer une véritable ruée de coups."
+		fr: "Il utilise ses quatre bras au combat pour délivrer une véritable ruée de coups.",
+		de: "Es verwendet seine vier Arme im Kampf, um seinen Gegner mit einem unglaublichen Schlaghagel einzudecken."
 	},
 
 	abilities: [{
 		name: {
 			fr: "Tandem",
-			de: "Tag Team",
+			de: "Kampfpartner",
 			en: "Tag Team",
 		},
 
 		effect: {
 			fr: "Quand vous jouez Mackogneur depuis votre main, si vous le placez sur votre Banc, retirez 3 marqueurs de dégâts de votre Pokémon Actif. S'il a moins de 3 marqueurs de dégâts, retirez-les tous. Échangez ensuite Mackogneur lumineux contre votre Pokémon Actif.",
 			en: "When you play Light Machamp from your hand, if is on your Bench, remove 3 damage counters than that, remove all of them. Then, switch Light Machamp with your Active Pokémon.",
-			de: "When you play Light Machamp from your hand, if is on your Bench, remove 3 damage counters than that, remove all of them. Then, switch Light Machamp with your Active Pokémon."
+			de: "Wenn du Helles Machomei aus deiner Hand spielst und es auf deine Bank legst, entferne 3 Schadensmarken von deinem aktiven Pokémon. Wenn es weniger Schadensmarken hat, entferne alle. Tausche dann Helles Machomei mit deinem aktiven Pokémon."
 		},
 
 		type: "Pokemon Power"

--- a/data/Neo/Neo Destiny/26.ts
+++ b/data/Neo/Neo Destiny/26.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Swinub",
-		fr: "Marcacrin"
+		fr: "Marcacrin",
+		de: "Quiekel"
 	},
 
 	stage: "Stage1",
@@ -40,12 +41,12 @@ const card: Card = {
 			name: {
 				en: "Knock Over",
 				fr: "Culbute",
-				de: "Knock Over"
+				de: "Umwerfen"
 			},
 			effect: {
 				en: "If there is a Stadium card in play, you may discard it.",
 				fr: "s'il y a une carte Stade en jeu, vous pouvez vous en défausser.",
-				de: "If there is a Stadium card ibn play, you may discard it."
+				de: "Falls eine Stadion-Karte im Spiel ist, darfst du sie auf den Ablagestapel ihres Besitzers legen."
 			},
 			damage: 30,
 
@@ -70,18 +71,19 @@ const card: Card = {
 
 	description: {
 		en: "Its legs are short, but its hooves are wide and flat, allowing it to easily walk over snow.",
-		fr: "Il a de courtes pattes, mais ses sabots sont larges et plats, ce qui lui permet de se déplacer facilement sur la neige."
+		fr: "Il a de courtes pattes, mais ses sabots sont larges et plats, ce qui lui permet de se déplacer facilement sur la neige.",
+		de: "Seine Beine sind kurz, aber seine Hufe sind breit und flach, sodass es einfach über Schnee gehen kann."
 	},
 
 	abilities: [{
 		name: {
 			fr: "Duvet",
-			de: "Fluffy Wool"
+			de: "Wuschelwolle"
 		},
 
 		effect: {
 			fr: "Pendant le tour de votre adversaire, si Cochignon est votre Pokémon Actif et si l'attaque de votre adversaire lui inflige des dégâts (même s'il est mis K.O.), lancez une pièce. Si c'est face, le Pokémon attaquant est maintenant Endormi. Ce pouvoir cesse de fonctionner si Cochignon est déjà Endormi, Confus ou Paralysé quand votre adversaire attaque.",
-			de: "During your opponent's turn, if Light Piloswine is your Active Pokémon and is damaged by your oppnent's attack (even if it's Knocked Out), flip a coin. If heads, the attacking Pokémon is now Asleep. This power stops working if Light Piloswine is already Asleep, Confused, or Paralyzed when your opponent attacks."
+			de: "Wirf eine Münze, wenn Helles Keifel dein aktives Pokémon ist und im Zug deines Gegners von einem Angriff deines Gegners Schaden nimmt (selbst wenn es kampfunfähig ist). Bei „Kopf“ schläft das verteidigende Pokémon jetzt. Diese Fähigkeit verliert ihre Wirkung, falls Helles Keifel bereits schläft, verwirrt oder gelähmt ist, wenn dein Gegner angreift."
 		},
 
 		type: "Pokemon Power"

--- a/data/Neo/Neo Destiny/27.ts
+++ b/data/Neo/Neo Destiny/27.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "[Give]",
 				fr: "[Give]",
-				de: "Give"
+				de: "Give [Give]"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), if you have Unown G, Unown I, Unown V, and Unown E on your Bench, you may flip a coin. If heads, search your deck for a basic Energy card and attach it to 1 of your Pokémon. Shuffle your deck afterward.",
 				fr: "Une fois pendant votre tour (avant votre attaque), si vous avez Zarbi [G], Zarbi [I], Zarbi [V] et Zarbi [E] sur votre Banc, vous pouvez lancer une pièce. Si c'est face, cherchez dans votre deck une carte Énergie de base et attachez-la à un de vos Pokémon. Mélangez ensuite votre deck.",
-				de: "Einmal in deinem Zug (vor deinem Angriff), wenn du Icognito G, Icognito I, Icognito V und Icognito E auf deiner Bank hats, kannst du eine Münze werfen. Durchsuche bei \"Kopf\" dein Deck nach einer Basis-Energiekarte und lege sie an eines deiner Pokémon an. Mische dein Deck danach."
+				de: "Einmal in deinem Zug (vor deinem Angriff), wenn du Icognito [G], Icognito [I], Icognito [V] und Icognito [E] auf deiner Bank hast, kannst du eine Münze werfen. Durchsuche bei „Kopf“ dein Deck nach einer Basis-Energiekarte und lege sie an eines deiner Pokémon an. Mische dein Deck danach."
 			},
 		},
 	],
@@ -68,7 +68,8 @@ const card: Card = {
 
 	description: {
 		en: "It is believed that the variety of types of this Pokémon were created by evolutionary adaptation, as each possesses a different ability.",
-		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente."
+		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente.",
+		de: "Es wird behauptet, dass die verschiedenen Sorten dieses Pokémon sich durch Anpassung entwickelt haben, da alle unterschiedliche Fähigkeiten haben."
 	},
 
 

--- a/data/Neo/Neo Destiny/28.ts
+++ b/data/Neo/Neo Destiny/28.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "[Help]",
 				fr: "Help",
-				de: "Help"
+				de: "Help [Help]"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), if you have Unown H, Unown E, Unown L, and Unown P on your Bench, you may shuffle your hand into your deck, then draw a new hand of the same number of cards.",
 				fr: "Une fois pendant votre tour (avant votre attaque), si vous avez Zarbi [H], Zarbi [E], Zarbi [L] et Zarbi [P] sur votre Banc, vous pouvez mélanger votre main à votre deck et piocher une nouvelle main ayant le même nombre de cartes que la précédente.",
-				de: "Du kannst immer einmal in deinem Zug (vor deinem Angriff), wenn du Icognito H, Icognito E, Icognito L und Icognito P auf deiner Bank hast, die Karten auf deiner Hand in dein Deck mischen und danach genauso viele Karten neu ziehen."
+				de: "Du kannst immer einmal in deinem Zug (vor deinem Angriff), wenn du Icognito [H], Icognito [E], Icognito [L] und Icognito [P] auf deiner Bank hast, die Karten auf deiner Hand in dein Deck mischen und danach genauso viele Karten neu ziehen."
 			},
 		},
 	],
@@ -68,7 +68,8 @@ const card: Card = {
 
 	description: {
 		en: "It is believed that the variety of types of this Pokémon were created by evolutionary adaptation, as each possesses a different ability.",
-		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente."
+		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente.",
+		de: "Es wird behauptet, dass die verschiedenen Sorten dieses Pokémon sich durch Anpassung entwickelt haben, da alle unterschiedliche Fähigkeiten besitzen."
 	},
 
 

--- a/data/Neo/Neo Destiny/29.ts
+++ b/data/Neo/Neo Destiny/29.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "[Want]",
 				fr: "[Want]",
-				de: "Want"
+				de: "Want [Want]"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), if you have Unown W, Unown A, Unown N, and Unown T on your Bench, you may flip a coin. If heads, put a Trainer card from your discard pile into your hand.",
 				fr: "Une fois pendant votre tour (avant votre attaque), si vous avez Zarbi [W], Zarbi [A], Zarbi [N] et Zarbi [T] sur votre Banc, vous pouvez lancer une pièce. Si c'est face, ajoutez une carte Dresseur de votre pile de défausse à votre main.",
-				de: "Once during your turn (before your attack), if you have Unown W, Unown A, Unown N, and Unown T on your Bench, you may flip a coin. If heads, put a Trainer card from your discard pile into your hand."
+				de: "Du kannst immer einmal in deinem Zug (vor deinem Angriff), wenn du Icognito [W], Icognito [A], Icognito [N], und Icognito [T] auf deiner Bank hast, eine Münze werfen. Nimm bei „Kopf“ eine Trainerkarte von deinem Ablagestapel auf deine Hand."
 			},
 		},
 	],
@@ -68,7 +68,8 @@ const card: Card = {
 
 	description: {
 		en: "It is believed that the variety of types of this Pokémon were created by evolutionary adaptation, as each possesses a different ability.",
-		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente."
+		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente.",
+		de: "Es wird behauptet, dass die verschiedenen Sorten dieses Pokémon sich durch Anpassung entwickelt haben, da alle unterschiedliche Fähigkeiten besitzen."
 	},
 
 

--- a/data/Neo/Neo Destiny/3.ts
+++ b/data/Neo/Neo Destiny/3.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Phanpy",
-		fr: "Phanpy"
+		fr: "Phanpy",
+		de: "Phanpy"
 	},
 
 	stage: "Stage1",
@@ -39,12 +40,12 @@ const card: Card = {
 			name: {
 				en: "Tusk Toss",
 				fr: "Koud'défense",
-				de: "Tusk Toss"
+				de: "Stoßzahnstoß"
 			},
 			effect: {
 				en: "If your opponent has any Benched Pokémon, flip a coin. If heads, return the Defending Pokémon and all cards attached to it to your opponent's hand. If tails, your opponent chooses 1 of his or her Benched Pokémon and switches it with the Defending Pokémon.",
 				fr: "Si votre adversaire a des Pokémon sur son Banc, lancez une pièce. Si c'est face, renvoyez le Pokémon Défenseur et toutes les cartes qui lui sont attachées dans la main de votre adversaire. Si c'est pile, votre adversaire choisit un des Pokémon de son Banc et l'échange contre le Pokémon Défenseur.",
-				de: "If your opponent has any Benched Pokémon, flip a coin. If heads, return the Defending Pokémon and all cards attached to it to your opponent's hand. If tails, your opponent chooses 1 of his or her Benched Pokémon and switches it with the Defending Pokémon."
+				de: "Falls dein Gegner mindestens ein Pokémon auf der Bank hat, wirf eine Münze. Bringe bei „Kopf“ das verteidigende Pokémon und alle daran angelegten Karten auf die Hand deines Gegners zurück. Bei „Zahl“ wählt dein Gegner eins seiner Pokémon auf der Bank und tauscht es mit dem verteidigenden Pokémon aus."
 			},
 
 		},
@@ -57,7 +58,7 @@ const card: Card = {
 			name: {
 				en: "Giant Tusk",
 				fr: "Défense géante",
-				de: "Giant Tusk"
+				de: "Riesenstoßzahn"
 			},
 
 			damage: 50,
@@ -83,7 +84,8 @@ const card: Card = {
 
 	description: {
 		en: "The larger its tusks, the higher its status in the herd.",
-		fr: "Plus ses défenses sont grosses, plus c'est un membre important du troupeau."
+		fr: "Plus ses défenses sont grosses, plus c'est un membre important du troupeau.",
+		de: "Je länger die Stoßzähne, desto größer das Ansehen in der Herde."
 	},
 
 

--- a/data/Neo/Neo Destiny/30.ts
+++ b/data/Neo/Neo Destiny/30.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "[XXXXX]",
 				fr: "XXXXX",
-				de: "XXXXX"
+				de: "XXXXX [XXXXX]"
 			},
 			effect: {
 				en: "Whenever 1 of your Pokémon with Unown in its name uses its Hidden Power attack, flip a coin until you get tails. That attack does 10 more damage for each heads. If you have more than 1 Unown X in play, use only 1 [XXXXX] per turn.",
 				fr: "Quand un de vos Pokémon Zarbi utilise son attaque Puissance cachée, lancez une pièce jusqu'à obtenir pile. Cette attaque fait 10 dégâts supplémentaires pour chaque face. Si vous avez plus d'un Zarbi [X] en jeu, utilisez seulement 1 [XXXXX] à chaque tour.",
-				de: "Immer wenn eines deiner Pokémon, die \"Icognito\" in ihren Namen haben, seinen Kraftreserve-Angriff verwendet, wirf eine Münze, bis \"Zahl\" kommt. Dieser Angriff fügt pro geworfenem \"Kopf\" 10 Schadenspunkte mehr zu. Wenn du mehr als ein Icognito X im Spiel, verwende XXXXX in jeden Zug nur einmal."
+				de: "Immer wenn eines deiner Pokémon, die „Icognito“ in ihrem Namen haben, seinen Kraftreserve-Angriff verwendet, wirf so lange eine Münze, bis „Zahl“ kommt. Dieser Angriff fügt pro geworfenem „Kopf“ 10 Schadenspunkte mehr zu. Wenn du mehr als ein 1 Icognito [X] im Spiel hast, verwende [XXXXX] in jedem Zug nur einmal."
 			},
 		},
 	],
@@ -68,7 +68,8 @@ const card: Card = {
 
 	description: {
 		en: "It is believed that the variety of types of this Pokémon were created by evolutionary adaptation, as each possesses a different ability.",
-		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente."
+		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente.",
+		de: "Es wird behauptet, dass die verschiedenen Sorten dieses Pokémon sich durch Anpassung entwickelt haben, da alle unterschiedliche Fähigkeiten besitzen."
 	},
 
 

--- a/data/Neo/Neo Destiny/31.ts
+++ b/data/Neo/Neo Destiny/31.ts
@@ -34,12 +34,12 @@ const card: Card = {
 			name: {
 				en: "Double Slap",
 				fr: "Torgnoles",
-				de: "Doubleslap"
+				de: "Duplexhieb"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Flip 2 coins. This attack does 20 damage times the number of heads."
+				de: "Wirf zwei Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20x",
 
@@ -54,13 +54,13 @@ const card: Card = {
 			name: {
 				en: "Egg Toss",
 				fr: "Lance Œuf",
-				de: "Egg Toss"
+				de: "Eierwurf"
 			},
 
 			effect: {
 				en: "Flip 2 coins. If either of them is tails, this attack does nothing.",
 				fr: "Lancez 2 pièces. Si vous obtenez un pile, cette attaque ne fait rien.",
-				de: "Flip 2 coins. If either of them is tails, this attack does nothing."
+				de: "Wirf zwei Münzen. Wenn mindestens eine von beiden „Zahl“ zeigt, hat dieser Angriff keine Auswirkungen."
 			},
 
 			damage: 80
@@ -85,7 +85,8 @@ const card: Card = {
 
 	description: {
 		en: "It holds its egg carefully when moving so as not to break it. Still, it is fast enough to disappear in the blink of an eye.",
-		fr: "Il serre précautionneusement son œuf pour ne pas le casser quand il bouge. Cependant, il reste assez rapide pour disparaître en un clin d'œil."
+		fr: "Il serre précautionneusement son œuf pour ne pas le casser quand il bouge. Cependant, il reste assez rapide pour disparaître en un clin d'œil.",
+		de: "Es hält sein Ei beim Herumlaufen sehr vorsichtig fest, damit es nicht zerbricht. Trotzdem ist es noch schnell genug, um blitzschnell zu verschwinden."
 	},
 
 

--- a/data/Neo/Neo Destiny/32.ts
+++ b/data/Neo/Neo Destiny/32.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Totodile",
-		fr: "Kaiminus"
+		fr: "Kaiminus",
+		de: "Karnimani"
 	},
 
 	stage: "Stage1",
@@ -40,13 +41,13 @@ const card: Card = {
 			name: {
 				en: "Clamping Jaw",
 				fr: "Gouffre",
-				de: "Clamping Jaw"
+				de: "Verschlingen"
 			},
 
 			effect: {
 				en: "The Defending Pokémon can't retreat during your opponent's next turn. If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing. (Benching either Pokémon ends this effect.)",
 				fr: "Le Pokémon Défenseur ne peut pas battre en retraite pendant le prochain tour de votre adversaire. Si le Pokémon Défenseur essaie d'attaquer pendant le prochain tour de votre adversaire, celui-ci lance une pièce. Si c'est pile, cette attaque ne fait rien. (Si l'un des deux Pokémon bat en retraite, cet effet prend fin.)",
-				de: "The Defending Pokémon can't retreat during your opponent's next turn. If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing. (Benching either Pokémon ends this effect.)"
+				de: "Das verteidigende Pokémon kann sich nicht während des nächsten Zuges deines Gegners zurückziehen. Wenn das verteidigende Pokémon während des nächsten Zuges deines Gegners versucht, anzugreifen, wirft dein Gegner eine Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen. (Kommt eins der beiden Pokémon auf die Bank, endet dieser Effekt.)"
 			},
 
 			damage: 20
@@ -64,7 +65,8 @@ const card: Card = {
 
 	description: {
 		en: "It has 49 teeth in its mouth that are constantly replacing themselves. Pull one out, and a new one grows in.",
-		fr: "Il a 49 dents dans sa gueule qui se régénèrent constamment. Arrachez-en une et une nouvelle pousse à sa place."
+		fr: "Il a 49 dents dans sa gueule qui se régénèrent constamment. Arrachez-en une et une nouvelle pousse à sa place.",
+		de: "Es hat 49 Zähne im Maul, die sich dauernd selbst ersetzen. Ziehe ihm einen Zahn, und ein neuer wächst nach."
 	},
 
 

--- a/data/Neo/Neo Destiny/33.ts
+++ b/data/Neo/Neo Destiny/33.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Exeggcute",
-		fr: "Noeunoeuf"
+		fr: "Noeunoeuf",
+		de: "Owei"
 	},
 
 	stage: "Stage1",
@@ -38,12 +39,12 @@ const card: Card = {
 			name: {
 				en: "Triple Headbutt",
 				fr: "Triple coup d'boule",
-				de: "Triple Headbutt"
+				de: "Dreifache Kopfnuss"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de faces.",
-				de: "Flip 3 coins. This attack does 10 damage times the number of heads."
+				de: "Wirf drei Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10x",
 
@@ -56,12 +57,12 @@ const card: Card = {
 			name: {
 				en: "MAX Burst",
 				fr: "Explosion maximale",
-				de: "MAX Burst"
+				de: "Maxi-Explosion"
 			},
 			effect: {
 				en: "Flip a number of coins equal to the number of Energy cards attached to your opponent's Pokémon. This attack does 20 damage times the number of heads.",
 				fr: "Lancez un nombre de pièces égal au nombre de cartes Énergie attachées au Pokémon de votre adversaire. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Flip a number of coins equal to the number of Energy cards attached to your opponent's Pokémon. This attack does 20 damage times the number of heads."
+				de: "Wirf so viele Münzen, wie Energiekarten an das aktive Pokémon deines Gegners angelegt sind. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20x",
 
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "If one of its heads falls off, it turns into an Exeggcute, which begins to look for other Exeggcutes using a special form of telepathy.",
-		fr: "S'il perd une de ses deux têtes, il se transforme en Nœunœuf, qui part aussitôt à la recherche d'un autre Nœunœuf grâce à une forme spéciale de télépathie."
+		fr: "S'il perd une de ses deux têtes, il se transforme en Nœunœuf, qui part aussitôt à la recherche d'un autre Nœunœuf grâce à une forme spéciale de télépathie.",
+		de: "Wenn einer seiner Köpfe herunterfällt, verwandelt sich dieser in ein Owei, der sofort nach anderen Oweis Ausschau hält und dabei eine Art Telepathie verwendet."
 	},
 
 

--- a/data/Neo/Neo Destiny/34.ts
+++ b/data/Neo/Neo Destiny/34.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Mareep",
-		fr: "Wattouat"
+		fr: "Wattouat",
+		de: "Voltilamm"
 	},
 
 	stage: "Stage1",
@@ -38,12 +39,12 @@ const card: Card = {
 			name: {
 				en: "High Voltage",
 				fr: "Haut voltage",
-				de: "High Voltage"
+				de: "Starkstrom"
 			},
 			effect: {
 				en: "Flip a coin. If heads, your opponent can't play Trainer cards during his or her next turn.",
 				fr: "Lancez une pièce. Si c'est face, votre adversaire ne peut pas jouer de cartes Dresseur pendant son prochain tour.",
-				de: "Flip a coin. If heads, your opponent can't play Trainer cards during his or her next turn."
+				de: "Wirf eine Münze. Bei „Kopf“ kann der Gegner während seines nächsten Zuges keine Trainer-Karten spielen."
 			},
 			damage: 10,
 
@@ -56,12 +57,12 @@ const card: Card = {
 			name: {
 				en: "Stun Wave",
 				fr: "Para-vague",
-				de: "Stun Wave"
+				de: "Betäubungswelle"
 			},
 			effect: {
 				en: "If the Defending Pokémon has a Pokémon Power, that power stops working until the end of your next turn.",
 				fr: "Si le Pokémon Défenseur a un Pouvoir Pokémon, ce pouvoir cesse de fonctionner jusqu'à la fin de votre prochain tour.",
-				de: "If the Defending Pokémon has a Pokémon Power, that Power stops working until the end of your next turn."
+				de: "Wenn das verteidigende Pokémon eine Pokémon-Power hat, funktioniert diese Power bis zum Ende deines nächsten Zuges nicht."
 			},
 			damage: 30,
 
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "As a result of storing massive amounts of electricity there, it can no longer grow wool on certain areas of its body.",
-		fr: "À cause des énormes quantités d'électricité qu'il stocke, sa laine ne pousse plus à certains endroits de son corps."
+		fr: "À cause des énormes quantités d'électricité qu'il stocke, sa laine ne pousse plus à certains endroits de son corps.",
+		de: "Da es an manchen Stellen seines Körpers riesige Mengen an Elektrizität speichert, kann es dort keine Wolle mehr wachsen lassen."
 	},
 
 

--- a/data/Neo/Neo Destiny/35.ts
+++ b/data/Neo/Neo Destiny/35.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pineco",
-		fr: "Pomdepik"
+		fr: "Pomdepik",
+		de: "Tannza"
 	},
 
 	stage: "Stage1",
@@ -38,12 +39,12 @@ const card: Card = {
 			name: {
 				en: "Armor Up",
 				fr: "Blindage",
-				de: "Armor Up"
+				de: "Aufrüsten"
 			},
 			effect: {
 				en: "Until the end of your next turn, if Dark Forretress would be Knocked Out by damage from an attack, flip a coin. If heads, Dark Forretress is not Knocked Out and its remaining HP become 10 instead.",
 				fr: "Jusqu'à la fin de votre prochain tour, si Foretress obscur doit être mis K.O. par les dégâts d'une attaque, lancez une pièce. Si c'est face, Foretress obscur n'est pas mis K.O. et ses points de vie deviennent 10.",
-				de: "Until the end of your next turn, if Dark Forretress would be Knocked Out by damage from an attack, flip a coin. If heads, Dark Forretress is not Knocked Out and its remaining HP become 10 instead."
+				de: "Falls Dunkles Forstellka bis zum Ende deines nächsten Zuges durch Schaden eines Angriffs kampfunfähig würde, wirf eine Münze. Bei „Kopf“ ist Dunkles Forstellka nicht kampfunfähig, und seine verbleibenden KP sind stattdessen 10."
 			},
 
 		},
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Dark Forretress does 60 damage to itself.",
 				fr: "Foretress obscur s'inflige 60 dégâts.",
-				de: "Dark Forretress does 60 damage to itself."
+				de: "Dunkles Forstellka fügt sich selbst 60 Schadenspunkte zu."
 			},
 			damage: 60,
 
@@ -78,7 +79,8 @@ const card: Card = {
 
 	description: {
 		en: "It stays motionless in trees, driving away with flying armored shards from its hard shell any who come close.",
-		fr: "Il reste immobile dans les arbres et chasse les intrus en leur lançant des piquants blindés."
+		fr: "Il reste immobile dans les arbres et chasse les intrus en leur lançant des piquants blindés.",
+		de: "Es sitzt bewegungslos in Bäumen und treibt all die, die ihm zu nahe kommen, mit fliegenden Scherben seines Panzers weg."
 	},
 
 

--- a/data/Neo/Neo Destiny/36.ts
+++ b/data/Neo/Neo Destiny/36.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Gastly",
-		fr: "Fantominus"
+		fr: "Fantominus",
+		de: "Nebulak"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Put a Baby Pokémon or Basic Pokémon card from your opponent's discard pile onto his or her Bench. Put 1 damage counter on that Pokémon. (You can't use this attack if your Bench is full.)",
 				fr: "Placez une carte Bébé Pokémon ou Pokémon de base de la pile de défausse de votre adversaire sur son Banc. Placez un marqueur de dégâts sur ce Pokémon. (Vous ne pouvez pas utiliser cette attaque si le Banc de votre adversaire est plein.)",
-				de: "Lege eine Baby-Pokémon- oder Basis-Pokémonkarte vom Ablagestapel deines Gegner auf seine Bank. Lege eine Schadensmarke auf dieses Pokémon. (du kannst diesen Angriff nicht verwenden, solange seine Bank voll ist.)"
+				de: "Lege eine Baby-Pokémon- oder Basis-Pokémonkarte vom Ablagestapel deines Gegners auf seine Bank. Lege eine Schadensmarke auf dieses Pokémon. (Du kannst diesen Angriff nicht verwenden, solange deine Bank voll ist.)"
 			},
 
 		},
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Asleep. If tails, the Defending Pokémon can't retreat during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Endormi. Si c'est pile, le Pokémon Défenseur ne peut pas battre en retraite pendant le prochain tour de votre adversaire.",
-				de: "Wirf eine Münze. Bei 'Kopf' schläft das verteidigende Pokémon während des nächsten Zuges deines Gegners nicht zurückziehen."
+				de: "Wirf eine Münze. Bei „Kopf“ schläft das verteidigende Pokémon jetzt. Bei „Zahl“ kann sich das verteidigende Pokémon während des nächsten Zuges deines Gegners nicht zurückziehen."
 			},
 			damage: 20,
 
@@ -76,7 +77,8 @@ const card: Card = {
 
 	description: {
 		en: "It silently hunts its prey in dark rooms.",
-		fr: "Il chasse sa proie silencieusement dans les salles obscures."
+		fr: "Il chasse sa proie silencieusement dans les salles obscures.",
+		de: "Es jagt leise seine Beute in dunklen Räumen."
 	},
 
 

--- a/data/Neo/Neo Destiny/37.ts
+++ b/data/Neo/Neo Destiny/37.ts
@@ -33,12 +33,12 @@ const card: Card = {
 			name: {
 				en: "Water Cannon",
 				fr: "Artillerie à O",
-				de: "Water Cannon"
+				de: "Aquakanone"
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon. This attack does 10 damage for each Energy card attached to Dark Omanyte. Don't apply Weakness and Resistance. You can't do more than 30 damage in this way.",
 				fr: "Choisissez 1 des Pokémon de votre adversaire. Cette attaque inflige 10 dégâts pour chaque  carte Énergie attachée à Amonita obscur. N'appliquez ni la Faiblesse, ni la Résistance. Vous ne pouvez pas infliger plus de 30 dégâts de cette manière.",
-				de: "Choose 1 of your opponent's Pokémon. This attack does 10 damage for each  Energy card attached to Dark Omanyte. Don't apply Weakness and Resistance. You can't do more than 30 damage in this way."
+				de: "Wähle eines der Pokémon deines Gegners. Dieser Angriff fügt für jede an Dunkles Amonitas angelegte {W}-Energiekarte 10 Schadenspunkte zu. Wende Schwäche und Resistenz nicht an. Du kannst auf diese Weise nicht mehr als 30 Schadenspunkte verursachen."
 			},
 
 		},
@@ -55,7 +55,8 @@ const card: Card = {
 
 	description: {
 		en: "This ancient Pokémon possessed 10 tentacles, which it used to swim through the ocean.",
-		fr: "Ce Pokémon antique possédait 10 tentacules, qu'il utilisait pour nager dans l'océan."
+		fr: "Ce Pokémon antique possédait 10 tentacules, qu'il utilisait pour nager dans l'océan.",
+		de: "Dieses uralte Pokémon hatte 10 Tentakel, mit denen es durch den Ozean schwamm."
 	},
 
 

--- a/data/Neo/Neo Destiny/38.ts
+++ b/data/Neo/Neo Destiny/38.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Larvitar",
-		fr: "Embrylex"
+		fr: "Embrylex",
+		de: "Larvitar"
 	},
 
 	stage: "Stage1",
@@ -39,12 +40,12 @@ const card: Card = {
 			name: {
 				en: "Rock Tackle",
 				fr: "Plaquage roc",
-				de: "Rock Tackle"
+				de: "Steintackle"
 			},
 			effect: {
 				en: "Dark Pupitar does 10 damage to itself. Dark Pupitar can't use this attack during your next turn.",
 				fr: "Ymphect obscur s'inflige 10 dégâts. Ymphect obscur ne peut pas utiliser cette attaque pendant votre prochain tour.",
-				de: "Dark Pupitar does 10 damage to itself. Dark Pupitar can't use this attack during your next turn."
+				de: "Dunkles Pupitar fügt sich selber 10 Schadenspunkte zu. Dunkles Pupitar kann in deinem nächsten Zug diesen Angriff nicht verwenden."
 			},
 			damage: 40,
 
@@ -58,12 +59,12 @@ const card: Card = {
 			name: {
 				en: "Explosive Evolution",
 				fr: "Évolution explosive",
-				de: "Explosive Evolution"
+				de: "Explosive Entwicklung"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Pokémon. Don't apply Weakness and Resistance. Then, search your deck for an Evolution card named Dark Tyranitar and put it on Dark Pupitar. (This counts as evolving Dark Pupitar.) Shuffle your deck afterward.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts à chaque Pokémon de votre adversaire. N'appliquez ni la Faiblesse, ni la Résistance. Cherchez ensuite dans votre deck une carte Évolution appelée Tyranocif obscur et placez-la sur Ymphect obscur. (Cela revient à faire évoluer Ymphect obscur.) Mélangez ensuite votre deck.",
-				de: "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Pokémon. Don't apply Weakness and Resistance. Then, search your deck for an Evolution card named Dark Tyranitar and put it on Dark Pupitar. (This counts as evolving Dark Pupitar.) Shuffle your deck afterward."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff jedem Pokémon deines Gegners 10 Schadenspunkte zu. Wende Schwäche und Resistenz nicht an. Durchsuche dann dein Deck nach einer Entwicklungskarte „Dunkles Despotar“ und lege diese auf Dunkles Pupitar. (Dies zählt als Entwickeln von Dunkles Pupitar.) Mische dein Deck nach."
 			},
 
 		},
@@ -87,7 +88,8 @@ const card: Card = {
 
 	description: {
 		en: "It is encased within a hard shell, yet retains a great deal of mobility—a dangerous combination.",
-		fr: "Il est protégé par une solide carapace, mais il garde une grande mobilité... Une combinaison dangereuse."
+		fr: "Il est protégé par une solide carapace, mais il garde une grande mobilité... Une combinaison dangereuse.",
+		de: "Es ist in einem harten Panzer eingezwängt und hat trotzdem eine hohe Beweglichkeit - eine gefährliche Kombination."
 	},
 
 

--- a/data/Neo/Neo Destiny/39.ts
+++ b/data/Neo/Neo Destiny/39.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Cyndaquil",
-		fr: "Héricendre"
+		fr: "Héricendre",
+		de: "Feurigel"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Show the top card of your opponent's deck to all players. If it's a Trainer card, discard it.",
 				fr: "Montrez la carte du dessus du deck de votre adversaire à tous les joueurs, si c'est une carte Dresseur, défaussez-vous en.",
-				de: "Zeige die oberste Karte deines Decks deines Gegners allen Spielern. Wenn es eine Trainer-Karte ist, lege diese auf seinen Ablagestapel."
+				de: "Zeige die oberste Karte des Decks deines Gegners allen Spielern. Wenn es eine Trainer-Karte ist, lege diese auf seinen Ablagestapel."
 			},
 
 		},
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "Discard the top 5 cards of your deck. (If there are fewer than 5 cards in your deck, discard all of them.) This attack does 20 damage for each Energy card you discarded in this way.",
 				fr: "Défaussez-vous des 5 premières cartes du dessus de votre deck. (Si vous avez moins de 5 cartes dans votre deck, défaussez-vous de toutes.) Cette attaque inflige 20 dégâts pour chaque carte Énergie  défaussée de cette manière.",
-				de: "Lege die obersten 5 Karten deines Decks auf deinen Ablagestapel. (Wenn weniger als 5 Karten in deinem Deck sind, lege sie alle ab.) Dieser Angriff fügt für jede so abgeworfene -Energiekarte 20 Schadenspunkte zu."
+				de: "Lege die obersten 5 Karten deines Decks auf deinen Ablagestapel. (Wenn weniger als 5 Karten in deinem Deck sind, lege sie alle ab.) Dieser Angriff fügt für jede so abgeworfene {R}-Energiekarte 20 Schadenspunkte zu."
 			},
 
 			damage: "20x"
@@ -80,7 +81,8 @@ const card: Card = {
 
 	description: {
 		en: "If it turns its back to an opponent, it is a sign that it is getting ready to attack.",
-		fr: "S'il tourne le dos à son adversaire, c'est signe qu'il se prépare à attaquer."
+		fr: "S'il tourne le dos à son adversaire, c'est signe qu'il se prépare à attaquer.",
+		de: "Wenn es einem Gegner den Rücken zukehrt, ist das ein Anzeichen dafür, dass es sich auf einen Angriff vorbereitet."
 	},
 
 

--- a/data/Neo/Neo Destiny/4.ts
+++ b/data/Neo/Neo Destiny/4.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Eevee",
-		fr: "Évoli"
+		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 10 more damage; if tails, this attack does 10 damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires. Si c'est pile, cette attaque inflige 10 dégâts.",
-				de: "Wirf eine Münze. Bei 'Kopf' fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu; bei 'Zahl' fügt dieser Angriff 10 Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu; bei „Zahl“ fügt dieser Angriff 10 Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -77,7 +78,8 @@ const card: Card = {
 
 	description: {
 		en: "The tips of its split tail quiver whenever it uses its psychic abilities to read its opponent's next move.",
-		fr: "La double extrémité de sa queue s'agite quand il utilise ses pouvoirs psychiques pour deviner quelle sera la prochaine action de son adversaire."
+		fr: "La double extrémité de sa queue s'agite quand il utilise ses pouvoirs psychiques pour deviner quelle sera la prochaine action de son adversaire.",
+		de: "Die Spitzen seines geteilten Schwanzes zittern, wenn es seine psychischen Fähigkeiten dazu nutzt, die nächste Aktion seines Gegners herauszufinden."
 	},
 
 

--- a/data/Neo/Neo Destiny/40.ts
+++ b/data/Neo/Neo Destiny/40.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Jigglypuff",
-		fr: "Rondoudou"
+		fr: "Rondoudou",
+		de: "Pummeluff"
 	},
 
 	stage: "Stage1",
@@ -39,12 +40,12 @@ const card: Card = {
 			name: {
 				en: "Dark Song",
 				fr: "Sombre chant",
-				de: "Dark Song"
+				de: "Finsteres Lied"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Asleep. If tails, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Endormi. Si c'est pile, le Pokémon Défenseur est maintenant Confus.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Asleep. If tails, the Defending Pokémon is now Confused."
+				de: "Wirf eine Münze. Bei „Kopf“ schläft das verteidigende Pokémon jetzt. Bei „Zahl“ ist das verteidigende Pokémon jetzt verwirrt."
 			},
 
 		},
@@ -57,12 +58,12 @@ const card: Card = {
 			name: {
 				en: "Slap Awake",
 				fr: "Réveil-gifle",
-				de: "Slap Awake"
+				de: "Wachrütteln"
 			},
 			effect: {
 				en: "If the Defending Pokémon is Asleep or Confused, this attack does 20 damage plus 20 more damage. Then, the Defending Pokémon is no longer Asleep or Confused.",
 				fr: "Si le Pokémon Défenseur est Endormi ou Confus, cette attaque inflige 20 dégâts plus 20 dégâts supplémentaires. Le Pokémon Défenseur n'est ensuite plus Endormi ou Confus.",
-				de: "If the Defending Pokémon is Asleep or Confused, this attack does 20 damage plus 20 more damage. Then, the Defending Pokémon is no longer Asleep or Confused."
+				de: "Wenn das verteidigende Pokémon schläft oder verwirrt ist, fügt dieser Angriff 20 Schadenspunkte plus 20 weitere Schadenspunkte zu. Danach schläft das verteidigende Pokémon nicht mehr bzw. ist nicht länger verwirrt."
 			},
 			damage: "20+",
 
@@ -87,7 +88,8 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon has soft, fine hair. When angered, it increases in size and has been known to charge those it considers a threat.",
-		fr: "Ce Pokémon a des poils fins et soyeux. Quand il se met en colère, il grossit et il n'est pas impossible qu'il charge ceux qu'il considère comme une menace."
+		fr: "Ce Pokémon a des poils fins et soyeux. Quand il se met en colère, il grossit et il n'est pas impossible qu'il charge ceux qu'il considère comme une menace.",
+		de: "Dieses Pokémon hat weiches, feines Haar. Wenn es geärgert wird, wächst es plötzlich an und stürmt auf diejenigen los, die eine Gefahr bedeuten."
 	},
 
 

--- a/data/Neo/Neo Destiny/41.ts
+++ b/data/Neo/Neo Destiny/41.ts
@@ -49,12 +49,12 @@ const card: Card = {
 			name: {
 				en: "Charging Horn",
 				fr: "Défonc'korne",
-				de: "Charging Horn"
+				de: "Rempelhorn"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 damage plus 30 more damage. If tails, this attack does 30 damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts plus 30 dégâts supplémentaires. Si c'est pile, cette attaque inflige 30 dégâts.",
-				de: "Flip a coin. If heads, this attack does 30 damage plus 30 more damage. If tails, this attack does 30 damage."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 30 Schadenspunkte plus 30 weitere Schadenspunkte zu. Bei „Zahl“ fügt dieser Angriff 30 Schadenspunkte zu."
 			},
 			damage: "30+",
 
@@ -72,7 +72,8 @@ const card: Card = {
 
 	description: {
 		en: "It is normally peaceful, but will attack any who get between it and honey, its favorite food.",
-		fr: "Généralement, il est pacifique, mais il attaquera tous ceux qui s'interposeront entre lui et son miel, sa nourriture préférée."
+		fr: "Généralement, il est pacifique, mais il attaquera tous ceux qui s'interposeront entre lui et son miel, sa nourriture préférée.",
+		de: "Es ist normalerweise friedlich, greift aber an, wenn sich ihm jemand auf seinem Weg zu seinem Lieblingsessen Honig in den Weg stellt."
 	},
 
 

--- a/data/Neo/Neo Destiny/42.ts
+++ b/data/Neo/Neo Destiny/42.ts
@@ -34,12 +34,12 @@ const card: Card = {
 			name: {
 				en: "One-Two Kick",
 				fr: "Double mawashi geri",
-				de: "One-Two Kick"
+				de: "Tritt-Kombination"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Flip 2 coins. This attack does 20 damage times the number of heads."
+				de: "Wirf zwei Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20x",
 
@@ -54,13 +54,13 @@ const card: Card = {
 			name: {
 				en: "Heel Drop",
 				fr: "Koud'talon",
-				de: "Heel Drop"
+				de: "Hackentrick"
 			},
 
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
-				de: "Flip a coin. If tails, this attack does nothing."
+				de: "Wirf eine Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 
 			damage: 60
@@ -78,7 +78,8 @@ const card: Card = {
 
 	description: {
 		en: "It has a perfect sense of balance and can lash out with powerful kicks from any position.",
-		fr: "Il a un sens parfait de l'équilibre et peut donner des coups puissants dans n'importe quelle position."
+		fr: "Il a un sens parfait de l'équilibre et peut donner des coups puissants dans n'importe quelle position.",
+		de: "Es hat eine perfekte Balance und kann aus jeder Position kräftige Tritte austeilen."
 	},
 
 

--- a/data/Neo/Neo Destiny/43.ts
+++ b/data/Neo/Neo Destiny/43.ts
@@ -33,12 +33,12 @@ const card: Card = {
 			name: {
 				en: "Corner",
 				fr: "Coincé",
-				de: "Corner"
+				de: "Falle"
 			},
 			effect: {
 				en: "The Defending Pokémon can't retreat during your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas battre en retraite pendant le prochain tour de votre adversaire.",
-				de: "The Defending Pokémon can't retreat during your opponent's next turn."
+				de: "Das verteidigende Pokémon kann sich im nächsten Zug deines Gegners nicht zurückziehen."
 			},
 
 		},
@@ -51,13 +51,13 @@ const card: Card = {
 			name: {
 				en: "Lunge",
 				fr: "Coup rapide",
-				de: "Lunge"
+				de: "Ausfall"
 			},
 
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
-				de: "Flip a coin. If tails, this attack does nothing."
+				de: "Wirf eine Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 
 			damage: 30
@@ -75,7 +75,8 @@ const card: Card = {
 
 	description: {
 		en: "When night falls, the air fills with the eerie cries of this Pokémon as it stakes out its territory.",
-		fr: "Quand la nuit tombe, les hurlements sinistres de ce Pokémon retentissent dans le silence tandis qu'il chasse sur son territoire."
+		fr: "Quand la nuit tombe, les hurlements sinistres de ce Pokémon retentissent dans le silence tandis qu'il chasse sur son territoire.",
+		de: "Wenn die Nacht hereinbricht, füllt sich die Luft mit den schaurigen Schreien dieses Pokémon, das sein Revier markiert."
 	},
 
 

--- a/data/Neo/Neo Destiny/44.ts
+++ b/data/Neo/Neo Destiny/44.ts
@@ -34,12 +34,12 @@ const card: Card = {
 			name: {
 				en: "Expand",
 				fr: "Pousstoidla",
-				de: "Expand"
+				de: "Ausdehnen"
 			},
 			effect: {
 				en: "All damage done to Jigglypuff during your opponent's next turn is reduced by 10 (after applying Weakness and Resistance).",
 				fr: "Tous les dégâts infligés à Rondoudou pendant le prochain tour de votre adversaire sont réduits de 10 (après application de la Faiblesse et de la Résistance).",
-				de: "All damage done to Jigglypuff during your opponent´s next turn is reduced by 10 (after applying Weakness and Resistance)."
+				de: "Aller Schaden, der Pummeluff im nächsten Zug deines Gegners zugefügt wird, wird um 10 reduziert (nach Verrechnung von Schwäche und Resistenz)."
 			},
 			damage: 10,
 
@@ -64,7 +64,8 @@ const card: Card = {
 
 	description: {
 		en: "If puffs its body up like a balloon and sings a lullaby that makes all who hear it fall into a deep sleep.",
-		fr: "Il gonfle son corps comme un ballon et chante une berceuse qui fait sombrer tous ceux qui l'entendent dans un profond sommeil."
+		fr: "Il gonfle son corps comme un ballon et chante une berceuse qui fait sombrer tous ceux qui l'entendent dans un profond sommeil.",
+		de: "Es bläst seinen Körper wie einen Ballon auf und singt ein Schlaflied, das alle, die es hören, sofort einschlafen lässt."
 	},
 
 

--- a/data/Neo/Neo Destiny/45.ts
+++ b/data/Neo/Neo Destiny/45.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Seel",
-		fr: "Otaria"
+		fr: "Otaria",
+		de: "Jurob"
 	},
 
 	stage: "Stage1",
@@ -39,12 +40,12 @@ const card: Card = {
 			name: {
 				en: "Freezing Breath",
 				fr: "Souffle glacial",
-				de: "Freezing Breath"
+				de: "Eisiger Atem"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed. If tails, the Defending Pokémon is now Asleep.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé. Si c'est pile, le Pokémon Défenseur est maintenant Endormi.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed. If tails, the Defending Pokémon is now Asleep."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das verteidigende Pokémon jetzt gelähmt. Bei „Zahl“ schläft das verteidigende Pokémon jetzt."
 			},
 			damage: 10,
 
@@ -58,12 +59,12 @@ const card: Card = {
 			name: {
 				en: "Ice Pillar",
 				fr: "Colonne de glace",
-				de: "Ice Pillar"
+				de: "Eissäule"
 			},
 			effect: {
 				en: "Until the end of your opponent's next turn, as long as Light Dewgong is your Active Pokémon, prevent all damage done by attacks to your Benched Pokémon. (Any other effects of attacks still happen.)",
 				fr: "Jusqu'à la fin du prochain tour de votre adversaire, tant que Lamantine lumineux est votre Pokémon Actif, prévenez tous les dégâts infligés par des attaques à votre Pokémon du Banc. (Tous les autres effets dus à des attaques subsistent.)",
-				de: "Until the end of your opponent's next turn, as long as Light Dewgong is your Active Pokémon, prevent all damage done by attacks to your Benched Pokémon. (Any other effects of attacks still happen.)"
+				de: "Verhindere bis zum Ende des nächsten Zuges deines Gegners, solange Helles Jugong dein aktives Pokémon ist, allen Schaden, den Angriffe den Pokémon auf deiner Bank zufügen. (Alle anderen Auswirkungen von Angriffen finden immer noch statt.)"
 			},
 			damage: 40,
 
@@ -81,7 +82,8 @@ const card: Card = {
 
 	description: {
 		en: "It has an aerodynamic shape that allows it to swim at great speeds. The colder the water gets, the more active it becomes.",
-		fr: "Il a une forme aérodynamique qui lui permet de nager à de grandes vitesses. Plus l'eau est froide, plus il est actif."
+		fr: "Il a une forme aérodynamique qui lui permet de nager à de grandes vitesses. Plus l'eau est froide, plus il est actif.",
+		de: "Es hat eine aerodynamische Form, die ihm erlaubt, mit hoher Geschwindigkeit zu schwimmen. Je kälter das Wasser ist, desto aktiver wird es."
 	},
 
 

--- a/data/Neo/Neo Destiny/46.ts
+++ b/data/Neo/Neo Destiny/46.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Eevee",
-		fr: "Évoli"
+		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "If you have any benched Pokémon, search your deck for a Energy card and attach it to 1 of them. Then shuffle your deck.",
 				fr: "Si vous avez des Pokémon sur votre Banc, cherchez une carte Énergie  dans votre deck et attachez-la à l'un d'eux. Mélangez ensuite votre deck.",
-				de: "Falls du mindestens ein Pokémon auf deiner Bank hast, durchsuche dein Deck nach einer -Energiekarte und lege diese an eines dieser Pokémon an. Mische dein Deck danach."
+				de: "Falls du mindestens ein Pokémon auf deiner Bank hast, durchsuche dein Deck nach einer {R}-Energiekarte und lege diese an eines dieser Pokémon an. Mische dein Deck danach."
 			},
 
 		},
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. For each heads, discard a Energy card attached to Light Flareon or this attack does nothing. This attack does 30 damage plus 20 damage for each heads.",
 				fr: "Lancez 2 pièces. Pour chaque face, défaussez-vous d'une carte Énergie  attachée à Pyroli lumineux ou cette attaque ne fait rien. Cette attaque inflige 30 dégâts plus 20 dégâts supplémentaires pour chaque face.",
-				de: "Wirf zwei Münzen. Lege pro 'Kopf' eine an Helles Flamara angelegte -Energiekarte auf deinen Ablagestapel, oder dieser Angriff hat keine Auswirkungen. Dieser Angriff fügt 30 Schadenspunkte plus 20 Schadenspunkte für jeden 'Kopf' zu."
+				de: "Wirf zwei Münzen. Lege pro „Kopf“ eine an Helles Flamara angelegte {R}-Energiekarte auf deinen Ablagestapel oder dieser Angriff hat keine Auswirkungen. Dieser Angriff fügt 30 Schadenspunkte plus 20 Schadenspunkte für jeden „Kopf“ zu."
 			},
 			damage: "30+",
 
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "It creates its flames by swallowing air into a special pouch within its body, then heating it to over 3000 degrees.",
-		fr: "Il crée ses flammes en inspirant l'air dans une poche spéciale de son corps et en le chauffant à plus de 3000 degrés."
+		fr: "Il crée ses flammes en inspirant l'air dans une poche spéciale de son corps et en le chauffant à plus de 3000 degrés.",
+		de: "Es erzeugt seine Flammen, indem es Luft in eine bestimmte Blase in seinem Körper saugt und diese dann auf über 1500 Grad erhitzt."
 	},
 
 

--- a/data/Neo/Neo Destiny/47.ts
+++ b/data/Neo/Neo Destiny/47.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Psyduck",
-		fr: "Psykokwak"
+		fr: "Psykokwak",
+		de: "Enton"
 	},
 
 	stage: "Stage1",
@@ -38,12 +39,12 @@ const card: Card = {
 			name: {
 				en: "Flipper Stroke",
 				fr: "Koud'palme",
-				de: "Flipper Stroke"
+				de: "Flossenschlag"
 			},
 			effect: {
 				en: "Your opponent looks at the top 3 cards of his or her deck. If any of them are basic Energy cards, he or she may show any number of them to you and put them into his or her hand. You do the same. Either way, each player shuffles his or her deck.",
 				fr: "Votre adversaire regarde les trois premières cartes du dessus de son deck. Si parmi elles se trouvent des cartes Énergie de base, il peut vous montrer n'importe quel nombre d'entre elles et les ajouter à sa main. Vous faites de même et chaque joueur mélange ensuite son deck.",
-				de: "Your opponent looks at the top 3 cards of his or her deck. If any of them are basic Energy cards, he or she may show any number of them to you and put them into his or her hand. You do the same. Either way, each player shuffles his or her deck."
+				de: "Dein Gegner schaut sich die obersten 3 Karten seines Decks an. Wenn darunter Basis-Energiekarten sind, darf er eine beliebige Anzahl davon dir zeigen und auf seine Hand nehmen. Du machst dasselbe. Unabhängig davon mischen danach alle Spieler ihr Deck."
 			},
 
 		},
@@ -56,12 +57,12 @@ const card: Card = {
 			name: {
 				en: "Core Blast",
 				fr: "Explosion centrale",
-				de: "Core Blast"
+				de: "Kernexplosion"
 			},
 			effect: {
 				en: "This attack does 30 damage plus 20 more damage for each Special Energy card attached to the Defending Pokémon.",
 				fr: "Cette attaque inflige 30 dégâts plus 20 dégâts supplémentaires pour chaque carte Énergie spéciale attachée au Pokémon Défenseur.",
-				de: "This attack does 30 damage plus 20 more damage for each Special Energy card attached to the Defending Pokémon."
+				de: "Dieser Angriff fügt 30 Schadenspunkte plus 20 Schadenspunkte für jede an das verteidigende Pokémon angelegte Spezial-Energiekarte zu."
 			},
 			damage: "30+",
 
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "The faster it swims, the brighter the glow on its forehead becomes.",
-		fr: "Plus il nage vite, plus l'aura sur son front brille."
+		fr: "Plus il nage vite, plus l'aura sur son front brille.",
+		de: "Je schneller es schwimmt, desto heller wird das Leuchten auf seiner Stirn."
 	},
 
 

--- a/data/Neo/Neo Destiny/48.ts
+++ b/data/Neo/Neo Destiny/48.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Eevee",
-		fr: "Évoli"
+		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -38,12 +39,12 @@ const card: Card = {
 			name: {
 				en: "Pulse Guard",
 				fr: "Pulsation protectrice",
-				de: "Pulse Guard"
+				de: "Aufpassimpuls"
 			},
 			effect: {
 				en: "During your opponent's next turn, whenever 30 or more damage is done to Light Jolteon (after applying Weakness and Resistance), prevent that damage. (Any other effects of attacks still happen.)",
 				fr: "Pendant le prochain tour de votre adversaire, si Voltali lumineux se voit infliger 30 dégâts ou plus (après application de la Faiblesse et de la Résistance), prévenez ces dégâts. (Tous les autres effets dus à des attaques subsistent.)",
-				de: "During your opponent's next turn, whenever 30 or more damage is done to Light Jolteon (after applying Weakness and Resistance), prevent that damage. (Any other effects of attacks still happen.)"
+				de: "Immer wenn im nächsten Zug deines Gegners Helles Blitza (nach der Verrechnung von Schwäche und Resistenz) 30 oder mehr Schadenspunkte zugefügt werden, verhindere diesen Schaden. (Alle anderen Auswirkungen von Angriffen finden immer noch statt.)"
 			},
 
 		},
@@ -56,12 +57,12 @@ const card: Card = {
 			name: {
 				en: "Thunder Needle",
 				fr: "Pic-éclair",
-				de: "Thunder Needle"
+				de: "Donnernadel"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 20 damage times the number of heads. If you get 2 or more heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces. Si vous obtenez au moins 2 faces, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Flip 3 coins. This attack does 20 damage times the number of heads. If you get 2 or more heads, the Defending Pokémon is now Paralyzed."
+				de: "Wirf drei Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu. Wenn du zweimal oder öfter „Kopf“ wirfst, ist das verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: "20x",
 
@@ -77,7 +78,8 @@ const card: Card = {
 
 	description: {
 		en: "It can collect the ambient electrical energy in its cells and expel it in massive bursts.",
-		fr: "Il peut stocker l'énergie électrique ambiante dans ses cellules et l'expulser sous forme d'explosions massives."
+		fr: "Il peut stocker l'énergie électrique ambiante dans ses cellules et l'expulser sous forme d'explosions massives.",
+		de: "Es kann die elektrische Energie seiner Umgebung in seinen Zellen speichern und sie dann in massiven Entladungen wieder abgeben."
 	},
 
 

--- a/data/Neo/Neo Destiny/49.ts
+++ b/data/Neo/Neo Destiny/49.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Machop",
-		fr: "Machoc"
+		fr: "Machoc",
+		de: "Machollo"
 	},
 
 	stage: "Stage1",
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "If the Defending Pokémon has no damage counters on it, this attack does 40 damage. If it has any, this attack does 20 damage.",
 				fr: "Si le Pokémon défenseur n'a pas de marqueurs de dégâts sur lui, cette attaque inflige 40 dégâts. S'il en a, cette attaque inflige 20 dégâts.",
-				de: "Wenn auf dem verteidigenden Pokémon keine Schadensmarke liegt, fügt dieser Angriff 20 Schadenspunkte zu."
+				de: "Wenn auf dem verteidigenden Pokémon keine Schadensmarke liegt, fügt dieser Angriff 40 Schadenspunkte zu. Hat es welche, fügt dieser Angriff 20 Schadenspunkte zu."
 			},
 
 			damage: 40
@@ -80,7 +81,8 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon never gets tired, no matter what it does or how hard it works.",
-		fr: "Ce Pokémon ne se fatigue jamais, quoi qu'il fasse, même s'il s'entraîne dur."
+		fr: "Ce Pokémon ne se fatigue jamais, quoi qu'il fasse, même s'il s'entraîne dur.",
+		de: "Dieses Pokémon wird nie müde, egal was es tut oder wie hart es arbeitet."
 	},
 
 

--- a/data/Neo/Neo Destiny/5.ts
+++ b/data/Neo/Neo Destiny/5.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Croconaw",
-		fr: "Crocrodil obscur"
+		fr: "Crocrodil obscur",
+		de: "Tyracroc"
 	},
 
 	stage: "Stage2",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Scare",
 				fr: "Frayeur",
-				de: "Scare"
+				de: "Angst einjagen"
 			},
 			effect: {
 				en: "As long as Dark Feraligatr is your Active Pokémon, all of your opponent's Baby Pokémon Powers stop working and your opponent's Baby Pokémon can't attack. This power stops working while Dark Feraligatr is Asleep, Confused, or Paralyzed.",
 				fr: "Tant qu'Aligatueur obscur reste votre Pokémon Actif, tous les Pouvoirs des Bébés Pokémon de votre adversaire cessent de fonctionner et les Bébés Pokémon de votre adversaire ne peuvent pas attaquer. Ce pouvoir cesse de fonctionner si Aligatueur obscur est Endormi, Confus ou Paralysé.",
-				de: "As long as Dark Feraligatr is your Active Pokémon, all of your opponent's Baby Pokémon Powers stop working and your opponent's Baby Pokémon can't attack. This power stops working while Dark Feraligatr is Asleep, Confused, or Paralyzed."
+				de: "Solange Dunkles Impergator dein aktives Pokémon ist, funktioniert keine Power eines Baby Pokémon deines Gegners und die Baby-Pokémon deines Gegners können nicht angreifen. Diese Fähigkeit verliert ihre Wirkung, solange Dunkles Impergator schläft, verwirrt oder gelähmt ist."
 			},
 		},
 	],
@@ -56,12 +57,12 @@ const card: Card = {
 			name: {
 				en: "Crushing Blow",
 				fr: "Koud'dent",
-				de: "Crushing Blow"
+				de: "Brechschlag"
 			},
 			effect: {
 				en: "If the Defending Pokémon has any Energy cards attached to it, flip a coin. If heads, choose 1 of those cards and discard it.",
 				fr: "Si des cartes Énergie sont attachées au Pokémon Défenseur, lancez une pièce. Si c'est face, choisissez-en une et obligez votre adversaire à s'en défausser.",
-				de: "If the Defending Pokémon has any Energy cards attached to it, flip a coin. If heads, choose 1 of those cards and discard it."
+				de: "Wirf eine Münze, falls an das verteidigende Pokémon mindestens eine Energiekarte angelegt ist. Wähle bei „Kopf“ eine dieser Karten und lege sie auf den Ablagestapel deines Gegners."
 			},
 			damage: 50,
 
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "Its powerful muscles allow it to move at a speed that belies its bulk.",
-		fr: "Ses muscles surpuissants lui permettent de se déplacer très vite et ce, malgré sa forte corpulence."
+		fr: "Ses muscles surpuissants lui permettent de se déplacer très vite et ce, malgré sa forte corpulence.",
+		de: "Dank seiner kraftvollen Muskeln kann es sich viel schneller fortbewegen, als man bei so einem dicken Bauch annimmt."
 	},
 
 

--- a/data/Neo/Neo Destiny/50.ts
+++ b/data/Neo/Neo Destiny/50.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Vulpix",
-		fr: "Goupix"
+		fr: "Goupix",
+		de: "Vulpix"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Put a Baby Pokémon or a Basic Pokémon card from your discard pile onto your Bench. (You can't use this attack if your Bench is full.)",
 				fr: "Placez une carte Bébé Pokémon ou Pokémon de base de votre pile de défausse sur votre Banc. (Vous ne pouvez pas utiliser cette attaque si votre Banc est plein.)",
-				de: "Discard a  Energy card attached to Light Ninetales in order to use this attack."
+				de: "Lege eine Baby-Pokémon- oder eine Basis-Pokémon-Karte aus deinem Ablagestapel auf deine Bank. (Du kannst diesen Angriff nicht verwenden, wenn deine Bank voll ist.)"
 			},
 
 			damage: 50
@@ -57,12 +58,12 @@ const card: Card = {
 			name: {
 				en: "Fire Blast",
 				fr: "Déflagration",
-				de: "Fire Blast"
+				de: "Feuersturm"
 			},
 			effect: {
 				en: "Discard a Energy card attached to Light Ninetales in order to use this attack.",
 				fr: "Défaussez-vous d'une carte Énergie  attachée à Feunard lumineux pour utiliser cette attaque.",
-				de: "Discard a  Energy card attached to Light Ninetales in order to use this attack."
+				de: "Lege eine an Helles Vulnona angelegte {R}-Energiekarte auf deinen Ablagestapel, um diesen Angriff zu verwenden."
 			},
 			damage: 50,
 
@@ -80,7 +81,8 @@ const card: Card = {
 
 	description: {
 		en: "It is said that each of its nine tails contains a different magical power.",
-		fr: "On dit que chacune de ses neuf queues renferme un pouvoir magique différent."
+		fr: "On dit que chacune de ses neuf queues renferme un pouvoir magique différent.",
+		de: "Es wird gesagt, dass jeder seiner neun Schwänze eine unterschiedliche magische Fähigkeit habe."
 	},
 
 

--- a/data/Neo/Neo Destiny/51.ts
+++ b/data/Neo/Neo Destiny/51.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Slowpoke",
-		fr: "Ramoloss"
+		fr: "Ramoloss",
+		de: "Flegmon"
 	},
 
 	stage: "Stage1",
@@ -38,12 +39,12 @@ const card: Card = {
 			name: {
 				en: "Fish Out",
 				fr: "À la pêche",
-				de: "Fish Out"
+				de: "Herausfischen"
 			},
 			effect: {
 				en: "Your opponent may choose up to 3 Baby Pokémon, Basic Pokémon, and/or Evolution cards from his or her discard pile and shuffle them into his or her deck. Either way, you may do the same.",
 				fr: "Votre adversaire peut choisir jusqu'à 3 cartes Bébé Pokémon, Pokémon de base et/ou Évolution de sa pile de défausse et les mélanger à son deck. Quelle que soit sa décision, vous pouvez faire de même.",
-				de: "Your opponent may choose up to 3 Baby Pokémon, Basic Pokémon, and/or Evolution cards from his or her discard pile and shuffle them into his or her deck. Either way, you may do the same."
+				de: "Dein Gegner darf bis zu drei Baby-Pokémon, Basis-Pokémon- und/oder Evolutionskarten aus seinem Ablagestapel wählen und in sein Deck mischen. Unabhängig davon darfst du dasselbe tun."
 			},
 
 		},
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "If there are more Energy cards attached to the Defending Pokémon than to Light Slowbro, this attack does 20 damage plus 20 more damage. If not, this attack does 20 damage.",
 				fr: "S'il y a plus d'Énergie attachées au Pokémon Défenseur qu'à Flagadoss lumineux, cette attaque inflige 20 dégâts plus 20 dégâts supplémentaires. Sinon, cette attaque inflige 20 dégâts.",
-				de: "If there are more Energy attached to the Defending Pokémon than to Light Slowbro, this attack does 20 damage plus 20 more damage. If not, this attack does 20 damage."
+				de: "Wenn an das verteidigende Pokémon mehr Energie angelegt ist, als an Helles Lahmus, fügt dieser Angriff 20 Schadenspunkte plus 20 weitere Schadenspunkte zu. Sonst fügt dieser Angriff 20 Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -78,7 +79,8 @@ const card: Card = {
 
 	description: {
 		en: "If the Shellder attached to its tail becomes separated, this Pokémon reverts to a normal Slowpoke.",
-		fr: "Si le Kokyias attaché à sa queue se défait, ce Pokémon redevient un Ramoloss normal."
+		fr: "Si le Kokyias attaché à sa queue se défait, ce Pokémon redevient un Ramoloss normal.",
+		de: "Wenn das Muschas, das an seinem Schwanz hängt, abgetrennt wird, wird es zu einem normalen Flegmon."
 	},
 
 

--- a/data/Neo/Neo Destiny/52.ts
+++ b/data/Neo/Neo Destiny/52.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Eevee",
-		fr: "Évoli"
+		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -38,12 +39,12 @@ const card: Card = {
 			name: {
 				en: "Wash Away",
 				fr: "Lavage",
-				de: "Wash Away"
+				de: "Wegwaschen"
 			},
 			effect: {
 				en: "If you have any Benched Pokémon, flip a coin. If heads, remove all damage counters from 1 of your Benched Pokémon and discard all Energy cards attached to it.",
 				fr: "Si vous avez des Pokémon sur votre Banc, lancez une pièce. Si c'est face, retirez tous les marqueurs de dégâts d'un des Pokémon de votre Banc et défaussez-vous de toutes les cartes Énergie qui y sont attachées.",
-				de: "If you have any Benched Pokémon, flip a coin. If heads, remove all damage counters from 1 of your Benched Pokémon and discard all Energy cards attached to it."
+				de: "Wirf eine Münze, wenn du mindestens ein Pokémon auf deiner Bank hast. Entferne bei „Kopf“ alle Schadensmarken von einem Pokémon auf deiner Bank und lege alle an es angelegten Energiekarten auf deinen Ablagestapel."
 			},
 
 		},
@@ -56,12 +57,12 @@ const card: Card = {
 			name: {
 				en: "Hypno Shower",
 				fr: "Hypnodouche",
-				de: "Hypnoshower"
+				de: "Hypnodusche"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep. Remove 1 damage counter from each Benched Pokémon (yours and your opponent's) with any damage counters on it.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi. Retirez un marqueur de dégâts de chaque Pokémon du Banc (le vôtre et celui de votre adversaire) ayant des marqueurs de dégâts sur lui.",
-				de: "The Defending Pokémon is now Asleep. Remove 1 damage counter from each Benched Pokémon (yours and your opponent's) with any damage counters on it."
+				de: "Das verteidigende Pokémon schläft jetzt. Entferne eine Schadensmarke von allen Pokémon auf der Bank (deinen und denen deines Gegners), auf denen Schadensmarken liegen."
 			},
 			damage: 30,
 
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "If its fins being to vibrate, it is a sign that it will begin raining soon.",
-		fr: "Si sa nageoire commence à vibrer, c'est signe qu'il va bientôt pleuvoir."
+		fr: "Si sa nageoire commence à vibrer, c'est signe qu'il va bientôt pleuvoir.",
+		de: "Wenn seine Flossen anfangen zu vibrieren, wird es bald Regen geben."
 	},
 
 

--- a/data/Neo/Neo Destiny/53.ts
+++ b/data/Neo/Neo Destiny/53.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Venonat",
-		fr: "Mimitoss"
+		fr: "Mimitoss",
+		de: "Bluzuk"
 	},
 
 	stage: "Stage1",
@@ -38,12 +39,12 @@ const card: Card = {
 			name: {
 				en: "Mysterious Wing",
 				fr: "Aile mystérieuse",
-				de: "Mysterious Wing"
+				de: "Seltsame Flügel"
 			},
 			effect: {
 				en: "Your opponent may choose a Baby Pokémon, Basic Pokémon, or Evolution card from his or her discard pile and put it into his or her hand. Either way, you may do the same.",
 				fr: "Votre adversaire peut choisir une carte Bébé Pokémon, Pokémon de base ou Évolution de sa pile de défausse et l'ajouter à sa main. Quelle que soit sa décision, vous pouvez faire de même.",
-				de: "Your opponent may choose a Baby Pokémon, Basic Pokémon, or Evolution card from his or her discard pile and put it into his or her hand. Either way, you may do the same."
+				de: "Dein Gegner darf eine Baby-Pokémon-,Basis-Pokémon- oder Evolutionskarte aus seinem Ablagestapel wählen und auf seine Hand nehmen. Unabhängig davon darfst du dasselbe tun."
 			},
 
 		},
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Synchronize",
 				fr: "Synchronisation",
-				de: "Synchronize"
+				de: "Übereinstimmen"
 			},
 			effect: {
 				en: "If Light Venomoth and the Defending Pokémon have a different number of Energy cards attached to them, this attack does nothing.",
 				fr: "Si Aéromite lumineux et le Pokémon Défenseur ont un nombre différent de cartes Énergie attachées à eux, cette attaque ne fait rien.",
-				de: "If Light Venomoth and the Defending Pokémon have a differenz number of Energy cards attached to them, this attack does nothing."
+				de: "Wenn an Helles Omot und das verteidigende Pokémon eine unterschiedliche Anzahl Energiekarten angelegt sind, hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 40,
 
@@ -83,7 +84,8 @@ const card: Card = {
 
 	description: {
 		en: "It defends itself by flapping its wings at high speed, spreading poisonous powder throughout the air.",
-		fr: "Il se défend en battant des ailes à toute vitesse, libérant une poudre empoisonnée dans les airs."
+		fr: "Il se défend en battant des ailes à toute vitesse, libérant une poudre empoisonnée dans les airs.",
+		de: "Es verteidigt sich selbst, indem es seine Flügel mit hoher Geschwindigkeit bewegt und dabei ein giftiges Puder in der Luft verteilt."
 	},
 
 

--- a/data/Neo/Neo Destiny/54.ts
+++ b/data/Neo/Neo Destiny/54.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Jigglypuff",
-		fr: "Rondoudou"
+		fr: "Rondoudou",
+		de: "Pummeluff"
 	},
 
 	stage: "Stage1",
@@ -38,12 +39,12 @@ const card: Card = {
 			name: {
 				en: "Evolution Song",
 				fr: "Chant évolutionnaire",
-				de: "Evolution Song"
+				de: "Entwicklungslied"
 			},
 			effect: {
 				en: "Your opponent may choose 1 of his or her Pokémon and search his or her deck for a card that evolves from that Pokémon. Your opponent attaches that card to that Pokémon. This counts as evolving that Pokémon. Either way, you may do the same, and then each player who searched shuffles his or her deck.",
 				fr: "Votre adversaire peut choisir un de ses Pokémon et chercher dans son deck une carte Évolution de ce Pokémon. Votre adversaire attache cette carte à ce Pokémon. Quelle que soit sa décision, vous pouvez faire de même. Chaque joueur ayant cherché une carte mélange ensuite son deck.",
-				de: "Your opponent may choose 1 of his or her Pokémon and search his or her deck for a card that evolves from that Pokémon. Your opponent attaches that card to that Pokémon. This counts as evolving that Pokémon. Either way, you may do the same, and then each player who searched shuffles his or her deck."
+				de: "Dein Gegner darf eines seiner Pokémon wählen und sein Deck nach einer Karte durchsuchen, die aus diesem Pokémon entsteht. Dein Gegner legt diese Karte an dieses Pokémon an. Dies zählt als Entwickeln dieses Pokémons. Unabhängig davon darfst du dasselbe tun, und jeder Spieler, der sein Deck durchsucht hat, mischt sein Deck danach."
 			},
 
 		},
@@ -56,12 +57,12 @@ const card: Card = {
 			name: {
 				en: "Body Slam",
 				fr: "Plaquage",
-				de: "Body Slam"
+				de: "Bodyslam"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -86,7 +87,8 @@ const card: Card = {
 
 	description: {
 		en: "If two of them brush against each other, they will not be able to separate themselves, as they enjoy touching each other's soft fur too much.",
-		fr: "Si deux d'entre eux se frottent l'un contre l'autre, ils ne peuvent plus se séparer. Ils aiment trop sentir la douceur de la fourrure l'un de l'autre."
+		fr: "Si deux d'entre eux se frottent l'un contre l'autre, ils ne peuvent plus se séparer. Ils aiment trop sentir la douceur de la fourrure l'un de l'autre.",
+		de: "Wenn zwei von ihnen sich aneinander reiben, wird man sie nicht mehr voneinander trennen können, dazu lieben sie das Berühren des Fells des anderen viel zu sehr."
 	},
 
 

--- a/data/Neo/Neo Destiny/55.ts
+++ b/data/Neo/Neo Destiny/55.ts
@@ -79,7 +79,8 @@ const card: Card = {
 
 	description: {
 		en: "It moves so fast as to be invisible to the naked eye. Even when standing still, its camouflage prevents it from being seen.",
-		fr: "Il se déplace si vite qu'il est invisible à l'oeil nu. Même quand il est immobile, son camouflage lui permet de ne pas être vu."
+		fr: "Il se déplace si vite qu'il est invisible à l'oeil nu. Même quand il est immobile, son camouflage lui permet de ne pas être vu.",
+		de: "Es bewegt sich so schnell, dass es für das menschliche Auge fast unsichtbar ist. Selbst wenn es sich nicht bewegt, verhindert seine Tarnung, dass es entdeckt wird."
 	},
 
 

--- a/data/Neo/Neo Destiny/56.ts
+++ b/data/Neo/Neo Destiny/56.ts
@@ -33,12 +33,12 @@ const card: Card = {
 			name: {
 				en: "Charm",
 				fr: "Charme",
-				de: "Charm"
+				de: "Charme"
 			},
 			effect: {
 				en: "If the Defending Pokémon attacks during your opponent's next turn, any damage it does is reduced by 10 (before applying Weakness and Resistance).",
 				fr: "Si le Pokémon Défenseur attaque pendant le prochain tour de votre adversaire, tous les dégâts qu'il inflige sont réduits de 10 (avant application de la Faiblesse et de la Résistance).",
-				de: "If the Defending Pokémon attacks during your opponent's next turn, any damage it does is reduced by 10 (before applying Weakness and Resistance)."
+				de: "Wenn das verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wird aller Schaden, den es zufügt, um 10 reduziert (vor der Verrechnung von Schwäche und Resistenz)."
 			},
 
 		},
@@ -50,12 +50,12 @@ const card: Card = {
 			name: {
 				en: "Spike Ball Tackle",
 				fr: "Charge balle pic",
-				de: "Spike Ball Tackle"
+				de: "Zackenballtackle"
 			},
 			effect: {
 				en: "Togepi does 10 damage to itself.",
 				fr: "Togepi s'inflige 10 dégâts.",
-				de: "Togepi does 10 damage to itself."
+				de: "Togepi fügt sich selber 10 Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "Its shell is said to contain happiness itself, which it will share with those who are kind to it.",
-		fr: "On raconte que sa coquille est pleine de bonheur, qu'il partage avec tous ceux qui sont gentils avec lui."
+		fr: "On raconte que sa coquille est pleine de bonheur, qu'il partage avec tous ceux qui sont gentils avec lui.",
+		de: "Es wird behauptet, dass seine Haut Fröhlichkeit enthält, die es gerne mit allen teilt, die nett zu ihm sind."
 	},
 
 

--- a/data/Neo/Neo Destiny/57.ts
+++ b/data/Neo/Neo Destiny/57.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "[Chase]",
 				fr: "[Chase]",
-				de: "Chase"
+				de: "Chase [Chase]"
 			},
 			effect: {
 				en: "As long as Unown C is your Active Pokémon, whenever your opponent's Active Pokémon tries to retreat, flip a coin. If heads, put 1 damage counter on that Pokémon. Apply Weakness and Resistance.",
 				fr: "Tant que Zarbi [C] est votre Pokémon Actif, si le Pokémon Actif de votre adversaire essaie de battre en retraite, lancez une pièce. Si c'est face, placez 1 marqueur de dégâts sur ce Pokémon. Appliquez la Faiblesse et la Résistance.",
-				de: "As laong as Unown C is your Active Pokémon, whenever your opponent's Active Pokémon tries to retreat, flip a coin. If heads, put 1 damage counter on that Pokémon. Apply Weakness and Resistance"
+				de: "Solange Icognito [C] dein aktives Pokémon ist, wirf immer ,wenn das aktive Pokémon deines Gegners versucht sich zurückzuziehen, eine Münze. Lege bei „Kopf“ 1 Schadensmarke auf dieses Pokémon. Wende Schwäche und Resistenz an."
 			},
 		},
 	],
@@ -68,7 +68,8 @@ const card: Card = {
 
 	description: {
 		en: "It is believed that the variety of types of this Pokémon were created by evolutionary adaptation, as each possesses a different ability.",
-		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente."
+		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente.",
+		de: "Es wird behauptet, dass die verschiedenen Sorten dieses Pokémon sich durch Anpassung entwickelt haben, da alle unterschiedliche Fähigkeiten besitzen."
 	},
 
 

--- a/data/Neo/Neo Destiny/58.ts
+++ b/data/Neo/Neo Destiny/58.ts
@@ -52,13 +52,14 @@ const card: Card = {
 
 	description: {
 		en: "It is believed that the variety of types of this Pokémon were created by evolutionary adaptation, as each possesses a different ability.",
-		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente."
+		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente.",
+		de: "Es wird behauptet, dass die verschiedenen Sorten dieses Pokémon sich durch Anpassung entwickelt haben, da alle unterschiedliche Fähigkeiten haben."
 	},
 
 	abilities: [{
 		name: {
 			fr: "[Perform]",
-			de: "Perform"
+			de: "Perform [Perform]"
 		},
 
 		effect: {

--- a/data/Neo/Neo Destiny/59.ts
+++ b/data/Neo/Neo Destiny/59.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "[Quicken]",
 				fr: "Quicken",
-				de: "Quicken"
+				de: "Quicken [Quicken]"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may flip a coin. If heads, prevent all effects of attacks, including damage, done to any of your Pokémon with Unown in its name during your opponent's next turn. If you have more than 1 Unown Q in play, use only 1 [Quicken] each turn. This power can be used even if Unown Q is Asleep, Confused, or Paralyzed.",
 				fr: "Une fois pendant votre tour (avant votre attaque), vous pouvez lancer une pièce. Si c'est face, prévenez tous les effets d'attaques, y compris les dégâts, infligés à vos Pokémon Zarbi pendant le prochain tour de votre adversaire. Si vous avez plus d'un Zarbi [Q] en jeu, utilisez seulement 1 [Quicken] à chaque tour. Ce pouvoir fonctionne même si Zarbi [Q] est Endormi, Confus ou Paralysé.",
-				de: "Du kannst immer einmal in deinem Zug (vor deinem Angriff) eine Münze werden. Verhindere bei \"Kopf\" alle Auswirkungen von Angriffen (einschließlich Schaden), die allen deinen Pokémon mit \"Icognito\" in ihren Namen im nächsten Zug deines Gegners zugefügt werden. Wenn du mehr als ein Icognito Q im Spiel hast, verwende nur ein Quicken pro Zug. Diese Power kann selbst dann verwendet werden, wenn icognito Q schläft, verwirrt oder gelähmt ist."
+				de: "Du kannst immer einmal in deinem Zug (vor deinem Angriff) eine Münze werfen. Verhindere bei „Kopf“ alle Auswirkungen von Angriffen (einschließlich Schaden), die allen deinen Pokémon mit „Icognito“ in ihrem Namen im nächsten Zug deines Gegners zugefügt werden. Wenn du mehr als ein Icognito [Q] im Spiel hast, verwende nur ein [Quicken] pro Zug. Diese Power kann selbst dann verwendet werden, wenn Icognito [Q] schläft, verwirrt oder gelähmt ist."
 			},
 		},
 	],
@@ -68,7 +68,8 @@ const card: Card = {
 
 	description: {
 		en: "It is believed that the variety of types of this Pokémon were created by evolutionary adaptation, as each possesses a different ability.",
-		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente."
+		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente.",
+		de: "Es wird behauptet, dass die verschiedenen Sorten dieses Pokémon sich durch Anpassung entwickelt haben, da alle unterschiedliche Fähigkeiten haben."
 	},
 
 

--- a/data/Neo/Neo Destiny/6.ts
+++ b/data/Neo/Neo Destiny/6.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Haunter",
-		fr: "Spectrum obscur"
+		fr: "Spectrum obscur",
+		de: "Alpollo"
 	},
 
 	stage: "Stage2",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Deep Sleep",
 				fr: "Gros dodo",
-				de: "Deep Sleep"
+				de: "Tiefer Schlaf"
 			},
 			effect: {
 				en: "As long as any Dark Gengar are in play, a player flips 2 coins for each of his or her Pokémon that is Asleep at the end of each turn. If either of them is tails, that Pokémon is still Asleep. This power stops working if Dark Gengar is Asleep, Confused, or Paralyzed.",
 				fr: "Tant qu'il y a un Ectoplasma obscur en jeu, chaque joueur lance 2 pièces à la fin de chaque tour pour chacun de ses Pokémon Endormis. Si vous obtenez au moins 1 pile, ce Pokémon reste Endormi. Ce pouvoir cesse de fonctionner si Ectoplasma obscur est Endormi, Confus ou Paralysé.",
-				de: "As long as any Dark Gengar are in play, a player flips 2 coins for each of his or her Pokémon that is Asleep at the end of each turn. If either of them is tails, that Pokémon is still Asleep. This power stops working while Dark Gengar is Asleep, Confused, or Paralyzed."
+				de: "Solange mindestens ein Dunkles Gengar im Spiel ist, wirft jeder Spieler für jedes seiner Pokémon, das schläft, am Ende jedes Zuges zwei Münzen. Wenn mindestens eine davon „Zahl“ zeigt, schläft das betroffene Pokémon weiter. Diese Fähigkeit verliert ihre Wirkung, solange Dunkles Gengar schläft, verwirrt oder gelähmt ist."
 			},
 		},
 	],
@@ -56,12 +57,12 @@ const card: Card = {
 			name: {
 				en: "Pull In",
 				fr: "Rangement",
-				de: "Pull In"
+				de: "Hereinziehen"
 			},
 			effect: {
 				en: "If your opponent has any Benched Pokémon, you may choose 1 of them and switch it with the Defending Pokémon (before doing damage or other effects of this attack). Either way, the Defending Pokémon is now Asleep.",
 				fr: "Si votre adversaire a des Pokémon sur son Banc, vous pouvez choisir l'un d'entre eux et l'échanger contre le Pokémon Défenseur (avant d'infliger les dégâts ou d'autres effets de cette attaque). Dans tous les cas, le Pokémon Défenseur est maintenant Endormi.",
-				de: "If your opponent has any Benched Pokémon, you may choose 1 of them and switch it with the Defending Pokémon (before doing damage or other effects of this attack). Either way, the Defending Pokémon is now Asleep."
+				de: "Falls dein Gegner mindestens ein Pokémon auf der Bank hat, darfst du eins davon wählen und mit dem verteidigenden Pokémon austauschen (bevor der Schaden und andere Effekte dieses Angriffs zugefügt werden). Auf jeden Fall schläft das verteidigende Pokémon jetzt."
 			},
 			damage: 30,
 
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "It absorbs the heat in the air around it. If you suddenly feel cold, it's because a Gengar has appeared.",
-		fr: "Il absorbe la chaleur de l'air autour de lui. Si vous avez soudain très froid, c'est qu'un Ectoplasma vient d'apparaître."
+		fr: "Il absorbe la chaleur de l'air autour de lui. Si vous avez soudain très froid, c'est qu'un Ectoplasma vient d'apparaître.",
+		de: "Es entzieht der Luft um sich herum alle Wärme. Wenn dir plötzlich kalt wird, könnte es sein, dass gerade ein Gengar vorbeigekommen ist."
 	},
 
 

--- a/data/Neo/Neo Destiny/60.ts
+++ b/data/Neo/Neo Destiny/60.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "[Zoom]",
 				fr: "[Zoom]",
-				de: "Zoom"
+				de: "Zoom [Zoom]"
 			},
 			effect: {
 				en: "As long as Unown Z is Benched, you pay no Energy cost to retreat a Pokémon with Unown in its name.",
 				fr: "Tant que Zarbi [Z] est sur votre Banc, vous ne payez aucun coût d'Énergie pour faire battre en retraite vos Pokémon Zarbi.",
-				de: "As long as Unwon Z is benched, you may pay no Energy cost to retreat Pokémon with Unown in its name."
+				de: "Solange Icognito [Z] auf deiner Bank ist, bezahlst du keine Energiekosten, um ein Pokémon mit Icognito im Namen zurückzuziehen."
 			},
 		},
 	],
@@ -68,7 +68,8 @@ const card: Card = {
 
 	description: {
 		en: "It is believed that the variety of types of this Pokémon were created by evolutionary adaptation, as each possesses a different ability.",
-		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente."
+		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente.",
+		de: "Es wird behauptet, dass die verschiedenen Sorten dieses Pokémon sich durch Anpassung entwickelt haben, da alle unterschiedliche Fähigkeiten haben."
 	},
 
 

--- a/data/Neo/Neo Destiny/61.ts
+++ b/data/Neo/Neo Destiny/61.ts
@@ -33,12 +33,12 @@ const card: Card = {
 			name: {
 				en: "Smokescreen",
 				fr: "Brouillard",
-				de: "Smokescreen"
+				de: "Rauchwolke"
 			},
 			effect: {
 				en: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
 				fr: "Si le Pokémon Défenseur essaie d'attaquer pendant le prochain tour de votre adversaire, votre adversaire lance une pièce. Si c'est pile, cette attaque ne fait rien.",
-				de: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+				de: "Wenn das verteidigende Pokémon versucht, während des nächsten Zuges deines Gegners anzugreifen, wirft dein Gegner eine Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 10,
 
@@ -56,7 +56,8 @@ const card: Card = {
 
 	description: {
 		en: "It is very meek and constantly crouches in a defensive posture. When threatened, it protects itself with the flame on its back.",
-		fr: "Il est très timide et il est souvent sur la défensive. Quand il se sent menacé, il se protège avec les flammes de son dos."
+		fr: "Il est très timide et il est souvent sur la défensive. Quand il se sent menacé, il se protège avec les flammes de son dos.",
+		de: "Es ist sehr schwächlich und ist dauernd in einer defensiven Haltung. Wenn es bedroht wird, schützt es sich mit der Flamme auf seinem Rücken."
 	},
 
 

--- a/data/Neo/Neo Destiny/62.ts
+++ b/data/Neo/Neo Destiny/62.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Remoraid",
-		fr: "Rémoraid"
+		fr: "Rémoraid",
+		de: "Remoraid"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "This attack does 20 damage plus 10 more damage for each Energy attached to Dark Octillery but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way.",
 				fr: "Cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires pour chaque Énergie attachée à Octillery obscur mais non utilisée pour payer le coût d'Énergie de cette attaque. Vous ne pouvez pas ajouter plus de 20 dégâts de cette manière.",
-				de: "Dieser Angriff fügt 20 Schadenspunkte plus 10 weitere Schadenspunkte für jeden an Dunkles Octillery angelegte Energiekarte, die nicht verwendet wurde, um für die Energiekosten dieses Angriffs zu bezahlen, zu. Du kannst auf diese Weise höchstens 20 weitere Schadenspunkte zufügen."
+				de: "Dieser Angriff fügt 20 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Dunkles Octillery angelegte Energiekarte, die nicht verwendet wurde, um für die Energiekosten dieses Angriffs zu bezahlen, zu. Du kannst auf diese Weise höchstens 20 weitere Schadenspunkte zufügen."
 			},
 			damage: "20+",
 
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed. If tails, during your opponent's next turn, your opponent pays more to retreat the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé. Si c'est pile, pendant le prochain tour de votre adversaire, votre adversaire paie  supplémentaires pour faire battre en retraite le Pokémon Défenseur.",
-				de: "Wirf eine Münze. Bei 'Kopf' ist das verteidigende Pokémon jetzt gelähmt. Bei 'Zahl' bezahlt dein Gegner während seines nächsten Zuges  mehr, wenn er das verteidigende Pokémon zurückziehen will."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das verteidigende Pokémon jetzt gelähmt. Bei „Zahl“ bezahlt dein Gegner während seines nächsten Zuges {C} mehr, wenn er das verteidigende Pokémon zurückziehen will."
 			},
 			damage: 20,
 
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "It likes to sleep in rock caves and will even steal other Octillery's nests.",
-		fr: "Il aime dormir dans les cavernes sous-marines et il lui arrive même de voler le nid d'un autre Octillery."
+		fr: "Il aime dormir dans les cavernes sous-marines et il lui arrive même de voler le nid d'un autre Octillery.",
+		de: "Es zieht sich zum Schlafen in Felshöhlen zurück und raubt manchmal auch die Nester anderer Octillerys aus."
 	},
 
 

--- a/data/Neo/Neo Destiny/63.ts
+++ b/data/Neo/Neo Destiny/63.ts
@@ -33,12 +33,12 @@ const card: Card = {
 			name: {
 				en: "Shed",
 				fr: "Mue",
-				de: "Shed"
+				de: "Häuten"
 			},
 			effect: {
 				en: "Remove 1 damage counter from Dratini.",
 				fr: "Retirez un marqueur de dégâts sur Minidraco.",
-				de: "Remove 1 damage counter from Dratini."
+				de: "Entferne eine Schadensmarke von Dratini."
 			},
 
 		},
@@ -49,12 +49,12 @@ const card: Card = {
 			name: {
 				en: "Fury Attack",
 				fr: "Furie",
-				de: "Fury Attack"
+				de: "Furienschlag"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de faces.",
-				de: "Flip 2 coins. This attack does 10 damage times the number of heads."
+				de: "Wirf zwei Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10x",
 
@@ -72,7 +72,8 @@ const card: Card = {
 
 	description: {
 		en: "Large from birth, this Pokémon increases in size throughout its life by regularly shedding its skin.",
-		fr: "Grand dès sa naissance, ce Pokémon augmente de taille durant sa vie en changeant régulièrement de peau."
+		fr: "Grand dès sa naissance, ce Pokémon augmente de taille durant sa vie en changeant régulièrement de peau.",
+		de: "Schon von Geburt an ist dieses Pokémon groß, und es wächst jedes Mal weiter, wenn es sich häutet."
 	},
 
 

--- a/data/Neo/Neo Destiny/64.ts
+++ b/data/Neo/Neo Destiny/64.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
-				de: "Das Verteidigende Pokémon schläft jetzt."
+				de: "Das verteidigende Pokémon schläft jetzt."
 			},
 			damage: 10,
 
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "Its shell is very durable, allowing it to survive even if the shell becomes cracked.",
-		fr: "Sa coquille est très solide. Elle lui permet de survivre même si elle est fissurée."
+		fr: "Sa coquille est très solide. Elle lui permet de survivre même si elle est fissurée.",
+		de: "Seine Schale ist sehr haltbar, dadurch kann es überleben, selbst wenn die Schale angeknackst ist."
 	},
 
 

--- a/data/Neo/Neo Destiny/65.ts
+++ b/data/Neo/Neo Destiny/65.ts
@@ -33,12 +33,12 @@ const card: Card = {
 			name: {
 				en: "Nightmare",
 				fr: "Cauchemar",
-				de: "Nightmare"
+				de: "Nachtmahr"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
-				de: "The Defending Pokémon is now Asleep."
+				de: "Das verteidigende Pokémon schläft jetzt."
 			},
 			damage: 10,
 
@@ -54,7 +54,8 @@ const card: Card = {
 
 	description: {
 		en: "Its gas-like body allows it to enter almost anywhere, but it is vulnerable to high winds.",
-		fr: "Son corps gazeux lui permet de se faufiler là où il veut, mais il le rend aussi vulnérable aux rafales de vent."
+		fr: "Son corps gazeux lui permet de se faufiler là où il veut, mais il le rend aussi vulnérable aux rafales de vent.",
+		de: "Sein gasartiger Körper erlaubt ihm, fast überall hineinzukommen, aber es muss sich vor starken Winden in Acht nehmen."
 	},
 
 

--- a/data/Neo/Neo Destiny/66.ts
+++ b/data/Neo/Neo Destiny/66.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage; if tails, this attack does 10 damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires ; si c'est pile, cette attaque inflige 10 dégâts.",
-				de: "Wirf eine Münze. Bei 'Kopf' fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu; bei 'Zahl' fügt dieser Angriff 10 Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu; bei „Zahl“ fügt dieser Angriff 10 Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -57,7 +57,7 @@ const card: Card = {
 			effect: {
 				en: "Does 10 damage plus 10 more damage for each Energy card attached to the Defending Pokémon.",
 				fr: "Inflige 10 dégâts plus 10 dégâts supplémentaires pour chaque carte Énergie attachée au Pokémon Défenseur.",
-				de: "Fügt 10 Schadenspunkte plus 10 weitere Schadenspunkte für jede an das Verteidigende Pokémon angelegte Energiekarte zu."
+				de: "Fügt 10 Schadenspunkte plus 10 weitere Schadenspunkte für jede an das verteidigende Pokémon angelegte Energiekarte zu."
 			},
 			damage: "10+",
 
@@ -68,7 +68,8 @@ const card: Card = {
 
 	description: {
 		en: "Its tail has a brain of its own, which can respond to stimuli such as scents. Many unsuspecting people have been bitten by it.",
-		fr: "Sa queue a sa vie propre. Elle réagit à ce qui l'entoure. Bon nombre de personnes ne se méfiant pas se sont fait mordre."
+		fr: "Sa queue a sa vie propre. Elle réagit à ce qui l'entoure. Bon nombre de personnes ne se méfiant pas se sont fait mordre.",
+		de: "Sein Schwanz hat ein eigenes Gehirn, das auf Anregungen wie zum Beispiel Gerüche reagieren kann. Viele, die das nicht erwartet haben, sind schon unvermutet gebissen worden."
 	},
 
 

--- a/data/Neo/Neo Destiny/67.ts
+++ b/data/Neo/Neo Destiny/67.ts
@@ -41,7 +41,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed and Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé et Empoisonné.",
-				de: "Wirf eine Münze. Bei 'Kopf' ist das verteidigende Pokémon jetzt gelähmt und vergiftet."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das verteidigende Pokémon jetzt gelähmt und vergiftet."
 			},
 
 			damage: 10
@@ -64,7 +64,8 @@ const card: Card = {
 
 	description: {
 		en: "It spends its days hanging from cliffs, swooping down on any prey it spots from its high vantage point.",
-		fr: "Il passe ses journées accroché aux falaises, attendant de fondre sur sa proie depuis son poste d'observation."
+		fr: "Il passe ses journées accroché aux falaises, attendant de fondre sur sa proie depuis son poste d'observation.",
+		de: "Es verbringt seine Tage damit, von Klippen herabzuhängen und sich auf jede Beute, die es entdeckt, zu stürzen."
 	},
 
 

--- a/data/Neo/Neo Destiny/68.ts
+++ b/data/Neo/Neo Destiny/68.ts
@@ -34,7 +34,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
-				de: "Bite"
+				de: "Biss"
 			},
 
 			damage: 20,
@@ -53,7 +53,8 @@ const card: Card = {
 
 	description: {
 		en: "It fears nothing, not even opponents larger than itself.",
-		fr: "Il n'a peur de rien, pas même d'adversaires plus grands que lui."
+		fr: "Il n'a peur de rien, pas même d'adversaires plus grands que lui.",
+		de: "Es fürchtet sich vor nichts, mögen die Gegner noch so groß sein."
 	},
 
 

--- a/data/Neo/Neo Destiny/69.ts
+++ b/data/Neo/Neo Destiny/69.ts
@@ -33,12 +33,12 @@ const card: Card = {
 			name: {
 				en: "Dodge",
 				fr: "Esquive",
-				de: "Dodge"
+				de: "Ausweichen"
 			},
 			effect: {
 				en: "If Hitmonchan would be damaged by an attack during your opponent's next turn, flip a coin. If heads, prevent that attack's damage done to Hitmonchan. (Any other effects of attacks still happen.)",
 				fr: "Si une attaque doit infliger des dégâts à Tygnon pendant le prochain tour de votre adversaire, lancez une pièce. Si c'est face, prévenez les dégâts infligés à Tygnon par cette attaque. (Tous les autres effets dus à des attaques subsistent.)",
-				de: "If Hitmonchan would be damaged by an attack during your opponent's next turn, flip a coin. If heads, prevent that attack's damage done to Hitmonchan. (Any other effects of attacks still happen.)"
+				de: "Wirf eine Münze, wenn Nockchan durch einen Angriff im nächsten Zug deines Gegners Schaden zugefügt würde. Verhindere bei „Kopf“ den Schaden, den dieser Angriff Nockchan zufügen würde. (Alle anderen Auswirkungen von Angriffen finden immer noch statt.)"
 			},
 
 		},
@@ -51,7 +51,7 @@ const card: Card = {
 			name: {
 				en: "Supersonic Jab",
 				fr: "Punch ultrason",
-				de: "Supersonic Jab"
+				de: "Superschall-Kinnhaken"
 			},
 
 			damage: 40,
@@ -70,7 +70,8 @@ const card: Card = {
 
 	description: {
 		en: "Its punches are blindingly fast, but it can only fight for three minutes before tiring and needing to rest.",
-		fr: "Ses coups sont super rapides, mais il ne peut se battre que pendant trois minutes avant qu'il ne soit fatigué et qu'il ne soit obligé de se reposer."
+		fr: "Ses coups sont super rapides, mais il ne peut se battre que pendant trois minutes avant qu'il ne soit fatigué et qu'il ne soit obligé de se reposer.",
+		de: "Seine Schläge kommen pfeilschnell, aber es kann nur etwa drei Minuten kämpfen, bevor es ermüdet und eine Pause braucht."
 	},
 
 

--- a/data/Neo/Neo Destiny/7.ts
+++ b/data/Neo/Neo Destiny/7.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Houndour",
-		fr: "Malosse"
+		fr: "Malosse",
+		de: "Hunduster"
 	},
 
 	stage: "Stage1",
@@ -38,12 +39,12 @@ const card: Card = {
 			name: {
 				en: "Eerie Howl",
 				fr: "Hurlement étrange",
-				de: "Eerie Howl"
+				de: "Schauriges Heulen"
 			},
 			effect: {
 				en: "If your opponent's Bench isn't full, look at his or her hand. If your opponent has any Baby Pokémon or Basic Pokémon there, choose 1 of them and put it on his or her Bench. Then, switch it with the Defending Pokémon.",
 				fr: "Si le Banc de votre adversaire n'est pas plein, regardez sa main. Si elle contient des Bébés Pokémon ou des Pokémon de base, choisissez-en un et placez-le sur son Banc. Puis échangez-le contre le Pokémon Défenseur.",
-				de: "If your opponent's Bench isn't full, look at his or her hand. If your opponent has any Baby Pokémon or Basic Pokémon there, choose 1 of them and put it on his or her Bench. Then, switch it with the Defending Pokémon."
+				de: "Wenn die Bank deines Gegners nicht voll ist, schaue dir die Karten auf seiner Hand an. Falls dein Gegner mindestens ein Baby-Pokémon oder Basis-Pokémon auf der Hand hat, wähle eines davon und lege es auf seine Bank. Tausche dieses Pokémon dann mit dem verteidigenden Pokémon aus."
 			},
 
 		},
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Dark Fire",
 				fr: "Sombre feu",
-				de: "Dark Fire"
+				de: "Finsteres Feuer"
 			},
 			effect: {
 				en: "If there are any Energy cards attached to Dark Houndoom, discard 1 of them and this attack does 30 damage plus 20 more damage (plus 10 more damage for the Energy you discarded). If there aren't any, this attack does 30 damage.",
 				fr: "S'il y a des cartes Énergie  attachées à Démolosse obscur, défaussez-vous en d'une. Cette attaque inflige 30 dégâts plus 20 dégâts supplémentaires (plus 10 dégâts pour la carte Énergie  défaussée). Sinon, cette attaque inflige 30 dégâts.",
-				de: "If there are any  Energy cards attached to Dark Houndoom, discard 1 of them and this attack does 30 damage plus 20 more damage (plus 10 more damage for the  Energy you discarded). If there aren't any, this attack does 30 damage."
+				de: "Falls mindestens eine {D}-Energiekarte an Dunkles Hundemon angelegt ist, lege eine davon auf deinen Ablagestapel, und dieser Angriff fügt 30 Schadenspunkte plus 20 weitere Schadenspunkte zu (plus 10 weitere für die abgelegte {D}-Energiekarte). Sonst fügt dieser Angriff 30 Schadenspunkte zu."
 			},
 			damage: "30+",
 
@@ -78,7 +79,8 @@ const card: Card = {
 
 	description: {
 		en: "The flame it breathes is actually a volatile poison it produces internally that ignites when exposed to air.",
-		fr: "Les flammes qu'il crache sont en fait un poison qu'il sécrète et qui s'enflamme au contact de l'air."
+		fr: "Les flammes qu'il crache sont en fait un poison qu'il sécrète et qui s'enflamme au contact de l'air.",
+		de: "Das Feuer, das es spuckt, ist in Wirklichkeit ein dampfendes Gift, das es in seinem Magen bildet und das sich entzündet, wenn es an die Luft kommt."
 	},
 
 

--- a/data/Neo/Neo Destiny/70.ts
+++ b/data/Neo/Neo Destiny/70.ts
@@ -33,12 +33,12 @@ const card: Card = {
 			name: {
 				en: "Leer",
 				fr: "Groz'yeux",
-				de: "Leer"
+				de: "Silberblick"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon can't attack during your opponent's next turn. (Benching or evolving either Pokémon ends this effect.)",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur ne peut pas attaquer pendant le prochain tour de votre adversaire. (Envoyer l'un des deux Pokémon sur son Banc ou le faire évoluer met fin à cet effet.)",
-				de: "Flip a coin. If heads, the Defending Pokémon can't attack during your opponent's next turn. (Benching or evolving either Pokémon ends this effect.)"
+				de: "Wirf eine Münze. Bei „Kopf“ kann das verteidigende Pokémon während des nächsten Zuges deines Gegners nicht angreifen. (Kommt eins der beiden Pokémon auf die Bank oder entwickelt sich, endet dieser Effekt.)"
 			},
 
 		},
@@ -50,7 +50,7 @@ const card: Card = {
 			name: {
 				en: "Rock Throw",
 				fr: "Jet-pierres",
-				de: "Rock Throw"
+				de: "Steinwurf"
 			},
 
 			damage: 20,
@@ -76,7 +76,8 @@ const card: Card = {
 
 	description: {
 		en: "It is born deep within the ground and has to burrow its way out.",
-		fr: "Il est né dans les profondeurs de la terre et il doit creuser pour sortir à l'air libre."
+		fr: "Il est né dans les profondeurs de la terre et il doit creuser pour sortir à l'air libre.",
+		de: "Es wird tief unter der Erde geboren und muss sich seinen Weg an die Oberfläche selber graben."
 	},
 
 

--- a/data/Neo/Neo Destiny/71.ts
+++ b/data/Neo/Neo Destiny/71.ts
@@ -34,12 +34,12 @@ const card: Card = {
 			name: {
 				en: "Swift",
 				fr: "Météores",
-				de: "Swift"
+				de: "Sternschauer"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by Weakness, Resistance, Pokémon Powers, or any other effects on the Defending Pokémon.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Faiblesse, la Résistance, les Pouvoirs Pokémon ou tout autre effet en action sur le Pokémon Défenseur.",
-				de: "This attack's damage isn't affected by Weakness, Resistance, Pokémon Powers, or any other effects on the Defending Pokémon."
+				de: "Die Schadenspunkte dieses Angriffs werden nicht durch Schwäche, Resistenz, Pokémon-Powers oder andere das verteidigende Pokémon betreffende Effekte beeinflusst."
 			},
 			damage: 20,
 
@@ -62,7 +62,8 @@ const card: Card = {
 
 	description: {
 		en: "Sensitive to cold, Ledyba gather in groups to share warmth when the temperature drops.",
-		fr: "Sensibles au froid, les Coxy se rassemblent en groupes pour partager leur chaleur quand la température descend dangereusement."
+		fr: "Sensibles au froid, les Coxy se rassemblent en groupes pour partager leur chaleur quand la température descend dangereusement.",
+		de: "Da sie die Kälte nicht gut vertragen, kuscheln sich Ledybas aneinander, um sich warmzuhalten, wenn die Temperatur fällt."
 	},
 
 

--- a/data/Neo/Neo Destiny/72.ts
+++ b/data/Neo/Neo Destiny/72.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Sunkern",
-		fr: "Tournegrin"
+		fr: "Tournegrin",
+		de: "Sonnkern"
 	},
 
 	stage: "Stage1",
@@ -39,12 +40,12 @@ const card: Card = {
 			name: {
 				en: "Reflected Sunlight",
 				fr: "Reflet du soleil",
-				de: "Reflected Sunlight"
+				de: "Reflektiertes Sonnenlicht"
 			},
 			effect: {
 				en: "Attach up to 2 Energy cards from your hand to 1 of your Pokémon.",
 				fr: "Attachez jusqu'à 2 cartes Énergie  de votre main à l'un de vos Pokémon .",
-				de: "Attached up to 2  Energy cards from your hand to 1 of your  Pokémon."
+				de: "Lege bis zu zwei 2 {G}-Energiekarten aus deiner Hand an eines deiner {G}-Pokémon an."
 			},
 
 		},
@@ -57,7 +58,7 @@ const card: Card = {
 			name: {
 				en: "Solarbeam",
 				fr: "Lance-soleil",
-				de: "Solarbeam"
+				de: "Solarstrahl"
 			},
 
 			damage: 40,
@@ -76,7 +77,8 @@ const card: Card = {
 
 	description: {
 		en: "Although it is extremely active during the day, it stops moving entirely as soon as the sun sets.",
-		fr: "Bien qu'extrêmement actif durant la journée, il cesse de bouger dès que le soleil se couche."
+		fr: "Bien qu'extrêmement actif durant la journée, il cesse de bouger dès que le soleil se couche.",
+		de: "Obwohl es tagsüber unheimlich aktiv ist, bewegt es sich gar nicht mehr, sobald die Sonne untergegangen ist."
 	},
 
 

--- a/data/Neo/Neo Destiny/73.ts
+++ b/data/Neo/Neo Destiny/73.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			name: {
 				en: "Chop",
 				fr: "Coup tranchant",
-				de: "Chop"
+				de: "Spaltschlag"
 			},
 
 			damage: 10,
@@ -47,7 +47,7 @@ const card: Card = {
 			name: {
 				en: "Punch",
 				fr: "Koud'poing",
-				de: "Punch"
+				de: "Boxhieb"
 			},
 
 			damage: 20,
@@ -66,7 +66,8 @@ const card: Card = {
 
 	description: {
 		en: "When bored, this super-strong Pokémon trains by lifting rocks.",
-		fr: "Quand il s'ennuie, ce Pokémon super fort s'entraîne en soulevant des rochers."
+		fr: "Quand il s'ennuie, ce Pokémon super fort s'entraîne en soulevant des rochers.",
+		de: "Wenn ihm langweilig ist, hebt dieses superstarke Pokémon Felsbrocken als Training."
 	},
 
 

--- a/data/Neo/Neo Destiny/74.ts
+++ b/data/Neo/Neo Destiny/74.ts
@@ -34,12 +34,12 @@ const card: Card = {
 			name: {
 				en: "Giant Wave",
 				fr: "Vague géante",
-				de: "Giant Wave"
+				de: "Riesenwelle"
 			},
 			effect: {
 				en: "Mantine can't attack during your next turn.",
 				fr: "Demanta ne peut pas attaquer pendant votre prochain tour.",
-				de: "Mantine can't attack during your next turn."
+				de: "Mantax kann während deines nächsten Zuges nicht angreifen."
 			},
 			damage: 40,
 
@@ -64,7 +64,8 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon is perfectly adapted to its ocean home. It can gather up enough speed to burst above the water like a whale.",
-		fr: "Ce Pokémon est parfaitement adapté au milieu océanique. Il peut accumuler suffisamment de vitesse pour bondir hors de l'eau comme une baleine."
+		fr: "Ce Pokémon est parfaitement adapté au milieu océanique. Il peut accumuler suffisamment de vitesse pour bondir hors de l'eau comme une baleine.",
+		de: "Dieses Pokémon hat sich perfekt an seine Meeresheimat angepasst. Es kann genug Kraft sammeln, um wie ein Wal aus dem Wasser zu springen."
 	},
 
 

--- a/data/Neo/Neo Destiny/75.ts
+++ b/data/Neo/Neo Destiny/75.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			name: {
 				en: "Headbutt",
 				fr: "Coup d'boule",
-				de: "Headbutt"
+				de: "Kopfnuss"
 			},
 
 			damage: 10,
@@ -52,7 +52,8 @@ const card: Card = {
 
 	description: {
 		en: "Its soft wool coat captures air, allowing it to remain cool during the summer and warm in the winter.",
-		fr: "Sa douce laine capture l'air ambiant, ce qui lui permet de rester frais en été et chaud en hiver."
+		fr: "Sa douce laine capture l'air ambiant, ce qui lui permet de rester frais en été et chaud en hiver.",
+		de: "Seine weiche Wolle filtert die Luft und hält es so während des Sommers kühl und im Winter warm."
 	},
 
 

--- a/data/Neo/Neo Destiny/76.ts
+++ b/data/Neo/Neo Destiny/76.ts
@@ -33,12 +33,12 @@ const card: Card = {
 			name: {
 				en: "Crushing Step",
 				fr: "Trépignement",
-				de: "Crushing Step"
+				de: "Zertreten"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 10 more damage; if tails, this attack does 10 damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires ; si c'est pile, cette attaque inflige 10 dégâts.",
-				de: "Flip a coin. If heads, this attack does 10 damage plus 10 more damage; if tails, this attack does 10 damage."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu; bei „Zahl“ fügt dieser Angriff 10 Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -63,7 +63,8 @@ const card: Card = {
 
 	description: {
 		en: "It hits people with its nose as a sign of affection but doesn't know its own strength and so sometimes knocks people off their feet.",
-		fr: "Il frappe les gens avec sa trompe en signe d'affection mais il ne connaît pas sa force ; et parfois, il frappe un peu trop fort..."
+		fr: "Il frappe les gens avec sa trompe en signe d'affection mais il ne connaît pas sa force ; et parfois, il frappe un peu trop fort...",
+		de: "Wenn es mit seinem Rüssel nach Leuten schlägt, ist das eigentlich ein Zeichen der Zuneigung. Leider kennt es seine eigene Stärke nicht gut genug, so dass es ab und zu auch Leute zu kräftig haut."
 	},
 
 

--- a/data/Neo/Neo Destiny/77.ts
+++ b/data/Neo/Neo Destiny/77.ts
@@ -53,7 +53,8 @@ const card: Card = {
 
 	description: {
 		en: "It waits suspended from tree branches for insects to fly into its mouth, often not moving for hours at a time.",
-		fr: "Il attend, suspendu à des branches d'arbre que des insectes volent dans sa gueule. Souvent, il reste immobile pendant des heures."
+		fr: "Il attend, suspendu à des branches d'arbre que des insectes volent dans sa gueule. Souvent, il reste immobile pendant des heures.",
+		de: "Es hängt von Zweigen herunter und wartet auf Insekten, die ihm ins Maul fliegen. Dabei bewegt es sich oft stundenlang nicht."
 	},
 
 

--- a/data/Neo/Neo Destiny/78.ts
+++ b/data/Neo/Neo Destiny/78.ts
@@ -34,7 +34,7 @@ const card: Card = {
 			name: {
 				en: "Sharpen",
 				fr: "Affûtage",
-				de: "Sharpen"
+				de: "Schärfer"
 			},
 
 			damage: 20,
@@ -60,7 +60,8 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon was created by human computer engineering. Its program is only capable of simple action and reaction.",
-		fr: "Ce Pokémon est le résultat de recherches informatiques. Son programme n'est capable que d'actions et de réactions simples."
+		fr: "Ce Pokémon est le résultat de recherches informatiques. Son programme n'est capable que d'actions et de réactions simples.",
+		de: "Dieses Pokémon wurde von Menschen mit dem Computer entwickelt. Sein Programm erlaubt ihm nur einfache Aktionen und Reaktionen."
 	},
 
 

--- a/data/Neo/Neo Destiny/79.ts
+++ b/data/Neo/Neo Destiny/79.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			name: {
 				en: "Flipper Splash",
 				fr: "Koud'palme",
-				de: "Flipper Splash"
+				de: "Flossenplatscher"
 			},
 
 			damage: 10,
@@ -47,12 +47,12 @@ const card: Card = {
 			name: {
 				en: "Migraine",
 				fr: "Maud'krâne",
-				de: "Migraine"
+				de: "Migräne"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused. If tails, Psyduck is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus. Si c'est pile, Psykokwak est maintenant Confus.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Confused. If tails, Psyduck is now Confused."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das verteidigende Pokémon jetzt verwirrt. Bei „Zahl“ ist Enton jetzt verwirrt."
 			},
 			damage: 20,
 
@@ -70,7 +70,8 @@ const card: Card = {
 
 	description: {
 		en: "Although possessed of great mental powers, it doesn't know how to use them.",
-		fr: "Bien que possédant d'immenses pouvoirs mentaux, il ne sait pas les utiliser."
+		fr: "Bien que possédant d'immenses pouvoirs mentaux, il ne sait pas les utiliser.",
+		de: "Obwohl es starke mentale Kräfte besitzt, weiß es nicht, wie es sie anwenden soll."
 	},
 
 

--- a/data/Neo/Neo Destiny/8.ts
+++ b/data/Neo/Neo Destiny/8.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Porygon",
-		fr: "Porygon"
+		fr: "Porygon",
+		de: "Porygon"
 	},
 
 	stage: "Stage1",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Spatial Distortion",
 				fr: "Distorsion spatiale",
-				de: "Spatial Distortion"
+				de: "Räumliche Abweichung"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may flip a coin. If heads, choose a Stadium card from your discard pile and put it into play. (If there's already a Stadium card in play, discard it.) This power can't be used if Dark Porygon2 is Asleep, Confused, or Paralyzed.",
 				fr: "Une fois pendant votre tour (avant votre attaque), vous pouvez lancer une pièce. Si c'est face, choisissez une carte Stade dans votre pile de défausse et mettez-la en jeu. (S'il y a déjà une carte Stade en jeu, défaussez-vous en.) Ce pouvoir ne fonctionne pas si Porygon2 obscur est Endormi, Confus ou Paralysé.",
-				de: "Once during your turn (before your attack), you may flip a coin. If heads, choose a Stadium card from your discard pile and put it into play. (If there's already a Stadium card in play, discard it.) This power can't be used if Dark Porygon2 is Asleep, Confused, or Paralyzed."
+				de: "Du kannst immer einmal in deinem Zug (vor deinem Angriff) eine Münze werfen. Wähle bei „Kopf“ eine Stadion-Karte aus deinem Ablagestapel und bringe sie ins Spiel. (Wenn bereits eine Stadion-Karte im Spiel ist, lege diese auf den Ablagestapel ihres Besitzers.) Diese Fähigkeit kann nicht verwendet werden, wenn Dunkles Porygon2 schläft, verwirrt oder gelähmt ist."
 			},
 		},
 	],
@@ -56,12 +57,12 @@ const card: Card = {
 			name: {
 				en: "Curve Attack",
 				fr: "Courbattaque",
-				de: "Curve Attack"
+				de: "Krümmungsangriff"
 			},
 			effect: {
 				en: "Flip a coin. If heads, prevent all damage done by attacks to Dark Porygon2 during your opponent's next turn. (Any other effects of attacks still happen.)",
 				fr: "Lancez une pièce. Si c'est face, prévenez tous les dégâts des attaques sur Porygon2 obscur pendant le prochain tour de votre adversaire. (Tous les autres effets dus à des attaques subsistent.)",
-				de: "Flip a coin. If heads, prevent all damage done by attacks to Dark Porygon2 during your opponent's next turn. (Any other effects of attacks still happen.)"
+				de: "Wirf eine Münze. Verhindere bei „Kopf“ allen Schaden, der Dunkles Porygon2 während des nächsten Zugs deines Gegners durch Angriffe zugefügt wird. (Alle anderen Auswirkungen von Angriffen finden immer noch statt.)"
 			},
 			damage: 20,
 
@@ -86,7 +87,8 @@ const card: Card = {
 
 	description: {
 		en: "Advances in technology have allowed it to evolve. It occasionally displays behavior not found in its programming.",
-		fr: "Les progrès de la technologie lui ont permis d'évoluer. Parfois, il affiche un comportement qui n'a pas été inclus dans sa programmation."
+		fr: "Les progrès de la technologie lui ont permis d'évoluer. Parfois, il affiche un comportement qui n'a pas été inclus dans sa programmation.",
+		de: "Dank Fortschritten in der Technologie konnte es sich weiterentwickeln. Ab und zu zeigt es ein Verhalten, das nicht so in der Programmierung drin ist."
 	},
 
 

--- a/data/Neo/Neo Destiny/80.ts
+++ b/data/Neo/Neo Destiny/80.ts
@@ -33,12 +33,12 @@ const card: Card = {
 			name: {
 				en: "Fury Strikes",
 				fr: "Attaques furieuses",
-				de: "Fury Strikes"
+				de: "Zornschläge"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de faces.",
-				de: "Flip 3 coins. This attack does 10 damage times the number of heads."
+				de: "Wirf drei Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10x",
 
@@ -54,7 +54,8 @@ const card: Card = {
 
 	description: {
 		en: "It can shoot a burst of water from its mouth to propel itself backward at high speeds, allowing it to flee from surprised enemies.",
-		fr: "Il peut lancer de l'eau avec sa gueule pour se propulser en arrière à grande vitesse, ce qui lui permet d'échapper à ses ennemis."
+		fr: "Il peut lancer de l'eau avec sa gueule pour se propulser en arrière à grande vitesse, ce qui lui permet d'échapper à ses ennemis.",
+		de: "Es kann aus seinem Maul einen Wasserschwall ausstoßen, um sich mit hoher Geschwindigkeit rückwärts fortzubewegen. Das ermöglicht ihm, staunenden Gegnern zu entfliehen."
 	},
 
 

--- a/data/Neo/Neo Destiny/81.ts
+++ b/data/Neo/Neo Destiny/81.ts
@@ -34,12 +34,12 @@ const card: Card = {
 			name: {
 				en: "Take Down",
 				fr: "Bélier",
-				de: "Take Down"
+				de: "Bodycheck"
 			},
 			effect: {
 				en: "Seel does 10 damage to itself.",
 				fr: "Otaria s'inflige 10 dégâts.",
-				de: "Seel does 10 damage to itself."
+				de: "Jurob fügt sich selber 10 Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -57,7 +57,8 @@ const card: Card = {
 
 	description: {
 		en: "Although clumsy on land, it moves easily through the arctic waters it calls home.",
-		fr: "Bien que peu doué pour marcher sur la terre ferme, il se déplace avec aisance dans ses eaux natales de l'Arctique."
+		fr: "Bien que peu doué pour marcher sur la terre ferme, il se déplace avec aisance dans ses eaux natales de l'Arctique.",
+		de: "Obwohl es an Land tapsig ist, bewegt es sich graziös durch die Eismeere, in denen es daheim ist."
 	},
 
 

--- a/data/Neo/Neo Destiny/82.ts
+++ b/data/Neo/Neo Destiny/82.ts
@@ -34,7 +34,7 @@ const card: Card = {
 			name: {
 				en: "Combustion",
 				fr: "Fournaise",
-				de: "Combustion"
+				de: "Glühen"
 			},
 
 			damage: 30,
@@ -53,7 +53,8 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon is often seen crawling around in volcanic regions.",
-		fr: "On voit souvent ce Pokémon ramper dans les régions volcaniques."
+		fr: "On voit souvent ce Pokémon ramper dans les régions volcaniques.",
+		de: "Dieses Pokémon kann man oft in vulkanischen Gebieten herumkriechen sehen."
 	},
 
 

--- a/data/Neo/Neo Destiny/83.ts
+++ b/data/Neo/Neo Destiny/83.ts
@@ -69,7 +69,8 @@ const card: Card = {
 
 	description: {
 		en: "It is very small and powerless. If attacked, the best it can do is flap its leaves in an attempt to frighten away its enemies.",
-		fr: "Il est tout petit et sans défense. S'il est attaqué, il agite ses feuilles en espérant effrayer ses ennemis."
+		fr: "Il est tout petit et sans défense. S'il est attaqué, il agite ses feuilles en espérant effrayer ses ennemis.",
+		de: "Es ist sehr klein und nicht besonders kräftig. Wenn es angegriffen wird, kann es nicht viel mehr tun, als seine Blätter zu rütteln und zu hoffen, dass das den Feind vertreibt."
 	},
 
 

--- a/data/Neo/Neo Destiny/84.ts
+++ b/data/Neo/Neo Destiny/84.ts
@@ -34,12 +34,12 @@ const card: Card = {
 			name: {
 				en: "Generate Cold",
 				fr: "Émanations glaciales",
-				de: "Generate Cold"
+				de: "Kälte erzeugen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -64,7 +64,8 @@ const card: Card = {
 
 	description: {
 		en: "It moves with its sensitive nose pressed to the ground, always searching for food.",
-		fr: "Il avance, son nez ultra-sensible contre le sol, toujours à la recherche de nourriture."
+		fr: "Il avance, son nez ultra-sensible contre le sol, toujours à la recherche de nourriture.",
+		de: "Wenn es läuft, presst es seine empfindliche Nase an den Boden und schnüffelt überall nach Essbarem."
 	},
 
 

--- a/data/Neo/Neo Destiny/85.ts
+++ b/data/Neo/Neo Destiny/85.ts
@@ -33,12 +33,12 @@ const card: Card = {
 			name: {
 				en: "Water Gun",
 				fr: "Pistolet à O",
-				de: "Water Gun"
+				de: "Aquaknarre"
 			},
 			effect: {
 				en: "Does 10 damage plus 10 more damage for each Energy attached to Totodile but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way.",
 				fr: "Inflige 10 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  attachée à Kaiminus en plus du coût en Énergie de cette attaque. Vous ne pouvez pas ajouter plus de 20 dégâts de cette façon.",
-				de: "Does 10 damage plus 10 more damage for each  Energy attached to Totodile but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+				de: "Fügt 10 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Karnimani angelegte {W}-Energie, die nicht zum Zahlen der Energiekosten für diesen Angriff verwendet wird, zu. Du kannst auf diese Weise höchstens 20 weitere Schadenspunkte zufügen."
 			},
 			damage: "10+",
 
@@ -56,7 +56,8 @@ const card: Card = {
 
 	description: {
 		en: "Its highly developed jaws are powerful enough to crush anything. Even experienced adult trainers must handle it with great caution.",
-		fr: "Ses mâchoires surdéveloppées sont assez puissantes pour écraser n'importe quoi. Même les dresseurs adultes les plus expérimentés font très attention."
+		fr: "Ses mâchoires surdéveloppées sont assez puissantes pour écraser n'importe quoi. Même les dresseurs adultes les plus expérimentés font très attention.",
+		de: "Seine hoch entwickelten Kiefer sind kräftig genug, um alles zu zermalmen. Selbst erfahrene Trainer müssen große Vorsicht walten lassen."
 	},
 
 

--- a/data/Neo/Neo Destiny/86.ts
+++ b/data/Neo/Neo Destiny/86.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "[Laugh]",
 				fr: "Laugh",
-				de: "Laugh"
+				de: "Laugh [Laugh]"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may flip a coin. If heads, each player shuffles his or her deck. This power can be used even if Unown L is Asleep, Confused, or Paralyzed.",
 				fr: "Une fois pendant votre tour (avant votre attaque), vous pouvez lancer une pièce. Si c'est face, chaque joueur mélange son deck. Ce pouvoir fonctionne même si Zarbi [L] est Endormi, Confus ou Paralysé.",
-				de: "Du kannst immer einmal in deinem Zug (vor deinem Angriff) eine Münze werden. Bei \"Kopf\" mischt jeder Spieler sein Deck. Diese Fähigkeit kann selbst dann verwendet werden, wenn Icognito J schläft, verwirrt oder gelähmt ist."
+				de: "Du kannst immer einmal in deinem Zug (vor deinem Angriff) eine Münze werfen. Bei „Kopf“ mischt jeder Spieler sein Deck. Diese Fähigkeit kann selbst dann verwendet werden, wenn Icognito [L] schläft, verwirrt oder gelähmt ist."
 			},
 		},
 	],
@@ -68,7 +68,8 @@ const card: Card = {
 
 	description: {
 		en: "It is believed that the variety of types of this Pokémon were created by evolutionary adaptation, as each possesses a different ability.",
-		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente."
+		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente.",
+		de: "Es wird behauptet, dass die verschiedenen Sorten dieses Pokémon sich durch Anpassung entwickelt haben, da alle unterschiedliche Fähigkeiten haben."
 	},
 
 

--- a/data/Neo/Neo Destiny/87.ts
+++ b/data/Neo/Neo Destiny/87.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "[Search]",
 				fr: "[Search]",
-				de: "Search"
+				de: "Search [Search]"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may look at 1 of your Prize cards. Return that Prize card face down. This power can be used even if Unown S is Asleep, Confused, or Paralyzed.",
 				fr: "Une fois pendant votre tour (avant votre attaque), vous pouvez regarder une de vos cartes Récompense. Retournez ensuite cette carte, face contre table. Ce pouvoir fonctionne même si Zarbi [S] est Endormi, Confus ou Paralysé.",
-				de: "Once during your turn (before your attack), you may look at 1 of your Prize cards. Return that Prize card face down. This power can be used even if Unown [S] is Asleep, Confused, or Paralyzed."
+				de: "Du kannst immer einmal in deinem Zug (vor deinem Angriff) dir eine deiner Preiskarten ansehen. Lege die Preiskarte verdeckt wieder hin. Diese Fähigkeit kann selbst dann verwendet werden, wenn Icognito [S] schläft, verwirrt oder gelähmt ist."
 			},
 		},
 	],
@@ -69,7 +69,8 @@ const card: Card = {
 
 	description: {
 		en: "It is believed that the variety of types of this Pokémon were created by evolutionary adaptation, as each possesses a different ability.",
-		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente."
+		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente.",
+		de: "Es wird behauptet, dass die verschiedenen Sorten dieses Pokémon sich durch Anpassung entwickelt haben, da alle unterschiedliche Fähigkeiten haben."
 	},
 
 

--- a/data/Neo/Neo Destiny/88.ts
+++ b/data/Neo/Neo Destiny/88.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "[Tell]",
 				fr: "[Tell]",
-				de: "Tell"
+				de: "Tell [Tell]"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may flip a coin. If heads, look at your opponent's hand and show your hand to your opponent. This power can be used even if Unown T is Asleep, Confused, or Paralyzed.",
 				fr: "Une fois pendant votre tour (avant votre attaque), vous pouvez lancer une pièce. Si c'est face, regardez la main de votre adversaire et montrez-lui la vôtre. Ce pouvoir fonctionne même si Zarbi [T] est Endormi, Confus ou Paralysé.",
-				de: "Once during your turn (before you attack), you may flip a coun. If heads, look at your opponent's hand and show your hand to your opponent. This power can be used even if Unown T is Asleep, Confused or Paralyzed"
+				de: "Du kannst immer einmal in deinem Zug (vor deinem Angriff) eine Münze werfen. Schaue dir bei „Kopf“ die Karten auf der Hand deines Gegners an und zeige die Karten auf deiner Hand deinem Gegner. Diese Fähigkeit kann selbst dann verwendet werden, wenn Icognito [T] schläft, verwirrt oder gelähmt ist."
 			},
 		},
 	],
@@ -69,7 +69,8 @@ const card: Card = {
 
 	description: {
 		en: "It is believed that the variety of types of this Pokémon were created by evolutionary adaptation, as each possesses a different ability.",
-		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente."
+		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente.",
+		de: "Es wird behauptet, dass die verschiedenen Sorten dieses Pokémon sich durch Anpassung entwickelt haben, da alle unterschiedliche Fähigkeiten besitzen."
 	},
 
 

--- a/data/Neo/Neo Destiny/89.ts
+++ b/data/Neo/Neo Destiny/89.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "[Vanish]",
 				fr: "Vanish",
-				de: "Vanish"
+				de: "Vanish [Vanish]"
 			},
 			effect: {
 				en: "When you play Unown V from your hand, you may flip a coin. If heads, return 1 of your Pokémon with Unown in its name (other than Unown V) to your hand. (Discard all cards attached to that card.)",
 				fr: "Quand vous jouez Zarbi [V] depuis votre main, vous pouvez lancer une pièce. Si c'est face, renvoyez 1 de vos Pokémon Zarbi (autre que Zarbi [V]) dans votre main. (Défaussez-vous de toutes les cartes attachées à ce Pokémon.)",
-				de: "When you play Unown V from your hand, you may flip a coun. If heads, return 1 of your Pokémon with Unown in its name (other than Unown V) to your hand. (Discard all cards attached to that card.)"
+				de: "Wenn du Icognito [V] aus deiner Hand ausspielst, kannst du eine Münze werfen. Bringe bei „Kopf“ eines deiner Pokémon, das „Icognito“ in seinem Namen hat (außer Icognito [V]) auf deine Hand zurück. (Lege alle an diese Karte angelegten Karten auf deinen Ablagestapel.)"
 			},
 		},
 	],
@@ -68,7 +68,8 @@ const card: Card = {
 
 	description: {
 		en: "It is believed that the variety of types of this Pokémon were created by evolutionary adaptation, as each possesses a different ability.",
-		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente."
+		fr: "On pense que la variété des types de ce Pokémon particulier est le résultat d'une adaptation due à un caprice de l'évolution, chacun possédant une capacité différente.",
+		de: "Es wird behauptet, dass die verschiedenen Sorten dieses Pokémon sich durch Anpassung entwickelt haben, da alle unterschiedliche Fähigkeiten besitzen."
 	},
 
 

--- a/data/Neo/Neo Destiny/9.ts
+++ b/data/Neo/Neo Destiny/9.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Scyther",
-		fr: "Insécateur"
+		fr: "Insécateur",
+		de: "Sichlor"
 	},
 
 	stage: "Stage1",
@@ -39,12 +40,12 @@ const card: Card = {
 			name: {
 				en: "Threaten",
 				fr: "Menace",
-				de: "Threaten"
+				de: "Bedrohen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, look at your opponent's hand. If he or she has any Trainer cards there, choose 1 of them. Your opponent shuffles that card into his or her deck.",
 				fr: "Lancez une pièce. Si c'est face, regardez la main de votre adversaire. S'il a des cartes Dresseur, choisissez-en une. Votre adversaire mélange cette carte à son deck.",
-				de: "Flip a coin. If heads, look at your opponent's hand. If he or she has any Trainer cards there, choose 1 of them. Your opponent shuffles that card into his or her deck."
+				de: "Wirf eine Münze. Schaue dir bei „Kopf“ die Karten auf der Hand deines Gegners an. Wenn er darunter mindestens eine Trainerkarte hat, wähle eine davon. Dein Gegner mischt diese Karte in sein Deck."
 			},
 
 		},
@@ -57,7 +58,7 @@ const card: Card = {
 			name: {
 				en: "Slash",
 				fr: "Tranche",
-				de: "Slash"
+				de: "Schlitzer"
 			},
 
 			damage: 30,
@@ -83,7 +84,8 @@ const card: Card = {
 
 	description: {
 		en: "Nothing can withstand the pressure of the vise-like grip of this Pokémon's steel claws.",
-		fr: "Rien ne peut résister à la pression des griffes d'acier de ce Pokémon, aussi puissantes qu'un étau."
+		fr: "Rien ne peut résister à la pression des griffes d'acier de ce Pokémon, aussi puissantes qu'un étau.",
+		de: "Niemand kann dem Druck des Schraubstockgriffs der Stahlklauen dieses Pokémon widerstehen."
 	},
 
 

--- a/data/Neo/Neo Destiny/90.ts
+++ b/data/Neo/Neo Destiny/90.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			name: {
 				en: "Gnaw",
 				fr: "Rogne",
-				de: "Gnaw"
+				de: "Nagen"
 			},
 
 			damage: 10,
@@ -49,7 +49,7 @@ const card: Card = {
 			effect: {
 				en: "The Defending Pokémon is now Poisoned.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné.",
-				de: "The Defending Pokémon is now Poisoned."
+				de: "Das verteidigende Pokémon ist jetzt vergiftet."
 			},
 			damage: 40,
 
@@ -67,7 +67,8 @@ const card: Card = {
 
 	description: {
 		en: "It possesses a type of radar, which it can use to find the insects it eats for food, even in pitch darkness.",
-		fr: "Il possède une sorte de radar qu'il utilise pour trouver les insectes qu'il mange, même dans l'obscurité la plus totale."
+		fr: "Il possède une sorte de radar qu'il utilise pour trouver les insectes qu'il mange, même dans l'obscurité la plus totale.",
+		de: "Es hat eine Art Radar, mit dem es die Insekten, von denen es sich ernährt, selbst in tiefster Dunkelheit finden kann."
 	},
 
 

--- a/data/Neo/Neo Destiny/91.ts
+++ b/data/Neo/Neo Destiny/91.ts
@@ -34,12 +34,12 @@ const card: Card = {
 			name: {
 				en: "Ember",
 				fr: "Flammèche",
-				de: "Ember"
+				de: "Glut"
 			},
 			effect: {
 				en: "Discard 1 Energy card attached to this Pokémon in order to use this attack.",
 				fr: "Défaussez-vous d'une carte Énergie  attachée à Goupix pour pouvoir utiliser cette attaque.",
-				de: "Discard 1 Energy card attached to Vulpix in order to use this attack."
+				de: "Lege eine an Vulpix angelegte {R}-Energiekarte auf deinen Ablagestapel, um diesen Angriff zu verwenden."
 			},
 			damage: 30,
 
@@ -57,7 +57,8 @@ const card: Card = {
 
 	description: {
 		en: "As it grows older, its white tail changes colors and splits into six different tails. Its body radiates a faint warmth.",
-		fr: "Tandis qu'il vieillit, sa queue blanche change de couleur et se sépare en six. Il émane de son corps une faible chaleur."
+		fr: "Tandis qu'il vieillit, sa queue blanche change de couleur et se sépare en six. Il émane de son corps une faible chaleur.",
+		de: "Wenn es älter wird, wechselt sein weißer Schwanz seine Farbe und teilt sich in sechs verschiedene Schwänze auf. Sein Körper strahlt eine leichte Wärme aus."
 	},
 
 

--- a/data/Neo/Neo Destiny/92.ts
+++ b/data/Neo/Neo Destiny/92.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. Each player pays Colorless more to retreat a Baby Pokémon or Basic Pokémon.",
 		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez-vous de cette carte si une autre carte Stade arrive en jeu.\n\nChaque joueur paie  supplémentaire pour faire battre en retraite un Bébé Pokémon ou un Pokémon de base.",
-		de: "Each player pays  more to retreat a Baby Pokémon or Basic Pokémon."
+		de: "Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadion-Karte ins Spiel kommt. Jeder Spieler bezahlt {C} mehr, um ein Baby-Pokémon oder ein Basis-Pokémon zurückzuziehen."
 	},
 
 

--- a/data/Neo/Neo Destiny/93.ts
+++ b/data/Neo/Neo Destiny/93.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Attach EXP.ALL to 1 of your Pokémon that doesn't have a Pokémon Tool attached to it. During your opponent's turn, if your Active Pokémon would be Knocked Out by your opponent's attack, you may take 1 of the basic Energy cards attached to your Active Pokémon and attach it to the Pokémon with EXP.ALL attached to it. If you do, discard EXP.ALL.",
 		fr: "Attachez Multi expédition à un de vos Pokémon qui n'a pas d'Outil Pokémon attaché à lui.\n\nPendant le tour de votre adversaire, si votre Pokémon Actif doit être mis K.O. par l'attaque de votre adversaire, vous pouvez prendre une des cartes Énergie de base attachées à votre Pokémon Actif et l'attacher au Pokémon ayant Multi expédition attachée à lui. Si vous le faites, défaussez-vous de Multi expédition.",
-		de: "During your opponent's turn, if your Active Pokémon would be Knocked Out by your opponent's attack, you may take 1 of the basic Energy cards attached to your Active Pokémon and attach it to the Pokémon with EXP.ALL attached to it. If you do, discard EXP.ALL."
+		de: "Lege den EP-Teiler an eines deiner Pokémon an, das keine Pokémon-Ausrüstung hat. Falls im Zug deines Gegners dein aktives Pokémon durch den Angriff deines Gegners kampfunfähig wurde, kannst du eine der an dein aktives Pokémon angelegten Basisenergiekarten nehmen und an das Pokémon mit dem EP-Teiler anlegen. Wenn du dies tust, lege den EP-Teiler auf deinen Ablagestapel."
 	},
 
 

--- a/data/Neo/Neo Destiny/94.ts
+++ b/data/Neo/Neo Destiny/94.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Look at your opponent's Prize cards. You may have your opponent shuffle them into his or her deck. If you do, your opponent takes that many cards from the top of his or her deck and sets them aside as his or her new Prize cards (without looking at them).",
 		fr: "Regardez les cartes Récompense de votre adversaire. Vous pouvez l'obliger à les mélanger à son deck. Si c'est le cas, votre adversaire prend le même nombre de cartes au-dessus de son deck et les utilise comme nouvelles cartes Récompense (sans les regarder).",
-		de: "Look at your opponent´s Prize card. You may have your opponent shuffle them into his or her deck. If you do, your opponent takes that many cards from the top of his or her deck and sets them aside as his or her new Prize cards (without looking at them)."
+		de: "Schaue dir die Preiskarten deines Gegners an. Du kannst entscheiden, ob dein Gegner sie in sein Deck zurückmischt. Wenn du dies tust, nimmt dein Gegner hinterher ebenso viele Karten oben von seinem Deck und legt sie als neue Preiskarten beiseite (ohne sie anzuschauen)."
 	},
 
 

--- a/data/Neo/Neo Destiny/95.ts
+++ b/data/Neo/Neo Destiny/95.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. Once during each player's turn (before attacking), that player may look at the top 2 cards of his or her deck and put them back in the same order.",
 		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez-vous de cette carte si une autre carte Stade arrive en jeu.\n\nUne fois pendant le tour de chaque joueur (avant son attaque), ce joueur peut regarder les 2 premières cartes du dessus de son deck et les replacer dans le même ordre.",
-		de: "Once during each player's turn (before attacking), that player may look at the top 2 cards of his or her deck and put them back in the same order."
+		de: "Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadion-Karte ins Spiel kommt. Einmal in jedem eigenen Zug (vor dem Angriff) darf jeder Spieler sich die obersten beiden Karten seines Decks ansehen und sie in derselben Reihenfolge zurücklegen."
 	},
 
 

--- a/data/Neo/Neo Destiny/96.ts
+++ b/data/Neo/Neo Destiny/96.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Flip a coin until you get tails. For each heads, return an Energy card attached to your opponent's Active Pokémon to your opponent's hand. If the Pokémon has fewer attached Energy cards than that, return all of them to your opponent's hand. Your turn is over now (you don't get to attack).",
 		fr: "Lancez une pièce jusqu'à obtenir pile. Pour chaque face, renvoyez une carte Énergie attachée au Pokémon Actif de votre adversaire dans sa main. Si le Pokémon a moins de cartes Énergie, renvoyez-les toutes dans sa main. Votre tour est terminé (vous ne pouvez pas attaquer).",
-		de: "Flip a coin until you get tails. For each heads, return an Energy card attached to your opponent's Active Pokémon to your opponent's hand. If the Pokémon has fewer attached Energy cards than that, return all of them to your opponent's hand. Your turn is over now (you don't get to attack)."
+		de: "Wirf eine Münze, bis „Zahl“ fällt. Bringe für jedes Mal „Kopf“ eine an das aktive Pokémon deines Gegners angelegte Energiekarte auf dessen Hand zurück. Wenn an dieses Pokémon weniger Energiekarten angelegt sind, bringe sie alle auf die Hand deines Gegners zurück. Dein Zug ist damit vorbei (du erhältst in diesem Zug keinen Angriff)."
 	},
 
 

--- a/data/Neo/Neo Destiny/97.ts
+++ b/data/Neo/Neo Destiny/97.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Attach Counterattack Claws to 1 of your Pokémon that doesn't have a Pokémon Tool attached to it. During your opponent's turn, if the Pokémon Counterattack Claws is attached to is your Active Pokémon and an opponent's attack damages it (even if it is Knocked Out), flip a coin. If heads, put 2 damage counters on the Defending Pokémon. Then, discard Counterattack Claws.",
 		fr: "Attachez Griffes de défense à un de vos Pokémon qui n'a pas d'Outil Pokémon attaché à lui.\n\nPendant le tour de votre adversaire, si Griffes de défense est attachée à votre Pokémon Actif et si l'attaque de votre adversaire lui inflige des dégâts (même s'il est mis K.O.), lancez une pièce. Si c'est face, placez 2 marqueurs de dégâts sur le Pokémon Actif. Défaussez-vous ensuite de Griffes de défense.",
-		de: "During your opponent´s turn, if the Pokémon Counterattack Claws is attached to is your Active Pokémon and an opponent´s attack damage it (even if it is Knocked Out), flip a coin. If heads, put 2 damage counters on the Defending Pokémon. Then, discard Counterattack Claws."
+		de: "Lege Gegenangriffs-Klauen an eines deiner Pokémon an, das keine Pokémon-Ausrüstung hat. Wenn im Zug deines Gegners das Pokémon, an das die Gegenangriffs-Klauen angelegt ist und der Angriff deines Gegners ihm Schaden zufügt (auch, wenn es dadurch kampfunfähig wurde), wirf eine Münze. Legen bei „Kopf“ 2 Schadensmarken auf das Pokémon deines Gegners, das dich gerade angegriffen hat. Lege dann die Gegenangriffs-Klauen auf deinen Ablagestapel."
 	},
 
 

--- a/data/Neo/Neo Destiny/98.ts
+++ b/data/Neo/Neo Destiny/98.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Choose an Energy card in your hand, show it to your opponent, and shuffle it into your deck. Then flip a coin. If heads, search your deck for up to 3 basic Energy cards. Show them to your opponent, and put them into your hand. Shuffle your deck afterward.",
 		fr: "Choisissez une carte Énergie dans votre main, montrez-la à votre adversaire et mélangez-la à votre deck. Lancez ensuite une pièce. Si c'est face, cherchez dans votre deck jusqu'à 3 cartes Énergie de base. Montrez-les à votre adversaire avant de les ajouter à votre main. Mélangez ensuite votre deck.",
-		de: "Choose an Energy card in your hand, show it to your opponent, and shuffle it into your deck. Then flip a coin. If heads, search your deck for up to 3 basic Energy cards. Show them to your opponent, and put them into your hand. Shuffle your deck afterward."
+		de: "Wähle eine Energiekarte auf deiner Hand, zeige sie deinem Gegner und mische sie in dein Deck. Wirf dann eine Münze. Durchsuche bei „Kopf“ dein Deck nach bis zu drei Basis-Energiekarten. Zeige diese deinem Gegner und nimm sie auf deine Hand. Mische dein Deck danach."
 	},
 
 

--- a/data/Neo/Neo Destiny/99.ts
+++ b/data/Neo/Neo Destiny/99.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. Once during each player's turn (before attacking), that player may flip a coin. If heads, that player puts a basic Energy card from his or her discard pile into his or her hand.",
 		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez-vous de cette carte si une autre carte Stade arrive en jeu.\n\nUne fois durant le tour de chaque joueur (avant son attaque), ce joueur peut lancer une pièce. Si c'est face, ce joueur peut ajouter une carte Énergie de base de sa pile de défausse à sa main.",
-		de: "Once during each player´s turn (before attacking), that player may flip a coin. If heads, that player puts a basic Energy card from his or her discard pile into his or her hand."
+		de: "Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadion-Karte ins Spiel kommt. Einmal in jedem eigenen Zug (vor dem Angriff) darf jeder Spieler eine Münze werfen. Bei „Kopf“ nimmt dieser Spieler eine Basis-Energiekarte aus seinem Ablagestapel auf seine Hand."
 	},
 
 


### PR DESCRIPTION
## Add missing German translations for neo4

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
