### PR TITLE
fix(cardmarket): Correct Cardmarket links for ecard3

### DIFF
--- a/data/E-Card/Skyridge/81.ts
+++ b/data/E-Card/Skyridge/81.ts
@@ -71,6 +71,9 @@ const card: Card = {
 			},
 		},
 	],
+	thirdParty: {
+		cardmarket: 275339,
+	},
 }
 
 export default card

--- a/data/E-Card/Skyridge/82.ts
+++ b/data/E-Card/Skyridge/82.ts
@@ -61,6 +61,9 @@ const card: Card = {
 			},
 		},
 	],
+	thirdParty: {
+		cardmarket: 275340,
+	},
 }
 
 export default card

--- a/data/E-Card/Skyridge/H17.ts
+++ b/data/E-Card/Skyridge/H17.ts
@@ -74,7 +74,7 @@ const card: Card = {
 			type: 'holo',
 			thirdParty: {
 				tcgplayer: 87010,
-				cardmarket: 275276
+				cardmarket: 275275
 			},
 		},
 	],

--- a/data/E-Card/Skyridge/H19.ts
+++ b/data/E-Card/Skyridge/H19.ts
@@ -82,7 +82,7 @@ const card: Card = {
 			type: 'holo',
 			thirdParty: {
 				tcgplayer: 87096,
-				cardmarket: 275277
+				cardmarket: 275278
 			},
 		},
 	],

--- a/data/E-Card/Skyridge/H31.ts
+++ b/data/E-Card/Skyridge/H31.ts
@@ -90,7 +90,7 @@ const card: Card = {
 			type: 'holo',
 			thirdParty: {
 				tcgplayer: 90280,
-				cardmarket: 275252
+				cardmarket: 275291
 			},
 		},
 	],


### PR DESCRIPTION
ref #1936
ref #906

## Changes

Correct Cardmarket product references for the ecard3 set across 5 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 3 duplicate-ID corrections, 2 missing Cardmarket links in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.