### PR TITLE
fix(cardmarket): Correct Cardmarket links for dp1

### DIFF
--- a/data/Diamond & Pearl/Diamond & Pearl/65.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/65.ts
@@ -78,7 +78,10 @@ const card: Card = {
 		{
 			type: "reverse"
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 277564,
+	}
 }
 
 export default card

--- a/data/Diamond & Pearl/Diamond & Pearl/66.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/66.ts
@@ -78,7 +78,10 @@ const card: Card = {
 		{
 			type: "reverse"
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 277565,
+	}
 }
 
 export default card

--- a/data/Diamond & Pearl/Diamond & Pearl/67.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/67.ts
@@ -78,7 +78,10 @@ const card: Card = {
 		{
 			type: "reverse"
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 277566,
+	}
 }
 
 export default card

--- a/data/Diamond & Pearl/Diamond & Pearl/68.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/68.ts
@@ -78,7 +78,10 @@ const card: Card = {
 		{
 			type: "reverse"
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 277567,
+	}
 }
 
 export default card


### PR DESCRIPTION
ref #906

## Changes

Correct Cardmarket product references for the dp1 set across 4 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 4 missing Cardmarket links in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.