### PR TITLE
fix(cardmarket): Correct Cardmarket links for svp

### DIFF
--- a/data/Scarlet & Violet/SVP Black Star Promos/105.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/105.ts
@@ -67,6 +67,9 @@ const card: Card = {
 			type: "holo"
 		}
 	],
+	thirdParty: {
+		cardmarket: 769401,
+	},
 }
 
 export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/106.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/106.ts
@@ -50,6 +50,9 @@ const card: Card = {
 			type: "holo"
 		}
 	],
+	thirdParty: {
+		cardmarket: 769402,
+	},
 }
 
 export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/107.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/107.ts
@@ -62,6 +62,9 @@ const card: Card = {
 			type: "normal"
 		}
 	],
+	thirdParty: {
+		cardmarket: 769403,
+	},
 }
 
 export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/108.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/108.ts
@@ -70,6 +70,9 @@ const card: Card = {
 			type: "normal"
 		}
 	],
+	thirdParty: {
+		cardmarket: 769404,
+	},
 }
 
 export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/109.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/109.ts
@@ -57,6 +57,9 @@ const card: Card = {
 			type: "normal"
 		}
 	],
+	thirdParty: {
+		cardmarket: 769405,
+	},
 }
 
 export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/110.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/110.ts
@@ -63,6 +63,9 @@ const card: Card = {
 			type: "holo"
 		}
 	],
+	thirdParty: {
+		cardmarket: 769406,
+	},
 }
 
 export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/111.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/111.ts
@@ -49,6 +49,9 @@ const card: Card = {
 			type: "normal"
 		}
 	],
+	thirdParty: {
+		cardmarket: 769407,
+	},
 }
 
 export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/112.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/112.ts
@@ -57,6 +57,9 @@ const card: Card = {
 			type: "normal"
 		}
 	],
+	thirdParty: {
+		cardmarket: 769408,
+	},
 }
 
 export default card

--- a/data/Scarlet & Violet/SVP Black Star Promos/113.ts
+++ b/data/Scarlet & Violet/SVP Black Star Promos/113.ts
@@ -70,6 +70,9 @@ const card: Card = {
 			type: "normal"
 		}
 	],
+	thirdParty: {
+		cardmarket: 769409,
+	},
 }
 
 export default card


### PR DESCRIPTION
ref #1391

## Changes

Correct Cardmarket product references for the svp set across 9 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 9 missing Cardmarket links in this set. This is a partial contribution to the SVP pricing coverage tracked by #1391 and does not close that issue. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.