### PR TITLE
fix(data): Add missing French evolveFrom translations for A3b

### DIFF
--- a/data/Pokémon TCG Pocket/Eevee Grove/002.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/002.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/004.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/004.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Bounsweet"
+		en: "Bounsweet",
+		fr: "Croquine"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/005.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/005.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Steenee"
+		en: "Steenee",
+		fr: "Candine"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/007.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/007.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Applin"
+		en: "Applin",
+		fr: "Verpom"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/008.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/008.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/009.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/009.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Eevee Grove/012.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/012.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Litten"
+		en: "Litten",
+		fr: "Flamiaou"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/013.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/013.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Torracat"
+		en: "Torracat",
+		fr: "Matoufeu"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/015.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/015.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Salandit"
+		en: "Salandit",
+		fr: "Tritox"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/016.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/016.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/017.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/017.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/019.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/019.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Vanillite"
+		en: "Vanillite",
+		fr: "Sorbébé"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/020.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/020.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Vanillish"
+		en: "Vanillish",
+		fr: "Sorboul"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/023.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/023.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Popplio"
+		en: "Popplio",
+		fr: "Otaquin"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/024.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/024.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Brionne"
+		en: "Brionne",
+		fr: "Otarlette"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Eevee Grove/025.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/025.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/027.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/027.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Joltik"
+		en: "Joltik",
+		fr: "Statitik"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/028.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/028.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/030.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/030.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Woobat"
+		en: "Woobat",
+		fr: "Chovsourir"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/032.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/032.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Swirlix"
+		en: "Swirlix",
+		fr: "Sucroquin"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/033.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/033.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/034.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/034.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Eevee Grove/037.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/037.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Milcery"
+		en: "Milcery",
+		fr: "Crèmy"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/039.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/039.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Barboach"
+		en: "Barboach",
+		fr: "Barloche"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/041.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/041.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Mienfoo"
+		en: "Mienfoo",
+		fr: "Kungfouine"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/043.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/043.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/046.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/046.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Purrloin"
+		en: "Purrloin",
+		fr: "Chacripan"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/050.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/050.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Meltan"
+		en: "Meltan",
+		fr: "Meltan"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/052.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/052.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Dragon"],
 
 	evolveFrom: {
-		en: "Dratini"
+		en: "Dratini",
+		fr: "Minidraco"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/053.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/053.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Dragon"],
 
 	evolveFrom: {
-		en: "Dragonair"
+		en: "Dragonair",
+		fr: "Draco"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Eevee Grove/059.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/059.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Aipom"
+		en: "Aipom",
+		fr: "Capumain"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/063.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/063.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Minccino"
+		en: "Minccino",
+		fr: "Chinchidou"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/065.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/065.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Skwovet"
+		en: "Skwovet",
+		fr: "Rongourmand"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/070.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/070.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/071.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/071.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/072.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/072.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/073.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/073.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/074.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/074.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/075.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/075.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/076.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/076.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/077.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/077.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/079.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/079.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Eevee Grove/080.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/080.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Brionne"
+		en: "Brionne",
+		fr: "Otarlette"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Eevee Grove/081.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/081.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Eevee Grove/082.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/082.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Dragon"],
 
 	evolveFrom: {
-		en: "Dragonair"
+		en: "Dragonair",
+		fr: "Draco"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Eevee Grove/087.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/087.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Eevee Grove/088.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/088.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Brionne"
+		en: "Brionne",
+		fr: "Otarlette"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Eevee Grove/089.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/089.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Eevee Grove/090.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/090.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Dragon"],
 
 	evolveFrom: {
-		en: "Dragonair"
+		en: "Dragonair",
+		fr: "Draco"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Eevee Grove/096.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/096.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Voltorb"
+		en: "Voltorb",
+		fr: "Voltorbe"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/098.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/098.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Ralts"
+		en: "Ralts",
+		fr: "Tarsal"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/099.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/099.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Kirlia"
+		en: "Kirlia",
+		fr: "Kirlia"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/101.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/101.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Ekans"
+		en: "Ekans",
+		fr: "Abo"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Eevee Grove/106.ts
+++ b/data/Pokémon TCG Pocket/Eevee Grove/106.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Kirlia"
+		en: "Kirlia",
+		fr: "Kirlia"
 	},
 
 	stage: "Stage2",


### PR DESCRIPTION
## Changes

Adds the missing French `evolveFrom` values to the 54 Eevee Grove (`A3b`) cards that only carried the English one.

## Details

- Each French `evolveFrom` value is the `name.fr` already used by that Pokémon's own cards elsewhere in the database, so no new translation is introduced — existing ones are only propagated.
- Every value was cross-checked against the official French species names.

Same shape as #2101, part of a series covering the ~800 `evolveFrom` entries still missing their French value, one set per PR.
