### PR TITLE
fix(cardmarket): Correct Cardmarket links for ex8

### DIFF
--- a/data/EX/Deoxys/105.ts
+++ b/data/EX/Deoxys/105.ts
@@ -102,6 +102,9 @@ const card: Card = {
 		},
 	],
 
+	thirdParty: {
+		cardmarket: 276508,
+	},
 }
 
 export default card

--- a/data/EX/Deoxys/106.ts
+++ b/data/EX/Deoxys/106.ts
@@ -95,6 +95,9 @@ const card: Card = {
 		},
 	],
 
+	thirdParty: {
+		cardmarket: 276509,
+	},
 }
 
 export default card

--- a/data/EX/Deoxys/107.ts
+++ b/data/EX/Deoxys/107.ts
@@ -91,7 +91,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
-				cardmarket: 276425,
+				cardmarket: 276510,
 				tcgplayer: 88636
 			},
 		},

--- a/data/EX/Deoxys/98.ts
+++ b/data/EX/Deoxys/98.ts
@@ -79,7 +79,7 @@ const card: Card = {
 			type: "holo",
 			thirdParty: {
 				tcgplayer: 84770,
-				cardmarket: 276419
+				cardmarket: 276501
 			},
 		},
 	],

--- a/data/EX/Deoxys/99.ts
+++ b/data/EX/Deoxys/99.ts
@@ -79,7 +79,7 @@ const card: Card = {
 			type: "holo",
 			thirdParty: {
 				tcgplayer: 84771,
-				cardmarket: 276419
+				cardmarket: 276502
 			},
 		},
 	],


### PR DESCRIPTION
ref #1936
ref #906

## Changes

Correct Cardmarket product references for the ex8 set across 5 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 3 duplicate-ID corrections, 2 missing Cardmarket links in this set. The post-apply audit retains 2 catalog detail mismatches for ex8-105, ex8-98; these remain review notes rather than being silently treated as resolved. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.