### PR TITLE
fix(data): Add missing French evolveFrom translations for A2a

### DIFF
--- a/data/Pokémon TCG Pocket/Triumphant Light/003.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/003.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Burmy"
+		en: "Burmy",
+		fr: "Cheniti"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/005.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/005.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Combee"
+		en: "Combee",
+		fr: "Apitrini"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/007.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/007.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Cherubi"
+		en: "Cherubi",
+		fr: "Ceribou"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/008.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/008.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Cherubi"
+		en: "Cherubi",
+		fr: "Ceribou"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/010.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/010.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Triumphant Light/012.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/012.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Houndour"
+		en: "Houndour",
+		fr: "Malosse"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/015.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/015.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Marill"
+		en: "Marill",
+		fr: "Marill"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/017.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/017.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Barboach"
+		en: "Barboach",
+		fr: "Barloche"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/019.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/019.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Snorunt"
+		en: "Snorunt",
+		fr: "Stalgamin"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/021.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/021.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Snover"
+		en: "Snover",
+		fr: "Blizzi"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/022.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/022.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Triumphant Light/026.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/026.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Pikachu"
+		en: "Pikachu",
+		fr: "Pikachu"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/028.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/028.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Electrike"
+		en: "Electrike",
+		fr: "Dynavolt"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/030.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/030.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Clefairy"
+		en: "Clefairy",
+		fr: "Mélofée"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/032.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/032.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Gastly"
+		en: "Gastly",
+		fr: "Fantominus"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/033.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/033.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Haunter"
+		en: "Haunter",
+		fr: "Spectrum"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/038.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/038.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Phanpy"
+		en: "Phanpy",
+		fr: "Phanpy"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/040.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/040.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Larvitar"
+		en: "Larvitar",
+		fr: "Embrylex"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/041.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/041.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Pupitar"
+		en: "Pupitar",
+		fr: "Ymphect"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/044.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/044.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Meditite"
+		en: "Meditite",
+		fr: "Méditikka"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/046.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/046.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Gible"
+		en: "Gible",
+		fr: "Griknot"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/047.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/047.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Gabite"
+		en: "Gabite",
+		fr: "Carmache"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Triumphant Light/049.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/049.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Zubat"
+		en: "Zubat",
+		fr: "Nosferapti"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/050.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/050.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Golbat"
+		en: "Golbat",
+		fr: "Nosferalto"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/052.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/052.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Croagunk"
+		en: "Croagunk",
+		fr: "Cradopaud"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/054.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/054.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Magnemite"
+		en: "Magnemite",
+		fr: "Magnéti"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/055.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/055.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Magneton"
+		en: "Magneton",
+		fr: "Magnéton"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/057.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/057.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Nosepass"
+		en: "Nosepass",
+		fr: "Tarinor"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Triumphant Light/059.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/059.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Bronzor"
+		en: "Bronzor",
+		fr: "Archéomire"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/065.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/065.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Hoothoot"
+		en: "Hoothoot",
+		fr: "Hoothoot"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/067.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/067.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Starly"
+		en: "Starly",
+		fr: "Étourmi"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/068.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/068.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Staravia"
+		en: "Staravia",
+		fr: "Étourvol"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/076.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/076.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Houndour"
+		en: "Houndour",
+		fr: "Malosse"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Triumphant Light/082.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/082.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Triumphant Light/083.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/083.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Triumphant Light/084.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/084.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Gabite"
+		en: "Gabite",
+		fr: "Carmache"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Triumphant Light/085.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/085.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Nosepass"
+		en: "Nosepass",
+		fr: "Tarinor"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Triumphant Light/091.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/091.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Triumphant Light/092.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/092.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Triumphant Light/093.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/093.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Gabite"
+		en: "Gabite",
+		fr: "Carmache"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Triumphant Light/094.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/094.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Nosepass"
+		en: "Nosepass",
+		fr: "Tarinor"
 	},
 
 	stage: "Stage1",


### PR DESCRIPTION
## Changes

Adds the missing French `evolveFrom` values to the 41 Triumphant Light (`A2a`) cards that only carried the English one.

## Details

- Each French `evolveFrom` value is the `name.fr` already used by that Pokémon's own cards elsewhere in the database, so no new translation is introduced — existing ones are only propagated.
- Every value was cross-checked against the official French species names.

Same shape as #2101, part of a series covering the ~800 `evolveFrom` entries still missing their French value, one set per PR.
