### PR TITLE
fix(cardmarket): Correct Cardmarket links for xy7

### DIFF
--- a/data/XY/Ancient Origins/11.ts
+++ b/data/XY/Ancient Origins/11.ts
@@ -123,7 +123,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 284191,
+		cardmarket: 284192,
 		tcgplayer: 101436
 	}
 }

--- a/data/XY/Ancient Origins/15.ts
+++ b/data/XY/Ancient Origins/15.ts
@@ -117,7 +117,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 284195,
+		cardmarket: 284196,
 		tcgplayer: 100621
 	}
 }

--- a/data/XY/Ancient Origins/18.ts
+++ b/data/XY/Ancient Origins/18.ts
@@ -124,7 +124,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 284198,
+		cardmarket: 284199,
 		tcgplayer: 101439
 	}
 }

--- a/data/XY/Ancient Origins/32.ts
+++ b/data/XY/Ancient Origins/32.ts
@@ -89,7 +89,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 284212,
+		cardmarket: 284213,
 		tcgplayer: 101453
 	}
 }

--- a/data/XY/Ancient Origins/41.ts
+++ b/data/XY/Ancient Origins/41.ts
@@ -103,7 +103,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 284216,
+		cardmarket: 284222,
 		tcgplayer: 101463
 	}
 }

--- a/data/XY/Ancient Origins/50.ts
+++ b/data/XY/Ancient Origins/50.ts
@@ -133,7 +133,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 284230,
+		cardmarket: 284231,
 		tcgplayer: 101472
 	}
 }

--- a/data/XY/Ancient Origins/67.ts
+++ b/data/XY/Ancient Origins/67.ts
@@ -122,7 +122,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 284245,
+		cardmarket: 284248,
 		tcgplayer: 101489
 	}
 }

--- a/data/XY/Ancient Origins/75a.ts
+++ b/data/XY/Ancient Origins/75a.ts
@@ -27,7 +27,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 284256
+		cardmarket: 295259
 	}
 }
 

--- a/data/XY/Ancient Origins/84.ts
+++ b/data/XY/Ancient Origins/84.ts
@@ -89,7 +89,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 284188,
+		cardmarket: 284265,
 		tcgplayer: 101507
 	}
 }

--- a/data/XY/Ancient Origins/86.ts
+++ b/data/XY/Ancient Origins/86.ts
@@ -92,7 +92,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 284206,
+		cardmarket: 284267,
 		tcgplayer: 101508
 	}
 }

--- a/data/XY/Ancient Origins/87.ts
+++ b/data/XY/Ancient Origins/87.ts
@@ -97,7 +97,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 284208,
+		cardmarket: 284268,
 		tcgplayer: 101509
 	}
 }

--- a/data/XY/Ancient Origins/89.ts
+++ b/data/XY/Ancient Origins/89.ts
@@ -88,7 +88,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 284217,
+		cardmarket: 284270,
 		tcgplayer: 101511
 	}
 }

--- a/data/XY/Ancient Origins/90.ts
+++ b/data/XY/Ancient Origins/90.ts
@@ -91,7 +91,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 284218,
+		cardmarket: 284271,
 		tcgplayer: 101512
 	}
 }

--- a/data/XY/Ancient Origins/91.ts
+++ b/data/XY/Ancient Origins/91.ts
@@ -93,7 +93,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 284223,
+		cardmarket: 284272,
 		tcgplayer: 101513
 	}
 }

--- a/data/XY/Ancient Origins/93.ts
+++ b/data/XY/Ancient Origins/93.ts
@@ -90,7 +90,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 284238,
+		cardmarket: 284274,
 		tcgplayer: 101515
 	}
 }

--- a/data/XY/Ancient Origins/94.ts
+++ b/data/XY/Ancient Origins/94.ts
@@ -99,7 +99,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 284249,
+		cardmarket: 284275,
 		tcgplayer: 101516
 	}
 }


### PR DESCRIPTION
ref #1936

## Changes

Correct Cardmarket product references for the xy7 set across 16 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 16 duplicate-ID corrections in this set. The post-apply audit retains 6 catalog detail mismatches for xy7-11, xy7-15, xy7-18, xy7-32, xy7-50, xy7-67; these remain review notes rather than being silently treated as resolved. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.