### PR TITLE
Add missing German translations for tk-xy-sy

### DIFF
--- a/data/Trainer kits/XY trainer Kit (Sylveon)/15.ts
+++ b/data/Trainer kits/XY trainer Kit (Sylveon)/15.ts
@@ -19,7 +19,8 @@ const card: Card = {
 	category: "Pokemon",
 
 	description: {
-		en: "It sends a soothing aura from its ribbonlike feelers to calm fights."
+		en: "It sends a soothing aura from its ribbonlike feelers to calm fights.",
+		de: "Seinen bandförmigen Fühlern lässt es beruhigende Wellen entströmen, die das Ende von Kämpfen herbeiführen."
 	},
 
 	stage: "Stage1",
@@ -27,19 +28,22 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Disarming Voice",
-			fr: "Voix Enjôleuse"
+			fr: "Voix Enjôleuse",
+			de: "Säuselstimme"
 		},
 
 		damage: 20,
 
 		effect: {
 			en: "Your opponent’s Active Pokémon is now Confused.",
-			fr: "Le Pokémon Actif de votre adversaire est maintenant Confus."
+			fr: "Le Pokémon Actif de votre adversaire est maintenant Confus.",
+			de: "Das Aktive Pokémon deines Gegners ist jetzt verwirrt."
 		}
 	}, {
 		name: {
 			en: "Fairy Wind",
-			fr: "Vent Féérique"
+			fr: "Vent Féérique",
+			de: "Feenbrise"
 		},
 
 		damage: 60

--- a/data/Trainer kits/XY trainer Kit (Sylveon)/23.ts
+++ b/data/Trainer kits/XY trainer Kit (Sylveon)/23.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Lanza 1 moneda. Si sale cara, cambia 1 de los Pokémon en Banca de tu rival por su Pokémon Activo.",
 		it: "Lancia una moneta. Se esce testa, scambia uno dei Pokémon nella panchina del tuo avversario con il suo Pokémon attivo.",
 		pt: "Jogue uma moeda. Se sair cara, troque 1 dos Pokémon no Banco do seu oponente pelo Pokémon Ativo desse oponente.",
-		de: "Wirf 1 Münze. Bei \"Kopf\" kannst du 1 Pokémon auf der Bank deines Gegners gegen sein Aktives Pokémon austauschen."
+		de: "Tausche das Aktive Pokémon deines Gegners gegen 1 Pokémon auf seiner Bank aus. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item"

--- a/data/Trainer kits/XY trainer Kit (Sylveon)/28.ts
+++ b/data/Trainer kits/XY trainer Kit (Sylveon)/28.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 2 cartas de Energía Básica, enséñalas y ponlas en tu mano. Baraja las cartas de tu baraja después.",
 		it: "Cerca nel tuo mazzo fino a due carte Energia base, mostrale e aggiungile alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure em seu baralho por até 2 cards de Energia básica, revele-os e coloque-os em sua mão. Em seguida, embaralhe seus cards.",
-		de: "Durchsuche dein Deck nach 2 Basis-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach 2 Basis-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item"

--- a/data/Trainer kits/XY trainer Kit (Sylveon)/30.ts
+++ b/data/Trainer kits/XY trainer Kit (Sylveon)/30.ts
@@ -19,7 +19,8 @@ const card: Card = {
 	category: "Pokemon",
 
 	description: {
-		en: "It sends a soothing aura from its ribbonlike feelers to calm fights."
+		en: "It sends a soothing aura from its ribbonlike feelers to calm fights.",
+		de: "Seinen bandförmigen Fühlern lässt es beruhigende Wellen entströmen, die das Ende von Kämpfen herbeiführen."
 	},
 
 	stage: "Stage1",
@@ -27,19 +28,22 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Disarming Voice",
-			fr: "Voix Enjôleuse"
+			fr: "Voix Enjôleuse",
+			de: "Säuselstimme"
 		},
 
 		damage: 20,
 
 		effect: {
 			en: "Your opponent’s Active Pokémon is now Confused.",
-			fr: "Le Pokémon Actif de votre adversaire est maintenant Confus."
+			fr: "Le Pokémon Actif de votre adversaire est maintenant Confus.",
+			de: "Das Aktive Pokémon deines Gegners ist jetzt verwirrt."
 		}
 	}, {
 		name: {
 			en: "Fairy Wind",
-			fr: "Vent Féérique"
+			fr: "Vent Féérique",
+			de: "Feenbrise"
 		},
 
 		damage: 60


### PR DESCRIPTION
## Add missing German translations for tk-xy-sy

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
