### PR TITLE
fix(data): Add missing French evolveFrom translations and repair regional form names for A2b

### DIFF
--- a/data/Pokémon TCG Pocket/Shining Revelry/002.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/002.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Weedle"
+		en: "Weedle",
+		fr: "Aspicot"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/003.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/003.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Kakuna"
+		en: "Kakuna",
+		fr: "Coconfort"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Shining Revelry/006.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/006.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Sprigatito"
+		en: "Sprigatito",
+		fr: "Poussacha"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/007.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/007.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Floragato"
+		en: "Floragato",
+		fr: "Matourgeon"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/009.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/009.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Charmander"
+		en: "Charmander",
+		fr: "Salamèche"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/010.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/010.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Charmeleon"
+		en: "Charmeleon",
+		fr: "Reptincel"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Shining Revelry/012.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/012.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Magmar"
+		en: "Magmar",
+		fr: "Magmar"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/013.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/013.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Paldean Tauros",
-		fr: "Taurosde Paldea",
-		es: "Taurosde Paldea",
-		it: "Taurosdi Paldea",
+		fr: "Tauros de Paldea",
+		es: "Tauros de Paldea",
+		it: "Tauros di Paldea",
 		de: "Paldea-Tauros",
-		'pt-br': "Taurosde Paldea",
+		'pt-br': "Tauros de Paldea",
 		ko: "팔데아켄타로스"
 	},
 

--- a/data/Pokémon TCG Pocket/Shining Revelry/015.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/015.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Tentacool"
+		en: "Tentacool",
+		fr: "Tentacool"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/017.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/017.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Buizel"
+		en: "Buizel",
+		fr: "Mustébouée"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/019.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/019.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Wiglett"
+		en: "Wiglett",
+		fr: "Taupikeau"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Shining Revelry/024.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/024.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Voltorb"
+		en: "Voltorb",
+		fr: "Voltorbe"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/027.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/027.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Pawmi"
+		en: "Pawmi",
+		fr: "Pohm"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/028.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/028.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Pawmo"
+		en: "Pawmo",
+		fr: "Pohmotte"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/030.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/030.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Abra"
+		en: "Abra",
+		fr: "Abra"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/031.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/031.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Kadabra"
+		en: "Kadabra",
+		fr: "Kadabra"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/034.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/034.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Drifloon"
+		en: "Drifloon",
+		fr: "Baudrive"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/038.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/038.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Machop"
+		en: "Machop",
+		fr: "Machoc"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/039.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/039.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Machoke"
+		en: "Machoke",
+		fr: "Machopeur"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/043.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/043.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Riolu"
+		en: "Riolu",
+		fr: "Riolu"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Shining Revelry/046.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/046.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Ekans"
+		en: "Ekans",
+		fr: "Abo"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/047.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/047.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Paldean Wooper",
-		fr: "Axolotode Paldea",
-		es: "Wooperde Paldea",
-		it: "Wooperdi Paldea",
+		fr: "Axoloto de Paldea",
+		es: "Wooper de Paldea",
+		it: "Wooper di Paldea",
 		de: "Paldea-Felino",
-		'pt-br': "Wooperde Paldea",
+		'pt-br': "Wooper de Paldea",
 		ko: "팔데아우파"
 	},
 

--- a/data/Pokémon TCG Pocket/Shining Revelry/048.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/048.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Paldean Wooper"
+		en: "Paldean Wooper",
+		fr: "Axoloto de Paldea"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Shining Revelry/048.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/048.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Paldean Clodsire ex",
-		fr: "Terraistede Paldea-ex",
-		es: "Clodsirede Paldea ex",
-		it: "Clodsiredi Paldea-ex",
+		fr: "Terraiste de Paldea-ex",
+		es: "Clodsire de Paldea ex",
+		it: "Clodsire di Paldea-ex",
 		de: "Paldea-Suelord-ex",
-		'pt-br': "Clodsirede Paldea ex",
+		'pt-br': "Clodsire de Paldea ex",
 		ko: "팔데아토오 ex"
 	},
 

--- a/data/Pokémon TCG Pocket/Shining Revelry/051.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/051.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Shroodle"
+		en: "Shroodle",
+		fr: "Gribouraigne"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/053.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/053.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Tinkatink"
+		en: "Tinkatink",
+		fr: "Forgerette"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/054.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/054.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Tinkatuff"
+		en: "Tinkatuff",
+		fr: "Forgella"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Shining Revelry/056.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/056.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Varoom"
+		en: "Varoom",
+		fr: "Vrombi"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/057.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/057.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Gimmighoul"
+		en: "Gimmighoul",
+		fr: "Mordudor"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/059.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/059.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Rattata"
+		en: "Rattata",
+		fr: "Rattata"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/061.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/061.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Jigglypuff"
+		en: "Jigglypuff",
+		fr: "Rondoudou"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/063.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/063.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Lickitung"
+		en: "Lickitung",
+		fr: "Excelangue"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/065.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/065.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Bidoof"
+		en: "Bidoof",
+		fr: "Keunotor"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Shining Revelry/067.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/067.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Buneary"
+		en: "Buneary",
+		fr: "Laporeille"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/073.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/073.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Floragato"
+		en: "Floragato",
+		fr: "Matourgeon"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/076.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/076.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Shroodle"
+		en: "Shroodle",
+		fr: "Gribouraigne"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/077.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/077.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Gimmighoul"
+		en: "Gimmighoul",
+		fr: "Mordudor"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/078.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/078.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Jigglypuff"
+		en: "Jigglypuff",
+		fr: "Rondoudou"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/079.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/079.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Kakuna"
+		en: "Kakuna",
+		fr: "Coconfort"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Shining Revelry/080.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/080.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Charmeleon"
+		en: "Charmeleon",
+		fr: "Reptincel"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Shining Revelry/081.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/081.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Wiglett"
+		en: "Wiglett",
+		fr: "Taupikeau"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Shining Revelry/084.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/084.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Riolu"
+		en: "Riolu",
+		fr: "Riolu"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Shining Revelry/085.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/085.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Paldean Wooper"
+		en: "Paldean Wooper",
+		fr: "Axoloto de Paldea"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Shining Revelry/085.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/085.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Paldean Clodsire ex",
-		fr: "Terraistede Paldea-ex",
-		es: "Clodsirede Paldea ex",
-		it: "Clodsiredi Paldea-ex",
+		fr: "Terraiste de Paldea-ex",
+		es: "Clodsire de Paldea ex",
+		it: "Clodsire di Paldea-ex",
 		de: "Paldea-Suelord-ex",
-		'pt-br': "Clodsirede Paldea ex",
+		'pt-br': "Clodsire de Paldea ex",
 		ko: "팔데아토오 ex"
 	},
 

--- a/data/Pokémon TCG Pocket/Shining Revelry/086.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/086.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Tinkatuff"
+		en: "Tinkatuff",
+		fr: "Forgella"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Shining Revelry/087.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/087.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Bidoof"
+		en: "Bidoof",
+		fr: "Keunotor"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Shining Revelry/093.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/093.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Paldean Wooper"
+		en: "Paldean Wooper",
+		fr: "Axoloto de Paldea"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Shining Revelry/093.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/093.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Paldean Clodsire ex",
-		fr: "Terraistede Paldea-ex",
-		es: "Clodsirede Paldea ex",
-		it: "Clodsiredi Paldea-ex",
+		fr: "Terraiste de Paldea-ex",
+		es: "Clodsire de Paldea ex",
+		it: "Clodsire di Paldea-ex",
 		de: "Paldea-Suelord-ex",
-		'pt-br': "Clodsirede Paldea ex",
+		'pt-br': "Clodsire de Paldea ex",
 		ko: "팔데아토오 ex"
 	},
 

--- a/data/Pokémon TCG Pocket/Shining Revelry/094.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/094.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Tinkatuff"
+		en: "Tinkatuff",
+		fr: "Forgella"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Shining Revelry/095.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/095.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Bidoof"
+		en: "Bidoof",
+		fr: "Keunotor"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Shining Revelry/098.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/098.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Weedle"
+		en: "Weedle",
+		fr: "Aspicot"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/100.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/100.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Charmander"
+		en: "Charmander",
+		fr: "Salamèche"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/106.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/106.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Varoom"
+		en: "Varoom",
+		fr: "Vrombi"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Shining Revelry/107.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/107.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Kakuna"
+		en: "Kakuna",
+		fr: "Coconfort"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Shining Revelry/108.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/108.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Charmeleon"
+		en: "Charmeleon",
+		fr: "Reptincel"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Shining Revelry/109.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/109.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Wiglett"
+		en: "Wiglett",
+		fr: "Taupikeau"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Shining Revelry/110.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/110.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Riolu"
+		en: "Riolu",
+		fr: "Riolu"
 	},
 
 	stage: "Stage1",


### PR DESCRIPTION
## Changes

Adds the missing French `evolveFrom` values to the 52 Shining Revelry (`A2b`) cards that only carried the English one. Also repairs 20 regional form names whose connector had lost its space.

## Details

- Each French `evolveFrom` value is the `name.fr` already used by that Pokémon's own cards elsewhere in the database, so no new translation is introduced — existing ones are only propagated.
- Every value was cross-checked against the official French species names.
- The regional form names were glued to their connector in fr, es, it and pt-br alike (`Exeggutorde Alola`, `Vulpixdi Alola`, `Noadkokod'Alola`). The space is restored in each language's own form, card suffixes such as `-ex` are preserved, and the French elision now uses the typographic apostrophe already dominant here and used by the official names.
- Description prose is left untouched.

Same shape as #2101, part of a series covering the ~800 `evolveFrom` entries still missing their French value, one set per PR.
