### PR TITLE
fix(cardmarket): Correct Cardmarket links for hgss3

### DIFF
--- a/data/HeartGold & SoulSilver/Undaunted/87.ts
+++ b/data/HeartGold & SoulSilver/Undaunted/87.ts
@@ -70,7 +70,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
-				cardmarket: 279340,
+				cardmarket: 279341,
 				tcgplayer: 86554
 			}
 		},

--- a/data/HeartGold & SoulSilver/Undaunted/88.ts
+++ b/data/HeartGold & SoulSilver/Undaunted/88.ts
@@ -81,7 +81,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
-				cardmarket: 86553,
+				cardmarket: 279340,
 				tcgplayer: 86553,
 			}
 		},


### PR DESCRIPTION
ref #906

## Changes

Correct Cardmarket product references for the hgss3 set across 2 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 2 other Cardmarket ID corrections in this set. The post-apply audit retains 1 catalog detail mismatch for hgss3-88; these remain review notes rather than being silently treated as resolved. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.