### PR TITLE
fix(cardmarket): Correct Cardmarket links for gym2

### DIFF
--- a/data/Gym/Gym Challenge/100.ts
+++ b/data/Gym/Gym Challenge/100.ts
@@ -26,7 +26,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 83859,
-				cardmarket: 274285
+				cardmarket: 274368
 			}
 		},
 	],

--- a/data/Gym/Gym Challenge/104.ts
+++ b/data/Gym/Gym Challenge/104.ts
@@ -26,7 +26,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 85709,
-				cardmarket: 274286
+				cardmarket: 274372
 			}
 		},
 	],

--- a/data/Gym/Gym Challenge/106.ts
+++ b/data/Gym/Gym Challenge/106.ts
@@ -26,7 +26,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 86503,
-				cardmarket: 274287
+				cardmarket: 274374
 			}
 		},
 	],

--- a/data/Gym/Gym Challenge/110.ts
+++ b/data/Gym/Gym Challenge/110.ts
@@ -26,7 +26,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 88861,
-				cardmarket: 274288
+				cardmarket: 274378
 			}
 		},
 	],

--- a/data/Gym/Gym Challenge/74.ts
+++ b/data/Gym/Gym Challenge/74.ts
@@ -76,7 +76,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 85717,
-				cardmarket: 274286
+				cardmarket: 274342
 			}
 		},
 	],

--- a/data/Gym/Gym Challenge/75.ts
+++ b/data/Gym/Gym Challenge/75.ts
@@ -70,6 +70,9 @@ const card: Card = {
 			}
 		},
 	],
+	thirdParty: {
+		cardmarket: 274343,
+	},
 }
 
 export default card

--- a/data/Gym/Gym Challenge/76.ts
+++ b/data/Gym/Gym Challenge/76.ts
@@ -70,6 +70,9 @@ const card: Card = {
 			}
 		},
 	],
+	thirdParty: {
+		cardmarket: 274344,
+	},
 }
 
 export default card

--- a/data/Gym/Gym Challenge/79.ts
+++ b/data/Gym/Gym Challenge/79.ts
@@ -58,7 +58,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 86512,
-				cardmarket: 274287
+				cardmarket: 274347
 			}
 		},
 	],

--- a/data/Gym/Gym Challenge/80.ts
+++ b/data/Gym/Gym Challenge/80.ts
@@ -77,7 +77,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 86517,
-				cardmarket: 274287
+				cardmarket: 274348
 			}
 		},
 	],

--- a/data/Gym/Gym Challenge/94.ts
+++ b/data/Gym/Gym Challenge/94.ts
@@ -70,7 +70,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 88865,
-				cardmarket: 274288
+				cardmarket: 274362
 			}
 		},
 	],

--- a/data/Gym/Gym Challenge/97.ts
+++ b/data/Gym/Gym Challenge/97.ts
@@ -69,7 +69,7 @@ const card: Card = {
 			stamp: ["1st-edition"],
 			thirdParty: {
 				tcgplayer: 88872,
-				cardmarket: 274288
+				cardmarket: 274365
 			}
 		},
 	],


### PR DESCRIPTION
ref #1936
ref #906

## Changes

Correct Cardmarket product references for the gym2 set across 11 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 9 duplicate-ID corrections, 2 missing Cardmarket links in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.