### PR TITLE
Add missing German translations for 2021swsh

### DIFF
--- a/data/McDonald's Collection/McDonald's Collection 2021/1.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/1.ts
@@ -4,7 +4,8 @@ import Set from '../McDonald\'s Collection 2021'
 const card: Card = {
 	name: {
 		en: "Bulbasaur",
-		fr: "Bulbizarre"
+		fr: "Bulbizarre",
+		de: "Bisasam"
 	},
 
 	illustrator: "Mizue",
@@ -32,7 +33,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Razor Leaf",
-				fr: "Tranch'Herbe"
+				fr: "Tranch'Herbe",
+				de: "Rasierblatt"
 			},
 
 			damage: 30,
@@ -50,7 +52,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "A strange seed was planted on its back at birth. The plant sprouts and grows with this Pokémon."
+		en: "A strange seed was planted on its back at birth. The plant sprouts and grows with this Pokémon.",
+		de: "Dieses Pokémon trägt von Geburt an einen Samen auf dem Rücken, der mit ihm keimt und wächst."
 	},
 
 	variants: [

--- a/data/McDonald's Collection/McDonald's Collection 2021/10.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/10.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Cyndaquil",
 		fr: "Héricendre",
+		de: "Feurigel"
 	},
 
 	illustrator: "kirisAki",
@@ -33,6 +34,7 @@ const card: Card = {
 			name: {
 				en: "Hammer In",
 				fr: "Enfoncement",
+				de: "Einhämmern"
 			},
 
 			damage: 30,
@@ -50,7 +52,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It has a timid nature. If it is startled, the flames on its back burn more vigorously."
+		en: "It has a timid nature. If it is startled, the flames on its back burn more vigorously.",
+		de: "Erschrickt sich dieses scheue Pokémon, lodern die Flammen auf seinem Rücken kräftiger."
 	},
 
 	variants: [

--- a/data/McDonald's Collection/McDonald's Collection 2021/11.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/11.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Torchic",
 		fr: "Poussifeu",
+		de: "Flemmli"
 	},
 
 	illustrator: "sui",
@@ -32,10 +33,12 @@ const card: Card = {
 			name: {
 				en: "Ember",
 				fr: "Flammèche",
+				de: "Glut"
 			},
 			effect: {
 				en: "Flip a coin. If tails, discard a Fire Energy attached to this Pokémon.",
 				fr: "Lancez une pièce. Si c'est pile, défaussez une Énergie Fire attachée à ce Pokémon.",
+				de: "Wirf 1 Münze. Lege bei „Zahl“ 1 an dieses Pokémon angelegte {R}-Energie auf deinen Ablagestapel."
 			},
 			damage: 20,
 
@@ -52,7 +55,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "A fire burns inside, so it feels very warm to hug. It launches fireballs of 1,800 degrees Fahrenheit."
+		en: "A fire burns inside, so it feels very warm to hug. It launches fireballs of 1,800 degrees Fahrenheit.",
+		de: "In seinem Inneren lodert ein Feuer. Es schleudert 1 000 °C heiße Feuerbälle."
 	},
 
 	variants: [

--- a/data/McDonald's Collection/McDonald's Collection 2021/12.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/12.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Chimchar",
 		fr: "Chimpenfeu",
+		de: "Panflam"
 	},
 
 	illustrator: "Kouki Saitou",
@@ -32,10 +33,12 @@ const card: Card = {
 			name: {
 				en: "Fury Swipes",
 				fr: "Super Roussi",
+				de: "Kratzfurie"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 10 damage for each heads.",
 				fr: "Le Pokémon Actif de votre adversaire est maintenant Brûlé.",
+				de: "Wirf 3 Münzen. Diese Attacke fügt 10 Schadenspunkte pro Kopf zu."
 			},
 			damage: "10×",
 
@@ -52,7 +55,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "The gas made in its belly burns from its rear end. The fire burns weakly when it feels sick."
+		en: "The gas made in its belly burns from its rear end. The fire burns weakly when it feels sick.",
+		de: "An seinem Rücken verbrennt es die Gase aus seinem Bauch. Geht es ihm schlecht, leuchtet es weniger hell."
 	},
 
 	variants: [

--- a/data/McDonald's Collection/McDonald's Collection 2021/13.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/13.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Tepig",
 		fr: "Gruikui",
+		de: "Floink"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -33,10 +34,12 @@ const card: Card = {
 			name: {
 				en: "Ember",
 				fr: "Flammèche",
+				de: "Glut"
 			},
 			effect: {
 				en: "Discard an Energy attached to this Pokémon.",
 				fr: "Défaussez une Énergie attachée à ce Pokémon.",
+				de: "Lege 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel."
 			},
 			damage: 30,
 
@@ -53,7 +56,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It blows fire through its nose. When it catches a cold, the fire becomes pitch-black smoke instead."
+		en: "It blows fire through its nose. When it catches a cold, the fire becomes pitch-black smoke instead.",
+		de: "Es schießt Flammen aus seinem Rüssel. Ist es erkältet, kommt statt Feuer aber nur pechschwarzer Rauch zum Vorschein."
 	},
 	
 	variants: [

--- a/data/McDonald's Collection/McDonald's Collection 2021/14.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/14.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Fennekin",
 		fr: "Feunnec",
+		de: "Fynx"
 	},
 
 	illustrator: "5ban Graphics",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Scratch",
 				fr: "Griffe",
+				de: "Kratzer"
 			},
 
 			damage: 10,
@@ -45,6 +47,7 @@ const card: Card = {
 			name: {
 				en: "Live Coal",
 				fr: "Charbon Mutant",
+				de: "Glühende Kohlen"
 			},
 
 			damage: 20,
@@ -62,7 +65,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Eating a twig fills it with energy, and its roomy ears give vent to air hotter than 390 degrees Fahrenheit."
+		en: "Eating a twig fills it with energy, and its roomy ears give vent to air hotter than 390 degrees Fahrenheit.",
+		de: "Wenn es Zweige frisst, fasst es neue Kraft und stößt über seine Ohren über 200 °C heiße Luft aus."
 	},
 
 	variants: [

--- a/data/McDonald's Collection/McDonald's Collection 2021/15.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/15.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Litten",
 		fr: "Flamiaou",
+		de: "Flamiau"
 	},
 
 	illustrator: "Akira Komayama",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
+				de: "Biss"
 			},
 
 			damage: 10,
@@ -45,6 +47,7 @@ const card: Card = {
 			name: {
 				en: "Flare",
 				fr: "Flamboiement",
+				de: "Flackern"
 			},
 
 			damage: 20,
@@ -62,7 +65,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "While grooming itself, it builds up fur inside its stomach. It sets the fur alight and spews fiery attacks, which change based on how it coughs."
+		en: "While grooming itself, it builds up fur inside its stomach. It sets the fur alight and spews fiery attacks, which change based on how it coughs.",
+		de: "Es verbrennt Haare, die es bei der Körperpflege verschluckt hat, indem es Feuer speit. Die Flammen variieren je nach Art des Speiens."
 	},
 
 	variants: [

--- a/data/McDonald's Collection/McDonald's Collection 2021/16.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/16.ts
@@ -6,6 +6,7 @@ const card: Card = {
 	name: {
 		en: "Scorbunny",
 		fr: "Flambino",
+		de: "Hopplo"
 	},
 
 	illustrator: "Hitoshi Ariga",
@@ -28,10 +29,12 @@ const card: Card = {
 			name: {
 				en: "Super Singe",
 				fr: "Super Roussi",
+				de: "Super-Versengung"
 			},
 			effect: {
 				en: "Flip a coin. If heads, your opponent’s Active Pokémon is now Burned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire est maintenant Brûlé.",
+				de: "Wirf 1 Münze. Bei Kopf ist das Aktive Pokémon deines Gegners jetzt verbrannt."
 			},
 			damage: 10,
 
@@ -48,7 +51,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "A warm-up of running around gets fire energy coursing through this Pokémon’s body. Once that happens, it’s ready to fight at full power."
+		en: "A warm-up of running around gets fire energy coursing through this Pokémon’s body. Once that happens, it’s ready to fight at full power.",
+		de: "Erhöht es durch Rennen seine Körpertemperatur, strömt Feuer-Energie durch seinen Körper. Dann kann es seine wahre Kraft entfesseln."
 	},
 	variants: [
 		{

--- a/data/McDonald's Collection/McDonald's Collection 2021/17.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/17.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Squirtle",
 		fr: "Carapuce",
+		de: "Schiggy"
 	},
 
 	illustrator: "tetsuya koizumi",
@@ -32,10 +33,12 @@ const card: Card = {
 			name: {
 				en: "Bubble",
 				fr: "Écume",
+				de: "Blubber"
 			},
 			effect: {
 				en: "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c’est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei Kopf ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 			},
 			damage: 10,
 
@@ -52,7 +55,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It shelters itself in its shell, then strikes back with spouts of water at every opportunity."
+		en: "It shelters itself in its shell, then strikes back with spouts of water at every opportunity.",
+		de: "Es zieht sich in seinen Panzer zurück und greift dann mit Wasserstrahlen seine Gegner an."
 	},
 
 	variants: [

--- a/data/McDonald's Collection/McDonald's Collection 2021/18.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/18.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Totodile",
 		fr: "Kaiminus",
+		de: "Karnimani"
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -32,10 +33,12 @@ const card: Card = {
 			name: {
 				en: "Fury Strikes",
 				fr: "Attaques Furieuses",
+				de: "Zornschläge"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10×",
 
@@ -52,7 +55,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It is small but rough and tough. It won’t hesitate to take a bite out of anything that moves."
+		en: "It is small but rough and tough. It won’t hesitate to take a bite out of anything that moves.",
+		de: "Es ist klein, aber zäh und stark. Es zögert nicht, jeden anzugreifen, wenn dieser ihm zu nahe kommt."
 	},
 
     variants: [

--- a/data/McDonald's Collection/McDonald's Collection 2021/19.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/19.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Mudkip",
 		fr: "Gobou",
+		de: "Hydropi"
 	},
 
 	illustrator: "Aya Kusube",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 10,
@@ -45,6 +47,7 @@ const card: Card = {
 			name: {
 				en: "Mud-Slap",
 				fr: "Coud'Boue",
+				de: "Lehmschelle"
 			},
 
 			damage: 20,
@@ -62,7 +65,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "To alert it, the fin on its head senses the flow of water. It has the strength to heft boulders."
+		en: "To alert it, the fin on its head senses the flow of water. It has the strength to heft boulders.",
+		de: "Die Flosse auf seinem Kopf prüft die Strömung des Wassers. Dieses Pokémon kann Felsen heben."
 	},
 
 	variants: [

--- a/data/McDonald's Collection/McDonald's Collection 2021/2.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/2.ts
@@ -4,7 +4,8 @@ import Set from '../McDonald\'s Collection 2021'
 const card: Card = {
 	name: {
 		en: "Chikorita",
-		fr: "Germignon"
+		fr: "Germignon",
+		de: "Endivie"
 	},
 
 	illustrator: "sowsow",
@@ -31,11 +32,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Mini Drain",
-				fr: "Mini-Assèchement"
+				fr: "Mini-Assèchement",
+				de: "Minisauger"
 			},
 			effect: {
 				en: "Heal 10 damage from this Pokémon.",
-				fr: "Soignez 10 dégâts à ce Pokémon."
+				fr: "Soignez 10 dégâts à ce Pokémon.",
+				de: "Heile 10 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 10,
 
@@ -52,7 +55,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It uses the leaf on its head to determine the temperature and humidity. It loves to sunbathe."
+		en: "It uses the leaf on its head to determine the temperature and humidity. It loves to sunbathe.",
+		de: "Mit dem Blatt auf seinem Kopf bestimmt es die Temperatur und Feuchtigkeit. Es liebt Sonnenbäder."
 	},
 
 	variants: [

--- a/data/McDonald's Collection/McDonald's Collection 2021/20.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/20.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Piplup",
 		fr: "Tiplouf",
+		de: "Plinfa"
 	},
 
 	illustrator: "Shibuzoh.",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Peck",
 				fr: "Picpic",
+				de: "Schnabel"
 			},
 
 			damage: 10,
@@ -45,6 +47,7 @@ const card: Card = {
 			name: {
 				en: "Wave Splash",
 				fr: "Grosse Vague",
+				de: "Wellenplatscher"
 			},
 
 			damage: 20,
@@ -62,7 +65,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Because it is very proud, it hates accepting food from people. Its thick down guards it from cold."
+		en: "Because it is very proud, it hates accepting food from people. Its thick down guards it from cold.",
+		de: "Es ist sehr stolz und nimmt daher kein Futter von anderen an. Seine dicken Daunen schützen vor Kälte."
 	},
     variants: [
           {

--- a/data/McDonald's Collection/McDonald's Collection 2021/21.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/21.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Oshawott",
 		fr: "Moustillon",
+		de: "Ottaro"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -33,10 +34,12 @@ const card: Card = {
 			name: {
 				en: "Water Pulse",
 				fr: "Vibraqua",
+				de: "Aquawelle"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Asleep.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Endormi.",
+				de: "Wirf 1 Münze. Bei „Kopf“ schläft das Verteidigende Pokémon jetzt."
 			},
 			damage: 20,
 
@@ -53,7 +56,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It fights using the scalchop on its stomach. In response to an attack, it retaliates immediately by slashing."
+		en: "It fights using the scalchop on its stomach. In response to an attack, it retaliates immediately by slashing.",
+		de: "Kämpft mit der Muschel auf seinem Bauch. Pariert es einen Angriff, schlägt es sofort mit einer Schnitt-Attacke zurück."
 	},
 	
 	variants: [

--- a/data/McDonald's Collection/McDonald's Collection 2021/22.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/22.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Froakie",
 		fr: "Grenousse",
+		de: "Froxy"
 	},
 
 	illustrator: "5ban Graphics",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Pound",
 				fr: "Écras'Face",
+				de: "Pfund"
 			},
 
 			damage: 10,
@@ -45,6 +47,7 @@ const card: Card = {
 			name: {
 				en: "Water Drip",
 				fr: "Goutte à Goutte",
+				de: "Spritzwasser"
 			},
 
 			damage: 20,
@@ -62,7 +65,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It secretes flexible bubbles from its chest and back. The bubbles reduce the damage it would otherwise take when attacked."
+		en: "It secretes flexible bubbles from its chest and back. The bubbles reduce the damage it would otherwise take when attacked.",
+		de: "Es stößt aus Brust und Rücken elastische Blasen aus, mit denen es gegnerische Angriffe abfängt und so den erlittenen Schaden verringert."
 	},
 	variants: [
 		{

--- a/data/McDonald's Collection/McDonald's Collection 2021/23.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/23.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Popplio",
 		fr: "Otaquin",
+		de: "Robball"
 	},
 
 	illustrator: "Kouki Saitou",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Pound",
 				fr: "Écras’Face",
+				de: "Pfund"
 			},
 
 			damage: 10,
@@ -45,6 +47,7 @@ const card: Card = {
 			name: {
 				en: "Water Gun",
 				fr: "Pistolet à O",
+				de: "Aquaknarre"
 			},
 
 			damage: 20,
@@ -62,7 +65,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "This Pokémon snorts body fluids from its nose, blowing balloons to smash into its foes. It’s famous for being a hard worker."
+		en: "This Pokémon snorts body fluids from its nose, blowing balloons to smash into its foes. It’s famous for being a hard worker.",
+		de: "Dieses Pokémon ist für seine Willensstärke bekannt. Bläst es Körperflüssigkeit durch die Nase, entsteht eine Blase, die als Waffe fungiert."
 	},
 	variants: [
 		{

--- a/data/McDonald's Collection/McDonald's Collection 2021/24.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/24.ts
@@ -6,6 +6,7 @@ const card: Card = {
 	name: {
 		en: "Sobble",
 		fr: "Larméléon",
+		de: "Memmeon"
 	},
 
 	illustrator: "Mizue",
@@ -29,10 +30,12 @@ const card: Card = {
 			name: {
 				en: "Bind",
 				fr: "Étreinte",
+				de: "Klammergriff"
 			},
 			effect: {
 				en: "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei Kopf ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 			},
 			damage: 20,
 
@@ -49,7 +52,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "When scared, this Pokémon cries. Its tears pack the chemical punch of 100 onions, and attackers won’t be able to resist weeping."
+		en: "When scared, this Pokémon cries. Its tears pack the chemical punch of 100 onions, and attackers won’t be able to resist weeping.",
+		de: "Hat es Angst, vergießt es Tränen, die Reizstoffe enthalten, welche andere ebenfalls zum Weinen bringen. Sie sind so stark wie 100 Zwiebeln."
 	},
 	variants: [
 		{

--- a/data/McDonald's Collection/McDonald's Collection 2021/25.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/25.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Pikachu",
 		fr: "Pikachu",
+		de: "Pikachu"
 	},
 
 	illustrator: "Sanosuke Sakuma",
@@ -32,10 +33,12 @@ const card: Card = {
 			name: {
 				en: "Meal Time",
 				fr: "À Belles Dents",
+				de: "Mahlzeit"
 			},
 			effect: {
 				en: "Flip a coin until you get tails. For each heads, draw a card.",
 				fr: "Lancez une pièce jusqu’à ce que vous obteniez un côté pile. Pour chaque côté face, piochez une carte.",
+				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis Zahl kommt. Ziehe pro Kopf 1 Karte."
 			},
 
 		},
@@ -47,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Gnaw",
 				fr: "Ronge",
+				de: "Nagen"
 			},
 
 			damage: 20,
@@ -71,7 +75,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Its nature is to store up electricity. Forests where nests of Pikachu live are dangerous, since the trees are so often struck by lightning."
+		en: "Its nature is to store up electricity. Forests where nests of Pikachu live are dangerous, since the trees are so often struck by lightning.",
+		de: "Es liegt in seiner Natur, konstant Elektrizität zu speichern. Die Wälder, in denen Pikachu leben, bergen stets die Gefahr eines Blitzgewitters."
 	},
 	variants: [
 		{

--- a/data/McDonald's Collection/McDonald's Collection 2021/3.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/3.ts
@@ -4,7 +4,8 @@ import Set from '../McDonald\'s Collection 2021'
 const card: Card = {
 	name: {
 		en: "Treecko",
-		fr: "Arcko"
+		fr: "Arcko",
+		de: "Geckarbor"
 	},
 
 	illustrator: "Akira Komayama",
@@ -32,11 +33,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Quick Attack",
-				fr: "Vive-Attaque"
+				fr: "Vive-Attaque",
+				de: "Ruckzuckhieb"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 more damage.",
-				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts supplémentaires."
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -53,7 +56,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Small hooks on the bottom of its feet catch on walls and ceilings. That is how it can hang from above."
+		en: "Small hooks on the bottom of its feet catch on walls and ceilings. That is how it can hang from above.",
+		de: "Dank seiner mit winzigen Stacheln besetzten Sohlen haftet es sogar kopfüber an Wänden und Decken."
 	},
 
 	variants: [

--- a/data/McDonald's Collection/McDonald's Collection 2021/4.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/4.ts
@@ -4,7 +4,8 @@ import Set from '../McDonald\'s Collection 2021'
 const card: Card = {
 	name: {
 		en: "Turtwig",
-		fr: "Tortipouss"
+		fr: "Tortipouss",
+		de: "Chelast"
 	},
 
 	illustrator: "OOYAMA",
@@ -32,7 +33,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Tackle",
-				fr: "Charge"
+				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 20,
@@ -46,7 +48,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Razor Leaf",
-				fr: "Tranch'Herbe"
+				fr: "Tranch'Herbe",
+				de: "Rasierblatt"
 			},
 
 			damage: 50,
@@ -64,7 +67,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It undertakes photosynthesis with its body, making oxygen. The leaf on its head wilts if it is thirsty."
+		en: "It undertakes photosynthesis with its body, making oxygen. The leaf on its head wilts if it is thirsty.",
+		de: "Sein Körper lebt von der Photosynthese, die Sauerstoff freisetzt. Ist es durstig, welkt sein Blatt."
 	},
 
 	variants: [

--- a/data/McDonald's Collection/McDonald's Collection 2021/5.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/5.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Snivy",
 		fr: "Vipélierre",
+		de: "Serpifeu"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -33,10 +34,12 @@ const card: Card = {
 			name: {
 				en: "Slam",
 				fr: "Souplesse",
+				de: "Slam"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 
@@ -60,7 +63,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It is very intelligent and calm. Being exposed to lots of sunlight makes its movements swifter."
+		en: "It is very intelligent and calm. Being exposed to lots of sunlight makes its movements swifter.",
+		de: "Eine kühle Denkernatur. Bekommt es genügend Sonnenlicht ab, erhöht sich die Geschwindigkeit seiner Bewegungen."
 	},
 	
 	variants: [

--- a/data/McDonald's Collection/McDonald's Collection 2021/6.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/6.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Chespin",
 		fr: "Marisson",
+		de: "Igamaro"
 	},
 
 	illustrator: "5ban Graphics",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Vine Whip",
 				fr: "Fouet Lianes",
+				de: "Rankenhieb"
 			},
 
 			damage: 10,
@@ -45,6 +47,7 @@ const card: Card = {
 			name: {
 				en: "Seed Bomb",
 				fr: "Canon Graine",
+				de: "Samenbomben"
 			},
 
 			damage: 20,
@@ -62,7 +65,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "The quills on its head are usually soft. When it flexes them, the points become so hard and sharp that they can pierce rock."
+		en: "The quills on its head are usually soft. When it flexes them, the points become so hard and sharp that they can pierce rock.",
+		de: "Wenn es seine Kraft auf die sonst eher weichen Stacheln auf seinem Kopf konzentriert, werden diese robust genug, um damit Steine zu zertrümmern."
 	},
 	
 	variants: [

--- a/data/McDonald's Collection/McDonald's Collection 2021/7.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/7.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Rowlet",
 		fr: "Brindibou",
+		de: "Bauz"
 	},
 
 	illustrator: "Megumi Mizutani",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 10,
@@ -45,6 +47,7 @@ const card: Card = {
 			name: {
 				en: "Leafage",
 				fr: "Feuillage",
+				de: "Blattwerk"
 			},
 
 			damage: 20,
@@ -62,7 +65,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "This wary Pokémon uses photosynthesis to store up energy during the day, while becoming active at night."
+		en: "This wary Pokémon uses photosynthesis to store up energy during the day, while becoming active at night.",
+		de: "Ein wachsames und nachtaktives Pokémon. Tagsüber sammelt es per Photosynthese Kräfte, um fit für die Nacht zu sein."
 	},
 
 	variants: [

--- a/data/McDonald's Collection/McDonald's Collection 2021/8.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/8.ts
@@ -6,6 +6,7 @@ const card: Card = {
 	name: {
 		en: "Grookey",
 		fr: "Ouistempo",
+		de: "Chimpep"
 	},
 
 	illustrator: "kirisAki",
@@ -29,6 +30,7 @@ const card: Card = {
 			name: {
 				en: "Branch Poke",
 				fr: "Tapotige",
+				de: "Zweigstoß"
 			},
 
 			damage: 30,
@@ -46,7 +48,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "When it uses its special stick to strike up a beat, the sound waves produced carry revitalizing energy to the plants and flowers in the area."
+		en: "When it uses its special stick to strike up a beat, the sound waves produced carry revitalizing energy to the plants and flowers in the area.",
+		de: "Der Rhythmus, den es mit seinem besonderen Schlägel erzeugt, verbreitet Schallwellen, die Pflanzen neue Vitalität verleihen können."
 	},
 
 	variants: [

--- a/data/McDonald's Collection/McDonald's Collection 2021/9.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2021/9.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Charmander",
 		fr: "Salamèche",
+		de: "Glumanda"
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Scratch",
 				fr: "Griffe",
+				de: "Kratzer"
 			},
 
 			damage: 10,
@@ -45,6 +47,7 @@ const card: Card = {
 			name: {
 				en: "Flame Tail",
 				fr: "Queue de Flammes",
+				de: "Flammenschweif"
 			},
 
 			damage: 20,
@@ -62,7 +65,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "The flame on its tail indicates Charmander’s life force. If it is healthy, the flame burns brightly."
+		en: "The flame on its tail indicates Charmander’s life force. If it is healthy, the flame burns brightly.",
+		de: "Die Flamme auf seiner Schweifspitze zeigt die Lebensenergie an. Ist es gesund, leuchtet sie hell."
 	},
 
 	variants: [


### PR DESCRIPTION
## Add missing German translations for 2021swsh

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
