### PR TITLE
fix(data): Capitalize the second word of French fossil names in dp2

### DIFF
--- a/data/Diamond & Pearl/Mysterious Treasures/116.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/116.ts
@@ -4,7 +4,7 @@ import Set from '../Mysterious Treasures'
 const card: Card = {
 	name: {
 		en: "Armor Fossil",
-		fr: "Fossile armure",
+		fr: "Fossile Armure",
 		de: "Panzerfossil"
 	},
 

--- a/data/Diamond & Pearl/Mysterious Treasures/117.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/117.ts
@@ -4,7 +4,7 @@ import Set from '../Mysterious Treasures'
 const card: Card = {
 	name: {
 		en: "Skull Fossil",
-		fr: "Fossile crâne",
+		fr: "Fossile Crâne",
 		de: "Kopffossil"
 	},
 

--- a/data/Diamond & Pearl/Mysterious Treasures/43.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/43.ts
@@ -25,7 +25,7 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Skull Fossil",
-		fr: "Fossile crâne",
+		fr: "Fossile Crâne",
 		de: "Kopffossil"
 	},
 

--- a/data/Diamond & Pearl/Mysterious Treasures/63.ts
+++ b/data/Diamond & Pearl/Mysterious Treasures/63.ts
@@ -25,7 +25,7 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Armor Fossil",
-		fr: "Fossile armure",
+		fr: "Fossile Armure",
 		de: "Panzerfossil"
 	},
 


### PR DESCRIPTION
## Changes

Capitalizes the second word of the French fossil Trainer names in Mysterious Treasures (`dp2`): `Fossile crâne` → `Fossile Crâne`, `Fossile armure` → `Fossile Armure`. 4 files.

## Details

- The French fossil names carry a capital on their second word, as shown in the official app.
- The database is already consistent with that for the other fossils — `Fossile Dôme`, `Fossile Nautile` and `Vieil Ambre` — so this only aligns the two that lagged behind.
- Affects both the Trainer cards' own `name.fr` and the `evolveFrom.fr` of the Pokémon evolving from them.
