### PR TITLE
fix(cardmarket): Correct Cardmarket links for dp6

### DIFF
--- a/data/Diamond & Pearl/Legends Awakened/112.ts
+++ b/data/Diamond & Pearl/Legends Awakened/112.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 278260,
+		cardmarket: 278261,
 		tcgplayer: 87844
 	},
 

--- a/data/Diamond & Pearl/Legends Awakened/30.ts
+++ b/data/Diamond & Pearl/Legends Awakened/30.ts
@@ -78,7 +78,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 278155,
+		cardmarket: 278179,
 		tcgplayer: 86048
 	},
 

--- a/data/Diamond & Pearl/Legends Awakened/37.ts
+++ b/data/Diamond & Pearl/Legends Awakened/37.ts
@@ -78,7 +78,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 278164,
+		cardmarket: 278186,
 		tcgplayer: 88662
 	},
 

--- a/data/Diamond & Pearl/Legends Awakened/50.ts
+++ b/data/Diamond & Pearl/Legends Awakened/50.ts
@@ -83,7 +83,10 @@ const card: Card = {
 		{
 			type: "reverse"
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 278199,
+	}
 }
 
 export default card

--- a/data/Diamond & Pearl/Legends Awakened/55.ts
+++ b/data/Diamond & Pearl/Legends Awakened/55.ts
@@ -90,7 +90,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 278154,
+		cardmarket: 278204,
 		tcgplayer: 85772
 	},
 

--- a/data/Diamond & Pearl/Legends Awakened/59.ts
+++ b/data/Diamond & Pearl/Legends Awakened/59.ts
@@ -83,7 +83,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 278207,
+		cardmarket: 278208,
 		tcgplayer: 86609
 	},
 

--- a/data/Diamond & Pearl/Legends Awakened/65.ts
+++ b/data/Diamond & Pearl/Legends Awakened/65.ts
@@ -92,7 +92,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 278213,
+		cardmarket: 278214,
 		tcgplayer: 87379
 	},
 

--- a/data/Diamond & Pearl/Legends Awakened/76.ts
+++ b/data/Diamond & Pearl/Legends Awakened/76.ts
@@ -82,7 +82,10 @@ const card: Card = {
 		{
 			type: "reverse"
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 278225,
+	}
 }
 
 export default card

--- a/data/Diamond & Pearl/Legends Awakened/77.ts
+++ b/data/Diamond & Pearl/Legends Awakened/77.ts
@@ -83,7 +83,10 @@ const card: Card = {
 			type: "normal",
 			stamp: ["yuka-furusawa"]
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 278226,
+	}
 }
 
 export default card

--- a/data/Diamond & Pearl/Legends Awakened/78.ts
+++ b/data/Diamond & Pearl/Legends Awakened/78.ts
@@ -81,7 +81,10 @@ const card: Card = {
 		{
 			type: "reverse"
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 278227,
+	}
 }
 
 export default card

--- a/data/Diamond & Pearl/Legends Awakened/79.ts
+++ b/data/Diamond & Pearl/Legends Awakened/79.ts
@@ -82,7 +82,10 @@ const card: Card = {
 		{
 			type: "reverse"
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 278228,
+	}
 }
 
 export default card

--- a/data/Diamond & Pearl/Legends Awakened/80.ts
+++ b/data/Diamond & Pearl/Legends Awakened/80.ts
@@ -84,7 +84,10 @@ const card: Card = {
 		{
 			type: "reverse"
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 278229,
+	}
 }
 
 export default card

--- a/data/Diamond & Pearl/Legends Awakened/81.ts
+++ b/data/Diamond & Pearl/Legends Awakened/81.ts
@@ -82,7 +82,10 @@ const card: Card = {
 		{
 			type: "reverse"
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 278230,
+	}
 }
 
 export default card

--- a/data/Diamond & Pearl/Legends Awakened/84.ts
+++ b/data/Diamond & Pearl/Legends Awakened/84.ts
@@ -80,7 +80,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 278232,
+		cardmarket: 278233,
 		tcgplayer: 83789
 	},
 

--- a/data/Diamond & Pearl/Legends Awakened/88.ts
+++ b/data/Diamond & Pearl/Legends Awakened/88.ts
@@ -74,7 +74,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 278236,
+		cardmarket: 278237,
 		tcgplayer: 84309
 	},
 

--- a/data/Diamond & Pearl/Legends Awakened/95.ts
+++ b/data/Diamond & Pearl/Legends Awakened/95.ts
@@ -80,7 +80,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 278243,
+		cardmarket: 278244,
 		tcgplayer: 85767
 	},
 

--- a/data/Diamond & Pearl/Legends Awakened/97.ts
+++ b/data/Diamond & Pearl/Legends Awakened/97.ts
@@ -80,7 +80,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 278245,
+		cardmarket: 278246,
 		tcgplayer: 85785
 	},
 


### PR DESCRIPTION
ref #1936
ref #906

## Changes

Correct Cardmarket product references for the dp6 set across 17 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 10 duplicate-ID corrections, 7 missing Cardmarket links in this set. The post-apply audit retains 1 catalog detail mismatch for dp6-37; these remain review notes rather than being silently treated as resolved. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.