### PR TITLE
fix(cardmarket): Correct Cardmarket links for hgss2

### DIFF
--- a/data/HeartGold & SoulSilver/Unleashed/84.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/84.ts
@@ -85,7 +85,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
-				cardmarket: 279170,
+				cardmarket: 279240,
 				tcgplayer: 84489
 			}
 		},

--- a/data/HeartGold & SoulSilver/Unleashed/86.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/86.ts
@@ -81,7 +81,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
-				cardmarket: 279174,
+				cardmarket: 279242,
 				tcgplayer: 86611
 			}
 		},

--- a/data/HeartGold & SoulSilver/Unleashed/87.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/87.ts
@@ -108,7 +108,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
-				cardmarket: 279180,
+				cardmarket: 279243,
 				tcgplayer: 89564
 			}
 		},

--- a/data/HeartGold & SoulSilver/Unleashed/88.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/88.ts
@@ -108,7 +108,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
-				cardmarket: 279182,
+				cardmarket: 279244,
 				tcgplayer: 90122
 			}
 		},

--- a/data/HeartGold & SoulSilver/Unleashed/89.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/89.ts
@@ -97,7 +97,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
-				cardmarket: 279183,
+				cardmarket: 279245,
 				tcgplayer: 90255
 			}
 		},

--- a/data/HeartGold & SoulSilver/Unleashed/90.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/90.ts
@@ -63,7 +63,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
-				cardmarket: 279246,
+				cardmarket: 279247,
 				tcgplayer: 85277,
 			}
 		},

--- a/data/HeartGold & SoulSilver/Unleashed/92.ts
+++ b/data/HeartGold & SoulSilver/Unleashed/92.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			type: "holo",
 			thirdParty: {
 				tcgplayer: 88539,
-				cardmarket: 279248
+				cardmarket: 279249
 			}
 		},
 	],


### PR DESCRIPTION
ref #1936

## Changes

Correct Cardmarket product references for the hgss2 set across 7 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 7 duplicate-ID corrections in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.