### PR TITLE
Add missing German translations for tk-xy-latio

### DIFF
--- a/data/Trainer kits/XY trainer Kit (Latios)/13.ts
+++ b/data/Trainer kits/XY trainer Kit (Latios)/13.ts
@@ -19,7 +19,8 @@ const card: Card = {
 	category: "Pokemon",
 
 	description: {
-		en: "It understands human speech and is highly intelligent. It is a tender Pokémon that dislikes fighting."
+		en: "It understands human speech and is highly intelligent. It is a tender Pokémon that dislikes fighting.",
+		de: "Es ist hochintelligent und versteht sogar die menschliche Sprache. Es ist friedlich und meidet Konflikte."
 	},
 
 	stage: "Basic",
@@ -27,19 +28,22 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Supersonic Flight",
-			fr: "Voyage Supersonique"
+			fr: "Voyage Supersonique",
+			de: "Überschallflug"
 		},
 
 		damage: 40,
 
 		effect: {
 			en: "Flip a coin. If tails, this attack does nothing.",
-			fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien."
+			fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+			de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 		}
 	}, {
 		name: {
 			en: "Psyburn",
-			fr: "Brûlure Psy"
+			fr: "Brûlure Psy",
+			de: "Psychoverbrennung"
 		},
 
 		damage: 70

--- a/data/Trainer kits/XY trainer Kit (Latios)/20.ts
+++ b/data/Trainer kits/XY trainer Kit (Latios)/20.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mira las 2 primeras cartas de tu baraja y pon 1 de ellas en tu mano. Descarta la otra carta.",
 		it: "Guarda le prime due carte del tuo mazzo e aggiungi una di esse alle carte che hai in mano. Scarta l’altra carta.",
 		pt: "Olhe os 2 cards de cima do seu baralho e coloque 1 deles de volta na sua mão. Descarte o outro card.",
-		de: "Schau dir die 2 obersten Karten deines Decks an und nimm 1 auf deine Hand. Lege die andere Karte auf deinen Ablagestapel."
+		de: "Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen. Schau dir die 2 obersten Karten deines Decks an und nimm 1 auf deine Hand. Lege die andere Karte auf deinen Ablagestapel."
 	},
 
 	trainerType: "Item",

--- a/data/Trainer kits/XY trainer Kit (Latios)/30.ts
+++ b/data/Trainer kits/XY trainer Kit (Latios)/30.ts
@@ -19,7 +19,8 @@ const card: Card = {
 	category: "Pokemon",
 
 	description: {
-		en: "It understands human speech and is highly intelligent. It is a tender Pokémon that dislikes fighting."
+		en: "It understands human speech and is highly intelligent. It is a tender Pokémon that dislikes fighting.",
+		de: "Es ist hochintelligent und versteht sogar die menschliche Sprache. Es ist friedlich und meidet Konflikte."
 	},
 
 	stage: "Basic",
@@ -27,19 +28,22 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Supersonic Flight",
-			fr: "Voyage Supersonique"
+			fr: "Voyage Supersonique",
+			de: "Überschallflug"
 		},
 
 		damage: 40,
 
 		effect: {
 			en: "Flip a coin. If tails, this attack does nothing.",
-			fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien."
+			fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+			de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 		}
 	}, {
 		name: {
 			en: "Psyburn",
-			fr: "Brûlure Psy"
+			fr: "Brûlure Psy",
+			de: "Psychoverbrennung"
 		},
 
 		damage: 70


### PR DESCRIPTION
## Add missing German translations for tk-xy-latio

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
