### PR TITLE
fix(cardmarket): Correct Cardmarket links for ex14

### DIFF
--- a/data/EX/Crystal Guardians/100.ts
+++ b/data/EX/Crystal Guardians/100.ts
@@ -71,7 +71,8 @@ const card: Card = {
 	retreat: 1,
 
 	thirdParty: {
-		tcgplayer: 84149
+		tcgplayer: 84149,
+			cardmarket: 277181,
 	},
 
 	variants: [

--- a/data/EX/Crystal Guardians/99.ts
+++ b/data/EX/Crystal Guardians/99.ts
@@ -73,7 +73,8 @@ const card: Card = {
 	retreat: 1,
 
 	thirdParty: {
-		tcgplayer: 83502
+		tcgplayer: 83502,
+			cardmarket: 277180,
 	},
 
 	variants: [


### PR DESCRIPTION
ref #906

## Changes

Correct Cardmarket product references for the ex14 set across 2 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 2 missing Cardmarket links in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.