### PR TITLE
fix(cardmarket): Correct Cardmarket links for xy6

### DIFF
--- a/data/XY/Roaring Skies/101.ts
+++ b/data/XY/Roaring Skies/101.ts
@@ -91,7 +91,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 282726,
+		cardmarket: 282769,
 		tcgplayer: 98137
 	}
 }

--- a/data/XY/Roaring Skies/103.ts
+++ b/data/XY/Roaring Skies/103.ts
@@ -89,7 +89,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 282730,
+		cardmarket: 282771,
 		tcgplayer: 98139
 	}
 }

--- a/data/XY/Roaring Skies/104.ts
+++ b/data/XY/Roaring Skies/104.ts
@@ -97,7 +97,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 282728,
+		cardmarket: 282772,
 		tcgplayer: 98140
 	}
 }

--- a/data/XY/Roaring Skies/106.ts
+++ b/data/XY/Roaring Skies/106.ts
@@ -95,7 +95,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 282745,
+		cardmarket: 295202,
 		tcgplayer: 98142
 	}
 }

--- a/data/XY/Roaring Skies/107.ts
+++ b/data/XY/Roaring Skies/107.ts
@@ -28,7 +28,7 @@ const card: Card = {
 	trainerType: "Supporter",
 
 	thirdParty: {
-		cardmarket: 282762,
+		cardmarket: 282775,
 		tcgplayer: 98143
 	}
 }

--- a/data/XY/Roaring Skies/108.ts
+++ b/data/XY/Roaring Skies/108.ts
@@ -28,7 +28,7 @@ const card: Card = {
 	trainerType: "Supporter",
 
 	thirdParty: {
-		cardmarket: 282764,
+		cardmarket: 282776,
 		tcgplayer: 98144
 	}
 }

--- a/data/XY/Roaring Skies/17.ts
+++ b/data/XY/Roaring Skies/17.ts
@@ -121,7 +121,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 282684,
+		cardmarket: 282685,
 		tcgplayer: 98053
 	}
 }

--- a/data/XY/Roaring Skies/28.ts
+++ b/data/XY/Roaring Skies/28.ts
@@ -91,7 +91,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 282695,
+		cardmarket: 282696,
 		tcgplayer: 98064
 	}
 }

--- a/data/XY/Roaring Skies/32.ts
+++ b/data/XY/Roaring Skies/32.ts
@@ -129,7 +129,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 282699,
+		cardmarket: 282700,
 		tcgplayer: 98068
 	}
 }

--- a/data/XY/Roaring Skies/46.ts
+++ b/data/XY/Roaring Skies/46.ts
@@ -102,7 +102,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 282713,
+		cardmarket: 282714,
 		tcgplayer: 98082
 	}
 }

--- a/data/XY/Roaring Skies/52.ts
+++ b/data/XY/Roaring Skies/52.ts
@@ -118,7 +118,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 282719,
+		cardmarket: 282720,
 		tcgplayer: 98088
 	}
 }

--- a/data/XY/Roaring Skies/55.ts
+++ b/data/XY/Roaring Skies/55.ts
@@ -91,7 +91,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 282722,
+		cardmarket: 282723,
 		tcgplayer: 98091
 	}
 }

--- a/data/XY/Roaring Skies/72.ts
+++ b/data/XY/Roaring Skies/72.ts
@@ -118,7 +118,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 282739,
+		cardmarket: 282740,
 		tcgplayer: 98108
 	}
 }

--- a/data/XY/Roaring Skies/74.ts
+++ b/data/XY/Roaring Skies/74.ts
@@ -101,7 +101,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 282721,
+		cardmarket: 282742,
 		tcgplayer: 98110
 	}
 }

--- a/data/XY/Roaring Skies/75.ts
+++ b/data/XY/Roaring Skies/75.ts
@@ -97,7 +97,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 282728,
+		cardmarket: 282743,
 		tcgplayer: 98111
 	}
 }

--- a/data/XY/Roaring Skies/77a.ts
+++ b/data/XY/Roaring Skies/77a.ts
@@ -95,7 +95,7 @@ const card: Card = {
 	retreat: 1,
 
 	thirdParty: {
-		cardmarket: 282745
+		cardmarket: 282774
 	}
 }
 

--- a/data/XY/Roaring Skies/8.ts
+++ b/data/XY/Roaring Skies/8.ts
@@ -116,7 +116,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 282675,
+		cardmarket: 282676,
 		tcgplayer: 98044
 	}
 }

--- a/data/XY/Roaring Skies/81.ts
+++ b/data/XY/Roaring Skies/81.ts
@@ -131,7 +131,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 282748,
+		cardmarket: 282749,
 		tcgplayer: 98117
 	}
 }

--- a/data/XY/Roaring Skies/92a.ts
+++ b/data/XY/Roaring Skies/92a.ts
@@ -27,7 +27,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 282760
+		cardmarket: 297897
 	}
 }
 

--- a/data/XY/Roaring Skies/98.ts
+++ b/data/XY/Roaring Skies/98.ts
@@ -98,7 +98,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 282694,
+		cardmarket: 282766,
 		tcgplayer: 98134
 	}
 }

--- a/data/XY/Roaring Skies/99.ts
+++ b/data/XY/Roaring Skies/99.ts
@@ -91,7 +91,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 282702,
+		cardmarket: 282767,
 		tcgplayer: 98135
 	}
 }


### PR DESCRIPTION
ref #1936

## Changes

Correct Cardmarket product references for the xy6 set across 21 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 21 duplicate-ID corrections in this set. The post-apply audit retains 8 catalog detail mismatches for xy6-17, xy6-28, xy6-46, xy6-52, xy6-72, xy6-74, xy6-8, xy6-81; these remain review notes rather than being silently treated as resolved. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.