### PR TITLE
fix(cardmarket): Correct Cardmarket links for col1

### DIFF
--- a/data/Call of Legends/Call of Legends/94.ts
+++ b/data/Call of Legends/Call of Legends/94.ts
@@ -24,7 +24,7 @@ const card: Card = {
 			type: "holo",
 			thirdParty: {
 				tcgplayer: 84678,
-				cardmarket: 279729
+				cardmarket: 279737
 			},
 		},
 	],

--- a/data/Call of Legends/Call of Legends/95.ts
+++ b/data/Call of Legends/Call of Legends/95.ts
@@ -24,7 +24,7 @@ const card: Card = {
 			type: "holo",
 			thirdParty: {
 				tcgplayer: 87351,
-				cardmarket: 279730
+				cardmarket: 279738
 			},
 		},
 	],


### PR DESCRIPTION
ref #1936

## Changes

Correct Cardmarket product references for the col1 set across 2 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 2 duplicate-ID corrections in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.