### PR TITLE
fix(cardmarket): Correct Cardmarket links for xy3

### DIFF
--- a/data/XY/Furious Fists/105.ts
+++ b/data/XY/Furious Fists/105.ts
@@ -91,7 +91,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 281668,
+		cardmarket: 281769,
 		tcgplayer: 92288
 	}
 }

--- a/data/XY/Furious Fists/106.ts
+++ b/data/XY/Furious Fists/106.ts
@@ -91,7 +91,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 281684,
+		cardmarket: 281770,
 		tcgplayer: 92289
 	}
 }

--- a/data/XY/Furious Fists/107.ts
+++ b/data/XY/Furious Fists/107.ts
@@ -107,7 +107,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 281718,
+		cardmarket: 281771,
 		tcgplayer: 92290
 	}
 }

--- a/data/XY/Furious Fists/108.ts
+++ b/data/XY/Furious Fists/108.ts
@@ -89,7 +89,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 281738,
+		cardmarket: 281772,
 		tcgplayer: 92254
 	}
 }

--- a/data/XY/Furious Fists/109.ts
+++ b/data/XY/Furious Fists/109.ts
@@ -28,7 +28,7 @@ const card: Card = {
 	trainerType: "Supporter",
 
 	thirdParty: {
-		cardmarket: 281752,
+		cardmarket: 281773,
 		tcgplayer: 92269
 	}
 }

--- a/data/XY/Furious Fists/110.ts
+++ b/data/XY/Furious Fists/110.ts
@@ -28,7 +28,7 @@ const card: Card = {
 	trainerType: "Supporter",
 
 	thirdParty: {
-		cardmarket: 281756,
+		cardmarket: 281774,
 		tcgplayer: 92274
 	}
 }

--- a/data/XY/Furious Fists/111.ts
+++ b/data/XY/Furious Fists/111.ts
@@ -28,7 +28,7 @@ const card: Card = {
 	trainerType: "Supporter",
 
 	thirdParty: {
-		cardmarket: 281759,
+		cardmarket: 281775,
 		tcgplayer: 92278
 	}
 }

--- a/data/XY/Furious Fists/60.ts
+++ b/data/XY/Furious Fists/60.ts
@@ -69,7 +69,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 281723,
+		cardmarket: 281724,
 		tcgplayer: 92237
 	}
 }

--- a/data/XY/Furious Fists/70.ts
+++ b/data/XY/Furious Fists/70.ts
@@ -75,7 +75,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 281733,
+		cardmarket: 281734,
 		tcgplayer: 92248
 	}
 }


### PR DESCRIPTION
ref #1936

## Changes

Correct Cardmarket product references for the xy3 set across 9 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 9 duplicate-ID corrections in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.