### PR TITLE
fix(cardmarket): Correct Cardmarket links for bw2

### DIFF
--- a/data/Black & White/Emerging Powers/10.ts
+++ b/data/Black & White/Emerging Powers/10.ts
@@ -67,7 +67,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 279974,
+		cardmarket: 279975,
 		tcgplayer: 84446
 	}
 }

--- a/data/Black & White/Emerging Powers/12.ts
+++ b/data/Black & White/Emerging Powers/12.ts
@@ -88,7 +88,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 279976,
+		cardmarket: 279977,
 		tcgplayer: 90568
 	}
 }

--- a/data/Black & White/Emerging Powers/25.ts
+++ b/data/Black & White/Emerging Powers/25.ts
@@ -72,7 +72,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 279989,
+		cardmarket: 279990,
 		tcgplayer: 83732
 	}
 }

--- a/data/Black & White/Emerging Powers/29.ts
+++ b/data/Black & White/Emerging Powers/29.ts
@@ -58,7 +58,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 279993,
+		cardmarket: 279994,
 		tcgplayer: 84524
 	}
 }

--- a/data/Black & White/Emerging Powers/31.ts
+++ b/data/Black & White/Emerging Powers/31.ts
@@ -82,7 +82,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 279995,
+		cardmarket: 279996,
 		tcgplayer: 83752
 	}
 }

--- a/data/Black & White/Emerging Powers/4.ts
+++ b/data/Black & White/Emerging Powers/4.ts
@@ -70,7 +70,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 279968,
+		cardmarket: 279969,
 		tcgplayer: 89090
 	}
 }

--- a/data/Black & White/Emerging Powers/42.ts
+++ b/data/Black & White/Emerging Powers/42.ts
@@ -84,7 +84,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 280006,
+		cardmarket: 280007,
 		tcgplayer: 89205
 	}
 }

--- a/data/Black & White/Emerging Powers/44.ts
+++ b/data/Black & White/Emerging Powers/44.ts
@@ -58,7 +58,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 280008,
+		cardmarket: 280009,
 		tcgplayer: 85846
 	}
 }

--- a/data/Black & White/Emerging Powers/46.ts
+++ b/data/Black & White/Emerging Powers/46.ts
@@ -78,7 +78,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 280010,
+		cardmarket: 280011,
 		tcgplayer: 85856
 	}
 }

--- a/data/Black & White/Emerging Powers/48.ts
+++ b/data/Black & White/Emerging Powers/48.ts
@@ -79,7 +79,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 280012,
+		cardmarket: 280013,
 		tcgplayer: 85852
 	}
 }

--- a/data/Black & White/Emerging Powers/50.ts
+++ b/data/Black & White/Emerging Powers/50.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 280014,
+		cardmarket: 280015,
 		tcgplayer: 88806
 	}
 }

--- a/data/Black & White/Emerging Powers/52.ts
+++ b/data/Black & White/Emerging Powers/52.ts
@@ -80,7 +80,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 280016,
+		cardmarket: 280017,
 		tcgplayer: 83934
 	}
 }

--- a/data/Black & White/Emerging Powers/55.ts
+++ b/data/Black & White/Emerging Powers/55.ts
@@ -66,7 +66,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 280019,
+		cardmarket: 280020,
 		tcgplayer: 84965
 	}
 }

--- a/data/Black & White/Emerging Powers/57.ts
+++ b/data/Black & White/Emerging Powers/57.ts
@@ -90,7 +90,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 280021,
+		cardmarket: 280022,
 		tcgplayer: 85337
 	}
 }

--- a/data/Black & White/Emerging Powers/6.ts
+++ b/data/Black & White/Emerging Powers/6.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 279970,
+		cardmarket: 279971,
 		tcgplayer: 89666
 	}
 }

--- a/data/Black & White/Emerging Powers/71.ts
+++ b/data/Black & White/Emerging Powers/71.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 280035,
+		cardmarket: 280036,
 		tcgplayer: 85426
 	}
 }

--- a/data/Black & White/Emerging Powers/73.ts
+++ b/data/Black & White/Emerging Powers/73.ts
@@ -86,7 +86,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 280037,
+		cardmarket: 280038,
 		tcgplayer: 85429
 	}
 }

--- a/data/Black & White/Emerging Powers/8.ts
+++ b/data/Black & White/Emerging Powers/8.ts
@@ -79,7 +79,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 279972,
+		cardmarket: 279973,
 		tcgplayer: 86686
 	}
 }

--- a/data/Black & White/Emerging Powers/87.ts
+++ b/data/Black & White/Emerging Powers/87.ts
@@ -80,7 +80,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 280051,
+		cardmarket: 280052,
 		tcgplayer: 88842
 	}
 }

--- a/data/Black & White/Emerging Powers/97.ts
+++ b/data/Black & White/Emerging Powers/97.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 280000,
+		cardmarket: 280062,
 		tcgplayer: 89906
 	}
 }

--- a/data/Black & White/Emerging Powers/98.ts
+++ b/data/Black & White/Emerging Powers/98.ts
@@ -83,7 +83,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 280054,
+		cardmarket: 280063,
 		tcgplayer: 89977
 	}
 }


### PR DESCRIPTION
ref #1936

## Changes

Correct Cardmarket product references for the bw2 set across 21 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 21 duplicate-ID corrections in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.