### PR TITLE
fix(cardmarket): Correct Cardmarket links for xy5

### DIFF
--- a/data/XY/Primal Clash/104.ts
+++ b/data/XY/Primal Clash/104.ts
@@ -132,7 +132,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 273634,
+		cardmarket: 273635,
 		tcgplayer: 96002
 	}
 }

--- a/data/XY/Primal Clash/108.ts
+++ b/data/XY/Primal Clash/108.ts
@@ -123,7 +123,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 273638,
+		cardmarket: 273639,
 		tcgplayer: 96006
 	}
 }

--- a/data/XY/Primal Clash/117.ts
+++ b/data/XY/Primal Clash/117.ts
@@ -91,7 +91,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 273647,
+		cardmarket: 273648,
 		tcgplayer: 96015
 	}
 }

--- a/data/XY/Primal Clash/121.ts
+++ b/data/XY/Primal Clash/121.ts
@@ -111,7 +111,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 273651,
+		cardmarket: 273652,
 		tcgplayer: 96019
 	}
 }

--- a/data/XY/Primal Clash/145.ts
+++ b/data/XY/Primal Clash/145.ts
@@ -90,7 +90,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 273550,
+		cardmarket: 273676,
 		tcgplayer: 96043
 	}
 }

--- a/data/XY/Primal Clash/146.ts
+++ b/data/XY/Primal Clash/146.ts
@@ -92,7 +92,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 273560,
+		cardmarket: 273677,
 		tcgplayer: 96044
 	}
 }

--- a/data/XY/Primal Clash/147.ts
+++ b/data/XY/Primal Clash/147.ts
@@ -91,7 +91,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 273569,
+		cardmarket: 273678,
 		tcgplayer: 96045
 	}
 }

--- a/data/XY/Primal Clash/148.ts
+++ b/data/XY/Primal Clash/148.ts
@@ -92,7 +92,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 273584,
+		cardmarket: 273679,
 		tcgplayer: 96046
 	}
 }

--- a/data/XY/Primal Clash/149.ts
+++ b/data/XY/Primal Clash/149.ts
@@ -99,7 +99,7 @@ const card: Card = {
 	suffix: "EX",
 
 	thirdParty: {
-		cardmarket: 273586,
+		cardmarket: 273680,
 		tcgplayer: 96047
 	}
 }

--- a/data/XY/Primal Clash/150.ts
+++ b/data/XY/Primal Clash/150.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 273615,
+		cardmarket: 273681,
 		tcgplayer: 96048
 	}
 }

--- a/data/XY/Primal Clash/151.ts
+++ b/data/XY/Primal Clash/151.ts
@@ -99,7 +99,7 @@ const card: Card = {
 	suffix: "EX",
 
 	thirdParty: {
-		cardmarket: 273617,
+		cardmarket: 273682,
 		tcgplayer: 96049
 	}
 }

--- a/data/XY/Primal Clash/152.ts
+++ b/data/XY/Primal Clash/152.ts
@@ -90,7 +90,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 273622,
+		cardmarket: 273683,
 		tcgplayer: 96050
 	}
 }

--- a/data/XY/Primal Clash/153.ts
+++ b/data/XY/Primal Clash/153.ts
@@ -100,7 +100,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 273624,
+		cardmarket: 273684,
 		tcgplayer: 96051
 	}
 }

--- a/data/XY/Primal Clash/155.ts
+++ b/data/XY/Primal Clash/155.ts
@@ -97,7 +97,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 273636,
+		cardmarket: 273686,
 		tcgplayer: 96053
 	}
 }

--- a/data/XY/Primal Clash/157.ts
+++ b/data/XY/Primal Clash/157.ts
@@ -28,7 +28,7 @@ const card: Card = {
 	trainerType: "Supporter",
 
 	thirdParty: {
-		cardmarket: 273655,
+		cardmarket: 273688,
 		tcgplayer: 96055
 	}
 }

--- a/data/XY/Primal Clash/158.ts
+++ b/data/XY/Primal Clash/158.ts
@@ -28,7 +28,7 @@ const card: Card = {
 	trainerType: "Supporter",
 
 	thirdParty: {
-		cardmarket: 273664,
+		cardmarket: 273689,
 		tcgplayer: 96056
 	}
 }

--- a/data/XY/Primal Clash/159.ts
+++ b/data/XY/Primal Clash/159.ts
@@ -28,7 +28,7 @@ const card: Card = {
 	trainerType: "Supporter",
 
 	thirdParty: {
-		cardmarket: 273665,
+		cardmarket: 273690,
 		tcgplayer: 96057
 	}
 }

--- a/data/XY/Primal Clash/160.ts
+++ b/data/XY/Primal Clash/160.ts
@@ -28,7 +28,7 @@ const card: Card = {
 	trainerType: "Supporter",
 
 	thirdParty: {
-		cardmarket: 273672,
+		cardmarket: 273691,
 		tcgplayer: 96058
 	}
 }

--- a/data/XY/Primal Clash/161.ts
+++ b/data/XY/Primal Clash/161.ts
@@ -27,7 +27,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 273656,
+		cardmarket: 273692,
 		tcgplayer: 96059
 	}
 }

--- a/data/XY/Primal Clash/164.ts
+++ b/data/XY/Primal Clash/164.ts
@@ -27,7 +27,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 273673,
+		cardmarket: 273695,
 		tcgplayer: 96062
 	}
 }

--- a/data/XY/Primal Clash/24.ts
+++ b/data/XY/Primal Clash/24.ts
@@ -118,7 +118,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 273554,
+		cardmarket: 273555,
 		tcgplayer: 95908
 	}
 }

--- a/data/XY/Primal Clash/26.ts
+++ b/data/XY/Primal Clash/26.ts
@@ -112,7 +112,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 273556,
+		cardmarket: 273557,
 		tcgplayer: 95918
 	}
 }

--- a/data/XY/Primal Clash/36.ts
+++ b/data/XY/Primal Clash/36.ts
@@ -101,7 +101,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 273566,
+		cardmarket: 273567,
 		tcgplayer: 95928
 	}
 }

--- a/data/XY/Primal Clash/37.ts
+++ b/data/XY/Primal Clash/37.ts
@@ -124,7 +124,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 273543,
+		cardmarket: 273568,
 		tcgplayer: 95929
 	}
 }

--- a/data/XY/Primal Clash/41.ts
+++ b/data/XY/Primal Clash/41.ts
@@ -120,7 +120,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 273571,
+		cardmarket: 273572,
 		tcgplayer: 95938
 	}
 }

--- a/data/XY/Primal Clash/46.ts
+++ b/data/XY/Primal Clash/46.ts
@@ -62,7 +62,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 273576,
+		cardmarket: 273577,
 		tcgplayer: 95944
 	}
 }

--- a/data/XY/Primal Clash/52.ts
+++ b/data/XY/Primal Clash/52.ts
@@ -100,7 +100,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 273582,
+		cardmarket: 273583,
 		tcgplayer: 95950
 	}
 }

--- a/data/XY/Primal Clash/60.ts
+++ b/data/XY/Primal Clash/60.ts
@@ -97,7 +97,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 273590,
+		cardmarket: 273591,
 		tcgplayer: 95958
 	}
 }

--- a/data/XY/Primal Clash/64.ts
+++ b/data/XY/Primal Clash/64.ts
@@ -108,7 +108,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 273594,
+		cardmarket: 273595,
 		tcgplayer: 95962
 	}
 }

--- a/data/XY/Primal Clash/66.ts
+++ b/data/XY/Primal Clash/66.ts
@@ -76,6 +76,9 @@ const card: Card = {
 	description: {
 		en: "Small and very docile, it protects itself with its small, poisonous horn when attacked.",
 	},
+	thirdParty: {
+		cardmarket: 273597,
+	},
 }
 
 export default card

--- a/data/XY/Primal Clash/69.ts
+++ b/data/XY/Primal Clash/69.ts
@@ -124,7 +124,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 273599,
+		cardmarket: 273600,
 		tcgplayer: 95967
 	}
 }

--- a/data/XY/Primal Clash/71.ts
+++ b/data/XY/Primal Clash/71.ts
@@ -84,7 +84,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 273601,
+		cardmarket: 273602,
 		tcgplayer: 95969
 	}
 }

--- a/data/XY/Primal Clash/77.ts
+++ b/data/XY/Primal Clash/77.ts
@@ -103,7 +103,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 273607,
+		cardmarket: 273608,
 		tcgplayer: 95975
 	}
 }

--- a/data/XY/Primal Clash/81.ts
+++ b/data/XY/Primal Clash/81.ts
@@ -122,7 +122,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 273611,
+		cardmarket: 273612,
 		tcgplayer: 95979
 	}
 }

--- a/data/XY/Primal Clash/9.ts
+++ b/data/XY/Primal Clash/9.ts
@@ -124,7 +124,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 273539,
+		cardmarket: 273540,
 		tcgplayer: 95893
 	}
 }

--- a/data/XY/Primal Clash/97.ts
+++ b/data/XY/Primal Clash/97.ts
@@ -130,7 +130,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 273627,
+		cardmarket: 273628,
 		tcgplayer: 95995
 	}
 }


### PR DESCRIPTION
ref #1936
ref #906

## Changes

Correct Cardmarket product references for the xy5 set across 36 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 35 duplicate-ID corrections, 1 missing Cardmarket link in this set. The post-apply audit retains 20 catalog detail mismatches for xy5-104, xy5-108, xy5-117, xy5-121, xy5-149, xy5-151, xy5-24, xy5-26, xy5-36, xy5-37, xy5-41, xy5-52, xy5-60, xy5-64, xy5-69, xy5-71, xy5-77, xy5-81, xy5-9, xy5-97; these remain review notes rather than being silently treated as resolved. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.