### PR TITLE
fix(data): Add missing French evolveFrom translations for tk-hs-r

### DIFF
--- a/data/Trainer kits/HS trainer Kit (Raichu)/19.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/19.ts
@@ -18,6 +18,7 @@ const card: Card = {
 	],
 	evolveFrom: {
 		en: "Pikachu",
+		fr: "Pikachu",
 	},
 	stage: "Stage1",
 	attacks: [


### PR DESCRIPTION
## Changes

Adds the missing French `evolveFrom` value to the single HS Trainer Kit (Raichu) (`tk-hs-r`) card that only carried the English one: `19.ts`, `Pikachu` → `Pikachu`.

## Details

- The French value is the `name.fr` already used by that Pokémon's own cards elsewhere in the database, and matches the official French species name.
- Only the `fr` key is added, no other field is touched.

Same shape as #2101 (`me05`), part of a series covering the ~800 `evolveFrom` entries still missing their French value, one set per PR.
