### PR TITLE
fix(cardmarket): Correct Cardmarket links for xy11

### DIFF
--- a/data/XY/Steam Siege/23.ts
+++ b/data/XY/Steam Siege/23.ts
@@ -103,7 +103,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 291527,
+		cardmarket: 291616,
 		tcgplayer: 121011
 	}
 }

--- a/data/XY/Steam Siege/34.ts
+++ b/data/XY/Steam Siege/34.ts
@@ -94,7 +94,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 291531,
+		cardmarket: 291569,
 		tcgplayer: 121021
 	}
 }

--- a/data/XY/Steam Siege/43.ts
+++ b/data/XY/Steam Siege/43.ts
@@ -82,6 +82,9 @@ const card: Card = {
 	description: {
 		en: "Its large ears are flapped like wings when it is listening to distant sounds. It extends toxic barbs when angered.",
 	},
+	thirdParty: {
+		cardmarket: 291536,
+	},
 }
 
 export default card

--- a/data/XY/Steam Siege/86.ts
+++ b/data/XY/Steam Siege/86.ts
@@ -103,7 +103,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 291547,
+		cardmarket: 291647,
 		tcgplayer: 121212
 	}
 }


### PR DESCRIPTION
ref #1936
ref #906

## Changes

Correct Cardmarket product references for the xy11 set across 4 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 3 duplicate-ID corrections, 1 missing Cardmarket link in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.