### PR TITLE
fix(cardmarket): Correct Cardmarket links for pl1

### DIFF
--- a/data/Platinum/Platinum/127.ts
+++ b/data/Platinum/Platinum/127.ts
@@ -79,7 +79,7 @@ const card: Card = {
 			type:"holo",
 			thirdParty: {
 				tcgplayer: 89115,
-				cardmarket: 278547
+				cardmarket: 278548
 			}
 		}
 	],


### PR DESCRIPTION
ref #1936

## Changes

Correct Cardmarket product references for the pl1 set across 1 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 1 duplicate-ID correction in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.