### PR TITLE
fix(cardmarket): Correct Cardmarket links for swsh10.5

### DIFF
--- a/data/Sword & Shield/Pokémon GO/004.ts
+++ b/data/Sword & Shield/Pokémon GO/004.ts
@@ -87,7 +87,7 @@ const card: Card = {
 		{
 			type: 'holo',
 			thirdParty: {
-				cardmarket: 665238,
+				cardmarket: 664538,
 				tcgplayer: 274465
 			}
 		},

--- a/data/Sword & Shield/Pokémon GO/005.ts
+++ b/data/Sword & Shield/Pokémon GO/005.ts
@@ -80,7 +80,7 @@ const card: Card = {
 		{
 			type: 'holo',
 			thirdParty: {
-				cardmarket: 665239,
+				cardmarket: 664541,
 				tcgplayer: 276943
 			}
 		},

--- a/data/Sword & Shield/Pokémon GO/011.ts
+++ b/data/Sword & Shield/Pokémon GO/011.ts
@@ -87,7 +87,7 @@ const card: Card = {
 		{
 			type: 'holo',
 			thirdParty: {
-				cardmarket: 665245,
+				cardmarket: 664547,
 				tcgplayer: 274467
 			}
 		},

--- a/data/Sword & Shield/Pokémon GO/018.ts
+++ b/data/Sword & Shield/Pokémon GO/018.ts
@@ -87,7 +87,7 @@ const card: Card = {
 		{
 			type: 'holo',
 			thirdParty: {
-				cardmarket: 665251,
+				cardmarket: 664555,
 				tcgplayer: 274468
 			}
 		},

--- a/data/Sword & Shield/Pokémon GO/031.ts
+++ b/data/Sword & Shield/Pokémon GO/031.ts
@@ -98,7 +98,7 @@ const card: Card = {
 		{
 			type: 'holo',
 			thirdParty: {
-				cardmarket: 665267,
+				cardmarket: 664571,
 				tcgplayer: 276963
 			}
 		},

--- a/data/Sword & Shield/Pokémon GO/040.ts
+++ b/data/Sword & Shield/Pokémon GO/040.ts
@@ -84,7 +84,7 @@ const card: Card = {
 		{
 			type: 'holo',
 			thirdParty: {
-				cardmarket: 665670,
+				cardmarket: 664580,
 				tcgplayer: 276999
 			}
 		},

--- a/data/Sword & Shield/Pokémon GO/047.ts
+++ b/data/Sword & Shield/Pokémon GO/047.ts
@@ -81,7 +81,7 @@ const card: Card = {
 		{
 			type: 'holo',
 			thirdParty: {
-				cardmarket: 665270,
+				cardmarket: 664589,
 				tcgplayer: 277019
 			}
 		},

--- a/data/Sword & Shield/Pokémon GO/048.ts
+++ b/data/Sword & Shield/Pokémon GO/048.ts
@@ -77,7 +77,7 @@ const card: Card = {
 		{
 			type: 'holo',
 			thirdParty: {
-				cardmarket: 665271,
+				cardmarket: 664591,
 				tcgplayer: 277023
 			}
 		},

--- a/data/Sword & Shield/Pokémon GO/049.ts
+++ b/data/Sword & Shield/Pokémon GO/049.ts
@@ -69,7 +69,7 @@ const card: Card = {
 		{
 			type: 'holo',
 			thirdParty: {
-				cardmarket: 665675,
+				cardmarket: 664592,
 				tcgplayer: 276962
 			}
 		},

--- a/data/Sword & Shield/Pokémon GO/050.ts
+++ b/data/Sword & Shield/Pokémon GO/050.ts
@@ -86,7 +86,7 @@ const card: Card = {
 		{
 			type: 'holo',
 			thirdParty: {
-				cardmarket: 665676,
+				cardmarket: 664594,
 				tcgplayer: 276964
 			}
 		},

--- a/data/Sword & Shield/Pokémon GO/053.ts
+++ b/data/Sword & Shield/Pokémon GO/053.ts
@@ -63,7 +63,7 @@ const card: Card = {
 		{
 			type: 'holo',
 			thirdParty: {
-				cardmarket: 665275,
+				cardmarket: 664602,
 				tcgplayer: 276971
 			}
 		},

--- a/data/Sword & Shield/Pokémon GO/071.ts
+++ b/data/Sword & Shield/Pokémon GO/071.ts
@@ -80,7 +80,7 @@ const card: Card = {
 		{
 			type: 'holo',
 			thirdParty: {
-				cardmarket: 665683,
+				cardmarket: 664686,
 				tcgplayer: 277000
 			}
 		},

--- a/data/Sword & Shield/Pokémon GO/072.ts
+++ b/data/Sword & Shield/Pokémon GO/072.ts
@@ -81,7 +81,7 @@ const card: Card = {
 		{
 			type: 'holo',
 			thirdParty: {
-				cardmarket: 665290,
+				cardmarket: 664688,
 				tcgplayer: 274470
 			}
 		},

--- a/data/Sword & Shield/Pokémon GO/073.ts
+++ b/data/Sword & Shield/Pokémon GO/073.ts
@@ -84,7 +84,7 @@ const card: Card = {
 		{
 			type: 'holo',
 			thirdParty: {
-				cardmarket: 665684,
+				cardmarket: 664692,
 				tcgplayer: 277001
 			}
 		},

--- a/data/Sword & Shield/Pokémon GO/074.ts
+++ b/data/Sword & Shield/Pokémon GO/074.ts
@@ -84,7 +84,7 @@ const card: Card = {
 		{
 			type: 'holo',
 			thirdParty: {
-				cardmarket: 665685,
+				cardmarket: 664694,
 				tcgplayer: 277004
 			}
 		},

--- a/data/Sword & Shield/Pokémon GO/075.ts
+++ b/data/Sword & Shield/Pokémon GO/075.ts
@@ -81,7 +81,7 @@ const card: Card = {
 		{
 			type: 'holo',
 			thirdParty: {
-				cardmarket: 665686,
+				cardmarket: 664696,
 				tcgplayer: 277005
 			}
 		},

--- a/data/Sword & Shield/Pokémon GO/076.ts
+++ b/data/Sword & Shield/Pokémon GO/076.ts
@@ -69,7 +69,7 @@ const card: Card = {
 		{
 			type: 'holo',
 			thirdParty: {
-				cardmarket: 665687,
+				cardmarket: 664698,
 				tcgplayer: 277006
 			}
 		},

--- a/data/Sword & Shield/Pokémon GO/077.ts
+++ b/data/Sword & Shield/Pokémon GO/077.ts
@@ -75,7 +75,7 @@ const card: Card = {
 		{
 			type: 'holo',
 			thirdParty: {
-				cardmarket: 665688,
+				cardmarket: 664700,
 				tcgplayer: 277008
 			}
 		},

--- a/data/Sword & Shield/Pokémon GO/078.ts
+++ b/data/Sword & Shield/Pokémon GO/078.ts
@@ -36,7 +36,7 @@ const card: Card = {
 		{
 			type: 'holo',
 			thirdParty: {
-				cardmarket: 665689,
+				cardmarket: 664706,
 				tcgplayer: 277009
 			}
 		},

--- a/data/Sword & Shield/Pokémon GO/079.ts
+++ b/data/Sword & Shield/Pokémon GO/079.ts
@@ -99,7 +99,7 @@ const card: Card = {
 			type: 'holo',
 			foil: 'rainbow',
 			thirdParty: {
-				cardmarket: 665690,
+				cardmarket: 664711,
 				tcgplayer: 277011
 			}
 		},

--- a/data/Sword & Shield/Pokémon GO/080.ts
+++ b/data/Sword & Shield/Pokémon GO/080.ts
@@ -78,7 +78,7 @@ const card: Card = {
 			type: 'holo',
 			foil: 'rainbow',
 			thirdParty: {
-				cardmarket: 665691,
+				cardmarket: 664714,
 				tcgplayer: 277013
 			}
 		},

--- a/data/Sword & Shield/Pokémon GO/081.ts
+++ b/data/Sword & Shield/Pokémon GO/081.ts
@@ -87,7 +87,7 @@ const card: Card = {
 			type: 'holo',
 			foil: 'rainbow',
 			thirdParty: {
-				cardmarket: 665692,
+				cardmarket: 664716,
 				tcgplayer: 277014
 			}
 		},

--- a/data/Sword & Shield/Pokémon GO/082.ts
+++ b/data/Sword & Shield/Pokémon GO/082.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			type: 'holo',
 			foil: 'rainbow',
 			thirdParty: {
-				cardmarket: 665693,
+				cardmarket: 664709,
 				tcgplayer: 277015
 			}
 		},

--- a/data/Sword & Shield/Pokémon GO/083.ts
+++ b/data/Sword & Shield/Pokémon GO/083.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			type: 'holo',
 			foil: 'rainbow',
 			thirdParty: {
-				cardmarket: 665694,
+				cardmarket: 664702,
 				tcgplayer: 277017
 			}
 		},

--- a/data/Sword & Shield/Pokémon GO/084.ts
+++ b/data/Sword & Shield/Pokémon GO/084.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			type: 'holo',
 			foil: 'rainbow',
 			thirdParty: {
-				cardmarket: 665695,
+				cardmarket: 664722,
 				tcgplayer: 277018
 			}
 		},

--- a/data/Sword & Shield/Pokémon GO/085.ts
+++ b/data/Sword & Shield/Pokémon GO/085.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			type: 'holo',
 			foil: 'rainbow',
 			thirdParty: {
-				cardmarket: 665696,
+				cardmarket: 664705,
 				tcgplayer: 277020
 			}
 		},

--- a/data/Sword & Shield/Pokémon GO/086.ts
+++ b/data/Sword & Shield/Pokémon GO/086.ts
@@ -96,7 +96,7 @@ const card: Card = {
 			type: 'holo',
 			foil: 'gold',
 			thirdParty: {
-				cardmarket: 665697,
+				cardmarket: 664727,
 				tcgplayer: 277024
 			}
 		},

--- a/data/Sword & Shield/Pokémon GO/087.ts
+++ b/data/Sword & Shield/Pokémon GO/087.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			type: 'holo',
 			foil: 'gold',
 			thirdParty: {
-				cardmarket: 665698,
+				cardmarket: 664729,
 				tcgplayer: 277025
 			}
 		},

--- a/data/Sword & Shield/Pokémon GO/088.ts
+++ b/data/Sword & Shield/Pokémon GO/088.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			type: 'holo',
 			foil: 'gold',
 			thirdParty: {
-				cardmarket: 665699,
+				cardmarket: 664733,
 				tcgplayer: 277026
 			}
 		},


### PR DESCRIPTION
ref #906

## Changes

Correct Cardmarket product references for the swsh10.5 set across 29 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 29 other Cardmarket ID corrections in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.