### PR TITLE
fix(cardmarket): Correct Cardmarket links for g1

### DIFF
--- a/data/XY/Generations/73a.ts
+++ b/data/XY/Generations/73a.ts
@@ -18,7 +18,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 288508
+		cardmarket: 311413
 	}
 }
 

--- a/data/XY/Generations/RC15.ts
+++ b/data/XY/Generations/RC15.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 288475
+		cardmarket: 288524
 	}
 }
 

--- a/data/XY/Generations/RC28.ts
+++ b/data/XY/Generations/RC28.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	retreat: 2,
 
 	thirdParty: {
-		cardmarket: 288515
+		cardmarket: 288537
 	}
 }
 

--- a/data/XY/Generations/RC29.ts
+++ b/data/XY/Generations/RC29.ts
@@ -78,7 +78,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 288464
+		cardmarket: 288538
 	}
 }
 

--- a/data/XY/Generations/RC32.ts
+++ b/data/XY/Generations/RC32.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	retreat: 2,
 
 	thirdParty: {
-		cardmarket: 288530
+		cardmarket: 288541
 	}
 }
 

--- a/data/XY/Generations/RC5.ts
+++ b/data/XY/Generations/RC5.ts
@@ -78,7 +78,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 288405
+		cardmarket: 288514
 	}
 }
 

--- a/data/XY/Generations/RC9.ts
+++ b/data/XY/Generations/RC9.ts
@@ -86,7 +86,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 288465
+		cardmarket: 288518
 	}
 }
 


### PR DESCRIPTION
ref #1936

## Changes

Correct Cardmarket product references for the g1 set across 7 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 7 duplicate-ID corrections in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.