### PR TITLE
fix(cardmarket): Correct Cardmarket links for basep

### DIFF
--- a/data/Base/Wizards Black Star Promos/1.ts
+++ b/data/Base/Wizards Black Star Promos/1.ts
@@ -95,7 +95,10 @@ const card: Card = {
 				tcgplayer: 696103
 			},
 		},
-	]
+	],
+	thirdParty: {
+		cardmarket: 275420,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/10.ts
+++ b/data/Base/Wizards Black Star Promos/10.ts
@@ -63,7 +63,10 @@ const card: Card = {
 				tcgplayer: 87309
 			},
 		},
-	]
+	],
+	thirdParty: {
+		cardmarket: 275429,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/11.ts
+++ b/data/Base/Wizards Black Star Promos/11.ts
@@ -76,7 +76,10 @@ const card: Card = {
 				tcgplayer: 618732
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275430,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/12.ts
+++ b/data/Base/Wizards Black Star Promos/12.ts
@@ -70,7 +70,10 @@ const card: Card = {
 				tcgplayer: 87416
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275431,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/13.ts
+++ b/data/Base/Wizards Black Star Promos/13.ts
@@ -71,7 +71,10 @@ const card: Card = {
 				tcgplayer: 90311
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275432,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/15.ts
+++ b/data/Base/Wizards Black Star Promos/15.ts
@@ -77,7 +77,10 @@ const card: Card = {
 				tcgplayer: 84422
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275434,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/16.ts
+++ b/data/Base/Wizards Black Star Promos/16.ts
@@ -22,7 +22,10 @@ const card: Card = {
 				tcgplayer: 84414
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275435,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/17.ts
+++ b/data/Base/Wizards Black Star Promos/17.ts
@@ -79,11 +79,14 @@ const card: Card = {
 			type: "holo",
 			subtype: "missing-hp"
 		}
-	]
+	],
 
 
 
 
+	thirdParty: {
+		cardmarket: 275436,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/18.ts
+++ b/data/Base/Wizards Black Star Promos/18.ts
@@ -62,7 +62,10 @@ const card: Card = {
 				tcgplayer: 89851
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275437,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/19.ts
+++ b/data/Base/Wizards Black Star Promos/19.ts
@@ -62,7 +62,10 @@ const card: Card = {
 				tcgplayer: 88862
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275438,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/2.ts
+++ b/data/Base/Wizards Black Star Promos/2.ts
@@ -89,7 +89,10 @@ const card: Card = {
 				tcgplayer: 85107
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275421,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/20.ts
+++ b/data/Base/Wizards Black Star Promos/20.ts
@@ -77,7 +77,10 @@ const card: Card = {
 				tcgplayer: 88429
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275439,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/21.ts
+++ b/data/Base/Wizards Black Star Promos/21.ts
@@ -73,7 +73,10 @@ const card: Card = {
 			type: "normal",
 			subtype: "aoki-error"
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275440,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/22.ts
+++ b/data/Base/Wizards Black Star Promos/22.ts
@@ -73,7 +73,10 @@ const card: Card = {
 			type: "normal",
 			subtype: "aoki-error"
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275441,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/23.ts
+++ b/data/Base/Wizards Black Star Promos/23.ts
@@ -73,7 +73,10 @@ const card: Card = {
 			type: "normal",
 			subtype: "aoki-error"
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275442,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/24.ts
+++ b/data/Base/Wizards Black Star Promos/24.ts
@@ -75,7 +75,10 @@ const card: Card = {
 				tcgplayer: 90784
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275443,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/25.ts
+++ b/data/Base/Wizards Black Star Promos/25.ts
@@ -93,7 +93,10 @@ const card: Card = {
 				tcgplayer: 85534
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275444,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/26.ts
+++ b/data/Base/Wizards Black Star Promos/26.ts
@@ -88,7 +88,10 @@ const card: Card = {
 				tcgplayer: 88068
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275445,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/27.ts
+++ b/data/Base/Wizards Black Star Promos/27.ts
@@ -75,7 +75,10 @@ const card: Card = {
 				tcgplayer: 88069
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275446,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/28.ts
+++ b/data/Base/Wizards Black Star Promos/28.ts
@@ -68,7 +68,10 @@ const card: Card = {
 				tcgplayer: 89643
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275447,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/29.ts
+++ b/data/Base/Wizards Black Star Promos/29.ts
@@ -68,7 +68,10 @@ const card: Card = {
 				tcgplayer: 87211
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275448,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/30.ts
+++ b/data/Base/Wizards Black Star Promos/30.ts
@@ -83,7 +83,10 @@ const card: Card = {
 				tcgplayer: 89928
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275449,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/31.ts
+++ b/data/Base/Wizards Black Star Promos/31.ts
@@ -57,7 +57,10 @@ const card: Card = {
 				tcgplayer: 84363
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275450,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/32.ts
+++ b/data/Base/Wizards Black Star Promos/32.ts
@@ -73,7 +73,10 @@ const card: Card = {
 				tcgplayer: 89353
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275451,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/33.ts
+++ b/data/Base/Wizards Black Star Promos/33.ts
@@ -98,7 +98,10 @@ const card: Card = {
 				tcgplayer: 88960
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275452,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/34.ts
+++ b/data/Base/Wizards Black Star Promos/34.ts
@@ -68,7 +68,10 @@ const card: Card = {
 				tcgplayer: 85270
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275453,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/35.ts
+++ b/data/Base/Wizards Black Star Promos/35.ts
@@ -57,7 +57,10 @@ const card: Card = {
 				tcgplayer: 88014
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275454,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/36.ts
+++ b/data/Base/Wizards Black Star Promos/36.ts
@@ -57,7 +57,10 @@ const card: Card = {
 				tcgplayer: 86259
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275455,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/37.ts
+++ b/data/Base/Wizards Black Star Promos/37.ts
@@ -87,7 +87,10 @@ const card: Card = {
 				tcgplayer: 86112
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275456,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/38.ts
+++ b/data/Base/Wizards Black Star Promos/38.ts
@@ -79,7 +79,10 @@ const card: Card = {
 				tcgplayer: 90215
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275457,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/39.ts
+++ b/data/Base/Wizards Black Star Promos/39.ts
@@ -84,7 +84,10 @@ const card: Card = {
 				tcgplayer: 87503
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275458,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/4.ts
+++ b/data/Base/Wizards Black Star Promos/4.ts
@@ -96,7 +96,10 @@ const card: Card = {
 				tcgplayer: 161752
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275423,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/40.ts
+++ b/data/Base/Wizards Black Star Promos/40.ts
@@ -22,7 +22,10 @@ const card: Card = {
 				tcgplayer: 88213
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275459,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/41.ts
+++ b/data/Base/Wizards Black Star Promos/41.ts
@@ -22,7 +22,10 @@ const card: Card = {
 				tcgplayer: 86894
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275460,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/42.ts
+++ b/data/Base/Wizards Black Star Promos/42.ts
@@ -22,7 +22,10 @@ const card: Card = {
 				tcgplayer: 88240
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275461,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/43.ts
+++ b/data/Base/Wizards Black Star Promos/43.ts
@@ -75,7 +75,10 @@ const card: Card = {
 				tcgplayer: 86961
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275462,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/45.ts
+++ b/data/Base/Wizards Black Star Promos/45.ts
@@ -63,7 +63,10 @@ const card: Card = {
 				tcgplayer: 88993
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275464,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/46.ts
+++ b/data/Base/Wizards Black Star Promos/46.ts
@@ -69,7 +69,10 @@ const card: Card = {
 				tcgplayer: 85111
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275465,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/47.ts
+++ b/data/Base/Wizards Black Star Promos/47.ts
@@ -66,7 +66,10 @@ const card: Card = {
 				tcgplayer: 87397
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275466,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/48.ts
+++ b/data/Base/Wizards Black Star Promos/48.ts
@@ -70,7 +70,10 @@ const card: Card = {
 				tcgplayer: 83648
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275467,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/49.ts
+++ b/data/Base/Wizards Black Star Promos/49.ts
@@ -75,7 +75,10 @@ const card: Card = {
 				tcgplayer: 89385
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275468,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/5.ts
+++ b/data/Base/Wizards Black Star Promos/5.ts
@@ -98,7 +98,10 @@ const card: Card = {
 				tcgplayer: 84909
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275424,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/50.ts
+++ b/data/Base/Wizards Black Star Promos/50.ts
@@ -53,7 +53,10 @@ const card: Card = {
 				tcgplayer: 84143
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275469,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/51.ts
+++ b/data/Base/Wizards Black Star Promos/51.ts
@@ -74,7 +74,10 @@ const card: Card = {
 				tcgplayer: 244347
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275470,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/52.ts
+++ b/data/Base/Wizards Black Star Promos/52.ts
@@ -66,7 +66,10 @@ const card: Card = {
 				tcgplayer: 244348
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275471,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/53.ts
+++ b/data/Base/Wizards Black Star Promos/53.ts
@@ -64,7 +64,10 @@ const card: Card = {
 				tcgplayer: 89601
 			},
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275472,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/6.ts
+++ b/data/Base/Wizards Black Star Promos/6.ts
@@ -92,7 +92,10 @@ const card: Card = {
 				tcgplayer: 83578
 			},
 		},
-	]
+	],
+	thirdParty: {
+		cardmarket: 275425,
+	}
 }
 
 export default card

--- a/data/Base/Wizards Black Star Promos/7.ts
+++ b/data/Base/Wizards Black Star Promos/7.ts
@@ -76,8 +76,11 @@ const card: Card = {
 				tcgplayer: 86309
 			},
 		},
-	]
+	],
 
+	thirdParty: {
+		cardmarket: 275426,
+	}
 }
 
 export default card


### PR DESCRIPTION
ref #906

## Changes

Correct Cardmarket product references for the basep set across 48 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 48 missing Cardmarket links in this set. The post-apply audit retains 2 catalog detail mismatches for basep-15, basep-52; these remain review notes rather than being silently treated as resolved. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.