### PR TITLE
Add missing German translations for sv03.5

### DIFF
--- a/data/Scarlet & Violet/151/001.ts
+++ b/data/Scarlet & Violet/151/001.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "While it is young, it uses the nutrients that are stored in the seed on its back in order to grow.",
+		de: "Nach der Geburt nimmt es für eine Weile Nährstoffe über den Samen auf seinem Rücken auf."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/002.ts
+++ b/data/Scarlet & Violet/151/002.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "Exposure to sunlight adds to its strength. Sunlight also makes the bud on its back grow larger.",
+		de: "Die Sonne macht es stärker. Die Knospe auf seinem Rücken wächst unter dem Einfluss von Sonnenlicht."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/004.ts
+++ b/data/Scarlet & Violet/151/004.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "From the time it is born, a flame burns at the tip of its tail. Its life would end if the flame were to go out.",
+		de: "Von Geburt an brennt die Flamme auf seiner Schwanzspitze. Sobald sie verglimmt, erlischt auch sein Lebenslicht."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/005.ts
+++ b/data/Scarlet & Violet/151/005.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "If it becomes agitated during battle, it spouts intense flames, incinerating its surroundings.",
+		de: "Steigert es sich in einen Kampf hinein, spuckt es Flammen, die alles in seiner Umgebung niederbrennen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/007.ts
+++ b/data/Scarlet & Violet/151/007.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "When it feels threatened, it draws its limbs inside its shell and sprays water from its mouth.",
+		de: "Fühlt es sich bedroht, verkriecht es sich in seinen Panzer und spuckt Wasser aus seinem Maul."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/008.ts
+++ b/data/Scarlet & Violet/151/008.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "It cleverly controls its furry ears and tail to maintain its balance while swimming.",
+		de: "Es balanciert geschickt mit seinen buschigen Ohren und dem Schweif, während es im Wasser schwimmt."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/010.ts
+++ b/data/Scarlet & Violet/151/010.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "Its short feet are tipped with suction pads that enable it to tirelessly climb slopes and walls.",
+		de: "Es hat Saugnäpfe an den Beinchen, mit denen es mühelos Steigungen und Mauern erklimmen kann."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/011.ts
+++ b/data/Scarlet & Violet/151/011.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "Even though it is encased in a sturdy shell, the body inside is tender. It can't withstand a harsh attack.",
+		de: "In seiner harten Schale ist ein weicher Körper. Einem brutalen Angriff hat es nichts entgegenzusetzen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/012.ts
+++ b/data/Scarlet & Violet/151/012.ts
@@ -83,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "It collects honey every day. It rubs honey onto the hairs on its legs to carry it back to its nest.",
+		de: "Es sammelt täglich Honig. Es reibt ihn in seine Beinhaare, um ihn in sein Nest zu transportieren."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/013.ts
+++ b/data/Scarlet & Violet/151/013.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "Its poison stinger is very powerful. Its bright-colored body is intended to warn off its enemies.",
+		de: "Sein Giftstachel ist gefährlich. Sein hellleuchtender Körper soll Feinde abschrecken."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/014.ts
+++ b/data/Scarlet & Violet/151/014.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "While awaiting evolution, it hides from predators under leaves and in nooks of branches.",
+		de: "Während es auf seine Entwicklung wartet, versteckt es sich unter Blättern und zwischen Ästen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/015.ts
+++ b/data/Scarlet & Violet/151/015.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "May appear in a swarm. Flies at violent speeds, all the while stabbing with the toxic stinger on its rear.",
+		de: "Es kann in Schwärmen auftauchen. Während seines rasanten Fluges sticht es mit dem Giftstachel an seinem Hinterteil zu."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/016.ts
+++ b/data/Scarlet & Violet/151/016.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "It is docile and prefers to avoid conflict. If disturbed, however, it can ferociously strike back.",
+		de: "Reizt man dieses an sich gutmütige Pokémon, wehrt es sich wütend."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/017.ts
+++ b/data/Scarlet & Violet/151/017.ts
@@ -60,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "Very protective of its sprawling territorial area, this Pokémon will fiercely peck at any intruder.",
+		de: "Dieses Pokémon verteidigt sein abgegrenztes Areal sorgsam gegen alle Eindringlinge."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/018.ts
+++ b/data/Scarlet & Violet/151/018.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It spreads its gorgeous wings widely to intimidate enemies. It races through the skies at Mach-2 speed.",
+		de: "Es breitet seine betörenden Schwingen aus, um den Gegner einzuschüchtern. Seine Fluggeschwindigkeit liegt bei Mach 2."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/019.ts
+++ b/data/Scarlet & Violet/151/019.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon is common but hazardous. Its sharp incisors can easily cut right through hard wood.",
+		de: "Ein weitverbreitetes Pokémon, das nicht ganz ungefährlich ist. Selbst hartes Holz zerkleinert es mit seinen scharfen Nagezähnen mühelos."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/020.ts
+++ b/data/Scarlet & Violet/151/020.ts
@@ -63,6 +63,7 @@ const card: Card = {
 
 	description: {
 		en: "Its whiskers are essential for maintaining its balance. No matter how friendly you are, it will get angry and bite you if you touch its whiskers.",
+		de: "Mit seinen Barthaaren hält es die Balance. Berührt man sie, wird es wütend und beißt zu, egal, wie zutraulich es auch sein mag."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/021.ts
+++ b/data/Scarlet & Violet/151/021.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "Due to its short wings, it can't fly long distances. It wanders about restlessly and pecks at bug Pokémon.",
+		de: "Aufgrund seiner kurzen Flügel kann es keine langen Strecken fliegen. Es rennt wild durch die Gegend, um Käfer-Pokémon aufzupicken."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/022.ts
+++ b/data/Scarlet & Violet/151/022.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "Carrying food through Fearow's territory is dangerous. It will snatch the food away from you in a flash!",
+		de: "Wer Essbares dabeihat, sollte sich nicht in Ibitaks Revier begeben, da sonst ein Überfall aus heiterem Himmel droht."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/023.ts
+++ b/data/Scarlet & Violet/151/023.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "The eggs of bird Pokémon are its favorite food. It swallows eggs whole, so sometimes an egg gets stuck, and Ekans faints.",
+		de: "Die Eier von Vogel-Pokémon, sein Leibgericht, verschlingt es am Stück. Bleibt ihm eines in der Kehle stecken, verliert es kurz das Bewusstsein."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/025.ts
+++ b/data/Scarlet & Violet/151/025.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "When it is angered, it immediately discharges the energy stored in the pouches in its cheeks.",
+		de: "Ist es wütend, entlädt sich augenblicklich die Elektrizität, die es in seinen Backentaschen gespeichert hat."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/026.ts
+++ b/data/Scarlet & Violet/151/026.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "Its tail discharges electricity into the ground, protecting it from getting shocked.",
+		de: "Mithilfe seines Schweifs entlädt es Elektrizität in den Boden, um sich auf diese Weise vor elektrischen Schlägen zu schützen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/027.ts
+++ b/data/Scarlet & Violet/151/027.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "It burrows into the ground to create its nest. If hard stones impede its tunneling, it uses its sharp claws to shatter them and then carries on digging.",
+		de: "Es gräbt sich seinen Bau im Erdboden. Stößt es dabei auf harte Steine, zerstört es diese mit seinen scharfen Krallen und gräbt unbeirrt weiter."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/028.ts
+++ b/data/Scarlet & Violet/151/028.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "It climbs trees by hooking on with its sharp claws. Sandslash shares the berries it gathers, dropping them down to Sandshrew waiting below the tree.",
+		de: "Mit seinen scharfen Krallen klettert es auf Bäume und wirft unten wartenden Sandan Beeren zu, die sie sich dann teilen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/029.ts
+++ b/data/Scarlet & Violet/151/029.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "It uses its hard incisor teeth to crush and eat berries. The tip of a female Nidoran's horn is a bit more rounded than the tip of a male's horn.",
+		de: "Mit ihren harten Vorderzähnen zerteilen sie Beeren, bevor sie diese essen. Die Spitze ihres Horns ist etwas abgerundeter als bei Männchen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/030.ts
+++ b/data/Scarlet & Violet/151/030.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "If the group is threatened, these Pokémon will band together to assault enemies with a chorus of ultrasonic waves.",
+		de: "Nähert sich Gefahr, schließen sie sich mit anderen Artgenossen zusammen und begegnen der Bedrohung mit einem Chor aus Ultraschallwellen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/031.ts
+++ b/data/Scarlet & Violet/151/031.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "It pacifies offspring by placing them in the gaps between the spines on its back. The spines will never secrete poison while young are present.",
+		de: "Es beruhigt seine Jungen, indem es diese zwischen den Stacheln auf seinem Rücken reiten lässt. Die Stacheln sondern derweil kein Gift ab."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/032.ts
+++ b/data/Scarlet & Violet/151/032.ts
@@ -46,6 +46,7 @@ const card: Card = {
 
 	description: {
 		en: "Small but brave, this Pokémon will hold its ground and even risk its life in battle to protect the female it's friendly with.",
+		de: "Trotz seiner geringen Größe ist es sehr mutig. Um ein befreundetes Weibchen zu beschützen, riskiert es sein Leben und kämpft unerschrocken."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/033.ts
+++ b/data/Scarlet & Violet/151/033.ts
@@ -67,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "It's nervous and quick to act aggressively. The potency of its poison increases along with the level of adrenaline present in its body.",
+		de: "Es ist nervös und wird schnell aggressiv. Steigt sein Adrenalinspiegel, erhöht sich gleichzeitig auch die Konzentration seines Gifts."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/034.ts
+++ b/data/Scarlet & Violet/151/034.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "Nidoking prides itself on its strength. It's forceful and spirited in battle, making use of its thick tail and diamond-crushing horn.",
+		de: "Nidoking ist stolz auf seine Kraft und kämpft sehr geschickt mit seinem dicken Schweif und seinem Horn, das selbst Diamanten zertrümmern kann."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/035.ts
+++ b/data/Scarlet & Violet/151/035.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "Its adorable behavior and cry make it highly popular. However, this cute Pokémon is rarely found.",
+		de: "Aufgrund seines reizenden Wesens und seines Rufes erfreut sich dieses Pokémon großer Beliebtheit. Leider ist es auch sehr selten."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/036.ts
+++ b/data/Scarlet & Violet/151/036.ts
@@ -83,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "Their ears are sensitive enough to hear a pin drop from over a mile away, so they're usually found in quiet places.",
+		de: "Ihr Gehör erfasst das Geräusch einer fallenden Nadel noch aus 1 km Entfernung. Sie bevorzugen daher ruhige Orte."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/037.ts
+++ b/data/Scarlet & Violet/151/037.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "As each tail grows, its fur becomes more lustrous. When held, it feels slightly warm.",
+		de: "Sein Fell wird geschmeidiger, wenn seine sechs Schweife wachsen. Wenn man das Fell berührt, fühlt es sich leicht warm an."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/039.ts
+++ b/data/Scarlet & Violet/151/039.ts
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "When its huge eyes waver, it sings a mysteriously soothing melody that lulls its enemies to sleep.",
+		de: "Wenn seine Kulleraugen zu flackern beginnen, singt es ein mysteriöses, wohlklingendes Lied, das Zuhörer in Schlaf versetzt."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/041.ts
+++ b/data/Scarlet & Violet/151/041.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "Zubat live in caves, down where the sun's light won't reach. In the morning, they gather together to keep each other warm as they sleep.",
+		de: "Zubat leben tief in Höhlen, wo das Sonnenlicht sie nicht erreicht. Bei Tagesanbruch rücken sie zusammen, um sich im Schlaf zu wärmen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/042.ts
+++ b/data/Scarlet & Violet/151/042.ts
@@ -67,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "Its feet are tiny, but this Pokémon walks skillfully. It sneaks up on sleeping prey before sinking in its fangs and slurping up blood.",
+		de: "Golbat kann trotz seiner kleinen Beine geschickt laufen. Es schleicht sich an schlafende Beute an, stößt seine Zähne in sie und schlürft ihr Blut."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/043.ts
+++ b/data/Scarlet & Violet/151/043.ts
@@ -46,6 +46,7 @@ const card: Card = {
 
 	description: {
 		en: "During the day, it stays in the cold underground to avoid the sun. It grows by bathing in moonlight.",
+		de: "Tagsüber versteckt es sich in der kalten Erde, um die Sonne zu meiden. Es wächst im Mondschein."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/044.ts
+++ b/data/Scarlet & Violet/151/044.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "What appears to be drool is actually sweet honey. It is very sticky and clings stubbornly if touched.",
+		de: "Was wie Speichel aussieht, ist eigentlich Honig. Er ist sehr klebrig und wenn man ihn berührt, bekommt man ihn nicht mehr ab."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/045.ts
+++ b/data/Scarlet & Violet/151/045.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "The larger its petals, the more toxic pollen it contains. Its big head is heavy and hard to hold up.",
+		de: "Je größer die Blütenblätter, desto mehr giftige Pollen enthält die Blüte. Aber es ist auch umso erschöpfter, da sein Kopf so schwer wird."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/046.ts
+++ b/data/Scarlet & Violet/151/046.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "The mushrooms, known as tochukaso, are controlling the bug. Even if the bug bugs the mushrooms, they tell it to bug off.",
+		de: "Paras’ Körper kann nicht nach seinem eigenen Willen handeln, da er von Tochukaso, den Pilzen auf seinem Rücken, kontrolliert wird."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/047.ts
+++ b/data/Scarlet & Violet/151/047.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "The bug is mostly dead, with the mushroom on its back having become the main body. If the mushroom comes off, the bug stops moving.",
+		de: "Der Pilz auf seinem Rücken ist sein wichtigstes Körperteil. Der Rest ist quasi leblos und kann sich ohne den Pilz nicht bewegen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/048.ts
+++ b/data/Scarlet & Violet/151/048.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "Poison oozes from all over its body. It catches small bug Pokémon at night that are attracted by light.",
+		de: "Aus seinem ganzen Körper tritt Gift aus. Es fängt und frisst nachts kleine Käfer-Pokémon, die von Licht angelockt wurden."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/049.ts
+++ b/data/Scarlet & Violet/151/049.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "The wings are covered with dustlike scales. Every time it flaps its wings, it looses highly toxic dust.",
+		de: "Seine Flügel sind mit staubähnlichen Schuppen überzogen. Mit jedem Flügelschlag verstreut es hochgiftigen Puder."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/050.ts
+++ b/data/Scarlet & Violet/151/050.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives about one yard underground, where it feeds on plant roots. It sometimes appears aboveground.",
+		de: "Dieses Pokémon lebt 1 m unter der Erde. Es frisst Wurzeln und kommt hin und wieder an die Oberfläche."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/051.ts
+++ b/data/Scarlet & Violet/151/051.ts
@@ -67,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "Its three heads bob separately up and down to loosen the soil nearby, making it easier for it to burrow.",
+		de: "Seine drei Köpfe bewegen sich abwechselnd hinauf und hinunter, um das Erdreich um sich herum zu lockern und leichter graben zu können."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/052.ts
+++ b/data/Scarlet & Violet/151/052.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "All it does is sleep during the daytime. At night, it patrols its territory with its eyes aglow.",
+		de: "Es schläft den ganzen Tag. Nachts patrouilliert es sein Revier mit glühenden Augen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/053.ts
+++ b/data/Scarlet & Violet/151/053.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "Although its fur has many admirers, it is tough to raise as a pet because of its fickle meanness.",
+		de: "Aufgrund seines schönen Fells wollen viele ein Snobilikat im Haus haben. Es ist jedoch schwer erziehbar, da es sehr schnell kratzt."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/054.ts
+++ b/data/Scarlet & Violet/151/054.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "It is constantly wracked by a headache. When the headache turns intense, it begins using mysterious powers.",
+		de: "Es wird permanent von Kopfschmerzen geplagt. Wird der Schmerz stärker, setzt es geheimnisvolle Kräfte ein."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/055.ts
+++ b/data/Scarlet & Violet/151/055.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "When it swims at full speed using its long, webbed limbs, its forehead somehow begins to glow.",
+		de: "Wenn es mit den Schwimmflossen an seinen langen Gliedmaßen schnell durchs Wasser schwimmt, beginnt seine Stirn zu glühen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/056.ts
+++ b/data/Scarlet & Violet/151/056.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives in groups in the treetops. If it loses sight of its group, it becomes infuriated by its loneliness.",
+		de: "Es lebt mit Artgenossen in Baumkronen. Verliert es sie aus den Augen, wird es vor Einsamkeit sofort zornig."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/057.ts
+++ b/data/Scarlet & Violet/151/057.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "It becomes wildly furious if it even senses someone looking at it. It chases anyone that meets its glare.",
+		de: "Spürt Rasaff, dass jemand es anblickt, wird es rasend vor Wut. Es verfolgt jeden, der es wagt, seinen Blick zu erwidern."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/058.ts
+++ b/data/Scarlet & Violet/151/058.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "It has a brave and trustworthy nature. It fearlessly stands up to bigger and stronger foes.",
+		de: "Es ist von Natur aus tapfer und vertrauenswürdig und scheut auch vor Gegnern nicht zurück, die größer und stärker sind als es selbst."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/059.ts
+++ b/data/Scarlet & Violet/151/059.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "An ancient picture scroll shows that people were captivated by its movement as it ran through prairies.",
+		de: "Eine alte Bildrolle zeigt, dass die Menschen von dem Anblick über Wiesen rennender Arkani verzaubert waren."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/060.ts
+++ b/data/Scarlet & Violet/151/060.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "In rivers with fast-flowing water, this Pokémon will cling to a rock by using its thick lips, which act like a suction cup.",
+		de: "In schnell fließenden Flüssen hält es sich mithilfe seiner dicken Lippen, die als Saugnapf fungieren, an Felsen fest."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/061.ts
+++ b/data/Scarlet & Violet/151/061.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon's sweat is a slimy mucus. When captured, Poliwhirl can slither from its enemies' grasp and escape.",
+		de: "Quaputzi schwitzt glitschigen Schleim, dank dem es leicht der Umklammerung eines Feindes entkommen kann."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/062.ts
+++ b/data/Scarlet & Violet/151/062.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "Poliwrath is skilled at both swimming and martial arts. It uses its well-trained arms to dish out powerful punches.",
+		de: "Es ist sowohl ein begnadeter Schwimmer als auch Kampfsportler. Mit seinen durchtrainierten Armen teilt es kräftige Schläge aus."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/063.ts
+++ b/data/Scarlet & Violet/151/063.ts
@@ -52,6 +52,7 @@ const card: Card = {
 
 	description: {
 		en: "Abra can teleport in its sleep. Apparently the more deeply Abra sleeps, the farther its teleportations go.",
+		de: "Es kann sich im Schlaf teleportieren. Je tiefer Abra schläft, desto weiter entfernt soll der Ort sein, an den es sich teleportiert."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/064.ts
+++ b/data/Scarlet & Violet/151/064.ts
@@ -69,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon's telekinesis is immensely powerful. To prepare for evolution, Kadabra stores up psychic energy in the star on its forehead.",
+		de: "Kadabra verfügt über enorme psychokinetische Macht. Als Vorbereitung für seine Entwicklung speichert es im Stern auf der Stirn Psycho-Kräfte."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/066.ts
+++ b/data/Scarlet & Violet/151/066.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "Always brimming with power, it passes time by lifting boulders. Doing so makes it even stronger.",
+		de: "Da es vor Kraft strotzt, hebt es zum Zeitvertreib Felsen. Dadurch gewinnt es an zusätzlicher Stärke."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/067.ts
+++ b/data/Scarlet & Violet/151/067.ts
@@ -63,6 +63,7 @@ const card: Card = {
 
 	description: {
 		en: "Its formidable body never gets tired. It helps people by doing work such as the moving of heavy goods.",
+		de: "Sein durchtrainierter Körper wird nie müde. Es hilft den Menschen, indem es schwere Sachen trägt."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/068.ts
+++ b/data/Scarlet & Violet/151/068.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "With four arms that react more quickly than it can think, it can execute many punches at once.",
+		de: "Seine vier Arme reagieren schneller, als es denken kann. Daher ist es in der Lage, unzählige Schläge reflexartig auszuführen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/069.ts
+++ b/data/Scarlet & Violet/151/069.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "Its bud looks like a human face. Because of the bud, it is rumored to be a type of legendary mandrake plant.",
+		de: "Seine Knospe ähnelt einem Menschengesicht. Man sagt, dass es mit der legendären Mandragora verwandt ist."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/070.ts
+++ b/data/Scarlet & Violet/151/070.ts
@@ -67,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "It spits out Poison Powder to immobilize the enemy and then finishes it with a spray of Acid.",
+		de: "Dieses Pokémon lähmt den Gegner mit Giftpuder, bevor es ihn mit Säure erledigt."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/071.ts
+++ b/data/Scarlet & Violet/151/071.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "Once ingested into this Pokémon's body, even the hardest object will melt into nothing.",
+		de: "Selbst die härtesten Objekte werden zersetzt, wenn der Körper sie erst aufgenommen hat."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/072.ts
+++ b/data/Scarlet & Violet/151/072.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon is mostly made of water. A Tentacool out in the ocean is very hard to spot, because its body blends in with the sea.",
+		de: "Tentacha besteht fast vollständig aus Wasser, wodurch man es im Meer nur sehr schwer erkennen kann."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/073.ts
+++ b/data/Scarlet & Violet/151/073.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "Its 80 tentacles can stretch and shrink freely. Tentacruel ensnares prey in a net of spread-out tentacles, delivering venomous stings to its catch.",
+		de: "Tentoxa kann seine 80 Tentakel beliebig ausfahren und einziehen. Es breitet sie netzartig aus, um Beute zu fangen und dann zu vergiften."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/074.ts
+++ b/data/Scarlet & Violet/151/074.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "It uses both hands to climb precipitous cliffs. People who see it in action have been known to take up bouldering.",
+		de: "Mit den Armen erklimmt es selbst steile Hänge. Unter den Menschen soll diese Klettermethode Vorbild für den Bouldersport gewesen sein."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/075.ts
+++ b/data/Scarlet & Violet/151/075.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "It travels by rolling down cliffs. If it falls into a river, it will explode with its last gasp.",
+		de: "Es bewegt sich rollend über Abhänge fort. Stürzt es versehentlich in einen Fluss, sprengt es sich in seiner Verzweiflung selbst in die Luft."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/077.ts
+++ b/data/Scarlet & Violet/151/077.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "If you've been accepted by Ponyta, its burning mane is mysteriously no longer hot to the touch.",
+		de: "Hat man erst einmal das Vertrauen eines Ponitas gewonnen, kann man seltsamerweise sogar seine feurige Mähne anfassen, ohne sich zu verbrennen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/078.ts
+++ b/data/Scarlet & Violet/151/078.ts
@@ -83,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "The fastest runner becomes the leader, and it decides the herd's pace and direction of travel.",
+		de: "Das schnellste Exemplar wird zum Anführer bestimmt und gibt als solcher den Zielort und die Geschwindigkeit der Herde vor."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/079.ts
+++ b/data/Scarlet & Violet/151/079.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "It is incredibly slow and dopey. It takes five seconds for it to feel pain when under attack.",
+		de: "Ein unglaublich träges und einfältiges Pokémon. Wenn es angegriffen wird, bemerkt es den Schmerz erst fünf Sekunden später."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/080.ts
+++ b/data/Scarlet & Violet/151/080.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "When a Slowpoke went hunting in the sea, its tail was bitten by a Shellder. That made it evolve into Slowbro.",
+		de: "Als Flegmon im Meer jagen ging, biss ein Muschas in seine Rute. Dadurch entwickelte es sich zu Lahmus."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/081.ts
+++ b/data/Scarlet & Violet/151/081.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "The electromagnetic waves emitted by the units at the sides of its head expel antigravity, which allows it to float.",
+		de: "Die seitlichen Module halten es in der Luft, indem sie mit elektromagnetischen Wellen die Schwerkraft überlisten."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/082.ts
+++ b/data/Scarlet & Violet/151/082.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "Three Magnemite are linked by a strong magnetic force. Earaches will occur if you get too close.",
+		de: "Drei Magnetilo sind durch ein starkes Magnetfeld verbunden. In seiner Nähe bekommt man Ohrensausen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/083.ts
+++ b/data/Scarlet & Violet/151/083.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "They use a plant stalk as a weapon, but not all of them use it in the same way. Several distinct styles of stalk fighting have been observed.",
+		de: "Im Kampf verwendet es eine Lauchstange als Waffe. Es gibt verschiedene Meinungen dazu, wie diese korrekt zu schwingen sei."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/084.ts
+++ b/data/Scarlet & Violet/151/084.ts
@@ -61,6 +61,7 @@ const card: Card = {
 
 	description: {
 		en: "The brains in its two heads appear to communicate emotions to each other with a telepathic power.",
+		de: "Die Gehirne der beiden Köpfe kommunizieren ihre Gefühle über Telepathie."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/085.ts
+++ b/data/Scarlet & Violet/151/085.ts
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "An odd species that is rarely found. The three heads respectively represent joy, sadness, and anger.",
+		de: "Ein seltsames Exemplar, das nur selten gefunden wird. Die drei Köpfe repräsentieren Freude, Trauer und Wut."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/086.ts
+++ b/data/Scarlet & Violet/151/086.ts
@@ -46,6 +46,7 @@ const card: Card = {
 
 	description: {
 		en: "Thanks to its thick fat, cold seas don't bother it at all, but it gets tired pretty easily in warm waters.",
+		de: "Kalte Meere machen ihm dank seiner dicken Fettschicht nichts aus. Wärmere Gewässer setzen ihm hingegen sehr zu."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/087.ts
+++ b/data/Scarlet & Violet/151/087.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "It sunbathes on the beach after meals. The rise in its body temperature helps its digestion.",
+		de: "Nach einer Mahlzeit genießt es ein Sonnenbad am Strand. Durch die erhöhte Körpertemperatur wird seine Verdauung unterstützt."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/088.ts
+++ b/data/Scarlet & Violet/151/088.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "Born from sludge, these Pokémon now gather in polluted places and increase the bacteria in their bodies.",
+		de: "Diese aus Schlamm entstandenen Pokémon scharen sich an dreckigen Orten, um ihre körpereigenen Bakterien zu kultivieren."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/089.ts
+++ b/data/Scarlet & Violet/151/089.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "It's thickly covered with a filthy, vile sludge. It is so toxic, even its footprints contain poison.",
+		de: "Der schmutzige Schleim dieses Pokémon ist extrem toxisch. Selbst die Spuren, die es hinterlässt, enthalten Gift."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/090.ts
+++ b/data/Scarlet & Violet/151/090.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "It is encased in a shell that is harder than diamond. Inside, however, it is surprisingly tender.",
+		de: "Seine Schale ist härter als Diamant. Im Inneren ist es jedoch überraschend weich."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/091.ts
+++ b/data/Scarlet & Violet/151/091.ts
@@ -63,6 +63,7 @@ const card: Card = {
 
 	description: {
 		en: "Cloyster that live in seas with harsh tidal currents grow large, sharp spikes on their shells.",
+		de: "Austos, die in Meeren mit starker Strömung leben, entwickeln große und scharfe Stacheln an ihrer Schale."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/092.ts
+++ b/data/Scarlet & Violet/151/092.ts
@@ -52,6 +52,7 @@ const card: Card = {
 
 	description: {
 		en: "It wraps its opponent in its gas-like body, slowly weakening its prey by poisoning it through the skin.",
+		de: "Es hüllt seine Beute in seinen Gaskörper ein und schwächt sie, indem es sie nach und nach über die Haut vergiftet."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/093.ts
+++ b/data/Scarlet & Violet/151/093.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It likes to lurk in the dark and tap shoulders with a gaseous hand. Its touch causes endless shuddering.",
+		de: "Es lauert gern im Dunkeln und tippt Leuten mit seiner gasförmigen Hand auf die Schulter. Seine Berührung erzeugt endloses Schaudern."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/094.ts
+++ b/data/Scarlet & Violet/151/094.ts
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "To steal the life of its target, it slips into the prey's shadow and silently waits for an opportunity.",
+		de: "Um Beute zu erlegen, versteckt es sich in deren Schatten und wartet still auf eine günstige Gelegenheit."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/095.ts
+++ b/data/Scarlet & Violet/151/095.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "It rapidly bores through the ground at 50 mph by squirming and twisting its massive, rugged body.",
+		de: "Es bohrt sich mit 80 km/h durch das Erdreich, indem es seinen massiven, rauen Körper dreht und windet."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/096.ts
+++ b/data/Scarlet & Violet/151/096.ts
@@ -52,6 +52,7 @@ const card: Card = {
 
 	description: {
 		en: "It remembers every dream it eats. It rarely eats the dreams of adults because children's are much tastier.",
+		de: "Es kann sich an jeden gefressenen Traum erinnern. Die Träume von Kindern schmecken ihm besser, weshalb es die von Erwachsenen nur selten frisst."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/097.ts
+++ b/data/Scarlet & Violet/151/097.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "When it locks eyes with an enemy, it will use a mix of psi moves, such as Hypnosis and Confusion.",
+		de: "Es heißt, wenn dieses Pokémon einem Gegner ins Auge blicke, setze es zahlreiche Psycho-Kräfte wie beispielsweise Hypnose ein."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/098.ts
+++ b/data/Scarlet & Violet/151/098.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "If it senses danger approaching, it cloaks itself with bubbles from its mouth so it will look bigger.",
+		de: "Wittert es Gefahr, hüllt es sich in Blasen aus seinem Maul, um größer zu erscheinen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/099.ts
+++ b/data/Scarlet & Violet/151/099.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "Its oversized claw is very powerful, but when it's not in battle, the claw just gets in the way.",
+		de: "Seine Riesenschere ist sehr stark, aber wenn es nicht kämpft, kommt sie ihm häufig in die Quere."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/100.ts
+++ b/data/Scarlet & Violet/151/100.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "It rolls to move. If the ground is uneven, a sudden jolt from hitting a bump can cause it to explode.",
+		de: "Es bewegt sich rollend fort. Rollt es über unebenen Boden, kann es plötzlich explodieren."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/101.ts
+++ b/data/Scarlet & Violet/151/101.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "The more energy it charges up, the faster it gets. But this also makes it more likely to explode.",
+		de: "Je mehr elektrische Energie es speichert, desto schneller ist es. Allerdings steigt dabei auch das Risiko, dass es explodiert."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/102.ts
+++ b/data/Scarlet & Violet/151/102.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "These Pokémon get nervous when they're not in a group of six. The minute even one member of the group goes missing, Exeggcute become cowardly.",
+		de: "Es muss immer aus sechs Mitgliedern bestehen, sonst herrscht Unruhe. Fehlt auch nur eines, steigt bei den anderen die Bereitschaft zur Flucht."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/103.ts
+++ b/data/Scarlet & Violet/151/103.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "When they work together, Exeggutor's three heads can put out powerful psychic energy. Cloudy days make this Pokémon sluggish.",
+		de: "Seine drei Köpfe setzen mächtige Psycho-Kräfte frei, wenn sie als Einheit agieren. Zieht sich der Himmel zu, bewegt es sich nur noch schwerfällig."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/104.ts
+++ b/data/Scarlet & Violet/151/104.ts
@@ -77,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon wears the skull of its deceased mother. Sometimes Cubone's dreams make it cry, but each tear Cubone sheds makes it stronger.",
+		de: "Es trägt den Schädel seiner verstorbenen Mutter. Manchmal weint Tragosso, während es träumt, doch jede vergossene Träne macht es stärker."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/105.ts
+++ b/data/Scarlet & Violet/151/105.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "When this Pokémon evolved, the skull of its mother fused to it. Marowak's temperament also turned vicious at the same time.",
+		de: "Durch die Entwicklung wurde der Schädel seiner Mutter, den es stets trug, zu einem Teil von ihm und es bekam einen aggressiven Charakter."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/106.ts
+++ b/data/Scarlet & Violet/151/106.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "The legs freely contract and stretch. The stretchy legs allow it to hit a distant foe with a rising kick.",
+		de: "Es kann seine Beine nach Belieben ausfahren und einziehen und so auch entfernte Gegner treffen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/107.ts
+++ b/data/Scarlet & Violet/151/107.ts
@@ -77,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "Its punches slice the air. However, it seems to need a short break after fighting for three minutes.",
+		de: "Seine Fäuste zerschneiden die Luft. Es muss jedoch alle drei Minuten eine kurze Pause einlegen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/108.ts
+++ b/data/Scarlet & Violet/151/108.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "Bug Pokémon are Lickitung's main food source. This Pokémon paralyzes its prey with a lick from its long tongue, then swallows the prey whole.",
+		de: "Es ernährt sich vorwiegend von Käfer-Pokémon. Hat es diese mit der langen Zunge abgeschleckt und dadurch gelähmt, verschlingt es sie im Nu."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/109.ts
+++ b/data/Scarlet & Violet/151/109.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "Its body is full of poisonous gas. It floats into garbage dumps, seeking out the fumes of raw, rotting trash.",
+		de: "Sein Körper ist zum Bersten voll mit Giftgas. Angelockt vom fauligen Geruch verrottender Abfälle, lungert es auf Müllhalden herum."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/110.ts
+++ b/data/Scarlet & Violet/151/110.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "Very rarely, a sudden mutation can result in two small Koffing twins becoming conjoined as a Weezing.",
+		de: "Sehr selten führt eine plötzliche Mutation eines Zwillings-Smogon zu einer Verbindung zu Smogmog."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/111.ts
+++ b/data/Scarlet & Violet/151/111.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "It can remember only one thing at a time. Once it starts rushing, it forgets why it started.",
+		de: "Es kann sich immer nur eine Sache merken. Sobald es losgestürmt ist, vergisst es augenblicklich den Auslöser dafür."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/112.ts
+++ b/data/Scarlet & Violet/151/112.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "Protected by an armor-like hide, it is capable of living in molten lava of 3,600 degrees Fahrenheit.",
+		de: "Sein ganzer Körper ist von einer panzerähnlichen Haut geschützt. Es kann sogar in bis zu 2 000 ºC heißer Lava leben."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/113.ts
+++ b/data/Scarlet & Violet/151/113.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "This kindly Pokémon lays highly nutritious eggs and shares them with injured Pokémon or people.",
+		de: "Ein freundliches Pokémon, das nahrhafte Eier legt, um diese mit verletzten Pokémon und Menschen zu teilen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/114.ts
+++ b/data/Scarlet & Violet/151/114.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "Hidden beneath a tangle of vines that grows nonstop even if the vines are torn off, this Pokémon's true appearance remains a mystery.",
+		de: "Seine wahre Gestalt ist weiterhin ein Mysterium, da sie von Ranken verdeckt wird, die unaufhörlich nachwachsen, selbst wenn sie abreißen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/116.ts
+++ b/data/Scarlet & Violet/151/116.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "They swim with dance-like motions and cause whirlpools to form. Horsea compete to see which of them can generate the biggest whirlpool.",
+		de: "Es schwimmt elegant wie ein Tänzer und erzeugt dabei Wasserstrudel. Mit Artgenossen wetteifert es darum, wer den größten Strudel formen kann."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/117.ts
+++ b/data/Scarlet & Violet/151/117.ts
@@ -63,6 +63,7 @@ const card: Card = {
 
 	description: {
 		en: "Seadra's mouth is slender, but its suction power is strong. In an instant, Seadra can suck in food that's larger than the opening of its mouth.",
+		de: "Selbst Beute, die größer als sein kleiner Mund ist, kann es dank dessen starker Saugkraft im Nu einsaugen und verspeisen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/118.ts
+++ b/data/Scarlet & Violet/151/118.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "Its dorsal and pectoral fins are strongly developed like muscles. It can swim at a speed of five knots.",
+		de: "Seine Rücken- und Brustflossen sind muskelähnlich entwickelt. Es erreicht beim Schwimmen eine Geschwindigkeit von bis zu fünf Knoten."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/119.ts
+++ b/data/Scarlet & Violet/151/119.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "Using its horn, it bores holes in riverbed boulders, making nests to prevent its eggs from washing away.",
+		de: "Es laicht in Löchern, die es mit seinem Horn in Felsen des Flussbettes gebohrt hat, damit seine Eier nicht vom Wasser fortgespült werden."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/120.ts
+++ b/data/Scarlet & Violet/151/120.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "Fish Pokémon nibble at it, but Staryu isn't bothered. Its body regenerates quickly, even if part of it is completely torn off.",
+		de: "Ihm macht es nichts aus, von Fisch-Pokémon angeknabbert zu werden, da sich sein Körper bei Verletzungen im Nu regeneriert."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/121.ts
+++ b/data/Scarlet & Violet/151/121.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "Starmie swims by spinning its body at high speed. As this Pokémon cruises through the ocean, it absorbs tiny plankton.",
+		de: "Starmie bewegt sich im Wasser fort, indem es seinen Körper mit hoher Geschwindigkeit rotieren lässt. Unterwegs absorbiert es winziges Plankton."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/122.ts
+++ b/data/Scarlet & Violet/151/122.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "It's known for its top-notch pantomime skills. It protects itself from all sorts of attacks by emitting auras from its fingers to create walls.",
+		de: "Es ist für die Pantomime geboren. Zur Abwehr unterschiedlichster Angriffe erzeugt es mit einem Kraftfeld aus seinen Fingerspitzen Schutzwände."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/123.ts
+++ b/data/Scarlet & Violet/151/123.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "It slashes through grass with its sharp scythes, moving too fast for the human eye to track.",
+		de: "Es bahnt sich mit seinen scharfen Sicheln so schnell einen Weg durch das Gras, dass es dabei für das menschliche Auge unsichtbar ist."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/125.ts
+++ b/data/Scarlet & Violet/151/125.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "With the coming of a storm, many of these Pokémon will gather under tall trees and sit there waiting for lightning to strike.",
+		de: "Bei Gewittern versammeln sich Elektek in der Nähe von hohen Bäumen, wo sie regungslos auf Blitzeinschläge warten."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/126.ts
+++ b/data/Scarlet & Violet/151/126.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "These Pokémon's bodies are constantly burning. Magmar are feared as one of the causes behind fires.",
+		de: "Sein Körper ist ständig in Flammen gehüllt, wodurch es als eine Ursache von Bränden gefürchtet wird."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/127.ts
+++ b/data/Scarlet & Violet/151/127.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon clamps its pincers down on its prey and then either splits the prey in half or flings it away.",
+		de: "Pinsir nimmt Beute mit seinen Hörnern in die Zange, um sie anschließend entzweizureißen oder mit Wucht fortzuschleudern."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/128.ts
+++ b/data/Scarlet & Violet/151/128.ts
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "When it targets an enemy, it charges furiously while whipping its body with its long tails.",
+		de: "Wenn Tauros Beute ins Visier genommen hat, stürmt es direkt auf sie zu und benutzt seine Schweife als Peitsche, um sich anzutreiben."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/129.ts
+++ b/data/Scarlet & Violet/151/129.ts
@@ -53,6 +53,7 @@ const card: Card = {
 
 	description: {
 		en: "An underpowered, pathetic Pokémon. It may jump high on rare occasions but never more than seven feet.",
+		de: "Ein schwaches und jämmerliches Pokémon. Manchmal gelingen ihm hohe Sprünge, aber über 2 m kommt es selten hinaus."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/130.ts
+++ b/data/Scarlet & Violet/151/130.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "Once it appears, it goes on a rampage. It remains enraged until it demolishes everything around it.",
+		de: "Taucht es auf, randaliert es. Es beruhigt sich erst, wenn es alles um sich zerstört hat."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/131.ts
+++ b/data/Scarlet & Violet/151/131.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "Crossing icy seas is no issue for this cold-resistant Pokémon. Its smooth skin is a little cool to the touch.",
+		de: "Es kommt gut mit Kälte zurecht und kann auch in eisigen Meeren problemlos schwimmen. Seine Haut fühlt sich glatt und kühl an."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/132.ts
+++ b/data/Scarlet & Violet/151/132.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "Its transformation ability is perfect. However, if made to laugh, it can't maintain its disguise.",
+		de: "Seine Verwandlungskunst ist perfekt. Bringt man es jedoch zum Lachen, fliegt seine Tarnung auf."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/133.ts
+++ b/data/Scarlet & Violet/151/133.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "Its ability to evolve into many forms allows it to adapt smoothly and perfectly to any environment.",
+		de: "Um sich jeder Umgebung perfekt anpassen zu können, ist es in der Lage, sich zu verschiedenen Pokémon zu entwickeln."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/134.ts
+++ b/data/Scarlet & Violet/151/134.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives close to water. Its long tail is ridged with a fin, which is often mistaken for a mermaid's.",
+		de: "Dieses Pokémon lebt nahe an Gewässern. Wegen seiner fischähnlichen Schwanzflosse wird es manchmal für eine Meerjungfrau gehalten."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/135.ts
+++ b/data/Scarlet & Violet/151/135.ts
@@ -83,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "It concentrates the weak electric charges emitted by its cells and launches wicked lightning bolts.",
+		de: "Es sammelt die schwache elektrische Energie, die von seinen Zellen ausgeht, und feuert starke Blitze ab."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/136.ts
+++ b/data/Scarlet & Violet/151/136.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "Inhaled air is carried to its flame sac, heated, and exhaled as fire that reaches over 3,000 degrees Fahrenheit.",
+		de: "Es speichert Atemluft in einem Flammensack. Dort erhitzt es sie auf 1700 ℃, um sie als Flammen auszuspucken."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/137.ts
+++ b/data/Scarlet & Violet/151/137.ts
@@ -53,6 +53,7 @@ const card: Card = {
 
 	description: {
 		en: "In recent years, this species has been very helpful in cyberspace. These Pokémon will go around checking to make sure no suspicious data exists.",
+		de: "In den letzten Jahren nahm es im Cyberspace bei der Suche nach verdächtigen Daten eine aktive Rolle ein."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/138.ts
+++ b/data/Scarlet & Violet/151/138.ts
@@ -63,6 +63,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon is a member of an ancient, extinct species. Omanyte paddles through water with its 10 tentacles, looking like it's just drifting along.",
+		de: "Ein einst ausgestorbenes Urzeit-Pokémon. Wenn es mit seinen zehn Tentakeln paddelnd durch das Wasser gleitet, meint man, es würde schweben."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/139.ts
+++ b/data/Scarlet & Violet/151/139.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "Omastar's sharp fangs could crush rock, but the Pokémon can attack only the prey that come within reach of its tentacles.",
+		de: "Mit seinen scharfen Zähnen ist es imstande, selbst Felsen zu zermalmen. Angreifen kann es jedoch nur Beute in Reichweite seiner Tentakel."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/140.ts
+++ b/data/Scarlet & Violet/151/140.ts
@@ -63,6 +63,7 @@ const card: Card = {
 
 	description: {
 		en: "While some say this species has gone extinct, Kabuto sightings are apparently fairly common in some places.",
+		de: "Es heißt zwar, dass Kabuto ausgestorben sei, doch in einer bestimmten Gegend trifft man es noch relativ häufig an."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/141.ts
+++ b/data/Scarlet & Violet/151/141.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "The cause behind the extinction of this species is unknown. Kabutops were aggressive Pokémon that inhabited warm seas.",
+		de: "Es ist unklar, warum dieses brutale urzeitliche Pokémon, das in warmen Meeren lebte, letztendlich ausstarb."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/142.ts
+++ b/data/Scarlet & Violet/151/142.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "Aerodactyl's sawlike fangs can shred skin to tatters—even the skin of Steel-type Pokémon.",
+		de: "Mit seinen Zähnen, die Sägeblättern gleichen, kann es selbst die Haut von Stahl-Pokémon zerfetzen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/143.ts
+++ b/data/Scarlet & Violet/151/143.ts
@@ -77,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon's stomach is so strong, even eating moldy or rotten food will not affect it.",
+		de: "Der Magen dieses Pokémon ist so resistent, dass es sogar Verschimmeltes oder Verdorbenes essen kann."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/144.ts
+++ b/data/Scarlet & Violet/151/144.ts
@@ -83,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon can control ice at will. Articuno is said to live in snowy mountains riddled with permafrost.",
+		de: "Arktos ist imstande, Eis zu manipulieren. Man sagt, es lebe in schneebedeckten Bergen, wo ewiger Winter herrscht."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/146.ts
+++ b/data/Scarlet & Violet/151/146.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "There are stories of this Pokémon using its radiant, flame-cloaked wings to light up paths for those lost in the mountains.",
+		de: "Überlieferungen nach soll Lavados mit seinen wunderschön lodernden Flügeln Bergpfade erleuchtet und dadurch Verirrten geholfen haben."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/147.ts
+++ b/data/Scarlet & Violet/151/147.ts
@@ -53,6 +53,7 @@ const card: Card = {
 
 	description: {
 		en: "It sheds many layers of skin as it grows larger. During this process, it is protected by a rapid waterfall.",
+		de: "Es häutet sich, um zu wachsen. Dabei wird es von einem tosenden Wasserfall beschützt."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/148.ts
+++ b/data/Scarlet & Violet/151/148.ts
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "They say that if it emits an aura from its whole body, the weather will begin to change instantly.",
+		de: "Man sagt, wenn sein ganzer Körper eine Aura ausstrahle, ändere sich augenblicklich das Wetter in seiner Umgebung."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/149.ts
+++ b/data/Scarlet & Violet/151/149.ts
@@ -79,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said that somewhere in the ocean lies an island where these gather. Only they live there.",
+		de: "Man sagt, dass es irgendwo im Meer eine Insel gibt, auf der sie sich versammeln. Nur sie leben dort."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/150.ts
+++ b/data/Scarlet & Violet/151/150.ts
@@ -83,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon created by recombining Mew's genes. It's said to have the most savage heart among Pokémon.",
+		de: "Die Gene von Mew wurden neu angeordnet, wodurch dieses Pokémon entstand. Es hat ein wildes Herz."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/152.ts
+++ b/data/Scarlet & Violet/151/152.ts
@@ -45,7 +45,7 @@ const card: Card = {
 		es: "Juega esta carta como si fuera un Pokémon {C} Básico de 60 PS. Esta carta no puede verse afectada por ninguna Condición Especial y no puede retirarse.\n\nEn cualquier momento durante tu turno, puedes descartar esta carta del juego.",
 		it: "Gioca questa carta come se fosse un Pokémon Base {C} con 60 PS. Questa carta non può essere influenzata da condizioni speciali e non può ritirarsi.\nDurante il tuo turno, in qualsiasi momento, puoi scartare questa carta dal gioco.",
 		pt: "Jogue esta carta como se fosse um Pokémon {C} Básico com PS 60. Esta carta não pode ser afetada por quaisquer Condições Especiais e não pode recuar.\nA qualquer momento, durante o seu turno, você poderá descartar esta carta do jogo.",
-		de: "Spiele diese Karte, als ob sie ein Basis-{C}-Pokémon mit 60 KP wäre. Diese Karte kann von keinen Speziellen Zuständen betroffen werden und sich nicht zurückziehen.\nDu kannst diese Karte jederzeit während deines Zuges aus dem Spiel nehmen und auf deinen Ablagestapel legen."
+		de: "Spiele diese Karte, als ob sie ein Basis-{C}-Pokémon mit 60 KP wäre. Diese Karte kann von keinen Speziellen Zuständen betroffen werden und sich nicht zurückziehen. Du kannst diese Karte jederzeit während deines Zuges aus dem Spiel nehmen und auf deinen Ablagestapel legen. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Scarlet & Violet/151/153.ts
+++ b/data/Scarlet & Violet/151/153.ts
@@ -45,7 +45,7 @@ const card: Card = {
 		es: "Juega esta carta como si fuera un Pokémon {C} Básico de 60 PS. Esta carta no puede verse afectada por ninguna Condición Especial y no puede retirarse.\n\nEn cualquier momento durante tu turno, puedes descartar esta carta del juego.",
 		it: "Gioca questa carta come se fosse un Pokémon Base {C} con 60 PS. Questa carta non può essere influenzata da condizioni speciali e non può ritirarsi.\n\nDurante il tuo turno, in qualsiasi momento, puoi scartare questa carta dal gioco.",
 		pt: "Jogue esta carta como se fosse um Pokémon {C} Básico com PS 60. Esta carta não pode ser afetada por quaisquer Condições Especiais e não pode recuar.\nA qualquer momento, durante o seu turno, você poderá descartar esta carta do jogo.",
-		de: "Spiele diese Karte, als ob sie ein Basis-{C}-Pokémon mit 60 KP wäre. Diese Karte kann von keinen Speziellen Zuständen betroffen werden und sich nicht zurückziehen.\nDu kannst diese Karte jederzeit während deines Zuges aus dem Spiel nehmen und auf deinen Ablagestapel legen."
+		de: "Spiele diese Karte, als ob sie ein Basis-{C}-Pokémon mit 60 KP wäre. Diese Karte kann von keinen Speziellen Zuständen betroffen werden und sich nicht zurückziehen. Du kannst diese Karte jederzeit während deines Zuges aus dem Spiel nehmen und auf deinen Ablagestapel legen. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Scarlet & Violet/151/154.ts
+++ b/data/Scarlet & Violet/151/154.ts
@@ -45,7 +45,7 @@ const card: Card = {
 		es: "Juega esta carta como si fuera un Pokémon {C} Básico de 60 PS. Esta carta no puede verse afectada por ninguna Condición Especial y no puede retirarse.\n\nEn cualquier momento durante tu turno, puedes descartar esta carta del juego.",
 		it: "Gioca questa carta come se fosse un Pokémon Base {C} con 60 PS. Questa carta non può essere influenzata da condizioni speciali e non può ritirarsi.\nDurante il tuo turno, in qualsiasi momento, puoi scartare questa carta dal gioco.",
 		pt: "Jogue esta carta como se fosse um Pokémon {C} Básico com PS 60. Esta carta não pode ser afetada por quaisquer Condições Especiais e não pode recuar.\nA qualquer momento, durante o seu turno, você poderá descartar esta carta do jogo.",
-		de: "Spiele diese Karte, als ob sie ein Basis-{C}-Pokémon mit 60 KP wäre. Diese Karte kann von keinen Speziellen Zuständen betroffen werden und sich nicht zurückziehen.\nDu kannst diese Karte jederzeit während deines Zuges aus dem Spiel nehmen und auf deinen Ablagestapel legen."
+		de: "Spiele diese Karte, als ob sie ein Basis-{C}-Pokémon mit 60 KP wäre. Diese Karte kann von keinen Speziellen Zuständen betroffen werden und sich nicht zurückziehen. Du kannst diese Karte jederzeit während deines Zuges aus dem Spiel nehmen und auf deinen Ablagestapel legen."
 	},
 
 	trainerType: "Item",

--- a/data/Scarlet & Violet/151/155.ts
+++ b/data/Scarlet & Violet/151/155.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "El Pokémon de Fase 2 al que esté unida esta carta no tiene ningún Coste de Retirada.",
 		it: "Il Pokémon di Fase 2 a cui è assegnata questa carta non ha costo di ritirata.",
 		pt: "O Pokémon Estágio 2 ao qual esta carta está ligada não tem custo de Recuo.",
-		de: "Das Phase-2-Pokémon, an das diese Karte angelegt ist, hat keine Rückzugskosten."
+		de: "Das Phase-2-Pokémon, an das diese Karte angelegt ist, hat keine Rückzugskosten. Du kannst während deines Zuges beliebig viele Pokémon-Ausrüstungen an deine Pokémon anlegen. Du kannst an jedes Pokémon nur 1 Pokémon-Ausrüstung anlegen, und sie bleibt angelegt."
 	},
 
 	trainerType: "Tool",

--- a/data/Scarlet & Violet/151/156.ts
+++ b/data/Scarlet & Violet/151/156.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mira las 8 primeras cartas de tu baraja. Puedes enseñar cualquier cantidad de Pokémon que encuentres entre ellas y ponerlos en tu mano. Pon el resto de las cartas de nuevo en tu baraja y barájalas todas.",
 		it: "Guarda le prime otto carte del tuo mazzo. Puoi mostrare un numero qualsiasi di Pokémon presenti tra esse e aggiungerli alle carte che hai in mano. Poi rimischia le altre carte nel tuo mazzo.",
 		pt: "Olhe as 8 cartas de cima do seu baralho. Você pode revelar qualquer número de Pokémon que encontrar lá e colocá-los na sua mão. Embaralhe as outras cartas de volta no seu baralho.",
-		de: "Schau dir die obersten 8 Karten deines Decks an. Du kannst beliebig viele Pokémon, die du dort findest, deinem Gegner zeigen und auf deine Hand nehmen. Mische die anderen Karten zurück in dein Deck."
+		de: "Schau dir die obersten 8 Karten deines Decks an. Du kannst beliebig viele Pokémon, die du dort findest, deinem Gegner zeigen und auf deine Hand nehmen. Mische die anderen Karten zurück in dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Scarlet & Violet/151/157.ts
+++ b/data/Scarlet & Violet/151/157.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Una vez durante el turno de cada jugador, ese jugador puede descartar 1 carta de Energía Básica de su mano para poder robar una carta.",
 		it: "Una sola volta durante il turno di ciascun giocatore, quel giocatore può scartare una carta Energia base che ha in mano per pescare una carta.",
 		pt: "Uma vez durante o turno de cada jogador, aquele jogador poderá descartar uma carta de Energia Básica da própria mão para comprar uma carta.",
-		de: "Einmal während des Zuges jedes Spielers kann jener Spieler 1 Basis-Energiekarte aus seiner Hand auf seinen Ablagestapel legen, um 1 Karte zu ziehen."
+		de: "Einmal während des Zuges jedes Spielers kann jener Spieler 1 Basis-Energiekarte aus seiner Hand auf seinen Ablagestapel legen, um 1 Karte zu ziehen. Du kannst während deines Zuges nur 1 Stadionkarte spielen. Lege sie neben die Aktive Position, und lege sie auf den Ablagestapel, wenn eine andere Stadionkarte ins Spiel gebracht wird. Eine Stadionkarte mit demselben Namen kann nicht gespielt werden."
 	},
 
 	trainerType: "Stadium",

--- a/data/Scarlet & Violet/151/158.ts
+++ b/data/Scarlet & Violet/151/158.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba 2 cartas. Mira tus cartas de Premio que están boca abajo.",
 		it: "Pesca due carte. Guarda le tue carte Premio coperte.",
 		pt: "Compre 2 cartas. Olhe as suas cartas de Prêmio viradas para baixo.",
-		de: "Ziehe 2 Karten. Sieh dir deine verdeckten Preiskarten an."
+		de: "Ziehe 2 Karten. Sieh dir deine verdeckten Preiskarten an. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Scarlet & Violet/151/159.ts
+++ b/data/Scarlet & Violet/151/159.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Lanza 1 moneda. Si sale cara, une 1 carta de Energía Básica de tu pila de descartes a uno de tus Pokémon en Banca.",
 		it: "Lancia una moneta. Se esce testa, assegna a uno dei tuoi Pokémon in panchina una carta Energia base dalla tua pila degli scarti.",
 		pt: "Jogue uma moeda. Se sair cara, ligue uma carta de Energia Básica da sua pilha de descarte a 1 dos seus Pokémon no Banco.",
-		de: "Wirf 1 Münze. Lege bei Kopf 1 Basis-Energiekarte aus deinem Ablagestapel an 1 Pokémon auf deiner Bank an."
+		de: "Wirf 1 Münze. Lege bei Kopf 1 Basis-Energiekarte aus deinem Ablagestapel an 1 Pokémon auf deiner Bank an. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Scarlet & Violet/151/160.ts
+++ b/data/Scarlet & Violet/151/160.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Tu rival enseña las cartas de su mano, y tú pones 1 Pokémon Básico que encuentres entre ellas en la Banca de tu rival. Si pones un Pokémon en su Banca de esta manera, cambia ese Pokémon por el Pokémon que esté en el Puesto Activo.",
 		it: "Il tuo avversario mostra le carte che ha in mano e tu metti un Pokémon Base presente tra esse nella sua panchina. Se hai messo un Pokémon nella sua panchina in questo modo, sostituisci quel Pokémon con il suo Pokémon in posizione attiva.",
 		pt: "Seu oponente revela a mão dele, e você coloca um Pokémon Básico que encontrar lá no Banco do seu oponente. Se você colocar um Pokémon no Banco dele desta forma, mande aquele Pokémon para o Campo Ativo.",
-		de: "Dein Gegner zeigt dir seine Handkarten und du legst 1 Basis-Pokémon, das du dort findest, auf die Bank deines Gegners. Wenn du auf diese Weise ein Pokémon auf seine Bank gelegt hast, wechsle jenes Pokémon in die Aktive Position ein."
+		de: "Dein Gegner zeigt dir seine Handkarten und du legst 1 Basis-Pokémon, das du dort findest, auf die Bank deines Gegners. Wenn du auf diese Weise ein Pokémon auf seine Bank gelegt hast, wechsle jenes Pokémon in die Aktive Position ein. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Scarlet & Violet/151/161.ts
+++ b/data/Scarlet & Violet/151/161.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon 1 Energía unida al Pokémon Activo de tu rival en su mano. Si lo haces, une 1 carta de Energía de tu mano a tu Pokémon Activo.",
 		it: "Prendi un'Energia assegnata al Pokémon attivo del tuo avversario e aggiungila alle carte che ha in mano. Se lo fai, assegna al tuo Pokémon attivo una carta Energia dalla tua mano.",
 		pt: "Coloque uma Energia ligada ao Pokémon Ativo do seu oponente na mão dele. Se fizer isto, ligue uma carta de Energia da sua mão ao seu Pokémon Ativo.",
-		de: "Gib deinem Gegner 1 an sein Aktives Pokémon angelegte Energie auf seine Hand. Wenn du das machst, lege 1 Energiekarte aus deiner Hand an dein Aktives Pokémon an."
+		de: "Gib deinem Gegner 1 an sein Aktives Pokémon angelegte Energie auf seine Hand. Wenn du das machst, lege 1 Energiekarte aus deiner Hand an dein Aktives Pokémon an. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Scarlet & Violet/151/162.ts
+++ b/data/Scarlet & Violet/151/162.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Tu rival enseña las cartas de su mano, y tú pones 1 Pokémon que encuentres entre ellas en la parte inferior de su baraja.",
 		it: "Il tuo avversario mostra le carte che ha in mano e tu metti un Pokémon presente tra esse in fondo al suo mazzo.",
 		pt: "Seu oponente revela a mão dele e você coloca um Pokémon que encontrar lá como a carta de baixo do baralho dele.",
-		de: "Dein Gegner zeigt dir seine Handkarten und du legst ein Pokémon, das du dort findest, unter sein Deck."
+		de: "Dein Gegner zeigt dir seine Handkarten und du legst ein Pokémon, das du dort findest, unter sein Deck. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Scarlet & Violet/151/163.ts
+++ b/data/Scarlet & Violet/151/163.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Al final de tu turno, si el Pokémon al que está unida esta carta está en el Puesto Activo, cúrale 20 puntos de daño.",
 		it: "Alla fine del tuo turno, se il Pokémon a cui è assegnata questa carta è in posizione attiva, curalo da 20 danni.",
 		pt: "No final do seu turno, se o Pokémon ao qual esta carta está ligada estiver no Campo Ativo, cure 20 pontos de dano dele.",
-		de: "Am Ende deines Zuges, wenn das Pokémon, an das diese Karte angelegt ist, in der Aktiven Position ist, heile 20 Schadenspunkte bei jenem Pokémon."
+		de: "Am Ende deines Zuges, wenn das Pokémon, an das diese Karte angelegt ist, in der Aktiven Position ist, heile 20 Schadenspunkte bei jenem Pokémon. Du kannst während deines Zuges beliebig viele Pokémon-Ausrüstungen an deine Pokémon anlegen. Du kannst an jedes Pokémon nur 1 Pokémon-Ausrüstung anlegen, und sie bleibt angelegt."
 	},
 
 	trainerType: "Tool",

--- a/data/Scarlet & Violet/151/164.ts
+++ b/data/Scarlet & Violet/151/164.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "El Pokémon Básico al que esté unida esta carta no tiene ninguna Debilidad.",
 		it: "Il Pokémon Base a cui è assegnata questa carta non ha debolezza.",
 		pt: "O Pokémon Básico ao qual esta carta está ligada não tem Fraqueza.",
-		de: "Das Basis-Pokémon, an das diese Karte angelegt ist, hat keine Schwäche."
+		de: "Das Basis-Pokémon, an das diese Karte angelegt ist, hat keine Schwäche. Du kannst während deines Zuges beliebig viele Pokémon-Ausrüstungen an deine Pokémon anlegen. Du kannst an jedes Pokémon nur 1 Pokémon-Ausrüstung anlegen, und sie bleibt angelegt."
 	},
 
 	trainerType: "Tool",

--- a/data/Scarlet & Violet/151/165.ts
+++ b/data/Scarlet & Violet/151/165.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Los ataques de los Pokémon de tu rival hacen 30 puntos de daño menos al Pokémon de Fase 1 al que esté unida esta carta (después de aplicar Debilidad y Resistencia).",
 		it: "Il Pokémon di Fase 1 a cui è assegnata questa carta subisce 30 danni in meno dagli attacchi dei Pokémon del tuo avversario, dopo aver applicato debolezza e resistenza.",
 		pt: "O Pokémon Estágio 1 ao qual esta carta está ligada recebe 30 pontos de dano a menos de ataques dos Pokémon do seu oponente (depois de aplicar Fraqueza e Resistência).",
-		de: "Dem Phase-1-Pokémon, an das diese Karte angelegt ist, werden durch Attacken von Pokémon deines Gegners 30 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden)."
+		de: "Dem Phase-1-Pokémon, an das diese Karte angelegt ist, werden durch Attacken von Pokémon deines Gegners 30 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden). Du kannst während deines Zuges beliebig viele Pokémon-Ausrüstungen an deine Pokémon anlegen. Du kannst an jedes Pokémon nur 1 Pokémon-Ausrüstung anlegen, und sie bleibt angelegt."
 	},
 
 	trainerType: "Tool",

--- a/data/Scarlet & Violet/151/166.ts
+++ b/data/Scarlet & Violet/151/166.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "While it is young, it uses the nutrients that are stored in the seed on its back in order to grow.",
+		de: "Nach der Geburt nimmt es für eine Weile Nährstoffe über den Samen auf seinem Rücken auf."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/167.ts
+++ b/data/Scarlet & Violet/151/167.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "Exposure to sunlight adds to its strength. Sunlight also makes the bud on its back grow larger.",
+		de: "Die Sonne macht es stärker. Die Knospe auf seinem Rücken wächst unter dem Einfluss von Sonnenlicht."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/168.ts
+++ b/data/Scarlet & Violet/151/168.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "From the time it is born, a flame burns at the tip of its tail. Its life would end if the flame were to go out.",
+		de: "Von Geburt an brennt die Flamme auf seiner Schwanzspitze. Sobald sie verglimmt, erlischt auch sein Lebenslicht."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/169.ts
+++ b/data/Scarlet & Violet/151/169.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "If it becomes agitated during battle, it spouts intense flames, incinerating its surroundings.",
+		de: "Steigert es sich in einen Kampf hinein, spuckt es Flammen, die alles in seiner Umgebung niederbrennen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/170.ts
+++ b/data/Scarlet & Violet/151/170.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "When it feels threatened, it draws its limbs inside its shell and sprays water from its mouth.",
+		de: "Fühlt es sich bedroht, verkriecht es sich in seinen Panzer und spuckt Wasser aus seinem Maul."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/171.ts
+++ b/data/Scarlet & Violet/151/171.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "It cleverly controls its furry ears and tail to maintain its balance while swimming.",
+		de: "Es balanciert geschickt mit seinen buschigen Ohren und dem Schweif, während es im Wasser schwimmt."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/172.ts
+++ b/data/Scarlet & Violet/151/172.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "Its short feet are tipped with suction pads that enable it to tirelessly climb slopes and walls.",
+		de: "Es hat Saugnäpfe an den Beinchen, mit denen es mühelos Steigungen und Mauern erklimmen kann."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/173.ts
+++ b/data/Scarlet & Violet/151/173.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "When it is angered, it immediately discharges the energy stored in the pouches in its cheeks.",
+		de: "Ist es wütend, entlädt sich augenblicklich die Elektrizität, die es in seinen Backentaschen gespeichert hat."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/174.ts
+++ b/data/Scarlet & Violet/151/174.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "Nidoking prides itself on its strength. It's forceful and spirited in battle, making use of its thick tail and diamond-crushing horn.",
+		de: "Nidoking ist stolz auf seine Kraft und kämpft sehr geschickt mit seinem dicken Schweif und seinem Horn, das selbst Diamanten zertrümmern kann."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/175.ts
+++ b/data/Scarlet & Violet/151/175.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "It is constantly wracked by a headache. When the headache turns intense, it begins using mysterious powers.",
+		de: "Es wird permanent von Kopfschmerzen geplagt. Wird der Schmerz stärker, setzt es geheimnisvolle Kräfte ein."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/176.ts
+++ b/data/Scarlet & Violet/151/176.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon's sweat is a slimy mucus. When captured, Poliwhirl can slither from its enemies' grasp and escape.",
+		de: "Quaputzi schwitzt glitschigen Schleim, dank dem es leicht der Umklammerung eines Feindes entkommen kann."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/177.ts
+++ b/data/Scarlet & Violet/151/177.ts
@@ -63,6 +63,7 @@ const card: Card = {
 
 	description: {
 		en: "Its formidable body never gets tired. It helps people by doing work such as the moving of heavy goods.",
+		de: "Sein durchtrainierter Körper wird nie müde. Es hilft den Menschen, indem es schwere Sachen trägt."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/178.ts
+++ b/data/Scarlet & Violet/151/178.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "Hidden beneath a tangle of vines that grows nonstop even if the vines are torn off, this Pokémon's true appearance remains a mystery.",
+		de: "Seine wahre Gestalt ist weiterhin ein Mysterium, da sie von Ranken verdeckt wird, die unaufhörlich nachwachsen, selbst wenn sie abreißen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/179.ts
+++ b/data/Scarlet & Violet/151/179.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "It's known for its top-notch pantomime skills. It protects itself from all sorts of attacks by emitting auras from its fingers to create walls.",
+		de: "Es ist für die Pantomime geboren. Zur Abwehr unterschiedlichster Angriffe erzeugt es mit einem Kraftfeld aus seinen Fingerspitzen Schutzwände."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/180.ts
+++ b/data/Scarlet & Violet/151/180.ts
@@ -63,6 +63,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon is a member of an ancient, extinct species. Omanyte paddles through water with its 10 tentacles, looking like it's just drifting along.",
+		de: "Ein einst ausgestorbenes Urzeit-Pokémon. Wenn es mit seinen zehn Tentakeln paddelnd durch das Wasser gleitet, meint man, es würde schweben."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/181.ts
+++ b/data/Scarlet & Violet/151/181.ts
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "They say that if it emits an aura from its whole body, the weather will begin to change instantly.",
+		de: "Man sagt, wenn sein ganzer Körper eine Aura ausstrahle, ändere sich augenblicklich das Wetter in seiner Umgebung."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/151/194.ts
+++ b/data/Scarlet & Violet/151/194.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mira las 8 primeras cartas de tu baraja. Puedes enseñar cualquier cantidad de Pokémon que encuentres entre ellas y ponerlos en tu mano. Pon el resto de las cartas de nuevo en tu baraja y barájalas todas.",
 		it: "Guarda le prime otto carte del tuo mazzo. Puoi mostrare un numero qualsiasi di Pokémon presenti tra esse e aggiungerli alle carte che hai in mano. Poi rimischia le altre carte nel tuo mazzo.",
 		pt: "Olhe as 8 cartas de cima do seu baralho. Você pode revelar qualquer número de Pokémon que encontrar lá e colocá-los na sua mão. Embaralhe as outras cartas de volta no seu baralho.",
-		de: "Schau dir die obersten 8 Karten deines Decks an. Du kannst beliebig viele Pokémon, die du dort findest, deinem Gegner zeigen und auf deine Hand nehmen. Mische die anderen Karten zurück in dein Deck."
+		de: "Schau dir die obersten 8 Karten deines Decks an. Du kannst beliebig viele Pokémon, die du dort findest, deinem Gegner zeigen und auf deine Hand nehmen. Mische die anderen Karten zurück in dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Scarlet & Violet/151/195.ts
+++ b/data/Scarlet & Violet/151/195.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba 2 cartas. Mira tus cartas de Premio que están boca abajo.",
 		it: "Pesca due carte. Guarda le tue carte Premio coperte.",
 		pt: "Compre 2 cartas. Olhe as suas cartas de Prêmio viradas para baixo.",
-		de: "Ziehe 2 Karten. Sieh dir deine verdeckten Preiskarten an."
+		de: "Ziehe 2 Karten. Sieh dir deine verdeckten Preiskarten an. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Scarlet & Violet/151/196.ts
+++ b/data/Scarlet & Violet/151/196.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Tu rival enseña las cartas de su mano, y tú pones 1 Pokémon Básico que encuentres entre ellas en la Banca de tu rival. Si pones un Pokémon en su Banca de esta manera, cambia ese Pokémon por el Pokémon que esté en el Puesto Activo.",
 		it: "Il tuo avversario mostra le carte che ha in mano e tu metti un Pokémon Base presente tra esse nella sua panchina. Se hai messo un Pokémon nella sua panchina in questo modo, sostituisci quel Pokémon con il suo Pokémon in posizione attiva.",
 		pt: "Seu oponente revela a mão dele, e você coloca um Pokémon Básico que encontrar lá no Banco do seu oponente. Se você colocar um Pokémon no Banco dele desta forma, mande aquele Pokémon para o Campo Ativo.",
-		de: "Dein Gegner zeigt dir seine Handkarten und du legst 1 Basis-Pokémon, das du dort findest, auf die Bank deines Gegners. Wenn du auf diese Weise ein Pokémon auf seine Bank gelegt hast, wechsle jenes Pokémon in die Aktive Position ein."
+		de: "Dein Gegner zeigt dir seine Handkarten und du legst 1 Basis-Pokémon, das du dort findest, auf die Bank deines Gegners. Wenn du auf diese Weise ein Pokémon auf seine Bank gelegt hast, wechsle jenes Pokémon in die Aktive Position ein. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Scarlet & Violet/151/197.ts
+++ b/data/Scarlet & Violet/151/197.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon 1 Energía unida al Pokémon Activo de tu rival en su mano. Si lo haces, une 1 carta de Energía de tu mano a tu Pokémon Activo.",
 		it: "Prendi un'Energia assegnata al Pokémon attivo del tuo avversario e aggiungila alle carte che ha in mano. Se lo fai, assegna al tuo Pokémon attivo una carta Energia dalla tua mano.",
 		pt: "Coloque uma Energia ligada ao Pokémon Ativo do seu oponente na mão dele. Se fizer isto, ligue uma carta de Energia da sua mão ao seu Pokémon Ativo.",
-		de: "Gib deinem Gegner 1 an sein Aktives Pokémon angelegte Energie auf seine Hand. Wenn du das machst, lege 1 Energiekarte aus deiner Hand an dein Aktives Pokémon an."
+		de: "Gib deinem Gegner 1 an sein Aktives Pokémon angelegte Energie auf seine Hand. Wenn du das machst, lege 1 Energiekarte aus deiner Hand an dein Aktives Pokémon an. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Scarlet & Violet/151/203.ts
+++ b/data/Scarlet & Violet/151/203.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Tu rival enseña las cartas de su mano, y tú pones 1 Pokémon Básico que encuentres entre ellas en la Banca de tu rival. Si pones un Pokémon en su Banca de esta manera, cambia ese Pokémon por el Pokémon que esté en el Puesto Activo.",
 		it: "Il tuo avversario mostra le carte che ha in mano e tu metti un Pokémon Base presente tra esse nella sua panchina. Se hai messo un Pokémon nella sua panchina in questo modo, sostituisci quel Pokémon con il suo Pokémon in posizione attiva.",
 		pt: "Seu oponente revela a mão dele, e você coloca um Pokémon Básico que encontrar lá no Banco do seu oponente. Se você colocar um Pokémon no Banco dele desta forma, mande aquele Pokémon para o Campo Ativo.",
-		de: "Dein Gegner zeigt dir seine Handkarten und du legst 1 Basis-Pokémon, das du dort findest, auf die Bank deines Gegners. Wenn du auf diese Weise ein Pokémon auf seine Bank gelegt hast, wechsle jenes Pokémon in die Aktive Position ein."
+		de: "Dein Gegner zeigt dir seine Handkarten und du legst 1 Basis-Pokémon, das du dort findest, auf die Bank deines Gegners. Wenn du auf diese Weise ein Pokémon auf seine Bank gelegt hast, wechsle jenes Pokémon in die Aktive Position ein. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Scarlet & Violet/151/204.ts
+++ b/data/Scarlet & Violet/151/204.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon 1 Energía unida al Pokémon Activo de tu rival en su mano. Si lo haces, une 1 carta de Energía de tu mano a tu Pokémon Activo.",
 		it: "Prendi un'Energia assegnata al Pokémon attivo del tuo avversario e aggiungila alle carte che ha in mano. Se lo fai, assegna al tuo Pokémon attivo una carta Energia dalla tua mano.",
 		pt: "Coloque uma Energia ligada ao Pokémon Ativo do seu oponente na mão dele. Se fizer isto, ligue uma carta de Energia da sua mão ao seu Pokémon Ativo.",
-		de: "Gib deinem Gegner 1 an sein Aktives Pokémon angelegte Energie auf seine Hand. Wenn du das machst, lege 1 Energiekarte aus deiner Hand an dein Aktives Pokémon an."
+		de: "Gib deinem Gegner 1 an sein Aktives Pokémon angelegte Energie auf seine Hand. Wenn du das machst, lege 1 Energiekarte aus deiner Hand an dein Aktives Pokémon an. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Scarlet & Violet/151/206.ts
+++ b/data/Scarlet & Violet/151/206.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cambia tu Pokémon Activo por uno de tus Pokémon en Banca.",
 		it: "Scambia il tuo Pokémon attivo con uno della tua panchina.",
 		pt: "Troque o seu Pokémon Ativo por 1 dos seus Pokémon no Banco.",
-		de: "Tausche dein Aktives Pokémon gegen 1 Pokémon auf deiner Bank aus."
+		de: "Tausche dein Aktives Pokémon gegen 1 Pokémon auf deiner Bank aus. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",


### PR DESCRIPTION
## Add missing German translations for sv03.5

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
