### PR TITLE
fix(cardmarket): Correct Cardmarket links for swshp

### DIFF
--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH033.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH033.ts
@@ -92,7 +92,7 @@ const card: Card = {
 	regulationMark: "D",
 
 	thirdParty: {
-		cardmarket: 465529
+		cardmarket: 491179
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH034.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH034.ts
@@ -84,7 +84,7 @@ const card: Card = {
 	regulationMark: "D",
 
 	thirdParty: {
-		cardmarket: 465534
+		cardmarket: 491184
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH054.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH054.ts
@@ -88,7 +88,7 @@ const card: Card = {
 	regulationMark: "D",
 
 	thirdParty: {
-		cardmarket: 453458
+		cardmarket: 505890
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH060.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH060.ts
@@ -83,7 +83,7 @@ const card: Card = {
 	regulationMark: "D",
 
 	thirdParty: {
-		cardmarket: 453308
+		cardmarket: 516324
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH064.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH064.ts
@@ -83,7 +83,7 @@ const card: Card = {
 	suffix: "V",
 
 	thirdParty: {
-		cardmarket: 496325
+		cardmarket: 496550
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH068.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH068.ts
@@ -88,7 +88,7 @@ const card: Card = {
 	regulationMark: "D",
 
 	thirdParty: {
-		cardmarket: 461684
+		cardmarket: 516339
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH070.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH070.ts
@@ -66,7 +66,7 @@ const card: Card = {
 	regulationMark: "D",
 
 	thirdParty: {
-		cardmarket: 427081
+		cardmarket: 516349
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH071.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH071.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	regulationMark: "D",
 
 	thirdParty: {
-		cardmarket: 427086
+		cardmarket: 516354
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH073.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH073.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	regulationMark: "D",
 
 	thirdParty: {
-		cardmarket: 427091
+		cardmarket: 516364
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH076.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH076.ts
@@ -89,7 +89,7 @@ const card: Card = {
 	suffix: "V",
 
 	thirdParty: {
-		cardmarket: 465529
+		cardmarket: 522960
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH077.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH077.ts
@@ -89,7 +89,7 @@ const card: Card = {
 	suffix: "V",
 
 	thirdParty: {
-		cardmarket: 465534
+		cardmarket: 522965
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH081.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH081.ts
@@ -103,7 +103,7 @@ const card: Card = {
 	regulationMark: "D",
 
 	thirdParty: {
-		cardmarket: 461664
+		cardmarket: 540631
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH095.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH095.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	regulationMark: "D",
 
 	thirdParty: {
-		cardmarket: 491204
+		cardmarket: 547026
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH110.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH110.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	suffix: "V",
 
 	thirdParty: {
-		cardmarket: 549396
+		cardmarket: 572538
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH116.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH116.ts
@@ -87,7 +87,7 @@ const card: Card = {
 	regulationMark: "D",
 
 	thirdParty: {
-		cardmarket: 427106
+		cardmarket: 557973
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH118.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH118.ts
@@ -87,7 +87,7 @@ const card: Card = {
 	regulationMark: "D",
 
 	thirdParty: {
-		cardmarket: 491204
+		cardmarket: 557975
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH119.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH119.ts
@@ -80,7 +80,7 @@ const card: Card = {
 	regulationMark: "E",
 
 	thirdParty: {
-		cardmarket: 461684
+		cardmarket: 557976
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH121.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH121.ts
@@ -38,7 +38,7 @@ const card: Card = {
 	regulationMark: "D",
 
 	thirdParty: {
-		cardmarket: 566764
+		cardmarket: 566765
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH127.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH127.ts
@@ -78,7 +78,7 @@ const card: Card = {
 	regulationMark: "E",
 
 	thirdParty: {
-		cardmarket: 491204
+		cardmarket: 568799
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH135.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH135.ts
@@ -81,7 +81,7 @@ const card: Card = {
 	retreat: 2,
 
 	thirdParty: {
-		cardmarket: 491179
+		cardmarket: 576734
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH143.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH143.ts
@@ -62,7 +62,7 @@ const card: Card = {
 	regulationMark: "E",
 
 	thirdParty: {
-		cardmarket: 461594
+		cardmarket: 576742
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH144.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH144.ts
@@ -75,7 +75,8 @@ const card: Card = {
 	retreat: 1,
 
 	thirdParty: {
-		tcgplayer: 248731
+		tcgplayer: 248731,
+			cardmarket: 576743,
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH145.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH145.ts
@@ -62,7 +62,7 @@ const card: Card = {
 	regulationMark: "E",
 
 	thirdParty: {
-		cardmarket: 461594
+		cardmarket: 576744
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH153.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH153.ts
@@ -58,7 +58,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 461594
+		cardmarket: 672386
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH175.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH175.ts
@@ -69,7 +69,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 491204
+		cardmarket: 583202
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH178.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH178.ts
@@ -47,7 +47,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 569233
+		cardmarket: 611309
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH179.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH179.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	regulationMark: "E",
 
 	thirdParty: {
-		cardmarket: 491199
+		cardmarket: 583204
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH181.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH181.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	regulationMark: "E",
 
 	thirdParty: {
-		cardmarket: 516359
+		cardmarket: 583206
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH183.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH183.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	regulationMark: "E",
 
 	thirdParty: {
-		cardmarket: 547021
+		cardmarket: 583208
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH189.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH189.ts
@@ -82,7 +82,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 453448
+		cardmarket: 609463
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH190.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH190.ts
@@ -69,7 +69,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 491204
+		cardmarket: 609464
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH191.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH191.ts
@@ -90,7 +90,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 604996
+		cardmarket: 606748
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH192.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH192.ts
@@ -88,7 +88,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 604998
+		cardmarket: 606749
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH193.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH193.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 516319
+		cardmarket: 609465
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH194.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH194.ts
@@ -77,7 +77,7 @@ const card: Card = {
 	regulationMark: "F",
 
 	thirdParty: {
-		cardmarket: 606748
+		cardmarket: 604996
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH196.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH196.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	regulationMark: "F",
 
 	thirdParty: {
-		cardmarket: 606749
+		cardmarket: 604998
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH210.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH210.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 580165
+		cardmarket: 659062
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH211.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH211.ts
@@ -90,7 +90,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 609461
+		cardmarket: 659063
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH212.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH212.ts
@@ -69,7 +69,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 491204
+		cardmarket: 659064
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH218.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH218.ts
@@ -28,7 +28,7 @@ const card: Card = {
 	regulationMark: "E",
 
 	thirdParty: {
-		cardmarket: 651353
+		cardmarket: 549431
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH232.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH232.ts
@@ -58,7 +58,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 547031
+		cardmarket: 664338
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH234.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH234.ts
@@ -69,7 +69,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 461594,
+		cardmarket: 653698,
 		tcgplayer: 277039
 	}
 }

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH235.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH235.ts
@@ -62,7 +62,7 @@ const card: Card = {
 	regulationMark: "F",
 
 	thirdParty: {
-		cardmarket: 576501
+		cardmarket: 664340
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH241.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH241.ts
@@ -94,7 +94,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 505880
+		cardmarket: 665984
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH243.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH243.ts
@@ -90,7 +90,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 505885
+		cardmarket: 665986
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH251.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH251.ts
@@ -34,6 +34,9 @@ const card: Card = {
         reverse: false,
         holo: true,
         firstEdition: false
+    },
+    thirdParty: {
+        cardmarket: 691252,
     }
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH260.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH260.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	regulationMark: "F",
 
 	thirdParty: {
-		cardmarket: 505255
+		cardmarket: 674368
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH277.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH277.ts
@@ -90,7 +90,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 437154
+		cardmarket: 682974
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH282.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH282.ts
@@ -91,7 +91,8 @@ const card: Card = {
 	regulationMark: "E",
 
 	thirdParty: {
-		tcgplayer: 488271
+		tcgplayer: 488271,
+			cardmarket: 692425,
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH283.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH283.ts
@@ -88,7 +88,8 @@ const card: Card = {
 	regulationMark: "E",
 
 	thirdParty: {
-		tcgplayer: 488274
+		tcgplayer: 488274,
+			cardmarket: 692426,
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH284.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH284.ts
@@ -88,7 +88,8 @@ const card: Card = {
 	regulationMark: "E",
 
 	thirdParty: {
-		tcgplayer: 488275
+		tcgplayer: 488275,
+			cardmarket: 692427,
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH285.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH285.ts
@@ -55,7 +55,7 @@ const card: Card = {
 	regulationMark: "F",
 
 	thirdParty: {
-		cardmarket: 461594,
+		cardmarket: 692429,
 		tcgplayer: 478423
 	}
 }

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH291.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH291.ts
@@ -87,7 +87,7 @@ const card: Card = {
 	regulationMark: "F",
 
 	thirdParty: {
-		cardmarket: 606600,
+		cardmarket: 606785,
 		tcgplayer: 475642
 	}
 }

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH302.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH302.ts
@@ -34,7 +34,10 @@ const card: Card = {
 			}
 		],
 
-	regulationMark: "E"
+	regulationMark: "E",
+	thirdParty: {
+		cardmarket: 703140,
+	}
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH303.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH303.ts
@@ -50,7 +50,10 @@ const card: Card = {
 		},
 	],
 
-	regulationMark: "F"
+	regulationMark: "F",
+	thirdParty: {
+		cardmarket: 690365,
+	}
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH304.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH304.ts
@@ -55,7 +55,10 @@ const card: Card = {
 		},
 	],
 
-	regulationMark: "F"
+	regulationMark: "F",
+	thirdParty: {
+		cardmarket: 690366,
+	}
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH305.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH305.ts
@@ -55,7 +55,10 @@ const card: Card = {
 		},
 	],
 
-	regulationMark: "F"
+	regulationMark: "F",
+	thirdParty: {
+		cardmarket: 690367,
+	}
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH307.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH307.ts
@@ -91,7 +91,10 @@ const card: Card = {
 			}
 		],
 
-	regulationMark: "F"
+	regulationMark: "F",
+	thirdParty: {
+		cardmarket: 703214,
+	}
 }
 
 export default card


### PR DESCRIPTION
ref #1936
ref #906

## Changes

Correct Cardmarket product references for the swshp set across 58 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 43 duplicate-ID corrections, 10 missing Cardmarket links, 5 other Cardmarket ID corrections in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.