### PR TITLE
fix(cardmarket): Correct Cardmarket links for sm5

### DIFF
--- a/data/Sun & Moon/Ultra Prism/105.ts
+++ b/data/Sun & Moon/Ultra Prism/105.ts
@@ -69,7 +69,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 316030,
+		cardmarket: 316031,
 		tcgplayer: 157722
 	}
 }

--- a/data/Sun & Moon/Ultra Prism/111.ts
+++ b/data/Sun & Moon/Ultra Prism/111.ts
@@ -90,7 +90,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 315946,
+		cardmarket: 316037,
 		tcgplayer: 157728
 	}
 }

--- a/data/Sun & Moon/Ultra Prism/157.ts
+++ b/data/Sun & Moon/Ultra Prism/157.ts
@@ -108,7 +108,7 @@ const card: Card = {
 	retreat: 2,
 
 	thirdParty: {
-		cardmarket: 315503,
+		cardmarket: 316081,
 		tcgplayer: 157773
 	}
 }

--- a/data/Sun & Moon/Ultra Prism/158.ts
+++ b/data/Sun & Moon/Ultra Prism/158.ts
@@ -112,7 +112,7 @@ const card: Card = {
 	retreat: 1,
 
 	thirdParty: {
-		cardmarket: 316064,
+		cardmarket: 316082,
 		tcgplayer: 157774
 	}
 }

--- a/data/Sun & Moon/Ultra Prism/159.ts
+++ b/data/Sun & Moon/Ultra Prism/159.ts
@@ -118,7 +118,7 @@ const card: Card = {
 	retreat: 2,
 
 	thirdParty: {
-		cardmarket: 315504,
+		cardmarket: 316083,
 		tcgplayer: 157775
 	}
 }

--- a/data/Sun & Moon/Ultra Prism/160.ts
+++ b/data/Sun & Moon/Ultra Prism/160.ts
@@ -117,7 +117,7 @@ const card: Card = {
 	retreat: 2,
 
 	thirdParty: {
-		cardmarket: 316066,
+		cardmarket: 316084,
 		tcgplayer: 157776
 	}
 }

--- a/data/Sun & Moon/Ultra Prism/161.ts
+++ b/data/Sun & Moon/Ultra Prism/161.ts
@@ -120,7 +120,7 @@ const card: Card = {
 	retreat: 2,
 
 	thirdParty: {
-		cardmarket: 315828,
+		cardmarket: 316085,
 		tcgplayer: 157777
 	}
 }

--- a/data/Sun & Moon/Ultra Prism/162.ts
+++ b/data/Sun & Moon/Ultra Prism/162.ts
@@ -118,7 +118,7 @@ const card: Card = {
 	retreat: 4,
 
 	thirdParty: {
-		cardmarket: 316068,
+		cardmarket: 316086,
 		tcgplayer: 157778
 	}
 }

--- a/data/Sun & Moon/Ultra Prism/163.ts
+++ b/data/Sun & Moon/Ultra Prism/163.ts
@@ -117,7 +117,7 @@ const card: Card = {
 	retreat: 3,
 
 	thirdParty: {
-		cardmarket: 315829,
+		cardmarket: 316087,
 		tcgplayer: 157779
 	}
 }

--- a/data/Sun & Moon/Ultra Prism/164.ts
+++ b/data/Sun & Moon/Ultra Prism/164.ts
@@ -115,7 +115,7 @@ const card: Card = {
 	retreat: 3,
 
 	thirdParty: {
-		cardmarket: 316026,
+		cardmarket: 316088,
 		tcgplayer: 157780
 	}
 }

--- a/data/Sun & Moon/Ultra Prism/165.ts
+++ b/data/Sun & Moon/Ultra Prism/165.ts
@@ -115,7 +115,7 @@ const card: Card = {
 	retreat: 3,
 
 	thirdParty: {
-		cardmarket: 316027,
+		cardmarket: 316089,
 		tcgplayer: 157781
 	}
 }

--- a/data/Sun & Moon/Ultra Prism/167.ts
+++ b/data/Sun & Moon/Ultra Prism/167.ts
@@ -28,7 +28,7 @@ const card: Card = {
 	trainerType: "Tool",
 
 	thirdParty: {
-		cardmarket: 316047,
+		cardmarket: 316091,
 		tcgplayer: 157783
 	}
 }

--- a/data/Sun & Moon/Ultra Prism/168.ts
+++ b/data/Sun & Moon/Ultra Prism/168.ts
@@ -28,7 +28,7 @@ const card: Card = {
 	trainerType: "Item",
 
 	thirdParty: {
-		cardmarket: 316054,
+		cardmarket: 316092,
 		tcgplayer: 157784
 	}
 }

--- a/data/Sun & Moon/Ultra Prism/21.ts
+++ b/data/Sun & Moon/Ultra Prism/21.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 315951,
+		cardmarket: 315952,
 		tcgplayer: 157638
 	}
 }

--- a/data/Sun & Moon/Ultra Prism/46.ts
+++ b/data/Sun & Moon/Ultra Prism/46.ts
@@ -74,7 +74,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 315975,
+		cardmarket: 315976,
 		tcgplayer: 157663
 	}
 }

--- a/data/Sun & Moon/Ultra Prism/62.ts
+++ b/data/Sun & Moon/Ultra Prism/62.ts
@@ -96,6 +96,9 @@ const card: Card = {
 	description: {
 		en: "Said to live in another world, this Pokémon devours light, drawing the moonless dark veil of night over the brightness of day.",
 	},
+	thirdParty: {
+		cardmarket: 315124,
+	},
 }
 
 export default card

--- a/data/Sun & Moon/Ultra Prism/7.ts
+++ b/data/Sun & Moon/Ultra Prism/7.ts
@@ -80,7 +80,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 315938,
+		cardmarket: 315939,
 		tcgplayer: 157624
 	}
 }

--- a/data/Sun & Moon/Ultra Prism/81.ts
+++ b/data/Sun & Moon/Ultra Prism/81.ts
@@ -91,7 +91,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 316007,
+		cardmarket: 316008,
 		tcgplayer: 157698
 	}
 }

--- a/data/Sun & Moon/Ultra Prism/97.ts
+++ b/data/Sun & Moon/Ultra Prism/97.ts
@@ -84,7 +84,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 316022,
+		cardmarket: 316023,
 		tcgplayer: 157714
 	}
 }


### PR DESCRIPTION
ref #1936
ref #906

## Changes

Correct Cardmarket product references for the sm5 set across 19 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 18 duplicate-ID corrections, 1 missing Cardmarket link in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.