### PR TITLE
fix(cardmarket): Correct Cardmarket links for xy10

### DIFF
--- a/data/XY/Fates Collide/105a.ts
+++ b/data/XY/Fates Collide/105a.ts
@@ -27,7 +27,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 289925
+		cardmarket: 295213
 	}
 }
 

--- a/data/XY/Fates Collide/11.ts
+++ b/data/XY/Fates Collide/11.ts
@@ -67,7 +67,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 289836,
+		cardmarket: 289837,
 		tcgplayer: 117774
 	}
 }

--- a/data/XY/Fates Collide/111a.ts
+++ b/data/XY/Fates Collide/111a.ts
@@ -27,7 +27,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 289931
+		cardmarket: 311411
 	}
 }
 

--- a/data/XY/Fates Collide/41.ts
+++ b/data/XY/Fates Collide/41.ts
@@ -84,7 +84,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 290534,
+		cardmarket: 290535,
 		tcgplayer: 117801
 	}
 }

--- a/data/XY/Fates Collide/43a.ts
+++ b/data/XY/Fates Collide/43a.ts
@@ -89,7 +89,7 @@ const card: Card = {
 	retreat: 3,
 
 	thirdParty: {
-		cardmarket: 289867
+		cardmarket: 311406
 	}
 }
 

--- a/data/XY/Fates Collide/44.ts
+++ b/data/XY/Fates Collide/44.ts
@@ -95,7 +95,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 289829,
+		cardmarket: 289868,
 		tcgplayer: 117804
 	}
 }

--- a/data/XY/Fates Collide/46.ts
+++ b/data/XY/Fates Collide/46.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 290536,
+		cardmarket: 290537,
 		tcgplayer: 117806
 	}
 }

--- a/data/XY/Fates Collide/49.ts
+++ b/data/XY/Fates Collide/49.ts
@@ -92,7 +92,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 289871,
+		cardmarket: 290538,
 		tcgplayer: 117809
 	}
 }

--- a/data/XY/Fates Collide/50.ts
+++ b/data/XY/Fates Collide/50.ts
@@ -84,7 +84,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 290538,
+		cardmarket: 289871,
 		tcgplayer: 117810
 	}
 }

--- a/data/XY/Fates Collide/53.ts
+++ b/data/XY/Fates Collide/53.ts
@@ -94,7 +94,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 289873,
+		cardmarket: 289874,
 		tcgplayer: 117811
 	}
 }

--- a/data/XY/Fates Collide/54a.ts
+++ b/data/XY/Fates Collide/54a.ts
@@ -107,7 +107,7 @@ const card: Card = {
 	retreat: 3,
 
 	thirdParty: {
-		cardmarket: 289875
+		cardmarket: 297893
 	}
 }
 

--- a/data/XY/Fates Collide/59.ts
+++ b/data/XY/Fates Collide/59.ts
@@ -109,7 +109,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 289829,
+		cardmarket: 289880,
 		tcgplayer: 117816
 	}
 }

--- a/data/XY/Fates Collide/87.ts
+++ b/data/XY/Fates Collide/87.ts
@@ -61,7 +61,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 289907,
+		cardmarket: 289908,
 		tcgplayer: 117860
 	}
 }

--- a/data/XY/Fates Collide/88.ts
+++ b/data/XY/Fates Collide/88.ts
@@ -99,7 +99,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 289909,
+		cardmarket: 290539,
 		tcgplayer: 117861
 	}
 }

--- a/data/XY/Fates Collide/89.ts
+++ b/data/XY/Fates Collide/89.ts
@@ -100,7 +100,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 290539,
+		cardmarket: 289909,
 		tcgplayer: 117862
 	}
 }


### PR DESCRIPTION
ref #1936
ref #906

## Changes

Correct Cardmarket product references for the xy10 set across 15 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 11 duplicate-ID corrections, 4 other Cardmarket ID corrections in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.