### PR TITLE
fix(data): Add missing French evolveFrom translations for A1a

### DIFF
--- a/data/Pokémon TCG Pocket/Mythical Island/002.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/002.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Exeggcute"
+		en: "Exeggcute",
+		fr: "Noeunoeuf"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Mythical Island/005.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/005.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Snivy"
+		en: "Snivy",
+		fr: "Vipélierre"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Mythical Island/006.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/006.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Servine"
+		en: "Servine",
+		fr: "Lianaja"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Mythical Island/008.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/008.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Morelull"
+		en: "Morelull",
+		fr: "Spododo"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Mythical Island/011.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/011.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Ponyta"
+		en: "Ponyta",
+		fr: "Ponyta"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Mythical Island/014.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/014.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Larvesta"
+		en: "Larvesta",
+		fr: "Pyronille"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Mythical Island/016.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/016.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Salandit"
+		en: "Salandit",
+		fr: "Tritox"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Mythical Island/018.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/018.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Magikarp"
+		en: "Magikarp",
+		fr: "Magicarpe"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Mythical Island/019.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/019.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Mythical Island/021.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/021.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Finneon"
+		en: "Finneon",
+		fr: "Écayon"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Mythical Island/023.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/023.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Chewtle"
+		en: "Chewtle",
+		fr: "Khélocrok"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Mythical Island/026.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/026.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Pikachu"
+		en: "Pikachu",
+		fr: "Pikachu"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Mythical Island/029.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/029.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Joltik"
+		en: "Joltik",
+		fr: "Statitik"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Mythical Island/035.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/035.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Elgyem"
+		en: "Elgyem",
+		fr: "Lewsor"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Mythical Island/037.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/037.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Flabébé"
+		en: "Flabébé",
+		fr: "Flabébé"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Mythical Island/038.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/038.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Floette"
+		en: "Floette",
+		fr: "Floette"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Mythical Island/040.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/040.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Psychic"],
 
 	evolveFrom: {
-		en: "Swirlix"
+		en: "Swirlix",
+		fr: "Sucroquin"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Mythical Island/042.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/042.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Mankey"
+		en: "Mankey",
+		fr: "Férosinge"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Mythical Island/044.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/044.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Geodude"
+		en: "Geodude",
+		fr: "Racaillou"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Mythical Island/045.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/045.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Graveler"
+		en: "Graveler",
+		fr: "Gravalanch"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Mythical Island/046.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/046.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Old Amber"
+		en: "Old Amber",
+		fr: "Vieil Ambre"
 	},
 
 	suffix: "EX",

--- a/data/Pokémon TCG Pocket/Mythical Island/050.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/050.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Koffing"
+		en: "Koffing",
+		fr: "Smogo"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Mythical Island/052.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/052.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Purrloin"
+		en: "Purrloin",
+		fr: "Chacripan"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Mythical Island/054.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/054.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Venipede"
+		en: "Venipede",
+		fr: "Venipatte"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Mythical Island/055.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/055.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Whirlipede"
+		en: "Whirlipede",
+		fr: "Scobolide"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Mythical Island/058.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/058.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Pidgey"
+		en: "Pidgey",
+		fr: "Roucool"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Mythical Island/059.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/059.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Pidgeotto"
+		en: "Pidgeotto",
+		fr: "Roucoups"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Mythical Island/069.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/069.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Exeggcute"
+		en: "Exeggcute",
+		fr: "Noeunoeuf"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Mythical Island/070.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/070.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Servine"
+		en: "Servine",
+		fr: "Lianaja"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Mythical Island/072.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/072.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Eevee"
+		en: "Eevee",
+		fr: "Évoli"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Mythical Island/076.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/076.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Magikarp"
+		en: "Magikarp",
+		fr: "Magicarpe"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Mythical Island/078.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/078.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Old Amber"
+		en: "Old Amber",
+		fr: "Vieil Ambre"
 	},
 	
 	suffix: "EX",

--- a/data/Pokémon TCG Pocket/Mythical Island/079.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/079.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Pidgeotto"
+		en: "Pidgeotto",
+		fr: "Roucoups"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Mythical Island/084.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/084.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Old Amber"
+		en: "Old Amber",
+		fr: "Vieil Ambre"
 	},
 	
 	suffix: "EX",


### PR DESCRIPTION
## Changes

Adds the missing French `evolveFrom` values to the 34 Mythical Island (`A1a`) cards that only carried the English one.

## Details

- Each French `evolveFrom` value is the `name.fr` already used by that Pokémon's own cards elsewhere in the database, so no new translation is introduced — existing ones are only propagated.
- Every value was cross-checked against the official French species names.

Same shape as #2101, part of a series covering the ~800 `evolveFrom` entries still missing their French value, one set per PR.
