### PR TITLE
fix(cardmarket): Correct Cardmarket links for dp4

### DIFF
--- a/data/Diamond & Pearl/Great Encounters/29.ts
+++ b/data/Diamond & Pearl/Great Encounters/29.ts
@@ -77,7 +77,10 @@ const card: Card = {
 		{
 			type: "reverse"
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 277931,
+	}
 }
 
 export default card

--- a/data/Diamond & Pearl/Great Encounters/4.ts
+++ b/data/Diamond & Pearl/Great Encounters/4.ts
@@ -86,7 +86,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 277905,
+		cardmarket: 277906,
 		tcgplayer: 84699
 	},
 

--- a/data/Diamond & Pearl/Great Encounters/56.ts
+++ b/data/Diamond & Pearl/Great Encounters/56.ts
@@ -77,7 +77,10 @@ const card: Card = {
 		{
 			type: "reverse"
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 277958,
+	}
 }
 
 export default card

--- a/data/Diamond & Pearl/Great Encounters/57.ts
+++ b/data/Diamond & Pearl/Great Encounters/57.ts
@@ -98,7 +98,10 @@ const card: Card = {
 			type: "normal",
 			stamp: ["michael-pramawat"]
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 277959,
+	}
 }
 
 export default card

--- a/data/Diamond & Pearl/Great Encounters/81.ts
+++ b/data/Diamond & Pearl/Great Encounters/81.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 277908,
+		cardmarket: 277983,
 		tcgplayer: 88311
 	},
 

--- a/data/Diamond & Pearl/Great Encounters/91.ts
+++ b/data/Diamond & Pearl/Great Encounters/91.ts
@@ -77,7 +77,10 @@ const card: Card = {
 		{
 			type: "reverse"
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 277993,
+	}
 }
 
 export default card


### PR DESCRIPTION
ref #1936
ref #906

## Changes

Correct Cardmarket product references for the dp4 set across 6 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 2 duplicate-ID corrections, 4 missing Cardmarket links in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.