### PR TITLE
fix(cardmarket): Correct Cardmarket links for hgss1

### DIFF
--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/105.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/105.ts
@@ -87,7 +87,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
-				cardmarket: 278986,
+				cardmarket: 279077,
 				tcgplayer: 83545
 			}
 		},

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/108.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/108.ts
@@ -82,7 +82,7 @@ const card: Card = {
 			type: "holo",
 			thirdParty: {
 				tcgplayer: 85420,
-				cardmarket: 278992
+				cardmarket: 279080
 			}
 		},
 	],

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/109.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/109.ts
@@ -84,7 +84,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
-				cardmarket: 278998,
+				cardmarket: 279081,
 				tcgplayer: 87294
 			}
 		},

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/111.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/111.ts
@@ -45,7 +45,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
-				cardmarket: 279083,
+				cardmarket: 279084,
 				tcgplayer: 86133
 			}
 		}

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/113.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/113.ts
@@ -45,7 +45,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
-				cardmarket: 279085,
+				cardmarket: 279086,
 				tcgplayer: 86918
 			}
 

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/19.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/19.ts
@@ -94,6 +94,9 @@ const card: Card = {
 		},
 	],
 
+	thirdParty: {
+		cardmarket: 278991,
+	},
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/26.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/26.ts
@@ -116,6 +116,9 @@ const card: Card = {
 		},
 	],
 
+	thirdParty: {
+		cardmarket: 278998,
+	},
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/96.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/96.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			type: "normal",
 			stamp: ["christopher-kan"],
 			thirdParty: {
-				cardmarket: 868183,
+				cardmarket: 279068,
 				tcgplayer: 480437
 			}
 		},


### PR DESCRIPTION
ref #1936
ref #906

## Changes

Correct Cardmarket product references for the hgss1 set across 8 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 4 duplicate-ID corrections, 2 missing Cardmarket links, 2 other Cardmarket ID corrections in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.