### PR TITLE
Add missing German translations for tk-xy-p

### DIFF
--- a/data/Trainer kits/XY trainer Kit (Pikachu Libre)/11.ts
+++ b/data/Trainer kits/XY trainer Kit (Pikachu Libre)/11.ts
@@ -23,13 +23,15 @@ const card: Card = {
 	illustrator: "Akira Komayama",
 
 	description: {
-		en: "It stores static electricity in its fur for discharging. It gives off sparks if a storm approaches."
+		en: "It stores static electricity in its fur for discharging. It gives off sparks if a storm approaches.",
+		de: "In seinem Fell speichert es statische Elektrizität für spätere Entladungen. Braut sich ein Sturm zusammen, entlädt es Funken."
 	},
 
 	attacks: [{
 		name: {
 			en: "Bite",
-			fr: "Morsure"
+			fr: "Morsure",
+			de: "Biss"
 		},
 
 		damage: 10

--- a/data/Trainer kits/XY trainer Kit (Pikachu Libre)/13.ts
+++ b/data/Trainer kits/XY trainer Kit (Pikachu Libre)/13.ts
@@ -33,23 +33,27 @@ const card: Card = {
 	illustrator: "match",
 
 	description: {
-		en: "It discharges electricity from its mane. It creates a thundercloud overhead to drop lightning bolts."
+		en: "It discharges electricity from its mane. It creates a thundercloud overhead to drop lightning bolts.",
+		de: "Aus seiner Mähne entlädt es Elektrizität. Es generiert eine Gewitterwolke, aus der es Blitze entlädt."
 	},
 
 	attacks: [{
 		name: {
 			en: "Random Spark",
-			fr: "Étincelle Surprise"
+			fr: "Étincelle Surprise",
+			de: "Zufälliger Funke"
 		},
 
 		effect: {
 			en: "This attack does 30 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)",
-			fr: "Cette attaque inflige 30 dégâts à l'un des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)"
+			fr: "Cette attaque inflige 30 dégâts à l'un des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+			de: "Dieser Angriff fügt 1 Pokémon deines Gegners 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 		}
 	}, {
 		name: {
 			en: "Bite",
-			fr: "Morsure"
+			fr: "Morsure",
+			de: "Biss"
 		},
 
 		damage: 40

--- a/data/Trainer kits/XY trainer Kit (Pikachu Libre)/14.ts
+++ b/data/Trainer kits/XY trainer Kit (Pikachu Libre)/14.ts
@@ -23,25 +23,29 @@ const card: Card = {
 	illustrator: "Yoshinobu Saito",
 
 	description: {
-		en: "It has small electric sacs on both its cheeks. If threatened, it looses electric charges from the sacs."
+		en: "It has small electric sacs on both its cheeks. If threatened, it looses electric charges from the sacs.",
+		de: "Es hat kleine Backentaschen, die mit Elektrizität gefüllt sind. Bei Gefahr entlädt es sie."
 	},
 
 	attacks: [{
 		name: {
 			en: "Quick Attack",
-			fr: "Vive-Attaque"
+			fr: "Vive-Attaque",
+			de: "Ruckzuckhieb"
 		},
 
 		damage: "10+",
 
 		effect: {
 			en: "Flip a coin. If heads, this attack does 30 more damage.",
-			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires."
+			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires.",
+			de: "Bei „Kopf“ fügt dieser Angriff 30 weitere Schadenspunkte zu."
 		}
 	}, {
 		name: {
 			en: "Flying Elekick",
-			fr: "Coup Élec' Volant"
+			fr: "Coup Élec' Volant",
+			de: "Fliegender Elekick"
 		},
 
 		damage: 50

--- a/data/Trainer kits/XY trainer Kit (Pikachu Libre)/16.ts
+++ b/data/Trainer kits/XY trainer Kit (Pikachu Libre)/16.ts
@@ -23,20 +23,23 @@ const card: Card = {
 	illustrator: "Kanako Eo",
 
 	description: {
-		en: "Despite the beauty of its lilting voice, it’s merciless to intruders that enter its territory."
+		en: "Despite the beauty of its lilting voice, it’s merciless to intruders that enter its territory.",
+		de: "Sein Zwitschern ist wunderschön, aber wenn Gegner sein Revier betreten, kennt es keine Gnade."
 	},
 
 	attacks: [{
 		name: {
 			en: "Acrobatics",
-			fr: "Acrobatie"
+			fr: "Acrobatie",
+			de: "Akrobatik"
 		},
 
 		damage: "10+",
 
 		effect: {
 			en: "Flip 2 coins. This attack does 10 more damage for each heads.",
-			fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts supplémentaires pour chaque côté face."
+			fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts supplémentaires pour chaque côté face.",
+			de: "Wirf 2 Münzen. Dieser Angriff fügt 10 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 		}
 	}],
 

--- a/data/Trainer kits/XY trainer Kit (Pikachu Libre)/20.ts
+++ b/data/Trainer kits/XY trainer Kit (Pikachu Libre)/20.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba 3 cartas.",
 		it: "Pesca tre carte.",
 		pt: "Compre 3 cards.",
-		de: "Ziehe 3 Karten."
+		de: "Ziehe 3 Karten. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Trainer kits/XY trainer Kit (Pikachu Libre)/22.ts
+++ b/data/Trainer kits/XY trainer Kit (Pikachu Libre)/22.ts
@@ -33,23 +33,27 @@ const card: Card = {
 	illustrator: "match",
 
 	description: {
-		en: "It discharges electricity from its mane. It creates a thundercloud overhead to drop lightning bolts."
+		en: "It discharges electricity from its mane. It creates a thundercloud overhead to drop lightning bolts.",
+		de: "Aus seiner Mähne entlädt es Elektrizität. Es generiert eine Gewitterwolke, aus der es Blitze entlädt."
 	},
 
 	attacks: [{
 		name: {
 			en: "Random Spark",
-			fr: "Étincelle Surprise"
+			fr: "Étincelle Surprise",
+			de: "Zufälliger Funke"
 		},
 
 		effect: {
 			en: "This attack does 30 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)",
-			fr: "Cette attaque inflige 30 dégâts à l'un des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)"
+			fr: "Cette attaque inflige 30 dégâts à l'un des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+			de: "Dieser Angriff fügt 1 Pokémon deines Gegners 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 		}
 	}, {
 		name: {
 			en: "Bite",
-			fr: "Morsure"
+			fr: "Morsure",
+			de: "Biss"
 		},
 
 		damage: 40

--- a/data/Trainer kits/XY trainer Kit (Pikachu Libre)/28.ts
+++ b/data/Trainer kits/XY trainer Kit (Pikachu Libre)/28.ts
@@ -23,13 +23,15 @@ const card: Card = {
 	illustrator: "Akira Komayama",
 
 	description: {
-		en: "It stores static electricity in its fur for discharging. It gives off sparks if a storm approaches."
+		en: "It stores static electricity in its fur for discharging. It gives off sparks if a storm approaches.",
+		de: "In seinem Fell speichert es statische Elektrizität für spätere Entladungen. Braut sich ein Sturm zusammen, entlädt es Funken."
 	},
 
 	attacks: [{
 		name: {
 			en: "Bite",
-			fr: "Morsure"
+			fr: "Morsure",
+			de: "Biss"
 		},
 
 		damage: 10

--- a/data/Trainer kits/XY trainer Kit (Pikachu Libre)/30.ts
+++ b/data/Trainer kits/XY trainer Kit (Pikachu Libre)/30.ts
@@ -23,25 +23,29 @@ const card: Card = {
 	illustrator: "Yoshinobu Saito",
 
 	description: {
-		en: "It has small electric sacs on both its cheeks. If threatened, it looses electric charges from the sacs."
+		en: "It has small electric sacs on both its cheeks. If threatened, it looses electric charges from the sacs.",
+		de: "Es hat kleine Backentaschen, die mit Elektrizität gefüllt sind. Bei Gefahr entlädt es sie."
 	},
 
 	attacks: [{
 		name: {
 			en: "Quick Attack",
-			fr: "Vive-Attaque"
+			fr: "Vive-Attaque",
+			de: "Ruckzuckhieb"
 		},
 
 		damage: "10+",
 
 		effect: {
 			en: "Flip a coin. If heads, this attack does 30 more damage.",
-			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires."
+			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires.",
+			de: "Bei „Kopf“ fügt dieser Angriff 30 weitere Schadenspunkte zu."
 		}
 	}, {
 		name: {
 			en: "Flying Elekick",
-			fr: "Coup Élec' Volant"
+			fr: "Coup Élec' Volant",
+			de: "Fliegender Elekick"
 		},
 
 		damage: 50

--- a/data/Trainer kits/XY trainer Kit (Pikachu Libre)/7.ts
+++ b/data/Trainer kits/XY trainer Kit (Pikachu Libre)/7.ts
@@ -23,20 +23,23 @@ const card: Card = {
 	illustrator: "Atsuko Nishida",
 
 	description: {
-		en: "It dislikes cold seasons. They migrate to other lands in search of warmth, flying over 180 miles a day."
+		en: "It dislikes cold seasons. They migrate to other lands in search of warmth, flying over 180 miles a day.",
+		de: "Es mag die kalte Jahreszeit nicht. Daher legt es auf der Suche nach wärmeren Gefilden mehr als 300 km am Tag zurück."
 	},
 
 	attacks: [{
 		name: {
 			en: "Double Peck",
-			fr: "Double Picpic"
+			fr: "Double Picpic",
+			de: "Doppelschnabel"
 		},
 
 		damage: "10×",
 
 		effect: {
 			en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
-			fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face."
+			fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+			de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 		}
 	}],
 


### PR DESCRIPTION
## Add missing German translations for tk-xy-p

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
