### PR TITLE
fix(cardmarket): Correct Cardmarket links for gym1

### DIFF
--- a/data/Gym/Gym Heroes/100.ts
+++ b/data/Gym/Gym Heroes/100.ts
@@ -26,7 +26,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 85282,
-				cardmarket: 274152
+				cardmarket: 274236
 			}
 		}
 	],

--- a/data/Gym/Gym Heroes/101.ts
+++ b/data/Gym/Gym Heroes/101.ts
@@ -26,7 +26,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 86849,
-				cardmarket: 274153
+				cardmarket: 274237
 			}
 		}
 	],

--- a/data/Gym/Gym Heroes/102.ts
+++ b/data/Gym/Gym Heroes/102.ts
@@ -26,7 +26,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 87524,
-				cardmarket: 274154
+				cardmarket: 274238
 			}
 		}
 	],

--- a/data/Gym/Gym Heroes/27.ts
+++ b/data/Gym/Gym Heroes/27.ts
@@ -75,7 +75,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 86852,
-				cardmarket: 274142
+				cardmarket: 274163
 			}
 		}
 	],

--- a/data/Gym/Gym Heroes/46.ts
+++ b/data/Gym/Gym Heroes/46.ts
@@ -78,7 +78,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 85296,
-				cardmarket: 274152
+				cardmarket: 274182
 			}
 		}
 	],

--- a/data/Gym/Gym Heroes/49.ts
+++ b/data/Gym/Gym Heroes/49.ts
@@ -76,7 +76,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 85311,
-				cardmarket: 274152
+				cardmarket: 274185
 			}
 		}
 	],

--- a/data/Gym/Gym Heroes/57.ts
+++ b/data/Gym/Gym Heroes/57.ts
@@ -59,7 +59,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 87551,
-				cardmarket: 274154
+				cardmarket: 274193
 			}
 		}
 	],

--- a/data/Gym/Gym Heroes/62.ts
+++ b/data/Gym/Gym Heroes/62.ts
@@ -59,7 +59,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 83869,
-				cardmarket: 274171
+				cardmarket: 274198
 			}
 		}
 	],

--- a/data/Gym/Gym Heroes/66.ts
+++ b/data/Gym/Gym Heroes/66.ts
@@ -71,7 +71,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 83964,
-				cardmarket: 274151
+				cardmarket: 274202
 			}
 		}
 	],

--- a/data/Gym/Gym Heroes/68.ts
+++ b/data/Gym/Gym Heroes/68.ts
@@ -67,7 +67,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 83972,
-				cardmarket: 274151
+				cardmarket: 274204
 			}
 		}
 	],

--- a/data/Gym/Gym Heroes/69.ts
+++ b/data/Gym/Gym Heroes/69.ts
@@ -70,7 +70,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 83975,
-				cardmarket: 274151
+				cardmarket: 274205
 			}
 		}
 	],

--- a/data/Gym/Gym Heroes/70.ts
+++ b/data/Gym/Gym Heroes/70.ts
@@ -64,7 +64,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 83980,
-				cardmarket: 274151
+				cardmarket: 274206
 			}
 		}
 	],

--- a/data/Gym/Gym Heroes/72.ts
+++ b/data/Gym/Gym Heroes/72.ts
@@ -65,7 +65,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 83982,
-				cardmarket: 274151
+				cardmarket: 274208
 			}
 		}
 	],

--- a/data/Gym/Gym Heroes/74.ts
+++ b/data/Gym/Gym Heroes/74.ts
@@ -72,7 +72,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 83989,
-				cardmarket: 274151
+				cardmarket: 274210
 			}
 		}
 	],

--- a/data/Gym/Gym Heroes/76.ts
+++ b/data/Gym/Gym Heroes/76.ts
@@ -58,7 +58,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 85285,
-				cardmarket: 274152
+				cardmarket: 274212
 			}
 		}
 	],

--- a/data/Gym/Gym Heroes/77.ts
+++ b/data/Gym/Gym Heroes/77.ts
@@ -72,7 +72,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 85293,
-				cardmarket: 274152
+				cardmarket: 274213
 			}
 		}
 	],

--- a/data/Gym/Gym Heroes/78.ts
+++ b/data/Gym/Gym Heroes/78.ts
@@ -71,7 +71,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 85303,
-				cardmarket: 274152
+				cardmarket: 274214
 			}
 		}
 	],

--- a/data/Gym/Gym Heroes/80.ts
+++ b/data/Gym/Gym Heroes/80.ts
@@ -70,7 +70,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 86857,
-				cardmarket: 274153
+				cardmarket: 274216
 			}
 		}
 	],

--- a/data/Gym/Gym Heroes/83.ts
+++ b/data/Gym/Gym Heroes/83.ts
@@ -74,7 +74,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 86869,
-				cardmarket: 274153
+				cardmarket: 274219
 			}
 		}
 	],

--- a/data/Gym/Gym Heroes/85.ts
+++ b/data/Gym/Gym Heroes/85.ts
@@ -70,7 +70,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 87529,
-				cardmarket: 274154
+				cardmarket: 274221
 			}
 		}
 	],

--- a/data/Gym/Gym Heroes/98.ts
+++ b/data/Gym/Gym Heroes/98.ts
@@ -26,7 +26,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 83960,
-				cardmarket: 274151
+				cardmarket: 274234
 			}
 		}
 	],


### PR DESCRIPTION
ref #1936

## Changes

Correct Cardmarket product references for the gym1 set across 21 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 21 duplicate-ID corrections in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.