### PR TITLE
fix(cardmarket): Correct Cardmarket links for ex12

### DIFF
--- a/data/EX/Legend Maker/90.ts
+++ b/data/EX/Legend Maker/90.ts
@@ -75,7 +75,8 @@ const card: Card = {
 	retreat: 3,
 
 	thirdParty: {
-		tcgplayer: 88658
+		tcgplayer: 88658,
+			cardmarket: 276967,
 	},
 
 	variants: [

--- a/data/EX/Legend Maker/91.ts
+++ b/data/EX/Legend Maker/91.ts
@@ -75,7 +75,8 @@ const card: Card = {
 	retreat: 3,
 
 	thirdParty: {
-		tcgplayer: 88673
+		tcgplayer: 88673,
+			cardmarket: 276968,
 	},
 
 	variants: [

--- a/data/EX/Legend Maker/92.ts
+++ b/data/EX/Legend Maker/92.ts
@@ -81,7 +81,8 @@ const card: Card = {
 	retreat: 3,
 
 	thirdParty: {
-		tcgplayer: 88678
+		tcgplayer: 88678,
+			cardmarket: 276969,
 	},
 
 	variants: [


### PR DESCRIPTION
ref #906

## Changes

Correct Cardmarket product references for the ex12 set across 3 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 3 missing Cardmarket links in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.