### PR TITLE
fix(data): Add missing French evolveFrom translations and repair regional form names for A3

### DIFF
--- a/data/Pokémon TCG Pocket/Celestial Guardians/002.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/002.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Exeggcute"
+		en: "Exeggcute",
+		fr: "Noeunoeuf"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/002.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/002.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Alolan Exeggutor",
-		fr: "Noadkokod'Alola",
-		es: "Exeggutorde Alola",
-		it: "Exeggutordi Alola",
+		fr: "Noadkoko d’Alola",
+		es: "Exeggutor de Alola",
+		it: "Exeggutor di Alola",
 		de: "Alola-Kokowei",
-		'pt-br': "Exeggutorde Alola",
+		'pt-br': "Exeggutor de Alola",
 		ko: "알로라나시"
 	},
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/004.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/004.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Surskit"
+		en: "Surskit",
+		fr: "Arakdo"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/008.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/008.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Phantump"
+		en: "Phantump",
+		fr: "Brocélôme"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/011.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/011.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Rowlet"
+		en: "Rowlet",
+		fr: "Brindibou"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/012.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/012.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Dartrix"
+		en: "Dartrix",
+		fr: "Efflèche"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/015.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/015.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Fomantis"
+		en: "Fomantis",
+		fr: "Mimantis"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/017.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/017.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Morelull"
+		en: "Morelull",
+		fr: "Spododo"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/019.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/019.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Bounsweet"
+		en: "Bounsweet",
+		fr: "Croquine"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/020.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/020.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Steenee"
+		en: "Steenee",
+		fr: "Candine"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/022.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/022.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Wimpod"
+		en: "Wimpod",
+		fr: "Sovkipou"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/026.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/026.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Growlithe"
+		en: "Growlithe",
+		fr: "Caninos"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/027.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/027.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Alolan Marowak",
-		fr: "Ossatueurd'Alola",
-		es: "Marowakde Alola",
-		it: "Marowakdi Alola",
+		fr: "Ossatueur d’Alola",
+		es: "Marowak de Alola",
+		it: "Marowak di Alola",
 		de: "Alola-Knogga",
-		'pt-br': "Marowakde Alola",
+		'pt-br': "Marowak de Alola",
 		ko: "알로라텅구리"
 	},
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/027.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/027.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Cubone"
+		en: "Cubone",
+		fr: "Osselait"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/028.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/028.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Fletchling"
+		en: "Fletchling",
+		fr: "Passerouge"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/029.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/029.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Fletchinder"
+		en: "Fletchinder",
+		fr: "Braisillon"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/032.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/032.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Litten"
+		en: "Litten",
+		fr: "Flamiaou"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/033.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/033.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Torracat"
+		en: "Torracat",
+		fr: "Matoufeu"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/036.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/036.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Salandit"
+		en: "Salandit",
+		fr: "Tritox"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/038.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/038.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Alolan Sandshrew",
-		fr: "Sabeletted'Alola",
-		es: "Sandshrewde Alola",
-		it: "Sandshrewdi Alola",
+		fr: "Sabelette d’Alola",
+		es: "Sandshrew de Alola",
+		it: "Sandshrew di Alola",
 		de: "Alola-Sandan",
-		'pt-br': "Sandshrewde Alola",
+		'pt-br': "Sandshrew de Alola",
 		ko: "알로라모래두지"
 	},
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/039.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/039.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Alolan Sandslash",
-		fr: "Sablaireaud'Alola",
-		es: "Sandslashde Alola",
-		it: "Sandslashdi Alola",
+		fr: "Sablaireau d’Alola",
+		es: "Sandslash de Alola",
+		it: "Sandslash di Alola",
 		de: "Alola-Sandamer",
-		'pt-br': "Sandslashde Alola",
+		'pt-br': "Sandslash de Alola",
 		ko: "알로라고지"
 	},
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/039.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/039.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Alolan Sandshrew"
+		en: "Alolan Sandshrew",
+		fr: "Sabelette d’Alola"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/040.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/040.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Alolan Vulpix",
-		fr: "Goupixd'Alola",
-		es: "Vulpixde Alola",
-		it: "Vulpixdi Alola",
+		fr: "Goupix d’Alola",
+		es: "Vulpix de Alola",
+		it: "Vulpix di Alola",
 		de: "Alola-Vulpix",
-		'pt-br': "Vulpixde Alola",
+		'pt-br': "Vulpix de Alola",
 		ko: "알로라식스테일"
 	},
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/041.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/041.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Alolan Vulpix"
+		en: "Alolan Vulpix",
+		fr: "Goupix d’Alola"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/041.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/041.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Alolan Ninetales",
-		fr: "Feunardd'Alola",
-		es: "Ninetalesde Alola",
-		it: "Ninetalesdi Alola",
+		fr: "Feunard d’Alola",
+		es: "Ninetales de Alola",
+		it: "Ninetales di Alola",
 		de: "Alola-Vulnona",
-		'pt-br': "Ninetalesde Alola",
+		'pt-br': "Ninetales de Alola",
 		ko: "알로라나인테일"
 	},
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/043.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/043.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Shellder"
+		en: "Shellder",
+		fr: "Kokiyas"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/047.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/047.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Popplio"
+		en: "Popplio",
+		fr: "Otaquin"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/048.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/048.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Brionne"
+		en: "Brionne",
+		fr: "Otarlette"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/049.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/049.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Crabrawler"
+		en: "Crabrawler",
+		fr: "Crabagarre"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/053.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/053.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Dewpider"
+		en: "Dewpider",
+		fr: "Araqua"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/058.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/058.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Pikachu"
+		en: "Pikachu",
+		fr: "Pikachu"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/058.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/058.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Alolan Raichu ex",
-		fr: "Raichud'Alola-ex",
-		es: "Raichude Alola ex",
-		it: "Raichudi Alola-ex",
+		fr: "Raichu d’Alola-ex",
+		es: "Raichu de Alola ex",
+		it: "Raichu di Alola-ex",
 		de: "Alola-Raichu-ex",
-		'pt-br': "Raichude Alola ex",
+		'pt-br': "Raichu de Alola ex",
 		ko: "알로라라이츄 ex"
 	},
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/059.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/059.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Alolan Geodude",
-		fr: "Racailloud'Alola",
-		es: "Geodudede Alola",
-		it: "Geodudedi Alola",
+		fr: "Racaillou d’Alola",
+		es: "Geodude de Alola",
+		it: "Geodude di Alola",
 		de: "Alola-Kleinstein",
-		'pt-br': "Geodudede Alola",
+		'pt-br': "Geodude de Alola",
 		ko: "알로라꼬마돌"
 	},
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/060.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/060.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Alolan Graveler",
-		fr: "Gravalanchd'Alola",
-		es: "Gravelerde Alola",
-		it: "Gravelerdi Alola",
+		fr: "Gravalanch d’Alola",
+		es: "Graveler de Alola",
+		it: "Graveler di Alola",
 		de: "Alola-Georok",
-		'pt-br': "Gravelerde Alola",
+		'pt-br': "Graveler de Alola",
 		ko: "알로라데구리"
 	},
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/060.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/060.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Alolan Geodude"
+		en: "Alolan Geodude",
+		fr: "Racaillou d’Alola"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/061.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/061.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Alolan Golem",
-		fr: "Grolemd'Alola",
-		es: "Golemde Alola",
-		it: "Golemdi Alola",
+		fr: "Grolem d’Alola",
+		es: "Golem de Alola",
+		it: "Golem di Alola",
 		de: "Alola-Geowaz",
-		'pt-br': "Golemde Alola",
+		'pt-br': "Golem de Alola",
 		ko: "알로라딱구리"
 	},
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/061.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/061.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Alolan Graveler"
+		en: "Alolan Graveler",
+		fr: "Gravalanch d’Alola"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/063.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/063.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Helioptile"
+		en: "Helioptile",
+		fr: "Galvaran"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/064.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/064.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Grubbin"
+		en: "Grubbin",
+		fr: "Larvibule"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/065.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/065.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Charjabug"
+		en: "Charjabug",
+		fr: "Chrysapile"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/072.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/072.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Spoink"
+		en: "Spoink",
+		fr: "Spoink"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/075.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/075.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Shuppet"
+		en: "Shuppet",
+		fr: "Polichombr"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/079.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/079.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Cutiefly"
+		en: "Cutiefly",
+		fr: "Bombydou"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/082.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/082.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Sandygast"
+		en: "Sandygast",
+		fr: "Bacabouh"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/086.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/086.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Cosmog"
+		en: "Cosmog",
+		fr: "Cosmog"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/087.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/087.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Cosmoem"
+		en: "Cosmoem",
+		fr: "Cosmovum"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/091.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/091.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Makuhita"
+		en: "Makuhita",
+		fr: "Makuhita"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/095.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/095.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Timburr"
+		en: "Timburr",
+		fr: "Charpenti"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/096.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/096.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Gurdurr"
+		en: "Gurdurr",
+		fr: "Ouvrifier"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/100.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/100.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Rockruff"
+		en: "Rockruff",
+		fr: "Rocabot"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/101.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/101.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Rockruff"
+		en: "Rockruff",
+		fr: "Rocabot"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/103.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/103.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Mudbray"
+		en: "Mudbray",
+		fr: "Tiboudet"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/106.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/106.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Alolan Rattata",
-		fr: "Rattatad'Alola",
-		es: "Rattatade Alola",
-		it: "Rattatadi Alola",
+		fr: "Rattata d’Alola",
+		es: "Rattata de Alola",
+		it: "Rattata di Alola",
 		de: "Alola-Rattfratz",
-		'pt-br': "Rattatade Alola",
+		'pt-br': "Rattata de Alola",
 		ko: "알로라꼬렛"
 	},
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/107.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/107.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Alolan Raticate",
-		fr: "Rattatacd'Alola",
-		es: "Raticatede Alola",
-		it: "Raticatedi Alola",
+		fr: "Rattatac d’Alola",
+		es: "Raticate de Alola",
+		it: "Raticate di Alola",
 		de: "Alola-Rattikarl",
-		'pt-br': "Raticatede Alola",
+		'pt-br': "Raticate de Alola",
 		ko: "알로라레트라"
 	},
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/107.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/107.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Alolan Rattata"
+		en: "Alolan Rattata",
+		fr: "Rattata d’Alola"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/108.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/108.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Alolan Meowth",
-		fr: "Miaoussd'Alola",
-		es: "Meowthde Alola",
-		it: "Meowthdi Alola",
+		fr: "Miaouss d’Alola",
+		es: "Meowth de Alola",
+		it: "Meowth di Alola",
 		de: "Alola-Mauzi",
-		'pt-br': "Meowthde Alola",
+		'pt-br': "Meowth de Alola",
 		ko: "알로라나옹"
 	},
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/109.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/109.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Alolan Persian",
-		fr: "Persiand'Alola",
-		es: "Persiande Alola",
-		it: "Persiandi Alola",
+		fr: "Persian d’Alola",
+		es: "Persian de Alola",
+		it: "Persian di Alola",
 		de: "Alola-Snobilikat",
-		'pt-br': "Persiande Alola",
+		'pt-br': "Persian de Alola",
 		ko: "알로라페르시온"
 	},
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/109.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/109.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Alolan Meowth"
+		en: "Alolan Meowth",
+		fr: "Miaouss d’Alola"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/110.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/110.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Alolan Grimer",
-		fr: "Tadmorvd'Alola",
-		es: "Grimerde Alola",
-		it: "Grimerdi Alola",
+		fr: "Tadmorv d’Alola",
+		es: "Grimer de Alola",
+		it: "Grimer di Alola",
 		de: "Alola-Sleima",
-		'pt-br': "Grimerde Alola",
+		'pt-br': "Grimer de Alola",
 		ko: "알로라질퍽이"
 	},
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/111.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/111.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Alolan Muk ex",
-		fr: "Grotadmorvd'Alola-ex",
-		es: "Mukde Alola ex",
-		it: "Mukdi Alola-ex",
+		fr: "Grotadmorv d’Alola-ex",
+		es: "Muk de Alola ex",
+		it: "Muk di Alola-ex",
 		de: "Alola-Sleimok-ex",
-		'pt-br': "Mukde Alola ex",
+		'pt-br': "Muk de Alola ex",
 		ko: "알로라질뻐기 ex"
 	},
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/111.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/111.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Alolan Grimer"
+		en: "Alolan Grimer",
+		fr: "Tadmorv d’Alola"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/114.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/114.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Trubbish"
+		en: "Trubbish",
+		fr: "Miamiasme"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/116.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/116.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Mareanie"
+		en: "Mareanie",
+		fr: "Vorastérie"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/117.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/117.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Alolan Diglett",
-		fr: "Taupiqueurd'Alola",
-		es: "Diglettde Alola",
-		it: "Diglettdi Alola",
+		fr: "Taupiqueur d’Alola",
+		es: "Diglett de Alola",
+		it: "Diglett di Alola",
 		de: "Alola-Digda",
-		'pt-br': "Diglettde Alola",
+		'pt-br': "Diglett de Alola",
 		ko: "알로라디그다"
 	},
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/118.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/118.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Alolan Diglett"
+		en: "Alolan Diglett",
+		fr: "Taupiqueur d’Alola"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/118.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/118.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Alolan Dugtrio",
-		fr: "Triopikeurd'Alola",
-		es: "Dugtriode Alola",
-		it: "Dugtriodi Alola",
+		fr: "Triopikeur d’Alola",
+		es: "Dugtrio de Alola",
+		it: "Dugtrio di Alola",
 		de: "Alola-Digdri",
-		'pt-br': "Dugtriode Alola",
+		'pt-br': "Dugtrio de Alola",
 		ko: "알로라닥트리오"
 	},
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/119.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/119.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Drilbur"
+		en: "Drilbur",
+		fr: "Rototaupe"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/120.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/120.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Karrablast"
+		en: "Karrablast",
+		fr: "Carabing"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/122.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/122.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Cosmoem"
+		en: "Cosmoem",
+		fr: "Cosmovum"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/126.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/126.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Dragon"],
 
 	evolveFrom: {
-		en: "Jangmo-o"
+		en: "Jangmo-o",
+		fr: "Bébécaille"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/127.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/127.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Dragon"],
 
 	evolveFrom: {
-		en: "Hakamo-o"
+		en: "Hakamo-o",
+		fr: "Écaïd"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/130.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/130.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Skitty"
+		en: "Skitty",
+		fr: "Skitty"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/134.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/134.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Pikipek"
+		en: "Pikipek",
+		fr: "Picassaut"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/135.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/135.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Trumbeak"
+		en: "Trumbeak",
+		fr: "Piclairon"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/137.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/137.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Yungoos"
+		en: "Yungoos",
+		fr: "Manglouton"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/139.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/139.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Stufful"
+		en: "Stufful",
+		fr: "Nounourson"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/156.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/156.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Exeggcute"
+		en: "Exeggcute",
+		fr: "Noeunoeuf"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/156.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/156.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Alolan Exeggutor",
-		fr: "Noadkokod'Alola",
-		es: "Exeggutorde Alola",
-		it: "Exeggutordi Alola",
+		fr: "Noadkoko d’Alola",
+		es: "Exeggutor de Alola",
+		it: "Exeggutor di Alola",
 		de: "Alola-Kokowei",
-		'pt-br': "Exeggutorde Alola",
+		'pt-br': "Exeggutor de Alola",
 		ko: "알로라나시"
 	},
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/158.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/158.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Steenee"
+		en: "Steenee",
+		fr: "Candine"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/160.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/160.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Alolan Marowak",
-		fr: "Ossatueurd'Alola",
-		es: "Marowakde Alola",
-		it: "Marowakdi Alola",
+		fr: "Ossatueur d’Alola",
+		es: "Marowak de Alola",
+		it: "Marowak di Alola",
 		de: "Alola-Knogga",
-		'pt-br': "Marowakde Alola",
+		'pt-br': "Marowak de Alola",
 		ko: "알로라텅구리"
 	},
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/160.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/160.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Cubone"
+		en: "Cubone",
+		fr: "Osselait"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/162.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/162.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Alolan Vulpix",
-		fr: "Goupixd'Alola",
-		es: "Vulpixde Alola",
-		it: "Vulpixdi Alola",
+		fr: "Goupix d’Alola",
+		es: "Vulpix de Alola",
+		it: "Vulpix di Alola",
 		de: "Alola-Vulpix",
-		'pt-br': "Vulpixde Alola",
+		'pt-br': "Vulpix de Alola",
 		ko: "알로라식스테일"
 	},
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/173.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/173.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Mudbray"
+		en: "Mudbray",
+		fr: "Tiboudet"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/178.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/178.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Stufful"
+		en: "Stufful",
+		fr: "Nounourson"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/180.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/180.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Dartrix"
+		en: "Dartrix",
+		fr: "Efflèche"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/182.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/182.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Torracat"
+		en: "Torracat",
+		fr: "Matoufeu"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/183.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/183.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Crabrawler"
+		en: "Crabrawler",
+		fr: "Crabagarre"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/185.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/185.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Pikachu"
+		en: "Pikachu",
+		fr: "Pikachu"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/185.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/185.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Alolan Raichu ex",
-		fr: "Raichud'Alola-ex",
-		es: "Raichude Alola ex",
-		it: "Raichudi Alola-ex",
+		fr: "Raichu d’Alola-ex",
+		es: "Raichu de Alola ex",
+		it: "Raichu di Alola-ex",
 		de: "Alola-Raichu-ex",
-		'pt-br': "Raichude Alola ex",
+		'pt-br': "Raichu de Alola ex",
 		ko: "알로라라이츄 ex"
 	},
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/186.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/186.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Cosmoem"
+		en: "Cosmoem",
+		fr: "Cosmovum"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/188.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/188.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Alolan Muk ex",
-		fr: "Grotadmorvd'Alola-ex",
-		es: "Mukde Alola ex",
-		it: "Mukdi Alola-ex",
+		fr: "Grotadmorv d’Alola-ex",
+		es: "Muk de Alola ex",
+		it: "Muk di Alola-ex",
 		de: "Alola-Sleimok-ex",
-		'pt-br': "Mukde Alola ex",
+		'pt-br': "Muk de Alola ex",
 		ko: "알로라질뻐기 ex"
 	},
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/188.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/188.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Alolan Grimer"
+		en: "Alolan Grimer",
+		fr: "Tadmorv d’Alola"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/189.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/189.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Cosmoem"
+		en: "Cosmoem",
+		fr: "Cosmovum"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/198.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/198.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Dartrix"
+		en: "Dartrix",
+		fr: "Efflèche"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/200.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/200.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Torracat"
+		en: "Torracat",
+		fr: "Matoufeu"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/201.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/201.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Crabrawler"
+		en: "Crabrawler",
+		fr: "Crabagarre"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/203.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/203.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Pikachu"
+		en: "Pikachu",
+		fr: "Pikachu"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/203.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/203.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Alolan Raichu ex",
-		fr: "Raichud'Alola-ex",
-		es: "Raichude Alola ex",
-		it: "Raichudi Alola-ex",
+		fr: "Raichu d’Alola-ex",
+		es: "Raichu de Alola ex",
+		it: "Raichu di Alola-ex",
 		de: "Alola-Raichu-ex",
-		'pt-br': "Raichude Alola ex",
+		'pt-br': "Raichu de Alola ex",
 		ko: "알로라라이츄 ex"
 	},
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/204.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/204.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Cosmoem"
+		en: "Cosmoem",
+		fr: "Cosmovum"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/206.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/206.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Alolan Muk ex",
-		fr: "Grotadmorvd'Alola-ex",
-		es: "Mukde Alola ex",
-		it: "Mukdi Alola-ex",
+		fr: "Grotadmorv d’Alola-ex",
+		es: "Muk de Alola ex",
+		it: "Muk di Alola-ex",
 		de: "Alola-Sleimok-ex",
-		'pt-br': "Mukde Alola ex",
+		'pt-br': "Muk de Alola ex",
 		ko: "알로라질뻐기 ex"
 	},
 

--- a/data/Pokémon TCG Pocket/Celestial Guardians/206.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/206.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Alolan Grimer"
+		en: "Alolan Grimer",
+		fr: "Tadmorv d’Alola"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/207.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/207.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Cosmoem"
+		en: "Cosmoem",
+		fr: "Cosmovum"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/211.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/211.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Bulbasaur"
+		en: "Bulbasaur",
+		fr: "Bulbizarre"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/212.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/212.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Ivysaur"
+		en: "Ivysaur",
+		fr: "Herbizarre"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/214.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/214.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Exeggcute"
+		en: "Exeggcute",
+		fr: "Noeunoeuf"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/216.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/216.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Squirtle"
+		en: "Squirtle",
+		fr: "Carapuce"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/217.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/217.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Wartortle"
+		en: "Wartortle",
+		fr: "Carabaffe"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/219.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/219.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Staryu"
+		en: "Staryu",
+		fr: "Stari"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/221.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/221.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Gastly"
+		en: "Gastly",
+		fr: "Fantominus"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/222.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/222.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Haunter"
+		en: "Haunter",
+		fr: "Spectrum"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/224.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/224.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Machop"
+		en: "Machop",
+		fr: "Machoc"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/225.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/225.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Machoke"
+		en: "Machoke",
+		fr: "Machopeur"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/227.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/227.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Cubone"
+		en: "Cubone",
+		fr: "Osselait"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/229.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/229.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Jigglypuff"
+		en: "Jigglypuff",
+		fr: "Rondoudou"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Celestial Guardians/230.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/230.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Ivysaur"
+		en: "Ivysaur",
+		fr: "Herbizarre"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/231.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/231.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Exeggcute"
+		en: "Exeggcute",
+		fr: "Noeunoeuf"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/232.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/232.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Wartortle"
+		en: "Wartortle",
+		fr: "Carabaffe"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/233.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/233.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Staryu"
+		en: "Staryu",
+		fr: "Stari"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/234.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/234.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Haunter"
+		en: "Haunter",
+		fr: "Spectrum"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/235.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/235.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Machoke"
+		en: "Machoke",
+		fr: "Machopeur"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/236.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/236.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Cubone"
+		en: "Cubone",
+		fr: "Osselait"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/237.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/237.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Jigglypuff"
+		en: "Jigglypuff",
+		fr: "Rondoudou"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/238.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/238.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Cosmoem"
+		en: "Cosmoem",
+		fr: "Cosmovum"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Celestial Guardians/239.ts
+++ b/data/Pokémon TCG Pocket/Celestial Guardians/239.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Cosmoem"
+		en: "Cosmoem",
+		fr: "Cosmovum"
 	},
 
 	stage: "Stage2",


### PR DESCRIPTION
## Changes

Adds the missing French `evolveFrom` values to the 99 Celestial Guardians (`A3`) cards that only carried the English one. Also repairs 100 regional form names whose connector had lost its space.

## Details

- Each French `evolveFrom` value is the `name.fr` already used by that Pokémon's own cards elsewhere in the database, so no new translation is introduced — existing ones are only propagated.
- Every value was cross-checked against the official French species names.
- The regional form names were glued to their connector in fr, es, it and pt-br alike (`Exeggutorde Alola`, `Vulpixdi Alola`, `Noadkokod'Alola`). The space is restored in each language's own form, card suffixes such as `-ex` are preserved, and the French elision now uses the typographic apostrophe already dominant here and used by the official names.
- Description prose is left untouched.

Same shape as #2101, part of a series covering the ~800 `evolveFrom` entries still missing their French value, one set per PR.
