### PR TITLE
fix(cardmarket): Correct Cardmarket links for sm6

### DIFF
--- a/data/Sun & Moon/Forbidden Light/128.ts
+++ b/data/Sun & Moon/Forbidden Light/128.ts
@@ -28,7 +28,7 @@ const card: Card = {
 	trainerType: "Supporter",
 
 	thirdParty: {
-		cardmarket: 327209,
+		cardmarket: 355616,
 		tcgplayer: 165766
 	}
 }

--- a/data/Sun & Moon/Forbidden Light/22.ts
+++ b/data/Sun & Moon/Forbidden Light/22.ts
@@ -78,7 +78,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 355541,
+		cardmarket: 355542,
 		tcgplayer: 165671
 	}
 }

--- a/data/Sun & Moon/Forbidden Light/47.ts
+++ b/data/Sun & Moon/Forbidden Light/47.ts
@@ -74,7 +74,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 355565,
+		cardmarket: 355566,
 		tcgplayer: 165698
 	}
 }

--- a/data/Sun & Moon/Forbidden Light/6.ts
+++ b/data/Sun & Moon/Forbidden Light/6.ts
@@ -67,7 +67,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 355526,
+		cardmarket: 355527,
 		tcgplayer: 165653
 	}
 }

--- a/data/Sun & Moon/Forbidden Light/71.ts
+++ b/data/Sun & Moon/Forbidden Light/71.ts
@@ -90,7 +90,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 327207,
+		cardmarket: 355658,
 		tcgplayer: 165723
 	}
 }

--- a/data/Sun & Moon/Forbidden Light/72.ts
+++ b/data/Sun & Moon/Forbidden Light/72.ts
@@ -94,7 +94,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 355658,
+		cardmarket: 355589,
 		tcgplayer: 165724
 	}
 }

--- a/data/Sun & Moon/Forbidden Light/84.ts
+++ b/data/Sun & Moon/Forbidden Light/84.ts
@@ -74,7 +74,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 355597
+		cardmarket: 355598
 	}
 }
 

--- a/data/Sun & Moon/Forbidden Light/92.ts
+++ b/data/Sun & Moon/Forbidden Light/92.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 355605,
+		cardmarket: 355606,
 		tcgplayer: 165752
 	}
 }


### PR DESCRIPTION
ref #1936
ref #906

## Changes

Correct Cardmarket product references for the sm6 set across 8 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 7 duplicate-ID corrections, 1 other Cardmarket ID correction in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.