### PR TITLE
fix(cardmarket): Correct Cardmarket links for bog

### DIFF
--- a/data/E-Card/Best of game/4.ts
+++ b/data/E-Card/Best of game/4.ts
@@ -74,7 +74,10 @@ const card: Card = {
 			stamp: ["winner"],
 			size: "jumbo"
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275414,
+	}
 }
 
 export default card

--- a/data/E-Card/Best of game/5.ts
+++ b/data/E-Card/Best of game/5.ts
@@ -73,7 +73,10 @@ const card: Card = {
 			stamp: ["winner"],
 			size: "jumbo"
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275415,
+	}
 }
 
 export default card

--- a/data/E-Card/Best of game/8.ts
+++ b/data/E-Card/Best of game/8.ts
@@ -71,7 +71,10 @@ const card: Card = {
 			stamp: ["winner"],
 			size: "jumbo"
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275418,
+	}
 }
 
 export default card

--- a/data/E-Card/Best of game/9.ts
+++ b/data/E-Card/Best of game/9.ts
@@ -60,7 +60,10 @@ const card: Card = {
 			stamp: ["winner"],
 			size: "jumbo"
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 275419,
+	}
 }
 
 export default card


### PR DESCRIPTION
ref #906

## Changes

Correct Cardmarket product references for the bog set across 4 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 4 missing Cardmarket links in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.