### PR TITLE
Add missing German translations for swsh4.5

### DIFF
--- a/data/Sword & Shield/Shining Fates/1.ts
+++ b/data/Sword & Shield/Shining Fates/1.ts
@@ -58,7 +58,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "If it flaps its wings really fast, it can generate shock waves that will shatter windows in the area."
+		en: "If it flaps its wings really fast, it can generate shock waves that will shatter windows in the area.",
+		de: "Schlägt es schnell mit den Flügeln, erzeugt es Schockwellen, durch die sogar Fenster zerbersten."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/10.ts
+++ b/data/Sword & Shield/Shining Fates/10.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Sinistrail-V",
-		en: "Dhelmise V"
+		en: "Dhelmise V",
+		de: "Moruda V"
 	},
 
 	attacks: [{
@@ -41,7 +42,7 @@ const card: Card = {
 			es: "Este ataque hace 30 puntos de daño a 1 de los Pokémon de tu rival por cada Energía Grass unida a este Pokémon. (No apliques Debilidad y Resistencia a los Pokémon en Banca).",
 			it: "Questo attacco infligge 30 danni a uno dei Pokémon del tuo avversario per ogni Energia Grass assegnata a questo Pokémon. Non applicare debolezza e resistenza ai Pokémon in panchina.",
 			pt: "Este ataque causa 30 pontos de dano a 1 dos Pokémon do seu oponente para cada Energia Grass ligada a este Pokémon (não aplique Fraqueza e Resistência aos Pokémon no Banco).",
-			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte Grass-Energie 1 Pokémon deines Gegners 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte {G}-Energie 1 Pokémon deines Gegners 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 		},
 
 		cost: ["Grass"]

--- a/data/Sword & Shield/Shining Fates/11.ts
+++ b/data/Sword & Shield/Shining Fates/11.ts
@@ -55,7 +55,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "When it uses its special stick to strike up a beat, the sound waves produced carry revitalizing energy to the plants and flowers in the area."
+		en: "When it uses its special stick to strike up a beat, the sound waves produced carry revitalizing energy to the plants and flowers in the area.",
+		de: "Der Rhythmus, den es mit seinem besonderen Schlägel erzeugt, verbreitet Schallwellen, die Pflanzen neue Vitalität verleihen können."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/12.ts
+++ b/data/Sword & Shield/Shining Fates/12.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Ouistempo",
-		en: "Grookey"
+		en: "Grookey",
+		de: "Chimpep"
 	},
 
 	abilities: [{
@@ -73,7 +74,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "The faster a Thwackey can beat out a rhythm with its two sticks, the more respect it wins from its peers."
+		en: "The faster a Thwackey can beat out a rhythm with its two sticks, the more respect it wins from its peers.",
+		de: "Je wilder der Beat, den ein Chimstix mit seinen zwei Schlägeln erzeugt, desto mehr wird es von seinen Artgenossen respektiert."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/13.ts
+++ b/data/Sword & Shield/Shining Fates/13.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Badabouin",
-		en: "Thwackey"
+		en: "Thwackey",
+		de: "Chimstix"
 	},
 
 	abilities: [{
@@ -43,7 +44,7 @@ const card: Card = {
 			es: "Una vez durante tu turno, puedes buscar en tu baraja hasta 2 cartas de Energía Grass y unirlas a 1 de tus Pokémon. Después, baraja las cartas de tu baraja.",
 			it: "Una sola volta durante il tuo turno, puoi cercare nel tuo mazzo fino a due carte Energia Grass e assegnarle a uno dei tuoi Pokémon. Poi rimischia le carte del tuo mazzo.",
 			pt: "Uma vez durante o seu turno, você poderá procurar por até 2 cartas de Energia Grass no seu baralho e ligá-las a 1 dos seus Pokémon. Em seguida, embaralhe o seu baralho.",
-			de: "Einmal während deines Zuges kannst du dein Deck nach bis zu 2 Grass-Energiekarten durchsuchen und sie an 1 deiner Pokémon anlegen. Mische anschließend dein Deck."
+			de: "Einmal während deines Zuges kannst du dein Deck nach bis zu 2 {G}-Energiekarten durchsuchen und sie an 1 deiner Pokémon anlegen. Mische anschließend dein Deck."
 		}
 	}],
 
@@ -73,7 +74,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "By drumming, it taps into the power of its special tree stump. The roots of the stump follow its direction in battle."
+		en: "By drumming, it taps into the power of its special tree stump. The roots of the stump follow its direction in battle.",
+		de: "Es kontrolliert die Macht seines speziellen Baumstumpfes durch Trommeln. Im Kampf manipuliert es damit Wurzeln."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/14.ts
+++ b/data/Sword & Shield/Shining Fates/14.ts
@@ -46,7 +46,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It whirls around in the wind while singing a joyous song. This delightful display has charmed many into raising this Pokémon."
+		en: "It whirls around in the wind while singing a joyous song. This delightful display has charmed many into raising this Pokémon.",
+		de: "Viele Leute werden ihre Trainer, weil sie es niedlich finden, wie diese Pokémon in sanften Brisen herumwirbeln und voller Freude singen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/15.ts
+++ b/data/Sword & Shield/Shining Fates/15.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Tournicoton",
-		en: "Gossifleur"
+		en: "Gossifleur",
+		de: "Cottini"
 	},
 
 	attacks: [{
@@ -80,7 +81,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "The cotton on the head of this Pokémon can be spun into a glossy, gorgeous yarn—a Galar regional specialty."
+		en: "The cotton on the head of this Pokémon can be spun into a glossy, gorgeous yarn—a Galar regional specialty.",
+		de: "Aus dem Flaum auf seinem Kopf werden wunderschöne, glänzende Fäden gesponnen. Die Galar-Region ist bekannt für dieses Produkt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/16.ts
+++ b/data/Sword & Shield/Shining Fates/16.ts
@@ -67,7 +67,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Once the vines on Zarude's body tear off, they become nutrients in the soil. This helps the plants of the forest grow."
+		en: "Once the vines on Zarude's body tear off, they become nutrients in the soil. This helps the plants of the forest grow.",
+		de: "Reißen die an seinem Körper wachsenden Ranken ab, werden sie zu Nährstoffen für den Boden, was den Pflanzen im Wald zum Wachstum verhilft."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/17.ts
+++ b/data/Sword & Shield/Shining Fates/17.ts
@@ -55,7 +55,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "When Reshiram's tail flares, the heat energy moves the atmosphere and changes the world's weather."
+		en: "When Reshiram's tail flares, the heat energy moves the atmosphere and changes the world's weather.",
+		de: "Lodert das Feuer in seinem Schweif auf, gerät die Erdatmosphäre durch die Hitze in Wallung und das Weltklima ändert sich."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/19.ts
+++ b/data/Sword & Shield/Shining Fates/19.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Pyrobut-V",
-		en: "Cinderace V"
+		en: "Cinderace V",
+		de: "Liberlo V"
 	},
 
 	attacks: [{

--- a/data/Sword & Shield/Shining Fates/2.ts
+++ b/data/Sword & Shield/Shining Fates/2.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Yanma",
-		en: "Yanma"
+		en: "Yanma",
+		de: "Yanma"
 	},
 
 	attacks: [{
@@ -72,7 +73,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "This six-legged Pokémon is easily capable of transporting an adult in flight. The wings on its tail help it stay balanced."
+		en: "This six-legged Pokémon is easily capable of transporting an adult in flight. The wings on its tail help it stay balanced.",
+		de: "Es kann mühelos einen Erwachsenen umhertragen. Die Federn an seinem Hinterteil stabilisieren seinen Flug."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/20.ts
+++ b/data/Sword & Shield/Shining Fates/20.ts
@@ -46,7 +46,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It makes its nest in the shade of corals. If it senses danger, it spits murky ink and flees."
+		en: "It makes its nest in the shade of corals. If it senses danger, it spits murky ink and flees.",
+		de: "Im Schatten von Korallen legt es sein Nest an. Bei Gefahr versprüht es Tinte und flieht."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/21.ts
+++ b/data/Sword & Shield/Shining Fates/21.ts
@@ -54,7 +54,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It is said to have widened the seas by causing downpours. It had been asleep in a marine trench."
+		en: "It is said to have widened the seas by causing downpours. It had been asleep in a marine trench.",
+		de: "Man sagt, es habe die Meere vergrößert, indem es es regnen ließ. Es schlief in einem Meeresgraben."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/22.ts
+++ b/data/Sword & Shield/Shining Fates/22.ts
@@ -46,7 +46,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It inflates the flotation sac around its neck and pokes its head out of the water to see what is going on."
+		en: "It inflates the flotation sac around its neck and pokes its head out of the water to see what is going on.",
+		de: "Es füllt den Schwimmreifen um seinen Hals mit Luft, um den Kopf über dem Wasser zu halten und die Umgebung zu überblicken."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/23.ts
+++ b/data/Sword & Shield/Shining Fates/23.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Mustébouée",
-		en: "Buizel"
+		en: "Buizel",
+		de: "Bamelin"
 	},
 
 	attacks: [{
@@ -51,7 +52,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Its flotation sac developed as a result of pursuing aquatic prey. It can double as a rubber raft."
+		en: "Its flotation sac developed as a result of pursuing aquatic prey. It can double as a rubber raft.",
+		de: "Da es seit jeher Beute im Wasser jagt, entwickelte es einen Rettungsring."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/24.ts
+++ b/data/Sword & Shield/Shining Fates/24.ts
@@ -68,7 +68,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It starts its life with a wondrous power that permits it to bond with any kind of Pokémon."
+		en: "It starts its life with a wondrous power that permits it to bond with any kind of Pokémon.",
+		de: "Es besitzt die wundersame Fähigkeit, das Herz eines jeden anderen Pokémon anzurühren."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/25.ts
+++ b/data/Sword & Shield/Shining Fates/25.ts
@@ -67,7 +67,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It expels its internal steam from the arms on its back. It has enough power to blow away a mountain."
+		en: "It expels its internal steam from the arms on its back. It has enough power to blow away a mountain.",
+		de: "Über die Arme auf seinem Rücken stößt es Wasserdampf aus. Seine Kraft reicht aus, um Berge zu versetzen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/26.ts
+++ b/data/Sword & Shield/Shining Fates/26.ts
@@ -58,7 +58,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It starts off battles by attacking with its rock-hard horn, but as soon as the opponent flinches, this Pokémon bites down and never lets go."
+		en: "It starts off battles by attacking with its rock-hard horn, but as soon as the opponent flinches, this Pokémon bites down and never lets go.",
+		de: "Im Kampf greift es mit dem steinharten Horn auf seinem Kopf an. Schreckt der Gegner zurück, schnappt es zu und lässt nicht wieder los."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/27.ts
+++ b/data/Sword & Shield/Shining Fates/27.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Khélocrok",
-		en: "Chewtle"
+		en: "Chewtle",
+		de: "Kamehaps"
 	},
 
 	abilities: [{
@@ -73,7 +74,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "This Pokémon rapidly extends its retractable neck to sink its sharp fangs into distant enemies and take them down."
+		en: "This Pokémon rapidly extends its retractable neck to sink its sharp fangs into distant enemies and take them down.",
+		de: "Sein streckbarer Hals ermöglicht es ihm, auch entfernte Gegner zu erreichen, die es dann mit seinen scharfen Zähnen ausschaltet."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/28.ts
+++ b/data/Sword & Shield/Shining Fates/28.ts
@@ -54,7 +54,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "This hungry Pokémon swallows Arrokuda whole. Occasionally, it makes a mistake and tries to swallow a Pokémon other than its preferred prey."
+		en: "This hungry Pokémon swallows Arrokuda whole. Occasionally, it makes a mistake and tries to swallow a Pokémon other than its preferred prey.",
+		de: "Es ist ein Vielfraß, der seine Beute, Pikuda, im Ganzen verschlingt. Manchmal erwischt es jedoch irrtümlicherweise ein anderes Pokémon."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/29.ts
+++ b/data/Sword & Shield/Shining Fates/29.ts
@@ -54,7 +54,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It spits out thread imbued with a frigid sort of energy and uses it to tie its body to branches, disguising itself as an icicle while it sleeps."
+		en: "It spits out thread imbued with a frigid sort of energy and uses it to tie its body to branches, disguising itself as an icicle while it sleeps.",
+		de: "Es spinnt einen eiskalten Faden, mit dem es sich an einen Ast hängt. Dabei tut es so, als wäre es ein Eiszapfen, um in Ruhe schlafen zu können."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/3.ts
+++ b/data/Sword & Shield/Shining Fates/3.ts
@@ -68,7 +68,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It has the power to travel across time, but it is said to appear only in peaceful times."
+		en: "It has the power to travel across time, but it is said to appear only in peaceful times.",
+		de: "Es kann durch die Zeit reisen, aber es erscheint nur zu friedlichen Zeiten."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/30.ts
+++ b/data/Sword & Shield/Shining Fates/30.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Frissonille",
-		en: "Snom"
+		en: "Snom",
+		de: "Snomnom"
 	},
 
 	abilities: [{
@@ -43,7 +44,7 @@ const card: Card = {
 			es: "Todas las veces que quieras durante tu turno, puedes unir 1 carta de Energía Water de tu mano a 1 de tus Pokémon Water en Banca.",
 			it: "Durante il tuo turno, puoi assegnare a uno dei tuoi Pokémon Water in panchina una carta Energia Water dalla tua mano tutte le volte che vuoi.",
 			pt: "Quantas vezes desejar durante o seu turno, você poderá ligar 1 carta de Energia Water da sua mão a 1 dos seus Pokémon Water no Banco.",
-			de: "Beliebig oft während deines Zuges kannst du 1 Water-Energiekarte aus deiner Hand an 1 Water-Pokémon auf deiner Bank anlegen."
+			de: "Beliebig oft während deines Zuges kannst du 1 {W}-Energiekarte aus deiner Hand an 1 {W}-Pokémon auf deiner Bank anlegen."
 		}
 	}],
 
@@ -73,7 +74,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It shows no mercy to any who desecrate fields and mountains. It will fly around on its icy wings, causing a blizzard to chase offenders away."
+		en: "It shows no mercy to any who desecrate fields and mountains. It will fly around on its icy wings, causing a blizzard to chase offenders away.",
+		de: "Verwüstet jemand Felder und Berge, vergibt es ihm niemals. Es bestraft den Täter, indem es mit seinen kalten Flügeln einen Schneesturm erzeugt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/31.ts
+++ b/data/Sword & Shield/Shining Fates/31.ts
@@ -55,7 +55,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "All of its fur dazzles if danger is sensed. It flees while the foe is momentarily blinded."
+		en: "All of its fur dazzles if danger is sensed. It flees while the foe is momentarily blinded.",
+		de: "In Gefahr blendet es seinen Gegner mit seinem Fell und flieht, während der Gegner einen Moment blind ist."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/32.ts
+++ b/data/Sword & Shield/Shining Fates/32.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Lixy",
-		en: "Shinx"
+		en: "Shinx",
+		de: "Sheinux"
 	},
 
 	abilities: [{
@@ -73,7 +74,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Strong electricity courses through the tips of its sharp claws. A light scratch causes fainting in foes."
+		en: "Strong electricity courses through the tips of its sharp claws. A light scratch causes fainting in foes.",
+		de: "Durch die Spitzen seiner scharfen Krallen strömt Elektrizität. Selbst kleine Kratzer verursachen Ohnmacht."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/33.ts
+++ b/data/Sword & Shield/Shining Fates/33.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Luxio",
-		en: "Luxio"
+		en: "Luxio",
+		de: "Luxio"
 	},
 
 	attacks: [{
@@ -72,7 +73,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "Luxray's ability to see through objects comes in handy when it's scouting for danger."
+		en: "Luxray's ability to see through objects comes in handy when it's scouting for danger.",
+		de: "Beim Aufspüren von Gefahren sind Luxtras hellseherische Fähigkeiten äußerst hilfreich."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/34.ts
+++ b/data/Sword & Shield/Shining Fates/34.ts
@@ -77,7 +77,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "One boy's invention led to the development of many different machines that take advantage of Rotom's unique capabilities."
+		en: "One boy's invention led to the development of many different machines that take advantage of Rotom's unique capabilities.",
+		de: "Die Erfindung eines jungen Tüftlers hat zu der Herstellung verschiedener Geräte geführt, die das Potenzial von Rotom nutzen können."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/35.ts
+++ b/data/Sword & Shield/Shining Fates/35.ts
@@ -75,7 +75,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "As it eats the seeds stored up in its pocket-like pouches, this Pokémon is not just satisfying its constant hunger. It's also generating electricity."
+		en: "As it eats the seeds stored up in its pocket-like pouches, this Pokémon is not just satisfying its constant hunger. It's also generating electricity.",
+		de: "Dieses immerzu hungrige Pokémon frisst Samen, die es in seinen beutelartigen Taschen verwahrt, und produziert so Elektrizität."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/36.ts
+++ b/data/Sword & Shield/Shining Fates/36.ts
@@ -75,7 +75,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "As it eats the seeds stored up in its pocket-like pouches, this Pokémon is not just satisfying its constant hunger. It's also generating electricity."
+		en: "As it eats the seeds stored up in its pocket-like pouches, this Pokémon is not just satisfying its constant hunger. It's also generating electricity.",
+		de: "Dieses immerzu hungrige Pokémon frisst Samen, die es in seinen beutelartigen Taschen verwahrt, und produziert so Elektrizität."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/38.ts
+++ b/data/Sword & Shield/Shining Fates/38.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Morpeko-V",
-		en: "Morpeko V"
+		en: "Morpeko V",
+		de: "Morpeko V"
 	},
 
 	attacks: [{

--- a/data/Sword & Shield/Shining Fates/4.ts
+++ b/data/Sword & Shield/Shining Fates/4.ts
@@ -46,7 +46,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It prefers harsh environments such as deserts. It can survive for 30 days on water stored in its body."
+		en: "It prefers harsh environments such as deserts. It can survive for 30 days on water stored in its body.",
+		de: "Es bevorzugt lebenswidrige Gebiete wie Wüsten. Der Wasserspeicher in seinem Körper reicht für bis zu 30 Tage."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/40.ts
+++ b/data/Sword & Shield/Shining Fates/40.ts
@@ -55,7 +55,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Its nest is a sloped, bowl-like pit in the desert. Once something has fallen in, there is no escape."
+		en: "Its nest is a sloped, bowl-like pit in the desert. Once something has fallen in, there is no escape.",
+		de: "Der Bau, den es sich in der Wüste errichtet, ist trichterförmig. Fällt man einmal hinein, gibt es kein Entkommen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/41.ts
+++ b/data/Sword & Shield/Shining Fates/41.ts
@@ -54,7 +54,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Its body is full of poisonous gas. It floats into garbage dumps, seeking out the fumes of raw, rotting trash."
+		en: "Its body is full of poisonous gas. It floats into garbage dumps, seeking out the fumes of raw, rotting trash.",
+		de: "Sein Körper ist zum Bersten voll mit Giftgas. Angelockt vom fauligen Geruch verrottender Abfälle, lungert es auf Müllhalden herum."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/42.ts
+++ b/data/Sword & Shield/Shining Fates/42.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Smogo",
-		en: "Koffing"
+		en: "Koffing",
+		de: "Smogon"
 	},
 
 	abilities: [{
@@ -81,7 +82,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "This Pokémon consumes particles that contaminate the air. Instead of leaving droppings, it expels clean air."
+		en: "This Pokémon consumes particles that contaminate the air. Instead of leaving droppings, it expels clean air.",
+		de: "Es saugt Schmutzpartikel aus der Atmosphäre und scheidet sie dann anstelle von Exkrementen in Form von sauberer Luft wieder aus."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/43.ts
+++ b/data/Sword & Shield/Shining Fates/43.ts
@@ -58,7 +58,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Although the poison from its fangs isn't that strong, it's potent enough to weaken prey that gets caught in its web."
+		en: "Although the poison from its fangs isn't that strong, it's potent enough to weaken prey that gets caught in its web.",
+		de: "Das Gift an seinen Mundwerkzeugen ist nicht sonderlich stark, jedoch ausreichend, um Beute zu schwächen, die ihm ins Netz gegangen ist."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/45.ts
+++ b/data/Sword & Shield/Shining Fates/45.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Nostenfer-V",
-		en: "Crobat V"
+		en: "Crobat V",
+		de: "Iksbat V"
 	},
 
 	attacks: [{

--- a/data/Sword & Shield/Shining Fates/46.ts
+++ b/data/Sword & Shield/Shining Fates/46.ts
@@ -59,7 +59,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "When its life comes to an end, it absorbs the life energy of every living thing and turns into a cocoon once more."
+		en: "When its life comes to an end, it absorbs the life energy of every living thing and turns into a cocoon once more.",
+		de: "Neigt sich seine Lebensspanne dem Ende zu, entzieht es anderen Lebewesen deren Energie und verwandelt sich zurück in einen Kokon."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/47.ts
+++ b/data/Sword & Shield/Shining Fates/47.ts
@@ -54,7 +54,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Aided by the soft pads on its feet, it silently raids the food stores of other Pokémon. It survives off its ill-gotten gains."
+		en: "Aided by the soft pads on its feet, it silently raids the food stores of other Pokémon. It survives off its ill-gotten gains.",
+		de: "Es stibitzt Futter, das andere Pokémon gefunden haben. Dank der samtweichen Ballen an seinen Pfoten ist sein Gang lautlos."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/48.ts
+++ b/data/Sword & Shield/Shining Fates/48.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Goupilou",
-		en: "Nickit"
+		en: "Nickit",
+		de: "Kleptifux"
 	},
 
 	attacks: [{
@@ -80,7 +81,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It secretly marks potential targets with a scent. By following the scent, it stalks its targets and steals from them when they least expect it."
+		en: "It secretly marks potential targets with a scent. By following the scent, it stalks its targets and steals from them when they least expect it.",
+		de: "Es markiert heimlich die Beute, auf die es ein Auge geworfen hat. Dann folgt es dem Geruch und stiehlt sie, wenn sich die Gelegenheit bietet."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/49.ts
+++ b/data/Sword & Shield/Shining Fates/49.ts
@@ -51,7 +51,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It digs up the ground with its trunk. It's also very strong, being able to carry loads of over five tons without any problem at all."
+		en: "It digs up the ground with its trunk. It's also very strong, being able to carry loads of over five tons without any problem at all.",
+		de: "Dieses Pokémon verfügt über eine Stärke, mit der es problemlos fünf Tonnen stemmen kann. Es nutzt seinen Rüssel, um in der Erde zu graben."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/5.ts
+++ b/data/Sword & Shield/Shining Fates/5.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			es: "Une hasta 2 cartas de Energía Grass de tu pila de descartes a tus Pokémon en Banca de la manera que desees.",
 			it: "Assegna ai tuoi Pokémon in panchina fino a due carte Energia Grass dalla tua pila degli scarti nel modo che preferisci.",
 			pt: "Ligue até 2 cartas de Energia Grass da sua pilha de descarte aos seus Pokémon no Banco como desejar.",
-			de: "Lege bis zu 2 Grass-Energiekarten aus deinem Ablagestapel beliebig an die Pokémon auf deiner Bank an."
+			de: "Lege bis zu 2 {G}-Energiekarten aus deinem Ablagestapel beliebig an die Pokémon auf deiner Bank an."
 		},
 
 		cost: ["Colorless"]
@@ -66,7 +66,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Bunches of delicious fruit grow around its neck. In warm areas, many ranches raise Tropius."
+		en: "Bunches of delicious fruit grow around its neck. In warm areas, many ranches raise Tropius.",
+		de: "Die leckeren Früchte an seinem Hals sind sehr beliebt. In warmen Gebieten gibt es viele Farmen, auf denen Tropius gezüchtet werden."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/51.ts
+++ b/data/Sword & Shield/Shining Fates/51.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Métamorph-V",
-		en: "Ditto V"
+		en: "Ditto V",
+		de: "Ditto V"
 	},
 
 	attacks: [{

--- a/data/Sword & Shield/Shining Fates/52.ts
+++ b/data/Sword & Shield/Shining Fates/52.ts
@@ -75,7 +75,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It has the ability to alter the composition of its body to suit its surrounding environment."
+		en: "It has the ability to alter the composition of its body to suit its surrounding environment.",
+		de: "Es ist imstande, seinen Körper perfekt an die jeweilige Umgebung anzupassen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/55.ts
+++ b/data/Sword & Shield/Shining Fates/55.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Nigosier-V",
-		en: "Cramorant V"
+		en: "Cramorant V",
+		de: "Urgl VMAX"
 	},
 
 	attacks: [{

--- a/data/Sword & Shield/Shining Fates/56.ts
+++ b/data/Sword & Shield/Shining Fates/56.ts
@@ -75,7 +75,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It uses the horns on its head to sense the emotions of others. Males will act as valets for those they serve, looking after their every need."
+		en: "It uses the horns on its head to sense the emotions of others. Males will act as valets for those they serve, looking after their every need.",
+		de: "Mit den Hörnern auf seinem Kopf erfasst es die Gefühle seines Gegenübers. Männchen kümmern sich wie Bedienstete um ihren Trainer."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/57.ts
+++ b/data/Sword & Shield/Shining Fates/57.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 3 cartas de Objeto diferentes que tengan la palabra \"Ball\" en su nombre, enséñalas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo fino a tre diverse carte Strumento con “Ball” nel nome, mostrale e aggiungile alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por até 3 cartas de Item diferentes no seu baralho que tenham a palavra \"Bola” em seu nome, revele-as e coloque-as na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach bis zu 3 verschiedenen Itemkarten, bei denen das Wort „Ball“ zum Namen gehört, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach bis zu 3 verschiedenen Itemkarten, bei denen das Wort „Ball“ zum Namen gehört, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Shining Fates/58.ts
+++ b/data/Sword & Shield/Shining Fates/58.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Cambia 1 de los Pokémon en Banca de tu rival por su Pokémon Activo.",
 		it: "Scambia uno dei Pokémon nella panchina del tuo avversario con il suo Pokémon attivo.",
 		pt: "Troque 1 dos Pokémon no Banco do seu oponente pelo Pokémon Ativo dele(a).",
-		de: "Tausche 1 Pokémon auf der Bank deines Gegners gegen sein Aktives Pokémon aus."
+		de: "Tausche 1 Pokémon auf der Bank deines Gegners gegen sein Aktives Pokémon aus. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Shining Fates/59.ts
+++ b/data/Sword & Shield/Shining Fates/59.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Roba 2 cartas. Si alguno de tus Pokémon quedó Fuera de Combate durante el último turno de tu rival, roba 2 cartas más.",
 		it: "Pesca due carte. Se uno qualsiasi dei tuoi Pokémon è stato messo KO durante l'ultimo turno del tuo avversario, pesca altre due carte.",
 		pt: "Compre 2 cartas. Se algum dos seus Pokémon tiver sido Nocauteado durante o último turno do seu oponente, compre 2 cartas a mais.",
-		de: "Ziehe 2 Karten. Wenn mindestens 1 deiner Pokémon während des letzten Zuges deines Gegners kampfunfähig wurde, ziehe 2 Karten mehr."
+		de: "Ziehe 2 Karten. Wenn mindestens 1 deiner Pokémon während des letzten Zuges deines Gegners kampfunfähig wurde, ziehe 2 Karten mehr. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Shining Fates/6.ts
+++ b/data/Sword & Shield/Shining Fates/6.ts
@@ -76,7 +76,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "At a distance, it launches its sharp feathers while flying about. If the enemy gets too close, Rowlet switches tactics and delivers vicious kicks."
+		en: "At a distance, it launches its sharp feathers while flying about. If the enemy gets too close, Rowlet switches tactics and delivers vicious kicks.",
+		de: "Während es durch die Lüfte fliegt, schleudert es scharfe Federn auf seine Ziele. Wenn Gegner ihm zu nahe kommen, greift es mit heftigen Tritten an."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/60.ts
+++ b/data/Sword & Shield/Shining Fates/60.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Descarta las cartas de tu mano y roba 7 cartas.",
 		it: "Scarta le carte che hai in mano e pesca sette carte.",
 		pt: "Descarte a sua mão e compre 7 cartas.",
-		de: "Lege deine Handkarten auf deinen Ablagestapel und ziehe 7 Karten."
+		de: "Lege deine Handkarten auf deinen Ablagestapel und ziehe 7 Karten. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Shining Fates/61.ts
+++ b/data/Sword & Shield/Shining Fates/61.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "El Zamazenta V al que esté unida esta carta obtiene 70 PS más.",
 		it: "Lo Zamazenta-V a cui è assegnata questa carta ha 70 PS in più.",
 		pt: "O Zamazenta V ao qual esta carta está ligada recebe 70 PS a mais.",
-		de: "Das Zamazenta-V, an das diese Karte angelegt ist, erhält +70 KP."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Das Zamazenta-V, an das diese Karte angelegt ist, erhält +70 KP. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sword & Shield/Shining Fates/62.ts
+++ b/data/Sword & Shield/Shining Fates/62.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Los ataques del Zacian V al que esté unida esta carta hacen 30 puntos de daño más al Pokémon Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
 		it: "Gli attacchi dello Zacian-V a cui è assegnata questa carta infliggono 30 danni in più al Pokémon attivo del tuo avversario, prima di aver applicato debolezza e resistenza.",
 		pt: "Os ataques do Zacian V ao qual esta carta está ligada causam 30 pontos de dano a mais ao Pokémon Ativo do seu oponente (antes de aplicar Fraqueza e Resistência).",
-		de: "Die Attacken des Zacian-V, an das diese Karte angelegt ist, fügen dem Aktiven Pokémon deines Gegners 30 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Die Attacken des Zacian-V, an das diese Karte angelegt ist, fügen dem Aktiven Pokémon deines Gegners 30 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden). Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sword & Shield/Shining Fates/63.ts
+++ b/data/Sword & Shield/Shining Fates/63.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Cura 50 puntos de daño a ambos Pokémon Activos.",
 		it: "Cura entrambi i Pokémon attivi da 50 danni.",
 		pt: "Cure 50 pontos de dano de ambos os Pokémon Ativos.",
-		de: "Heile 50 Schadenspunkte bei beiden Aktiven Pokémon."
+		de: "Heile 50 Schadenspunkte bei beiden Aktiven Pokémon. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Shining Fates/65.ts
+++ b/data/Sword & Shield/Shining Fates/65.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 3 cartas de Objeto diferentes que tengan la palabra \"Ball\" en su nombre, enséñalas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo fino a tre diverse carte Strumento con “Ball” nel nome, mostrale e aggiungile alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por até 3 cartas de Item diferentes no seu baralho que tenham a palavra \"Bola” em seu nome, revele-as e coloque-as na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach bis zu 3 verschiedenen Itemkarten, bei denen das Wort „Ball“ zum Namen gehört, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach bis zu 3 verschiedenen Itemkarten, bei denen das Wort „Ball“ zum Namen gehört, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Shining Fates/66.ts
+++ b/data/Sword & Shield/Shining Fates/66.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Cambia tu Pokémon Activo por 1 de tus Pokémon en Banca. Si lo haces, roba 3 cartas.",
 		it: "Scambia il tuo Pokémon attivo con uno della tua panchina. Se lo fai, pesca tre carte.",
 		pt: "Troque o seu Pokémon Ativo por 1 dos seus Pokémon no Banco. Se fizer isto, compre 3 cartas.",
-		de: "Tausche dein Aktives Pokémon gegen 1 Pokémon auf deiner Bank aus. Wenn du das machst, ziehe 3 Karten."
+		de: "Tausche dein Aktives Pokémon gegen 1 Pokémon auf deiner Bank aus. Wenn du das machst, ziehe 3 Karten. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Shining Fates/67.ts
+++ b/data/Sword & Shield/Shining Fates/67.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 2 cartas de Fósil Raro y ponlas en tu Banca. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo fino a due carte Fossile Raro e mettile nella tua panchina. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por até 2 cartas Fóssil Raro no seu baralho e coloque-as no seu Banco. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach bis zu 2 Seltenes Fossil-Karten und lege sie auf deine Bank. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach bis zu 2 Seltenes Fossil-Karten und lege sie auf deine Bank. Mische anschließend dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Shining Fates/68.ts
+++ b/data/Sword & Shield/Shining Fates/68.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Roba 2 cartas. Si alguno de tus Pokémon quedó Fuera de Combate durante el último turno de tu rival, roba 2 cartas más.",
 		it: "Pesca due carte. Se uno qualsiasi dei tuoi Pokémon è stato messo KO durante l'ultimo turno del tuo avversario, pesca altre due carte.",
 		pt: "Compre 2 cartas. Se algum dos seus Pokémon tiver sido Nocauteado durante o último turno do seu oponente, compre 2 cartas a mais.",
-		de: "Ziehe 2 Karten. Wenn mindestens 1 deiner Pokémon während des letzten Zuges deines Gegners kampfunfähig wurde, ziehe 2 Karten mehr."
+		de: "Ziehe 2 Karten. Wenn mindestens 1 deiner Pokémon während des letzten Zuges deines Gegners kampfunfähig wurde, ziehe 2 Karten mehr. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Shining Fates/69.ts
+++ b/data/Sword & Shield/Shining Fates/69.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Busca en tu baraja 1 carta de Energía y 1 carta de Pokémon Darkness, enséñalas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo una carta Energia e un Pokémon Darkness, mostrali e aggiungili alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por 1 carta de Energia e 1 Pokémon Darkness no seu baralho, revele-os e coloque-os na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach 1 Energiekarte und 1 Darkness-Pokémon, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach 1 Energiekarte und 1 {D}-Pokémon, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Shining Fates/7.ts
+++ b/data/Sword & Shield/Shining Fates/7.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Brindibou",
-		en: "Rowlet"
+		en: "Rowlet",
+		de: "Bauz"
 	},
 
 	attacks: [{
@@ -51,7 +52,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It throws one knifelike feather after another at its enemies, and each one precisely strikes a weak point. These feathers are known as blade quills."
+		en: "It throws one knifelike feather after another at its enemies, and each one precisely strikes a weak point. These feathers are known as blade quills.",
+		de: "Es bombardiert seine Feinde mit messerscharfen Federn, die man „Flügelklingen“ nennt, und trifft mit jedem Wurf zielsicher ihre Schwachstellen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/70.ts
+++ b/data/Sword & Shield/Shining Fates/70.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Busca en tu baraja 1 Pokémon, enséñalo y ponlo en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo un Pokémon, mostralo e aggiungilo alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por 1 Pokémon no seu baralho, revele-o e coloque-o na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Shining Fates/71.ts
+++ b/data/Sword & Shield/Shining Fates/71.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Une hasta 2 cartas de Energía Básica de tu pila de descartes a 1 de tus Pokémon VMAX. Si has unido alguna carta de Energía de esta manera, descarta las cartas de tu mano.",
 		it: "Assegna a uno dei tuoi Pokémon-VMAX fino a due carte Energia base dalla tua pila degli scarti. Se hai assegnato delle carte Energia in questo modo, scarta le carte che hai in mano.",
 		pt: "Ligue até 2 cartas de Energia básica da sua pilha de descarte a 1 dos seus Pokémon VMAX. Se você ligou qualquer carta de Energia desta forma, descarte a sua mão.",
-		de: "Lege bis zu 2 Basis-Energiekarten aus deinem Ablagestapel an 1 deiner Pokémon-VMAX an. Wenn du auf diese Weise mindestens 1 Energiekarte angelegt hast, lege deine Handkarten auf deinen Ablagestapel."
+		de: "Lege bis zu 2 Basis-Energiekarten aus deinem Ablagestapel an 1 deiner Pokémon-VMAX an. Wenn du auf diese Weise mindestens 1 Energiekarte angelegt hast, lege deine Handkarten auf deinen Ablagestapel. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Shining Fates/72.ts
+++ b/data/Sword & Shield/Shining Fates/72.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Busca en tu baraja una carta de Entrenador, enséñala y ponla en tu mano. Baraja las cartas de tu baraja después.",
 		it: "Cerca nel tuo mazzo una carta Allenatore, mostrala e aggiungila alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure um card de Treinador em seu baralho, revele-o e coloque-o em sua mão. Em seguida, embaralhe seus cards.",
-		de: "Durchsuche dein Deck nach 1 Trainerkarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach 1 Trainerkarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Shining Fates/73.ts
+++ b/data/Sword & Shield/Shining Fates/73.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Charmilly-V",
-		en: "Alcremie V"
+		en: "Alcremie V",
+		de: "Pokusan V"
 	},
 
 	attacks: [{
@@ -41,7 +42,7 @@ const card: Card = {
 			es: "Por cada uno de tus Pokémon en Banca, busca en tu baraja 1 carta de Energía Psychic y únela a ese Pokémon. Después, baraja las cartas de tu baraja.",
 			it: "Cerca nel tuo mazzo una carta Energia Psychic per ogni Pokémon nella tua panchina e assegnala a quel Pokémon. Poi rimischia le carte del tuo mazzo.",
 			pt: "Para cada um dos seus Pokémon no Banco, procure por 1 carta de Energia Psychic no seu baralho e ligue-a àquele Pokémon. Em seguida, embaralhe o seu baralho.",
-			de: "Durchsuche für jedes Pokémon auf deiner Bank dein Deck nach 1 Psychic-Energiekarte und lege sie an jenes Pokémon an. Mische anschließend dein Deck."
+			de: "Durchsuche für jedes Pokémon auf deiner Bank dein Deck nach 1 {P}-Energiekarte und lege sie an jenes Pokémon an. Mische anschließend dein Deck."
 		},
 
 		cost: ["Colorless"]

--- a/data/Sword & Shield/Shining Fates/8.ts
+++ b/data/Sword & Shield/Shining Fates/8.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Efflèche",
-		en: "Dartrix"
+		en: "Dartrix",
+		de: "Arboretoss"
 	},
 
 	abilities: [{
@@ -82,7 +83,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "As if wielding a bow, it launches the arrow quills hidden among the feathers of its wings. Decidueye's shots never miss."
+		en: "As if wielding a bow, it launches the arrow quills hidden among the feathers of its wings. Decidueye's shots never miss.",
+		de: "Dieses Pokémon kann die Federn seiner Flügel wie Pfeile abschießen. Hat es sein Ziel angepeilt, trifft es garantiert."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates/9.ts
+++ b/data/Sword & Shield/Shining Fates/9.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			es: "Si alguno de tus Pokémon Grass quedó Fuera de Combate por el daño de un ataque de tu rival durante su último turno, este ataque hace 90 puntos de daño más.",
 			it: "Se uno qualsiasi dei tuoi Pokémon Grass è stato messo KO dai danni inflitti da un attacco dell'avversario durante il suo ultimo turno, questo attacco infligge 90 danni in più.",
 			pt: "Se algum dos seus Pokémon Grass tiver sido Nocauteado pelo dano de um ataque do seu oponente durante o último turno dele(a), este ataque causará 90 pontos de dano a mais.",
-			de: "Wenn mindestens 1 deiner Grass-Pokémon während des letzten Zuges deines Gegners durch Schaden einer Attacke kampfunfähig wurde, fügt diese Attacke 90 Schadenspunkte mehr zu."
+			de: "Wenn mindestens 1 deiner {G}-Pokémon während des letzten Zuges deines Gegners durch Schaden einer Attacke kampfunfähig wurde, fügt diese Attacke 90 Schadenspunkte mehr zu."
 		},
 
 		damage: "30+",


### PR DESCRIPTION
## Add missing German translations for swsh4.5

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
