### PR TITLE
fix(cardmarket): Correct Cardmarket links for ex11

### DIFF
--- a/data/EX/Delta Species/30.ts
+++ b/data/EX/Delta Species/30.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	retreat: 1,
 
 	thirdParty: {
-		cardmarket: 276778
+		cardmarket: 276793
 	},
 
 	variants: [

--- a/data/EX/Delta Species/36.ts
+++ b/data/EX/Delta Species/36.ts
@@ -72,7 +72,7 @@ const card: Card = {
 	retreat: 1,
 
 	thirdParty: {
-		cardmarket: 276798,
+		cardmarket: 276799,
 		tcgplayer: 84833
 	},
 

--- a/data/EX/Delta Species/37.ts
+++ b/data/EX/Delta Species/37.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 1,
 
 	thirdParty: {
-		cardmarket: 276798,
+		cardmarket: 276800,
 		tcgplayer: 84834
 	},
 

--- a/data/EX/Delta Species/38.ts
+++ b/data/EX/Delta Species/38.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	retreat: 1,
 
 	thirdParty: {
-		cardmarket: 276798,
+		cardmarket: 276801,
 		tcgplayer: 84835
 	},
 

--- a/data/EX/Delta Species/39.ts
+++ b/data/EX/Delta Species/39.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 1,
 
 	thirdParty: {
-		cardmarket: 276798,
+		cardmarket: 276802,
 		tcgplayer: 84836
 	},
 

--- a/data/EX/Delta Species/40.ts
+++ b/data/EX/Delta Species/40.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 1,
 
 	thirdParty: {
-		cardmarket: 276798,
+		cardmarket: 276803,
 		tcgplayer: 84837
 	},
 

--- a/data/EX/Delta Species/42.ts
+++ b/data/EX/Delta Species/42.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 2,
 
 	thirdParty: {
-		cardmarket: 276804
+		cardmarket: 276805
 	},
 
 	variants: [

--- a/data/EX/Delta Species/54.ts
+++ b/data/EX/Delta Species/54.ts
@@ -81,7 +81,7 @@ const card: Card = {
 	retreat: 2,
 
 	thirdParty: {
-		cardmarket: 276816
+		cardmarket: 276817
 	},
 
 	variants: [

--- a/data/EX/Delta Species/58.ts
+++ b/data/EX/Delta Species/58.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	retreat: 1,
 
 	thirdParty: {
-		cardmarket: 276820
+		cardmarket: 276821
 	},
 
 	variants: [

--- a/data/EX/Delta Species/61.ts
+++ b/data/EX/Delta Species/61.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 1,
 
 	thirdParty: {
-		cardmarket: 276798,
+		cardmarket: 276824,
 		tcgplayer: 84838
 	},
 

--- a/data/EX/Delta Species/62.ts
+++ b/data/EX/Delta Species/62.ts
@@ -72,7 +72,7 @@ const card: Card = {
 	retreat: 1,
 
 	thirdParty: {
-		cardmarket: 276798,
+		cardmarket: 276825,
 		tcgplayer: 84839
 	},
 

--- a/data/EX/Delta Species/63.ts
+++ b/data/EX/Delta Species/63.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 1,
 
 	thirdParty: {
-		cardmarket: 276798,
+		cardmarket: 276826,
 		tcgplayer: 84840
 	},
 

--- a/data/EX/Delta Species/64.ts
+++ b/data/EX/Delta Species/64.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	retreat: 1,
 
 	thirdParty: {
-		cardmarket: 276798,
+		cardmarket: 276827,
 		tcgplayer: 84841
 	},
 

--- a/data/EX/Delta Species/66.ts
+++ b/data/EX/Delta Species/66.ts
@@ -67,7 +67,7 @@ const card: Card = {
 	retreat: 1,
 
 	thirdParty: {
-		cardmarket: 276828
+		cardmarket: 276829
 	},
 
 	variants: [


### PR DESCRIPTION
ref #1936

## Changes

Correct Cardmarket product references for the ex11 set across 14 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 14 duplicate-ID corrections in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.