### PR TITLE
fix(cardmarket): Correct Cardmarket links for sm8

### DIFF
--- a/data/Sun & Moon/Lost Thunder/105.ts
+++ b/data/Sun & Moon/Lost Thunder/105.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 365706,
+		cardmarket: 365742,
 		tcgplayer: 178918
 	}
 }

--- a/data/Sun & Moon/Lost Thunder/115.ts
+++ b/data/Sun & Moon/Lost Thunder/115.ts
@@ -69,7 +69,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 365751,
+		cardmarket: 365752,
 		tcgplayer: 178928
 	}
 }

--- a/data/Sun & Moon/Lost Thunder/12.ts
+++ b/data/Sun & Moon/Lost Thunder/12.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 365578,
+		cardmarket: 365579,
 		tcgplayer: 178809
 	}
 }

--- a/data/Sun & Moon/Lost Thunder/142.ts
+++ b/data/Sun & Moon/Lost Thunder/142.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 365722,
+		cardmarket: 365779,
 		tcgplayer: 178961
 	}
 }

--- a/data/Sun & Moon/Lost Thunder/143.ts
+++ b/data/Sun & Moon/Lost Thunder/143.ts
@@ -94,7 +94,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 365754,
+		cardmarket: 365780,
 		tcgplayer: 178962
 	}
 }

--- a/data/Sun & Moon/Lost Thunder/162.ts
+++ b/data/Sun & Moon/Lost Thunder/162.ts
@@ -84,7 +84,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 365797,
+		cardmarket: 365798,
 		tcgplayer: 178985
 	}
 }

--- a/data/Sun & Moon/Lost Thunder/164.ts
+++ b/data/Sun & Moon/Lost Thunder/164.ts
@@ -91,7 +91,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 365799,
+		cardmarket: 365800,
 		tcgplayer: 178987
 	}
 }

--- a/data/Sun & Moon/Lost Thunder/23.ts
+++ b/data/Sun & Moon/Lost Thunder/23.ts
@@ -61,7 +61,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 365616,
+		cardmarket: 365663,
 		tcgplayer: 178824
 	}
 }

--- a/data/Sun & Moon/Lost Thunder/24.ts
+++ b/data/Sun & Moon/Lost Thunder/24.ts
@@ -67,7 +67,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 365663,
+		cardmarket: 365616,
 		tcgplayer: 178825
 	}
 }

--- a/data/Sun & Moon/Lost Thunder/40.ts
+++ b/data/Sun & Moon/Lost Thunder/40.ts
@@ -62,7 +62,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 365679,
+		cardmarket: 365680,
 		tcgplayer: 178843
 	}
 }

--- a/data/Sun & Moon/Lost Thunder/59.ts
+++ b/data/Sun & Moon/Lost Thunder/59.ts
@@ -92,7 +92,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 364940,
+		cardmarket: 365698,
 		tcgplayer: 178866
 	}
 }

--- a/data/Sun & Moon/Lost Thunder/6.ts
+++ b/data/Sun & Moon/Lost Thunder/6.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 365573,
+		cardmarket: 365574,
 		tcgplayer: 178803
 	}
 }

--- a/data/Sun & Moon/Lost Thunder/65.ts
+++ b/data/Sun & Moon/Lost Thunder/65.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 365702,
+		cardmarket: 365703,
 		tcgplayer: 178874
 	}
 }

--- a/data/Sun & Moon/Lost Thunder/76.ts
+++ b/data/Sun & Moon/Lost Thunder/76.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 365713,
+		cardmarket: 365714,
 		tcgplayer: 178885
 	}
 }

--- a/data/Sun & Moon/Lost Thunder/91.ts
+++ b/data/Sun & Moon/Lost Thunder/91.ts
@@ -83,7 +83,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 365727,
+		cardmarket: 365728,
 		tcgplayer: 178902
 	}
 }

--- a/data/Sun & Moon/Lost Thunder/92.ts
+++ b/data/Sun & Moon/Lost Thunder/92.ts
@@ -83,7 +83,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 365727,
+		cardmarket: 365729,
 		tcgplayer: 178903
 	}
 }


### PR DESCRIPTION
ref #1936
ref #906

## Changes

Correct Cardmarket product references for the sm8 set across 16 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 14 duplicate-ID corrections, 2 other Cardmarket ID corrections in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.