### PR TITLE
fix(data): Add missing French evolveFrom translations for A2

### DIFF
--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/002.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/002.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Oddish"
+		en: "Oddish",
+		fr: "Mystherbe"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/003.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/003.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Gloom"
+		en: "Gloom",
+		fr: "Ortide"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/005.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/005.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Tangela"
+		en: "Tangela",
+		fr: "Saquedeneu"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/007.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/007.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Yanma"
+		en: "Yanma",
+		fr: "Yanma"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/009.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/009.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Roselia"
+		en: "Roselia",
+		fr: "Rosélia"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/011.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/011.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Turtwig"
+		en: "Turtwig",
+		fr: "Tortipouss"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/012.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/012.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Grotle"
+		en: "Grotle",
+		fr: "Boskara"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/014.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/014.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Kricketot"
+		en: "Kricketot",
+		fr: "Crikzik"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/016.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/016.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Burmy"
+		en: "Burmy",
+		fr: "Cheniti"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/018.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/018.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Combee"
+		en: "Combee",
+		fr: "Apitrini"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/020.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/020.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/024.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/024.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Magmar"
+		en: "Magmar",
+		fr: "Magmar"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/026.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/026.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Slugma"
+		en: "Slugma",
+		fr: "Limagma"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/028.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/028.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Chimchar"
+		en: "Chimchar",
+		fr: "Ouisticram"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/029.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/029.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Monferno"
+		en: "Monferno",
+		fr: "Chimpenfeu"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/032.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/032.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Swinub"
+		en: "Swinub",
+		fr: "Marcacrin"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/033.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/033.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Piloswine"
+		en: "Piloswine",
+		fr: "Cochignon"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/036.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/036.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Piplup"
+		en: "Piplup",
+		fr: "Tiplouf"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/037.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/037.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Prinplup"
+		en: "Prinplup",
+		fr: "Prinplouf"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/039.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/039.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Buizel"
+		en: "Buizel",
+		fr: "Mustébouée"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/041.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/041.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Shellos"
+		en: "Shellos",
+		fr: "Sancoki"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/043.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/043.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Finneon"
+		en: "Finneon",
+		fr: "Écayon"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/045.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/045.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Snover"
+		en: "Snover",
+		fr: "Blizzi"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/046.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/046.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/052.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/052.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Magnemite"
+		en: "Magnemite",
+		fr: "Magnéti"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/053.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/053.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Magneton"
+		en: "Magneton",
+		fr: "Magnéton"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/055.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/055.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Voltorb"
+		en: "Voltorb",
+		fr: "Voltorbe"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/057.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/057.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Electabuzz"
+		en: "Electabuzz",
+		fr: "Élektek"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/059.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/059.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Shinx"
+		en: "Shinx",
+		fr: "Lixy"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/060.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/060.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Luxio"
+		en: "Luxio",
+		fr: "Luxio"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/064.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/064.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Togepi"
+		en: "Togepi",
+		fr: "Togepi"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/065.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/065.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Togetic"
+		en: "Togetic",
+		fr: "Togetic"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/067.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/067.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Misdreavus"
+		en: "Misdreavus",
+		fr: "Feuforêve"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/069.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/069.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Ralts"
+		en: "Ralts",
+		fr: "Tarsal"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/071.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/071.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Duskull"
+		en: "Duskull",
+		fr: "Skelénox"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/072.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/072.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Dusclops"
+		en: "Dusclops",
+		fr: "Téraclope"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/074.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/074.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Drifloon"
+		en: "Drifloon",
+		fr: "Baudrive"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/081.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/081.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Rhyhorn"
+		en: "Rhyhorn",
+		fr: "Rhinocorne"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/082.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/082.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Rhydon"
+		en: "Rhydon",
+		fr: "Rhinoféros"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/084.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/084.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Gligar"
+		en: "Gligar",
+		fr: "Scorplane"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/088.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/088.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Skull Fossil"
+		en: "Skull Fossil",
+		fr: "Fossile Crâne"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/089.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/089.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Cranidos"
+		en: "Cranidos",
+		fr: "Kranidos"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/090.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/090.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Burmy"
+		en: "Burmy",
+		fr: "Cheniti"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/092.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/092.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Riolu"
+		en: "Riolu",
+		fr: "Riolu"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/094.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/094.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Hippopotas"
+		en: "Hippopotas",
+		fr: "Hippopotas"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/095.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/095.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Kirlia"
+		en: "Kirlia",
+		fr: "Kirlia"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/097.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/097.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Murkrow"
+		en: "Murkrow",
+		fr: "Cornèbre"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/099.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/099.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Sneasel"
+		en: "Sneasel",
+		fr: "Farfuret"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/101.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/101.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Poochyena"
+		en: "Poochyena",
+		fr: "Medhyèna"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/103.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/103.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Stunky"
+		en: "Stunky",
+		fr: "Moufouette"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/106.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/106.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Skorupi"
+		en: "Skorupi",
+		fr: "Rapion"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/108.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/108.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Croagunk"
+		en: "Croagunk",
+		fr: "Cradopaud"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/113.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/113.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Armor Fossil"
+		en: "Armor Fossil",
+		fr: "Fossile Armure"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/114.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/114.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Shieldon"
+		en: "Shieldon",
+		fr: "Dinoclier"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/115.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/115.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Burmy"
+		en: "Burmy",
+		fr: "Cheniti"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/117.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/117.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Bronzor"
+		en: "Bronzor",
+		fr: "Archéomire"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/118.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/118.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Nosepass"
+		en: "Nosepass",
+		fr: "Tarinor"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/122.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/122.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Dragon"],
 
 	evolveFrom: {
-		en: "Gible"
+		en: "Gible",
+		fr: "Griknot"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/123.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/123.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Dragon"],
 
 	evolveFrom: {
-		en: "Gabite"
+		en: "Gabite",
+		fr: "Carmache"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/125.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/125.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Lickitung"
+		en: "Lickitung",
+		fr: "Excelangue"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/128.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/128.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Porygon"
+		en: "Porygon",
+		fr: "Porygon"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/129.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/129.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Porygon2"
+		en: "Porygon2",
+		fr: "Porygon2"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/131.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/131.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Aipom"
+		en: "Aipom",
+		fr: "Capumain"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/133.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/133.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Starly"
+		en: "Starly",
+		fr: "Étourmi"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/134.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/134.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Staravia"
+		en: "Staravia",
+		fr: "Étourvol"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/136.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/136.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Bidoof"
+		en: "Bidoof",
+		fr: "Keunotor"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/138.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/138.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Buneary"
+		en: "Buneary",
+		fr: "Laporeille"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/140.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/140.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Glameow"
+		en: "Glameow",
+		fr: "Chaglam"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/156.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/156.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Tangela"
+		en: "Tangela",
+		fr: "Saquedeneu"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/160.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/160.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Piloswine"
+		en: "Piloswine",
+		fr: "Cochignon"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/161.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/161.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Shellos"
+		en: "Shellos",
+		fr: "Sancoki"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/169.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/169.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Rhydon"
+		en: "Rhydon",
+		fr: "Rhinoféros"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/170.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/170.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Riolu"
+		en: "Riolu",
+		fr: "Riolu"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/175.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/175.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Dragon"],
 
 	evolveFrom: {
-		en: "Gabite"
+		en: "Gabite",
+		fr: "Carmache"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/176.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/176.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Staravia"
+		en: "Staravia",
+		fr: "Étourvol"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/180.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/180.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Yanma"
+		en: "Yanma",
+		fr: "Yanma"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/181.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/181.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Monferno"
+		en: "Monferno",
+		fr: "Chimpenfeu"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/184.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/184.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Misdreavus"
+		en: "Misdreavus",
+		fr: "Feuforêve"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/185.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/185.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Kirlia"
+		en: "Kirlia",
+		fr: "Kirlia"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/186.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/186.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Sneasel"
+		en: "Sneasel",
+		fr: "Farfuret"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/189.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/189.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Lickitung"
+		en: "Lickitung",
+		fr: "Excelangue"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/196.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/196.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Yanma"
+		en: "Yanma",
+		fr: "Yanma"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/197.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/197.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Monferno"
+		en: "Monferno",
+		fr: "Chimpenfeu"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/199.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/199.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Misdreavus"
+		en: "Misdreavus",
+		fr: "Feuforêve"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/200.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/200.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Kirlia"
+		en: "Kirlia",
+		fr: "Kirlia"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/201.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/201.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Sneasel"
+		en: "Sneasel",
+		fr: "Farfuret"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Space-Time Smackdown/203.ts
+++ b/data/Pokémon TCG Pocket/Space-Time Smackdown/203.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Lickitung"
+		en: "Lickitung",
+		fr: "Excelangue"
 	},
 
 	stage: "Stage1",


### PR DESCRIPTION
## Changes

Adds the missing French `evolveFrom` values to the 87 Space-Time Smackdown (`A2`) cards that only carried the English one.

## Details

- Each French `evolveFrom` value is the `name.fr` already used by that Pokémon's own cards elsewhere in the database, so no new translation is introduced — existing ones are only propagated.
- Every value was cross-checked against the official French species names.
- `Skull Fossil` and `Armor Fossil` use `Fossile Crâne` / `Fossile Armure`: the French fossil names carry a capital on their second word, consistent with `Fossile Dôme`, `Fossile Nautile` and `Vieil Ambre` already in the database.

Same shape as #2101, part of a series covering the ~800 `evolveFrom` entries still missing their French value, one set per PR.
