### PR TITLE
fix(data): Add missing French evolveFrom translations for A4a

### DIFF
--- a/data/Pokémon TCG Pocket/Secluded Springs/002.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/002.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Hoppip"
+		en: "Hoppip",
+		fr: "Granivol"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/003.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/003.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Skiploom"
+		en: "Skiploom",
+		fr: "Floravol"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Secluded Springs/005.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/005.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Sunkern"
+		en: "Sunkern",
+		fr: "Tournegrin"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/009.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/009.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Slugma"
+		en: "Slugma",
+		fr: "Limagma"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/011.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/011.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Fletchling"
+		en: "Fletchling",
+		fr: "Passerouge"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/012.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/012.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Fletchinder"
+		en: "Fletchinder",
+		fr: "Braisillon"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/014.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/014.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Poliwag"
+		en: "Poliwag",
+		fr: "Ptitard"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/016.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/016.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Tentacool"
+		en: "Tentacool",
+		fr: "Tentacool"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/018.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/018.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Slowpoke"
+		en: "Slowpoke",
+		fr: "Ramoloss"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/022.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/022.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Feebas"
+		en: "Feebas",
+		fr: "Barpau"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/027.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/027.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Tynamo"
+		en: "Tynamo",
+		fr: "Anchwatt"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/028.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/028.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Eelektrik"
+		en: "Eelektrik",
+		fr: "Lampéroie"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/031.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/031.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Yamper"
+		en: "Yamper",
+		fr: "Voltoutou"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/033.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/033.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Misdreavus"
+		en: "Misdreavus",
+		fr: "Feuforêve"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/035.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/035.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Galarian Corsola"
+		en: "Galarian Corsola",
+		fr: "Corayon de Galar"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/039.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/039.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Frillish"
+		en: "Frillish",
+		fr: "Viskuse"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/041.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/041.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Diglett"
+		en: "Diglett",
+		fr: "Taupiqueur"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/042.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/042.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Poliwhirl"
+		en: "Poliwhirl",
+		fr: "Têtarte"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Secluded Springs/044.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/044.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Phanpy"
+		en: "Phanpy",
+		fr: "Phanpy"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/047.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/047.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Dwebble"
+		en: "Dwebble",
+		fr: "Crabicoque"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/050.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/050.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Zorua"
+		en: "Zorua",
+		fr: "Zorua"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/052.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/052.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Inkay"
+		en: "Inkay",
+		fr: "Sepiatop"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/054.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/054.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Skrelp"
+		en: "Skrelp",
+		fr: "Venalgue"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/055.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/055.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Dragon"],
 
 	evolveFrom: {
-		en: "Swablu"
+		en: "Swablu",
+		fr: "Tylton"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/058.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/058.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Lickitung"
+		en: "Lickitung",
+		fr: "Excelangue"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/061.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/061.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Teddiursa"
+		en: "Teddiursa",
+		fr: "Teddiursa"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/072.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/072.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Feebas"
+		en: "Feebas",
+		fr: "Barpau"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/078.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/078.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Skiploom"
+		en: "Skiploom",
+		fr: "Floravol"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Secluded Springs/082.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/082.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Poliwhirl"
+		en: "Poliwhirl",
+		fr: "Têtarte"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Secluded Springs/086.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/086.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Skiploom"
+		en: "Skiploom",
+		fr: "Floravol"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Secluded Springs/089.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/089.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Poliwhirl"
+		en: "Poliwhirl",
+		fr: "Têtarte"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Secluded Springs/092.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/092.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Chimchar"
+		en: "Chimchar",
+		fr: "Ouisticram"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/094.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/094.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Psyduck"
+		en: "Psyduck",
+		fr: "Psykokwak"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/096.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/096.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Krabby"
+		en: "Krabby",
+		fr: "Krabby"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/099.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/099.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Gible"
+		en: "Gible",
+		fr: "Griknot"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Secluded Springs/101.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/101.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Monferno"
+		en: "Monferno",
+		fr: "Chimpenfeu"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Secluded Springs/103.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/103.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Gabite"
+		en: "Gabite",
+		fr: "Carmache"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Secluded Springs/104.ts
+++ b/data/Pokémon TCG Pocket/Secluded Springs/104.ts
@@ -18,7 +18,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Paldean Wooper"
+		en: "Paldean Wooper",
+		fr: "Axoloto de Paldea"
 	},
 
 	stage: "Stage1",


### PR DESCRIPTION
## Changes

Adds the missing French `evolveFrom` values to the 38 Secluded Springs (`A4a`) cards that only carried the English one.

## Details

- Each French `evolveFrom` value is the `name.fr` already used by that Pokémon's own cards elsewhere in the database, so no new translation is introduced — existing ones are only propagated.
- Every value was cross-checked against the official French species names.

Same shape as #2101, part of a series covering the ~800 `evolveFrom` entries still missing their French value, one set per PR.
