### PR TITLE
fix(cardmarket): Correct Cardmarket links for xy8

### DIFF
--- a/data/XY/BREAKthrough/100.ts
+++ b/data/XY/BREAKthrough/100.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 286314,
+		cardmarket: 286346,
 		tcgplayer: 107219
 	}
 }

--- a/data/XY/BREAKthrough/109.ts
+++ b/data/XY/BREAKthrough/109.ts
@@ -86,7 +86,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 286354,
+		cardmarket: 286355,
 		tcgplayer: 107228
 	}
 }

--- a/data/XY/BREAKthrough/116.ts
+++ b/data/XY/BREAKthrough/116.ts
@@ -98,7 +98,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 286361,
+		cardmarket: 286362,
 		tcgplayer: 107235
 	}
 }

--- a/data/XY/BREAKthrough/132.ts
+++ b/data/XY/BREAKthrough/132.ts
@@ -91,7 +91,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 286377,
+		cardmarket: 286378,
 		tcgplayer: 107251
 	}
 }

--- a/data/XY/BREAKthrough/146a.ts
+++ b/data/XY/BREAKthrough/146a.ts
@@ -28,7 +28,7 @@ const card: Card = {
 	trainerType: "Item",
 
 	thirdParty: {
-		cardmarket: 286392
+		cardmarket: 782671
 	}
 }
 

--- a/data/XY/BREAKthrough/157.ts
+++ b/data/XY/BREAKthrough/157.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 286307,
+		cardmarket: 286403,
 		tcgplayer: 107277
 	}
 }

--- a/data/XY/BREAKthrough/158.ts
+++ b/data/XY/BREAKthrough/158.ts
@@ -89,7 +89,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 286307,
+		cardmarket: 286404,
 		tcgplayer: 107278
 	}
 }

--- a/data/XY/BREAKthrough/163.ts
+++ b/data/XY/BREAKthrough/163.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 286307,
+		cardmarket: 286409,
 		tcgplayer: 107282
 	}
 }

--- a/data/XY/BREAKthrough/164.ts
+++ b/data/XY/BREAKthrough/164.ts
@@ -89,7 +89,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 286307,
+		cardmarket: 286410,
 		tcgplayer: 107283
 	}
 }

--- a/data/XY/BREAKthrough/32.ts
+++ b/data/XY/BREAKthrough/32.ts
@@ -84,7 +84,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 286277,
+		cardmarket: 286278,
 		tcgplayer: 107151
 	}
 }

--- a/data/XY/BREAKthrough/52.ts
+++ b/data/XY/BREAKthrough/52.ts
@@ -91,7 +91,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 286297,
+		cardmarket: 286298,
 		tcgplayer: 107171
 	}
 }

--- a/data/XY/BREAKthrough/62.ts
+++ b/data/XY/BREAKthrough/62.ts
@@ -89,7 +89,7 @@ const card: Card = {
 	stage: "Basic",
 
 	thirdParty: {
-		cardmarket: 286307,
+		cardmarket: 286308,
 		tcgplayer: 107181
 	}
 }

--- a/data/XY/BREAKthrough/8.ts
+++ b/data/XY/BREAKthrough/8.ts
@@ -79,7 +79,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 286253,
+		cardmarket: 286254,
 		tcgplayer: 107127
 	}
 }

--- a/data/XY/BREAKthrough/9.ts
+++ b/data/XY/BREAKthrough/9.ts
@@ -85,7 +85,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 286253,
+		cardmarket: 286255,
 		tcgplayer: 107128
 	}
 }

--- a/data/XY/BREAKthrough/90.ts
+++ b/data/XY/BREAKthrough/90.ts
@@ -98,7 +98,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 286335,
+		cardmarket: 286336,
 		tcgplayer: 107209
 	}
 }


### PR DESCRIPTION
ref #1936

## Changes

Correct Cardmarket product references for the xy8 set across 15 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 15 duplicate-ID corrections in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.