### PR TITLE
Add missing German translations for det1

### DIFF
--- a/data/Sun & Moon/Detective Pikachu/1.ts
+++ b/data/Sun & Moon/Detective Pikachu/1.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Busca en tu baraja 1 Pokémon Grass, enséñalo y ponlo en tu mano. Después, baraja las cartas de tu baraja.",
 				it: "Cerca nel tuo mazzo un Pokémon Grass, mostralo e aggiungilo alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 				pt: "Procure por 1 Pokémon Grass no seu baralho, revele-o e coloque-o na sua mão. Em seguida, embaralhe o seu baralho.",
-				de: "Durchsuche dein Deck nach 1 Grass-Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck."
+				de: "Durchsuche dein Deck nach 1 {G}-Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck."
 			},
 
 		},
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "A strange seed was planted on its back at birth. The plant sprouts and grows with this Pokémon.",
+		de: "Dieses Pokémon trägt von Geburt an einen Samen auf dem Rücken, der mit ihm keimt und wächst."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Detective Pikachu/10.ts
+++ b/data/Sun & Moon/Detective Pikachu/10.ts
@@ -96,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "He loves to show off his vast knowledge. This expressive Pikachu is like a middle-aged man.",
+		de: "Er liebt es, sein großes Wissen unter Beweis zu stellen. Dieses gesprächige Pikachu verhält sich wie ein Mann mittleren Alters."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Detective Pikachu/11.ts
+++ b/data/Sun & Moon/Detective Pikachu/11.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Its pantomime skills are wonderful. You may become enraptured while watching it, but next thing you know, Mr. Mime has made a real wall.",
+		de: "Sein Können als Pantomime ist verblüffend. Vor lauter Bewunderung merkt man gar nicht, wie plötzlich eine echte Wand vor einem erscheint."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Detective Pikachu/12.ts
+++ b/data/Sun & Moon/Detective Pikachu/12.ts
@@ -73,7 +73,7 @@ const card: Card = {
 				es: "Descarta 2 Energías Psychic de este Pokémon.",
 				it: "Scarta due Energie Psychic assegnate a questo Pokémon.",
 				pt: "Descarte 2 Energias Psychic deste Pokémon.",
-				de: "Lege 2 Psychic-Energien von diesem Pokémon auf deinen Ablagestapel."
+				de: "Lege 2 {P}-Energien von diesem Pokémon auf deinen Ablagestapel."
 			},
 			damage: 130,
 
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon was created by years of horrific gene splicing and DNA engineering experiments.",
+		de: "Dieses Pokémon ist das Resultat eines jahrelangen und skrupellosen Experimentes."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Detective Pikachu/13.ts
+++ b/data/Sun & Moon/Detective Pikachu/13.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Machoke",
 		fr: "Machopeur",
+		de: "Maschock"
 	},
 
 	stage: "Stage2",
@@ -93,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "It grasps its opponents with its four arms and twists them up in an intricate hold. People call it \"the Machamp special.\"",
+		de: "Es ergreift seinen Gegner mit seinen vier Armen und hält ihn in einem komplizierten Würgegriff. Man nennt dies Machomeis Spezialgriff."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Detective Pikachu/14.ts
+++ b/data/Sun & Moon/Detective Pikachu/14.ts
@@ -71,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "Recordings of Jigglypuff's strange lullabies can be purchased from department stores. These CDs can be found near the bedding area.",
+		de: "In der Bettenabteilung von Kaufhäusern erhält man auch CDs mit Pummeluffs wundersam einlullendem Gesang."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Detective Pikachu/15.ts
+++ b/data/Sun & Moon/Detective Pikachu/15.ts
@@ -73,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "It grows close to others easily and is also easily spoiled. The disparity between its face and its actions makes many young people wild about it.",
+		de: "Es wird schnell zahm und wird gerne verwöhnt. Viele lieben den Kontrast zwischen seiner mürrischen Miene und dem putzigen Charakter"
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Detective Pikachu/16.ts
+++ b/data/Sun & Moon/Detective Pikachu/16.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "It checks out whatever's around it by licking everything. If you don't clean off a spot where it's licked you, you'll break out in a rash!",
+		de: "Mit seiner langen Zunge leckt es an allem, um es zu prüfen. Lässt man eine abgeleckte Stelle unbehandelt, entwickelt sich ein Ausschlag."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Detective Pikachu/17.ts
+++ b/data/Sun & Moon/Detective Pikachu/17.ts
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "While it can transform into anything, each Ditto apparently has its own strengths and weaknesses when it comes to transformations.",
+		de: "Ditto kann jede beliebige Gestalt annehmen, wobei aber jedes Exemplar individuelle Stärken und Schwächen aufweist."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Detective Pikachu/18.ts
+++ b/data/Sun & Moon/Detective Pikachu/18.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Vigoroth",
 		fr: "Vigoroth",
+		de: "Muntier"
 	},
 
 	stage: "Stage2",
@@ -73,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "The world's laziest Pokémon. It moves to another spot when there's no food left within its reach.",
+		de: "Das faulste Pokémon der Welt. Es bewegt sich nur, wenn alles Essbare in Reichweite verputzt ist."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Detective Pikachu/2.ts
+++ b/data/Sun & Moon/Detective Pikachu/2.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Lombre",
 		fr: "Lombre",
+		de: "Lombrero"
 	},
 
 	stage: "Stage2",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "If it hears festive music, all its muscles fill with energy. It can't help breaking out into a dance.",
+		de: "Hört es fröhliche Musik, füllen sich seine Muskeln mit Energie. Es muss dann einfach tanzen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Detective Pikachu/3.ts
+++ b/data/Sun & Moon/Detective Pikachu/3.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It scatters its shining spores around itself. Even though they're dangerous, nighttime tours of forests where Morelull live are popular.",
+		de: "Es streut blinkende Sporen aus. Obgleich nicht ungefährlich, sind nächtliche Führungen durch Wälder, in denen Bubungus leben, sehr beliebt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Detective Pikachu/4.ts
+++ b/data/Sun & Moon/Detective Pikachu/4.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "The flame on its tail indicates Charmander's life force. If it is healthy, the flame burns brightly.",
+		de: "Die Flamme auf seiner Schweifspitze zeigt die Lebensenergie an. Ist es gesund, leuchtet sie hell."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Detective Pikachu/5.ts
+++ b/data/Sun & Moon/Detective Pikachu/5.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Charmeleon",
 		fr: "Reptincel",
+		de: "Glutexo"
 	},
 
 	stage: "Stage2",
@@ -91,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "When expelling a blast of superhot fire, the red flame at the tip of its tail burns more intensely.",
+		de: "Wenn dieses Pokémon einen Strahl glühenden Feuers speit, leuchtet seine Schwanzspitze auf."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Detective Pikachu/6.ts
+++ b/data/Sun & Moon/Detective Pikachu/6.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Growlithe",
 		fr: "Caninos",
+		de: "Fukano"
 	},
 
 	stage: "Stage1",
@@ -87,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Legends tell of its fighting alongside a general and conquering a whole country.",
+		de: "Der Legende nach soll es vor langer Zeit an der Seite eines Kriegshelden gekämpft und so an der Eroberung eines Landes mitgewirkt haben."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Detective Pikachu/7.ts
+++ b/data/Sun & Moon/Detective Pikachu/7.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "Using psychokinesis gives it a headache, so it normally passes the time spacing out and doing as little as possible.",
+		de: "Wenn es seine Psycho-Kräfte einsetzt, bekommt es Kopfschmerzen. Deshalb steht es lieber untätig und geistesabwesend herum."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Detective Pikachu/8.ts
+++ b/data/Sun & Moon/Detective Pikachu/8.ts
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "In the distant past, they were fairly strong, but they have become gradually weaker over time.",
+		de: "Vor langer, langer Zeit war es anscheinend ziemlich stark, doch es wurde zusehends schwächer und schwächer."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Detective Pikachu/9.ts
+++ b/data/Sun & Moon/Detective Pikachu/9.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Frogadier",
 		fr: "Croâporal",
+		de: "Amphizel"
 	},
 
 	stage: "Stage2",
@@ -92,6 +93,7 @@ const card: Card = {
 
 	description: {
 		en: "It creates throwing stars out of compressed water. When it spins them and throws them at high speed, these stars can split metal in two.",
+		de: "Es stellt Wurfsterne aus komprimiertem Wasser her, die durch ihre hohe Drehgeschwindigkeit beim Werfen sogar Metall durchtrennen."
 	},
 
 	thirdParty: {


### PR DESCRIPTION
## Add missing German translations for det1

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
