### PR TITLE
fix(cardmarket): Correct Cardmarket links for bw9

### DIFF
--- a/data/Black & White/Plasma Freeze/115.ts
+++ b/data/Black & White/Plasma Freeze/115.ts
@@ -28,7 +28,7 @@ const card: Card = {
 	trainerType: "Supporter",
 
 	thirdParty: {
-		cardmarket: 280979,
+		cardmarket: 280993,
 		tcgplayer: 85695
 	}
 }

--- a/data/Black & White/Plasma Freeze/40.ts
+++ b/data/Black & White/Plasma Freeze/40.ts
@@ -59,6 +59,9 @@ const card: Card = {
 	description: {
 		en: "While it does not prefer to fight, even one drop of the poison it secretes from its barbs can be fatal.",
 	},
+	thirdParty: {
+		cardmarket: 280918,
+	},
 }
 
 export default card

--- a/data/Black & White/Plasma Freeze/43.ts
+++ b/data/Black & White/Plasma Freeze/43.ts
@@ -58,6 +58,9 @@ const card: Card = {
 	description: {
 		en: "It scans its surroundings by raising its ears out of the grass. Its toxic horn is for protection.",
 	},
+	thirdParty: {
+		cardmarket: 280921,
+	},
 }
 
 export default card

--- a/data/Black & White/Plasma Freeze/55.ts
+++ b/data/Black & White/Plasma Freeze/55.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 280932,
+		cardmarket: 280933,
 		tcgplayer: 90679
 	}
 }

--- a/data/Black & White/Plasma Freeze/57.ts
+++ b/data/Black & White/Plasma Freeze/57.ts
@@ -81,7 +81,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 280934,
+		cardmarket: 280935,
 		tcgplayer: 84388
 	}
 }

--- a/data/Black & White/Plasma Freeze/72.ts
+++ b/data/Black & White/Plasma Freeze/72.ts
@@ -65,7 +65,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 280949,
+		cardmarket: 280950,
 		tcgplayer: 87971
 	}
 }

--- a/data/Black & White/Plasma Freeze/74.ts
+++ b/data/Black & White/Plasma Freeze/74.ts
@@ -87,7 +87,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 280951,
+		cardmarket: 280952,
 		tcgplayer: 83849
 	}
 }

--- a/data/Black & White/Plasma Freeze/76.ts
+++ b/data/Black & White/Plasma Freeze/76.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 280953,
+		cardmarket: 280954,
 		tcgplayer: 84732
 	}
 }

--- a/data/Black & White/Plasma Freeze/90.ts
+++ b/data/Black & White/Plasma Freeze/90.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 280967,
+		cardmarket: 280968,
 		tcgplayer: 85093
 	}
 }


### PR DESCRIPTION
ref #1936
ref #906

## Changes

Correct Cardmarket product references for the bw9 set across 9 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 7 duplicate-ID corrections, 2 missing Cardmarket links in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.