### PR TITLE
Add missing German translations for tk-xy-latia

### DIFF
--- a/data/Trainer kits/XY trainer Kit (Latias)/14.ts
+++ b/data/Trainer kits/XY trainer Kit (Latias)/14.ts
@@ -23,27 +23,31 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It can telepathically communicate with people. It changes its appearance using its down that refracts light."
+		en: "It can telepathically communicate with people. It changes its appearance using its down that refracts light.",
+		de: "Mittels Telepathie kann es mit Menschen kommunizieren. Mit seinen Daunen, die das Licht brechen, kann es sein Aussehen verändern."
 	},
 
 	attacks: [{
 		name: {
 			en: "Psychic Sphere",
-			fr: "Sphère Psy"
+			fr: "Sphère Psy",
+			de: "Psychosphäre"
 		},
 
 		damage: 20
 	}, {
 		name: {
 			en: "Psychic Prism",
-			fr: "Prisme Psy"
+			fr: "Prisme Psy",
+			de: "Psychoprisma"
 		},
 
 		damage: "60+",
 
 		effect: {
 			en: "Flip a coin. If heads, this attack does 20 more damage.",
-			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires."
+			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+			de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 		}
 	}],
 

--- a/data/Trainer kits/XY trainer Kit (Latias)/20.ts
+++ b/data/Trainer kits/XY trainer Kit (Latias)/20.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mira las 2 primeras cartas de tu baraja y pon 1 de ellas en tu mano. Descarta la otra carta.",
 		it: "Guarda le prime due carte del tuo mazzo e aggiungi una di esse alle carte che hai in mano. Scarta l’altra carta.",
 		pt: "Olhe os 2 cards de cima do seu baralho e coloque 1 deles de volta na sua mão. Descarte o outro card.",
-		de: "Schau dir die 2 obersten Karten deines Decks an und nimm 1 auf deine Hand. Lege die andere Karte auf deinen Ablagestapel."
+		de: "Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen. Schau dir die 2 obersten Karten deines Decks an und nimm 1 auf deine Hand. Lege die andere Karte auf deinen Ablagestapel."
 	},
 
 	trainerType: "Item",

--- a/data/Trainer kits/XY trainer Kit (Latias)/29.ts
+++ b/data/Trainer kits/XY trainer Kit (Latias)/29.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mira las 2 primeras cartas de tu baraja y pon 1 de ellas en tu mano. Descarta la otra carta.",
 		it: "Guarda le prime due carte del tuo mazzo e aggiungi una di esse alle carte che hai in mano. Scarta l’altra carta.",
 		pt: "Olhe os 2 cards de cima do seu baralho e coloque 1 deles de volta na sua mão. Descarte o outro card.",
-		de: "Schau dir die 2 obersten Karten deines Decks an und nimm 1 auf deine Hand. Lege die andere Karte auf deinen Ablagestapel."
+		de: "Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen. Schau dir die 2 obersten Karten deines Decks an und nimm 1 auf deine Hand. Lege die andere Karte auf deinen Ablagestapel."
 	},
 
 	trainerType: "Item",

--- a/data/Trainer kits/XY trainer Kit (Latias)/30.ts
+++ b/data/Trainer kits/XY trainer Kit (Latias)/30.ts
@@ -23,27 +23,31 @@ const card: Card = {
 	illustrator: "Masakazu Fukuda",
 
 	description: {
-		en: "It can telepathically communicate with people. It changes its appearance using its down that refracts light."
+		en: "It can telepathically communicate with people. It changes its appearance using its down that refracts light.",
+		de: "Mittels Telepathie kann es mit Menschen kommunizieren. Mit seinen Daunen, die das Licht brechen, kann es sein Aussehen verändern."
 	},
 
 	attacks: [{
 		name: {
 			en: "Psychic Sphere",
-			fr: "Sphère Psy"
+			fr: "Sphère Psy",
+			de: "Psychosphäre"
 		},
 
 		damage: 20
 	}, {
 		name: {
 			en: "Psychic Prism",
-			fr: "Prisme Psy"
+			fr: "Prisme Psy",
+			de: "Psychoprisma"
 		},
 
 		damage: "60+",
 
 		effect: {
 			en: "Flip a coin. If heads, this attack does 20 more damage.",
-			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires."
+			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+			de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 		}
 	}],
 

--- a/data/Trainer kits/XY trainer Kit (Latias)/4.ts
+++ b/data/Trainer kits/XY trainer Kit (Latias)/4.ts
@@ -19,7 +19,8 @@ const card: Card = {
 	category: "Pokemon",
 
 	description: {
-		en: "These friendly Pokémon send signals to one another with beautiful chirps and tail-feather movements."
+		en: "These friendly Pokémon send signals to one another with beautiful chirps and tail-feather movements.",
+		de: "Ein sehr zutrauliches Pokémon. Durch Zwitschern und Bewegen der Schwanzfedern sendet es Signale an seine Gefährten."
 	},
 
 	stage: "Basic",
@@ -27,21 +28,24 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Peck",
-			fr: "Picpic"
+			fr: "Picpic",
+			de: "Schnabel"
 		},
 
 		damage: 10
 	}, {
 		name: {
 			en: "Quick Attack",
-			fr: "Vive-Attaque"
+			fr: "Vive-Attaque",
+			de: "Ruckzuckhieb"
 		},
 
 		damage: "10+",
 
 		effect: {
 			en: "Flip a coin. If heads, this attack does 20 more damage.",
-			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires."
+			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+			de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 		}
 	}],
 


### PR DESCRIPTION
## Add missing German translations for tk-xy-latia

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
