### PR TITLE
Add missing German translations for bw9

### DIFF
--- a/data/Black & White/Plasma Freeze/1.ts
+++ b/data/Black & White/Plasma Freeze/1.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Triple Stab",
 				fr: "Aiguillon Triple",
+				de: "Triplexstich"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 10,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "It eats its weight in leaves every day. It fends off attackers with the needle on its head.",
+		de: "Es frisst täglich sein Gewicht in Blättern. Die Nadel auf seinem Kopf dient der Verteidigung."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/10.ts
+++ b/data/Black & White/Plasma Freeze/10.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cacnea",
 		fr: "Cacnea",
+		de: "Tuska"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Rapid-Fire Needles",
 				fr: "Salve d'Aiguilles",
+				de: "Schnellfeuernadeln"
 			},
 			effect: {
 				en: "Does 30 damage to 1 of your Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 30 dégâts à 1 de vos Pokémon. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 1 deiner Pokémon 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 60,
 
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Payback",
 				fr: "Représailles",
+				de: "Gegenstoß"
 			},
 			effect: {
 				en: "If your opponent has only 1 Prize card left, this attack does 60 more damage and discard an Energy attached to the Defending Pokémon.",
 				fr: "S'il ne reste qu'une seule carte Récompense à votre adversaire, cette attaque inflige 60 dégâts supplémentaires et vous défaussez une Énergie attachée au Pokémon Défenseur.",
+				de: "Wenn dein Gegner nur 1 Preiskarte übrig hat, fügt dieser Angriff 60 weitere Schadenspunkte zu. Lege 1 an das Verteidigende Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 30,
 
@@ -85,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "It becomes active at night, seeking prey that is exhausted from the day's desert heat.",
+		de: "Ein nachtaktives Pokémon, das Beute sucht, die durch die Tageshitze der Wüste bereits erschöpft ist."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/100.ts
+++ b/data/Black & White/Plasma Freeze/100.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cada vez que algún jugador una una Energía de su mano a 1 de sus Pokémon (excluidos los Pokémon del Equipo Plasma), pon 2 contadores de daño en ese Pokémon.",
 		it: "Quando uno dei giocatori assegna un’Energia dalla sua mano a uno dei suoi Pokémon, esclusi i Pokémon Team Plasma, metti due segnalini danno su quel Pokémon.",
 		pt: "Sempre que qualquer jogador ligar uma Energia de sua própria mão a 1 dos Pokémon desse mesmo jogador (exceto Pokémon da Equipe Plasma), coloque 2 marcadores de danos nesse Pokémon.",
-		de: "Lege jedes Mal, wenn ein Spieler eine Energie von seiner Hand an 1 seiner Pokémon (ausgenommen Team-Plasma-Pokémon) anlegt, 2 Schadensmarken auf das Pokémon."
+		de: "Lege jedes Mal, wenn ein Spieler 1 Energie von seiner Hand an 1 seiner Pokémon anlegt (ausgenommen Team Plasma-Pokémon), 2 Schadensmarken auf das Pokémon. Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 
 	trainerType: "Stadium",

--- a/data/Black & White/Plasma Freeze/101.ts
+++ b/data/Black & White/Plasma Freeze/101.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Tu rival enseña las cartas de su mano, pone todas las cartas de Objeto que encuentre entre ellas en su baraja y las baraja todas. Después, tú robas un número de cartas igual al número de cartas de Objeto que tu rival haya puesto en su baraja.",
 		it: "Il tuo avversario mostra la sua mano e rimischia tutte le carte Strumento che ha in mano nel suo mazzo. Poi pesca un numero di carte pari al numero di carte Strumento che il tuo avversario ha rimischiato nel suo mazzo.",
 		pt: "Seu oponente revela a mão e embaralha todos os cards de Item encontrados em sua mão no próprio baralho. Em seguida, compre um número de cards igual ao número de cards de Item que seu oponente embaralhou em seu deck.",
-		de: "Dein Gegner deckt seine Handkarten auf und mischt alle dort gefundenen Itemkarten in sein Deck. Ziehe anschließend genauso viele Karten, wie dein Gegner Itemkarten in sein Deck gemischt hat."
+		de: "Dein Gegner deckt seine Handkarten auf und mischt alle dort gefundenen Itemkarten zurück in sein Deck. Ziehe anschließend genauso viele Karten, wie dein Gegner Itemkarten zurück in sein Deck gemischt hat. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Black & White/Plasma Freeze/102.ts
+++ b/data/Black & White/Plasma Freeze/102.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon una carta del Equipo Plasma de tu pila de descartes en tu mano.",
 		it: "Prendi una carta Team Plasma dalla tua pila degli scarti e aggiungila a quelle che hai in mano.",
 		pt: "Coloque um card da Equipe Plasma da sua pilha de descarte em sua mão.",
-		de: "Nimm 1 Team-Plasma-Karte von deinem Ablagestapel auf deine Hand."
+		de: "Nimm 1 Team Plasma-Karte von deinem Ablagestapel auf deine Hand. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Black & White/Plasma Freeze/103.ts
+++ b/data/Black & White/Plasma Freeze/103.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta 2 cartas de tu mano. (Si no puedes descartar 2 cartas, no puedes jugar esta carta.) Pon 4 cartas de Energía Básica de tu pila de descartes en tu mano. (No puedes elegir una carta que hayas descartado con el efecto de esta carta.)",
 		it: "Scarta due delle carte che hai in mano. Se non puoi scartarne due, non puoi giocare questa carta. Prendi quattro carte Energia base dalla tua pila degli scarti e aggiungile a quelle che hai in mano. Ricorda che non puoi scegliere una carta scartata con l’effetto di questa carta.",
 		pt: "Descarte 2 cards da sua mão. (Se você não puder descartar 2 cards, não poderá jogar esse card.) Coloque 4 cards de Energia básica da sua pilha de descarte em sua mão. (Não é possível escolher um card que foi descartado com o efeito deste card.)",
-		de: "Lege 2 Karten von deiner Hand auf deinen Ablagestapel. (Wenn du keine 2 Karten von der Hand auf deinen Ablagestapel legen kannst, kannst du diese Karte nicht spielen.) Nimm 4 Basis-Energiekarten von deinem Ablagestapel auf deine Hand. (Du darfst keine Karte nehmen, die du aufgrund dieser Karte auf den Ablagestapel gelegt hast.)"
+		de: "Lege 2 Karten von deiner Hand auf deinen Ablagestapel. (Wenn du keine 2 Karten auf deinen Ablagestapel legen kannst, kannst du diese Karte nicht spielen.) Nimm 4 Basis-Energiekarten von deinem Ablagestapel auf deine Hand. (Du kannst keine Karte auswählen, die du mit dem Effekt dieser Karte auf deinen Ablagestapel gelegt hast.) Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Plasma Freeze/104.ts
+++ b/data/Black & White/Plasma Freeze/104.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "El Pokémon al que esté unida esta carta es un Pokémon del Equipo Plasma.",
 		it: "Il Pokémon a cui è assegnata questa carta è un Pokémon del Team Plasma.",
 		pt: "O Pokémon ao qual este card está ligado é um Pokémon da Equipe Plasma.",
-		de: "Das Pokémon, an das diese Karte angelegt ist, ist ein Team Plasma-Pokémon."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Das Pokémon, an das diese Karte angelegt ist, ist ein Team Plasma-Pokémon. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Black & White/Plasma Freeze/105.ts
+++ b/data/Black & White/Plasma Freeze/105.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja a un Pokémon del Equipo Plasma, enséñalo y ponlo en tu mano. Baraja las cartas de tu baraja después.",
 		it: "Cerca nel tuo mazzo un Pokémon Team Plasma, mostralo e aggiungilo alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure um Pokémon da Equipe Plasma em seu baralho, revele-o e coloque-o em sua mão. Em seguida, embaralhe seus cards.",
-		de: "Durchsuche dein Deck nach 1 Team-Plasma-Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach 1 Team Plasma-Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Plasma Freeze/106.ts
+++ b/data/Black & White/Plasma Freeze/106.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Esta carta proporciona Energía Colorless.",
 		it: "Questa carta fornisce Energia Colorless",
 		pt: "Este card fornece Energia Colorless.",
-		de: "Diese Karte liefert Colorless"
+		de: "Diese Karte liefert {C}-Energie."
 	},
 
 	energyType: "Special",

--- a/data/Black & White/Plasma Freeze/107.ts
+++ b/data/Black & White/Plasma Freeze/107.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Si el Pokémon al que está unida esta carta queda Fuera de Combate, tu rival coge 1 carta de Premio menos.",
 		it: "Se il Pokémon a cui è assegnata questa carta viene messo K.O., il tuo avversario prende una carta Premio in meno.",
 		pt: "Se o Pokémon ao qual este card está ligado for Nocauteado, seu oponente levará 1 card de Prêmio a menos.",
-		de: "Wenn das Pokémon, an das diese Karte angelegt ist, kampfunfähig wird, darf dein Gegner dafür 1 Preiskarte weniger als üblich nehmen."
+		de: "Dein Deck darf nicht mehr als 1 ASS-KLASSE-Karte enthalten. Wenn das Pokémon, an das diese Karte angelegt ist, kampfunfähig wird, nimmt dein Gegner 1 Preiskarte weniger als erlaubt. Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Black & White/Plasma Freeze/108.ts
+++ b/data/Black & White/Plasma Freeze/108.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Si el Pokémon al que está unida esta carta es tu Pokémon Activo y resulta dañado por un ataque de tu rival (incluso si ese Pokémon queda Fuera de Combate), pon 6 contadores de daño en el Pokémon Atacante.",
 		it: "Se il Pokémon a cui è assegnata questa carta è il tuo Pokémon attivo e viene danneggiato da un attacco del tuo avversario, anche se viene messo K.O., metti sei segnalini danno sul Pokémon attaccante.",
 		pt: "Se este card estiver ligado a seu Pokémon Ativo e ele for danificado pelo ataque de um oponente (mesmo se esse Pokémon for Nocauteado), coloque 6 marcadores de danos no Pokémon Atacante.",
-		de: "Wenn das Pokémon, an das diese Karte angelegt ist, dein Aktives Pokémon ist, und es durch einen gegnerischen Angriff Schaden erhält (auch wenn dieses Pokémon dadurch kampfunfähig wird), lege 6 Schadensmarken auf das Angreifende Pokémon."
+		de: "Dein Deck darf nicht mehr als 1 ASS-KLASSE-Karte enthalten. Wenn das Pokémon, an das diese Karte angelegt ist, dein Aktives Pokémon ist und durch einen gegnerischen Angriff Schaden erhält (auch wenn dieses Pokémon dadurch kampfunfähig wird), lege 6 Schadensmarken auf das Angreifende Pokémon. Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Black & White/Plasma Freeze/109.ts
+++ b/data/Black & White/Plasma Freeze/109.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Heat Boiler",
 				fr: "Coup de Chaud",
+				de: "Hitzekessel"
 			},
 			effect: {
 				en: "If this Pokémon is affected by a Special Condition, this attack does 60 more damage.",
 				fr: "Si ce Pokémon est affecté par un État Spécial, cette attaque inflige 60 dégâts supplémentaires.",
+				de: "Wenn dieses Pokémon von einem Speziellen Zustand betroffen ist, fügt dieser Angriff 60 weitere Schadenspunkte zu."
 			},
 			damage: 60,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Dynamite Press",
 				fr: "Pression Explosive",
+				de: "Dynamitdruck"
 			},
 			effect: {
 				en: "If this Pokémon has any Plasma Energy attached to it, this attack does 10 more damage for each damage counter on the Defending Pokémon.",
 				fr: "Si de l'Énergie Plasma est attachée à ce Pokémon, cette attaque inflige 10 dégâts supplémentaires pour chaque marqueur de dégâts placé sur le Pokémon Défenseur.",
+				de: "Wenn an dieses Pokémon bereits Plasma-Energie angelegt ist, fügt dieser Angriff 10 weitere Schadenspunkte für jede Schadensmarke auf dem Verteidigenden Pokémon zu."
 			},
 			damage: 80,
 

--- a/data/Black & White/Plasma Freeze/11.ts
+++ b/data/Black & White/Plasma Freeze/11.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Energy Crush",
 				fr: "Écras'Énergie",
+				de: "Zermalmende Energie"
 			},
 			effect: {
 				en: "Does 20 damage times the amount of Energy attached to all of your opponent's Pokémon.",
 				fr: "Inflige 20 dégâts multipliés par le nombre d'Énergies attachées à tous les Pokémon de votre adversaire.",
+				de: "Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl der an allen Pokémon deines Gegners angelegten Energien zu."
 			},
 			damage: 20,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Leaf Blade",
 				fr: "Lame-Feuille",
+				de: "Laubklinge"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 60,
 
@@ -86,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "With cells similar to those of plants, it performs photosynthesis inside its body and creates pure air.",
+		de: "Da seine Zellstruktur der von Pflanzen gleicht, kann sein Körper Photosynthese betreiben und saubere Luft erzeugen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/110.ts
+++ b/data/Black & White/Plasma Freeze/110.ts
@@ -34,10 +34,12 @@ const card: Card = {
 			name: {
 				en: "Raiden Knuckle",
 				fr: "Appel Foudroyant",
+				de: "Herr des Donners"
 			},
 			effect: {
 				en: "Attach an Energy card from your discard pile to 1 of your Benched Team Plasma Pokémon.",
 				fr: "Attachez une carte Énergie de votre pile de défausse à 1 de vos Pokémon de la Team Plasma sur votre Banc.",
+				de: "Nimm 1 Energiekarte von deinem Ablagestapel und lege sie an 1 Team Plasma-Pokémon auf deiner Bank an."
 			},
 			damage: 30,
 
@@ -52,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Thunderous Noise",
 				fr: "Grondement Tonitruant",
+				de: "Donnerschall"
 			},
 			effect: {
 				en: "If this Pok��mon has any Plasma Energy attached to it, discard an Energy attached to the Defending Pokémon.",
 				fr: "Si de l'Énergie Plasma est attachée à ce Pokémon, défaussez une Énergie attachée au Pokémon Défenseur.",
+				de: "Wenn an dieses Pokémon bereits Plasma-Energie angelegt ist, lege 1 an das Verteidigende Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 90,
 

--- a/data/Black & White/Plasma Freeze/111.ts
+++ b/data/Black & White/Plasma Freeze/111.ts
@@ -34,7 +34,7 @@ const card: Card = {
 				es: "Conectar Poder",
 				it: "Collegaforza",
 				pt: "Conexão de Poder",
-				de: "Volltreffer"
+				de: "Kraftkombo"
 			},
 			effect: {
 				en: "Your Team Plasma Pokémon’s attacks (excluding Deoxys-EX) do 10 more damage to the Active Pokémon (before applying Weakness and Resistance).",
@@ -42,7 +42,7 @@ const card: Card = {
 				es: "Los ataques de tus Pokémon del Equipo Plasma (excepto Deoxys-EX) hacen 10 puntos de daño más a los Pokémon Activos (antes de aplicar Debilidad y Resistencia).",
 				it: "Gli attacchi dei tuoi Pokémon Team Plasma (eccetto Deoxys-EX) infliggono 10 danni in più al Pokémon attivo, prima di aver applicato debolezza e resistenza.",
 				pt: "Os ataques dos seus Pokémon da Equipe Plasma (exceto Deoxys-EX) causam 10 de danos adicionais ao Pokémon Ativo (antes da aplicação de Fraqueza e Resistência).",
-				de: "Die Angriffe deiner Team-Plasma-Pokémon (mit Ausnahme von Deoxys-EX) fügen den Aktiven Pokémon 10 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
+				de: "Die Angriffe deiner Team Plasma-Pokémon (mit Ausnahme von Deoxys-EX) fügen den Aktiven Pokémon 10 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 		},
 	],
@@ -55,10 +55,12 @@ const card: Card = {
 			name: {
 				en: "Helix Force",
 				fr: "Force Spirale",
+				de: "Helixkraft"
 			},
 			effect: {
 				en: "If this Pokémon has any Plasma Energy attached to it, this attack does 30 more damage for each Energy attached to the Defending Pokémon.",
 				fr: "Si de l'Énergie Plasma est attachée à ce Pokémon, cette attaque inflige 30 dégâts supplémentaires pour chaque Énergie attachée au Pokémon Défenseur.",
+				de: "Wenn an dieses Pokémon bereits Plasma-Energie angelegt ist, fügt dieser Angriff 30 weitere Schadenspunkte für jede an das Verteidigende Pokémon angelegte Energie zu."
 			},
 			damage: 30,
 

--- a/data/Black & White/Plasma Freeze/112.ts
+++ b/data/Black & White/Plasma Freeze/112.ts
@@ -34,7 +34,7 @@ const card: Card = {
 				es: "Plumón Reluciente",
 				it: "Splendipiume",
 				pt: "Desabrilhantar",
-				de: "Strahlender Schild"
+				de: "Daunenschimmer"
 			},
 			effect: {
 				en: "Prevent all effects of attacks, including damage, done to this Pokémon by your opponent’s Pokémon with Abilities.",
@@ -42,7 +42,7 @@ const card: Card = {
 				es: "Evita todos los efectos de los ataques, incluido el daño, infligidos a este Pokémon por los Pokémon con habilidades de tu rival.",
 				it: "Previeni tutti gli effetti degli attacchi, inclusi i danni, inflitti a questo Pokémon dai Pokémon con abilità del tuo avversario.",
 				pt: "Impede todos os efeitos de ataques, inclusive danos, causados neste Pokémon pelo Pokémon do seu oponente com Habilidades.",
-				de: "Verhindere alle Effekte von Angriffen, einschließlich Schaden, die diesem Pokémon durch gegnerische Pokémon mit Fähigkeiten zugefügt werden."
+				de: "Verhindere alle Effekte von Angriffen, einschließlich Schaden, die diesem Pokémon durch gegnerische Pokémon, die Fähigkeiten besitzen, zugefügt werden."
 			},
 		},
 	],
@@ -56,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Barrier Break",
 				fr: "Brise Barrière",
+				de: "Barrierebrecher"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by Weakness, Resistance, or any other effects on the Defending Pokémon.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Faiblesse, la Résistance ou tout autre effet en action sur le Pokémon Défenseur.",
+				de: "Der Schaden dieses Angriffs wird durch Schwäche, Resistenz oder alle anderen Effekte auf dem Verteidigenden Pokémon nicht verändert."
 			},
 			damage: 70,
 

--- a/data/Black & White/Plasma Freeze/113.ts
+++ b/data/Black & White/Plasma Freeze/113.ts
@@ -35,10 +35,12 @@ const card: Card = {
 			name: {
 				en: "Mach Flight",
 				fr: "Vol Supersonique",
+				de: "Tempoflug"
 			},
 			effect: {
 				en: "The Defending Pokémon can't retreat during your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas battre en retraite pendant le prochain tour de votre adversaire.",
+				de: "Das Verteidigende Pokémon kann sich während des nächsten Zuges deines Gegners nicht zurückziehen."
 			},
 			damage: 40,
 
@@ -52,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Luster Purge",
 				fr: "Lumi-Éclat",
+				de: "Scheinwerfer"
 			},
 			effect: {
 				en: "Discard all Energy attached to this Pokémon.",
 				fr: "Défaussez toutes les Énergies attachées à ce Pokémon.",
+				de: "Lege alle an dieses Pokémon angelegten Energien auf deinen Ablagestapel."
 			},
 			damage: 150,
 

--- a/data/Black & White/Plasma Freeze/114.ts
+++ b/data/Black & White/Plasma Freeze/114.ts
@@ -34,10 +34,12 @@ const card: Card = {
 			name: {
 				en: "Windfall",
 				fr: "Rafale de Vent",
+				de: "Warmer Regen"
 			},
 			effect: {
 				en: "Shuffle your hand into your deck. Then, draw 6 cards.",
 				fr: "Mélangez votre main avec votre deck. Ensuite, piochez 6 cartes.",
+				de: "Mische deine Handkarten in dein Deck. Ziehe anschließend 6 Karten."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Jet Blast",
 				fr: "Rafale d'Explosions",
+				de: "Hochdruckwelle"
 			},
 			effect: {
 				en: "Does 30 more damage for each Plasma Energy attached to this Pokémon.",
 				fr: "Inflige 30 dégâts supplémentaires pour chaque Énergie Plasma attachée à ce Pokémon.",
+				de: "Dieser Angriff fügt 30 weitere Schadenspunkte für jede an dieses Pokémon angelegte Plasma-Energie zu."
 			},
 			damage: 60,
 

--- a/data/Black & White/Plasma Freeze/115.ts
+++ b/data/Black & White/Plasma Freeze/115.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Tu rival enseña las cartas de su mano, pone todas las cartas de Objeto que encuentre entre ellas en su baraja y las baraja todas. Después, tú robas un número de cartas igual al número de cartas de Objeto que tu rival haya puesto en su baraja.",
 		it: "Il tuo avversario mostra la sua mano e rimischia tutte le carte Strumento che ha in mano nel suo mazzo. Poi pesca un numero di carte pari al numero di carte Strumento che il tuo avversario ha rimischiato nel suo mazzo.",
 		pt: "Seu oponente revela a mão e embaralha todos os cards de Item encontrados em sua mão no próprio baralho. Em seguida, compre um número de cards igual ao número de cards de Item que seu oponente embaralhou em seu deck.",
-		de: "Dein Gegner deckt seine Handkarten auf und mischt alle dort gefundenen Itemkarten in sein Deck. Ziehe anschließend genauso viele Karten, wie dein Gegner Itemkarten in sein Deck gemischt hat."
+		de: "Dein Gegner deckt seine Handkarten auf und mischt alle dort gefundenen Itemkarten zurück in sein Deck. Ziehe anschließend genauso viele Karten, wie dein Gegner Itemkarten zurück in sein Deck gemischt hat. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Black & White/Plasma Freeze/116.ts
+++ b/data/Black & White/Plasma Freeze/116.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta las cartas de tu mano y roba 7 cartas.",
 		it: "Scarta la tua mano e pesca sette carte.",
 		pt: "Descarte sua mão e compre 7 cards.",
-		de: "Lege deine Handkarten auf deinen Ablagestapel und ziehe 7 neue Karten."
+		de: "Lege deine Handkarten auf deinen Ablagestapel und ziehe 7 neue Karten. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Black & White/Plasma Freeze/117.ts
+++ b/data/Black & White/Plasma Freeze/117.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Prinplup",
 		fr: "Prinplouf",
+		de: "Pliprin"
 	},
 
 	stage: "Stage2",
@@ -63,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Attack Command",
 				fr: "Ordre d'Assaut",
+				de: "Angriffsbefehl"
 			},
 			effect: {
 				en: "Does 10 damage times the number of Pokémon in play (both yours and your opponent's).",
 				fr: "Inflige 10 dégâts multipliés par le nombre de Pokémon en jeu (les vôtres et ceux de votre adversaire).",
+				de: "Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl der Pokémon im Spiel (deiner und der deines Gegners) zu."
 			},
 			damage: 10,
 
@@ -84,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "This extremely rare Pokémon is a different color than usual. It is very hard to find.",
+		de: "Dieses sehr seltene Pokémon hat eine andere Farbe als üblich. Es ist schwer zu finden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/118.ts
+++ b/data/Black & White/Plasma Freeze/118.ts
@@ -60,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Psychic",
 				fr: "Psyko",
+				de: "Psychokinese"
 			},
 			effect: {
 				en: "Does 10 more damage for each Energy attached to the Defending Pokémon.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque Énergie attachée au Pokémon Défenseur.",
+				de: "Dieser Angriff fügt 10 weitere Schadenspunkte für jede an das Verteidigende Pokémon angelegte Energie zu."
 			},
 			damage: 50,
 
@@ -81,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "This extremely rare Pokémon is a different color than usual. It is very hard to find.",
+		de: "Dieses sehr seltene Pokémon hat eine andere Farbe als üblich. Es ist schwer zu finden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/119.ts
+++ b/data/Black & White/Plasma Freeze/119.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Trubbish",
 		fr: "Miamiasme",
+		de: "Unratütox"
 	},
 
 	stage: "Stage1",
@@ -65,6 +66,7 @@ const card: Card = {
 			name: {
 				en: "Sludge Toss",
 				fr: "Giclée Vaseuse",
+				de: "Schleimwurf"
 			},
 
 			damage: 60,
@@ -83,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "This extremely rare Pokémon is a different color than usual. It is very hard to find.",
+		de: "Dieses sehr seltene Pokémon hat eine andere Farbe als üblich. Es ist schwer zu finden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/12.ts
+++ b/data/Black & White/Plasma Freeze/12.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Vengeance",
 				fr: "Rétorsion",
+				de: "Rache"
 			},
 			effect: {
 				en: "Does 10 more damage for each Pokémon in your discard pile.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque Pokémon dans votre pile de défausse.",
+				de: "Dieser Angriff fügt für jedes Pokémon in deinem Ablagestapel 10 weitere Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Heat Tackle",
 				fr: "Charge Énergétique",
+				de: "Hitze Tackle"
 			},
 			effect: {
 				en: "This Pokémon does 10 damage to itself.",
 				fr: "Ce Pokémon s'inflige 10 dégâts.",
+				de: "Dieses Pokémon fügt sich selbst 10 Schadenspunkte zu."
 			},
 			damage: 90,
 
@@ -80,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "Inhaled air is carried to its flame sac, heated, and exhaled as fire that reaches over 3,000 degrees F.",
+		de: "Speichert Atemluft in einer Feuerlunge. Dort erhitzt es sie auf 1 700 Grad, um sie als Flammen auszuspucken."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/120.ts
+++ b/data/Black & White/Plasma Freeze/120.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gabite",
 		fr: "Carmache",
+		de: "Knarksel"
 	},
 
 	stage: "Stage2",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Mach Cut",
 				fr: "Coupe Vive",
+				de: "Schallschnitt"
 			},
 			effect: {
 				en: "Discard a Special Energy attached to the Defending Pokémon.",
 				fr: "Défaussez une Énergie spéciale attachée au Pokémon Défenseur.",
+				de: "Lege 1 an das Verteidigende Pokémon angelegte Spezial-Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 60,
 
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Dragonblade",
 				fr: "Draco-Lame",
+				de: "Drachenklinge"
 			},
 			effect: {
 				en: "Discard the top 2 cards of your deck.",
 				fr: "Défaussez les 2 cartes du dessus de votre deck.",
+				de: "Lege die obersten 2 Karten deines Decks auf deinen Ablagestapel."
 			},
 			damage: 100,
 
@@ -78,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "This extremely rare Pokémon is a different color than usual. It is very hard to find.",
+		de: "Dieses sehr seltene Pokémon hat eine andere Farbe als üblich. Es ist schwer zu finden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/121.ts
+++ b/data/Black & White/Plasma Freeze/121.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cura todos los puntos de daño a 1 de tus Pokémon. Después, descarta todas las Energías unidas a ese Pokémon.",
 		it: "Cura uno dei tuoi Pokémon da tutti i danni. Poi scarta tutta l’Energia assegnata a quel Pokémon.",
 		pt: "Cure todos os danos de 1 dos seus Pokémon. Em seguida, descarte toda a Energia ligada a este Pokémon.",
-		de: "Heile allen Schaden bei 1 deiner Pokémon. Lege anschließend alle an dieses Pokémon angelegten Energien auf deinen Ablagestapel."
+		de: "Heile allen Schaden bei 1 deiner Pokémon. Lege alle Energien, die an das Pokémon angelegt sind, auf deinen Ablagestapel. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Plasma Freeze/122.ts
+++ b/data/Black & White/Plasma Freeze/122.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta 2 cartas de tu mano. (Si no puedes descartar 2 cartas, no puedes jugar esta carta.) Busca en tu baraja a un Pokémon, enséñalo y ponlo en tu mano. Baraja las cartas de tu baraja después.",
 		it: "Scarta due delle carte che hai in mano. Se non puoi scartarne due, non puoi giocare questa carta. Cerca nel tuo mazzo un Pokémon, mostralo e aggiungilo alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Descarte 2 cards da sua mão. (Se você não puder descartar 2 cards, não poderá jogar esse card.) Procure um Pokémon em seu baralho, revele-o e coloque-o em sua mão. Em seguida, embaralhe seus cards.",
-		de: "Lege 2 Karten von deiner Hand auf deinen Ablagestapel. (Wenn du keine 2 Karten von der Hand auf deinen Ablagestapel legen kannst, kannst du diese Karte nicht spielen.) Durchsuche dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck."
+		de: "Lege 2 Karten von deiner Hand auf deinen Ablagestapel. (Wenn du keine 2 Karten auf deinen Ablagestapel legen kannst, kannst du diese Karte nicht spielen.) Durchsuche dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Plasma Freeze/13.ts
+++ b/data/Black & White/Plasma Freeze/13.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Heat Boiler",
 				fr: "Coup de Chaud",
+				de: "Hitzekessel"
 			},
 			effect: {
 				en: "If this Pokémon is affected by a Special Condition, this attack does 60 more damage.",
 				fr: "Si ce Pokémon est affecté par un État Spécial, cette attaque inflige 60 dégâts supplémentaires.",
+				de: "Wenn dieses Pokémon von einem Speziellen Zustand betroffen ist, fügt dieser Angriff 60 weitere Schadenspunkte zu."
 			},
 			damage: 60,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Dynamite Press",
 				fr: "Pression Explosive",
+				de: "Dynamitdruck"
 			},
 			effect: {
 				en: "If this Pokémon has any Plasma Energy attached to it, this attack does 10 more damage for each damage counter on the Defending Pokémon.",
 				fr: "Si de l'Énergie Plasma est attachée à ce Pokémon, cette attaque inflige 10 dégâts supplémentaires pour chaque marqueur de dégâts placé sur le Pokémon Défenseur.",
+				de: "Wenn an dieses Pokémon bereits Plasma-Energie angelegt ist, fügt dieser Angriff 10 weitere Schadenspunkte für jede Schadensmarke auf dem Verteidigenden Pokémon zu."
 			},
 			damage: 80,
 

--- a/data/Black & White/Plasma Freeze/14.ts
+++ b/data/Black & White/Plasma Freeze/14.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Singe",
 				fr: "Roussi",
+				de: "Versengung"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Burned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Brûlé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verbrannt."
 			},
 
 		},
@@ -51,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Live Coal",
 				fr: "Charbon Mutant",
+				de: "Glühende Kohlen"
 			},
 
 			damage: 20,
@@ -69,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "Its flame is usually out, but it starts shining when it absorbs life force from people or Pokémon.",
+		de: "Seine Flamme entzündet sich erst, wenn es einem Menschen oder einem Pokémon die Lebensenergie absaugt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/15.ts
+++ b/data/Black & White/Plasma Freeze/15.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Litwick",
 		fr: "Funécire",
+		de: "Lichtel"
 	},
 
 	stage: "Stage1",
@@ -42,6 +43,7 @@ const card: Card = {
 			name: {
 				en: "Live Coal",
 				fr: "Charbon Mutant",
+				de: "Glühende Kohlen"
 			},
 
 			damage: 20,
@@ -56,10 +58,12 @@ const card: Card = {
 			name: {
 				en: "Searing Flame",
 				fr: "Flammes Calcinantes",
+				de: "Sengende Flammen"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Burned.",
 				fr: "Le Pokémon Défenseur est maintenant Brûlé.",
+				de: "Das Verteidigende Pokémon ist jetzt verbrannt."
 			},
 			damage: 40,
 
@@ -77,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "The spirits it absorbs fuel its baleful fire. It hangs around hospitals waiting for people to pass on.",
+		de: "Es nährt seine Flamme mit den Seelen seiner Opfer. Heutzutage irrt es auf der Suche nach Seelen durch Krankenhäuser."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/16.ts
+++ b/data/Black & White/Plasma Freeze/16.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Lampent",
 		fr: "Mélancolux",
+		de: "Laternecto"
 	},
 
 	stage: "Stage2",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Una vez durante tu turno (antes de tu ataque), puedes buscar en tu baraja una carta de Energía Fire y unirla a 1 de tus Pokémon. Si lo haces, pon 1 contador de daño en ese Pokémon. Baraja las cartas de tu baraja después.",
 				it: "Una sola volta durante il tuo turno, prima di attaccare, puoi cercare nel tuo mazzo una carta Energia Fire e assegnarla a uno dei tuoi Pokémon. Se lo fai, aggiungi un segnalino danno al Pokémon. Poi rimischia le carte del tuo mazzo.",
 				pt: "Uma vez durante sua vez de jogar (antes de atacar), você pode procurar um card de Energia Fire em seu baralho e ligá-lo a 1 de seus Pokémon. Se fizer isso, coloque 1 marcador de dano nesse Pokémon. Em seguida, embaralhe seus cards.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du dein Deck nach 1 Fire-Energiekarte durchsuchen und sie an 1 deiner Pokémon anlegen. Wenn du das machst, lege 1 Schadensmarke auf dieses Pokémon. Mische anschließend dein Deck."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du dein Deck nach 1 {R}-Energiekarte durchsuchen und sie an 1 deiner Pokémon anlegen. Wenn du das machst, lege 1 Schadensmarke auf das Pokémon. Mische anschließend dein Deck."
 			},
 		},
 	],
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Absorb Life",
 				fr: "Absorption",
+				de: "Lebensverkoster"
 			},
 			effect: {
 				en: "Heal 30 damage from this Pokémon.",
 				fr: "Soignez 30 dégâts à ce Pokémon.",
+				de: "Heile 30 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 70,
 
@@ -86,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "The spirits burned up in its ominous flame lose their way and wander this world forever.",
+		de: "Seelen, die das Feuer seiner schaurigen Flammen gekostet haben, irren bis ans Ende der Tage ziellos durch diese Welt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/17.ts
+++ b/data/Black & White/Plasma Freeze/17.ts
@@ -38,10 +38,12 @@ const card: Card = {
 			name: {
 				en: "Purifying Flame",
 				fr: "Flamme Purifiante",
+				de: "Reinigende Flamme"
 			},
 			effect: {
 				en: "Remove all Special Conditions from this Pokémon.",
 				fr: "Retirez tous les États Spéciaux de ce Pokémon.",
+				de: "Alle Speziellen Zustände auf diesem Pokémon verlieren ihre Wirkung."
 			},
 			damage: 50,
 
@@ -56,10 +58,12 @@ const card: Card = {
 			name: {
 				en: "Fusion Flare",
 				fr: "Flamme Croix",
+				de: "Kreuzflamme"
 			},
 			effect: {
 				en: "If Zekrom is on your Bench, this attack does 40 more damage.",
 				fr: "Si Zekrom est sur votre Banc, cette attaque inflige 40 dégâts supplémentaires.",
+				de: "Wenn sich Zekrom auf deiner Bank befindet, fügt dieser Angriff 40 weitere Schadenspunkte zu."
 			},
 			damage: 80,
 
@@ -77,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "This legendary Pokémon can scorch the world with fire. It helps those who want to build a world of truth.",
+		de: "Ein Legendäres Pokémon mit der Macht, die Welt mit seinen Flammen einzuäschern. Hilft allen, die nach Wirklichkeit streben."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/18.ts
+++ b/data/Black & White/Plasma Freeze/18.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Fin Smack",
 				fr: "Coup d'Aileron",
+				de: "Flossenklatscher"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 10,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "It makes its nest in the shade of corals. If it senses danger, it spits murky ink and flees.",
+		de: "Im Schatten von Korallen legt es sein Nest an. Bei Gefahr versprüht es Tinte und flieht."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/19.ts
+++ b/data/Black & White/Plasma Freeze/19.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Horsea",
 		fr: "Hypotrempe",
+		de: "Seeper"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Smokescreen",
 				fr: "Brouillard",
+				de: "Rauchwolke"
 			},
 			effect: {
 				en: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
 				fr: "Si le Pokémon Défenseur essaie d'attaquer pendant le prochain tour de votre adversaire, ce dernier lance une pièce. Si c’est pile, son attaque ne fait rien.",
+				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 20,
 
@@ -62,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "Its spines provide protection. Its fins and bones are prized as traditional-medicine ingredients.",
+		de: "Seine Stacheln schützen es. Seine Flossen und Knochen werden bei der Herstellung von Medizin verwendet."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/2.ts
+++ b/data/Black & White/Plasma Freeze/2.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Weedle",
 		fr: "Aspicot",
+		de: "Hornliu"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Hide",
 				fr: "Cachette",
+				de: "Verstecken"
 			},
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, évitez tous les effets d'attaques (y compris les dégâts) infligés à ce Pokémon pendant le prochain tour de votre adversaire.",
+				de: "Wirf 1 Münze. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die diesem Pokémon zugefügt werden."
 			},
 
 		},
@@ -61,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "While awaiting evolution, it hides from predators under leaves and in nooks of branches.",
+		de: "Während es auf seine Entwicklung wartet, versteckt es sich unter Blättern und zwischen Ästen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/20.ts
+++ b/data/Black & White/Plasma Freeze/20.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Refreshing Rain",
 				fr: "Ondée Rafraîchissante",
+				de: "Erquicklicher Regen"
 			},
 			effect: {
 				en: "Heal 30 damage from each of your Pokémon.",
 				fr: "Soignez 30 dégâts à chacun de vos Pokémon.",
+				de: "Heile 30 Schadenspunkte bei jedem deiner Pokémon."
 			},
 
 		},
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Gold Breaker",
 				fr: "Goliastruction",
+				de: "Goldbrecher"
 			},
 			effect: {
 				en: "If the Defending Pokémon is a Pokémon-EX, this attack does 50 more damage.",
 				fr: "Si le Pokémon Défenseur est un Pokémon-EX, cette attaque inflige 50 dégâts supplémentaires.",
+				de: "Wenn das Verteidigende Pokémon ein Pokémon-EX ist, fügt dieser Angriff 50 weitere Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -77,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "Its cell composition is similar to water molecules. As a result, it can't be seen when it melts away into water.",
+		de: "Seine Zellstruktur ist der von Wassermolekülen ähnlich. Daher kann es mit Wasser eins werden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/21.ts
+++ b/data/Black & White/Plasma Freeze/21.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Slam",
 				fr: "Souplesse",
+				de: "Slam"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "When walking on land, it covers its body with a poisonous film that keeps its skin from dehydrating.",
+		de: "An Land bedeckt es die Haut mit einer giftigen Schicht, die es vor dem Austrocknen bewahrt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/22.ts
+++ b/data/Black & White/Plasma Freeze/22.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Wooper",
 		fr: "Axoloto",
+		de: "Felino"
 	},
 
 	stage: "Stage1",
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Mud Gun",
 				fr: "Giclée de Boue",
+				de: "Schlammkanone"
 			},
 			effect: {
 				en: "If this Pokémon has any Fighting Energy attached to it, this attack does 30 more damage.",
 				fr: "Si de l'Énergie Fighting est attachée à ce Pokémon, cette attaque inflige 30 dégâts supplémentaires.",
+				de: "Wenn an dieses Pokémon bereits {F}-Energie angelegt ist, fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: 60,
 
@@ -86,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It has an easygoing nature. It doesn't care if it bumps its head on boats and boulders while swimming.",
+		de: "Es ist sehr unbekümmert und stört sich nicht daran, wenn es während des Schwimmens an etwas stößt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/23.ts
+++ b/data/Black & White/Plasma Freeze/23.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "El Coste de Retirada de cada uno de tus Pokémon del Equipo Plasma en juego es de ColorlessColorless menos.",
 				it: "Il costo di ritirata di ciascun Pokémon Team Plasma in gioco scende di ColorlessColorless.",
 				pt: "O Custo para Recuar de cada um de seus Pokémon da Equipe Plasma em jogo será de Colorless Colorless a menos.",
-				de: "Die Rückzugskosten aller Team-Plasma-Pokémon im Spiel verringern sich um Colorless Colorless."
+				de: "Die Rückzugskosten all deiner Team Plasma-Pokémon im Spiel verringern sich um {C}{C}."
 			},
 		},
 	],
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Icy Wind",
 				fr: "Vent Glace",
+				de: "Eissturm"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 			damage: 60,
 
@@ -86,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It lowers its body heat to freeze its fur. The hairs then become like needles it can fire.",
+		de: "Wenn es seine Körpertemperatur senkt, erstarren die Haare seines Fells zu Eis und dienen ihm als nadelartige Geschosse."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/24.ts
+++ b/data/Black & White/Plasma Freeze/24.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Surprise Attack",
 				fr: "Attaque Surprise",
+				de: "Überraschungsangriff"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 20,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "By vibrating its cheeks, it emits sound waves imperceptible to humans and warns others of danger.",
+		de: "Erzeugt mit seinen Wangen für Menschen unhörbare Schallwellen, um Artgenossen vor Gefahr zu warnen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/25.ts
+++ b/data/Black & White/Plasma Freeze/25.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Tympole",
 		fr: "Tritonde",
+		de: "Schallquap"
 	},
 
 	stage: "Stage1",
@@ -42,6 +43,7 @@ const card: Card = {
 			name: {
 				en: "Vibration",
 				fr: "Vibration",
+				de: "Schwingung"
 			},
 
 			damage: 20,
@@ -56,10 +58,12 @@ const card: Card = {
 			name: {
 				en: "Suspicious Soundwave",
 				fr: "Onde Sonore Suspecte",
+				de: "Seltsame Schallwelle"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: 30,
 
@@ -77,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives in the water and on land. It uses its long, sticky tongue to immobilize its opponents.",
+		de: "Es lebt zu Wasser und zu Lande. Mit seiner langen, klebrigen Zunge raubt es Gegnern die Bewegungsfreiheit."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/26.ts
+++ b/data/Black & White/Plasma Freeze/26.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Palpitoad",
 		fr: "Batracné",
+		de: "Mebrana"
 	},
 
 	stage: "Stage2",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Seismic Punch",
 				fr: "Poing Sismique",
+				de: "Erderschütterer"
 			},
 			effect: {
 				en: "Does 30 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 30 dégâts à chaque Pokémon de Banc (les vôtres et ceux de votre adversaire). (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt jedem Pokémon auf der Bank (deinen und denen deines Gegners) 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 30,
 
@@ -60,10 +63,12 @@ const card: Card = {
 			name: {
 				en: "Splashing Turn",
 				fr: "Tour Éclaboussant",
+				de: "Platschende Drehung"
 			},
 			effect: {
 				en: "Switch this Pokémon with 1 of your Benched Pokémon.",
 				fr: "Échangez ce Pokémon avec 1 de vos Pokémon de Banc.",
+				de: "Tausche dieses Pokémon gegen 1 Pokémon auf deiner Bank aus."
 			},
 			damage: 80,
 
@@ -81,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "By putting power into its bumps, it creates vibrations and increases the power of its punches.",
+		de: "Konzentriert es all seine Energie auf seine Beulen, um sie vibrieren zu lassen, erhöht sich die Stärke seiner Hiebe."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/27.ts
+++ b/data/Black & White/Plasma Freeze/27.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Jump On",
 				fr: "Saut",
+				de: "Draufspringen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 weitere Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "Theoretically, this Pokémon formed from icicles bathed in energy from the morning sun. Their breath is -58° F.",
+		de: "Ein Eiszapfen, der durch die Energie der aufgehenden Sonne zum Pokémon wurde. Es speit minus 50 Grad kalten Odem."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/28.ts
+++ b/data/Black & White/Plasma Freeze/28.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Vanillite",
 		fr: "Sorbébé",
+		de: "Gelatini"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Surefire Spin",
 				fr: "Tourbillon Glacé",
+				de: "Narrensicherer Dreher"
 			},
 			effect: {
 				en: "Flip 2 coins. If both of them are heads, this attack does 40 more damage.",
 				fr: "Lancez 2 pièces. Si vous obtenez 2 côtés face, cette attaque inflige 40 dégâts supplémentaires.",
+				de: "Wirf 2 Münzen. Zeigen beide „Kopf“, fügt dieser Angriff 40 weitere Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -63,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "They cool down the surrounding air and create ice particles, which they use to freeze their foes.",
+		de: "Es produziert Eiskörner, indem es die Luft um sich herum abkühlt, und zieht mit ihnen eine Eisschicht um seinen Gegner."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/29.ts
+++ b/data/Black & White/Plasma Freeze/29.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Vanillish",
 		fr: "Sorboul",
+		de: "Gelatroppo"
 	},
 
 	stage: "Stage2",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "ChillMAX",
 				fr: "Gel Maximal",
+				de: "Kalter Schauer"
 			},
 			effect: {
 				en: "Flip a coin for each Energy attached to this Pokémon. This attack does 60 damage times the number of heads.",
 				fr: "Lancez une pièce pour chaque Énergie attachée à ce Pokémon. Cette attaque inflige 60 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf für jede an dieses Pokémon angelegte Energie 1 Münze. Dieser Angriff fügt 60 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 60,
 
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Cold Breath",
 				fr: "Souffle Froid",
+				de: "Eisiger Atem"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 			damage: 40,
 
@@ -78,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "Swallowing large amounts of water, they make snow clouds inside their bodies and, when angry, cause violent blizzards.",
+		de: "Es verschluckt Unmengen an Wasser und wandelt es intern in Schneewolken um. Ist es wütend, erzeugt es Schneestürme."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/3.ts
+++ b/data/Black & White/Plasma Freeze/3.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Kakuna",
 		fr: "Coconfort",
+		de: "Kokuna"
 	},
 
 	stage: "Stage2",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Swift Sting",
 				fr: "Piqûre Vive",
+				de: "Flinker Stachel"
 			},
 			effect: {
 				en: "If this Pokémon has full HP, this attack does 40 more damage, and the Defending Pokémon is now Confused and Poisoned.",
 				fr: "Si ce Pokémon a tous ses PV, cette attaque inflige 40 dégâts supplémentaires, et le Pokémon Défenseur est maintenant Confus et Empoisonné.",
+				de: "Wenn dieses Pokémon volle KP hat, fügt dieser Angriff 40 weitere Schadenspunkte zu und das Verteidigende Pokémon ist jetzt verwirrt und vergiftet."
 			},
 			damage: 20,
 
@@ -58,6 +61,7 @@ const card: Card = {
 			name: {
 				en: "Pierce",
 				fr: "Transpercement",
+				de: "Durchbohren"
 			},
 
 			damage: 60,
@@ -76,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "Its best attack involves flying around at high speed, striking with poison needles, then flying off.",
+		de: "Sein bester Angriff: schnell auf den Gegner zufliegen, mit Giftstacheln zustechen und davonfliegen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/30.ts
+++ b/data/Black & White/Plasma Freeze/30.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Call Sign",
 				fr: "Signe d’Appel",
+				de: "Rufzeichen"
 			},
 			effect: {
 				en: "Search your deck for a Water Pokémon, reveal it, and put it into your hand. Shuffle your deck afterward.",
 				fr: "Cherchez un Pokémon Water dans votre deck, montrez-le, puis ajoutez-le à votre main. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 1 {W}-Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck."
 			},
 
 		},
@@ -50,10 +52,12 @@ const card: Card = {
 			name: {
 				en: "Cryofreeze",
 				fr: "Cryogel",
+				de: "Kryofrost"
 			},
 			effect: {
 				en: "Discard an Energy attached to this Pokémon. The Defending Pokémon can't attack during your opponent's next turn.",
 				fr: "Défaussez une Énergie attachée à ce Pokémon. Le Pokémon Défenseur ne peut pas attaquer pendant le prochain tour de votre adversaire.",
+				de: "Lege 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel. Das Verteidigende Pokémon kann während des nächsten Zuges deines Gegners nicht angreifen."
 			},
 			damage: 10,
 
@@ -71,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "They are composed of ice crystals. They capture prey with chains of ice, freezing the prey at -148° F.",
+		de: "Es fängt seine Beute mit Ketten aus Eiskristallen und kühlt sie auf eine Temperatur von minus 100 Grad ab."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/31.ts
+++ b/data/Black & White/Plasma Freeze/31.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Frost Spear",
 				fr: "Lance de Givre",
+				de: "Frostspeer"
 			},
 			effect: {
 				en: "Does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 30 dégâts à 1 des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 1 Pokémon auf der Bank deines Gegners 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 30,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Blizzard Burn",
 				fr: "Blizzard Étourdissant",
+				de: "Blizzardbrand"
 			},
 			effect: {
 				en: "This Pokémon can't attack during your next turn.",
 				fr: "Ce Pokémon ne peut pas attaquer pendant votre prochain tour.",
+				de: "Dieses Pokémon kann während deines nächsten Zuges nicht angreifen."
 			},
 			damage: 120,
 
@@ -75,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "This legendary ice Pokémon waits for a hero to fill in the missing parts of its body with truth or ideals.",
+		de: "Ein Legendäres Eis-Pokémon, das auf den Helden wartet, der seinen verstümmelten Körper mit Wunsch und Wirklichkeit heilt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/32.ts
+++ b/data/Black & White/Plasma Freeze/32.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Rollout",
 				fr: "Roulade",
+				de: "Walzer"
 			},
 
 			damage: 20,
@@ -55,6 +56,7 @@ const card: Card = {
 
 	description: {
 		en: "It looks just like a Poké Ball. It is dangerous because it may electrocute or explode on touch.",
+		de: "Sieht aus wie ein Pokéball. Es ist gefährlich, da es bei Berührung explodieren kann."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/33.ts
+++ b/data/Black & White/Plasma Freeze/33.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Voltorb",
 		fr: "Voltorbe",
+		de: "Voltobal"
 	},
 
 	stage: "Stage1",
@@ -65,6 +66,7 @@ const card: Card = {
 			name: {
 				en: "Electro Ball",
 				fr: "Boule Élek",
+				de: "Elektroball"
 			},
 
 			damage: 60,
@@ -83,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "It is known to drift on winds if it is bloated to bursting with stored electricity.",
+		de: "Es lässt sich vom Wind treiben, wenn es so voller Elektrizität ist, dass es fast explodiert."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/34.ts
+++ b/data/Black & White/Plasma Freeze/34.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Pin Missile",
 				fr: "Dard-Nuée",
+				de: "Nadelrakete"
 			},
 			effect: {
 				en: "Flip 4 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 4 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 4 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Electri-Defuse",
 				fr: "Neutralivolt",
+				de: "Elektro-Entschärfung"
 			},
 			effect: {
 				en: "If the Defending Pokémon is a Pokémon-EX, that Pokémon can't attack during your opponent's next turn.",
 				fr: "Si le Pokémon Défenseur est un Pokémon-EX, il ne peut pas attaquer pendant le prochain tour de votre adversaire.",
+				de: "Wenn das Verteidigende Pokémon ein Pokémon-EX ist, kann es während des nächsten Zuges deines Gegners nicht angreifen."
 			},
 			damage: 40,
 
@@ -78,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "By storing electricity in its body, it can shoot its bristlelike fur like a barrage of missiles.",
+		de: "Lädt sich sein Körper mit Elektrizität, richten sich alle seine Haare auf und dienen ihm als Geschosse."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/35.ts
+++ b/data/Black & White/Plasma Freeze/35.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Static Shock",
 				fr: "Choc Statique",
+				de: "Statischer Schock"
 			},
 
 			damage: 20,
@@ -55,6 +56,7 @@ const card: Card = {
 
 	description: {
 		en: "It discharges positive and negative electricity from its antenna tips to shock its foes.",
+		de: "Über seine Antennen entlädt es Elektrizität, mit der es seinen Gegnern einen Schlag versetzt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/36.ts
+++ b/data/Black & White/Plasma Freeze/36.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Chinchou",
 		fr: "Loupio",
+		de: "Lampi"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Special Tackle",
 				fr: "Charge Spéciale",
+				de: "Spezial-Tackle"
 			},
 			effect: {
 				en: "If this Pokémon has any Special Energy attached to it, this attack does 30 more damage.",
 				fr: "Si de l'Énergie spéciale est attachée à ce Pokémon, cette attaque inflige 30 dégâts supplémentaires.",
+				de: "Wenn an dieses Pokémon bereits Spezial-Energie angelegt ist, fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Extreme Current",
 				fr: "Courant Extrême",
+				de: "Extreme Strömung"
 			},
 			effect: {
 				en: "Discard an Energy attached to this Pokémon.",
 				fr: "Défaussez une Énergie attachée à ce Pokémon.",
+				de: "Lege 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel."
 			},
 			damage: 90,
 
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "Lanturn's light can shine up from great depths. It is nicknamed \"The Deep-Sea Star.\"",
+		de: "Lanturns Licht kann aus großen Tiefen heraufscheinen. Man nennt es auch „Tiefseestern“."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/37.ts
+++ b/data/Black & White/Plasma Freeze/37.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Minor Errand-Running",
 				fr: "Rendez-vous Mineur",
+				de: "Kleine Besorgung"
 			},
 			effect: {
 				en: "Search your deck for 2 basic Energy cards, reveal them, and put them into your hand. Shuffle your deck afterward.",
 				fr: "Cherchez 2 cartes Énergie de base dans votre deck, montrez-les, puis ajoutez-les à votre main. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 2 Basis-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
 			},
 
 		},
@@ -50,10 +52,12 @@ const card: Card = {
 			name: {
 				en: "Electric Tail",
 				fr: "Électro-Queue",
+				de: "Stromschweif"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 10,
 
@@ -71,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "A pair may be seen rubbing their cheek pouches together in an effort to share stored electricity.",
+		de: "Um gespeicherte Elektrizität zu teilen, reiben zwei von ihnen ihre Backentaschen aneinander."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/38.ts
+++ b/data/Black & White/Plasma Freeze/38.ts
@@ -34,10 +34,12 @@ const card: Card = {
 			name: {
 				en: "Raiden Knuckle",
 				fr: "Appel Foudroyant",
+				de: "Herr des Donners"
 			},
 			effect: {
 				en: "Attach an Energy card from your discard pile to 1 of your Benched Team Plasma Pokémon.",
 				fr: "Attachez une carte Énergie de votre pile de défausse à 1 de vos Pokémon de la Team Plasma sur votre Banc.",
+				de: "Nimm 1 Energiekarte von deinem Ablagestapel und lege sie an 1 Team Plasma-Pokémon auf deiner Bank an."
 			},
 			damage: 30,
 
@@ -52,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Thunderous Noise",
 				fr: "Grondement Tonitruant",
+				de: "Donnerschall"
 			},
 			effect: {
 				en: "If this Pokémon has any Plasma Energy attached to it, discard an Energy attached to the Defending Pokémon.",
 				fr: "Si de l'Énergie Plasma est attachée à ce Pokémon, défaussez une Énergie attachée au Pokémon Défenseur.",
+				de: "Wenn an dieses Pokémon bereits Plasma-Energie angelegt ist, lege 1 an das Verteidigende Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 90,
 

--- a/data/Black & White/Plasma Freeze/39.ts
+++ b/data/Black & White/Plasma Freeze/39.ts
@@ -38,10 +38,12 @@ const card: Card = {
 			name: {
 				en: "Mach Claw",
 				fr: "Instagriffe",
+				de: "Tempoklaue"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by Resistance.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Résistance.",
+				de: "Der Schaden dieses Angriffs wird durch Resistenz nicht verändert."
 			},
 			damage: 50,
 
@@ -56,10 +58,12 @@ const card: Card = {
 			name: {
 				en: "Fusion Bolt",
 				fr: "Éclair Croix",
+				de: "Kreuzdonner"
 			},
 			effect: {
 				en: "If Reshiram is on your Bench, this attack does 40 more damage.",
 				fr: "Si Reshiram est sur votre Banc, cette attaque inflige 40 dégâts supplémentaires.",
+				de: "Wenn sich Reshiram auf deiner Bank befindet, fügt dieser Angriff 40 weitere Schadenspunkte zu."
 			},
 			damage: 80,
 
@@ -77,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "This legendary Pokémon can scorch the world with lightning. It assists those who want to build an ideal world.",
+		de: "Ein Legendäres Pokémon mit der Macht, die Welt durch Donner einzuäschern. Hilft allen, die einer Welt der Wünsche harren."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/4.ts
+++ b/data/Black & White/Plasma Freeze/4.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Una vez durante tu turno (antes de tu ataque), si este Pokémon está en tu pila de descartes, puedes ponerlo en tu mano.",
 				it: "Una sola volta durante il tuo turno, prima di attaccare, se questo Pokémon è nella tua pila degli scarti, puoi aggiungerlo alle carte che hai in mano.",
 				pt: "Uma vez durante sua vez de jogar (antes de atacar), se este Pokémon estiver em sua pilha de descarte, você poderá colocá-lo em sua mão.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn sich dieses Pokémon auf deinem Ablagestapel befindet, dieses Pokémon auf deine Hand nehmen."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn sich dieses Pokémon in deinem Ablagestapel befindet, dieses Pokémon auf deine Hand nehmen."
 			},
 		},
 	],
@@ -59,6 +59,7 @@ const card: Card = {
 			name: {
 				en: "Seed Bomb",
 				fr: "Canon Graine",
+				de: "Samenbomben"
 			},
 
 			damage: 20,
@@ -84,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "Its six eggs converse using telepathy. They can quickly gather if they become separated.",
+		de: "Die sechs Eier kommunizieren telepathisch. Werden sie getrennt, finden sie sich schnell wieder."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/40.ts
+++ b/data/Black & White/Plasma Freeze/40.ts
@@ -35,10 +35,12 @@ const card: Card = {
 			name: {
 				en: "Poison Sting",
 				fr: "Dard-Venin",
+				de: "Giftstachel"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Empoisonné.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet."
 			},
 			damage: 20,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "While it does not prefer to fight, even one drop of the poison it secretes from its barbs can be fatal.",
+		de: "Es mag keine Kämpfe. Ein einziger Tropfen des Gifts aus seinen Widerhaken hat eine fatale Wirkung."
 	},
 }
 

--- a/data/Black & White/Plasma Freeze/41.ts
+++ b/data/Black & White/Plasma Freeze/41.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Nidoran♀",
 		fr: "Nidoran♀",
+		de: "Nidoran♀"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Poison Sting",
 				fr: "Dard-Venin",
+				de: "Giftstachel"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné.",
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet."
 			},
 			damage: 20,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Double Kick",
 				fr: "Double Pied",
+				de: "Doppelkick"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 40 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 40 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 40,
 
@@ -80,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "When it senses danger, it raises all the barbs on its body. These barbs grow slower than Nidorino's.",
+		de: "Bei Gefahr fährt es die Widerhaken am Körper aus. Diese wachsen langsamer als die von Nidorino."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/42.ts
+++ b/data/Black & White/Plasma Freeze/42.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Nidorina",
 		fr: "Nidorina",
+		de: "Nidorina"
 	},
 
 	stage: "Stage2",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Poison Horn",
 				fr: "Corne Empoisonnée",
+				de: "Gifthorn"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné.",
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet."
 			},
 			damage: 50,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Double Stomp",
 				fr: "Double Écrasement",
+				de: "Doppelstampfer"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 30 more damage for each heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts supplémentaires pour chaque côté face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 60,
 
@@ -80,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "Its entire body is armored with hard scales. It will protect the young in its burrow with its life.",
+		de: "Sein ganzer Körper ist mit harten Schuppen bedeckt. Es beschützt sein Junges mit seinem Leben."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/43.ts
+++ b/data/Black & White/Plasma Freeze/43.ts
@@ -34,10 +34,12 @@ const card: Card = {
 			name: {
 				en: "Hit Back",
 				fr: "Réplique",
+				de: "Rückschlag"
 			},
 			effect: {
 				en: "If this Pokémon has no damage counters on it, this attack does nothing.",
 				fr: "Si ce Pokémon n'a aucun marqueur de dégâts, cette attaque ne fait rien.",
+				de: "Wenn auf diesem Pokémon keine Schadensmarken liegen, hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 30,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "It scans its surroundings by raising its ears out of the grass. Its toxic horn is for protection.",
+		de: "Es untersucht die Umgebung, indem es die Ohren spitzt und lauscht. Sein giftiges Horn schützt es."
 	},
 }
 

--- a/data/Black & White/Plasma Freeze/44.ts
+++ b/data/Black & White/Plasma Freeze/44.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Nidoran♂",
 		fr: "Nidoran♂",
+		de: "Nidoran♂"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Double Kick",
 				fr: "Double Pied",
+				de: "Doppelkick"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 30 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 30,
 
@@ -59,6 +62,7 @@ const card: Card = {
 			name: {
 				en: "Horn Attack",
 				fr: "Koud'Korne",
+				de: "Hornattacke"
 			},
 
 			damage: 50,
@@ -77,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "It has a violent disposition and stabs foes with its horn, which oozes poison upon impact.",
+		de: "Es ist aggressiv und greift seine Gegner mit dem Horn an, welches bei Berührung Gift absondert."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/45.ts
+++ b/data/Black & White/Plasma Freeze/45.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Lure Poison",
 				fr: "Appât Vénéneux",
+				de: "Lockendes Gift"
 			},
 			effect: {
 				en: "Flip a coin. If heads, switch 1 of your opponent's Benched Pokémon with the Defending Pokémon. The new Defending Pokémon is now Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, échangez 1 des Pokémon de Banc de votre adversaire avec le Pokémon Défenseur. Le nouveau Pokémon Défenseur est maintenant Empoisonné.",
+				de: "Wirf 1 Münze. Tausche bei „Kopf“ 1 Pokémon auf der Bank deines Gegners gegen das Verteidigende Pokémon aus. Das neue Verteidigende Pokémon ist jetzt vergiftet."
 			},
 
 		},
@@ -52,6 +54,7 @@ const card: Card = {
 			name: {
 				en: "Sludge Toss",
 				fr: "Giclée Vaseuse",
+				de: "Schleimwurf"
 			},
 
 			damage: 30,
@@ -70,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "Born from sludge, these Pokémon now gather in polluted places and increase the bacteria in their bodies.",
+		de: "Diese aus Schlamm entstandenen Pokémon scharen sich an dreckigen Orten, um ihre körpereigenen Bakterien zu kultivieren."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/46.ts
+++ b/data/Black & White/Plasma Freeze/46.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Grimer",
 		fr: "Tadmorv",
+		de: "Sleima"
 	},
 
 	stage: "Stage1",
@@ -43,10 +44,12 @@ const card: Card = {
 			name: {
 				en: "Poison Suction",
 				fr: "Succion Empoisonnée",
+				de: "Giftsauger"
 			},
 			effect: {
 				en: "If the Defending Pokémon is Poisoned, heal 60 damage from this Pokémon.",
 				fr: "Si le Pokémon Défenseur est Empoisonné, soignez 60 dégâts à ce Pokémon.",
+				de: "Wenn das Verteidigende Pokémon vergiftet ist, heile 60 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 60,
 
@@ -61,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Sludge Crash",
 				fr: "Flot de Vase",
+				de: "Schlammrutsch"
 			},
 			effect: {
 				en: "Flip a coin until you get tails. For each heads, discard an Energy attached to the Defending Pokémon.",
 				fr: "Lancez une pièce jusqu'à ce que vous obteniez un côté pile. Pour chaque côté face, défaussez une Énergie attachée au Pokémon Défenseur.",
+				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Lege pro „Kopf“ 1 an das Verteidigende Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 80,
 
@@ -82,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "It's so stinky! Muk's body contains toxic elements, and any plant will wilt when it passes by.",
+		de: "Ihr Gestank ist unerträglich. Das starke Gift, aus dem ihr Körper besteht, macht jeder Pflanze in ihrem Weg den Garaus."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/47.ts
+++ b/data/Black & White/Plasma Freeze/47.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Evita todo el daño infligido a tus Pokémon en Banca por ataques.",
 				it: "Previeni tutto il danno inflitto dagli attacchi ai tuoi Pokémon in panchina.",
 				pt: "Impede todos os danos causados por ataques a seus Pokémon no Banco.",
-				de: "Verhindere allen Schaden, der Pokémon auf deiner Bank durch Angriffe zugefügt wird."
+				de: "Verhindere allen Schaden, der den Pokémon auf deiner Bank durch Angriffe zugefügt würde."
 			},
 		},
 	],
@@ -59,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Psy Bolt",
 				fr: "Choc Mental",
+				de: "Konfusion"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 20,
 
@@ -80,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It shapes an invisible wall in midair by minutely vibrating its fingertips to stop molecules in the air.",
+		de: "Formt eine unsichtbare Wand mitten in der Luft, indem es minutiös mit den Fingerspitzen vibriert."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/48.ts
+++ b/data/Black & White/Plasma Freeze/48.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Psy Alert",
 				fr: "Alerte Psychique",
+				de: "Psy-Alarm"
 			},
 			effect: {
 				en: "Draw cards until you have 6 cards in your hand.",
 				fr: "Piochez des cartes jusqu'à ce que vous ayez 6 cartes en main.",
+				de: "Ziehe so viele Karten, bis du 6 Karten auf der Hand hast."
 			},
 			damage: 20,
 
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Shadow Ball",
 				fr: "Ball'Ombre",
+				de: "Spukball"
 			},
 			effect: {
 				en: "This attack does 40 damage to 1 of your opponent's Pokémon. Also apply Weakness and Resistance for Benched Pokémon.",
 				fr: "Cette attaque inflige 40 dégâts à 1 des Pokémon de votre adversaire. Appliquez aussi la Faiblesse et la Résistance aux Pokémon de Banc.",
+				de: "Dieser Angriff fügt 1 Pokémon deines Gegners 40 Schadenspunkte zu. Wende Schwäche und Resistenz auch bei Pokémon auf der Bank an."
 			},
 
 		},
@@ -76,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Its fur is so sensitive, it can feel minute shifts in the air and predict the weather…and its foes' thoughts.",
+		de: "Die Haare seines Fells sind so feinfühlig, dass es am Wind ablesen kann, was seine Gegner denken und wie das Wetter wird."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/49.ts
+++ b/data/Black & White/Plasma Freeze/49.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Scratch",
 				fr: "Griffe",
+				de: "Kratzer"
 			},
 
 			damage: 10,
@@ -49,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Shadow Cage",
 				fr: "Cage d’Ombre",
+				de: "Schattenverlies"
 			},
 			effect: {
 				en: "The Defending Pokémon can't retreat during your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas battre en retraite pendant le prochain tour de votre adversaire.",
+				de: "Das Verteidigende Pokémon kann sich während des nächsten Zuges deines Gegners nicht zurückziehen."
 			},
 			damage: 20,
 
@@ -63,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "It hides in the darkness of caves. Its diet of gems has transformed its eyes into gemstones.",
+		de: "Es versteckt sich im Dunkeln von Höhlen. Seine Augen sind Edelsteine."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/5.ts
+++ b/data/Black & White/Plasma Freeze/5.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Exeggcute",
 		fr: "Noeunoeuf",
+		de: "Owei"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Blockade",
 				fr: "Blocus",
+				de: "Blockade"
 			},
 			effect: {
 				en: "Your opponent can't play any Supporter cards from his or her hand during his or her next turn.",
 				fr: "Votre adversaire ne peut pas jouer de cartes Supporter de sa main pendant son prochain tour.",
+				de: "Dein Gegner kann während seines nächsten Zuges keine Unterstützerkarten von seiner Hand spielen."
 			},
 			damage: 10,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Stomp",
 				fr: "Écrasement",
+				de: "Stampfer"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: 60,
 
@@ -86,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "It is called \"The Walking Jungle.\" If a head grows too big, it falls off and becomes an Exeggcute.",
+		de: "Man nennt es den „Laufenden Dschungel“. Wird ein Kopf zu groß, fällt er ab und wird zu einem Owei."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/50.ts
+++ b/data/Black & White/Plasma Freeze/50.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Calculate",
 				fr: "Calcul",
+				de: "Berechnen"
 			},
 			effect: {
 				en: "Look at the top 4 cards of your deck and put them back on top of your deck in any order.",
 				fr: "Regardez les 4 cartes du dessus de votre deck et replacez-les sur le dessus de votre deck dans l'ordre de votre choix.",
+				de: "Schau dir die obersten 4 Karten deines Decks an und lege sie in beliebiger Reihenfolge zurück auf dein Deck."
 			},
 
 		},
@@ -51,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Psypunch",
 				fr: "Coup de Poing Psy",
+				de: "Psyhieb"
 			},
 
 			damage: 20,
@@ -69,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "Its cells are all magnetic, and it communicates with others by using magnetic pulses.",
+		de: "Ihre Zellen sind magnetisch geladen. Sie sondern über ihre Körper Magnetkräfte ab, um miteinander zu kommunizieren."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/51.ts
+++ b/data/Black & White/Plasma Freeze/51.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Beldum",
 		fr: "Terhal",
+		de: "Tanhel"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Psy Bolt",
 				fr: "Choc Mental",
+				de: "Konfusion"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 10,
 
@@ -58,6 +61,7 @@ const card: Card = {
 			name: {
 				en: "Psypunch",
 				fr: "Coup de Poing Psy",
+				de: "Psyhieb"
 			},
 
 			damage: 50,
@@ -76,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It is formed by two Beldum joining together. Its two brains are linked, amplifying its psychic power.",
+		de: "Es besteht aus zwei Tanhel. Dank der Vereinigung ihrer beiden Hirne verfügen sie über gesteigerte Psycho-Kräfte."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/52.ts
+++ b/data/Black & White/Plasma Freeze/52.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Metang",
 		fr: "Métang",
+		de: "Metang"
 	},
 
 	stage: "Stage2",
@@ -42,7 +43,7 @@ const card: Card = {
 				es: "Búsqueda de Plasma",
 				it: "Ricerca Plasma",
 				pt: "Busca de Plasma",
-				de: "Plasmasuche"
+				de: "Plasma-Suche"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may search your deck for a Team Plasma card, reveal it, and put it into your hand. Shuffle your deck afterward. You may not use an Ability with the same name during your turn.",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Una vez durante tu turno (antes de tu ataque), puedes buscar en tu baraja una carta del Equipo Plasma, enseñarla y ponerla en tu mano. Baraja las cartas de tu baraja después. No puedes usar una habilidad con el mismo nombre durante tu turno.",
 				it: "Una sola volta durante il tuo turno, prima di attaccare, puoi cercare nel tuo mazzo una carta Team Plasma, mostrarla e aggiungerla alle carte che hai in mano. Poi rimischia le carte del tuo mazzo. Non puoi utilizzare un’abilità con lo stesso nome durante il tuo turno.",
 				pt: "Uma vez durante sua vez de jogar (antes de atacar), você pode procurar um card da Equipe Plasma em seu deck, revelá-lo e colocá-lo na sua mão. Em seguida, embaralhe seus cards. Você não poderá usar uma Habilidade com o mesmo nome durante sua vez de jogar.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du dein Deck nach 1 Team-Plasma-Karte durchsuchen, sie deinem Gegner zeigen und auf deine Hand nehmen. Mische anschließend dein Deck. Du kannst keine Fähigkeit mit demselben Namen während deines Zuges einsetzen."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du dein Deck nach 1 Team Plasma-Karte durchsuchen, sie deinem Gegner zeigen und auf deine Hand nehmen. Mische anschließend dein Deck. Du kannst während deines Zuges keine Fähigkeit mit dem gleichen Namen einsetzen."
 			},
 		},
 	],
@@ -66,10 +67,12 @@ const card: Card = {
 			name: {
 				en: "Mind Bend",
 				fr: "Contrôleur d'Esprit",
+				de: "Gedankenverbiegung"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Confused.",
 				fr: "Le Pokémon Défenseur est maintenant Confus.",
+				de: "Das Verteidigende Pokémon ist jetzt verwirrt."
 			},
 			damage: 60,
 
@@ -87,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "With four linked brains, it's more intelligent than a supercomputer, and it uses calculations to analyze foes.",
+		de: "Dank seiner vier vernetzten Hirne kann es Gegner besser als ein Supercomputer mit komplizierten Formeln analysieren."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/53.ts
+++ b/data/Black & White/Plasma Freeze/53.ts
@@ -34,7 +34,7 @@ const card: Card = {
 				es: "Conectar Poder",
 				it: "Collegaforza",
 				pt: "Conexão de Poder",
-				de: "Volltreffer"
+				de: "Kraftkombo"
 			},
 			effect: {
 				en: "Your Team Plasma Pokémon’s attacks (excluding Deoxys-EX) do 10 more damage to the Active Pokémon (before applying Weakness and Resistance).",
@@ -42,7 +42,7 @@ const card: Card = {
 				es: "Los ataques de tus Pokémon del Equipo Plasma (excepto Deoxys-EX) hacen 10 puntos de daño más a los Pokémon Activos (antes de aplicar Debilidad y Resistencia).",
 				it: "Gli attacchi dei tuoi Pokémon Team Plasma (eccetto Deoxys-EX) infliggono 10 danni in più al Pokémon attivo, prima di aver applicato debolezza e resistenza.",
 				pt: "Os ataques dos seus Pokémon da Equipe Plasma (exceto Deoxys-EX) causam 10 de danos adicionais ao Pokémon Ativo (antes da aplicação de Fraqueza e Resistência).",
-				de: "Die Angriffe deiner Team-Plasma-Pokémon (mit Ausnahme von Deoxys-EX) fügen den Aktiven Pokémon 10 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
+				de: "Die Angriffe deiner Team Plasma-Pokémon (mit Ausnahme von Deoxys-EX) fügen den Aktiven Pokémon 10 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 		},
 	],
@@ -55,10 +55,12 @@ const card: Card = {
 			name: {
 				en: "Helix Force",
 				fr: "Force Spirale",
+				de: "Helixkraft"
 			},
 			effect: {
 				en: "If this Pokémon has any Plasma Energy attached to it, this attack does 30 more damage for each Energy attached to the Defending Pokémon.",
 				fr: "Si de l'Énergie Plasma est attachée à ce Pokémon, cette attaque inflige 30 dégâts supplémentaires pour chaque Énergie attachée au Pokémon Défenseur.",
+				de: "Wenn an dieses Pokémon bereits Plasma-Energie angelegt ist, fügt dieser Angriff 30 weitere Schadenspunkte für jede an das Verteidigende Pokémon angelegte Energie zu."
 			},
 			damage: 30,
 

--- a/data/Black & White/Plasma Freeze/54.ts
+++ b/data/Black & White/Plasma Freeze/54.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Transfer Pain",
 				fr: "Transfert de Douleur",
+				de: "Schmerztranfer"
 			},
 			effect: {
 				en: "Move 1 damage counter from any of your Pokémon to any of your opponent's Pokémon.",
 				fr: "Déplacez 1 marqueur de dégâts de l'un de vos Pokémon vers l'un des Pokémon de votre adversaire.",
+				de: "Verschiebe 1 Schadensmarke von einem deiner Pokémon auf ein Pokémon deines Gegners."
 			},
 
 		},
@@ -56,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "These Pokémon arose from the spirits of people interred in graves. Each retains memories of its former life.",
+		de: "Es entsteht aus den Seelen von längst begrabenen Menschen und kann sich immer noch an deren Vergangenheit erinnern."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/55.ts
+++ b/data/Black & White/Plasma Freeze/55.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Will-O-Wisp",
 				fr: "Feu Follet",
+				de: "Irrlicht"
 			},
 
 			damage: 10,
@@ -50,6 +51,7 @@ const card: Card = {
 			name: {
 				en: "Ram",
 				fr: "Collision",
+				de: "Ramme"
 			},
 
 			damage: 30,
@@ -68,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "These Pokémon arose from the spirits of people interred in graves. Each retains memories of its former life.",
+		de: "Es entsteht aus den Seelen von längst begrabenen Menschen und kann sich immer noch an deren Vergangenheit erinnern."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/56.ts
+++ b/data/Black & White/Plasma Freeze/56.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Yamask",
 		fr: "Tutafeh",
+		de: "Makabaja"
 	},
 
 	stage: "Stage1",
@@ -42,7 +43,7 @@ const card: Card = {
 				es: "Tres Metros Bajo Tierra",
 				it: "Sottoterra",
 				pt: "Sete Palmos sob a Terra",
-				de: "Radieschen von unten"
+				de: "Grausame Gruft"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may Knock Out this Pokémon. If you do, put 3 damage counters on your opponent’s Pokémon in any way you like.",
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Slap of Misfortune",
 				fr: "Revers de Fortune",
+				de: "Unglückshieb"
 			},
 			effect: {
 				en: "Whenever your opponent flips a coin during his or her next turn, treat it as tails.",
 				fr: "Chaque fois que votre adversaire lance une pièce pendant son prochain tour, considérez que c'est pile.",
+				de: "Immer wenn dein Gegner während seines nächsten Zuges 1 Münze wirft, wird das Ergebnis als „Zahl“ gewertet."
 			},
 			damage: 70,
 
@@ -86,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "Grave robbers who mistake them for real coffins and get too close end up trapped inside their bodies.",
+		de: "Grabräuber, die es mit einem echten Sarg verwechseln und ihm zu nahe kommen, hält es im Inneren seines Körpers gefangen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/57.ts
+++ b/data/Black & White/Plasma Freeze/57.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Yamask",
 		fr: "Tutafeh",
+		de: "Makabaja"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Elongating Arms",
 				fr: "Bras à Rallonges",
+				de: "Lange Arme"
 			},
 			effect: {
 				en: "This attack does 30 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige 30 dégâts à 1 des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 1 Pokémon deines Gegners 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Crazy Slap",
 				fr: "Gifle Folle",
+				de: "Irrer Hieb"
 			},
 			effect: {
 				en: "Flip 4 coins. This attack does 40 damage times the number of heads.",
 				fr: "Lancez 4 pièces. Cette attaque inflige 40 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 4 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 40,
 
@@ -78,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "Grave robbers who mistake them for real coffins and get too close end up trapped inside their bodies.",
+		de: "Grabräuber, die es mit einem echten Sarg verwechseln und ihm zu nahe kommen, hält es im Inneren seines Körpers gefangen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/58.ts
+++ b/data/Black & White/Plasma Freeze/58.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Nidorino",
 		fr: "Nidorino",
+		de: "Nidorino"
 	},
 
 	stage: "Stage2",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Lovestrike",
 				fr: "Coup de Foudre",
+				de: "Liebestaumel"
 			},
 			effect: {
 				en: "Does 40 more damage for each Nidoqueen on your Bench.",
 				fr: "Inflige 40 dégâts supplémentaires pour chaque Nidoqueen sur votre Banc.",
+				de: "Dieser Angriff fügt für jedes Nidoqueen auf deiner Bank 40 weitere Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -60,6 +63,7 @@ const card: Card = {
 			name: {
 				en: "Horn Drill",
 				fr: "Empal'Korne",
+				de: "Hornbohrer"
 			},
 
 			damage: 90,
@@ -85,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "One swing of its mighty tail can snap a telephone pole as if it were a matchstick.",
+		de: "Ein Schlag mit seinem gewaltigen Schweif kann einen Telegrafenmasten knicken wie ein Streichholz."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/59.ts
+++ b/data/Black & White/Plasma Freeze/59.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Scratch",
 				fr: "Griffe",
+				de: "Kratzer"
 			},
 
 			damage: 20,
@@ -54,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives in treetop colonies. If one becomes enraged, the whole colony rampages for no reason.",
+		de: "Es lebt mit anderen in Baumkronen. Wird eines von ihnen wütend, werden alle anderen auch wütend."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/6.ts
+++ b/data/Black & White/Plasma Freeze/6.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Pound",
 				fr: "Écras'Face",
+				de: "Pfund"
 			},
 
 			damage: 10,
@@ -49,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Reckless Charge",
 				fr: "Attaque Imprudente",
+				de: "Waghalsiger Sturmangriff"
 			},
 			effect: {
 				en: "This Pokémon does 10 damage to itself.",
 				fr: "Ce Pokémon s'inflige 10 dégâts.",
+				de: "Dieses Pokémon fügt sich selbst 10 Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -77,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "The soles of its feet are covered by countless tiny spikes, enabling it to walk on walls and ceilings.",
+		de: "Seine Fußsohlen sind mit kleinen Stacheln bedeckt, so dass es an Wänden und Decken Halt findet."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/60.ts
+++ b/data/Black & White/Plasma Freeze/60.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Mankey",
 		fr: "Férosinge",
+		de: "Menki"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Fury Swipes",
 				fr: "Combo-Griffe",
+				de: "Kratzfurie"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 30 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 30,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Karate Chop",
 				fr: "Poing-Karaté",
+				de: "Karateschlag"
 			},
 			effect: {
 				en: "Does 80 damage minus 10 damage for each damage counter on this Pokémon.",
 				fr: "Inflige 80 dégâts moins 10 dégâts pour chaque marqueur de dégâts placé sur ce Pokémon.",
+				de: "Dieser Angriff fügt 80 Schadenspunkte minus 10 Schadenspunkte für jede Schadensmarke auf diesem Pokémon zu."
 			},
 			damage: 80,
 
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "It grows angry if you see its eyes and gets angrier if you run. If you beat it, it gets even madder.",
+		de: "Siehst du ihm in die Augen, wird es wütend. Rennst du weg, wird es noch wütender. Ärgerst du es..."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/61.ts
+++ b/data/Black & White/Plasma Freeze/61.ts
@@ -38,6 +38,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 30,
@@ -53,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Swing Around",
 				fr: "Balançoire",
+				de: "Gegenschwung"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 60 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 60 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 60 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 60,
 
@@ -74,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "Opening its large mouth, it ingests massive amounts of soil and creates long tunnels.",
+		de: "Es gräbt lange Tunnel, indem es sein riesiges Maul öffnet und große Mengen an Erdreich verschluckt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/62.ts
+++ b/data/Black & White/Plasma Freeze/62.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Continuous Slap",
 				fr: "Gifles Sans Fin",
+				de: "Dauerhieb"
 			},
 			effect: {
 				en: "Flip a coin until you get tails. This attack does 20 damage times the number of heads.",
 				fr: "Lancez une pièce jusqu'à ce que vous obteniez un côté pile. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -54,6 +56,7 @@ const card: Card = {
 			name: {
 				en: "Hammer In",
 				fr: "Enfoncer",
+				de: "Einhämmern"
 			},
 
 			damage: 60,
@@ -72,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "It toughens its body by slamming into thick trees. Many snapped trees can be found near its nest.",
+		de: "Es stärkt seinen Körper, indem es gegen Bäume rennt. In seiner Nähe finden sich viele umgekippte Bäume."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/63.ts
+++ b/data/Black & White/Plasma Freeze/63.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Makuhita",
 		fr: "Makuhita",
+		de: "Makuhita"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Fake Out",
 				fr: "Bluff",
+				de: "Mogelhieb"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 30,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Pivot Throw",
 				fr: "Lancer Tournant",
+				de: "Schleuderwurf"
 			},
 			effect: {
 				en: "During your opponent's next turn, any damage done to this Pokémon by attacks is increased by 20 (after applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, tous les dégâts infligés à ce Pokémon par des attaques sont augmentés de 20 (après application de la Faiblesse et de la Résistance).",
+				de: "Während des nächsten Zuges deines Gegners wird Schaden, der diesem Pokémon durch Angriffe zugefügt wird, um 20 Schadenspunkte erhöht (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 			damage: 90,
 
@@ -80,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "It loves to match power with big-bodied Pokémon. It can knock a truck flying with its arm thrusts.",
+		de: "Es liebt das Kräftemessen mit großen Pokémon. Mit seinem Armwurf kann es LKW durch die Luft werfen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/64.ts
+++ b/data/Black & White/Plasma Freeze/64.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -42,7 +43,7 @@ const card: Card = {
 				es: "Sombra Oscura",
 				it: "Tonoscuro",
 				pt: "Máscara da Escuridão",
-				de: "Finsterer Schatten"
+				de: "Schwarzer Schatten"
 			},
 			effect: {
 				en: "Each of your Team Plasma Pokémon in play gets +20 HP.",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Cada uno de tus Pokémon del Equipo Plasma en juego obtiene 20 PV más.",
 				it: "Ciascuno dei tuoi Pokémon Team Plasma in gioco ottiene 20 PV in più.",
 				pt: "Cada um dos seus Pokémon da Equipe Plasma em jogo recebe +20 PS.",
-				de: "Jedes deiner Team-Plasma-Pokémon im Spiel erhält +20 KP."
+				de: "Jedes deiner Team Plasma-Pokémon im Spiel erhält +20 KP."
 			},
 		},
 	],
@@ -65,6 +66,7 @@ const card: Card = {
 			name: {
 				en: "Darkness Fang",
 				fr: "Croc Obscur",
+				de: "Fänge der Dunkelheit"
 			},
 
 			damage: 70,
@@ -90,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "When exposed to the moon's aura, the rings on its body glow faintly and it's filled with a mysterious power.",
+		de: "Wird es der Aura des Mondes ausgesetzt, glühen seine Ringe und es wird von einer mysteriösen Kraft durchströmt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/65.ts
+++ b/data/Black & White/Plasma Freeze/65.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Quick Attack",
 				fr: "Vive-Attaque",
+				de: "Ruckzuckhieb"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -65,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "A smart and sneaky Pokémon, it makes its opponents flinch by suddenly showing the claws hidden in its paws.",
+		de: "Dieses durchtriebene Pokémon lässt seine Gegner zurückschrecken, indem es auf einmal seine langen Krallen ausfährt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/66.ts
+++ b/data/Black & White/Plasma Freeze/66.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Sneasel",
 		fr: "Farfuret",
+		de: "Sniebel"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Hail",
 				fr: "Grêle",
+				de: "Hagelsturm"
 			},
 			effect: {
 				en: "This attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige 10 dégâts à chacun des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt jedem Pokémon deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Vilify",
 				fr: "Calomnie",
+				de: "Kalkuliertes Risiko"
 			},
 			effect: {
 				en: "Discard as many Pokémon as you like from your hand. This attack does 30 damage times the number of Pokémon you discarded.",
 				fr: "Défaussez autant de Pokémon que vous voulez de votre main. Cette attaque inflige 30 dégâts multipliés par le nombre de Pokémon que vous avez défaussés.",
+				de: "Lege beliebig viele Pokémon von deiner Hand auf deinen Ablagestapel. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl der von dir abgelegten Pokémon zu."
 			},
 			damage: 30,
 
@@ -84,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "They communicate by clawing signs in boulders and work together to surround enemies.",
+		de: "Sie sprechen sich miteinander ab, indem sie Muster in Steine ritzen, um ihre Gegner dann gemeinsam einzukreisen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/67.ts
+++ b/data/Black & White/Plasma Freeze/67.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Mind Jack",
 				fr: "Emprise Mentale",
+				de: "Gedankenstoß"
 			},
 			effect: {
 				en: "Does 20 more damage for each of your opponent's Benched Pokémon.",
 				fr: "Inflige 20 dégâts supplémentaires pour chaque Pokémon de Banc de votre adversaire.",
+				de: "Dieser Angriff fügt 20 weitere Schadenspunkte für jedes Pokémon auf der Bank deines Gegners zu."
 			},
 			damage: 20,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Fearsome Shadow",
 				fr: "Ombre Redoutable",
+				de: "Furchtbarer Schatten"
 			},
 			effect: {
 				en: "Your opponent reveals his or her hand.",
 				fr: "Votre adversaire montre sa main.",
+				de: "Dein Gegner deckt seine Handkarten auf."
 			},
 			damage: 60,
 
@@ -82,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "It appears from deep in the mountains to warn people about upcoming disasters it has sensed with its horn.",
+		de: "Es steigt von den Bergen herab, um die Menschen vor Unheil zu warnen, das es mit seinem Horn vorhergesehen hat."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/68.ts
+++ b/data/Black & White/Plasma Freeze/68.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Gentle Slap",
 				fr: "Gifle Douce",
+				de: "Sanfter Hieb"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 10,
 
@@ -65,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "They live hidden under hot desert sands in order to keep their body temperature from dropping.",
+		de: "Es vergräbt sich im heißen Wüstensand, um nicht auszukühlen, und fristet sein Leben im Verborgenen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/69.ts
+++ b/data/Black & White/Plasma Freeze/69.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Sandile",
 		fr: "Mascaïman",
+		de: "Ganovil"
 	},
 
 	stage: "Stage1",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
+				de: "Biss"
 			},
 
 			damage: 20,
@@ -55,6 +57,7 @@ const card: Card = {
 			name: {
 				en: "Corkscrew Punch",
 				fr: "Poing Tire-Bouchon",
+				de: "Korkenzieherhieb"
 			},
 
 			damage: 50,
@@ -80,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "Protected by thin membranes, their eyes can see even in the dead of night. They live in groups of a few individuals.",
+		de: "Ihre Augen sind von einer dünnen Membran umgeben und können auch nachts sehen. Sie bilden kleine Rudel."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/7.ts
+++ b/data/Black & White/Plasma Freeze/7.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Treecko",
 		fr: "Arcko",
+		de: "Geckarbor"
 	},
 
 	stage: "Stage1",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Pound",
 				fr: "Écras'Face",
+				de: "Pfund"
 			},
 
 			damage: 20,
@@ -54,6 +56,7 @@ const card: Card = {
 			name: {
 				en: "Cut",
 				fr: "Coupe",
+				de: "Zerschneider"
 			},
 
 			damage: 30,
@@ -79,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives in dense jungles. While closing in on its prey, it leaps from branch to branch.",
+		de: "Es lebt im dichten Dschungel. Es springt von Ast zu Ast, wenn es sich einer Beute nähert."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/70.ts
+++ b/data/Black & White/Plasma Freeze/70.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Krokorok",
 		fr: "Escroco",
+		de: "Rokkaiman"
 	},
 
 	stage: "Stage2",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Piston Headbutt",
 				fr: "Coup de Piston",
+				de: "Kolbenschwinger"
 			},
 			effect: {
 				en: "Move an Energy attached to the Defending Pokémon to 1 of your opponent's Benched Pokémon.",
 				fr: "Déplacez une Énergie attachée au Pokémon Défenseur vers 1 des Pokémon de Banc de votre adversaire.",
+				de: "Verschiebe 1 an das Verteidigende Pokémon angelegte Energie auf 1 Pokémon auf der Bank deines Gegners."
 			},
 			damage: 30,
 
@@ -58,6 +61,7 @@ const card: Card = {
 			name: {
 				en: "Hammer In",
 				fr: "Enfoncer",
+				de: "Einhämmern"
 			},
 
 			damage: 80,
@@ -83,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "Very violent Pokémon, they try to clamp down on anything that moves in front of their eyes.",
+		de: "Ein äußerst grausames Pokémon. Es greift jeden, der ihm unter die Augen kommt, mit seinen scharfen Reißzähnen an."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/71.ts
+++ b/data/Black & White/Plasma Freeze/71.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Slash",
 				fr: "Tranche",
+				de: "Schlitzer"
 			},
 
 			damage: 10,
@@ -61,6 +62,7 @@ const card: Card = {
 
 	description: {
 		en: "Ignoring their injuries, groups attack by sinking the blades that cover their bodies into their prey.",
+		de: "Selbst wenn sie verletzt sind, greifen sie ihren Gegner unbeirrt in der Gruppe an, indem sie ihre Klingen in ihn hineinrammen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/72.ts
+++ b/data/Black & White/Plasma Freeze/72.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Cut",
 				fr: "Coupe",
+				de: "Zerschneider"
 			},
 
 			damage: 30,
@@ -62,6 +63,7 @@ const card: Card = {
 
 	description: {
 		en: "Ignoring their injuries, groups attack by sinking the blades that cover their bodies into their prey.",
+		de: "Selbst wenn sie verletzt sind, greifen sie ihren Gegner unbeirrt in der Gruppe an, indem sie ihre Klingen in ihn hineinrammen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/73.ts
+++ b/data/Black & White/Plasma Freeze/73.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pawniard",
 		fr: "Scalpion",
+		de: "Gladiantri"
 	},
 
 	stage: "Stage1",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Slash",
 				fr: "Tranche",
+				de: "Schlitzer"
 			},
 
 			damage: 40,
@@ -55,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Dragon Slayer",
 				fr: "Dragon Slayer",
+				de: "Drachentöter"
 			},
 			effect: {
 				en: "If the Defending Pokémon is a Dragon Pokémon, this attack does 40 more damage.",
 				fr: "Si le Pokémon Défenseur est un Pokémon Dragon, cette attaque inflige 40 dégâts supplémentaires.",
+				de: "Wenn das Verteidigende Pokémon ein {N}-Pokémon ist, fügt dieser Angriff 40 weitere Schadenspunkte zu."
 			},
 			damage: 80,
 
@@ -83,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "This pitiless Pokémon commands a group of Pawniard to hound prey into immobility. It then moves in to finish the prey off.",
+		de: "Ein kaltblütiges Pokémon, das Gegner zunächst mit einer Schar von Gladiantri lähmt und dann zweiteilt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/74.ts
+++ b/data/Black & White/Plasma Freeze/74.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pawniard",
 		fr: "Scalpion",
+		de: "Gladiantri"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Cut Down",
 				fr: "Retranchement",
+				de: "Umsägen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, défaussez une Énergie attachée au Pokémon Défenseur.",
+				de: "Wirf 1 Münze. Lege bei „Kopf“ 1 an das Verteidigende Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 30,
 
@@ -59,6 +62,7 @@ const card: Card = {
 			name: {
 				en: "Slicing Blade",
 				fr: "Lame Tranchante",
+				de: "Schwertschneide"
 			},
 
 			damage: 70,
@@ -84,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "This pitiless Pokémon commands a group of Pawniard to hound prey into immobility. It then moves in to finish the prey off.",
+		de: "Ein kaltblütiges Pokémon, das Gegner zunächst mit einer Schar von Gladiantri lähmt und dann zweiteilt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/75.ts
+++ b/data/Black & White/Plasma Freeze/75.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Push Down",
 				fr: "Renversement",
+				de: "Runterdrücken"
 			},
 			effect: {
 				en: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon.",
 				fr: "Votre adversaire échange le Pokémon Défenseur avec 1 de ses Pokémon de Banc.",
+				de: "Dein Gegner tauscht das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
 			},
 			damage: 20,
 
@@ -54,6 +56,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
+				de: "Biss"
 			},
 
 			damage: 30,
@@ -79,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "Lacking sight, it's unaware of its surroundings, so it bumps into things and eats anything that moves.",
+		de: "Da es nichts sehen kann, rammt und frisst es alles, was ihm auf dem Weg in die Quere kommt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/76.ts
+++ b/data/Black & White/Plasma Freeze/76.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Slam",
 				fr: "Souplesse",
+				de: "Slam"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -65,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "Lacking sight, it's unaware of its surroundings, so it bumps into things and eats anything that moves.",
+		de: "Da es nichts sehen kann, rammt und frisst es alles, was ihm auf dem Weg in die Quere kommt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/77.ts
+++ b/data/Black & White/Plasma Freeze/77.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Deino",
 		fr: "Solochi",
+		de: "Kapuno"
 	},
 
 	stage: "Stage1",
@@ -42,6 +43,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
+				de: "Biss"
 			},
 
 			damage: 30,
@@ -56,10 +58,12 @@ const card: Card = {
 			name: {
 				en: "Body Slam",
 				fr: "Plaquage",
+				de: "Bodyslam"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 30,
 
@@ -84,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "The two heads do not get along. Whichever head eats more than the other gets to be the leader.",
+		de: "Seine zwei Köpfe sind sich spinnefeind. Beide versuchen, über Fresswettbewerbe die Oberhand zu gewinnen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/78.ts
+++ b/data/Black & White/Plasma Freeze/78.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Zweilous",
 		fr: "Diamat",
+		de: "Duodino"
 	},
 
 	stage: "Stage2",
@@ -43,10 +44,12 @@ const card: Card = {
 			name: {
 				en: "Tractorbeam",
 				fr: "Rayon Inversion",
+				de: "Traktorstrahl"
 			},
 			effect: {
 				en: "Switch 1 of your opponent's Benched Pokémon with the Defending Pokémon. This attack does 40 damage to the new Defending Pokémon.",
 				fr: "Échangez 1 des Pokémon de Banc de votre adversaire avec le Pokémon Défenseur. Cette attaque inflige 40 dégâts au nouveau Pokémon Défenseur.",
+				de: "Tausche 1 Pokémon auf der Bank deines Gegners gegen das Verteidigende Pokémon aus. Dieser Angriff fügt dem neuen Verteidigenden Pokémon 40 Schadenspunkte zu."
 			},
 
 		},
@@ -60,10 +63,12 @@ const card: Card = {
 			name: {
 				en: "Obsidian Fang",
 				fr: "Croc d'Obsidienne",
+				de: "Schwarze Fänge"
 			},
 			effect: {
 				en: "Before doing damage, discard all Pokémon Tool cards attached to the Defending Pokémon.",
 				fr: "Avant d'infliger des dégâts, défaussez toutes les cartes Outil Pokémon attachées au Pokémon Défenseur.",
+				de: "Lege, bevor du Schaden zufügst, alle an das Verteidigende Pokémon angelegten Pokémon-Ausrüstungen auf den Ablagestapel deines Gegners."
 			},
 			damage: 80,
 
@@ -88,6 +93,7 @@ const card: Card = {
 
 	description: {
 		en: "It responds to movement by attacking. This scary, three-headed Pokémon devours everything in its path!",
+		de: "Ein kaltblütiges Pokémon, das auf alles reagiert, was sich bewegt, indem es mit seinen drei Köpfen danach schnappt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/79.ts
+++ b/data/Black & White/Plasma Freeze/79.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Onix",
 		fr: "Onix",
+		de: "Onix"
 	},
 
 	stage: "Stage1",
@@ -43,10 +44,12 @@ const card: Card = {
 			name: {
 				en: "Metal Defender",
 				fr: "Défense Métallique",
+				de: "Metallverteidiger"
 			},
 			effect: {
 				en: "During your opponent's next turn, this Pokémon has no Weakness.",
 				fr: "Pendant le prochain tour de votre adversaire, ce Pokémon n'a pas de Faiblesse.",
+				de: "Während des nächsten Zuges deines Gegners hat dieses Pokémon keine Schwäche."
 			},
 			damage: 50,
 
@@ -62,6 +65,7 @@ const card: Card = {
 			name: {
 				en: "Heavy Impact",
 				fr: "Gros Impact",
+				de: "Schwerer Einschlag"
 			},
 
 			damage: 100,
@@ -87,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "The iron it ingested with the soil it swallowed transformed its body and made it harder than diamonds.",
+		de: "Durch all die eisenhaltige Erde, die es verschluckt hat, wurde sein Körper härter als ein Diamant."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/8.ts
+++ b/data/Black & White/Plasma Freeze/8.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Grovyle",
 		fr: "Massko",
+		de: "Reptain"
 	},
 
 	stage: "Stage2",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "X-Scissor",
 				fr: "Plaie-Croix",
+				de: "Kreuzschere"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 40 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 40 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 40 weitere Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Energy Bloom",
 				fr: "Énergie Florissante",
+				de: "Energieschwall"
 			},
 			effect: {
 				en: "Heal 20 damage from each of your Pokémon that has any Energy attached to it.",
 				fr: "Soignez 20 dégâts à chacun de vos Pokémon auquel de l'Énergie est attachée.",
+				de: "Heile 20 Schadenspunkte bei jedem deiner Pokémon, an das Energie angelegt ist."
 			},
 			damage: 80,
 
@@ -87,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "The leaves that grow on its arms can slice down thick trees. It is without peer in jungle combat.",
+		de: "Die Blätter an seinen Armen können dicke Bäume fällen. Im Dschungelkampf gibt es kein stärkeres Pokémon."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/80.ts
+++ b/data/Black & White/Plasma Freeze/80.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Astonish",
 				fr: "Étonnement",
+				de: "Erstauner"
 			},
 			effect: {
 				en: "Flip a coin. If heads, choose a random card from your opponent's hand. Your opponent reveals that card and shuffles it into his or her deck.",
 				fr: "Lancez une pièce. Si c'est face, choisissez une carte au hasard de la main de votre adversaire. Votre adversaire montre la carte choisie et la mélange avec son deck.",
+				de: "Wirf 1 Münze. Wähle bei „Kopf“ 1 zufällige Karte aus der verdeckten Hand deines Gegners. Dein Gegner zeigt diese Karte und mischt sie zurück in sein Deck."
 			},
 
 		},
@@ -52,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Big Ol' Bite",
 				fr: "Morsure Sans Merci",
+				de: "Mächtiger Mampfer"
 			},
 			effect: {
 				en: "Heal 30 damage from this Pokémon. The Defending Pokémon can't retreat during your opponent's next turn.",
 				fr: "Soignez 30 dégâts à ce Pokémon. Le Pokémon Défenseur ne peut pas battre en retraite pendant le prochain tour de votre adversaire.",
+				de: "Heile 30 Schadenspunkte bei diesem Pokémon. Das Verteidigende Pokémon kann sich während des nächsten Zuges deines Gegners nicht zurückziehen."
 			},
 			damage: 30,
 
@@ -80,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "Attached to its head is a huge set of jaws formed by horns. It can chew through iron beams.",
+		de: "Auf seinem Kopf befindet sich ein riesiger Kiefer, der aus Hörnern besteht. Er kann Eisen zermalmen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/81.ts
+++ b/data/Black & White/Plasma Freeze/81.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Shed Skin",
 				fr: "Mue",
+				de: "Expidermis"
 			},
 			effect: {
 				en: "Heal 20 damage from this Pokémon.",
 				fr: "Soignez 20 dégâts à ce Pokémon.",
+				de: "Heile 20 Schadenspunkte bei diesem Pokémon."
 			},
 
 		},
@@ -51,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Tail Smack",
 				fr: "Coup de Queue",
+				de: "Schweifschlag"
 			},
 
 			damage: 20,
@@ -69,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "It is called the \"Mirage Pokémon\" because so few have seen it. Its shed skin has been found.",
+		de: "Man nennt es „Illusion-Pokémon“, denn nur wenige haben es gesehen. Nur seine Haut wurde oft gefunden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/82.ts
+++ b/data/Black & White/Plasma Freeze/82.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Dratini",
 		fr: "Minidraco",
+		de: "Dratini"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Wrap",
 				fr: "Ligotage",
+				de: "Wickel"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 20,
 
@@ -58,6 +61,7 @@ const card: Card = {
 			name: {
 				en: "Tail Smack",
 				fr: "Coup de Queue",
+				de: "Schweifschlag"
 			},
 
 			damage: 50,
@@ -76,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "If its body takes on an aura, the weather changes instantly. It is said to live in seas and lakes.",
+		de: "Erscheint um seinen Körper eine Aura, gibt es einen Wetterwechsel. Es soll in Seen und Meeren leben."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/83.ts
+++ b/data/Black & White/Plasma Freeze/83.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Dragonair",
 		fr: "Draco",
+		de: "Dragonir"
 	},
 
 	stage: "Stage2",
@@ -43,10 +44,12 @@ const card: Card = {
 			name: {
 				en: "Deafen",
 				fr: "Rendre Sourd",
+				de: "Ohren betäuben"
 			},
 			effect: {
 				en: "Your opponent can't play any Item cards from his or her hand during his or her next turn.",
 				fr: "Votre adversaire ne peut pas jouer de cartes Objet de sa main pendant son prochain tour.",
+				de: "Dein Gegner kann während seines nächsten Zuges keine Itemkarten von seiner Hand spielen."
 			},
 			damage: 60,
 
@@ -61,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Healwing",
 				fr: "Aile Soin",
+				de: "Heilschwinge"
 			},
 			effect: {
 				en: "Heal 30 damage from this Pokémon.",
 				fr: "Soignez 30 dégâts à ce Pokémon.",
+				de: "Heile 30 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 90,
 
@@ -82,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said to make its home somewhere in the sea. It guides crews of shipwrecks to shore.",
+		de: "Man sagt, es lebe in den Meeren. Es bringt Schiffbrüchige sicher an Land."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/84.ts
+++ b/data/Black & White/Plasma Freeze/84.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Seadra",
 		fr: "Hypocéan",
+		de: "Seemon"
 	},
 
 	stage: "Stage2",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Dragon Vortex",
 				fr: "Vortex Draconique",
+				de: "Drachenwirbel"
 			},
 			effect: {
 				en: "Does 20 damage times the number of Water Energy cards and Lightning Energy cards in your discard pile. Then, shuffle all of those cards back into your deck.",
 				fr: "Inflige 20 dégâts multipliés par le nombre de cartes Énergie Water et de cartes Énergie Lightning dans votre pile de défausse. Ensuite, mélangez toutes ces cartes avec votre deck.",
+				de: "Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl der {W}- und {L}-Energiekarten in deinem Ablagestapel zu. Mische diese Karten anschließend zurück in dein Deck."
 			},
 			damage: 20,
 
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Tri Bullet",
 				fr: "Triple Décharge",
+				de: "Kugeltrio"
 			},
 			effect: {
 				en: "This attack does 30 damage to 3 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige 30 dégâts à 3 des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 3 Pokémon deines Gegners jeweils 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -76,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives in caves on the seafloor and creates giant whirlpools every time it moves.",
+		de: "Es lebt in Höhlen auf dem Meeresgrund. Jedes Mal, wenn es sich bewegt, entsteht ein Strudel."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/85.ts
+++ b/data/Black & White/Plasma Freeze/85.ts
@@ -34,7 +34,7 @@ const card: Card = {
 				es: "Plumón Reluciente",
 				it: "Splendipiume",
 				pt: "Desabrilhantar",
-				de: "Strahlender Schild"
+				de: "Daunenschimmer"
 			},
 			effect: {
 				en: "Prevent all effects of attacks, including damage, done to this Pokémon by your opponent’s Pokémon with Abilities.",
@@ -42,7 +42,7 @@ const card: Card = {
 				es: "Evita todos los efectos de los ataques, incluido el daño, infligidos a este Pokémon por los Pokémon con habilidades de tu rival.",
 				it: "Previeni tutti gli effetti degli attacchi, inclusi i danni, inflitti a questo Pokémon dai Pokémon con abilità del tuo avversario.",
 				pt: "Impede todos os efeitos de ataques, inclusive danos, causados neste Pokémon pelo Pokémon do seu oponente com Habilidades.",
-				de: "Verhindere alle Effekte von Angriffen, einschließlich Schaden, die diesem Pokémon durch gegnerische Pokémon mit Fähigkeiten zugefügt werden."
+				de: "Verhindere alle Effekte von Angriffen, einschließlich Schaden, die diesem Pokémon durch gegnerische Pokémon, die Fähigkeiten besitzen, zugefügt werden."
 			},
 		},
 	],
@@ -56,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Barrier Break",
 				fr: "Brise Barrière",
+				de: "Barrierebrecher"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by Weakness, Resistance, or any other effects on the Defending Pokémon.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Faiblesse, la Résistance ou tout autre effet en action sur le Pokémon Défenseur.",
+				de: "Der Schaden dieses Angriffs wird durch Schwäche, Resistenz oder alle anderen Effekte auf dem Verteidigenden Pokémon nicht verändert."
 			},
 			damage: 70,
 

--- a/data/Black & White/Plasma Freeze/86.ts
+++ b/data/Black & White/Plasma Freeze/86.ts
@@ -35,10 +35,12 @@ const card: Card = {
 			name: {
 				en: "Mach Flight",
 				fr: "Vol Supersonique",
+				de: "Tempoflug"
 			},
 			effect: {
 				en: "The Defending Pokémon can't retreat during your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas battre en retraite pendant le prochain tour de votre adversaire.",
+				de: "Das Verteidigende Pokémon kann sich während des nächsten Zuges deines Gegners nicht zurückziehen."
 			},
 			damage: 40,
 
@@ -52,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Luster Purge",
 				fr: "Lumi-Éclat",
+				de: "Scheinwerfer"
 			},
 			effect: {
 				en: "Discard all Energy attached to this Pokémon.",
 				fr: "Défaussez toutes les Énergies attachées à ce Pokémon.",
+				de: "Lege alle an dieses Pokémon angelegten Energien auf deinen Ablagestapel."
 			},
 			damage: 150,
 

--- a/data/Black & White/Plasma Freeze/87.ts
+++ b/data/Black & White/Plasma Freeze/87.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Lunge",
 				fr: "Coup Rapide",
+				de: "Ausfall"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 30,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "It searches for food all day. It gnaws on hard objects to wear down its fangs, which grow constantly during its lifetime.",
+		de: "Sucht den lieben langen Tag nach Futter. Da seine Nagezähne immer nachwachsen, wetzt es sie an harten Objekten ab."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/88.ts
+++ b/data/Black & White/Plasma Freeze/88.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Rattata",
 		fr: "Rattata",
+		de: "Rattfratz"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Transfer Junk",
 				fr: "Transfert de Camelote",
+				de: "Trödeltransfer"
 			},
 			effect: {
 				en: "Put a Team Plasma Pokémon, a Team Plasma Trainer card, and a Team Plasma Energy card from your discard pile into your hand.",
 				fr: "Ajoutez un Pokémon de la Team Plasma, une carte Dresseur de la Team Plasma et une carte Énergie de la Team Plasma de votre pile de défausse à votre main.",
+				de: "Nimm 1 Team Plasma-Pokémon, 1 Team Plasma-Trainerkarte und 1 Team Plasma-Energiekarte von deinem Ablagestapel auf deine Hand."
 			},
 
 		},
@@ -56,6 +59,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
+				de: "Biss"
 			},
 
 			damage: 30,
@@ -74,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "With its long fangs, this surprisingly violent Pokémon can gnaw away even thick concrete with ease.",
+		de: "Ein überraschend brutales Pokémon. Seine langen Nagezähne sind äußerst stark und durchbrechen selbst Beton."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/89.ts
+++ b/data/Black & White/Plasma Freeze/89.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Growl",
 				fr: "Rugissement",
+				de: "Heuler"
 			},
 			effect: {
 				en: "During your opponent's next turn, any damage done by attacks from the Defending Pokémon is reduced by 20 (before applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, tous les dégâts infligés par des attaques du Pokémon Défenseur sont réduits de 20 (avant application de la Faiblesse et de la Résistance).",
+				de: "Während des nächsten Zuges deines Gegners wird Schaden, der durch Angriffe des Verteidigenden Pokémon zugefügt wird, um 20 Schadenspunkte reduziert (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Quick Attack",
 				fr: "Vive-Attaque",
+				de: "Ruckzuckhieb"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 weitere Schadenspunkte zu."
 			},
 			damage: 10,
 
@@ -72,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "Thanks to its unstable genetic makeup, this special Pokémon conceals many different possible evolutions.",
+		de: "Aufgrund einer genetischen Anomalie kann seine Entwicklung viele verschiedene Formen annehmen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/9.ts
+++ b/data/Black & White/Plasma Freeze/9.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Poison Sting",
 				fr: "Dard-Venin",
+				de: "Giftstachel"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Empoisonné.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet."
 			},
 
 		},
@@ -63,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "By storing water in its body, this desert dweller can survive for 30 days without water.",
+		de: "Dieser Wüstenbewohner speichert Wasser in seinem Körper. So kann er 30 Tage ohne Wasser überleben."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/90.ts
+++ b/data/Black & White/Plasma Freeze/90.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Signs of Evolution",
 				fr: "Signes d'Évolution",
+				de: "Spuren der Evolution"
 			},
 			effect: {
 				en: "Search your deck for 3 Pokémon of different types that evolve from Eevee. Reveal them and put them into your hand. Shuffle your deck afterward.",
 				fr: "Cherchez dans votre deck 3 Pokémon de différents types qui sont une évolution d'Évoli. Montrez-les puis ajoutez-les à votre main. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 3 vom Typ her unterschiedlichen Pokémon, die sich aus Evoli entwickeln. Zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
 			},
 
 		},
@@ -52,6 +54,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
+				de: "Biss"
 			},
 
 			damage: 30,
@@ -70,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "Thanks to its unstable genetic makeup, this special Pokémon conceals many different possible evolutions.",
+		de: "Aufgrund einer genetischen Anomalie kann seine Entwicklung viele verschiedene Formen annehmen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/91.ts
+++ b/data/Black & White/Plasma Freeze/91.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Dual Draw",
 				fr: "Pioche Mutuelle",
+				de: "Doppelzug"
 			},
 			effect: {
 				en: "Each player draws 2 cards.",
 				fr: "Chaque joueur pioche 2 cartes.",
+				de: "Jeder Spieler zieht 2 Karten."
 			},
 
 		},
@@ -63,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It marks time precisely. Some countries consider it to be a wise friend, versed in the world's ways.",
+		de: "Es sagt präzise die Uhrzeit an. In manchen Regionen verehrt man es zudem als weisen Freund."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/92.ts
+++ b/data/Black & White/Plasma Freeze/92.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Hoothoot",
 		fr: "Hoothoot",
+		de: "Hoothoot"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Powerful Vision",
 				fr: "Vision Puissante",
+				de: "Mächtige Vision"
 			},
 			effect: {
 				en: "Does 10 damage times the number of cards in your opponent's hand.",
 				fr: "Inflige 10 dégâts multipliés par le nombre de cartes dans la main de votre adversaire.",
+				de: "Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl der Karten auf der Hand deines Gegners zu."
 			},
 			damage: 10,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Fly",
 				fr: "Vol",
+				de: "Fliegen"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien. Si c'est face, évitez tous les effets d'attaques (y compris les dégâts) infligés à ce Pokémon pendant le prochain tour de votre adversaire.",
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die diesem Pokémon zugefügt werden."
 			},
 			damage: 50,
 
@@ -87,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "Its eyes are specially developed to enable it to see clearly even in murky darkness and minimal light.",
+		de: "Seine Augen sind so gut entwickelt, dass es selbst in tiefster Dunkelheit noch klar sehen kann."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/93.ts
+++ b/data/Black & White/Plasma Freeze/93.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Max Milk",
 				fr: "Lait Max",
+				de: "Megamilch"
 			},
 			effect: {
 				en: "Heal all damage from 1 of your Pokémon. Then, discard all Energy attached to this Pokémon.",
 				fr: "Soignez tous les dégâts de l'un de vos Pokémon. Ensuite, défaussez toutes les Énergies attachées à ce Pokémon.",
+				de: "Heile allen Schaden bei 1 deiner Pokémon. Lege anschließend alle an dieses Pokémon angelegten Energien auf deinen Ablagestapel."
 			},
 
 		},
@@ -52,6 +54,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 30,
@@ -70,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said that kids who drink Miltank's milk grow up to become hearty, healthy adults.",
+		de: "Man sagt, dass Kinder, die Miltanks Milch trinken, zu gesunden Erwachsenen heranwachsen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/94.ts
+++ b/data/Black & White/Plasma Freeze/94.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Mientras este Pokémon sea tu Pokémon Activo, este Pokémon es del mismo tipo que el Pokémon Activo de tu rival.",
 				it: "Fintanto che questo Pokémon è il tuo Pokémon attivo, avrà lo stesso tipo del Pokémon attivo del tuo avversario.",
 				pt: "Desde que este Pokémon seja seu Pokémon Ativo, esse Pokémon é do mesmo tipo do Pokémon Ativo do seu oponente.",
-				de: "Solang dieses Pokémon dein Aktives Pokémon ist, ist dieses Pokémon vom gleichen Typ wie das Aktive Pokémon deines Gegners."
+				de: "Solang dieses Pokémon dein Aktives Pokémon ist, hat dieses Pokémon den gleichen Typ wie das Aktive Pokémon deines Gegners."
 			},
 		},
 	],
@@ -58,10 +58,12 @@ const card: Card = {
 			name: {
 				en: "Imittack",
 				fr: "Imit’Attaque",
+				de: "Nachmacher"
 			},
 			effect: {
 				en: "Choose 1 of the Defending Pokémon's attacks. If this Pokémon has the necessary Energy to use that attack, use it as this attack.",
 				fr: "Choisissez 1 des attaques du Pokémon Défenseur. Si ce Pokémon a l'Énergie nécessaire pour utiliser l'attaque choisie, utilisez-la  à la place de cette attaque.",
+				de: "Wähle 1 Angriff des Verteidigenden Pokémon. Wenn an dieses Pokémon die für den gewählten Angriff erforderliche Energie angelegt ist, verwende ihn als diesen Angriff."
 			},
 
 		},
@@ -78,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It can freely change its body's color. The zigzag pattern on its belly doesn't change, however.",
+		de: "Es kann nach Belieben seine Farbe ändern. Nur das gezackte Muster auf seinem Bauch bleibt gleich."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/95.ts
+++ b/data/Black & White/Plasma Freeze/95.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 10,
@@ -61,6 +62,7 @@ const card: Card = {
 
 	description: {
 		en: "Because they are weak individually, they form groups. However, they bicker if the group grows too big.",
+		de: "Einzeln sind sie schwach. Daher bilden sie Gruppen. Werden diese jedoch zu groß, zanken sie sich."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/96.ts
+++ b/data/Black & White/Plasma Freeze/96.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Starly",
 		fr: "Étourmi",
+		de: "Staralili"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Take Down",
 				fr: "Bélier",
+				de: "Bodycheck"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this Pokémon does 10 damage to itself.",
 				fr: "Lancez une pièce. Si c'est pile, ce Pokémon s'inflige 10 dégâts.",
+				de: "Wirf 1 Münze. Bei „Zahl“ fügt sich dieses Pokémon selbst 10 Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -70,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "Recognizing their own weakness, they always live in a group. When alone, a Staravia cries noisily.",
+		de: "Staravia verbergen ihre Schwäche in Gruppen. Sind sie allein, kann man sie an ihren lauten Rufen erkennen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/97.ts
+++ b/data/Black & White/Plasma Freeze/97.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Staravia",
 		fr: "Étourvol",
+		de: "Staravia"
 	},
 
 	stage: "Stage2",
@@ -43,6 +44,7 @@ const card: Card = {
 			name: {
 				en: "Wing Attack",
 				fr: "Cru-Aile",
+				de: "Flügelschlag"
 			},
 
 			damage: 60,
@@ -58,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Strong Breeze",
 				fr: "Forte Brise",
+				de: "Steife Brise"
 			},
 			effect: {
 				en: "Your opponent shuffles the Defending Pokémon and all cards attached to it into his or her deck.",
 				fr: "Votre adversaire mélange le Pokémon Défenseur et toutes les cartes qui lui sont attachées avec son deck.",
+				de: "Dein Gegner mischt das Verteidigende Pokémon und alle daran angelegten Karten zurück in sein Deck."
 			},
 
 		},
@@ -85,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It never stops attacking even if it is injured. It fusses over the shape of its comb.",
+		de: "Selbst mit einer Verletzung greift es immer weiter an. Ziert sich etwas aufgrund der Form seines Kamms."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Freeze/98.ts
+++ b/data/Black & White/Plasma Freeze/98.ts
@@ -34,10 +34,12 @@ const card: Card = {
 			name: {
 				en: "Windfall",
 				fr: "Rafale de Vent",
+				de: "Warmer Regen"
 			},
 			effect: {
 				en: "Shuffle your hand into your deck. Then, draw 6 cards.",
 				fr: "Mélangez votre main avec votre deck. Ensuite, piochez 6 cartes.",
+				de: "Mische deine Handkarten in dein Deck. Ziehe anschließend 6 Karten."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Jet Blast",
 				fr: "Rafale d'Explosions",
+				de: "Hochdruckwelle"
 			},
 			effect: {
 				en: "Does 30 more damage for each Plasma Energy attached to this Pokémon.",
 				fr: "Inflige 30 dégâts supplémentaires pour chaque Énergie Plasma attachée à ce Pokémon.",
+				de: "Dieser Angriff fügt 30 weitere Schadenspunkte für jede an dieses Pokémon angelegte Plasma-Energie zu."
 			},
 			damage: 60,
 

--- a/data/Black & White/Plasma Freeze/99.ts
+++ b/data/Black & White/Plasma Freeze/99.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "El Pokémon al que esté unida esta carta no tiene ningún Coste de Retirada.",
 		it: "Il Pokémon a cui questa carta è assegnata non ha alcun costo di ritirata.",
 		pt: "O Pokémon ao qual este card está ligado não tem Custo para Recuar.",
-		de: "Das Pokémon, an das diese Karte angelegt ist, hat keine Rückzugskosten."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Das Pokémon, an das diese Karte angelegt ist, hat keine Rückzugskosten. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",


### PR DESCRIPTION
## Add missing German translations for bw9

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
