### PR TITLE
fix(data): Capitalize the second word of French fossil names in pl1

### DIFF
--- a/data/Platinum/Platinum/119.ts
+++ b/data/Platinum/Platinum/119.ts
@@ -4,7 +4,7 @@ import Set from '../Platinum'
 const card: Card = {
 	name: {
 		en: "Armor Fossil",
-		fr: "Fossile armure",
+		fr: "Fossile Armure",
 		de: "Schildfossil"
 	},
 

--- a/data/Platinum/Platinum/120.ts
+++ b/data/Platinum/Platinum/120.ts
@@ -4,7 +4,7 @@ import Set from '../Platinum'
 const card: Card = {
 	name: {
 		en: "Skull Fossil",
-		fr: "Fossile crâne",
+		fr: "Fossile Crâne",
 		de: "Kopffossil"
 	},
 

--- a/data/Platinum/Platinum/46.ts
+++ b/data/Platinum/Platinum/46.ts
@@ -23,7 +23,7 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Skull Fossil",
-		fr: "Fossile crâne"
+		fr: "Fossile Crâne"
 	},
 
 	stage: "Stage1",

--- a/data/Platinum/Platinum/62.ts
+++ b/data/Platinum/Platinum/62.ts
@@ -23,7 +23,7 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Armor Fossil",
-		fr: "Fossile armure"
+		fr: "Fossile Armure"
 	},
 
 	stage: "Stage1",


### PR DESCRIPTION
## Changes

Capitalizes the second word of the French fossil Trainer names in Platinum (`pl1`): `Fossile crâne` → `Fossile Crâne`, `Fossile armure` → `Fossile Armure`. 4 files.

## Details

- The French fossil names carry a capital on their second word, as shown in the official app.
- The database is already consistent with that for the other fossils — `Fossile Dôme`, `Fossile Nautile` and `Vieil Ambre` — so this only aligns the two that lagged behind.
- Affects both the Trainer cards' own `name.fr` and the `evolveFrom.fr` of the Pokémon evolving from them.
