### PR TITLE
fix(data): Add missing French evolveFrom translations for base3

### DIFF
--- a/data/Base/Fossil/39.ts
+++ b/data/Base/Fossil/39.ts
@@ -25,6 +25,7 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Magby",
+		fr: "Magby",
 		de: "Magby"
 	},
 


### PR DESCRIPTION
## Changes

Adds the missing French `evolveFrom` value to the single Fossil (`base3`) card that only carried the English one: `39.ts`, `Magby` → `Magby`.

## Details

- The French value is the `name.fr` already used by that Pokémon's own cards elsewhere in the database, and matches the official French species name.
- Only the `fr` key is added, no other field is touched.

Same shape as #2101 (`me05`), part of a series covering the ~800 `evolveFrom` entries still missing their French value, one set per PR.
