### PR TITLE
Add missing German translations for hgss2

### DIFF
--- a/data/HeartGold & SoulSilver/Unleashed/90.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/90.ts
@@ -41,7 +41,7 @@ const card: Card = {
 
 		effect: {
 			en: "Discard a Fire Energy attached to Entei & Raikou LEGEND.",
-			de: "Lege 1 an Entei & Raikou-LEGENDE angelegte -Energie auf deinen Ablagestapel."
+			de: "Lege 1 an Entei & Raikou-LEGENDE angelegte {R}-Energie auf deinen Ablagestapel."
 		},
 
 		cost: ["Fire", "Colorless"]

--- a/data/HeartGold & SoulSilver/Unleashed/94.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/94.ts
@@ -60,7 +60,7 @@ const card: Card = {
 
 		effect: {
 			en: "Return 2 Water Energy attached to Suicune & Entei LEGEND to your hand. Choose 1 of your opponent's Benched Pokémon. This attack does 100 damage to that Pokémon. (Don't apply Weakness or Resistance for Benched Pokémon.)",
-			de: "Nimm 2 -Energiekarten, die an Suicune & Entei-LEGENDE angelegt sind, zurück auf deine Hand. Dieser Angriff fügt 1 Pokémon auf der Bank deines Gegners 100 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+			de: "Nimm 2 {W}-Energiekarten, die an Suicune & Entei-LEGENDE angelegt sind, zurück auf deine Hand. Dieser Angriff fügt 1 Pokémon auf der Bank deines Gegners 100 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 		},
 
 		cost: ["Water", "Water", "Colorless"]


### PR DESCRIPTION
## Add missing German translations for hgss2

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
