### PR TITLE
fix(data): Add missing French evolveFrom translations for A3a

### DIFF
--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/002.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/002.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Petilil"
+		en: "Petilil",
+		fr: "Chlorobule"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/004.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/004.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Rowlet"
+		en: "Rowlet",
+		fr: "Brindibou"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/005.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/005.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Dartrix"
+		en: "Dartrix",
+		fr: "Efflèche"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/012.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/012.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Carvanha"
+		en: "Carvanha",
+		fr: "Carvanha"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/014.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/014.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Shinx"
+		en: "Shinx",
+		fr: "Lixy"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/015.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/015.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Luxio"
+		en: "Luxio",
+		fr: "Luxio"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/017.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/017.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Blitzle"
+		en: "Blitzle",
+		fr: "Zébibron"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/023.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/023.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Clefairy"
+		en: "Clefairy",
+		fr: "Mélofée"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/025.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/025.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Phantump"
+		en: "Phantump",
+		fr: "Brocélôme"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/027.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/027.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Morelull"
+		en: "Morelull",
+		fr: "Spododo"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/029.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/029.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Meditite"
+		en: "Meditite",
+		fr: "Méditikka"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/031.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/031.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Baltoy"
+		en: "Baltoy",
+		fr: "Balbuto"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/033.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/033.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Rockruff"
+		en: "Rockruff",
+		fr: "Rocabot"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/036.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/036.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Sandygast"
+		en: "Sandygast",
+		fr: "Bacabouh"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/038.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/038.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Alolan Meowth"
+		en: "Alolan Meowth",
+		fr: "Miaouss d’Alola"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/040.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/040.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Sandile"
+		en: "Sandile",
+		fr: "Mascaïman"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/041.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/041.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Krokorok"
+		en: "Krokorok",
+		fr: "Escroco"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/045.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/045.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Poipole"
+		en: "Poipole",
+		fr: "Vémini"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/047.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/047.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Alolan Diglett"
+		en: "Alolan Diglett",
+		fr: "Taupiqueur d’Alola"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/049.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/049.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Aron"
+		en: "Aron",
+		fr: "Galekid"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/050.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/050.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Lairon"
+		en: "Lairon",
+		fr: "Galegon"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/052.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/052.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Ferroseed"
+		en: "Ferroseed",
+		fr: "Grindur"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/055.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/055.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Lillipup"
+		en: "Lillipup",
+		fr: "Ponchiot"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/056.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/056.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Herdier"
+		en: "Herdier",
+		fr: "Ponchien"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/058.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/058.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Stufful"
+		en: "Stufful",
+		fr: "Nounourson"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/061.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/061.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Type: Null"
+		en: "Type: Null",
+		fr: "Type:0"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/074.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/074.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Type: Null"
+		en: "Type: Null",
+		fr: "Type:0"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/078.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/078.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Rockruff"
+		en: "Rockruff",
+		fr: "Rocabot"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/080.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/080.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Alolan Diglett"
+		en: "Alolan Diglett",
+		fr: "Taupiqueur d’Alola"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/085.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/085.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Rockruff"
+		en: "Rockruff",
+		fr: "Rocabot"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/087.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/087.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Metal"],
 
 	evolveFrom: {
-		en: "Alolan Diglett"
+		en: "Alolan Diglett",
+		fr: "Taupiqueur d’Alola"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/090.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/090.ts
@@ -17,7 +17,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Growlithe"
+		en: "Growlithe",
+		fr: "Caninos"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/092.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/092.ts
@@ -17,7 +17,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Froakie"
+		en: "Froakie",
+		fr: "Grenousse"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/093.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/093.ts
@@ -17,7 +17,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Frogadier"
+		en: "Frogadier",
+		fr: "Croâporal"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/096.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/096.ts
@@ -17,7 +17,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Pidgey"
+		en: "Pidgey",
+		fr: "Roucool"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/097.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/097.ts
@@ -17,7 +17,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Pidgeotto"
+		en: "Pidgeotto",
+		fr: "Roucoups"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/098.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/098.ts
@@ -17,7 +17,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Old Amber"
+		en: "Old Amber",
+		fr: "Vieil Ambre"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/100.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/100.ts
@@ -17,7 +17,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Growlithe"
+		en: "Growlithe",
+		fr: "Caninos"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/101.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/101.ts
@@ -17,7 +17,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Old Amber"
+		en: "Old Amber",
+		fr: "Vieil Ambre"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Extradimensional Crisis/102.ts
+++ b/data/Pokémon TCG Pocket/Extradimensional Crisis/102.ts
@@ -17,7 +17,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Pidgeotto"
+		en: "Pidgeotto",
+		fr: "Roucoups"
 	},
 
 	stage: "Stage2",


### PR DESCRIPTION
## Changes

Adds the missing French `evolveFrom` values to the 40 Extradimensional Crisis (`A3a`) cards that only carried the English one.

## Details

- Each French `evolveFrom` value is the `name.fr` already used by that Pokémon's own cards elsewhere in the database, so no new translation is introduced — existing ones are only propagated.
- Every value was cross-checked against the official French species names.

Same shape as #2101, part of a series covering the ~800 `evolveFrom` entries still missing their French value, one set per PR.
