### PR TITLE
fix(cardmarket): Correct Cardmarket links for xy1

### DIFF
--- a/data/XY/XY/141.ts
+++ b/data/XY/XY/141.ts
@@ -93,7 +93,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 281338,
+		cardmarket: 281478,
 		tcgplayer: 90325
 	}
 }

--- a/data/XY/XY/142.ts
+++ b/data/XY/XY/142.ts
@@ -91,7 +91,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 281366,
+		cardmarket: 281479,
 		tcgplayer: 83902
 	}
 }

--- a/data/XY/XY/143.ts
+++ b/data/XY/XY/143.ts
@@ -96,7 +96,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 281383,
+		cardmarket: 281480,
 		tcgplayer: 85196
 	}
 }

--- a/data/XY/XY/144.ts
+++ b/data/XY/XY/144.ts
@@ -98,7 +98,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 281415,
+		cardmarket: 281481,
 		tcgplayer: 90700
 	}
 }

--- a/data/XY/XY/145.ts
+++ b/data/XY/XY/145.ts
@@ -98,7 +98,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 281417,
+		cardmarket: 281482,
 		tcgplayer: 89249
 	}
 }

--- a/data/XY/XY/146.ts
+++ b/data/XY/XY/146.ts
@@ -100,7 +100,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 281433,
+		cardmarket: 281483,
 		tcgplayer: 90672
 	}
 }

--- a/data/XY/XY/75.ts
+++ b/data/XY/XY/75.ts
@@ -92,7 +92,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 281411,
+		cardmarket: 281412,
 		tcgplayer: 86284
 	}
 }

--- a/data/XY/XY/77.ts
+++ b/data/XY/XY/77.ts
@@ -109,7 +109,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 281413,
+		cardmarket: 281414,
 		tcgplayer: 87137
 	}
 }

--- a/data/XY/XY/86.ts
+++ b/data/XY/XY/86.ts
@@ -109,7 +109,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 281422,
+		cardmarket: 281423,
 		tcgplayer: 83463
 	}
 }

--- a/data/XY/XY/88.ts
+++ b/data/XY/XY/88.ts
@@ -76,7 +76,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 281424,
+		cardmarket: 281425,
 		tcgplayer: 86323
 	}
 }

--- a/data/XY/XY/90.ts
+++ b/data/XY/XY/90.ts
@@ -109,7 +109,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 281426,
+		cardmarket: 281427,
 		tcgplayer: 90602
 	}
 }


### PR DESCRIPTION
ref #1936

## Changes

Correct Cardmarket product references for the xy1 set across 11 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 11 duplicate-ID corrections in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.