### PR TITLE
fix(cardmarket): Correct Cardmarket links for sm2

### DIFF
--- a/data/Sun & Moon/Guardians Rising/143.ts
+++ b/data/Sun & Moon/Guardians Rising/143.ts
@@ -28,7 +28,7 @@ const card: Card = {
 	trainerType: "Supporter",
 
 	thirdParty: {
-		cardmarket: 296848,
+		cardmarket: 297578,
 		tcgplayer: 131051
 	}
 }

--- a/data/Sun & Moon/Guardians Rising/63.ts
+++ b/data/Sun & Moon/Guardians Rising/63.ts
@@ -62,7 +62,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 297523,
+		cardmarket: 297524,
 		tcgplayer: 130973
 	}
 }


### PR DESCRIPTION
ref #1936

## Changes

Correct Cardmarket product references for the sm2 set across 2 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 2 duplicate-ID corrections in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.