### PR TITLE
fix(cardmarket): Correct Cardmarket links for dp3

### DIFF
--- a/data/Diamond & Pearl/Secret Wonders/39.ts
+++ b/data/Diamond & Pearl/Secret Wonders/39.ts
@@ -76,7 +76,10 @@ const card: Card = {
 		{
 			type: "reverse",
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 277792,
+	}
 }
 
 export default card

--- a/data/Diamond & Pearl/Secret Wonders/68.ts
+++ b/data/Diamond & Pearl/Secret Wonders/68.ts
@@ -72,7 +72,10 @@ const card: Card = {
 		{
 			type: "reverse",
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 277821,
+	}
 }
 
 export default card

--- a/data/Diamond & Pearl/Secret Wonders/69.ts
+++ b/data/Diamond & Pearl/Secret Wonders/69.ts
@@ -76,7 +76,10 @@ const card: Card = {
 		{
 			type: "reverse",
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 277822,
+	}
 }
 
 export default card

--- a/data/Diamond & Pearl/Secret Wonders/70.ts
+++ b/data/Diamond & Pearl/Secret Wonders/70.ts
@@ -76,7 +76,10 @@ const card: Card = {
 		{
 			type: "reverse",
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 277823,
+	}
 }
 
 export default card

--- a/data/Diamond & Pearl/Secret Wonders/71.ts
+++ b/data/Diamond & Pearl/Secret Wonders/71.ts
@@ -76,7 +76,10 @@ const card: Card = {
 		{
 			type: "reverse",
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 277824,
+	}
 }
 
 export default card

--- a/data/Diamond & Pearl/Secret Wonders/72.ts
+++ b/data/Diamond & Pearl/Secret Wonders/72.ts
@@ -76,7 +76,10 @@ const card: Card = {
 		{
 			type: "reverse",
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 277825,
+	}
 }
 
 export default card

--- a/data/Diamond & Pearl/Secret Wonders/97.ts
+++ b/data/Diamond & Pearl/Secret Wonders/97.ts
@@ -77,7 +77,10 @@ const card: Card = {
 		{
 			type: "reverse",
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 277850,
+	}
 }
 
 export default card


### PR DESCRIPTION
ref #906

## Changes

Correct Cardmarket product references for the dp3 set across 7 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 7 missing Cardmarket links in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.