### PR TITLE
fix(cardmarket): Correct Cardmarket links for sm115

### DIFF
--- a/data/Sun & Moon/Hidden Fates/22.ts
+++ b/data/Sun & Moon/Hidden Fates/22.ts
@@ -82,7 +82,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 394782,
+		cardmarket: 396617,
 		tcgplayer: 197666
 	}
 }

--- a/data/Sun & Moon/Hidden Fates/25.ts
+++ b/data/Sun & Moon/Hidden Fates/25.ts
@@ -56,7 +56,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 394722,
+		cardmarket: 394767,
 		tcgplayer: 197669
 	}
 }

--- a/data/Sun & Moon/Hidden Fates/26.ts
+++ b/data/Sun & Moon/Hidden Fates/26.ts
@@ -54,7 +54,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 394767,
+		cardmarket: 394722,
 		tcgplayer: 197670
 	}
 }

--- a/data/Sun & Moon/Hidden Fates/39.ts
+++ b/data/Sun & Moon/Hidden Fates/39.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 394597,
+		cardmarket: 394652,
 		tcgplayer: 197683
 	}
 }

--- a/data/Sun & Moon/Hidden Fates/45.ts
+++ b/data/Sun & Moon/Hidden Fates/45.ts
@@ -57,6 +57,9 @@ const card: Card = {
 	description: {
 		en: "The plant stalk it holds is its weapon. The stalk is used like a sword to cut all sorts of things.",
 	},
+	thirdParty: {
+		cardmarket: 394572,
+	},
 }
 
 export default card

--- a/data/Sun & Moon/Hidden Fates/48.ts
+++ b/data/Sun & Moon/Hidden Fates/48.ts
@@ -71,7 +71,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 394587,
+		cardmarket: 396647,
 		tcgplayer: 197693
 	}
 }

--- a/data/Sun & Moon/Hidden Fates/49.ts
+++ b/data/Sun & Moon/Hidden Fates/49.ts
@@ -53,7 +53,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 396647,
+		cardmarket: 394587,
 		tcgplayer: 197694
 	}
 }

--- a/data/Sun & Moon/Hidden Fates/51.ts
+++ b/data/Sun & Moon/Hidden Fates/51.ts
@@ -28,6 +28,9 @@ const card: Card = {
 	},
 	trainerType: "Supporter",
 
+	thirdParty: {
+		cardmarket: 394807,
+	},
 }
 
 export default card

--- a/data/Sun & Moon/Hidden Fates/52.ts
+++ b/data/Sun & Moon/Hidden Fates/52.ts
@@ -28,6 +28,9 @@ const card: Card = {
 	},
 	trainerType: "Supporter",
 
+	thirdParty: {
+		cardmarket: 396657,
+	},
 }
 
 export default card

--- a/data/Sun & Moon/Hidden Fates/53.ts
+++ b/data/Sun & Moon/Hidden Fates/53.ts
@@ -28,6 +28,9 @@ const card: Card = {
 	},
 	trainerType: "Supporter",
 
+	thirdParty: {
+		cardmarket: 394632,
+	},
 }
 
 export default card

--- a/data/Sun & Moon/Hidden Fates/54.ts
+++ b/data/Sun & Moon/Hidden Fates/54.ts
@@ -28,6 +28,9 @@ const card: Card = {
 	},
 	trainerType: "Stadium",
 
+	thirdParty: {
+		cardmarket: 394582,
+	},
 }
 
 export default card

--- a/data/Sun & Moon/Hidden Fates/55.ts
+++ b/data/Sun & Moon/Hidden Fates/55.ts
@@ -28,6 +28,9 @@ const card: Card = {
 	},
 	trainerType: "Supporter",
 
+	thirdParty: {
+		cardmarket: 394742,
+	},
 }
 
 export default card

--- a/data/Sun & Moon/Hidden Fates/56.ts
+++ b/data/Sun & Moon/Hidden Fates/56.ts
@@ -28,6 +28,9 @@ const card: Card = {
 	},
 	trainerType: "Supporter",
 
+	thirdParty: {
+		cardmarket: 394617,
+	},
 }
 
 export default card

--- a/data/Sun & Moon/Hidden Fates/59.ts
+++ b/data/Sun & Moon/Hidden Fates/59.ts
@@ -28,6 +28,9 @@ const card: Card = {
 	},
 	trainerType: "Supporter",
 
+	thirdParty: {
+		cardmarket: 394627,
+	},
 }
 
 export default card

--- a/data/Sun & Moon/Hidden Fates/60.ts
+++ b/data/Sun & Moon/Hidden Fates/60.ts
@@ -28,6 +28,9 @@ const card: Card = {
 	},
 	trainerType: "Supporter",
 
+	thirdParty: {
+		cardmarket: 394622,
+	},
 }
 
 export default card

--- a/data/Sun & Moon/Hidden Fates/61.ts
+++ b/data/Sun & Moon/Hidden Fates/61.ts
@@ -28,6 +28,9 @@ const card: Card = {
 	},
 	trainerType: "Stadium",
 
+	thirdParty: {
+		cardmarket: 394577,
+	},
 }
 
 export default card

--- a/data/Sun & Moon/Hidden Fates/62.ts
+++ b/data/Sun & Moon/Hidden Fates/62.ts
@@ -28,6 +28,9 @@ const card: Card = {
 	},
 	trainerType: "Supporter",
 
+	thirdParty: {
+		cardmarket: 394752,
+	},
 }
 
 export default card

--- a/data/Sun & Moon/Hidden Fates/63.ts
+++ b/data/Sun & Moon/Hidden Fates/63.ts
@@ -28,6 +28,9 @@ const card: Card = {
 	},
 	trainerType: "Supporter",
 
+	thirdParty: {
+		cardmarket: 396662,
+	},
 }
 
 export default card

--- a/data/Sun & Moon/Hidden Fates/65.ts
+++ b/data/Sun & Moon/Hidden Fates/65.ts
@@ -28,6 +28,9 @@ const card: Card = {
 	},
 	trainerType: "Supporter",
 
+	thirdParty: {
+		cardmarket: 396667,
+	},
 }
 
 export default card

--- a/data/Sun & Moon/Hidden Fates/9.ts
+++ b/data/Sun & Moon/Hidden Fates/9.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	retreat: 3,
 
 	thirdParty: {
-		cardmarket: 381243,
+		cardmarket: 394737,
 		tcgplayer: 197651
 	}
 }


### PR DESCRIPTION
ref #1936
ref #906

## Changes

Correct Cardmarket product references for the sm115 set across 20 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 1 duplicate-ID correction, 13 missing Cardmarket links, 6 other Cardmarket ID corrections in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.