### PR TITLE
fix(data): Add missing French evolveFrom translations and repair regional form names for P-A

### DIFF
--- a/data/Pokémon TCG Pocket/Promos-A/013.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/013.ts
@@ -64,7 +64,8 @@ const card: Card = {
 	hp: 120,
 
 	evolveFrom: {
-		en: "Metapod"
+		en: "Metapod",
+		fr: "Chrysacier"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Promos-A/018.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/018.ts
@@ -50,7 +50,8 @@ const card: Card = {
 	hp: 160,
 
 	evolveFrom: {
-		en: "Ivysaur"
+		en: "Ivysaur",
+		fr: "Herbizarre"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Promos-A/019.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/019.ts
@@ -64,7 +64,8 @@ const card: Card = {
 	hp: 120,
 
 	evolveFrom: {
-		en: "Frogadier"
+		en: "Frogadier",
+		fr: "Croâporal"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Promos-A/020.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/020.ts
@@ -50,7 +50,8 @@ const card: Card = {
 	hp: 70,
 
 	evolveFrom: {
-		en: "Gastly"
+		en: "Gastly",
+		fr: "Fantominus"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Promos-A/028.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/028.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fire"],
 
 	evolveFrom: {
-		en: "Larvesta"
+		en: "Larvesta",
+		fr: "Pyronille"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Promos-A/029.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/029.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Wartortle"
+		en: "Wartortle",
+		fr: "Carabaffe"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Promos-A/031.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/031.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Minccino"
+		en: "Minccino",
+		fr: "Chinchidou"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Promos-A/036.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/036.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Electabuzz"
+		en: "Electabuzz",
+		fr: "Élektek"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Promos-A/043.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/043.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Cherubi"
+		en: "Cherubi",
+		fr: "Ceribou"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Promos-A/044.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/044.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Lightning"],
 
 	evolveFrom: {
-		en: "Pikachu"
+		en: "Pikachu",
+		fr: "Pikachu"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Promos-A/047.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/047.ts
@@ -22,7 +22,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Staravia"
+		en: "Staravia",
+		fr: "Étourvol"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Promos-A/053.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/053.ts
@@ -35,7 +35,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	evolveFrom: {
-		en: "Buizel"
+		en: "Buizel",
+		fr: "Mustébouée"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Promos-A/054.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/054.ts
@@ -35,7 +35,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Pawmo"
+		en: "Pawmo",
+		fr: "Pohmotte"
 	},
 
 	weaknesses: [{

--- a/data/Pokémon TCG Pocket/Promos-A/055.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/055.ts
@@ -35,7 +35,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	evolveFrom: {
-		en: "Machoke"
+		en: "Machoke",
+		fr: "Machopeur"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Promos-A/068.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/068.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Fighting"],
 
 	evolveFrom: {
-		en: "Rockruff"
+		en: "Rockruff",
+		fr: "Rocabot"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Promos-A/069.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/069.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Grass"],
 
 	evolveFrom: {
-		en: "Exeggcute"
+		en: "Exeggcute",
+		fr: "Noeunoeuf"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Promos-A/069.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/069.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Alolan Exeggutor",
-		fr: "Noadkokod'Alola",
-		es: "Exeggutorde Alola",
-		it: "Exeggutordi Alola",
+		fr: "Noadkoko d’Alola",
+		es: "Exeggutor de Alola",
+		it: "Exeggutor di Alola",
 		de: "Alola-Kokowei",
-		'pt-br': "Exeggutorde Alola",
+		'pt-br': "Exeggutor de Alola",
 		ko: "알로라나시"
 	},
 

--- a/data/Pokémon TCG Pocket/Promos-A/070.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/070.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Water"],
 
 	evolveFrom: {
-		en: "Alolan Vulpix"
+		en: "Alolan Vulpix",
+		fr: "Goupix d’Alola"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Promos-A/070.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/070.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Alolan Ninetales",
-		fr: "Feunardd'Alola",
-		es: "Ninetalesde Alola",
-		it: "Ninetalesdi Alola",
+		fr: "Feunard d’Alola",
+		es: "Ninetales de Alola",
+		it: "Ninetales di Alola",
 		de: "Alola-Vulnona",
-		'pt-br': "Ninetalesde Alola",
+		'pt-br': "Ninetales de Alola",
 		ko: "알로라나인테일"
 	},
 

--- a/data/Pokémon TCG Pocket/Promos-A/072.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/072.ts
@@ -6,11 +6,11 @@ const card: Card = {
 
 	name: {
 		en: "Alolan Grimer",
-		fr: "Tadmorvd'Alola",
-		es: "Grimerde Alola",
-		it: "Grimerdi Alola",
+		fr: "Tadmorv d’Alola",
+		es: "Grimer de Alola",
+		it: "Grimer di Alola",
 		de: "Alola-Sleima",
-		'pt-br': "Grimerde Alola",
+		'pt-br': "Grimer de Alola",
 		ko: "알로라질퍽이"
 	},
 

--- a/data/Pokémon TCG Pocket/Promos-A/073.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/073.ts
@@ -23,7 +23,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Trumbeak"
+		en: "Trumbeak",
+		fr: "Piclairon"
 	},
 
 	description: {


### PR DESCRIPTION
## Changes

Adds the missing French `evolveFrom` values to the 18 Promos-A (`P-A`) cards that only carried the English one. Also repairs 12 regional form names whose connector had lost its space.

## Details

- Each French `evolveFrom` value is the `name.fr` already used by that Pokémon's own cards elsewhere in the database, so no new translation is introduced — existing ones are only propagated.
- Every value was cross-checked against the official French species names.
- The regional form names were glued to their connector in fr, es, it and pt-br alike (`Exeggutorde Alola`, `Vulpixdi Alola`, `Noadkokod'Alola`). The space is restored in each language's own form, card suffixes such as `-ex` are preserved, and the French elision now uses the typographic apostrophe already dominant here and used by the official names.
- Description prose is left untouched.

Same shape as #2101, part of a series covering the ~800 `evolveFrom` entries still missing their French value, one set per PR.
