### PR TITLE
fix(data): Add missing French evolveFrom translations for A4

### DIFF
--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/002.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/002.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Oddish"
+		en: "Oddish",
+		fr: "Mystherbe"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/003.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/003.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Gloom"
+		en: "Gloom",
+		fr: "Ortide"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/005.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/005.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Tangela"
+		en: "Tangela",
+		fr: "Saquedeneu"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/009.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/009.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Chikorita"
+		en: "Chikorita",
+		fr: "Germignon"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/010.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/010.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Bayleef"
+		en: "Bayleef",
+		fr: "Macronium"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/012.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/012.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Ledyba"
+		en: "Ledyba",
+		fr: "Coxy"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/014.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/014.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Hoppip"
+		en: "Hoppip",
+		fr: "Granivol"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/015.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/015.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Skiploom"
+		en: "Skiploom",
+		fr: "Floravol"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/017.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/017.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Sunkern"
+		en: "Sunkern",
+		fr: "Tournegrin"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/019.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/019.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Yanma"
+		en: "Yanma",
+		fr: "Yanma"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/024.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/024.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Cherubi"
+		en: "Cherubi",
+		fr: "Ceribou"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/026.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/026.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Vulpix"
+		en: "Vulpix",
+		fr: "Goupix"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/028.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/028.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Cyndaquil"
+		en: "Cyndaquil",
+		fr: "Héricendre"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/029.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/029.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Quilava"
+		en: "Quilava",
+		fr: "Feurisson"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/031.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/031.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Slugma"
+		en: "Slugma",
+		fr: "Limagma"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/036.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/036.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Darumaka"
+		en: "Darumaka",
+		fr: "Darumarond"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/039.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/039.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Poliwag"
+		en: "Poliwag",
+		fr: "Ptitard"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/040.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/040.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Poliwhirl"
+		en: "Poliwhirl",
+		fr: "Têtarte"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/042.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/042.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Horsea"
+		en: "Horsea",
+		fr: "Hypotrempe"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/043.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/043.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Seadra"
+		en: "Seadra",
+		fr: "Hypocéan"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/045.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/045.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Magikarp"
+		en: "Magikarp",
+		fr: "Magicarpe"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/047.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/047.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Totodile"
+		en: "Totodile",
+		fr: "Kaiminus"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/048.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/048.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Croconaw"
+		en: "Croconaw",
+		fr: "Crocrodil"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/050.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/050.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Marill"
+		en: "Marill",
+		fr: "Marill"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/052.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/052.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Wooper"
+		en: "Wooper",
+		fr: "Axoloto"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/056.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/056.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Remoraid"
+		en: "Remoraid",
+		fr: "Rémoraid"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/061.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/061.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Corphish"
+		en: "Corphish",
+		fr: "Écrapince"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/063.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/063.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Ducklett"
+		en: "Ducklett",
+		fr: "Couaneton"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/065.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/065.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Chinchou"
+		en: "Chinchou",
+		fr: "Loupio"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/068.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/068.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Mareep"
+		en: "Mareep",
+		fr: "Wattouat"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/069.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/069.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Flaaffy"
+		en: "Flaaffy",
+		fr: "Lainergie"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/074.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/074.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Slowpoke"
+		en: "Slowpoke",
+		fr: "Ramoloss"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/079.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/079.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Togepi"
+		en: "Togepi",
+		fr: "Togepi"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/080.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/080.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Togetic"
+		en: "Togetic",
+		fr: "Togetic"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/082.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/082.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Natu"
+		en: "Natu",
+		fr: "Natu"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/083.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/083.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/089.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/089.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Snubbull"
+		en: "Snubbull",
+		fr: "Snubbull"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/091.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/091.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Munna"
+		en: "Munna",
+		fr: "Munna"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/095.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/095.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Gligar"
+		en: "Gligar",
+		fr: "Scorplane"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/097.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/097.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Swinub"
+		en: "Swinub",
+		fr: "Marcacrin"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/098.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/098.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Piloswine"
+		en: "Piloswine",
+		fr: "Cochignon"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/100.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/100.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Phanpy"
+		en: "Phanpy",
+		fr: "Phanpy"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/104.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/104.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Larvitar"
+		en: "Larvitar",
+		fr: "Embrylex"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/106.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/106.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Binacle"
+		en: "Binacle",
+		fr: "Opermine"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/108.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/108.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Zubat"
+		en: "Zubat",
+		fr: "Nosferapti"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/109.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/109.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Golbat"
+		en: "Golbat",
+		fr: "Nosferalto"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/111.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/111.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Spinarak"
+		en: "Spinarak",
+		fr: "Mimigal"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/112.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/112.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/114.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/114.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Murkrow"
+		en: "Murkrow",
+		fr: "Cornèbre"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/116.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/116.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Sneasel"
+		en: "Sneasel",
+		fr: "Farfuret"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/118.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/118.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Houndour"
+		en: "Houndour",
+		fr: "Malosse"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/119.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/119.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Pupitar"
+		en: "Pupitar",
+		fr: "Ymphect"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/121.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/121.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Pineco"
+		en: "Pineco",
+		fr: "Pomdepik"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/122.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/122.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Onix"
+		en: "Onix",
+		fr: "Onix"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/123.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/123.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Scyther"
+		en: "Scyther",
+		fr: "Insécateur"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/127.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/127.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Klink"
+		en: "Klink",
+		fr: "Tic"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/128.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/128.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Klang"
+		en: "Klang",
+		fr: "Clic"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/130.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/130.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Spearow"
+		en: "Spearow",
+		fr: "Piafabec"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/132.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/132.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Chansey"
+		en: "Chansey",
+		fr: "Leveinard"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/136.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/136.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Porygon"
+		en: "Porygon",
+		fr: "Porygon"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/137.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/137.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Porygon2"
+		en: "Porygon2",
+		fr: "Porygon2"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/139.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/139.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Sentret"
+		en: "Sentret",
+		fr: "Fouinette"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/141.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/141.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Hoothoot"
+		en: "Hoothoot",
+		fr: "Hoothoot"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/143.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/143.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Aipom"
+		en: "Aipom",
+		fr: "Capumain"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/146.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/146.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Teddiursa"
+		en: "Teddiursa",
+		fr: "Teddiursa"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/163.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/163.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Gloom"
+		en: "Gloom",
+		fr: "Ortide"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/169.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/169.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Remoraid"
+		en: "Remoraid",
+		fr: "Rémoraid"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/172.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/172.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Flaaffy"
+		en: "Flaaffy",
+		fr: "Lainergie"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/174.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/174.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Natu"
+		en: "Natu",
+		fr: "Natu"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/179.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/179.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Pupitar"
+		en: "Pupitar",
+		fr: "Ymphect"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/180.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/180.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Scyther"
+		en: "Scyther",
+		fr: "Insécateur"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/185.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/185.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Chansey"
+		en: "Chansey",
+		fr: "Leveinard"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/188.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/188.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Seadra"
+		en: "Seadra",
+		fr: "Hypocéan"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/189.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/189.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Chinchou"
+		en: "Chinchou",
+		fr: "Loupio"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/190.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/190.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/191.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/191.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Phanpy"
+		en: "Phanpy",
+		fr: "Phanpy"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/192.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/192.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Golbat"
+		en: "Golbat",
+		fr: "Nosferalto"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/193.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/193.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/203.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/203.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Seadra"
+		en: "Seadra",
+		fr: "Hypocéan"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/204.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/204.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Chinchou"
+		en: "Chinchou",
+		fr: "Loupio"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/205.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/205.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/206.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/206.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Phanpy"
+		en: "Phanpy",
+		fr: "Phanpy"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/207.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/207.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Golbat"
+		en: "Golbat",
+		fr: "Nosferalto"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/208.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/208.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/213.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/213.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/215.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/215.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Magikarp"
+		en: "Magikarp",
+		fr: "Magicarpe"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/216.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/216.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/218.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/218.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Magnemite"
+		en: "Magnemite",
+		fr: "Magnéti"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/219.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/219.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/222.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/222.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Mankey"
+		en: "Mankey",
+		fr: "Férosinge"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/224.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/224.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Nidoran♀"
+		en: "Nidoran♀",
+		fr: "Nidoran♀"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/225.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/225.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Nidorina"
+		en: "Nidorina",
+		fr: "Nidorina"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/227.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/227.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Nidoran♂"
+		en: "Nidoran♂",
+		fr: "Nidoran♂"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/228.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/228.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Nidorino"
+		en: "Nidorino",
+		fr: "Nidorino"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/232.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/232.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Yanma"
+		en: "Yanma",
+		fr: "Yanma"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/233.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/233.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/234.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/234.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Magikarp"
+		en: "Magikarp",
+		fr: "Magicarpe"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/235.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/235.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/237.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/237.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Misdreavus"
+		en: "Misdreavus",
+		fr: "Feuforêve"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/238.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/238.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Sneasel"
+		en: "Sneasel",
+		fr: "Farfuret"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/239.ts
+++ b/data/Pokémon TCG Pocket/Wisdom of Sea and Sky/239.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Lickitung"
+		en: "Lickitung",
+		fr: "Excelangue"
 	},
 
 	stage: "Stage1",


### PR DESCRIPTION
## Changes

Adds the missing French `evolveFrom` values to the 101 Wisdom of Sea and Sky (`A4`) cards that only carried the English one.

## Details

- Each French `evolveFrom` value is the `name.fr` already used by that Pokémon's own cards elsewhere in the database, so no new translation is introduced — existing ones are only propagated.
- Every value was cross-checked against the official French species names.

Same shape as #2101, part of a series covering the ~800 `evolveFrom` entries still missing their French value, one set per PR.
