### PR TITLE
Add missing German translations for swsh10tg

### DIFF
--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG01.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG01.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "The Pokémon is known to bring blizzards. A shake of its massive body is enough to cause whiteout conditions.",
+		de: "Dieses Pokémon löst Blizzards aus. Wenn es seinen großen Körper schüttelt, wird in seiner Umgebung alles sofort schneeweiß."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG02.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG02.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It ate a sour apple, and that induced its evolution. In its cheeks, it stores an acid capable of causing chemical burns.",
+		de: "Nach dem Verzehr eines sauren Apfels hat es sich entwickelt. In den Backentaschen speichert es eine saure Substanz, die zu Verbrennungen führt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG03.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG03.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			es: "Cuando tu Pokémon Activo queda Fuera de Combate por el daño de un ataque de los Pokémon de tu rival, puedes mover cualquier cantidad de Energías Water de ese Pokémon a este Pokémon.",
 			it: "Quando il tuo Pokémon attivo viene messo KO dai danni inflitti da un attacco di un Pokémon del tuo avversario, puoi spostare un numero qualsiasi di Energie Water da quel Pokémon a questo Pokémon.",
 			pt: "Quando seu Pokémon Ativo for Nocauteado pelo dano de um ataque dos Pokémon do seu oponente, você poderá mover qualquer quantidade de Energia Water daquele Pokémon para este Pokémon.",
-			de: "Wenn dein Aktives Pokémon durch Schaden einer Attacke der Pokémon deines Gegners kampfunfähig wird, kannst du beliebig viele Water-Energien von jenem Pokémon auf dieses Pokémon verschieben."
+			de: "Wenn dein Aktives Pokémon durch Schaden einer Attacke der Pokémon deines Gegners kampfunfähig wird, kannst du beliebig viele {W}-Energien von jenem Pokémon auf dieses Pokémon verschieben."
 		}
 	}],
 
@@ -71,7 +71,7 @@ const card: Card = {
 			es: "Este ataque hace 40 puntos de daño por cada Energía Water unida a este Pokémon.",
 			it: "Questo attacco infligge 40 danni per ogni Energia Water assegnata a questo Pokémon.",
 			pt: "Este ataque causa 40 pontos de dano para cada Energia Water ligada a este Pokémon.",
-			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte Water-Energie 40 Schadenspunkte zu."
+			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte {W}-Energie 40 Schadenspunkte zu."
 		},
 
 		damage: "40×"
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It stores energy by sleeping at underwater depths at which no other life forms can survive.",
+		de: "Kein anderes Lebewesen kann in den Tiefen existieren, in denen es schläft und so Energie speichert."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG04.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG04.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			es: "Todas las veces que quieras durante tu turno, puedes unir 1 carta de Energía Water de tu mano a 1 de tus Pokémon Water en Banca.",
 			it: "Durante il tuo turno, puoi assegnare a uno dei tuoi Pokémon Water in panchina una carta Energia Water dalla tua mano tutte le volte che vuoi.",
 			pt: "Quantas vezes desejar durante o seu turno, você poderá ligar 1 carta de Energia Water da sua mão a 1 dos seus Pokémon Water no Banco.",
-			de: "Beliebig oft während deines Zuges kannst du 1 Water-Energiekarte aus deiner Hand an 1 Water-Pokémon auf deiner Bank anlegen."
+			de: "Beliebig oft während deines Zuges kannst du 1 {W}-Energiekarte aus deiner Hand an 1 {W}-Pokémon auf deiner Bank anlegen."
 		}
 	}],
 
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It shows no mercy to any who desecrate fields and mountains. It will fly around on its icy wings, causing a blizzard to chase offenders away.",
+		de: "Verwüstet jemand Felder und Berge, vergibt es ihm niemals. Es bestraft den Täter, indem es mit seinen kalten Flügeln einen Schneesturm erzeugt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG05.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG05.ts
@@ -71,7 +71,7 @@ const card: Card = {
 			es: "Este ataque hace 30 puntos de daño más por cada Energía Psychic unida a este Pokémon.",
 			it: "Questo attacco infligge 30 danni in più per ogni Energia Psychic assegnata a questo Pokémon.",
 			pt: "Este ataque causa 30 pontos de dano a mais para cada Energia Psychic ligada a este Pokémon.",
-			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte Psychic-Energie 30 Schadenspunkte mehr zu."
+			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte {P}-Energie 30 Schadenspunkte mehr zu."
 		},
 
 		damage: "60+"
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "To protect its Trainer, it will expend all its psychic power to create a small black hole.",
+		de: "Wenn es seinen Trainer schützen will, nimmt es all seine Psycho-Kräfte zusammen, um so ein kleines schwarzes Loch zu erzeugen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG06.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG06.ts
@@ -95,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "The black orbs shine with an uncanny light when the Pokémon is erecting invisible barriers. The fur shed from its beard retains heat well and is a highly useful material for winter clothing.",
+		de: "Die schwarzen Kugeln leuchten auf ominöse Weise, wenn es unsichtbare Wände erschafft. Das Barthaar, das es verliert, wird als Material für warme Winterkleidung hoch geschätzt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG07.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG07.ts
@@ -57,6 +57,7 @@ const card: Card = {
 
 	description: {
 		en: "The six of them work together as one Pokémon. Teamwork is also their battle strategy, and they constantly change their formation as they fight.",
+		de: "Sie bilden zu sechst ein Pokémon. Es kann im Kampf seine Formation nach Belieben ändern und legt bemerkenswerte Teamarbeit an den Tag."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG08.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG08.ts
@@ -87,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "A violent creature that fells towering trees with its crude axes and shields itself with hard stone. If one should chance upon this Pokémon in the wilds, one's only recourse is to flee.",
+		de: "Harter Fels schützt seinen Körper, während es mit den wuchtigen Äxten gewaltige Bäume fällt. Begegnet man diesem ungestümen Pokémon in der Wildnis, so suche man sein Heil in der Flucht!"
 	},
 
 	variants: [

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG09.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG09.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			es: "Si tu rival tiene algún Pokémon VMAX en juego, los ataques de este Pokémon cuestan ColorlessColorlessColorless menos.",
 			it: "Se il tuo avversario ha dei Pokémon-VMAX in gioco, il costo degli attacchi di questo Pokémon è ridotto di ColorlessColorlessColorless.",
 			pt: "Se o seu oponente tiver algum Pokémon VMAX em jogo, os ataques deste Pokémon custarão ColorlessColorlessColorless a menos.",
-			de: "Wenn dein Gegner mindestens 1 Pokémon-VMAX im Spiel hat, verringern sich die Kosten der Attacken dieses Pokémon um ColorlessColorlessColorless."
+			de: "Wenn dein Gegner mindestens 1 Pokémon-VMAX im Spiel hat, verringern sich die Kosten der Attacken dieses Pokémon um {C}{C}{C}."
 		}
 	}],
 
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It chases down prey in a pack of around ten. They defeat foes with perfectly coordinated teamwork.",
+		de: "Es jagt in Rudeln von ungefähr zehn Magnayen. Beim Einkreisen der Beute arbeiten sie perfekt zusammen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG10.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG10.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It evolved after experiencing numerous fights. While crossing its arms, it lets out a shout that would make any opponent flinch.",
+		de: "Durch das Austragen unzähliger Kämpfe hat es sich entwickelt. Formt es mit den Armen ein „X“ und stößt einen Schrei aus, verschreckt das jeden."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG11.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG11.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			es: "Todas las veces que quieras durante tu turno, puedes mover 1 Energía Metal de 1 de tus Pokémon a otro de tus Pokémon.",
 			it: "Durante il tuo turno, puoi spostare un'Energia Metal da uno a un altro dei tuoi Pokémon tutte le volte che vuoi.",
 			pt: "Quantas vezes desejar durante o seu turno, você poderá mover 1 Energia Metal de 1 dos seus Pokémon para outro Pokémon seu.",
-			de: "Beliebig oft während deines Zuges kannst du 1 Metal-Energie von 1 deiner Pokémon auf 1 anderes deiner Pokémon verschieben."
+			de: "Beliebig oft während deines Zuges kannst du 1 {M}-Energie von 1 deiner Pokémon auf 1 anderes deiner Pokémon verschieben."
 		}
 	}],
 
@@ -86,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "Many scientists suspect that this Pokémon originated outside the Galar region, based on the patterns on its body.",
+		de: "Wegen seinem Muster denken viele Forscher, dass dieses Pokémon ursprünglich nicht aus Galar stammt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG12.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG12.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "It always stands on one foot. It changes feet so fast, the movement can rarely be seen.",
+		de: "Es steht immer auf einem Bein. Es wechselt sein Standbein so schnell, dass man es kaum sieht."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG18.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG18.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			es: "Una vez durante tu turno, puedes unir 1 carta de Energía Psychic de tu mano a 1 de tus Pokémon Psychic en Banca. Si has unido Energía a un Pokémon de esta manera, roba 2 cartas.",
 			it: "Una sola volta durante il tuo turno, puoi assegnare a uno dei tuoi Pokémon Psychic in panchina una carta Energia Psychic dalla tua mano. Se hai assegnato dell'Energia a un Pokémon in questo modo, pesca due carte.",
 			pt: "Uma vez durante o seu turno, você poderá ligar 1 carta de Energia Psychic da sua mão a 1 dos seus Pokémon Psychic no Banco. Se você ligou Energia a um Pokémon desta forma, compre 2 cartas.",
-			de: "Einmal während deines Zuges kannst du 1 Psychic-Energiekarte aus deiner Hand an 1 Psychic-Pokémon auf deiner Bank anlegen. Wenn du auf diese Weise Energie an ein Pokémon angelegt hast, ziehe 2 Karten."
+			de: "Einmal während deines Zuges kannst du 1 {P}-Energiekarte aus deiner Hand an 1 {P}-Pokémon auf deiner Bank anlegen. Wenn du auf diese Weise Energie an ein Pokémon angelegt hast, ziehe 2 Karten."
 		}
 	}],
 
@@ -71,7 +71,7 @@ const card: Card = {
 			es: "Este ataque hace 30 puntos de daño más por cada Energía Psychic unida a todos tus Pokémon.",
 			it: "Questo attacco infligge 30 danni in più per ogni Energia Psychic assegnata ai tuoi Pokémon.",
 			pt: "Este ataque causa 30 pontos de dano a mais para cada Energia Psychic ligada a todos os seus Pokémon.",
-			de: "Diese Attacke fügt für jede an alle deine Pokémon angelegte Psychic-Energie 30 Schadenspunkte mehr zu."
+			de: "Diese Attacke fügt für jede an alle deine Pokémon angelegte {P}-Energie 30 Schadenspunkte mehr zu."
 		},
 
 		damage: "10+"

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG19.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG19.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			es: "Los ataques de este Pokémon cuestan Colorless menos por cada uno de los Pokémon V en juego de tu rival.",
 			it: "Il costo degli attacchi di questo Pokémon è ridotto di Colorless per ogni Pokémon-V in gioco del tuo avversario.",
 			pt: "Os ataques deste Pokémon custam Colorless a menos para cada Pokémon V do seu oponente em jogo.",
-			de: "Die Kosten der Attacken dieses Pokémon verringern sich für jedes Pokémon-V deines Gegners im Spiel um Colorless."
+			de: "Die Kosten der Attacken dieses Pokémon verringern sich für jedes Pokémon-V deines Gegners im Spiel um {C}."
 		}
 	}],
 

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG20.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG20.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			es: "Una vez durante tu turno, puedes unir 1 carta de Energía Darkness de tu pila de descartes a este Pokémon. No puedes usar más de 1 habilidad Alas Incendiarias en cada turno.",
 			it: "Una sola volta durante il tuo turno, puoi assegnare a questo Pokémon una carta Energia Darkness dalla tua pila degli scarti. Puoi usare l'abilità Ali Estremafiamma solo una volta per turno.",
 			pt: "Uma vez durante o seu turno, você poderá ligar 1 carta de Energia Darkness da sua pilha de descarte a este Pokémon. Você não pode usar mais de 1 Habilidade Asas de Fogaréu por turno.",
-			de: "Einmal während deines Zuges kannst du 1 Darkness-Energiekarte aus deinem Ablagestapel an dieses Pokémon anlegen. Du kannst immer nur jeweils 1 Fähigkeit Flammende Schattenflügel einsetzen."
+			de: "Einmal während deines Zuges kannst du 1 {D}-Energiekarte aus deinem Ablagestapel an dieses Pokémon anlegen. Du kannst immer nur jeweils 1 Fähigkeit Flammende Schattenflügel einsetzen."
 		}
 	}],
 

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG21.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG21.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			es: "Una vez durante tu turno, puedes mirar las 3 primeras cartas de tu baraja y unir cualquier cantidad de cartas de Energía Metal que encuentres entre ellas a este Pokémon. Pon el resto de las cartas en tu mano. Si usas esta habilidad, tu turno termina.",
 			it: "Una sola volta durante il tuo turno, puoi guardare le prime tre carte del tuo mazzo e assegnare un numero qualsiasi di carte Energia Metal presenti tra esse a questo Pokémon. Aggiungi le altre carte a quelle che hai in mano. Se usi questa abilità, il tuo turno finisce.",
 			pt: "Uma vez durante o seu turno, você poderá olhar as 3 cartas de cima do seu baralho e ligar qualquer número de cartas de Energia Metal que encontrar lá a este Pokémon. Coloque as outras cartas na sua mão. Se você usar esta Habilidade, o seu turno acabará.",
-			de: "Einmal während deines Zuges kannst du dir die obersten 3 Karten deines Decks anschauen und beliebig viele Metal-Energiekarten, die du dort findest, an dieses Pokémon anlegen. Nimm die anderen Karten auf deine Hand. Wenn du diese Fähigkeit einsetzt, endet dein Zug."
+			de: "Einmal während deines Zuges kannst du dir die obersten 3 Karten deines Decks anschauen und beliebig viele {M}-Energiekarten, die du dort findest, an dieses Pokémon anlegen. Nimm die anderen Karten auf deine Hand. Wenn du diese Fähigkeit einsetzt, endet dein Zug."
 		}
 	}],
 

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG24.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG24.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Roba 3 cartas. Si has robado alguna carta de esta manera, descarta hasta 3 cartas de tu mano. (Debes descartar por lo menos 1 carta).",
 		it: "Pesca tre carte. Se hai pescato delle carte in questo modo, scarta fino a tre carte che hai in mano. Devi scartare almeno una carta.",
 		pt: "Compre 3 cartas. Se você comprar qualquer carta desta forma, descarte até 3 cartas da sua mão (você deve descartar pelo menos 1 carta).",
-		de: "Ziehe 3 Karten. Wenn du auf diese Weise mindestens 1 Karte gezogen hast, lege bis zu 3 Karten aus deiner Hand auf deinen Ablagestapel. (Du musst mindestens 1 Karte auf deinen Ablagestapel legen.)"
+		de: "Ziehe 3 Karten. Wenn du auf diese Weise mindestens 1 Karte gezogen hast, lege bis zu 3 Karten aus deiner Hand auf deinen Ablagestapel. (Du musst mindestens 1 Karte auf deinen Ablagestapel legen.) Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG25.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG25.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Descarta las 5 primeras cartas de tu baraja y une cualquier carta de Energía que hayas descartado de esta manera a tus Pokémon Fighting en Banca de la manera que desees.",
 		it: "Scarta le prime cinque carte del tuo mazzo e assegna ai tuoi Pokémon Fighting in panchina le carte Energia che hai appena scartato nel modo che preferisci.",
 		pt: "Descarte as 5 cartas de cima do seu baralho e ligue quaisquer cartas de Energia que você descartou desta forma aos seus Pokémon Fighting no Banco como desejar.",
-		de: "Lege die obersten 5 Karten deines Decks auf deinen Ablagestapel und lege alle Energiekarten, die du auf diese Weise auf deinen Ablagestapel gelegt hast, beliebig an die Fighting-Pokémon auf deiner Bank an."
+		de: "Lege die obersten 5 Karten deines Decks auf deinen Ablagestapel und lege alle Energiekarten, die du auf diese Weise auf deinen Ablagestapel gelegt hast, beliebig an die {F}-Pokémon auf deiner Bank an. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG26.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG26.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Une 1 carta de Energía Water de tu pila de descartes a 1 de tus Pokémon V. Si lo haces, roba 3 cartas.",
 		it: "Assegna una carta Energia Water dalla tua pila degli scarti a uno dei tuoi Pokémon-V. Se lo fai, pesca tre carte.",
 		pt: "Ligue 1 carta de Energia Water da sua pilha de descarte a 1 dos seus Pokémon V. Se fizer isto, compre 3 cartas.",
-		de: "Lege 1 Water-Energiekarte aus deinem Ablagestapel an 1 deiner Pokémon-V an. Wenn du das machst, ziehe 3 Karten."
+		de: "Lege 1 {W}-Energiekarte aus deinem Ablagestapel an 1 deiner Pokémon-V an. Wenn du das machst, ziehe 3 Karten. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG27.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG27.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Descarta hasta 2 cartas de tu mano y roba 2 cartas por cada carta que hayas descartado de esta manera.",
 		it: "Scarta fino a due carte che hai in mano e pesca due carte per ogni carta che hai scartato in questo modo.",
 		pt: "Descarte até 2 cartas da sua mão e compre 2 cartas para cada carta descartada desta forma.",
-		de: "Lege bis zu 2 Karten aus deiner Hand auf deinen Ablagestapel und ziehe 2 Karten für jede auf diese Weise auf deinen Ablagestapel gelegte Karte."
+		de: "Lege bis zu 2 Karten aus deiner Hand auf deinen Ablagestapel und ziehe 2 Karten für jede auf diese Weise auf deinen Ablagestapel gelegte Karte. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG28.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG28.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Busca en tu baraja 1 carta de Energía y 1 carta de Pokémon Darkness, enséñalas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo una carta Energia e un Pokémon Darkness, mostrali e aggiungili alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por 1 carta de Energia e 1 Pokémon Darkness no seu baralho, revele-os e coloque-os na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach 1 Energiekarte und 1 Darkness-Pokémon, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach 1 Energiekarte und 1 {D}-Pokémon, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Astral Radiance Trainer Gallery/TG30.ts
+++ b/data/Sword & Shield/Astral Radiance Trainer Gallery/TG30.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			es: "Una vez durante tu turno, puedes unir 1 carta de Energía Psychic de tu mano a 1 de tus Pokémon Psychic en Banca. Si has unido Energía a un Pokémon de esta manera, roba 2 cartas.",
 			it: "Una sola volta durante il tuo turno, puoi assegnare a uno dei tuoi Pokémon Psychic in panchina una carta Energia Psychic dalla tua mano. Se hai assegnato dell'Energia a un Pokémon in questo modo, pesca due carte.",
 			pt: "Uma vez durante o seu turno, você poderá ligar 1 carta de Energia Psychic da sua mão a 1 dos seus Pokémon Psychic no Banco. Se você ligou Energia a um Pokémon desta forma, compre 2 cartas.",
-			de: "Einmal während deines Zuges kannst du 1 Psychic-Energiekarte aus deiner Hand an 1 Psychic-Pokémon auf deiner Bank anlegen. Wenn du auf diese Weise Energie an ein Pokémon angelegt hast, ziehe 2 Karten."
+			de: "Einmal während deines Zuges kannst du 1 {P}-Energiekarte aus deiner Hand an 1 {P}-Pokémon auf deiner Bank anlegen. Wenn du auf diese Weise Energie an ein Pokémon angelegt hast, ziehe 2 Karten."
 		}
 	}],
 
@@ -71,7 +71,7 @@ const card: Card = {
 			es: "Este ataque hace 30 puntos de daño más por cada Energía Psychic unida a todos tus Pokémon.",
 			it: "Questo attacco infligge 30 danni in più per ogni Energia Psychic assegnata ai tuoi Pokémon.",
 			pt: "Este ataque causa 30 pontos de dano a mais para cada Energia Psychic ligada a todos os seus Pokémon.",
-			de: "Diese Attacke fügt für jede an alle deine Pokémon angelegte Psychic-Energie 30 Schadenspunkte mehr zu."
+			de: "Diese Attacke fügt für jede an alle deine Pokémon angelegte {P}-Energie 30 Schadenspunkte mehr zu."
 		},
 
 		damage: "10+"


### PR DESCRIPTION
## Add missing German translations for swsh10tg

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
