### PR TITLE
fix(cardmarket): Correct Cardmarket links for ex16

### DIFF
--- a/data/EX/Power Keepers/100.ts
+++ b/data/EX/Power Keepers/100.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	retreat: 1,
 
 	thirdParty: {
-		tcgplayer: 85503
+		tcgplayer: 85503,
+			cardmarket: 277406,
 	},
 
 	variants: [

--- a/data/EX/Power Keepers/101.ts
+++ b/data/EX/Power Keepers/101.ts
@@ -81,7 +81,8 @@ const card: Card = {
 	retreat: 1,
 
 	thirdParty: {
-		tcgplayer: 86351
+		tcgplayer: 86351,
+			cardmarket: 277407,
 	},
 
 	variants: [

--- a/data/EX/Power Keepers/102.ts
+++ b/data/EX/Power Keepers/102.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	retreat: 1,
 
 	thirdParty: {
-		tcgplayer: 90292
+		tcgplayer: 90292,
+			cardmarket: 277408,
 	},
 
 	variants: [


### PR DESCRIPTION
ref #906

## Changes

Correct Cardmarket product references for the ex16 set across 3 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 3 missing Cardmarket links in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.