### PR TITLE
fix(data): Add missing French evolveFrom translations for base2

### DIFF
--- a/data/Base/Jungle/11.ts
+++ b/data/Base/Jungle/11.ts
@@ -26,6 +26,7 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Munchlax",
+		fr: "Goinfrex",
 		it: "Munchlax",
 		de: "Mampfaxo"
 	},

--- a/data/Base/Jungle/22.ts
+++ b/data/Base/Jungle/22.ts
@@ -26,6 +26,7 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Mime Jr.",
+		fr: "Mime Jr.",
 		it: "Mime Jr.",
 		de: "Pantimimi"
 	},

--- a/data/Base/Jungle/27.ts
+++ b/data/Base/Jungle/27.ts
@@ -26,6 +26,7 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Munchlax",
+		fr: "Goinfrex",
 		it: "Munchlax",
 		de: "Mampfaxo"
 	},

--- a/data/Base/Jungle/6.ts
+++ b/data/Base/Jungle/6.ts
@@ -26,6 +26,7 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Mime Jr.",
+		fr: "Mime Jr.",
 		it: "Mime Jr.",
 		de: "Pantimimi"
 	},

--- a/data/Base/Jungle/60.ts
+++ b/data/Base/Jungle/60.ts
@@ -26,6 +26,7 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pichu",
+		fr: "Pichu",
 		it: "Pichu",
 		de: "Pichu"
 	},


### PR DESCRIPTION
## Changes

Adds the missing French `evolveFrom` values to the 5 Jungle (`base2`) cards that only carried the English one.

## Details

- Each French value is the `name.fr` already used by that Pokémon's own cards elsewhere in the database, so no new translation is introduced — existing ones are only propagated.
- Every value was cross-checked against the official French species names and matches exactly.
- Only the `fr` key is added, no other field is touched.

Same shape as #2101 (`me05`), part of a series covering the ~800 `evolveFrom` entries still missing their French value, one set per PR.
