### PR TITLE
fix(cardmarket): Correct Cardmarket links for swsh1

### DIFF
--- a/data/Sword & Shield/Sword & Shield/10.ts
+++ b/data/Sword & Shield/Sword & Shield/10.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	dexId: [810],
 
 	thirdParty: {
-		cardmarket: 427156,
+		cardmarket: 436229,
 		tcgplayer: 208284
 	}
 }

--- a/data/Sword & Shield/Sword & Shield/102.ts
+++ b/data/Sword & Shield/Sword & Shield/102.ts
@@ -66,7 +66,7 @@ const card: Card = {
 	dexId: [343],
 
 	thirdParty: {
-		cardmarket: 436624,
+		cardmarket: 436629,
 		tcgplayer: 208412
 	}
 }

--- a/data/Sword & Shield/Sword & Shield/108.ts
+++ b/data/Sword & Shield/Sword & Shield/108.ts
@@ -83,7 +83,7 @@ const card: Card = {
 	dexId: [843],
 
 	thirdParty: {
-		cardmarket: 436654,
+		cardmarket: 436659,
 		tcgplayer: 208417
 	}
 }

--- a/data/Sword & Shield/Sword & Shield/11.ts
+++ b/data/Sword & Shield/Sword & Shield/11.ts
@@ -83,7 +83,7 @@ const card: Card = {
 	dexId: [810],
 
 	thirdParty: {
-		cardmarket: 436229,
+		cardmarket: 427156,
 		tcgplayer: 208286
 	}
 }

--- a/data/Sword & Shield/Sword & Shield/110.ts
+++ b/data/Sword & Shield/Sword & Shield/110.ts
@@ -105,7 +105,7 @@ const card: Card = {
 	dexId: [844],
 
 	thirdParty: {
-		cardmarket: 436664,
+		cardmarket: 436669,
 		tcgplayer: 208419
 	}
 }

--- a/data/Sword & Shield/Sword & Shield/112.ts
+++ b/data/Sword & Shield/Sword & Shield/112.ts
@@ -67,7 +67,7 @@ const card: Card = {
 	dexId: [852],
 
 	thirdParty: {
-		cardmarket: 436674,
+		cardmarket: 436679,
 		tcgplayer: 208421
 	}
 }

--- a/data/Sword & Shield/Sword & Shield/114.ts
+++ b/data/Sword & Shield/Sword & Shield/114.ts
@@ -74,7 +74,7 @@ const card: Card = {
 	dexId: [874],
 
 	thirdParty: {
-		cardmarket: 427191,
+		cardmarket: 436689,
 		tcgplayer: 208423
 	}
 }

--- a/data/Sword & Shield/Sword & Shield/13.ts
+++ b/data/Sword & Shield/Sword & Shield/13.ts
@@ -101,7 +101,7 @@ const card: Card = {
 	dexId: [811],
 
 	thirdParty: {
-		cardmarket: 436234,
+		cardmarket: 436239,
 		tcgplayer: 208292
 	}
 }

--- a/data/Sword & Shield/Sword & Shield/140.ts
+++ b/data/Sword & Shield/Sword & Shield/140.ts
@@ -87,7 +87,7 @@ const card: Card = {
 	dexId: [143],
 
 	thirdParty: {
-		cardmarket: 427236,
+		cardmarket: 436799,
 		tcgplayer: 208456
 	}
 }

--- a/data/Sword & Shield/Sword & Shield/146.ts
+++ b/data/Sword & Shield/Sword & Shield/146.ts
@@ -66,7 +66,7 @@ const card: Card = {
 	dexId: [572],
 
 	thirdParty: {
-		cardmarket: 436819,
+		cardmarket: 436824,
 		tcgplayer: 208466
 	}
 }

--- a/data/Sword & Shield/Sword & Shield/15.ts
+++ b/data/Sword & Shield/Sword & Shield/15.ts
@@ -110,7 +110,7 @@ const card: Card = {
 	dexId: [812],
 
 	thirdParty: {
-		cardmarket: 427196,
+		cardmarket: 436244,
 		tcgplayer: 208294
 	}
 }

--- a/data/Sword & Shield/Sword & Shield/153.ts
+++ b/data/Sword & Shield/Sword & Shield/153.ts
@@ -84,7 +84,7 @@ const card: Card = {
 	dexId: [831],
 
 	thirdParty: {
-		cardmarket: 436854,
+		cardmarket: 436859,
 		tcgplayer: 208475
 	}
 }

--- a/data/Sword & Shield/Sword & Shield/17.ts
+++ b/data/Sword & Shield/Sword & Shield/17.ts
@@ -72,7 +72,7 @@ const card: Card = {
 	dexId: [824],
 
 	thirdParty: {
-		cardmarket: 436249,
+		cardmarket: 436254,
 		tcgplayer: 208296
 	}
 }

--- a/data/Sword & Shield/Sword & Shield/3.ts
+++ b/data/Sword & Shield/Sword & Shield/3.ts
@@ -92,7 +92,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 436189,
+		cardmarket: 436194,
 		tcgplayer: 208269
 	}
 }

--- a/data/Sword & Shield/Sword & Shield/30.ts
+++ b/data/Sword & Shield/Sword & Shield/30.ts
@@ -73,7 +73,7 @@ const card: Card = {
 	dexId: [813],
 
 	thirdParty: {
-		cardmarket: 427161,
+		cardmarket: 436314,
 		tcgplayer: 208308
 	}
 }

--- a/data/Sword & Shield/Sword & Shield/31.ts
+++ b/data/Sword & Shield/Sword & Shield/31.ts
@@ -83,7 +83,7 @@ const card: Card = {
 	dexId: [813],
 
 	thirdParty: {
-		cardmarket: 436314,
+		cardmarket: 427161,
 		tcgplayer: 208309
 	}
 }

--- a/data/Sword & Shield/Sword & Shield/33.ts
+++ b/data/Sword & Shield/Sword & Shield/33.ts
@@ -92,7 +92,7 @@ const card: Card = {
 	dexId: [814],
 
 	thirdParty: {
-		cardmarket: 436319,
+		cardmarket: 436324,
 		tcgplayer: 208311
 	}
 }

--- a/data/Sword & Shield/Sword & Shield/35.ts
+++ b/data/Sword & Shield/Sword & Shield/35.ts
@@ -106,7 +106,7 @@ const card: Card = {
 	dexId: [815],
 
 	thirdParty: {
-		cardmarket: 427226,
+		cardmarket: 436329,
 		tcgplayer: 208313
 	}
 }

--- a/data/Sword & Shield/Sword & Shield/36.ts
+++ b/data/Sword & Shield/Sword & Shield/36.ts
@@ -107,7 +107,7 @@ const card: Card = {
 	dexId: [815],
 
 	thirdParty: {
-		cardmarket: 427226,
+		cardmarket: 436334,
 		tcgplayer: 208314
 	}
 }

--- a/data/Sword & Shield/Sword & Shield/38.ts
+++ b/data/Sword & Shield/Sword & Shield/38.ts
@@ -74,7 +74,7 @@ const card: Card = {
 	dexId: [850],
 
 	thirdParty: {
-		cardmarket: 436339,
+		cardmarket: 436344,
 		tcgplayer: 208316
 	}
 }

--- a/data/Sword & Shield/Sword & Shield/43.ts
+++ b/data/Sword & Shield/Sword & Shield/43.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 436364,
+		cardmarket: 436369,
 		tcgplayer: 208342
 	}
 }

--- a/data/Sword & Shield/Sword & Shield/46.ts
+++ b/data/Sword & Shield/Sword & Shield/46.ts
@@ -92,7 +92,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 436379,
+		cardmarket: 436384,
 		tcgplayer: 208345
 	}
 }

--- a/data/Sword & Shield/Sword & Shield/57.ts
+++ b/data/Sword & Shield/Sword & Shield/57.ts
@@ -92,7 +92,7 @@ const card: Card = {
 	dexId: [817],
 
 	thirdParty: {
-		cardmarket: 436419,
+		cardmarket: 436424,
 		tcgplayer: 208354
 	}
 }

--- a/data/Sword & Shield/Sword & Shield/59.ts
+++ b/data/Sword & Shield/Sword & Shield/59.ts
@@ -106,7 +106,7 @@ const card: Card = {
 	dexId: [818],
 
 	thirdParty: {
-		cardmarket: 427216,
+		cardmarket: 436429,
 		tcgplayer: 208356
 	}
 }

--- a/data/Sword & Shield/Sword & Shield/68.ts
+++ b/data/Sword & Shield/Sword & Shield/68.ts
@@ -89,7 +89,7 @@ const card: Card = {
 	dexId: [170],
 
 	thirdParty: {
-		cardmarket: 436469,
+		cardmarket: 436474,
 		tcgplayer: 208367
 	}
 }

--- a/data/Sword & Shield/Sword & Shield/74.ts
+++ b/data/Sword & Shield/Sword & Shield/74.ts
@@ -83,7 +83,7 @@ const card: Card = {
 	dexId: [835],
 
 	thirdParty: {
-		cardmarket: 436494,
+		cardmarket: 436499,
 		tcgplayer: 208372
 	}
 }

--- a/data/Sword & Shield/Sword & Shield/97.ts
+++ b/data/Sword & Shield/Sword & Shield/97.ts
@@ -91,7 +91,7 @@ const card: Card = {
 	dexId: [111],
 
 	thirdParty: {
-		cardmarket: 436599,
+		cardmarket: 436604,
 		tcgplayer: 208406
 	}
 }


### PR DESCRIPTION
closes #1939
ref #1936
ref #906

## Changes

Correct Cardmarket product references for the swsh1 set across 27 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 22 duplicate-ID corrections, 5 other Cardmarket ID corrections in this set. The swsh1-140 reference changed from Cardmarket product 427236 to 436799; the resulting product matches the regular Snorlax listing, so this PR closes #1939. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.