### PR TITLE
fix(cardmarket): Correct Cardmarket links for swsh3.5

### DIFF
--- a/data/Sword & Shield/Champion's Path/62.ts
+++ b/data/Sword & Shield/Champion's Path/62.ts
@@ -37,6 +37,9 @@ const card: Card = {
 
 	description: {
 		en: "Professor's Research (Magnolia)"
+	},
+	thirdParty: {
+		cardmarket: 500165,
 	}
 }
 


### PR DESCRIPTION
ref #906

## Changes

Correct Cardmarket product references for the swsh3.5 set across 1 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 1 missing Cardmarket link in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.