### PR TITLE
fix(cardmarket): Correct Cardmarket links for hgss4

### DIFF
--- a/data/HeartGold & SoulSilver/Triumphant/101.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/101.ts
@@ -69,7 +69,7 @@ const card: Card = {
 			type: "holo",
 			thirdParty: {
 				tcgplayer: 87914,
-				cardmarket: 279631
+				cardmarket: 279632
 			}
 		},
 		{

--- a/data/HeartGold & SoulSilver/Triumphant/69.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/69.ts
@@ -88,6 +88,9 @@ const card: Card = {
 		},
 	],
 
+	thirdParty: {
+		cardmarket: 279599,
+	},
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Triumphant/70.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/70.ts
@@ -85,6 +85,9 @@ const card: Card = {
 		},
 	],
 
+	thirdParty: {
+		cardmarket: 279600,
+	},
 }
 
 export default card

--- a/data/HeartGold & SoulSilver/Triumphant/92.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/92.ts
@@ -76,7 +76,7 @@ const card: Card = {
 			type: "holo",
 			thirdParty: {
 				tcgplayer: 84148,
-				cardmarket: 279533
+				cardmarket: 279622
 			}
 		},
 		{

--- a/data/HeartGold & SoulSilver/Triumphant/93.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/93.ts
@@ -87,7 +87,7 @@ const card: Card = {
 			type: "holo",
 			thirdParty: {
 				tcgplayer: 85160,
-				cardmarket: 279564
+				cardmarket: 279623
 			}
 		},
 	],

--- a/data/HeartGold & SoulSilver/Triumphant/95.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/95.ts
@@ -101,7 +101,7 @@ const card: Card = {
 			type: "holo",
 			thirdParty: {
 				tcgplayer: 86968,
-				cardmarket: 279556
+				cardmarket: 279625
 			}
 		},
 	],

--- a/data/HeartGold & SoulSilver/Triumphant/98.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/98.ts
@@ -105,7 +105,7 @@ const card: Card = {
 			type: "holo",
 			thirdParty: {
 				tcgplayer: 90694,
-				cardmarket: 279584
+				cardmarket: 279628
 			}
 		},
 		{

--- a/data/HeartGold & SoulSilver/Triumphant/99.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/99.ts
@@ -70,7 +70,7 @@ const card: Card = {
 			type: "holo",
 			thirdParty: {
 				tcgplayer: 84705,
-				cardmarket: 279629
+				cardmarket: 279630
 			}
 		},
 		{


### PR DESCRIPTION
ref #1936
ref #906

## Changes

Correct Cardmarket product references for the hgss4 set across 8 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 6 duplicate-ID corrections, 2 missing Cardmarket links in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.