### PR TITLE
fix(cardmarket): Correct Cardmarket links for sm3

### DIFF
--- a/data/Sun & Moon/Burning Shadows/122.ts
+++ b/data/Sun & Moon/Burning Shadows/122.ts
@@ -28,7 +28,8 @@ const card: Card = {
 	trainerType: "Item",
 
 	thirdParty: {
-		tcgplayer: 138626
+		tcgplayer: 138626,
+			cardmarket: 299522,
 	},
 
 	variants: [

--- a/data/Sun & Moon/Burning Shadows/76.ts
+++ b/data/Sun & Moon/Burning Shadows/76.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 299477,
+		cardmarket: 299478,
 		tcgplayer: 138562
 	},
 


### PR DESCRIPTION
ref #1936
ref #906

## Changes

Correct Cardmarket product references for the sm3 set across 2 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 1 duplicate-ID correction, 1 missing Cardmarket link in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.