### PR TITLE
fix(cardmarket): Correct Cardmarket links for lc

### DIFF
--- a/data/Legendary Collection/Legendary Collection/82.ts
+++ b/data/Legendary Collection/Legendary Collection/82.ts
@@ -73,7 +73,10 @@ const card: Card = {
 				tcgplayer: 87715
 			}
 		},
-	]
+	],
+	thirdParty: {
+		cardmarket: 274847,
+	}
 }
 
 export default card

--- a/data/Legendary Collection/Legendary Collection/83.ts
+++ b/data/Legendary Collection/Legendary Collection/83.ts
@@ -59,7 +59,10 @@ const card: Card = {
 				tcgplayer: 87724
 			}
 		},
-	]
+	],
+	thirdParty: {
+		cardmarket: 274848,
+	}
 }
 
 export default card


### PR DESCRIPTION
ref #906

## Changes

Correct Cardmarket product references for the lc set across 2 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 2 missing Cardmarket links in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.