### PR TITLE
fix(cardmarket): Correct Cardmarket links for pl4

### DIFF
--- a/data/Platinum/Arceus/95.ts
+++ b/data/Platinum/Arceus/95.ts
@@ -69,7 +69,10 @@ const card: Card = {
 				tcgplayer: 83603
 			}
 		},
-	]
+	],
+	thirdParty: {
+		cardmarket: 278967,
+	}
 }
 
 export default card

--- a/data/Platinum/Arceus/96.ts
+++ b/data/Platinum/Arceus/96.ts
@@ -69,7 +69,10 @@ const card: Card = {
 				tcgplayer: 83604
 			}
 		},
-	]
+	],
+	thirdParty: {
+		cardmarket: 278968,
+	}
 }
 
 export default card

--- a/data/Platinum/Arceus/97.ts
+++ b/data/Platinum/Arceus/97.ts
@@ -73,7 +73,10 @@ const card: Card = {
 			}
 		},
 	],
-	retreat: 0
+	retreat: 0,
+	thirdParty: {
+		cardmarket: 278969,
+	}
 }
 
 export default card

--- a/data/Platinum/Arceus/98.ts
+++ b/data/Platinum/Arceus/98.ts
@@ -75,7 +75,10 @@ const card: Card = {
 				tcgplayer: 88906
 			}
 		},
-	]
+	],
+	thirdParty: {
+		cardmarket: 278970,
+	}
 }
 
 export default card

--- a/data/Platinum/Arceus/99.ts
+++ b/data/Platinum/Arceus/99.ts
@@ -71,7 +71,10 @@ const card: Card = {
 				tcgplayer: 89757
 			}
 		},
-	]
+	],
+	thirdParty: {
+		cardmarket: 278971,
+	}
 }
 
 export default card

--- a/data/Platinum/Arceus/AR1.ts
+++ b/data/Platinum/Arceus/AR1.ts
@@ -68,7 +68,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
-				cardmarket: 278861,
+				cardmarket: 278865,
 				tcgplayer: 83592
 			}
 		}

--- a/data/Platinum/Arceus/AR2.ts
+++ b/data/Platinum/Arceus/AR2.ts
@@ -68,7 +68,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
-				cardmarket: 278861,
+				cardmarket: 278864,
 				tcgplayer: 83593
 			}
 		}

--- a/data/Platinum/Arceus/AR3.ts
+++ b/data/Platinum/Arceus/AR3.ts
@@ -62,7 +62,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
-				cardmarket: 278861,
+				cardmarket: 278863,
 				tcgplayer: 83594
 			}
 		}

--- a/data/Platinum/Arceus/AR5.ts
+++ b/data/Platinum/Arceus/AR5.ts
@@ -75,7 +75,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
-				cardmarket: 278861,
+				cardmarket: 278867,
 				tcgplayer: 83596
 			}
 		}

--- a/data/Platinum/Arceus/AR6.ts
+++ b/data/Platinum/Arceus/AR6.ts
@@ -68,7 +68,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
-				cardmarket: 278861,
+				cardmarket: 278862,
 				tcgplayer: 83597
 			}
 		}

--- a/data/Platinum/Arceus/AR7.ts
+++ b/data/Platinum/Arceus/AR7.ts
@@ -62,7 +62,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
-				cardmarket: 278861,
+				cardmarket: 278866,
 				tcgplayer: 83598
 			}
 		}

--- a/data/Platinum/Arceus/AR8.ts
+++ b/data/Platinum/Arceus/AR8.ts
@@ -69,7 +69,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
-				cardmarket: 278861,
+				cardmarket: 278868,
 				tcgplayer: 83599
 			}
 		}

--- a/data/Platinum/Arceus/AR9.ts
+++ b/data/Platinum/Arceus/AR9.ts
@@ -69,7 +69,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
-				cardmarket: 278861,
+				cardmarket: 278871,
 				tcgplayer: 83600
 			}
 		}


### PR DESCRIPTION
ref #1936
ref #906

## Changes

Correct Cardmarket product references for the pl4 set across 13 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 8 duplicate-ID corrections, 5 missing Cardmarket links in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.