### PR TITLE
fix(cardmarket): Correct Cardmarket links for pop5

### DIFF
--- a/data/POP/POP Series 5/16.ts
+++ b/data/POP/POP Series 5/16.ts
@@ -73,6 +73,9 @@ const card: Card = {
 		},
 	],
 
+	thirdParty: {
+		cardmarket: 277498,
+	},
 }
 
 export default card

--- a/data/POP/POP Series 5/17.ts
+++ b/data/POP/POP Series 5/17.ts
@@ -83,6 +83,9 @@ const card: Card = {
 		},
 	],
 
+	thirdParty: {
+		cardmarket: 277499,
+	},
 }
 
 export default card

--- a/data/POP/POP Series 5/6.ts
+++ b/data/POP/POP Series 5/6.ts
@@ -28,6 +28,9 @@ const card: Card = {
 		},
 	],
 
+	thirdParty: {
+		cardmarket: 277488,
+	},
 }
 
 export default card

--- a/data/POP/POP Series 5/9.ts
+++ b/data/POP/POP Series 5/9.ts
@@ -27,6 +27,9 @@ const card: Card = {
 		},
 	],
 
+	thirdParty: {
+		cardmarket: 277491,
+	},
 }
 
 export default card


### PR DESCRIPTION
ref #906

## Changes

Correct Cardmarket product references for the pop5 set across 4 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 4 missing Cardmarket links in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.