### PR TITLE
fix(cardmarket): Correct Cardmarket links for ru1

### DIFF
--- a/data/Platinum/Pokémon Rumble/10.ts
+++ b/data/Platinum/Pokémon Rumble/10.ts
@@ -59,7 +59,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
-				cardmarket: 278850,
+				cardmarket: 278851,
 				tcgplayer: 87404
 			},
 		}

--- a/data/Platinum/Pokémon Rumble/3.ts
+++ b/data/Platinum/Pokémon Rumble/3.ts
@@ -54,7 +54,10 @@ const card: Card = {
 		{
 			type:"normal"
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 278844,
+	}
 }
 
 export default card

--- a/data/Platinum/Pokémon Rumble/4.ts
+++ b/data/Platinum/Pokémon Rumble/4.ts
@@ -53,7 +53,10 @@ const card: Card = {
 		{
 			type:"normal"
 		}
-	]
+	],
+	thirdParty: {
+		cardmarket: 278845,
+	}
 }
 
 export default card


### PR DESCRIPTION
ref #1936
ref #906

## Changes

Correct Cardmarket product references for the ru1 set across 3 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 1 duplicate-ID correction, 2 missing Cardmarket links in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.