### PR TITLE
fix(cardmarket): Correct Cardmarket links for dp2

### DIFF
--- a/data/Diamond & Pearl/Mysterious Treasures/37.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/37.ts
@@ -82,7 +82,10 @@ const card: Card = {
 		{
 			type: "reverse",
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 277666,
+	}
 }
 
 export default card

--- a/data/Diamond & Pearl/Mysterious Treasures/65.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/65.ts
@@ -83,7 +83,10 @@ const card: Card = {
 		{
 			type: "reverse",
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 277694,
+	}
 }
 
 export default card

--- a/data/Diamond & Pearl/Mysterious Treasures/66.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/66.ts
@@ -82,7 +82,10 @@ const card: Card = {
 		{
 			type: "reverse",
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 277695,
+	}
 }
 
 export default card

--- a/data/Diamond & Pearl/Mysterious Treasures/67.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/67.ts
@@ -82,7 +82,10 @@ const card: Card = {
 		{
 			type: "reverse",
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 277696,
+	}
 }
 
 export default card

--- a/data/Diamond & Pearl/Mysterious Treasures/91.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/91.ts
@@ -84,7 +84,10 @@ const card: Card = {
 		{
 			type: "reverse",
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 277720,
+	}
 }
 
 export default card

--- a/data/Diamond & Pearl/Mysterious Treasures/92.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/92.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 277687,
+		cardmarket: 277721,
 		tcgplayer: 87951
 	},
 


### PR DESCRIPTION
ref #1936
ref #906

## Changes

Correct Cardmarket product references for the dp2 set across 6 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 1 duplicate-ID correction, 5 missing Cardmarket links in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.