### PR TITLE
fix(cardmarket): Correct Cardmarket links for base1

### DIFF
--- a/data/Base/Base Set/55.ts
+++ b/data/Base/Base Set/55.ts
@@ -91,6 +91,9 @@ const card: Card = {
 			subtype: "1999-2000-copyright",
 		}
 	],
+	thirdParty: {
+		cardmarket: 273750,
+	},
 }
 
 export default card


### PR DESCRIPTION
ref #906

## Changes

Correct Cardmarket product references for the base1 set across 1 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 1 missing Cardmarket link in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.