### PR TITLE
fix(cardmarket): Correct Cardmarket links for ex15

### DIFF
--- a/data/EX/Dragon Frontiers/100.ts
+++ b/data/EX/Dragon Frontiers/100.ts
@@ -80,7 +80,10 @@ const card: Card = {
 		{
 			type: "holo"
 		},
-	]
+	],
+	thirdParty: {
+		cardmarket: 277305,
+	}
 }
 
 export default card

--- a/data/EX/Dragon Frontiers/101.ts
+++ b/data/EX/Dragon Frontiers/101.ts
@@ -77,11 +77,14 @@ const card: Card = {
 			type: "holo",
 			stamp: ["dylan-lefavour"]
 		},
-	]
+	],
 
 
 
 
+	thirdParty: {
+		cardmarket: 277306,
+	}
 }
 
 export default card

--- a/data/EX/Dragon Frontiers/37.ts
+++ b/data/EX/Dragon Frontiers/37.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	retreat: 1,
 
 	thirdParty: {
-		cardmarket: 277227
+		cardmarket: 277242
 	},
 
 	variants: [

--- a/data/EX/Dragon Frontiers/42.ts
+++ b/data/EX/Dragon Frontiers/42.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	retreat: 1,
 
 	thirdParty: {
-		cardmarket: 277229
+		cardmarket: 277247
 	},
 
 	variants: [

--- a/data/EX/Dragon Frontiers/50.ts
+++ b/data/EX/Dragon Frontiers/50.ts
@@ -56,7 +56,7 @@ const card: Card = {
 	retreat: 1,
 
 	thirdParty: {
-		cardmarket: 277236
+		cardmarket: 277255
 	},
 
 	variants: [

--- a/data/EX/Dragon Frontiers/56.ts
+++ b/data/EX/Dragon Frontiers/56.ts
@@ -74,7 +74,10 @@ const card: Card = {
 			type: "normal",
 			stamp: ["set-logo"]
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 277261,
+	}
 }
 
 export default card

--- a/data/EX/Dragon Frontiers/57.ts
+++ b/data/EX/Dragon Frontiers/57.ts
@@ -74,7 +74,10 @@ const card: Card = {
 			type: "normal",
 			stamp: ["set-logo"]
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 277262,
+	}
 }
 
 export default card

--- a/data/EX/Dragon Frontiers/69.ts
+++ b/data/EX/Dragon Frontiers/69.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	retreat: 1,
 
 	thirdParty: {
-		cardmarket: 277273
+		cardmarket: 277274
 	},
 
 	variants: [

--- a/data/EX/Dragon Frontiers/88.ts
+++ b/data/EX/Dragon Frontiers/88.ts
@@ -28,7 +28,10 @@ const card: Card = {
 			type: "normal",
 			stamp: ["set-logo"]
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 277293,
+	}
 }
 
 export default card


### PR DESCRIPTION
ref #1936
ref #906

## Changes

Correct Cardmarket product references for the ex15 set across 9 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 4 duplicate-ID corrections, 5 missing Cardmarket links in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.