### PR TITLE
fix(data): Capitalize the second word of French fossil names in dpp

### DIFF
--- a/data/Diamond & Pearl/DP Black Star Promos/DP07.ts
+++ b/data/Diamond & Pearl/DP Black Star Promos/DP07.ts
@@ -25,7 +25,7 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Skull Fossil",
-		fr: "Fossile crâne"
+		fr: "Fossile Crâne"
 	},
 
 	stage: "Stage1",

--- a/data/Diamond & Pearl/DP Black Star Promos/DP08.ts
+++ b/data/Diamond & Pearl/DP Black Star Promos/DP08.ts
@@ -25,7 +25,7 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Armor Fossil",
-		fr: "Fossile armure"
+		fr: "Fossile Armure"
 	},
 
 	stage: "Stage1",


### PR DESCRIPTION
## Changes

Capitalizes the second word of the French fossil Trainer names in DP Black Star Promos (`dpp`): `Fossile crâne` → `Fossile Crâne`, `Fossile armure` → `Fossile Armure`. 2 files.

## Details

- The French fossil names carry a capital on their second word, as shown in the official app.
- The database is already consistent with that for the other fossils — `Fossile Dôme`, `Fossile Nautile` and `Vieil Ambre` — so this only aligns the two that lagged behind.
- Affects both the Trainer cards' own `name.fr` and the `evolveFrom.fr` of the Pokémon evolving from them.
