### PR TITLE
fix(cardmarket): Correct Cardmarket links for xy2

### DIFF
--- a/data/XY/Flashfire/100.ts
+++ b/data/XY/Flashfire/100.ts
@@ -90,7 +90,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 281494,
+		cardmarket: 281583,
 		tcgplayer: 91238
 	}
 }

--- a/data/XY/Flashfire/101.ts
+++ b/data/XY/Flashfire/101.ts
@@ -90,7 +90,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 281518,
+		cardmarket: 281584,
 		tcgplayer: 91239
 	}
 }

--- a/data/XY/Flashfire/102.ts
+++ b/data/XY/Flashfire/102.ts
@@ -90,7 +90,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 281524,
+		cardmarket: 281585,
 		tcgplayer: 91240
 	}
 }

--- a/data/XY/Flashfire/103.ts
+++ b/data/XY/Flashfire/103.ts
@@ -89,7 +89,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 281561,
+		cardmarket: 281586,
 		tcgplayer: 91241
 	}
 }

--- a/data/XY/Flashfire/104.ts
+++ b/data/XY/Flashfire/104.ts
@@ -28,7 +28,7 @@ const card: Card = {
 	trainerType: "Supporter",
 
 	thirdParty: {
-		cardmarket: 281573,
+		cardmarket: 281587,
 		tcgplayer: 91242
 	}
 }

--- a/data/XY/Flashfire/105.ts
+++ b/data/XY/Flashfire/105.ts
@@ -28,7 +28,7 @@ const card: Card = {
 	trainerType: "Supporter",
 
 	thirdParty: {
-		cardmarket: 281576
+		cardmarket: 281588
 	}
 }
 

--- a/data/XY/Flashfire/106.ts
+++ b/data/XY/Flashfire/106.ts
@@ -28,7 +28,7 @@ const card: Card = {
 	trainerType: "Supporter",
 
 	thirdParty: {
-		cardmarket: 281577
+		cardmarket: 281589
 	}
 }
 

--- a/data/XY/Flashfire/12.ts
+++ b/data/XY/Flashfire/12.ts
@@ -86,7 +86,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 281494,
+		cardmarket: 281495,
 		tcgplayer: 91145
 	}
 }

--- a/data/XY/Flashfire/19.ts
+++ b/data/XY/Flashfire/19.ts
@@ -62,7 +62,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 281501,
+		cardmarket: 281502,
 		tcgplayer: 91152
 	}
 }

--- a/data/XY/Flashfire/51.ts
+++ b/data/XY/Flashfire/51.ts
@@ -91,7 +91,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 281533,
+		cardmarket: 281534,
 		tcgplayer: 91184
 	}
 }

--- a/data/XY/Flashfire/54.ts
+++ b/data/XY/Flashfire/54.ts
@@ -92,7 +92,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 281536,
+		cardmarket: 281537,
 		tcgplayer: 91191
 	}
 }

--- a/data/XY/Flashfire/63.ts
+++ b/data/XY/Flashfire/63.ts
@@ -68,7 +68,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 281545
+		cardmarket: 281546
 	}
 }
 

--- a/data/XY/Flashfire/65.ts
+++ b/data/XY/Flashfire/65.ts
@@ -100,7 +100,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 281547,
+		cardmarket: 281548,
 		tcgplayer: 91202
 	}
 }

--- a/data/XY/Flashfire/88a.ts
+++ b/data/XY/Flashfire/88a.ts
@@ -27,7 +27,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 281571
+		cardmarket: 311412
 	}
 }
 


### PR DESCRIPTION
ref #1936

## Changes

Correct Cardmarket product references for the xy2 set across 14 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 14 duplicate-ID corrections in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.