### PR TITLE
Add missing German translations for ex14

### DIFF
--- a/data/EX/Crystal Guardians/1.ts
+++ b/data/EX/Crystal Guardians/1.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Shuppet",
-		fr: "Polichombr"
+		fr: "Polichombr",
+		de: "Shuppet"
 	},
 
 	stage: "Stage1",

--- a/data/EX/Crystal Guardians/100.ts
+++ b/data/EX/Crystal Guardians/100.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "If Celebi ☆ would be Knocked Out by damage from an opponent's attack, you may flip a coin. If heads, Celebi ☆ is not Knocked Out, discard all cards attached to Celebi ☆, and put Celebi ☆ on the bottom of your deck.",
 				fr: "Si les dégâts d'une attaque de votre adversaire mettent Celebi ☆ K.O, vous pouvez lancer une pièce. Si c'est face, Celebi ☆ n'est pas mis K.O. Défaussez toutes les cartes attachées à Celebi ☆ et placez-le au dessous de votre deck.",
-				de: "Wenn der Schaden eines gegnerischen Angriffs Celebi ☆ kampfunfähig machen würde, wirf 1 Münze. Bei \"Kopf\" wird Celebi ☆ nicht kampfunfähig. Lege stattdessen Celebi ☆ unter dein Deck und alle Karten, die an Celebi ☆ angelegt sind, auf den Ablagestapel."
+				de: "Wenn der Schaden eines gegnerischen Angriffs Celebi ☆ kampfunfähig machen würde, wirf 1 Münze. Bei „Kopf“ wird Celebi nicht kampfunfähig. Lege stattdessen Celebi ☆ unter dein Deck und alle Karten, die an Celebi ☆ angelegt sind, auf den Ablagestapel."
 			},
 		},
 	],
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "Count the amount of Energy attached to Celebi Star. Put that many damage counters on 1 of your opponent's Pokémon.",
 				fr: "Comptabilisez le nombre d'Énergies attachées à Celebi Star. Placez autant de marqueurs de dégât sur 1 des Pokémon de votre adversaire.",
-				de: "Zähle die Anzahl Energien, die an Celebi Star abgelegt sind. Lege genauso viele Schadensmarken auf 1 gegnerisches Pokémon."
+				de: "Zähle die Anzahl Energien, die an Celebi ☆ abgelegt sind. Lege genauso viele Schadensmarken auf 1 gegnerisches Pokémon."
 			},
 
 		},

--- a/data/EX/Crystal Guardians/11.ts
+++ b/data/EX/Crystal Guardians/11.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Gulpin",
-		fr: "Gloupti"
+		fr: "Gloupti",
+		de: "Schluppuck"
 	},
 
 	stage: "Stage1",

--- a/data/EX/Crystal Guardians/13.ts
+++ b/data/EX/Crystal Guardians/13.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Jigglypuff",
-		fr: "Rondoudou"
+		fr: "Rondoudou",
+		de: "Pummeluff"
 	},
 
 	stage: "Stage1",

--- a/data/EX/Crystal Guardians/14.ts
+++ b/data/EX/Crystal Guardians/14.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Wartortle",
-		fr: "Carabaffe"
+		fr: "Carabaffe",
+		de: "Schillok"
 	},
 
 	stage: "Stage2",
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Does 50 damage plus 20 more damage for each Water Energy attached to Blastoise but not used to pay for this attack's Energy cost. You can't add more than 40 damage in this way.",
 				fr: "Inflige 50 dégâts plus 20 dégâts supplémentaires pour chaque Énergie  attachée à Tortank qui n'a pas été utilisée pour payer le Coût en Énergie de cette attaque. Vous ne pouvez pas ajouter plus de 40 dégâts de cette façon.",
-				de: "Dieser Angriff fügt 50 Schadenspunkte plus 20 weitere Schadenspunkte für jede an Turtok angelegte -Energie zu, die nicht zum Zahlen der Energiekosten für diesen Angriff verwendet wurde. Es lassen sich so nicht mehr als 40 Schadenspunkte hinzufügen."
+				de: "Dieser Angriff fügt 50 Schadenspunkte plus 20 weitere Schadenspunkte für jede an Turtok angelegte {W}-Energie zu, die nicht zum Zahlen der Energiekosten für diesen Angriff verwendet wurde. Es lassen sich so nicht mehr als 40 Schadenspunkte hinzufügen."
 			},
 			damage: "50+",
 

--- a/data/EX/Crystal Guardians/15.ts
+++ b/data/EX/Crystal Guardians/15.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Cacnea",
-		fr: "Cacnea"
+		fr: "Cacnea",
+		de: "Tuska"
 	},
 
 	stage: "Stage1",

--- a/data/EX/Crystal Guardians/16.ts
+++ b/data/EX/Crystal Guardians/16.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Torchic",
-		fr: "Poussifeu"
+		fr: "Poussifeu",
+		de: "Flemmli"
 	},
 
 	stage: "Stage1",

--- a/data/EX/Crystal Guardians/17.ts
+++ b/data/EX/Crystal Guardians/17.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Duskull",
-		fr: "Skelenox"
+		fr: "Skelenox",
+		de: "Zwirrlicht"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "As long as Dusclops is your Active Pokémon, your opponent can't attach any Special Energy cards (except for Darkness and Metal Energy cards) from his or her hand to his or her Active Pokémon.",
 				fr: "Tant que Teraclope est votre Pokémon Actif, votre adversaire ne peut pas attacher de cartes Énergie spéciale (cartes Énergie  et  exceptées) de sa main à son Pokémon Actif.",
-				de: "Solange Zwirrklop dein Aktives Pokémon ist, kann dein Gegner keine Spezialenergiekarten (außer - und -Energiekarten) von seiner Hand an sein Aktives Pokémon anlegen."
+				de: "Solange Zwirrklop dein Aktives Pokémon ist, kann dein Gegner keine Spezialenergiekarten (außer {D}- und {M}-Energiekarten) von seiner Hand an sein Aktives Pokémon anlegen."
 			},
 		},
 	],

--- a/data/EX/Crystal Guardians/18.ts
+++ b/data/EX/Crystal Guardians/18.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Spearow",
-		fr: "Piafabec"
+		fr: "Piafabec",
+		de: "Habitak"
 	},
 
 	stage: "Stage1",

--- a/data/EX/Crystal Guardians/19.ts
+++ b/data/EX/Crystal Guardians/19.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Treecko",
-		fr: "Arcko"
+		fr: "Arcko",
+		de: "Geckarbor"
 	},
 
 	stage: "Stage1",

--- a/data/EX/Crystal Guardians/2.ts
+++ b/data/EX/Crystal Guardians/2.ts
@@ -26,7 +26,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Wartortle",
-		fr: "Carabaffe"
+		fr: "Carabaffe",
+		de: "Schillok"
 	},
 
 	stage: "Stage2",

--- a/data/EX/Crystal Guardians/20.ts
+++ b/data/EX/Crystal Guardians/20.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Spoink",
-		fr: "Spoink"
+		fr: "Spoink",
+		de: "Spoink"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Any damage done to Grumpig by attacks from Fire Pokémon and Water Pokémon is reduced by 30 (after applying Weakness and Resistance).",
 				fr: "Tous dégâts infligés à Groret par des attaques de Pokémon  et  sont réduits de 30 (après application de la Faiblesse et de la Résistance).",
-				de: "Jeder Schaden, der Groink durch Angriffe von -Pokémon und -Pokémon zugefügt wird, wird um 30 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
+				de: "Jeder Schaden, der Groink durch Angriffe von {R}-Pokémon und {W}-Pokémon zugefügt wird, wird um 30 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 		},
 	],

--- a/data/EX/Crystal Guardians/21.ts
+++ b/data/EX/Crystal Guardians/21.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "You pay Colorless less to retreat your Jigglypuff, Wigglytuff, Wigglytuff ex, and Igglybuff.",
 				fr: "Vous payez un  de moins pour faire battre Rondoudou, Groudoudou, Grodoudou ex et Toudoudou en retraite.",
-				de: "Der Rückzug deiner Pummeluff, Knuddeluff, Knuddeluff ex und Fluffeluff kostet dich  weniger.",
+				de: "Der Rückzug deiner Pummeluff, Knuddeluff, Knuddeluff ex und Fluffeluff kostet dich {C} weniger.",
 			},
 		},
 		{

--- a/data/EX/Crystal Guardians/22.ts
+++ b/data/EX/Crystal Guardians/22.ts
@@ -26,7 +26,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Krabby",
-		fr: "Krabby"
+		fr: "Krabby",
+		de: "Krabby"
 	},
 
 	stage: "Stage1",
@@ -45,7 +46,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 30,
 

--- a/data/EX/Crystal Guardians/23.ts
+++ b/data/EX/Crystal Guardians/23.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Whismur",
-		fr: "Chuchmur"
+		fr: "Chuchmur",
+		de: "Flurmel"
 	},
 
 	stage: "Stage1",

--- a/data/EX/Crystal Guardians/24.ts
+++ b/data/EX/Crystal Guardians/24.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Mudkip",
-		fr: "Gobou"
+		fr: "Gobou",
+		de: "Hydropi"
 	},
 
 	stage: "Stage1",

--- a/data/EX/Crystal Guardians/25.ts
+++ b/data/EX/Crystal Guardians/25.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Meditite",
-		fr: "Méditikka"
+		fr: "Méditikka",
+		de: "Meditie"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "As long as Medicham has any Psychic Energy cards attached to it, Medicham is both Psychic and Fighting type.",
 				fr: "Tant que Charmina possède des cartes Énergie , il est de type  et .",
-				de: "Solange an Meditalis mindestens eine -Energiekarte angelegt ist, ist Meditalis ein Pokémon vom Typ  und ."
+				de: "Solange an Meditalis mindestens eine {P}-Energiekarte angelegt ist, ist Meditalis ein Pokémon vom Typ {P} und {F}."
 			},
 		},
 	],
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 

--- a/data/EX/Crystal Guardians/26.ts
+++ b/data/EX/Crystal Guardians/26.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Wingull",
-		fr: "Goélise"
+		fr: "Goélise",
+		de: "Wingull"
 	},
 
 	stage: "Stage1",

--- a/data/EX/Crystal Guardians/27.ts
+++ b/data/EX/Crystal Guardians/27.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Marshtomp",
-		fr: "Flobio"
+		fr: "Flobio",
+		de: "Moorabbel"
 	},
 
 	stage: "Stage2",

--- a/data/EX/Crystal Guardians/28.ts
+++ b/data/EX/Crystal Guardians/28.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Ivysaur",
-		fr: "Herbizarre"
+		fr: "Herbizarre",
+		de: "Bisaknosp"
 	},
 
 	stage: "Stage2",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "All Energy cards that provide only Colorless Energy attached to your Grass Pokémon provide Grass Energy instead.",
 				fr: "Toutes les cartes Énergie fournissant uniquement de l'Énergie  attachées à vos Pokémon  fournissent de l'Énergie .",
-				de: "Alle Energiekarten, die nur -Energie liefern und an deine Pokémon vom Typ  angelegt sind, liefern stattdessen -Energie."
+				de: "Alle Energiekarten, die nur {C}-Energie liefern und an deine Pokémon vom Typ {G} angelegt sind, liefern stattdessen {G}-Energie."
 			},
 		},
 	],
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Does 20 damage plus 10 more damage for each Grass Energy attached to all of your Pokémon.",
 				fr: "Inflige 20 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  attachée à tous vos Pokémon.",
-				de: "Dieser Angriff fügt 20 Schadenspunkte plus 10 weitere Schadenspunkte für jede an deine Pokémon angelegte -Energie zu."
+				de: "Dieser Angriff fügt 20 Schadenspunkte plus 10 weitere Schadenspunkte für jede an deine Pokémon angelegte {G}-Energie zu."
 			},
 			damage: "20+",
 

--- a/data/EX/Crystal Guardians/29.ts
+++ b/data/EX/Crystal Guardians/29.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Charmander",
-		fr: "Salamèche"
+		fr: "Salamèche",
+		de: "Glumanda"
 	},
 
 	stage: "Stage1",
@@ -63,7 +64,7 @@ const card: Card = {
 			effect: {
 				en: "Discard a Fire Energy attached to Charmeleon.",
 				fr: "Défaussez une Énergie  attachée à Reptincel.",
-				de: "Entferne 1 -Energie von Glutexo und lege sie auf deinen Ablagestapel."
+				de: "Entferne 1 {R}-Energie von Glutexo und lege sie auf deinen Ablagestapel."
 			},
 			damage: 60,
 

--- a/data/EX/Crystal Guardians/3.ts
+++ b/data/EX/Crystal Guardians/3.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Numel",
-		fr: "Chamallot"
+		fr: "Chamallot",
+		de: "Camaub"
 	},
 
 	stage: "Stage1",

--- a/data/EX/Crystal Guardians/30.ts
+++ b/data/EX/Crystal Guardians/30.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Charmander",
-		fr: "Salamèche"
+		fr: "Salamèche",
+		de: "Glumanda"
 	},
 
 	stage: "Stage1",
@@ -59,7 +60,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, Charmeleon does 10 damage to itself.",
 				fr: "Lancez une pièce. Si c'est pile, Reptincel s'inflige 10 dégâts.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" fügt sich Glutexo selbst 10 Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Zahl“ fügt sich Glutexo selbst 10 Schadenspunkte zu."
 			},
 			damage: 50,
 

--- a/data/EX/Crystal Guardians/31.ts
+++ b/data/EX/Crystal Guardians/31.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Torchic",
-		fr: "Poussifeu"
+		fr: "Poussifeu",
+		de: "Flemmli"
 	},
 
 	stage: "Stage1",
@@ -63,7 +64,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 damage plus 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts plus 20 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 30 Schadenspunkte plus 20 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "30+",
 

--- a/data/EX/Crystal Guardians/32.ts
+++ b/data/EX/Crystal Guardians/32.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Treecko",
-		fr: "Arcko"
+		fr: "Arcko",
+		de: "Geckarbor"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Grovyle during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, prévenez tous les effets d'une attaque, dégâts inclus, infligés à Massko lors du prochain tour de votre adversaire.",
-				de: "Wirf 1 Münze. Verhindere bei \"Kopf\" während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die Reptain zugefügt werden."
+				de: "Wirf 1 Münze. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die Reptain zugefügt werden."
 			},
 
 		},

--- a/data/EX/Crystal Guardians/34.ts
+++ b/data/EX/Crystal Guardians/34.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Bulbasaur",
-		fr: "Bulbizarre"
+		fr: "Bulbizarre",
+		de: "Bisasam"
 	},
 
 	stage: "Stage1",

--- a/data/EX/Crystal Guardians/35.ts
+++ b/data/EX/Crystal Guardians/35.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Bulbasaur",
-		fr: "Bulbizarre"
+		fr: "Bulbizarre",
+		de: "Bisasam"
 	},
 
 	stage: "Stage1",
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 40 damage plus 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 40 dégâts plus 20 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 40 Schadenspunkte plus 20 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 40 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "40+",
 

--- a/data/EX/Crystal Guardians/36.ts
+++ b/data/EX/Crystal Guardians/36.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Aron",
-		fr: "Galekid"
+		fr: "Galekid",
+		de: "Stollunior"
 	},
 
 	stage: "Stage1",

--- a/data/EX/Crystal Guardians/37.ts
+++ b/data/EX/Crystal Guardians/37.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Lotad",
-		fr: "Nénupiot"
+		fr: "Nénupiot",
+		de: "Loturzel"
 	},
 
 	stage: "Stage1",

--- a/data/EX/Crystal Guardians/38.ts
+++ b/data/EX/Crystal Guardians/38.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Mudkip",
-		fr: "Gobou"
+		fr: "Gobou",
+		de: "Hydropi"
 	},
 
 	stage: "Stage1",

--- a/data/EX/Crystal Guardians/39.ts
+++ b/data/EX/Crystal Guardians/39.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Seedot",
-		fr: "Grainipiot"
+		fr: "Grainipiot",
+		de: "Samurzel"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Attach a Darkness Energy card from your hand to Nuzleaf.",
 				fr: "Attachez une carte Énergie  de votre main à Pifeuil.",
-				de: "Lege eine -Energiekarte von deiner Hand an Blanas an."
+				de: "Lege eine {D}-Energiekarte von deiner Hand an Blanas an."
 			},
 
 		},

--- a/data/EX/Crystal Guardians/4.ts
+++ b/data/EX/Crystal Guardians/4.ts
@@ -26,7 +26,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Charmeleon",
-		fr: "Reptincel"
+		fr: "Reptincel",
+		de: "Glutexo"
 	},
 
 	stage: "Stage2",
@@ -63,7 +64,7 @@ const card: Card = {
 			effect: {
 				en: "Discard all Metal Energy attached to Charizard.",
 				fr: "Défaussez toutes les Énergies  attachées à Dracaufeu.",
-				de: "Lege alle an Glurak angelegte -Energie auf deinen Ablagestapel."
+				de: "Lege alle an Glurak angelegte {M}-Energie auf deinen Ablagestapel."
 			},
 			damage: 120,
 

--- a/data/EX/Crystal Guardians/42.ts
+++ b/data/EX/Crystal Guardians/42.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Squirtle",
-		fr: "Carapuce"
+		fr: "Carapuce",
+		de: "Schiggy"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 

--- a/data/EX/Crystal Guardians/43.ts
+++ b/data/EX/Crystal Guardians/43.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Squirtle",
-		fr: "Carapuce"
+		fr: "Carapuce",
+		de: "Schiggy"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon can't attack during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur ne pourra pas attaquer lors du prochain tour de votre adversaire.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" kann das Verteidigende Pokémon im nächsten Zug deines Gegners nicht angreifen."
+				de: "Wirf 1 Münze. Bei „Kopf“ kann das Verteidigende Pokémon im nächsten Zug deines Gegners nicht angreifen."
 			},
 
 		},

--- a/data/EX/Crystal Guardians/46.ts
+++ b/data/EX/Crystal Guardians/46.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Attach a Grass Energy card from your hand to Bulbasaur.",
 				fr: "Attachez une carte Énergie  de votre main à Bulbizarre.",
-				de: "Lege eine -Energiekarte von deiner Hand an Bisasam an."
+				de: "Lege eine {G}-Energiekarte von deiner Hand an Bisasam an."
 			},
 
 		},

--- a/data/EX/Crystal Guardians/47.ts
+++ b/data/EX/Crystal Guardians/47.ts
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 

--- a/data/EX/Crystal Guardians/5.ts
+++ b/data/EX/Crystal Guardians/5.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Diglett",
-		fr: "Dynavolt"
+		fr: "Dynavolt",
+		de: "Digda"
 	},
 
 	stage: "Stage1",

--- a/data/EX/Crystal Guardians/52.ts
+++ b/data/EX/Crystal Guardians/52.ts
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 

--- a/data/EX/Crystal Guardians/54.ts
+++ b/data/EX/Crystal Guardians/54.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 

--- a/data/EX/Crystal Guardians/55.ts
+++ b/data/EX/Crystal Guardians/55.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "If Lotad has any Water Energy attached to it, the Retreat Cost for Lotad is 0.",
 				fr: "Si Nenupiot possède une Énergie , son Coût de retraite est de 0.",
-				de: "Wenn mindestens 1 -Energie an Loturzel angelegt ist, hat Loturzel Rückzugskosten 0."
+				de: "Wenn mindestens 1 {W}-Energie an Loturzel angelegt ist, hat Loturzel Rückzugskosten 0."
 			},
 		},
 	],

--- a/data/EX/Crystal Guardians/6.ts
+++ b/data/EX/Crystal Guardians/6.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Lombre",
-		fr: "Lombre"
+		fr: "Lombre",
+		de: "Lombrero"
 	},
 
 	stage: "Stage2",

--- a/data/EX/Crystal Guardians/64.ts
+++ b/data/EX/Crystal Guardians/64.ts
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 

--- a/data/EX/Crystal Guardians/65.ts
+++ b/data/EX/Crystal Guardians/65.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 20,
 

--- a/data/EX/Crystal Guardians/66.ts
+++ b/data/EX/Crystal Guardians/66.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
 				fr: "Si le Pokémon Défenseur essaye d'attaquer lors du prochain tour de votre adversaire, celui-ci lance une pièce. Si c'est pile, cette attaque est sans effet.",
-				de: "Wenn das Verteidigende Pokémon im nächsten Zug deines Gegners angreift, wirft dein Gegner 1 Münze. Bei \"Zahl\" hat der entsprechende Angriff keine Auswirkungen."
+				de: "Wenn das Verteidigende Pokémon im nächsten Zug deines Gegners angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat der entsprechende Angriff keine Auswirkungen."
 			},
 			damage: 10,
 

--- a/data/EX/Crystal Guardians/67.ts
+++ b/data/EX/Crystal Guardians/67.ts
@@ -33,12 +33,12 @@ const card: Card = {
 			name: {
 				en: "Paralyzing Gaze",
 				fr: "Regard paralysant",
-				de: "Lähmender Kick"
+				de: "Lähmender Blick"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 
 		},

--- a/data/EX/Crystal Guardians/68.ts
+++ b/data/EX/Crystal Guardians/68.ts
@@ -51,7 +51,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt verwirrt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: 10,
 

--- a/data/EX/Crystal Guardians/69.ts
+++ b/data/EX/Crystal Guardians/69.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt verwirrt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 
 		},

--- a/data/EX/Crystal Guardians/71.ts
+++ b/data/EX/Crystal Guardians/71.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. If you have any cards in your hand, shuffle 1 of them into your deck, then draw 3 cards.",
 		fr: "Si vous avez des cartes en main, mélangez-en 1 à votre deck puis piochez 3 cartes.",
-		de: "Wenn du mindestens 1 Karte auf der Hand hast, mische 1 von ihnen in dein Deck und ziehe dann 3 Karten.",
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Wenn du mindestens 1 Karte auf der Hand hast, mische 1 von ihnen in dein Deck und ziehe dann 3 Karten.",
 	},
 
 	thirdParty: {

--- a/data/EX/Crystal Guardians/72.ts
+++ b/data/EX/Crystal Guardians/72.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Search your deck for a Supporter card, a Pokémon Tool card, and a basic Energy card. Show them to your opponent, and put them into your hand. Shuffle your deck afterward.",
 		fr: "Choisissez dans votre deck une carte Supporter, une carte Outil Pokémon et une carte Énergie de base. Montrez-les à votre adversaire et placez-les dans votre main. Ensuite, mélangez votre deck.",
-		de: "Durchsuche dein Deck nach einer Pokémon-Ausrüstungs-Karte und einer Basis-Energiekarte. Zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach.",
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Durchsuche dein Deck nach einer Pokémon-Ausrüstungs-Karte und einer Basis-Energiekarte. Zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach.",
 	},
 
 	thirdParty: {

--- a/data/EX/Crystal Guardians/73.ts
+++ b/data/EX/Crystal Guardians/73.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Search your deck for a Basic Pokémon or Evolution card (excluding Pokémon-ex), show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
 		fr: "Choisissez dans votre deck un Pokémon de base ou une carte Évolution (Pokémon-ex exclus). Montrez-le (ou la) à votre adversaire et placez-le (ou la) dans votre main. Ensuite, mélangez votre deck.",
-		de: "Durchsuche dein Deck nach einer Basis-Pokémon-Karte oder einer Evolutionskarte (kein Pokémon-ex), zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach.",
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Durchsuche dein Deck nach einer Basis-Pokémon-Karte oder einer Evolutionskarte (kein Pokémon-ex), zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach.",
 	},
 
 	thirdParty: {

--- a/data/EX/Crystal Guardians/74.ts
+++ b/data/EX/Crystal Guardians/74.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "Attach Cessation Crystal to 1 of your Pokémon (excluding Pokémon-ex) that doesn't already have a Pokémon Tool attached to it. If the Pokémon Cessation Crystal is attached to is a Pokémon-ex, discard this card. As long as Cessation Crystal is attached to an Active Pokémon, each player's Pokémon (both yours and your opponent's) can't use any Poké-Powers or Poké-Bodies.",
 		fr: "Attachez Arrêt de cristal à 1 de vos Pokémon (Pokémon-ex exclus) qui ne possède pas déjà d'Outil Pokémon. Si le Pokémon auquel Arrêt de cristal est attachée est un Pokémon-ex, défaussez cette carte.\n\nTant qu'Arrêt de cristal est attachée à un Pokémon Actif, les Pokémon de chaque joueur (les vôtres et ceux de votre adversaire) ne peuvent pas utiliser de Poké-Powers ou de Poké-Bodies.",
-		de: "Solange Kristall des Stillstandes an einem Aktiven Pokémon anliegt, können Pokémon (deine und die deines Gegners) keine Poké-Power und Poké-Body benutzen."
+		de: "Lege Kristall des Stillstandes an 1 deiner Pokémon an (kein Pokémon-ex), an dem noch keine Pokémon-Ausrüstung anliegt. Wenn Kristall des Stillstands an ein Pokémon-ex angelegt ist, lege diese Karte auf deinen Ablagestapel. Solange Kristall des Stillstandes an einem Aktiven Pokémon anliegt, können Pokémon (deine und die deines Gegners) keine Poké-Power und Poké-Body benutzen."
 	},
 
 	thirdParty: {

--- a/data/EX/Crystal Guardians/75.ts
+++ b/data/EX/Crystal Guardians/75.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card. Each Special Energy card that provides 2 or more Energy (both yours and your opponent's) now provides only 1 Colorless Energy. This isn't affected by any Poké-Powers or Poké-Bodies.",
 		fr: "Chaque carte Énergie spéciale fournissant 2 Énergies ou plus (les vôtres et celles de votre adversaire) fournit maintenant 1 Énergie Incolore uniquement. Cet effet n'est pas affecté par les Poké-Powers ou les Poké-Bodies.",
-		de: "Jede Spezialenergiekarte, die 2 oder mehr Energie liefert (deine und die deines Gegners), liefert jetzt nur noch 1  Energie, Poké-Power und Poké-Body haben keine Einfluss hierauf.",
+		de: "Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadion-Karte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen. Jede Spezialenergiekarte, die 2 oder mehr Energie liefert (deine und die deines Gegners), liefert jetzt nur noch 1 {C} Energie, Poké-Power und Poké-Body haben keine Einfluss hierauf.",
 	},
 
 	thirdParty: {

--- a/data/EX/Crystal Guardians/76.ts
+++ b/data/EX/Crystal Guardians/76.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "Attach Crystal Shard to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card. As long as Crystal Shard is attached to a Pokémon, that Pokémon's type is Colorless. If that Pokémon attacks, discard this card at the end of the turn.",
 		fr: "Attachez Écharde de cristal à 1 de vos Pokémon qui ne possède pas déjà d'Outil Pokémon. Si ce Pokémon est mis K.O, défaussez cette carte.\n\nTant qu'Écharde de cristal est attachée à un Pokémon, ce Pokémon est de type . S'il attaque, défaussez cette carte à la fin du tour.",
-		de: "Solange diese Karte an ein Pokémon angelegt ist, erhält das Pokémon den Typ . Wenn das Pokémon angreift, lege diese Karte am Ende deines Zuges auf deinen Ablagestapel."
+		de: "Lege Kristallsplitter an 1 deiner Pokémon an, an dem noch keine Pokémon-Ausrüstung anliegt. Wenn das Pokémon, an das Kristallsplitter angelegt ist, kampfunfähig gemacht wird, lege Kristallsplitter auf den Ablagestapel. Solange diese Karte an ein Pokémon angelegt ist, erhält das Pokémon den Typ {C}. Wenn das Pokémon angreift, lege diese Karte am Ende deines Zuges auf deinen Ablagestapel."
 	},
 
 	thirdParty: {

--- a/data/EX/Crystal Guardians/78.ts
+++ b/data/EX/Crystal Guardians/78.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "Flip 2 coins. For each heads, search your deck for a Basic Pokémon card, show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
 		fr: "Lancez 2 pièces. Pour chaque face, choisissez dans votre deck un Pokémon de base, montrez-le à votre adversaire et placez-le dans votre main. Ensuite, mélangez votre deck.",
-		de: "Wirf 2 Münzen. Durchsuche dein Deck pro \"Kopf\" nach einer Basis-Pokémon-Karte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
+		de: "Wirf 2 Münzen. Durchsuche dein Deck pro „Kopf“ nach einer Basis-Pokémon-Karte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 	},
 
 	thirdParty: {

--- a/data/EX/Crystal Guardians/79.ts
+++ b/data/EX/Crystal Guardians/79.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card. Prevent all effects of an attack, including damage, done by either player's Active Pokémon. If an Active Pokémon uses an attack, that attack ends, and discard this card.",
 		fr: "Prévenez tous les effets d'une attaque, dégâts inclus, infligés par les Pokémon Actifs de chaque joueur. Si un Pokémon Actif utilise une attaque, cette attaque se termine. Défaussez cette carte.",
-		de: "Verhindere alle Effekte von Angriffen, inklusive Schaden, die durch Aktive Pokémon (deins oder das deines Gegners) verursacht werden. Wenn ein Aktives Pokémon einen Angriff einsetzt, wird dieser Angriff ohne Auswirkungen beendet und der Holon-Kreis auf deinen Ablagestapel gelegt.",
+		de: "Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadion-Karte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen. Verhindere alle Effekte von Angriffen, inklusive Schaden, die durch Aktive Pokémon (deins oder das deines Gegners) verursacht werden. Wenn ein Aktives Pokémon einen Angriff einsetzt, wird dieser Angriff ohne Auswirkungen beendet und der Holon-Kreis auf deinen Ablagestapel gelegt.",
 	},
 
 	thirdParty: {

--- a/data/EX/Crystal Guardians/8.ts
+++ b/data/EX/Crystal Guardians/8.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Electrike",
-		fr: "Dynavolt"
+		fr: "Dynavolt",
+		de: "Frizelbliz"
 	},
 
 	stage: "Stage1",

--- a/data/EX/Crystal Guardians/80.ts
+++ b/data/EX/Crystal Guardians/80.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "Attach Memory Berry to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card. The Pokémon this card is attached to can use any attack from its Basic Pokémon or its Stage 1 Evolution card. (You still have to pay for that attack's Energy cost.) If that Pokémon attacks, discard this card at the end of the turn.",
 		fr: "Attachez Baie de mémoire à 1 de vos Pokémon qui ne possède pas déjà d'Outil Pokémon. Si ce Pokémon est mis K.O, défaussez cette carte.\n\nLe Pokémon auquel cette carte est attachée peut utiliser n'importe quelle attaque de sa carte Pokémon de base ou de sa carte Évolution de Niveau 1. (Vous devez toujours payer le Coût en Énergie de cette attaque.) Si ce Pokémon attaque, défaussez cette carte à la fin du tour.",
-		de: "Das Pokémon, an das diese Karte anliegt, kann jeden Angriff seiner Basis- oder Phase 1-Pokémon-Karten verwenden. (Du musst die Energiekosten für diesen Angriff trotzdem bezahlen.) Wenn dieses Pokémon angreift, lege die Karte am Ende des Zuges auf den Ablagestapel."
+		de: "Lege Erinnerungsbeere an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn dieses Pokémon kampfunfähig wird, lege Erinnerungsbeere auf den Ablagestapel. Das Pokémon, an das diese Karte anliegt, kann jeden Angriff seiner Basis- oder Phase 1-Pokémon-Karten verwenden. (Du musst die Energiekosten für diesen Angriff trotzdem bezahlen.) Wenn dieses Pokémon angreift, lege die Karte am Ende des Zuges auf den Ablagestapel."
 	},
 
 	thirdParty: {

--- a/data/EX/Crystal Guardians/81.ts
+++ b/data/EX/Crystal Guardians/81.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "Attach Mysterious Shard to 1 of your Pokémon (excluding Pokémon-ex) that doesn't already have a Pokémon Tool attached to it. If the Pokémon Mysterious Shard is attached to is a Pokémon-ex, discard this card. Prevent all effects of attacks, including damage, done to the Pokémon that Mysterious Shard is attached to by your opponent's Pokémon-ex. Discard this card at the end of your opponent's next turn.",
 		fr: "Attachez Écharde mystérieuse à 1 de vos Pokémon (Pokémon-ex exclus) qui ne possède pas déjà d'Outil Pokémon. Si le Pokémon auquel Écharde mystérieuse est attachée est un Pokémon-ex, défaussez cette carte.\n\nPrévenez tous les effets d'une attaque, dégâts inclus, infligés au Pokémon auquel Écharde mystérieuse est attachée par des Pokémon-ex de votre adversaire. Défaussez cette carte à la fin du prochain tour de votre adversaire.",
-		de: "Verhindere alle Effekte von Angriffen, inklusive Schaden, die dem Pokémon, an das Mysteriöser Splitter angelegt ist, von gegnerischen Pokémon-ex zugefügt werden. Lege Mysteriöser Splitter am Ende des nächsten Zuges deines Gegners auf deinen Ablagestapel."
+		de: "Lege Mysteriöser Splitter an 1 deiner Pokémon an (kein Pokémon-ex), an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn Mysteriöser Splitter an einem Pokémon-ex angelegt ist, lege diese Karte auf deinen Ablagestapel. Verhindere alle Effekte von Angriffen, inklusive Schaden, die dem Pokémon, an das Mysteriöser Splitter angelegt ist, von gegnerischen Pokémon-ex zugefügt werden. Lege Mysteriöser Splitter am Ende des nächsten Zuges deines Gegners auf deinen Ablagestapel."
 	},
 
 	thirdParty: {

--- a/data/EX/Crystal Guardians/82.ts
+++ b/data/EX/Crystal Guardians/82.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "Flip a coin. If heads, search your deck for a Basic Pokémon or Evolution card, show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
 		fr: "Lancez une pièce. Si c'est face, choisissez dans votre deck un Pokémon de base ou une carte Évolution, montrez-le (ou la) à votre adversaire et placez-le (ou la) dans votre main. Ensuite, mélangez votre deck.",
-		de: "Wirf 1 Münze. Bei \"Kopf\" durchsuche dein Deck nach einer Basis-Pokémon-Karte oder einer Evolutionskarte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
+		de: "Wirf 1 Münze. Bei „Kopf“ durchsuche dein Deck nach einer Basis-Pokémon-Karte oder einer Evolutionskarte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 	},
 
 	thirdParty: {

--- a/data/EX/Crystal Guardians/89.ts
+++ b/data/EX/Crystal Guardians/89.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Lairon",
-		fr: "Galegon"
+		fr: "Galegon",
+		de: "Stollrak"
 	},
 
 	suffix: "ex",

--- a/data/EX/Crystal Guardians/90.ts
+++ b/data/EX/Crystal Guardians/90.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Combusken",
-		fr: "Galifeu"
+		fr: "Galifeu",
+		de: "Jungglut"
 	},
 
 	suffix: "ex",

--- a/data/EX/Crystal Guardians/91.ts
+++ b/data/EX/Crystal Guardians/91.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Skitty",
-		fr: "Skitty"
+		fr: "Skitty",
+		de: "Eneco"
 	},
 
 	suffix: "ex",

--- a/data/EX/Crystal Guardians/92.ts
+++ b/data/EX/Crystal Guardians/92.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Loudred",
-		fr: "Ramboum"
+		fr: "Ramboum",
+		de: "Krakeelo"
 	},
 
 	suffix: "ex",

--- a/data/EX/Crystal Guardians/94.ts
+++ b/data/EX/Crystal Guardians/94.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "As long as your opponent has any Pokémon-ex or Stage 2 Evolved Pokémon in play, Jirachi ex pays Colorless less Energy to use Shield Beam or Super Psy Bolt.",
 				fr: "Tant que votre adversaire possède des Pokémon-ex ou des Pokémon Évolués de Niveau 2 en jeu, Jirachi ex paye une Énergie  de moins pour utiliser Rayon protecteur ou Super psy.",
-				de: "Solange dein Gegner mindestens 1 Pokémon-ex oder ein entwickeltes Pokémon der Phase 2 im Spiel hat, kosten Jirachi ex' Schildstrahl und Super-Psischlag 1  weniger."
+				de: "Solange dein Gegner mindestens 1 Pokémon-ex oder ein entwickeltes Pokémon der Phase 2 im Spiel hat, kosten Jirachi ex' Schildstrahl und Super-Psischlag 1 {C} weniger."
 			},
 		},
 	],

--- a/data/EX/Crystal Guardians/96.ts
+++ b/data/EX/Crystal Guardians/96.ts
@@ -26,7 +26,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Grovyle",
-		fr: "Massko"
+		fr: "Massko",
+		de: "Reptain"
 	},
 
 	stage: "Stage2",
@@ -42,7 +43,7 @@ const card: Card = {
 			effect: {
 				en: "Each player's Pokémon-ex can't use any Poké-Powers and pays Colorless more Energy to use its attacks. Each Pokémon can't be affected by more than 1 Extra Liquid Poké-Body.",
 				fr: "Le Pokémon-ex de chaque joueur ne peut pas utiliser de Poké-Powers et paye une Énergie  de plus pour utiliser ses attaques. Chaque Pokémon ne peut pas être affecté par plus d'1 Poké-Body Liquide supplémentaire.",
-				de: "Die Pokémon-ex aller Spieler können keine Poké-Power einsetzen und ihre Angriffe kosten 1  mehr. Jedes Pokémon kann nur von 1 Extraflüssigkeit Poké-Body betroffen sein."
+				de: "Die Pokémon-ex aller Spieler können keine Poké-Power einsetzen und ihre Angriffe kosten 1 {C} mehr. Jedes Pokémon kann nur von 1 Extraflüssigkeit Poké-Body betroffen sein."
 			},
 		},
 	],

--- a/data/EX/Crystal Guardians/97.ts
+++ b/data/EX/Crystal Guardians/97.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Nuzleaf",
-		fr: "Pifeuil"
+		fr: "Pifeuil",
+		de: "Blanas"
 	},
 
 	suffix: "ex",

--- a/data/EX/Crystal Guardians/98.ts
+++ b/data/EX/Crystal Guardians/98.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Marshtomp",
-		fr: "Flobio"
+		fr: "Flobio",
+		de: "Moorabbel"
 	},
 
 	suffix: "ex",


### PR DESCRIPTION
## Add missing German translations for ex14

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
