### PR TITLE
Add missing German translations for tk-bw-z

### DIFF
--- a/data/Trainer kits/BW trainer Kit (Zoroark)/1.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/1.ts
@@ -29,7 +29,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Scratch",
-			fr: "Griffe"
+			fr: "Griffe",
+			de: "Kratzer"
 		},
 		damage: 10
 	}, {
@@ -39,7 +40,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Slash",
-			fr: "Tranche"
+			fr: "Tranche",
+			de: "Schlitzer"
 		},
 		damage: 20
 	}],
@@ -55,7 +57,8 @@ const card: Card = {
 	}],
 
 	description: {
-		en: "Its cute act is a ruse. When victims let down their guard, they find their items taken. It attacks with sharp claws."
+		en: "Its cute act is a ruse. When victims let down their guard, they find their items taken. It attacks with sharp claws.",
+		de: "Es lenkt die Menschen durch sein süßes Verhalten ab, um sie zu bestehlen. Ist es wütend, kratzt es gern mal."
 	},
 
 	retreat: 1,

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/12.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/12.ts
@@ -31,7 +31,8 @@ const card: Card = {
 				],
 				name: {
 					en: "Tackle",
-					fr: "Charge"
+					fr: "Charge",
+					de: "Tackle"
 				},
 				damage: 10
 			}, {
@@ -41,7 +42,8 @@ const card: Card = {
 				],
 				name: {
 					en: "Bite",
-					fr: "Morsure"
+					fr: "Morsure",
+					de: "Biss"
 				},
 				damage: 20
 			}
@@ -55,7 +57,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "Using food stored in cheek pouches, they can keep watch for days. They use their tails to communicate with others."
+		en: "Using food stored in cheek pouches, they can keep watch for days. They use their tails to communicate with others.",
+		de: "Hortet in seinen Backentaschen Futter, um tagelang Wache stehen zu können, und gibt Kameraden über seine Rute Signale."
 	},
 
 	retreat: 1,

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/13.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/13.ts
@@ -30,11 +30,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Lunge",
-			fr: "Coup Rapide"
+			fr: "Coup Rapide",
+			de: "Ausfall"
 		},
 		effect: {
 			en: "Flip a coin. If tails, this attack does nothing.",
-			fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien."
+			fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+			de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 		},
 		damage: 30
 	}],
@@ -50,7 +52,8 @@ const card: Card = {
 	}],
 
 	description: {
-		en: "To protect themselves from danger, they hide their true identities by transforming into people and Pokémon."
+		en: "To protect themselves from danger, they hide their true identities by transforming into people and Pokémon.",
+		de: "Es tarnt sich als Mensch oder als andere Pokémon. Es schützt sich vor Gefahren, indem es seine wahre Gestalt geheim hält."
 	},
 
 	retreat: 1,

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/14.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/14.ts
@@ -29,11 +29,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Quick Attack",
-			fr: "Vive-Attaque"
+			fr: "Vive-Attaque",
+			de: "Ruckzuckhieb"
 		},
 		effect: {
 			en: "Flip a coin. If heads, this attack does 10 more damage.",
-			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts supplémentaires."
+			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts supplémentaires.",
+			de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 10 weitere Schadenspunkte zu."
 		},
 		damage: "10+"
 	}],
@@ -49,7 +51,8 @@ const card: Card = {
 	}],
 
 	description: {
-		en: "Each follows its Trainer's orders as best it can, but they sometimes fail to understand complicated commands."
+		en: "Each follows its Trainer's orders as best it can, but they sometimes fail to understand complicated commands.",
+		de: "Gewöhnlich hört es zwar auf das, was sein Trainer sagt, doch manchmal kommt es mit komplizierten Befehlen nicht klar."
 	},
 
 	retreat: 1,

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/15.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/15.ts
@@ -38,7 +38,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Gust",
-			fr: "Tornade"
+			fr: "Tornade",
+			de: "Windstoß"
 		},
 		damage: 20
 	}, {
@@ -48,11 +49,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Quick Attack",
-			fr: "Vive-Attaque"
+			fr: "Vive-Attaque",
+			de: "Ruckzuckhieb"
 		},
 		effect: {
 			en: "Flip a coin. If heads, this attack does 30 more damage.",
-			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires."
+			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires.",
+			de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 weitere Schadenspunkte zu."
 		},
 		damage: "20+"
 	}],
@@ -68,7 +71,8 @@ const card: Card = {
 	}],
 
 	description: {
-		en: "It can return to its Trainer's location regardless of the distance separating them."
+		en: "It can return to its Trainer's location regardless of the distance separating them.",
+		de: "Egal wie weit es auch von seinem Trainer entfernt ist, es findet immer wieder zu ihm zurück."
 	},
 
 	retreat: 1,

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/17.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/17.ts
@@ -40,11 +40,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Fury Swipes",
-			fr: "Combo-Griffe"
+			fr: "Combo-Griffe",
+			de: "Kratzfurie"
 		},
 		effect: {
 			en: "Flip 3 coins. This attack does 20 damage times the number of heads.",
-			fr: "Lancez 3 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face."
+			fr: "Lancez 3 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+			de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 		},
 		damage: "20×"
 	}, {
@@ -55,7 +57,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Night Daze",
-			fr: "Explonuit"
+			fr: "Explonuit",
+			de: "Nachtflut"
 		},
 		damage: 80
 	}],
@@ -71,7 +74,8 @@ const card: Card = {
 	}],
 
 	description: {
-		en: "Bonds between these Pokémon are very strong. It protects the safety of its pack by tricking its opponents."
+		en: "Bonds between these Pokémon are very strong. It protects the safety of its pack by tricking its opponents.",
+		de: "Seit jeher beschützt es das Rudel, indem es die Gestalt des Feindes annimmt. Es ist sehr loyal zu seinen Artgenossen."
 	},
 
 	retreat: 2,

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/19.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/19.ts
@@ -29,11 +29,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Tail Slap",
-			fr: "Plumo-Queue"
+			fr: "Plumo-Queue",
+			de: "Kehrschelle"
 		},
 		effect: {
 			en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
-			fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face."
+			fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+			de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 		},
 		damage: "10x"
 	}],
@@ -44,7 +46,8 @@ const card: Card = {
 	}],
 
 	description: {
-		en: "They greet one another by rubbing each other with their tails, which are always kept well groomed and clean."
+		en: "They greet one another by rubbing each other with their tails, which are always kept well groomed and clean.",
+		de: "Sie sorgen dafür, dass ihre Schweife stets schön sauber sind, da sie diese zur Begrüßung aneinanderreiben."
 	},
 
 	retreat: 1,

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/2.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/2.ts
@@ -40,11 +40,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Confuse Ray",
-			fr: "Onde Folie"
+			fr: "Onde Folie",
+			de: "Konfustrahl"
 		},
 		effect: {
 			en: "The Defending Pokémon is now Confused.",
-			fr: "Le Pokémon Défenseur est maintenant Confus."
+			fr: "Le Pokémon Défenseur est maintenant Confus.",
+			de: "Das Verteidigende Pokémon ist jetzt verwirrt."
 		}
 	}, {
 		cost: [
@@ -53,11 +55,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Hyper Fang",
-			fr: "Croc de Mort"
+			fr: "Croc de Mort",
+			de: "Hyperzahn"
 		},
 		effect: {
 			en: "Flip a coin. If tails, this attack does nothing.",
-			fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien."
+			fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+			de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 		},
 		damage: 60
 	}],
@@ -68,7 +72,8 @@ const card: Card = {
 	}],
 
 	description: {
-		en: "They make the patterns on their bodies shine in order to threaten predators. Keen eyesight lets them see in the dark."
+		en: "They make the patterns on their bodies shine in order to threaten predators. Keen eyesight lets them see in the dark.",
+		de: "Schüchtert Gegner ein, indem es die Maserung seines Fells aufblitzen lässt. Auch im Dunkeln entgeht ihm nichts."
 	},
 
 	retreat: 1,

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/21.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/21.ts
@@ -29,11 +29,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Quick Attack",
-			fr: "Vive-Attaque"
+			fr: "Vive-Attaque",
+			de: "Ruckzuckhieb"
 		},
 		effect: {
 			en: "Flip a coin. If heads, this attack does 10 more damage.",
-			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts supplémentaires."
+			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts supplémentaires.",
+			de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 10 weitere Schadenspunkte zu."
 		},
 		damage: "10+"
 	}],
@@ -49,7 +51,8 @@ const card: Card = {
 	}],
 
 	description: {
-		en: "Each follows its Trainer's orders as best it can, but they sometimes fail to understand complicated commands."
+		en: "Each follows its Trainer's orders as best it can, but they sometimes fail to understand complicated commands.",
+		de: "Gewöhnlich hört es zwar auf das, was sein Trainer sagt, doch manchmal kommt es mit komplizierten Befehlen nicht klar."
 	},
 
 	retreat: 1,

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/23.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/23.ts
@@ -30,11 +30,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Lunge",
-			fr: "Coup Rapide"
+			fr: "Coup Rapide",
+			de: "Ausfall"
 		},
 		effect: {
 			en: "Flip a coin. If tails, this attack does nothing.",
-			fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien."
+			fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+			de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 		},
 		damage: 30
 	}],
@@ -50,7 +52,8 @@ const card: Card = {
 	}],
 
 	description: {
-		en: "To protect themselves from danger, they hide their true identities by transforming into people and Pokémon."
+		en: "To protect themselves from danger, they hide their true identities by transforming into people and Pokémon.",
+		de: "Es tarnt sich als Mensch oder als andere Pokémon. Es schützt sich vor Gefahren, indem es seine wahre Gestalt geheim hält."
 	},
 
 	retreat: 1,

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/25.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/25.ts
@@ -29,7 +29,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Scratch",
-			fr: "Griffe"
+			fr: "Griffe",
+			de: "Kratzer"
 		},
 		damage: 10
 	}, {
@@ -39,7 +40,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Slash",
-			fr: "Tranche"
+			fr: "Tranche",
+			de: "Schlitzer"
 		},
 		damage: 20
 	}],
@@ -55,7 +57,8 @@ const card: Card = {
 	}],
 
 	description: {
-		en: "Its cute act is a ruse. When victims let down their guard, they find their items taken. It attacks with sharp claws."
+		en: "Its cute act is a ruse. When victims let down their guard, they find their items taken. It attacks with sharp claws.",
+		de: "Es lenkt die Menschen durch sein süßes Verhalten ab, um sie zu bestehlen. Ist es wütend, kratzt es gern mal."
 	},
 
 	retreat: 1,

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/29.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/29.ts
@@ -29,7 +29,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Tackle",
-			fr: "Charge"
+			fr: "Charge",
+			de: "Tackle"
 		},
 		damage: 10
 	}, {
@@ -39,7 +40,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Bite",
-			fr: "Morsure"
+			fr: "Morsure",
+			de: "Biss"
 		},
 		damage: 20
 	}],
@@ -50,7 +52,8 @@ const card: Card = {
 	}],
 
 	description: {
-		en: "Using food stored in cheek pouches, they can keep watch for days. They use their tails to communicate with others."
+		en: "Using food stored in cheek pouches, they can keep watch for days. They use their tails to communicate with others.",
+		de: "Hortet in seinen Backentaschen Futter, um tagelang Wache stehen zu können, und gibt Kameraden über seine Rute Signale."
 	},
 
 	retreat: 1,

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/30.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/30.ts
@@ -40,11 +40,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Fury Swipes",
-			fr: "Combo-Griffe"
+			fr: "Combo-Griffe",
+			de: "Kratzfurie"
 		},
 		effect: {
 			en: "Flip 3 coins. This attack does 20 damage times the number of heads.",
-			fr: "Lancez 3 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face."
+			fr: "Lancez 3 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+			de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 		},
 		damage: "20×"
 	}, {
@@ -55,7 +57,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Night Daze",
-			fr: "Explonuit"
+			fr: "Explonuit",
+			de: "Nachtflut"
 		},
 		damage: 80
 	}],
@@ -71,7 +74,8 @@ const card: Card = {
 	}],
 
 	description: {
-		en: "Bonds between these Pokémon are very strong. It protects the safety of its pack by tricking its opponents."
+		en: "Bonds between these Pokémon are very strong. It protects the safety of its pack by tricking its opponents.",
+		de: "Seit jeher beschützt es das Rudel, indem es die Gestalt des Feindes annimmt. Es ist sehr loyal zu seinen Artgenossen."
 	},
 
 	retreat: 2,

--- a/data/Trainer kits/BW trainer Kit (Zoroark)/4.ts
+++ b/data/Trainer kits/BW trainer Kit (Zoroark)/4.ts
@@ -29,11 +29,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Tail Slap",
-			fr: "Plumo-Queue"
+			fr: "Plumo-Queue",
+			de: "Kehrschelle"
 		},
 		effect: {
 			en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
-			fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face."
+			fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+			de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 		},
 		damage: "10x"
 	}],
@@ -44,7 +46,8 @@ const card: Card = {
 	}],
 
 	description: {
-		en: "They greet one another by rubbing each other with their tails, which are always kept well groomed and clean."
+		en: "They greet one another by rubbing each other with their tails, which are always kept well groomed and clean.",
+		de: "Sie sorgen dafür, dass ihre Schweife stets schön sauber sind, da sie diese zur Begrüßung aneinanderreiben."
 	},
 
 	retreat: 1,


### PR DESCRIPTION
## Add missing German translations for tk-bw-z

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
