### PR TITLE
fix(cardmarket): Correct Cardmarket links for sm3.5

### DIFF
--- a/data/Sun & Moon/Shining Legends/78.ts
+++ b/data/Sun & Moon/Shining Legends/78.ts
@@ -113,7 +113,7 @@ const card: Card = {
 	retreat: 2,
 
 	thirdParty: {
-		cardmarket: 301167,
+		cardmarket: 302215,
 		tcgplayer: 146698
 	}
 }


### PR DESCRIPTION
ref #1936

## Changes

Correct Cardmarket product references for the sm3.5 set across 1 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 1 duplicate-ID correction in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.