### PR TITLE
fix(cardmarket): Correct Cardmarket links for xyp

### DIFF
--- a/data/XY/XY Black Star Promos/XY10.ts
+++ b/data/XY/XY Black Star Promos/XY10.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 554158
+		cardmarket: 281335
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY100.ts
+++ b/data/XY/XY Black Star Promos/XY100.ts
@@ -57,7 +57,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 289557
+		cardmarket: 289820
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY101.ts
+++ b/data/XY/XY Black Star Promos/XY101.ts
@@ -57,7 +57,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 554275
+		cardmarket: 289821
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY107.ts
+++ b/data/XY/XY Black Star Promos/XY107.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	retreat: 2,
 
 	thirdParty: {
-		cardmarket: 554275
+		cardmarket: 289557
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY109.ts
+++ b/data/XY/XY Black Star Promos/XY109.ts
@@ -81,7 +81,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 289556
+		cardmarket: 289559
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY114.ts
+++ b/data/XY/XY Black Star Promos/XY114.ts
@@ -78,7 +78,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 281306
+		cardmarket: 291577
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY116.ts
+++ b/data/XY/XY Black Star Promos/XY116.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 289806
+		cardmarket: 291973
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY124.ts
+++ b/data/XY/XY Black Star Promos/XY124.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	retreat: 1,
 
 	thirdParty: {
-		cardmarket: 554190
+		cardmarket: 293003
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY125.ts
+++ b/data/XY/XY Black Star Promos/XY125.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	retreat: 2,
 
 	thirdParty: {
-		cardmarket: 554275
+		cardmarket: 293004
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY128.ts
+++ b/data/XY/XY Black Star Promos/XY128.ts
@@ -74,7 +74,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 289804
+		cardmarket: 290101
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY13.ts
+++ b/data/XY/XY Black Star Promos/XY13.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 553054
+		cardmarket: 281333
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY130.ts
+++ b/data/XY/XY Black Star Promos/XY130.ts
@@ -86,7 +86,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 554153
+		cardmarket: 290103
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY138.ts
+++ b/data/XY/XY Black Star Promos/XY138.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 552879
+		cardmarket: 290107
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY14.ts
+++ b/data/XY/XY Black Star Promos/XY14.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 552809
+		cardmarket: 281331
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY141.ts
+++ b/data/XY/XY Black Star Promos/XY141.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 289722
+		cardmarket: 291582
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY144.ts
+++ b/data/XY/XY Black Star Promos/XY144.ts
@@ -84,7 +84,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 554133
+		cardmarket: 291584
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY145.ts
+++ b/data/XY/XY Black Star Promos/XY145.ts
@@ -70,7 +70,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 553958
+		cardmarket: 291585
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY149.ts
+++ b/data/XY/XY Black Star Promos/XY149.ts
@@ -79,7 +79,7 @@ const card: Card = {
 	retreat: 2,
 
 	thirdParty: {
-		cardmarket: 552954
+		cardmarket: 290108
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY150.ts
+++ b/data/XY/XY Black Star Promos/XY150.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	retreat: 2,
 
 	thirdParty: {
-		cardmarket: 552959
+		cardmarket: 290109
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY153.ts
+++ b/data/XY/XY Black Star Promos/XY153.ts
@@ -73,6 +73,9 @@ const card: Card = {
 	description: {
 		en: "It will reveal itself before a pure-hearted Trainer by shining its bright, rainbow-colored wings.",
 	},
+	thirdParty: {
+		cardmarket: 291589,
+	},
 }
 
 export default card

--- a/data/XY/XY Black Star Promos/XY160.ts
+++ b/data/XY/XY Black Star Promos/XY160.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 289803
+		cardmarket: 295151
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY162.ts
+++ b/data/XY/XY Black Star Promos/XY162.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 281310
+		cardmarket: 295153
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY164.ts
+++ b/data/XY/XY Black Star Promos/XY164.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 553958
+		cardmarket: 295155
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY167.ts
+++ b/data/XY/XY Black Star Promos/XY167.ts
@@ -70,6 +70,9 @@ const card: Card = {
 
 
 
+	thirdParty: {
+		cardmarket: 295158,
+	},
 }
 
 export default card

--- a/data/XY/XY Black Star Promos/XY175.ts
+++ b/data/XY/XY Black Star Promos/XY175.ts
@@ -71,6 +71,9 @@ const card: Card = {
 
 
 
+	thirdParty: {
+		cardmarket: 295166,
+	},
 }
 
 export default card

--- a/data/XY/XY Black Star Promos/XY177a.ts
+++ b/data/XY/XY Black Star Promos/XY177a.ts
@@ -18,7 +18,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 293006
+		cardmarket: 311408
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY178.ts
+++ b/data/XY/XY Black Star Promos/XY178.ts
@@ -79,7 +79,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 289720
+		cardmarket: 295167
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY18.ts
+++ b/data/XY/XY Black Star Promos/XY18.ts
@@ -72,7 +72,7 @@ const card: Card = {
 	retreat: 4,
 
 	thirdParty: {
-		cardmarket: 552844
+		cardmarket: 281311
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY185.ts
+++ b/data/XY/XY Black Star Promos/XY185.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 553958
+		cardmarket: 295174
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY186.ts
+++ b/data/XY/XY Black Star Promos/XY186.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 554053
+		cardmarket: 295180
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY188.ts
+++ b/data/XY/XY Black Star Promos/XY188.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 291578
+		cardmarket: 295181
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY189.ts
+++ b/data/XY/XY Black Star Promos/XY189.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 553953
+		cardmarket: 295176
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY190.ts
+++ b/data/XY/XY Black Star Promos/XY190.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 291576
+		cardmarket: 295182
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY191.ts
+++ b/data/XY/XY Black Star Promos/XY191.ts
@@ -72,7 +72,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 293189
+		cardmarket: 295177
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY193.ts
+++ b/data/XY/XY Black Star Promos/XY193.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 295150
+		cardmarket: 295184
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY194.ts
+++ b/data/XY/XY Black Star Promos/XY194.ts
@@ -78,7 +78,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 552884
+		cardmarket: 295178
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY196.ts
+++ b/data/XY/XY Black Star Promos/XY196.ts
@@ -80,7 +80,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 295149
+		cardmarket: 295185
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY197.ts
+++ b/data/XY/XY Black Star Promos/XY197.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 289806
+		cardmarket: 295186
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY20.ts
+++ b/data/XY/XY Black Star Promos/XY20.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	retreat: 1,
 
 	thirdParty: {
-		cardmarket: 678788
+		cardmarket: 281310
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY202.ts
+++ b/data/XY/XY Black Star Promos/XY202.ts
@@ -79,7 +79,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 289809
+		cardmarket: 295187
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY204.ts
+++ b/data/XY/XY Black Star Promos/XY204.ts
@@ -18,7 +18,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 554217
+		cardmarket: 295189
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY205.ts
+++ b/data/XY/XY Black Star Promos/XY205.ts
@@ -18,7 +18,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 554217
+		cardmarket: 295190
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY206.ts
+++ b/data/XY/XY Black Star Promos/XY206.ts
@@ -18,7 +18,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 554217
+		cardmarket: 295191
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY207.ts
+++ b/data/XY/XY Black Star Promos/XY207.ts
@@ -18,7 +18,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 554217
+		cardmarket: 295192
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY208.ts
+++ b/data/XY/XY Black Star Promos/XY208.ts
@@ -18,7 +18,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 554217
+		cardmarket: 295193
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY21.ts
+++ b/data/XY/XY Black Star Promos/XY21.ts
@@ -81,7 +81,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 848304
+		cardmarket: 281309
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY210.ts
+++ b/data/XY/XY Black Star Promos/XY210.ts
@@ -18,7 +18,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 554217
+		cardmarket: 295195
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY22.ts
+++ b/data/XY/XY Black Star Promos/XY22.ts
@@ -81,7 +81,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 552884
+		cardmarket: 281306
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY24.ts
+++ b/data/XY/XY Black Star Promos/XY24.ts
@@ -83,7 +83,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 678788
+		cardmarket: 289696
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY46.ts
+++ b/data/XY/XY Black Star Promos/XY46.ts
@@ -80,7 +80,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 553519
+		cardmarket: 289709
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY60.ts
+++ b/data/XY/XY Black Star Promos/XY60.ts
@@ -80,7 +80,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 289556
+		cardmarket: 289785
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY62.ts
+++ b/data/XY/XY Black Star Promos/XY62.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	retreat: 2,
 
 	thirdParty: {
-		cardmarket: 786640
+		cardmarket: 289720
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY67a.ts
+++ b/data/XY/XY Black Star Promos/XY67a.ts
@@ -79,7 +79,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 289787
+		cardmarket: 311403
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY68.ts
+++ b/data/XY/XY Black Star Promos/XY68.ts
@@ -81,7 +81,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 553074
+		cardmarket: 289788
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY71.ts
+++ b/data/XY/XY Black Star Promos/XY71.ts
@@ -67,7 +67,7 @@ const card: Card = {
 	retreat: 2,
 
 	thirdParty: {
-		cardmarket: 553491
+		cardmarket: 289790
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY72.ts
+++ b/data/XY/XY Black Star Promos/XY72.ts
@@ -70,7 +70,7 @@ const card: Card = {
 	retreat: 2,
 
 	thirdParty: {
-		cardmarket: 553449
+		cardmarket: 289791
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY73.ts
+++ b/data/XY/XY Black Star Promos/XY73.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	retreat: 2,
 
 	thirdParty: {
-		cardmarket: 553219
+		cardmarket: 289792
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY79.ts
+++ b/data/XY/XY Black Star Promos/XY79.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 289791
+		cardmarket: 289802
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY80.ts
+++ b/data/XY/XY Black Star Promos/XY80.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 553908
+		cardmarket: 289803
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY84.ts
+++ b/data/XY/XY Black Star Promos/XY84.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	retreat: 1,
 
 	thirdParty: {
-		cardmarket: 554190
+		cardmarket: 289809
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY85.ts
+++ b/data/XY/XY Black Star Promos/XY85.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	retreat: 2,
 
 	thirdParty: {
-		cardmarket: 553491
+		cardmarket: 289810
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY89.ts
+++ b/data/XY/XY Black Star Promos/XY89.ts
@@ -79,7 +79,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 554190
+		cardmarket: 289812
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY90.ts
+++ b/data/XY/XY Black Star Promos/XY90.ts
@@ -72,7 +72,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 289790
+		cardmarket: 289813
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY91.ts
+++ b/data/XY/XY Black Star Promos/XY91.ts
@@ -20,7 +20,7 @@ const card: Card = {
 	trainerType: "Stadium",
 
 	thirdParty: {
-		cardmarket: 709547
+		cardmarket: 289793
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY94.ts
+++ b/data/XY/XY Black Star Promos/XY94.ts
@@ -64,7 +64,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 552809
+		cardmarket: 289814
 	}
 }
 

--- a/data/XY/XY Black Star Promos/XY95.ts
+++ b/data/XY/XY Black Star Promos/XY95.ts
@@ -78,7 +78,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 289809
+		cardmarket: 289815
 	}
 }
 


### PR DESCRIPTION
ref #1936
ref #906

## Changes

Correct Cardmarket product references for the xyp set across 66 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 42 duplicate-ID corrections, 3 missing links, and 21 other Cardmarket ID corrections in this set. The global post-apply audit reports no changed-reference duplicates, catalog-missing links, expansion mismatches, or name mismatches for xyp.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, and `git diff --check`.