### PR TITLE
fix(cardmarket): Correct Cardmarket links for sm9

### DIFF
--- a/data/Sun & Moon/Team Up/115.ts
+++ b/data/Sun & Moon/Team Up/115.ts
@@ -94,7 +94,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 369042,
+		cardmarket: 369043,
 		tcgplayer: 183902
 	}
 }

--- a/data/Sun & Moon/Team Up/117.ts
+++ b/data/Sun & Moon/Team Up/117.ts
@@ -83,7 +83,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 369044,
+		cardmarket: 369045,
 		tcgplayer: 183904
 	}
 }

--- a/data/Sun & Moon/Team Up/12.ts
+++ b/data/Sun & Moon/Team Up/12.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 368944,
+		cardmarket: 368945,
 		tcgplayer: 183783
 	}
 }

--- a/data/Sun & Moon/Team Up/122.ts
+++ b/data/Sun & Moon/Team Up/122.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 369048,
+		cardmarket: 369049,
 		tcgplayer: 183911
 	}
 }

--- a/data/Sun & Moon/Team Up/127.ts
+++ b/data/Sun & Moon/Team Up/127.ts
@@ -93,6 +93,9 @@ const card: Card = {
 	description: {
 		en: "The plant stalk it holds is its weapon. The stalk is used like a sword to cut all sorts of things.",
 	},
+	thirdParty: {
+		cardmarket: 369054,
+	},
 }
 
 export default card

--- a/data/Sun & Moon/Team Up/23.ts
+++ b/data/Sun & Moon/Team Up/23.ts
@@ -78,7 +78,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 368954,
+		cardmarket: 368955,
 		tcgplayer: 183794
 	}
 }

--- a/data/Sun & Moon/Team Up/3.ts
+++ b/data/Sun & Moon/Team Up/3.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 368935,
+		cardmarket: 368936,
 		tcgplayer: 183774
 	}
 }

--- a/data/Sun & Moon/Team Up/35.ts
+++ b/data/Sun & Moon/Team Up/35.ts
@@ -97,7 +97,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 368965,
+		cardmarket: 368966,
 		tcgplayer: 183808
 	}
 }

--- a/data/Sun & Moon/Team Up/54.ts
+++ b/data/Sun & Moon/Team Up/54.ts
@@ -82,6 +82,9 @@ const card: Card = {
 	description: {
 		en: "Although small, its venomous barbs render this Pokémon dangerous. The female has smaller horns.",
 	},
+	thirdParty: {
+		cardmarket: 368984,
+	},
 }
 
 export default card

--- a/data/Sun & Moon/Team Up/57.ts
+++ b/data/Sun & Moon/Team Up/57.ts
@@ -76,6 +76,9 @@ const card: Card = {
 	description: {
 		en: "It scans its surroundings by raising its ears out of the grass. Its toxic horn is for protection.",
 	},
+	thirdParty: {
+		cardmarket: 368987,
+	},
 }
 
 export default card


### PR DESCRIPTION
ref #1936
ref #906

## Changes

Correct Cardmarket product references for the sm9 set across 10 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 7 duplicate-ID corrections, 3 missing Cardmarket links in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.