### PR TITLE
fix(cardmarket): Correct Cardmarket links for xy4

### DIFF
--- a/data/XY/Phantom Forces/113.ts
+++ b/data/XY/Phantom Forces/113.ts
@@ -96,7 +96,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 281827,
+		cardmarket: 281920,
 		tcgplayer: 94682
 	}
 }

--- a/data/XY/Phantom Forces/114.ts
+++ b/data/XY/Phantom Forces/114.ts
@@ -96,7 +96,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 281840,
+		cardmarket: 281921,
 		tcgplayer: 94683
 	}
 }

--- a/data/XY/Phantom Forces/115.ts
+++ b/data/XY/Phantom Forces/115.ts
@@ -95,7 +95,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 281864,
+		cardmarket: 281922,
 		tcgplayer: 94684
 	}
 }

--- a/data/XY/Phantom Forces/116.ts
+++ b/data/XY/Phantom Forces/116.ts
@@ -95,7 +95,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 281873,
+		cardmarket: 281923,
 		tcgplayer: 94685
 	}
 }

--- a/data/XY/Phantom Forces/117.ts
+++ b/data/XY/Phantom Forces/117.ts
@@ -28,7 +28,7 @@ const card: Card = {
 	trainerType: "Supporter",
 
 	thirdParty: {
-		cardmarket: 281897,
+		cardmarket: 281924,
 		tcgplayer: 94660
 	}
 }

--- a/data/XY/Phantom Forces/118.ts
+++ b/data/XY/Phantom Forces/118.ts
@@ -28,7 +28,7 @@ const card: Card = {
 	trainerType: "Supporter",
 
 	thirdParty: {
-		cardmarket: 281906,
+		cardmarket: 281925,
 		tcgplayer: 94686
 	}
 }

--- a/data/XY/Phantom Forces/119.ts
+++ b/data/XY/Phantom Forces/119.ts
@@ -28,7 +28,7 @@ const card: Card = {
 	trainerType: "Supporter",
 
 	thirdParty: {
-		cardmarket: 281917,
+		cardmarket: 281926,
 		tcgplayer: 94679
 	}
 }

--- a/data/XY/Phantom Forces/12.ts
+++ b/data/XY/Phantom Forces/12.ts
@@ -102,7 +102,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 281814,
+		cardmarket: 281815,
 		tcgplayer: 94145
 	}
 }

--- a/data/XY/Phantom Forces/122.ts
+++ b/data/XY/Phantom Forces/122.ts
@@ -100,7 +100,7 @@ const card: Card = {
 	retreat: 2,
 
 	thirdParty: {
-		cardmarket: 281868,
+		cardmarket: 281929,
 		tcgplayer: 94689
 	}
 }

--- a/data/XY/Phantom Forces/29.ts
+++ b/data/XY/Phantom Forces/29.ts
@@ -93,7 +93,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 281833,
+		cardmarket: 281834,
 		tcgplayer: 94162
 	}
 }

--- a/data/XY/Phantom Forces/65a.ts
+++ b/data/XY/Phantom Forces/65a.ts
@@ -96,7 +96,7 @@ const card: Card = {
 	retreat: 3,
 
 	thirdParty: {
-		cardmarket: 281871
+		cardmarket: 311407
 	}
 }
 


### PR DESCRIPTION
ref #1936
ref #906

## Changes

Correct Cardmarket product references for the xy4 set across 11 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 10 duplicate-ID corrections, 1 other Cardmarket ID correction in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.