### PR TITLE
fix(cardmarket): Correct Cardmarket links for sm1

### DIFF
--- a/data/Sun & Moon/Sun & Moon/168.ts
+++ b/data/Sun & Moon/Sun & Moon/168.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	energyType: "Normal",
 
 	thirdParty: {
-		cardmarket: 295475
+		cardmarket: 295675
 	}
 }
 

--- a/data/Sun & Moon/Sun & Moon/171.ts
+++ b/data/Sun & Moon/Sun & Moon/171.ts
@@ -14,7 +14,7 @@ const card: Card = {
 	energyType: "Normal",
 
 	thirdParty: {
-		cardmarket: 295476
+		cardmarket: 295674
 	}
 }
 


### PR DESCRIPTION
ref #1936

## Changes

Correct Cardmarket product references for the sm1 set across 2 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 2 duplicate-ID corrections in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.