### PR TITLE
fix(cardmarket): Correct Cardmarket links for xy9

### DIFF
--- a/data/XY/BREAKpoint/107a.ts
+++ b/data/XY/BREAKpoint/107a.ts
@@ -27,7 +27,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 288282
+		cardmarket: 297896
 	}
 }
 

--- a/data/XY/BREAKpoint/23.ts
+++ b/data/XY/BREAKpoint/23.ts
@@ -69,7 +69,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 288197,
+		cardmarket: 288198,
 		tcgplayer: 111526
 	}
 }

--- a/data/XY/BREAKpoint/98a.ts
+++ b/data/XY/BREAKpoint/98a.ts
@@ -28,7 +28,7 @@ const card: Card = {
 	trainerType: "Supporter",
 
 	thirdParty: {
-		cardmarket: 288273
+		cardmarket: 311410
 	}
 }
 

--- a/data/XY/BREAKpoint/98b.ts
+++ b/data/XY/BREAKpoint/98b.ts
@@ -27,7 +27,7 @@ const card: Card = {
 	},
 
 	thirdParty: {
-		cardmarket: 288273
+		cardmarket: 782672
 	}
 }
 


### PR DESCRIPTION
ref #1936

## Changes

Correct Cardmarket product references for the xy9 set across 4 card files.

## Details

This is a set-scoped part of the Cardmarket cleanup. The changes update exact card references produced by the conservative safe-fix workflow and do not modify the audit tooling or generated reports.

The baseline comparison identified 4 duplicate-ID corrections in this set. The changed references have no post-apply cross-card duplicate, catalog-missing, expansion-mismatch, or name-mismatch status.

Validation completed with `bun run validate`, 9/9 Cardmarket regression tests, `git diff --check`, and exact per-branch scope verification.