### PR TITLE
fix(data): Add missing French evolveFrom translations for A1

### DIFF
--- a/data/Pokémon TCG Pocket/Genetic Apex/002.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/002.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Bulbasaur"
+		en: "Bulbasaur",
+		fr: "Bulbizarre"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/003.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/003.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Ivysaur"
+		en: "Ivysaur",
+		fr: "Herbizarre"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/004.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/004.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Ivysaur"
+		en: "Ivysaur",
+		fr: "Herbizarre"
 	},
 
 	suffix: "EX",

--- a/data/Pokémon TCG Pocket/Genetic Apex/006.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/006.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Caterpie"
+		en: "Caterpie",
+		fr: "Chenipan"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/007.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/007.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Metapod"
+		en: "Metapod",
+		fr: "Chrysacier"
 	},
 
 	abilities: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/009.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/009.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Weedle"
+		en: "Weedle",
+		fr: "Aspicot"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/010.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/010.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Kakuna"
+		en: "Kakuna",
+		fr: "Coconfort"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/012.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/012.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Oddish"
+		en: "Oddish",
+		fr: "Mystherbe"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/013.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/013.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Gloom"
+		en: "Gloom",
+		fr: "Ortide"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/015.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/015.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Paras"
+		en: "Paras",
+		fr: "Paras"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/017.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/017.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Venonat"
+		en: "Venonat",
+		fr: "Mimitoss"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/019.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/019.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Bellsprout"
+		en: "Bellsprout",
+		fr: "Chétiflor"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/020.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/020.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Weepinbell"
+		en: "Weepinbell",
+		fr: "Boustiflor"
 	},
 
 	abilities: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/022.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/022.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Exeggcute"
+		en: "Exeggcute",
+		fr: "Noeunoeuf"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/023.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/023.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Exeggcute"
+		en: "Exeggcute",
+		fr: "Noeunoeuf"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/028.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/028.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Cottonee"
+		en: "Cottonee",
+		fr: "Doudouvet"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/030.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/030.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Petilil"
+		en: "Petilil",
+		fr: "Chlorobule"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/032.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/032.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Skiddo"
+		en: "Skiddo",
+		fr: "Cabriolaine"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/034.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/034.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Charmander"
+		en: "Charmander",
+		fr: "Salamèche"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/035.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/035.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Charmeleon"
+		en: "Charmeleon",
+		fr: "Reptincel"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/036.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/036.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Charmeleon"
+		en: "Charmeleon",
+		fr: "Reptincel"
 	},
 
 	suffix: "EX",

--- a/data/Pokémon TCG Pocket/Genetic Apex/038.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/038.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Vulpix"
+		en: "Vulpix",
+		fr: "Goupix"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/040.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/040.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Growlithe"
+		en: "Growlithe",
+		fr: "Caninos"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/041.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/041.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Growlithe"
+		en: "Growlithe",
+		fr: "Caninos"
 	},
 
 	suffix: "EX",

--- a/data/Pokémon TCG Pocket/Genetic Apex/043.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/043.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Ponyta"
+		en: "Ponyta",
+		fr: "Ponyta"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/045.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/045.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/050.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/050.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Salandit"
+		en: "Salandit",
+		fr: "Tritox"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/052.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/052.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Sizzlipede"
+		en: "Sizzlipede",
+		fr: "Grillepattes"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/054.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/054.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Squirtle"
+		en: "Squirtle",
+		fr: "Carapuce"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/055.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/055.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Wartortle"
+		en: "Wartortle",
+		fr: "Carabaffe"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/056.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/056.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Wartortle"
+		en: "Wartortle",
+		fr: "Carabaffe"
 	},
 
 	suffix: "EX",

--- a/data/Pokémon TCG Pocket/Genetic Apex/058.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/058.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Psyduck"
+		en: "Psyduck",
+		fr: "Psykokwak"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/060.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/060.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Poliwag"
+		en: "Poliwag",
+		fr: "Ptitard"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/061.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/061.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Poliwhirl"
+		en: "Poliwhirl",
+		fr: "Têtarte"
 	},
 
 	abilities: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/063.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/063.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Tentacool"
+		en: "Tentacool",
+		fr: "Tentacool"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/065.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/065.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Seel"
+		en: "Seel",
+		fr: "Otaria"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/067.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/067.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Shellder"
+		en: "Shellder",
+		fr: "Kokiyas"
 	},
 
 	abilities: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/069.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/069.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Krabby"
+		en: "Krabby",
+		fr: "Krabby"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/071.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/071.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Horsea"
+		en: "Horsea",
+		fr: "Hypotrempe"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/073.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/073.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Goldeen"
+		en: "Goldeen",
+		fr: "Poissirène"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/075.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/075.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Staryu"
+		en: "Staryu",
+		fr: "Stari"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/076.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/076.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Staryu"
+		en: "Staryu",
+		fr: "Stari"
 	},
 
 	suffix: "EX",

--- a/data/Pokémon TCG Pocket/Genetic Apex/078.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/078.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Magikarp"
+		en: "Magikarp",
+		fr: "Magicarpe"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/080.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/080.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/081.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/081.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Helix Fossil"
+		en: "Helix Fossil",
+		fr: "Fossile Nautile"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/082.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/082.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Omanyte"
+		en: "Omanyte",
+		fr: "Amonita"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/086.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/086.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Ducklett"
+		en: "Ducklett",
+		fr: "Couaneton"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/088.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/088.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Froakie"
+		en: "Froakie",
+		fr: "Grenousse"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/089.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/089.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Frogadier"
+		en: "Frogadier",
+		fr: "Croâporal"
 	},
 
 	abilities: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/093.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/093.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Snom"
+		en: "Snom",
+		fr: "Frissonille"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/095.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/095.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Pikachu"
+		en: "Pikachu",
+		fr: "Pikachu"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/098.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/098.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Magnemite"
+		en: "Magnemite",
+		fr: "Magnéti"
 	},
 
 	abilities: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/100.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/100.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Voltorb"
+		en: "Voltorb",
+		fr: "Voltorbe"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/102.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/102.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/106.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/106.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Blitzle"
+		en: "Blitzle",
+		fr: "Zébibron"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/108.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/108.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Tynamo"
+		en: "Tynamo",
+		fr: "Anchwatt"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/109.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/109.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Eelektrik"
+		en: "Eelektrik",
+		fr: "Lampéroie"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/111.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/111.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Helioptile"
+		en: "Helioptile",
+		fr: "Galvaran"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/114.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/114.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Clefairy"
+		en: "Clefairy",
+		fr: "Mélofée"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/116.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/116.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Abra"
+		en: "Abra",
+		fr: "Abra"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/117.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/117.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Kadabra"
+		en: "Kadabra",
+		fr: "Kadabra"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/119.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/119.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Slowpoke"
+		en: "Slowpoke",
+		fr: "Ramoloss"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/121.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/121.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Gastly"
+		en: "Gastly",
+		fr: "Fantominus"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/122.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/122.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Haunter"
+		en: "Haunter",
+		fr: "Spectrum"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/123.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/123.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Haunter"
+		en: "Haunter",
+		fr: "Spectrum"
 	},
 
 	suffix: "EX",

--- a/data/Pokémon TCG Pocket/Genetic Apex/125.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/125.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Drowzee"
+		en: "Drowzee",
+		fr: "Soporifik"
 	},
 
 	abilities: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/131.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/131.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Ralts"
+		en: "Ralts",
+		fr: "Tarsal"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/132.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/132.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Kirlia"
+		en: "Kirlia",
+		fr: "Kirlia"
 	},
 
 	abilities: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/134.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/134.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Woobat"
+		en: "Woobat",
+		fr: "Chovsourir"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/136.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/136.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Golett"
+		en: "Golett",
+		fr: "Gringolem"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/138.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/138.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Sandshrew"
+		en: "Sandshrew",
+		fr: "Sabelette"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/140.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/140.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Diglett"
+		en: "Diglett",
+		fr: "Taupiqueur"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/142.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/142.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Mankey"
+		en: "Mankey",
+		fr: "Férosinge"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/144.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/144.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Machop"
+		en: "Machop",
+		fr: "Machoc"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/145.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/145.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Machoke"
+		en: "Machoke",
+		fr: "Machopeur"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/146.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/146.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Machoke"
+		en: "Machoke",
+		fr: "Machopeur"
 	},
 
 	suffix: "EX",

--- a/data/Pokémon TCG Pocket/Genetic Apex/148.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/148.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Geodude"
+		en: "Geodude",
+		fr: "Racaillou"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/149.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/149.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Graveler"
+		en: "Graveler",
+		fr: "Gravalanch"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/152.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/152.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Cubone"
+		en: "Cubone",
+		fr: "Osselait"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/153.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/153.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Cubone"
+		en: "Cubone",
+		fr: "Osselait"
 	},
 
 	suffix: "EX",

--- a/data/Pokémon TCG Pocket/Genetic Apex/157.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/157.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Rhyhorn"
+		en: "Rhyhorn",
+		fr: "Rhinocorne"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/158.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/158.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Dome Fossil"
+		en: "Dome Fossil",
+		fr: "Fossile Dôme"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/159.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/159.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Kabuto"
+		en: "Kabuto",
+		fr: "Kabuto"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/161.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/161.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Mienfoo"
+		en: "Mienfoo",
+		fr: "Kungfouine"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/163.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/163.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Clobbopus"
+		en: "Clobbopus",
+		fr: "Poulpaf"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/165.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/165.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Ekans"
+		en: "Ekans",
+		fr: "Abo"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/167.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/167.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Nidoran♀"
+		en: "Nidoran♀",
+		fr: "Nidoran♀"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/168.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/168.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Nidorina"
+		en: "Nidorina",
+		fr: "Nidorina"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/170.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/170.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Nidoran♂"
+		en: "Nidoran♂",
+		fr: "Nidoran♂"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/171.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/171.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Nidorino"
+		en: "Nidorino",
+		fr: "Nidorino"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/173.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/173.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Zubat"
+		en: "Zubat",
+		fr: "Nosferapti"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/175.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/175.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Grimer"
+		en: "Grimer",
+		fr: "Tadmorv"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/177.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/177.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Koffing"
+		en: "Koffing",
+		fr: "Smogo"
 	},
 
 	abilities: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/180.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/180.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Pawniard"
+		en: "Pawniard",
+		fr: "Scalpion"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/182.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/182.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Meltan"
+		en: "Meltan",
+		fr: "Meltan"
 	},
 
 	abilities: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/184.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/184.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Dratini"
+		en: "Dratini",
+		fr: "Minidraco"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/185.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/185.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Dragonair"
+		en: "Dragonair",
+		fr: "Draco"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/187.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/187.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Pidgey"
+		en: "Pidgey",
+		fr: "Roucool"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/188.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/188.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Pidgeotto"
+		en: "Pidgeotto",
+		fr: "Roucoups"
 	},
 
 	abilities: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/190.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/190.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Rattata"
+		en: "Rattata",
+		fr: "Rattata"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/192.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/192.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Spearow"
+		en: "Spearow",
+		fr: "Piafabec"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/194.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/194.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Jigglypuff"
+		en: "Jigglypuff",
+		fr: "Rondoudou"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/195.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/195.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Jigglypuff"
+		en: "Jigglypuff",
+		fr: "Rondoudou"
 	},
 
 	suffix: "EX",

--- a/data/Pokémon TCG Pocket/Genetic Apex/197.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/197.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Meowth"
+		en: "Meowth",
+		fr: "Miaouss"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/200.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/200.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Doduo"
+		en: "Doduo",
+		fr: "Doduo"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/210.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/210.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Old Amber"
+		en: "Old Amber",
+		fr: "Vieil Ambre"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/213.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/213.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Minccino"
+		en: "Minccino",
+		fr: "Chinchidou"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/215.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/215.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Wooloo"
+		en: "Wooloo",
+		fr: "Moumouton"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/228.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/228.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Oddish"
+		en: "Oddish",
+		fr: "Mystherbe"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/231.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/231.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Ponyta"
+		en: "Ponyta",
+		fr: "Ponyta"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/233.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/233.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Magikarp"
+		en: "Magikarp",
+		fr: "Magicarpe"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/235.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/235.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Voltorb"
+		en: "Voltorb",
+		fr: "Voltorbe"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/236.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/236.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Kadabra"
+		en: "Kadabra",
+		fr: "Kadabra"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/240.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/240.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Nidorina"
+		en: "Nidorina",
+		fr: "Nidorina"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/241.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/241.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Nidorino"
+		en: "Nidorino",
+		fr: "Nidorino"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/242.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/242.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Zubat"
+		en: "Zubat",
+		fr: "Nosferapti"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/243.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/243.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Koffing"
+		en: "Koffing",
+		fr: "Smogo"
 	},
 
 	abilities: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/244.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/244.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Dragonair"
+		en: "Dragonair",
+		fr: "Draco"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/245.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/245.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Pidgeotto"
+		en: "Pidgeotto",
+		fr: "Roucoups"
 	},
 
 	abilities: [{

--- a/data/Pokémon TCG Pocket/Genetic Apex/251.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/251.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Ivysaur"
+		en: "Ivysaur",
+		fr: "Herbizarre"
 	},
 
 	suffix: "EX",

--- a/data/Pokémon TCG Pocket/Genetic Apex/252.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/252.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Exeggcute"
+		en: "Exeggcute",
+		fr: "Noeunoeuf"
 	},
 
 	suffix: "EX",

--- a/data/Pokémon TCG Pocket/Genetic Apex/253.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/253.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Charmeleon"
+		en: "Charmeleon",
+		fr: "Reptincel"
 	},
 
 	suffix: "EX",

--- a/data/Pokémon TCG Pocket/Genetic Apex/254.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/254.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Growlithe"
+		en: "Growlithe",
+		fr: "Caninos"
 	},
 
 	suffix: "EX",

--- a/data/Pokémon TCG Pocket/Genetic Apex/256.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/256.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Wartortle"
+		en: "Wartortle",
+		fr: "Carabaffe"
 	},
 
 	suffix: "EX",

--- a/data/Pokémon TCG Pocket/Genetic Apex/257.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/257.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Staryu"
+		en: "Staryu",
+		fr: "Stari"
 	},
 
 	suffix: "EX",

--- a/data/Pokémon TCG Pocket/Genetic Apex/261.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/261.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Haunter"
+		en: "Haunter",
+		fr: "Spectrum"
 	},
 
 	suffix: "EX",

--- a/data/Pokémon TCG Pocket/Genetic Apex/263.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/263.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Machoke"
+		en: "Machoke",
+		fr: "Machopeur"
 	},
 
 	suffix: "EX",

--- a/data/Pokémon TCG Pocket/Genetic Apex/264.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/264.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Cubone"
+		en: "Cubone",
+		fr: "Osselait"
 	},
 
 	suffix: "EX",

--- a/data/Pokémon TCG Pocket/Genetic Apex/265.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/265.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Jigglypuff"
+		en: "Jigglypuff",
+		fr: "Rondoudou"
 	},
 
 	suffix: "EX",

--- a/data/Pokémon TCG Pocket/Genetic Apex/277.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/277.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Haunter"
+		en: "Haunter",
+		fr: "Spectrum"
 	},
 
 	suffix: "EX",

--- a/data/Pokémon TCG Pocket/Genetic Apex/278.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/278.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Machoke"
+		en: "Machoke",
+		fr: "Machopeur"
 	},
 
 	suffix: "EX",

--- a/data/Pokémon TCG Pocket/Genetic Apex/279.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/279.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Jigglypuff"
+		en: "Jigglypuff",
+		fr: "Rondoudou"
 	},
 
 	suffix: "EX",

--- a/data/Pokémon TCG Pocket/Genetic Apex/280.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/280.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Charmeleon"
+		en: "Charmeleon",
+		fr: "Reptincel"
 	},
 
 	suffix: "EX",

--- a/data/Pokémon TCG Pocket/Genetic Apex/284.ts
+++ b/data/Pokémon TCG Pocket/Genetic Apex/284.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Charmeleon"
+		en: "Charmeleon",
+		fr: "Reptincel"
 	},
 
 	suffix: "EX",


### PR DESCRIPTION
## Changes

Adds the missing French `evolveFrom` values to the 134 Genetic Apex (`A1`) cards that only carried the English one.

## Details

- Each French `evolveFrom` value is the `name.fr` already used by that Pokémon's own cards elsewhere in the database, so no new translation is introduced — existing ones are only propagated.
- Every value was cross-checked against the official French species names.

Same shape as #2101, part of a series covering the ~800 `evolveFrom` entries still missing their French value, one set per PR.
