### PR TITLE
Add missing German translations for tk-sm-r

### DIFF
--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/1.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/1.ts
@@ -3,7 +3,8 @@ import Set from '../SM trainer Kit (Alolan Raichu)'
 
 const card: Card = {
 	name: {
-		en: "Lightning Energy"
+		en: "Lightning Energy",
+		de: "Elektro-Energie"
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/10.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/10.ts
@@ -3,7 +3,8 @@ import Set from '../SM trainer Kit (Alolan Raichu)'
 
 const card: Card = {
 	name: {
-		en: "Lightning Energy"
+		en: "Lightning Energy",
+		de: "Elektro-Energie"
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/11.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/11.ts
@@ -27,10 +27,12 @@ const card: Card = {
 				"Psychic",
 			],
 			name: {
-				en: "Astonish"
+				en: "Astonish",
+				de: "Erstauner"
 			},
 			effect: {
-				en: "Choose a random card from your opponent's hand. Your opponent reveals that card and shuffles it into their deck."
+				en: "Choose a random card from your opponent's hand. Your opponent reveals that card and shuffles it into their deck.",
+				de: "Wähle 1 zufällige Karte aus der Hand deines Gegners. Dein Gegner zeigt jene Karte und mischt sie in sein Deck."
 			}
 		},
 	],

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/12.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/12.ts
@@ -3,7 +3,8 @@ import Set from '../SM trainer Kit (Alolan Raichu)'
 
 const card: Card = {
 	name: {
-		en: "Lightning Energy"
+		en: "Lightning Energy",
+		de: "Elektro-Energie"
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/13.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/13.ts
@@ -27,10 +27,12 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
-				en: "Peck Bugs"
+				en: "Peck Bugs",
+				de: "Insektenleser"
 			},
 			effect: {
-				en: "If your opponent's Active Pokémon is a Grass Pokémon, this attack does 30 more damage."
+				en: "If your opponent's Active Pokémon is a Grass Pokémon, this attack does 30 more damage.",
+				de: "Wenn das Aktive Pokémon deines Gegners ein {G}-Pokémon ist, fügt diese Attacke 30 Schadenspunkte mehr zu."
 			},
 			damage: "10+"
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/14.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/14.ts
@@ -25,27 +25,31 @@ const card: Card = {
 	illustrator: "kodama",
 
 	description: {
-		en: "A plan was recently announced to gather many Pikachu and make an electric power plant."
+		en: "A plan was recently announced to gather many Pikachu and make an electric power plant.",
+		de: "Vor Kurzem wurden Pläne verkündet, mithilfe einer großen Anzahl an Pikachu ein ganzes Kraftwerk zu betreiben."
 	},
 
 	attacks: [{
 		name: {
 			en: "Tail Whap",
-			fr: "Queue Battoir"
+			fr: "Queue Battoir",
+			de: "Schweifvertrimmer"
 		},
 
 		damage: 10
 	}, {
 		name: {
 			en: "Spark",
-			fr: "Étincelle"
+			fr: "Étincelle",
+			de: "Funkensprung"
 		},
 
 		damage: 20,
 
 		effect: {
 			en: "This attack does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)",
-			fr: "Cette attaque inflige 10 dégâts à l'un des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)"
+			fr: "Cette attaque inflige 10 dégâts à l'un des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+			de: "Diese Attacke fügt 1 Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 		}
 	}],
 

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/16.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/16.ts
@@ -28,7 +28,8 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
-				en: "Vice Grip"
+				en: "Vice Grip",
+				de: "Klammer"
 			},
 			damage: 20
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/17.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/17.ts
@@ -35,25 +35,29 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	description: {
-		en: "It only evolves to this form in the Alola region. According to researchers, its diet is one of the causes of this change."
+		en: "It only evolves to this form in the Alola region. According to researchers, its diet is one of the causes of this change.",
+		de: "Es entwickelt sich nur in Alola zu dieser Form. Forscher behaupten, dass einer der Gründe dafür das dortige Futter sei."
 	},
 
 	attacks: [{
 		name: {
 			en: "Quick Attack",
-			fr: "Vive-Attaque"
+			fr: "Vive-Attaque",
+			de: "Ruckzuckhieb"
 		},
 
 		damage: "10+",
 
 		effect: {
 			en: "Flip a coin. If heads, this attack does 30 more damage.",
-			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires."
+			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires.",
+			de: "Wirf 1 Münze. Bei Kopf fügt diese Attacke 30 Schadenspunkte mehr zu."
 		}
 	}, {
 		name: {
 			en: "Electric Surfer",
-			fr: "Surfeur Électrique"
+			fr: "Surfeur Électrique",
+			de: "Elektrosurfer"
 		},
 
 		damage: 70

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/18.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/18.ts
@@ -38,10 +38,12 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
-				en: "Bear Hug"
+				en: "Bear Hug",
+				de: "Dicke Umarmung"
 			},
 			effect: {
-				en: "The Defending Pokémon can't retreat during your opponent's next turn."
+				en: "The Defending Pokémon can't retreat during your opponent's next turn.",
+				de: "Das Verteidigende Pokémon kann sich während des nächsten Zuges deines Gegners nicht zurückziehen."
 			},
 			damage: 40
 		},
@@ -52,10 +54,12 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
-				en: "Superpower"
+				en: "Superpower",
+				de: "Kraftkoloss"
 			},
 			effect: {
-				en: "You may do 40 more damage. If you do, this Pokémon does 20 damage to itself."
+				en: "You may do 40 more damage. If you do, this Pokémon does 20 damage to itself.",
+				de: "Du kannst 40 Schadenspunkte mehr zufügen. Wenn du das machst, fügt dieses Pokémon sich selbst 20 Schadenspunkte zu."
 			},
 			damage: "80+"
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/19.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/19.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Roba 3 cartas.",
 		it: "Pesca tre carte.",
 		pt: "Compre 3 cartas.",
-		de: "Ziehe 3 Karten."
+		de: "Ziehe 3 Karten. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/22.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/22.ts
@@ -27,10 +27,12 @@ const card: Card = {
 				"Psychic",
 			],
 			name: {
-				en: "Psychic Boom"
+				en: "Psychic Boom",
+				de: "Psychoknall"
 			},
 			effect: {
-				en: "This attack does 10 damage times the amount of Energy attached to your opponent's Active Pokémon."
+				en: "This attack does 10 damage times the amount of Energy attached to your opponent's Active Pokémon.",
+				de: "Diese Attacke fügt 10 Schadenspunkte mal der Anzahl der an das Aktive Pokémon deines Gegners angelegten Energien zu."
 			},
 			damage: "10×"
 		},
@@ -40,7 +42,8 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
-				en: "Headbutt"
+				en: "Headbutt",
+				de: "Kopfnuss"
 			},
 			damage: 20
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/23.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/23.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Roba 3 cartas.",
 		it: "Pesca tre carte.",
 		pt: "Compre 3 cartas.",
-		de: "Ziehe 3 Karten."
+		de: "Ziehe 3 Karten. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/24.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/24.ts
@@ -3,7 +3,8 @@ import Set from '../SM trainer Kit (Alolan Raichu)'
 
 const card: Card = {
 	name: {
-		en: "Psychic Energy"
+		en: "Psychic Energy",
+		de: "Psycho-Energie"
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/26.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/26.ts
@@ -27,10 +27,12 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
-				en: "Defense Curl"
+				en: "Defense Curl",
+				de: "Einigler"
 			},
 			effect: {
-				en: "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent's next turn."
+				en: "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent's next turn.",
+				de: "Wirf 1 Münze. Verhindere bei Kopf allen Schaden, der diesem Pokémon während des nächsten Zuges deines Gegners durch Attacken zugefügt wird."
 			}
 		},
 		{
@@ -38,10 +40,12 @@ const card: Card = {
 				"Lightning",
 			],
 			name: {
-				en: "Discharge"
+				en: "Discharge",
+				de: "Ladungsstoß"
 			},
 			effect: {
-				en: "Discard all Lightning Energy from this Pokémon. This attack does 30 damage for each card you discarded in this way."
+				en: "Discard all Lightning Energy from this Pokémon. This attack does 30 damage for each card you discarded in this way.",
+				de: "Lege alle {L}-Energien von diesem Pokémon auf deinen Ablagestapel. Diese Attacke fügt 30 Schadenspunkte mal der Anzahl der auf diese Weise auf deinen Ablagestapel gelegten Karten zu."
 			},
 			damage: "30×"
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/27.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/27.ts
@@ -3,7 +3,8 @@ import Set from '../SM trainer Kit (Alolan Raichu)'
 
 const card: Card = {
 	name: {
-		en: "Psychic Energy"
+		en: "Psychic Energy",
+		de: "Psycho-Energie"
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/28.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/28.ts
@@ -3,7 +3,8 @@ import Set from '../SM trainer Kit (Alolan Raichu)'
 
 const card: Card = {
 	name: {
-		en: "Psychic Energy"
+		en: "Psychic Energy",
+		de: "Psycho-Energie"
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/29.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/29.ts
@@ -25,27 +25,31 @@ const card: Card = {
 	illustrator: "kodama",
 
 	description: {
-		en: "A plan was recently announced to gather many Pikachu and make an electric power plant."
+		en: "A plan was recently announced to gather many Pikachu and make an electric power plant.",
+		de: "Vor Kurzem wurden Pläne verkündet, mithilfe einer großen Anzahl an Pikachu ein ganzes Kraftwerk zu betreiben."
 	},
 
 	attacks: [{
 		name: {
 			en: "Tail Whap",
-			fr: "Queue Battoir"
+			fr: "Queue Battoir",
+			de: "Schweifvertrimmer"
 		},
 
 		damage: 10
 	}, {
 		name: {
 			en: "Spark",
-			fr: "Étincelle"
+			fr: "Étincelle",
+			de: "Funkensprung"
 		},
 
 		damage: 20,
 
 		effect: {
 			en: "This attack does 10 damage to 1 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)",
-			fr: "Cette attaque inflige 10 dégâts à l'un des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)"
+			fr: "Cette attaque inflige 10 dégâts à l'un des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+			de: "Diese Attacke fügt 1 Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 		}
 	}],
 

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/3.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/3.ts
@@ -3,7 +3,8 @@ import Set from '../SM trainer Kit (Alolan Raichu)'
 
 const card: Card = {
 	name: {
-		en: "Lightning Energy"
+		en: "Lightning Energy",
+		de: "Elektro-Energie"
 	},
 
 	illustrator: "N/A",

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/30.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/30.ts
@@ -35,25 +35,29 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	description: {
-		en: "It only evolves to this form in the Alola region. According to researchers, its diet is one of the causes of this change."
+		en: "It only evolves to this form in the Alola region. According to researchers, its diet is one of the causes of this change.",
+		de: "Es entwickelt sich nur in Alola zu dieser Form. Forscher behaupten, dass einer der Gründe dafür das dortige Futter sei."
 	},
 
 	attacks: [{
 		name: {
 			en: "Quick Attack",
-			fr: "Vive-Attaque"
+			fr: "Vive-Attaque",
+			de: "Ruckzuckhieb"
 		},
 
 		damage: "10+",
 
 		effect: {
 			en: "Flip a coin. If heads, this attack does 30 more damage.",
-			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires."
+			fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires.",
+			de: "Wirf 1 Münze. Bei Kopf fügt diese Attacke 30 Schadenspunkte mehr zu."
 		}
 	}, {
 		name: {
 			en: "Electric Surfer",
-			fr: "Surfeur Électrique"
+			fr: "Surfeur Électrique",
+			de: "Elektrosurfer"
 		},
 
 		damage: 70

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/4.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/4.ts
@@ -28,7 +28,8 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
-				en: "Tackle"
+				en: "Tackle",
+				de: "Tackle"
 			},
 			damage: 30
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/5.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/5.ts
@@ -3,7 +3,8 @@ import Set from '../SM trainer Kit (Alolan Raichu)'
 
 const card: Card = {
 	name: {
-		en: "Lightning Energy"
+		en: "Lightning Energy",
+		de: "Elektro-Energie"
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/6.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/6.ts
@@ -37,10 +37,12 @@ const card: Card = {
 				"Psychic",
 			],
 			name: {
-				en: "Super Poison Breath"
+				en: "Super Poison Breath",
+				de: "Super-Gifthauch"
 			},
 			effect: {
-				en: "Your opponent's Active Pokémon is now Poisoned."
+				en: "Your opponent's Active Pokémon is now Poisoned.",
+				de: "Das Aktive Pokémon deines Gegners ist jetzt vergiftet."
 			}
 		},
 		{
@@ -49,10 +51,12 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
-				en: "Acrobatics"
+				en: "Acrobatics",
+				de: "Akrobatik"
 			},
 			effect: {
-				en: "Flip 2 coins. This attack does 20 more damage for each heads."
+				en: "Flip 2 coins. This attack does 20 more damage for each heads.",
+				de: "Wirf 2 Münzen. Diese Attacke fügt 20 Schadenspunkte mehr pro Kopf zu."
 			},
 			damage: "10+"
 		},

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/7.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/7.ts
@@ -3,7 +3,8 @@ import Set from '../SM trainer Kit (Alolan Raichu)'
 
 const card: Card = {
 	name: {
-		en: "Lightning Energy"
+		en: "Lightning Energy",
+		de: "Elektro-Energie"
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/8.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/8.ts
@@ -3,7 +3,8 @@ import Set from '../SM trainer Kit (Alolan Raichu)'
 
 const card: Card = {
 	name: {
-		en: "Lightning Energy"
+		en: "Lightning Energy",
+		de: "Elektro-Energie"
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/SM trainer Kit (Alolan Raichu)/9.ts
+++ b/data/Trainer kits/SM trainer Kit (Alolan Raichu)/9.ts
@@ -3,7 +3,8 @@ import Set from '../SM trainer Kit (Alolan Raichu)'
 
 const card: Card = {
 	name: {
-		en: "Lightning Energy"
+		en: "Lightning Energy",
+		de: "Elektro-Energie"
 	},
 
 	rarity: "None",


### PR DESCRIPTION
## Add missing German translations for tk-sm-r

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
