### PR TITLE
Add missing German translations for ex1

### DIFF
--- a/data/EX/Ruby & Sapphire/1.ts
+++ b/data/EX/Ruby & Sapphire/1.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Lairon",
-		fr: "Galegon"
+		fr: "Galegon",
+		de: "Stollrak"
 	},
 
 	stage: "Stage2",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Retaliate",
 				fr: "Représailles",
-				de: "Retaliate"
+				de: "Vergeltung"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage times the number of damage counters on Aggron.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts pour chaque marqueur de dégât sur Galeking.",
-				de: "Flip a coin. If heads, this attack does 10 damage times the numer of damage counters on Aggron"
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff für jede Schadensmarke auf Stollos 10 Schadenspunkte zu."
 			},
 			damage: "10×",
 
@@ -55,7 +56,7 @@ const card: Card = {
 			name: {
 				en: "Mega Punch",
 				fr: "Ultimapoing",
-				de: "Mega Punch"
+				de: "Megahieb"
 			},
 
 			damage: 40,
@@ -72,12 +73,12 @@ const card: Card = {
 			name: {
 				en: "Double Lariat",
 				fr: "Double lasso",
-				de: "Double Lariat"
+				de: "Doppel-Lasso"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 70 damage times the number of heads.",
 				fr: "Lancez deux pièces. Cette attaque inflige 70 dégâts multipliés par le nombre de face.",
-				de: "Flip 2 coins. This attack does 70 damage times the numer of heads."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 70 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "70×",
 

--- a/data/EX/Ruby & Sapphire/10.ts
+++ b/data/EX/Ruby & Sapphire/10.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Poochyena",
-		fr: "Medhyèna"
+		fr: "Medhyèna",
+		de: "Fiffyen"
 	},
 
 	stage: "Stage1",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Intimidating Fang",
 				fr: "Croc intimidant",
-				de: "Intimidating Fang"
+				de: "Beeindruckende Fangzähne"
 			},
 			effect: {
 				en: "As long as Mightyena is your Active Pokémon, any damage done to your Pokémon by an opponent's attack is reduced by 10 (before applying Weakness and Resistance).",
 				fr: "Tant que Grahyena est votre Pokémon Actif, les dégâts qui lui sont infligés par une attaque de votre adversaire sont réduits de 10 (avant application de la Faiblesse et de la Résistance).",
-				de: "As long as Mightyena is your Active Pokémon, any damage done to your Pokémon by an opponent's attack is reduced by 10 (before applying Weakness and Resistance)."
+				de: "Solange Magnayen dein Aktives Pokémon ist, wird aller Schaden, der deinen Pokémon durch gegnerische Angriffe zugefügt wird, um 10 Schadenspunkte reduziert (bevor Schwäche und Resistenz verrechnet werden)."
 			}
 		},
 	],
@@ -54,12 +55,12 @@ const card: Card = {
 			name: {
 				en: "Shakedown",
 				fr: "Dépouiller",
-				de: "Shakedown"
+				de: "Abschütteln"
 			},
 			effect: {
 				en: "Flip a coin. If heads, choose 1 card from your opponent's hand without looking and discard it.",
 				fr: "Lancez une pièce. Si c'est face, choisissez une carte de la main de votre adversaire sans la regarder et défaussez-la.",
-				de: "Flip a coin. If heads, choose 1 card from your opponent's hand without looking and discard it."
+				de: "Wirf eine Münze. Bei „Kopf“ wähle 1 zufällige Karte von der Hand deines Gegners. Dein Gegner legt diese Karte auf seinen Ablagestapel."
 			},
 			damage: 40,
 

--- a/data/EX/Ruby & Sapphire/100.ts
+++ b/data/EX/Ruby & Sapphire/100.ts
@@ -32,12 +32,12 @@ const card: Card = {
 			name: {
 				en: "Smokescreen",
 				fr: "Brouillard",
-				de: "Smokescreen"
+				de: "Rauchwolke"
 			},
 			effect: {
 				en: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
 				fr: "Si le Pokémon Défenseur essaye d'attaquer pendant le prochain tour de votre adversaire, votre adversaire doit lancer une pièce. Si c'est pile, l'attaque est sans effet.",
-				de: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners anzugreifen versucht, wirft dein Gegner eine Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 10,
 
@@ -51,12 +51,12 @@ const card: Card = {
 			name: {
 				en: "Super Singe",
 				fr: "Ça sent le roussi !",
-				de: "Super Singe"
+				de: "Super-Versengung"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Burned.",
 				fr: "Le Pokémon Défenseur est maintenant Brûlé.",
-				de: "The Defending Pokémon is now Burned."
+				de: "Das Verteidigende Pokémon ist jetzt verbrannt."
 			},
 			damage: 40,
 

--- a/data/EX/Ruby & Sapphire/102.ts
+++ b/data/EX/Ruby & Sapphire/102.ts
@@ -32,12 +32,12 @@ const card: Card = {
 			name: {
 				en: "Agility",
 				fr: "Hâte",
-				de: "Agility"
+				de: "Agilität"
 			},
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Scyther ex during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, pendant le prochain tour de votre adversaire, prévenez tous les effets d'attaque, y compris les dégâts, infligés à Insécateur Ex.",
-				de: "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Scyther ex during your opponent's next turn"
+				de: "Wirf eine Münze. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte von Angriffen (einschließlich Schaden), die Sichlor zugefügt werden."
 			},
 			damage: 10,
 
@@ -51,7 +51,7 @@ const card: Card = {
 			name: {
 				en: "Slash",
 				fr: "Tranche",
-				de: "Slash"
+				de: "Schlitzer"
 			},
 
 			damage: 50,

--- a/data/EX/Ruby & Sapphire/103.ts
+++ b/data/EX/Ruby & Sapphire/103.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez deux pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de face.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl Kopf zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10×",
 
@@ -56,7 +56,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin for each of your Pokémon in play (including Sneasel ex). This attack does 20 damage times the number of heads.",
 				fr: "Lancez une pièce pour chaque Pokémon que vous avez en jeu (Farfuret Ex inclus). Cette attaque inflige 20 dégâts multipliés par le nombre de face.",
-				de: "Wirf eine Münze für jedes deiner Pokémon (einschließlich dieses Pokémon). Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl Kopf zu."
+				de: "Wirf eine Münze für jedes deiner Pokémon im Spiel (einschließlich dieses Pokémon). Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 

--- a/data/EX/Ruby & Sapphire/11.ts
+++ b/data/EX/Ruby & Sapphire/11.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Grovyle",
-		fr: "Massko"
+		fr: "Massko",
+		de: "Reptain"
 	},
 
 	stage: "Stage2",

--- a/data/EX/Ruby & Sapphire/12.ts
+++ b/data/EX/Ruby & Sapphire/12.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Vigoroth",
-		fr: "Vigoroth"
+		fr: "Vigoroth",
+		de: "Muntier"
 	},
 
 	stage: "Stage2",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Lazy",
 				fr: "Fainéant",
-				de: "Lazy"
+				de: "Faulheit"
 			},
 			effect: {
 				en: "As long as Slaking is your Active Pokémon, your opponent's Pokémon can't use any Poké-Powers.",
 				fr: "Tant que Monaflemit est votre Pokémon Actif, le Pokémon de votre adversaire ne peut utiliser de Poké-Powers.",
-				de: "As long as Slaking is your Active Pokémon, your opponent's Pokémon can't use any Poké-Powers."
+				de: "Solange Letarking dein Aktives Pokémon ist, können gegnerische Pokémon keine Poké-Power benutzen."
 			}
 		},
 	],
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Critical Move",
 				fr: "Mouvement décisif",
-				de: "Critical Move"
+				de: "Entscheidung"
 			},
 			effect: {
 				en: "Discard a basic Energy card attached to Slaking or this attack does nothing. Slaking can't attack during your next turn.",
 				fr: "Défaussez une carte Énergie de base attachée à Monaflemit ou cette attaque est sans effet. Monaflemit ne pourra pas attaquer pendant votre prochain tour.",
-				de: "Discard a basic Energy card attached to Slaking or this attack does nothing. Slaking can't attack during your next turn."
+				de: "Entferne 1 Basis-Energiekarte von Letarking und lege sie auf den Ablagestapel, sonst hat dieser Angriff keine Auswirkungen. Letarking kann in deinem nächsten Zug nicht angreifen."
 			},
 			damage: 100,
 

--- a/data/EX/Ruby & Sapphire/13.ts
+++ b/data/EX/Ruby & Sapphire/13.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Marshtomp",
-		fr: "Flobio"
+		fr: "Flobio",
+		de: "Moorabbel"
 	},
 
 	stage: "Stage2",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may attach a Water Energy card from your hand to your Active Pokémon. This power can't be used if Swampert is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez attacher une carte Énergie  de votre main à votre Pokémon Actif. Ce pouvoir ne peut être utilisé si Laggron est affecté par un État Spécial.",
-				de: "Während deines Zuges (vor deinem Angriff) kannst du einmal eine  -Energiekarte von deiner Hand an dein Aktives Pokémon anlegen. Diese Poké-Power kann nicht verwendet werden, falls Sumpex von einem Speziellen Zustand betroffen ist."
+				de: "Während deines Zuges (vor deinem Angriff) kannst du einmal eine {W}-Energiekarte von deiner Hand an dein Aktives Pokémon anlegen. Diese Poké-Power kann nicht verwendet werden, falls Sumpex von einem Speziellen Zustand betroffen ist."
 			}
 		},
 	],

--- a/data/EX/Ruby & Sapphire/14.ts
+++ b/data/EX/Ruby & Sapphire/14.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Wailmer",
-		fr: "Wailmer"
+		fr: "Wailmer",
+		de: "Wailmer"
 	},
 
 	stage: "Stage1",
@@ -38,12 +39,12 @@ const card: Card = {
 			name: {
 				en: "Take Down",
 				fr: "Bélier",
-				de: "Take Down"
+				de: "Bodycheck"
 			},
 			effect: {
 				en: "Wailord does 20 damage to itself.",
 				fr: "Wailord s'inflige 20 dégâts.",
-				de: "Wailord does 20 damage to itself."
+				de: "Wailord fügt sich selbst 20 Schadenspunkte zu."
 			},
 			damage: 50,
 
@@ -59,7 +60,7 @@ const card: Card = {
 			name: {
 				en: "Surf",
 				fr: "Surf",
-				de: "Surf"
+				de: "Surfer"
 			},
 
 			damage: 70,

--- a/data/EX/Ruby & Sapphire/15.ts
+++ b/data/EX/Ruby & Sapphire/15.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Combusken",
-		fr: "Galifeu"
+		fr: "Galifeu",
+		de: "Jungglut"
 	},
 
 	stage: "Stage2",
@@ -37,12 +38,12 @@ const card: Card = {
 			name: {
 				en: "Clutch",
 				fr: "Serre",
-				de: "Clutch"
+				de: "Greifer"
 			},
 			effect: {
 				en: "The Defending Pokémon can't retreat until the end of your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas battre en retraite tant que le prochain tour de votre adversaire n'est pas terminé.",
-				de: "The Defending Pokémon can't retreat until the end of your opponent's next turn."
+				de: "Das Verteidigende Pokémon kann sich im nächsten Zug deines Gegner nicht zurückziehen."
 			},
 			damage: 20,
 
@@ -57,12 +58,12 @@ const card: Card = {
 			name: {
 				en: "Flamethrower",
 				fr: "Lance-flamme",
-				de: "Flamethrower"
+				de: "Flammenwurf"
 			},
 			effect: {
 				en: "Discard a Fire Energy card attached to Blaziken.",
 				fr: "Défaussez une carte Énergie  attachée à Brasegali.",
-				de: "Discard a  Energy card attached to Blaziken."
+				de: "Lege 1 an Lohgock angelegte {R}-Energiekarte auf deinen Ablagestapel."
 			},
 			damage: 80,
 

--- a/data/EX/Ruby & Sapphire/16.ts
+++ b/data/EX/Ruby & Sapphire/16.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Shroomish",
-		fr: "Balignon"
+		fr: "Balignon",
+		de: "Knilz"
 	},
 
 	stage: "Stage1",
@@ -37,7 +38,7 @@ const card: Card = {
 			name: {
 				en: "Headbutt",
 				fr: "Coup d'boule",
-				de: "Headbutt"
+				de: "Kopfnuss"
 			},
 
 			damage: 20,
@@ -52,12 +53,12 @@ const card: Card = {
 			name: {
 				en: "Battle Blast",
 				fr: "Combat explosif",
-				de: "Battle Blast"
+				de: "Kampflust"
 			},
 			effect: {
 				en: "Does 40 damage plus 10 more damage for each Fighting Energy attached to Breloom.",
 				fr: "Inflige 40 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  attachée à Chapignon.",
-				de: "Does 40 damage plus 10 more damage for each  Energy card attached to Breloom."
+				de: "Dieser Angriff fügt 40 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Kapilz angelegte {F}-Energie zu."
 			},
 			damage: "40+",
 

--- a/data/EX/Ruby & Sapphire/17.ts
+++ b/data/EX/Ruby & Sapphire/17.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Phanpy",
-		fr: "Phanpy"
+		fr: "Phanpy",
+		de: "Phanpy"
 	},
 
 	stage: "Stage1",
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 60 damage times the number of heads.",
 				fr: "Lancez deux pièces. Cette attaque inflige 60 dégâts multipliés par le nombre de face.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 60 Schadenspunkte mal der Anzahl 'Kopf' zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 60 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "60×",
 

--- a/data/EX/Ruby & Sapphire/18.ts
+++ b/data/EX/Ruby & Sapphire/18.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "If any of your opponent's Active Pokémon are Evolved Pokémon, search your deck for any 1 card and put it into your hand. Shuffle your deck afterward.",
 				fr: "Si un des Pokémon Actifs de votre adversaire est un Pokémon Évolué, choisissez une carte dans votre deck et placez-la dans votre main. Mélangez ensuite votre deck.",
-				de: "Wenn dein Gegner ein entwickeltes Pokémon als Aktives Pokémon hat, durchsuche dein Deck nach 1 beliebigen Karte und nimm sie auf die Hand. Mische dein Deck danach."
+				de: "Wenn der Gegner ein entwickeltes Pokémon als Aktives Pokémon hat, durchsuche dein Deck nach 1 beliebigen Karte und nimm sie auf die Hand. Mische dein Deck danach."
 			},
 
 		},
@@ -53,7 +53,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, your opponent returns the Defending Pokémon and all cards attached to it to his or her hand. (If your opponent doesn't have any Benched Pokémon or other Active Pokémon, this attack does nothing.)",
 				fr: "Lancez une pièce. Si c'est face, votre adversaire doit reprendre dans sa main le Pokémon Défenseur et toutes les cartes qui lui sont attachées (il ne se passe rien si votre adversaire n'a pas d'autres Pokémon Actifs ou d'autres Pokémon sur son Banc).",
-				de: "Wirf eine Münze. Bei 'Kopf' nimmt dein Gegner das Verteidigende Pokémon und alle Karten, die daran angelegt sind, auf die Hand. (Hat dein Gegner kein Pokémon auf der Bank oder kein weiteres Aktives Pokémon, dann hat dieser Angriff keine Auswirkungen.)"
+				de: "Wirf eine Münze. Bei „Kopf“ nimmt dein Gegner das Verteidigende Pokémon und alle Karten, die daran angelegt sind, auf die Hand. (Hat dein Gegner kein Pokémon auf der Bank oder kein weiteres Aktives Pokémon, dann hat dieser Angriff keine Auswirkungen.)"
 			},
 
 		},

--- a/data/EX/Ruby & Sapphire/19.ts
+++ b/data/EX/Ruby & Sapphire/19.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Wingull",
-		fr: "Goélise"
+		fr: "Goélise",
+		de: "Wingull"
 	},
 
 	stage: "Stage1",
@@ -73,7 +74,7 @@ const card: Card = {
 			effect: {
 				en: "After your attack, remove from Pelipper the number of damage counters equal to the damage you did to the Defending Pokémon. If Pelipper has fewer damage counters than that, remove all of them.",
 				fr: "Après avoir attaqué, retirez à Bekipan autant de marqueurs de dégât que vous avez infligé de dégâts au Pokémon Défenseur. Si Bekipan a moins de marqueurs de dégât que de points infligés, retirez-lui tous ses marqueurs de dégât.",
-				de: "Entferne nach deinem Angriff Schadensmarken von Pelipper entsprechend der Höhe der Schadenspunkte, die dem Verteidigenden Pokémon zugefügt wurden. Sollten weniger Schadenspunkte auf Pelipper liegen, entferne alle."
+				de: "Entferne nach deinem Angriff Schadensmarken von Pelipper entsprechend der Höhe der Schadenspunkte, die dem Verteidigenden Pokémon zugefügt wurden. Sollten weniger Schadensmarken auf Pelipper liegen, entferne alle."
 			},
 			damage: 20,
 

--- a/data/EX/Ruby & Sapphire/2.ts
+++ b/data/EX/Ruby & Sapphire/2.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Silcoon",
-		fr: "Armulys"
+		fr: "Armulys",
+		de: "Schaloko"
 	},
 
 	stage: "Stage2",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Withering Dust",
 				fr: "Poussière desséchante",
-				de: "Withering Dust"
+				de: "Staub des Verdorrens"
 			},
 			effect: {
 				en: "As long as Beautifly is in play, do not apply Resistance for all Active Pokémon.",
 				fr: "Tant que Charmillon est en jeu, vous ne pouvez pas appliquer la Résistance aux Pokémon Actifs.",
-				de: "As long as Beautifly is in play, do not apply Resistance for all Active Pokémon."
+				de: "Solange sich Papinella im Spiel befindet, werden die Resistenzen von allen Aktiven Pokémon nicht angewendet."
 			}
 		},
 	],
@@ -52,12 +53,12 @@ const card: Card = {
 			name: {
 				en: "Stun Spore",
 				fr: "Poussière paralysante",
-				de: "Stun Spore"
+				de: "Stachelspore"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -71,12 +72,12 @@ const card: Card = {
 			name: {
 				en: "Parallel Gain",
 				fr: "Gain parallèle",
-				de: "Parallel Gain"
+				de: "Allgemeine Erholung"
 			},
 			effect: {
 				en: "Remove 1 damage counter from each of your Pokémon, including Beautifly.",
 				fr: "Retirez un marqueur de dégât à tous vos Pokémon, Charmillon inclus.",
-				de: "Remove 1 damage counter from each of your Pokémon, including Beautifly"
+				de: "Entferne 1 Schadensmarke von allen deinen Pokémon inklusive Papinella."
 			},
 			damage: 50,
 

--- a/data/EX/Ruby & Sapphire/20.ts
+++ b/data/EX/Ruby & Sapphire/20.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Grovyle",
-		fr: "Massko"
+		fr: "Massko",
+		de: "Reptain"
 	},
 
 	stage: "Stage2",
@@ -59,7 +60,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 50 damage times the number of heads.",
 				fr: "Lancez deux pièces. Cette attaque inflige 50 dégâts multipliés par le nombre de face.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl 'Kopf' zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "50×",
 

--- a/data/EX/Ruby & Sapphire/21.ts
+++ b/data/EX/Ruby & Sapphire/21.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Goldeen",
-		fr: "Poissirène"
+		fr: "Poissirène",
+		de: "Goldini"
 	},
 
 	stage: "Stage1",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Water Arrow",
 				fr: "Flèche d'eau",
-				de: "Water Arrow"
+				de: "Wasserpfeil"
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Choisissez un des Pokémon de votre adversaire : cette attaque inflige 20 dégâts à ce Pokémon. (Ne pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc).",
-				de: "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -53,12 +54,12 @@ const card: Card = {
 			name: {
 				en: "Fast Stream",
 				fr: "Torrent",
-				de: "Fast Stream"
+				de: "Reißender Strom"
 			},
 			effect: {
 				en: "Move 1 Energy card attached to the Defending Pokémon to the other Defending Pokémon. (Ignore this effect if your opponent has only 1 Defending Pokémon.)",
 				fr: "Prenez une carte Énergie attachée au Pokémon Défenseur et attachez-la à l'autre Pokémon Défenseur. (Ne tenez pas compte de cet effet si votre adversaire ne possède qu'un seul Pokémon Défenseur).",
-				de: "Move 1 Energy card attached to the Defending Pokémon to the other Defending Pokémon. (Ignore this effect if your opponent has only 1 Defending Pokémon.)"
+				de: "Nimm 1 Energiekarte von dem Verteidigenden Pokémon und lege sie an das andere Verteidigende Pokémon an. (Dieser Effekt hat keine Auswirkung, wenn der Gegner nur 1 Verteidigendes Pokémon hat.)"
 			},
 			damage: 30,
 

--- a/data/EX/Ruby & Sapphire/22.ts
+++ b/data/EX/Ruby & Sapphire/22.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Carvanha",
-		fr: "Carvanha"
+		fr: "Carvanha",
+		de: "Kanivanha"
 	},
 
 	stage: "Stage1",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Rough Skin",
 				fr: "Peau dure",
-				de: "Rough Skin"
+				de: "Rauhaut"
 			},
 			effect: {
 				en: "If Sharpedo is your Active Pokémon and is damaged by an opponent's attack (even if Sharpedo is Knocked Out), put 2 damage counters on the Attacking Pokémon.",
 				fr: "Si Sharpedo est votre Pokémon Actif et qu'une attaque de votre adversaire lui inflige des dégâts (même si Sharpedo est mis K.O.), placez un marqueur de dégât sur le Pokémon Attaquant.",
-				de: "If Sharpedo is your Active Pokémon and is damaged by an opponent's attack (even if Sharpedo is Knocked Out), put 2 damage counters on the Attacking Pokémon"
+				de: "Wenn Tohaido dein Aktives Pokémon ist und durch einen gegnerischen Angriff Schaden erhält (auch wenn Tohaido dadurch kampfunfähig wird), legst du 1 Schadensmarke auf das Angreifende Pokémon."
 			}
 		},
 	],
@@ -54,12 +55,12 @@ const card: Card = {
 			name: {
 				en: "Dark Slash",
 				fr: "Entaille",
-				de: "Dark Slash"
+				de: "Dunkler Hieb"
 			},
 			effect: {
 				en: "You may discard a Darkness Energy card attached to Sharpedo. If you do, this attack does 40 damage plus 30 more damage.",
 				fr: "Vous pouvez défausser une carte Énergie  attachée à Sharpedo. Les dégâts de base de cette attaque sont de 70 au lieu de 40.",
-				de: "You may discard a  Energy card attached to Sharpedo. If you do, this attack does 40 damage plus 30 more damage."
+				de: "Du kannst eine {W}-Energiekarte, die an Tohaido angelegt ist, auf den Ablagestapel legen. Wenn du das machst, beträgt der Grundschaden dieses Angriffs 70 Schadenspunkte anstelle von 40."
 			},
 			damage: "40+",
 

--- a/data/EX/Ruby & Sapphire/23.ts
+++ b/data/EX/Ruby & Sapphire/23.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Marshtomp",
-		fr: "Flobio"
+		fr: "Flobio",
+		de: "Moorabbel"
 	},
 
 	stage: "Stage2",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), when you attach a Water Energy card from your hand to Swampert, remove 1 damage counter from Swampert.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), si vous attachez une carte Énergie  de votre main à Laggron, retirez-lui un marqueur de dégât.",
-				de: "Einmal in deinem Zug (vor deinem Angriff), wenn du eine -Energiekarte von der Hand an Sumpex anlegst, entferne 1 Schadensmarke von Sumpex."
+				de: "Einmal in deinem Zug (vor deinem Angriff), wenn du eine {W}-Energiekarte von der Hand an Sumpex anlegst, entferne 1 Schadensmarke von Sumpex."
 			}
 		},
 	],
@@ -57,7 +58,7 @@ const card: Card = {
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Choisissez un des Pokémon de votre adversaire : cette attaque inflige 20 dégâts à ce Pokémon. (Ne pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc).",
-				de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 20 Schadenspunkte zu. (Wende Schwäche und Resistenz für Pokémon auf der Bank nicht an.)"
+				de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},

--- a/data/EX/Ruby & Sapphire/24.ts
+++ b/data/EX/Ruby & Sapphire/24.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Koffing",
-		fr: "Smogo"
+		fr: "Smogo",
+		de: "Smogon"
 	},
 
 	stage: "Stage1",

--- a/data/EX/Ruby & Sapphire/25.ts
+++ b/data/EX/Ruby & Sapphire/25.ts
@@ -31,7 +31,7 @@ const card: Card = {
 			name: {
 				en: "Rollout",
 				fr: "Roulade",
-				de: "Rollout"
+				de: "Walzer"
 			},
 
 			damage: 10,
@@ -45,12 +45,12 @@ const card: Card = {
 			name: {
 				en: "Double Stab",
 				fr: "Coup double",
-				de: "Double Stab"
+				de: "Doppelstich"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez deux pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de face.",
-				de: "Flip 2 coins. This attack does 20 damage times the number of heads."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 

--- a/data/EX/Ruby & Sapphire/26.ts
+++ b/data/EX/Ruby & Sapphire/26.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Wurmple",
-		fr: "Chenipotte"
+		fr: "Chenipotte",
+		de: "Waumpel"
 	},
 
 	stage: "Stage1",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Hard Cocoon",
 				fr: "Carapace",
-				de: "Hard Cocoon"
+				de: "Harter Kokon"
 			},
 			effect: {
 				en: "During your opponent's turn, if Cascoon would be damaged by an opponent's attack (after applying Weakness and Resistance), flip a coin. If heads, reduce that damage by 30.",
 				fr: "Pendant le tour de votre adversaire, si l'une de ses attaques inflige des dégâts à Blindalys (après application de la Faiblesse et de la Résistance), lancez une pièce. Si c'est face, réduisez ces dégâts de 30.",
-				de: "During your opponent's turn, if Cascoon would be damaged by an opponent's attack (after applying Weakness and Resistance), flip a coin. If heads, reduce that damage by 30."
+				de: "Wirf eine Münze, wenn Panekon im Zug deines Gegner Schaden (nachdem Schwäche und Resistenz verrechnet wurden) von einem gegnerischen Angriff bekommen würde. Bei „Kopf“ wird der Schaden um 30 Schadenspunkte reduziert."
 			}
 		},
 	],
@@ -52,12 +53,12 @@ const card: Card = {
 			name: {
 				en: "Poison Thread",
 				fr: "Fil empoisonné",
-				de: "Poison Thread"
+				de: "Giftiger Faden"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné.",
-				de: "The Defending Pokémon is now Poisoned."
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet."
 			},
 
 		},

--- a/data/EX/Ruby & Sapphire/27.ts
+++ b/data/EX/Ruby & Sapphire/27.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Torchic",
-		fr: "Poussifeu"
+		fr: "Poussifeu",
+		de: "Flemmli"
 	},
 
 	stage: "Stage1",
@@ -56,7 +57,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 40 damage times the number of heads.",
 				fr: "Lancez deux pièces. Cette attaque inflige 40 dégâts multipliés par le nombre de face.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "40×",
 

--- a/data/EX/Ruby & Sapphire/28.ts
+++ b/data/EX/Ruby & Sapphire/28.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Torchic",
-		fr: "Poussifeu"
+		fr: "Poussifeu",
+		de: "Flemmli"
 	},
 
 	stage: "Stage1",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "When you attach a Fire Energy card from your hand to Combusken, remove all Special Conditions from Combusken.",
 				fr: "Lorsque vous attachez une carte Énergie  à Galifeu, retirez-lui tous ses États Spéciaux.",
-				de: "Wenn du eine -Energiekarte an Jungglut anlegst, verlieren alle Speziellen Zustände auf Jungglut ihre Wirkung."
+				de: "Wenn du eine {R}-Energiekarte an Jungglut anlegst, verlieren alle Speziellen Zustände auf Jungglut ihre Wirkung."
 			}
 		},
 	],
@@ -58,7 +59,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, l'attaque est sans effet.",
-				de: "Wirf eine Münze. Bei 'Zahl' hat dieser Angriff keine Auswirkungen."
+				de: "Wirf eine Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 50,
 

--- a/data/EX/Ruby & Sapphire/29.ts
+++ b/data/EX/Ruby & Sapphire/29.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Skitty",
-		fr: "Skitty"
+		fr: "Skitty",
+		de: "Eneco"
 	},
 
 	stage: "Stage1",

--- a/data/EX/Ruby & Sapphire/3.ts
+++ b/data/EX/Ruby & Sapphire/3.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Combusken",
-		fr: "Galifeu"
+		fr: "Galifeu",
+		de: "Jungglut"
 	},
 
 	stage: "Stage2",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Firestarter",
 				fr: "Pyroteknik",
-				de: "Firestarter"
+				de: "Brandstiftung"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may attach a Fire Energy card from your discard pile to 1 of your Benched Pokémon. This power can't be used if Blaziken is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez attacher une Carte Énergie  de votre pile de défausse à un des Pokémon de votre Banc. Ce pouvoir ne peut être utilisé si Brasegali est affecté par un État Spécial.",
-				de: "Once during your turn (before your attack), you may attach a  Energy card from your discard pile to 1 of your Benched Pokémon. This power can't be used if Blaziken is affected by a Special Condition."
+				de: "Während deines Zuges (vor deinem Angriff) kannst du einmal eine {R}-Energiekarte von deinem Ablagestapel nehmen und an 1 Pokémon auf deiner Bank anlegen. Diese Poké-Power kann nicht verwendet werden, falls Lohgock von einem Speziellen Zustand betroffen ist."
 			}
 		},
 	],
@@ -54,12 +55,12 @@ const card: Card = {
 			name: {
 				en: "Fire Stream",
 				fr: "Courant de feu",
-				de: "Fire Stream"
+				de: "Feuerstrom"
 			},
 			effect: {
 				en: "Discard a Fire Energy card attached to Blaziken. If you do, this attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Vous pouvez défausser une Carte Énergie  attachée à Brasegali. Cette attaque inflige alors 10 dégâts à chacun des Pokémon du Banc de votre adversaire. (Ne pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc.)",
-				de: "Discard a  Energy card attached to Blaziken. If you do, this attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Entferne eine {R}-Energiekarte von Lohgock und lege sie auf den Ablagestapel. Wenn du das machst, fügt dieser Angriff jedem gegnerischen Pokémon auf der Bank 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 50,
 

--- a/data/EX/Ruby & Sapphire/30.ts
+++ b/data/EX/Ruby & Sapphire/30.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Charge",
 				fr: "Recharge",
-				de: "Charge"
+				de: "Laden"
 			},
 			effect: {
 				en: "Attach a Lightning Energy card from your discard pile to Electrike.",
 				fr: "Attachez une carte Énergie  de votre pile de défausse à Dynavolt.",
-				de: "Attack a  Energy card from your discard pile to Electrike."
+				de: "Nimm eine {L}-Energiekarte von deinem Ablagestapel und lege sie an Frizelbliz an."
 			},
 
 		},
@@ -48,12 +48,12 @@ const card: Card = {
 			name: {
 				en: "Thunder Jolt",
 				fr: "Secousse tonnerre",
-				de: "Thunder Jolt"
+				de: "Donnerrüttler"
 			},
 			effect: {
 				en: "Flip a coin. If tails, Electrike does 10 damage to itself.",
 				fr: "Lancez une pièce. Si c'est pile, Dynavolt s'inflige 10 dégâts.",
-				de: "Flip a coin. If tails, Electrike does 10 damage to itself."
+				de: "Wirf eine Münze. Bei „Zahl“ fügt sich Frizelbliz selbst 10 Schadenspunkte zu."
 			},
 			damage: 30,
 

--- a/data/EX/Ruby & Sapphire/31.ts
+++ b/data/EX/Ruby & Sapphire/31.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Treecko",
-		fr: "Arcko"
+		fr: "Arcko",
+		de: "Geckarbor"
 	},
 
 	stage: "Stage1",

--- a/data/EX/Ruby & Sapphire/32.ts
+++ b/data/EX/Ruby & Sapphire/32.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Treecko",
-		fr: "Arcko"
+		fr: "Arcko",
+		de: "Geckarbor"
 	},
 
 	stage: "Stage1",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "When you attach a Grass Energy card from your hand to Grovyle, remove all Special Conditions from Grovyle.",
 				fr: "Lorsque vous attachez une carte Énergie  de votre main à Massko, retirez-lui tous ses États Spéciaux.",
-				de: "Wenn du eine -Energiekarte von der Hand an Reptain anlegst, verlieren alle Speziellen Zustände auf Reptain ihre Wirkung."
+				de: "Wenn du eine {G}-Energiekarte von der Hand an Reptain anlegst, verlieren alle Speziellen Zustände auf Reptain ihre Wirkung."
 			}
 		},
 	],

--- a/data/EX/Ruby & Sapphire/33.ts
+++ b/data/EX/Ruby & Sapphire/33.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Makuhita",
-		fr: "Makuhita"
+		fr: "Makuhita",
+		de: "Makuhita"
 	},
 
 	stage: "Stage1",
@@ -42,7 +43,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 40 damage plus 10 more damage for each heads.",
 				fr: "Lancez deux pièces. Cette attaque inflige 40 dégâts plus 10 dégâts supplémentaires pour chaque face.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte plus 10 Schadenspunkte für jede Münze, die das Ergebnis \"Kopf\" zeigt, zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte plus 10 Schadenspunkte für jede Münze, die das Ergebnis „Kopf“ zeigt, zu."
 			},
 			damage: "40+",
 

--- a/data/EX/Ruby & Sapphire/34.ts
+++ b/data/EX/Ruby & Sapphire/34.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Ralts",
-		fr: "Tarsal"
+		fr: "Tarsal",
+		de: "Trasla"
 	},
 
 	stage: "Stage1",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Removal Beam",
 				fr: "Rayon désintégrateur",
-				de: "Removal Beam"
+				de: "Entfernungsstrahl"
 			},
 			effect: {
 				en: "Flip a coin. If heads, discard 1 Energy card attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, défaussez une carte Énergie attachée au Pokémon Défenseur.",
-				de: "Flip a coin. If heads, discard 1 Energy card attached to the Defending Pokémon."
+				de: "Wirf eine Münze. Bei „Kopf“ muss dein Gegner 1 Energiekarte, die an dem Verteidigenden Pokémon angelegt ist, auf den Ablagestapel legen."
 			},
 			damage: 10,
 
@@ -55,7 +56,7 @@ const card: Card = {
 			name: {
 				en: "Super Psy",
 				fr: "Super psy",
-				de: "Super Psy"
+				de: "Super-Psischlag"
 			},
 
 			damage: 50,

--- a/data/EX/Ruby & Sapphire/35.ts
+++ b/data/EX/Ruby & Sapphire/35.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Ralts",
-		fr: "Tarsal"
+		fr: "Tarsal",
+		de: "Trasla"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, each Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, chaque Pokémon Défenseur est maintenant Confus.",
-				de: "Wirf eine Münze. Bei 'Kopf' sind alle Verteidigenden Pokémon jetzt verwirrt."
+				de: "Wirf eine Münze. Bei „Kopf“ sind alle Verteidigenden Pokémon jetzt verwirrt."
 			},
 
 		},
@@ -57,7 +58,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, put damage counters on the Defending Pokémon until it is 10 HP away from being Knocked Out.",
 				fr: "Lancez une pièce. Si c'est face, placez des marqueurs de dégât sur le Pokémon Défenseur jusqu'à ce qu'il ne lui reste plus que 10 PV.",
-				de: "Wirf eine Münze. Bei 'Kopf' legst du so viele Schadensmarken auf das Verteidigende Pokémon, dass es nur noch 10 Schadenspunkte davon entfernt ist, kampfunfähig zu werden."
+				de: "Wirf eine Münze. Bei „Kopf“ legst du so viele Schadensmarken auf das Verteidigende Pokémon, dass es nur noch 10 Schadenspunkte davon entfernt ist, kampfunfähig zu werden."
 			},
 
 		},

--- a/data/EX/Ruby & Sapphire/36.ts
+++ b/data/EX/Ruby & Sapphire/36.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Aron",
-		fr: "Galekid"
+		fr: "Galekid",
+		de: "Stollunior"
 	},
 
 	stage: "Stage1",
@@ -37,7 +38,7 @@ const card: Card = {
 			name: {
 				en: "Ram",
 				fr: "Charge",
-				de: "Ram"
+				de: "Ramme"
 			},
 
 			damage: 20,
@@ -52,7 +53,7 @@ const card: Card = {
 			name: {
 				en: "Metal Claw",
 				fr: "Griffe acier",
-				de: "Metal Claw"
+				de: "Metallklaue"
 			},
 
 			damage: 40,

--- a/data/EX/Ruby & Sapphire/37.ts
+++ b/data/EX/Ruby & Sapphire/37.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Aron",
-		fr: "Galekid"
+		fr: "Galekid",
+		de: "Stollunior"
 	},
 
 	stage: "Stage1",
@@ -56,12 +57,12 @@ const card: Card = {
 			name: {
 				en: "One-Two Strike",
 				fr: "En deux coups",
-				de: "Links-Rechts-Kombo"
+				de: "Links-Rechts Kombo"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 30 damage plus 20 more damage for each heads.",
 				fr: "Lancez deux pièces. Cette attaque inflige 30 dégâts plus 20 dégâts supplémentaires pour chaque face.",
-				de: "Wirf zwei Münzen. Dieser Angriff fügt 30 Schadenspunkte plus 20 Schadenspunkte für jede Münze, die das Ergebnis 'Kopf' zeigt, zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte plus 20 Schadenspunkte für jede Münze, die das Ergebnis „Kopf“ zeigt, zu."
 			},
 			damage: "30+",
 

--- a/data/EX/Ruby & Sapphire/38.ts
+++ b/data/EX/Ruby & Sapphire/38.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Zigzagoon",
-		fr: "Zigzaton"
+		fr: "Zigzaton",
+		de: "Zigzachs"
 	},
 
 	stage: "Stage1",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Seek Out",
 				fr: "À la recherche",
-				de: "Seek Out"
+				de: "Spürnase"
 			},
 			effect: {
 				en: "Search your deck for up to 2 cards and put them into your hand. Shuffle your deck afterward.",
 				fr: "Choisissez deux cartes dans votre deck. Montrez-les à votre adversaire et placez-les dans votre main. Mélangez ensuite votre deck.",
-				de: "Search your deck for up to 2 cards and put them into your hand. Shuffle your deck afterward."
+				de: "Durchsuche dein Deck nach 2 beliebigen Karten, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 			},
 
 		},
@@ -53,12 +54,12 @@ const card: Card = {
 			name: {
 				en: "Continuous Headbutt",
 				fr: "Coup d'boule sans fin",
-				de: "Continuous Headbutt"
+				de: "Anhaltender Kopstoß"
 			},
 			effect: {
 				en: "Flip a coin until you get tails. This attack does 40 damage times the number of heads.",
 				fr: "Lancez une pièce jusqu'à ce que ce soit pile. Cette attaque inflige 40 dégâts multipliés par le nombre de face.",
-				de: "Flip a coin until you get tails. This attack does 40 damage times the number of heads."
+				de: "Wirf solange eine Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Für jedesmal, wo die Münze „Kopf“ gezeigt hat, fügt dieser Angriff 40 Schadenspunkte zu."
 			},
 			damage: "40×",
 

--- a/data/EX/Ruby & Sapphire/39.ts
+++ b/data/EX/Ruby & Sapphire/39.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Electrike",
-		fr: "Dynavolt"
+		fr: "Dynavolt",
+		de: "Frizelbliz"
 	},
 
 	stage: "Stage1",
@@ -37,12 +38,12 @@ const card: Card = {
 			name: {
 				en: "Thundershock",
 				fr: "Éclair",
-				de: "Thundershock"
+				de: "Donnerschock"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -56,12 +57,12 @@ const card: Card = {
 			name: {
 				en: "Gigashock",
 				fr: "Electrochok",
-				de: "Gigashock"
+				de: "Gigaschock"
 			},
 			effect: {
 				en: "Does 10 damage to 2 of your opponent's Benched Pokémon (1 if there is only 1). (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à deux des Pokémon du Banc de votre adversaire (ou un s'il n'y en a qu'un). (Ne pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc).",
-				de: "Does 10 damage to 2 of your opponent's Benched Pokémon. (1 if there is only 1). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Dieser Angriff fügt 2 gegnerischen Pokémon auf der Bank (1 wenn nur 1 vorhanden ist) 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 40,
 

--- a/data/EX/Ruby & Sapphire/4.ts
+++ b/data/EX/Ruby & Sapphire/4.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Numel",
-		fr: "Chamallot"
+		fr: "Chamallot",
+		de: "Camaub"
 	},
 
 	stage: "Stage1",
@@ -37,12 +38,12 @@ const card: Card = {
 			name: {
 				en: "Lava Burn",
 				fr: "Brûlure de lave",
-				de: "Lava Burn"
+				de: "Brennende Lava"
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Benched Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Choisissez un Pokémon du Banc de votre adversaire: cette attaque inflige 10 dégâts à ce Pokémon (Ne pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc).",
-				de: "Choose 1 of your opponent's Benched Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Wähle 1 gegnerisches Pokémon auf der Bank. Dieser Angriff fügt dem gewählten Pokémon 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 20,
 
@@ -57,12 +58,12 @@ const card: Card = {
 			name: {
 				en: "Fire Spin",
 				fr: "Danseflamme",
-				de: "Fire Spin"
+				de: "Feuerwirbel"
 			},
 			effect: {
 				en: "Discard 2 basic Energy cards attached to Camerupt or this attack does nothing.",
 				fr: "Défaussez deux cartes Énergie de base attachées à Camerupt ou cette attaque est sans effet.",
-				de: "Discard 2 basic Energy cards attached to Camerupt or this attack does nothing."
+				de: "Entferne 2 Basis-Energiekarten von Camerupt und lege sie auf den Ablagestapel, sonst hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 100,
 

--- a/data/EX/Ruby & Sapphire/40.ts
+++ b/data/EX/Ruby & Sapphire/40.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Mudkip",
-		fr: "Gobou"
+		fr: "Gobou",
+		de: "Hydropi"
 	},
 
 	stage: "Stage1",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Bubble",
 				fr: "Écume",
-				de: "Bubble"
+				de: "Blubber"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed"
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 
@@ -55,7 +56,7 @@ const card: Card = {
 			name: {
 				en: "Slash",
 				fr: "Tranche",
-				de: "Slash"
+				de: "Schlitzer"
 			},
 
 			damage: 40,

--- a/data/EX/Ruby & Sapphire/41.ts
+++ b/data/EX/Ruby & Sapphire/41.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Mudkip",
-		fr: "Gobou"
+		fr: "Gobou",
+		de: "Hydropi"
 	},
 
 	stage: "Stage1",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "When you attach a Water Energy card from your hand to Marshtomp, remove all Special Conditions from Marshtomp.",
 				fr: "Lorsque vous attachez une carte Énergie  de votre main à Flobio, retirez-lui tous ses États Spéciaux.",
-				de: "Wenn du eine -Energiekarte an Moorabbel anlegst, verlieren alle Speziellen Zustände auf Moorabbel ihre Wirkung."
+				de: "Wenn du eine {W}-Energiekarte an Moorabbel anlegst, verlieren alle Speziellen Zustände auf Moorabbel ihre Wirkung."
 			}
 		},
 	],

--- a/data/EX/Ruby & Sapphire/42.ts
+++ b/data/EX/Ruby & Sapphire/42.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Poochyena",
-		fr: "Medhyèna"
+		fr: "Medhyèna",
+		de: "Fiffyen"
 	},
 
 	stage: "Stage1",
@@ -57,7 +58,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 damage plus 30 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 60 dégâts.",
-				de: "Wirf eine Münze. Bei 'Kopf' fügt dieser Angriff 30 Schadenspunkte plus 30 weitere Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 30 Schadenspunkte plus 30 weitere Schadenspunkte zu."
 			},
 			damage: "30+",
 

--- a/data/EX/Ruby & Sapphire/43.ts
+++ b/data/EX/Ruby & Sapphire/43.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Wurmple",
-		fr: "Chenipotte"
+		fr: "Chenipotte",
+		de: "Waumpel"
 	},
 
 	stage: "Stage1",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Hard Cocoon",
 				fr: "Carapace",
-				de: "Hard Cocoon"
+				de: "Harter Kokon"
 			},
 			effect: {
 				en: "During your opponent's turn, if Silcoon would be damaged by an opponent's attack (after applying Weakness and Resistance), flip a coin. If heads, reduce that damage by 30.",
 				fr: "Pendant le tour de votre adversaire, si l'une de ses attaques inflige des dégâts à Almurys (après application de la Faiblesse et de la Résistance), lancez une pièce. Si c'est face, réduisez ces dégâts de 30.",
-				de: "During your opponent's turn, if Silcoon would be damaged by an opponent's attack (after applying Weakness and Resistance), flip a coin. If heads, reduce that damage by 30."
+				de: "Wirf eine Münze, wenn Schaloko im Zug deines Gegners Schaden (nachdem Schwäche und Resistenz verrechnet wurden) von einem gegnerischen Angriff bekommen würde. Bei „Kopf“ wird der Schaden um 30 Schadenspunkte reduziert."
 			}
 		},
 	],
@@ -52,12 +53,12 @@ const card: Card = {
 			name: {
 				en: "Gooey Thread",
 				fr: "Fil gluant",
-				de: "Gooey Thread"
+				de: "Klebriger Faden"
 			},
 			effect: {
 				en: "The Defending Pokémon can't retreat until the end of your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas battre en retraite tant que le prochain tour de votre adversaire n'est pas terminé.",
-				de: "The Defending Pokémon can't retreat until the end of your opponent's next turn."
+				de: "Das Verteidigende Pokémon kann sich im nächsten Zug deines Gegners nicht zurückziehen."
 			},
 			damage: 10,
 

--- a/data/EX/Ruby & Sapphire/45.ts
+++ b/data/EX/Ruby & Sapphire/45.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Claw",
 				fr: "Mâchoire",
-				de: "Claw"
+				de: "Klaue"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, l'attaque est sans effet.",
-				de: "Flip a coin. If tails, this attack does nothing."
+				de: "Wirf eine Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 20,
 
@@ -49,12 +49,12 @@ const card: Card = {
 			name: {
 				en: "Slack Off",
 				fr: "Paresse",
-				de: "Slack Off"
+				de: "Tagedieb"
 			},
 			effect: {
 				en: "Remove all damage counters from Slakoth. Slakoth can't attack during your next turn.",
 				fr: "Retirez à Paracool tous ses marqueurs de dégât. Paracool ne pourra pas attaquer pendant votre prochain tour.",
-				de: "Remove all damage counters from Slakoth. Slakoth can't attack during your next turn."
+				de: "Entferne alle Schadensmarken von Bummelz. Bummelz kann in deinem nächsten Zug nicht angreifen."
 			},
 
 		},

--- a/data/EX/Ruby & Sapphire/46.ts
+++ b/data/EX/Ruby & Sapphire/46.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Taillow",
-		fr: "Nirondelle"
+		fr: "Nirondelle",
+		de: "Schwalbini"
 	},
 
 	stage: "Stage1",

--- a/data/EX/Ruby & Sapphire/47.ts
+++ b/data/EX/Ruby & Sapphire/47.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Slakoth",
-		fr: "Parecool"
+		fr: "Parecool",
+		de: "Bummelz"
 	},
 
 	stage: "Stage1",
@@ -42,7 +43,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez trois pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de face.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 

--- a/data/EX/Ruby & Sapphire/48.ts
+++ b/data/EX/Ruby & Sapphire/48.ts
@@ -32,12 +32,12 @@ const card: Card = {
 			name: {
 				en: "Rest",
 				fr: "Repos",
-				de: "Rest"
+				de: "Ruhe"
 			},
 			effect: {
 				en: "Remove all Special Conditions and 4 damage counters from Wailmer (all if there are less than 4). Wailmer is now Asleep.",
 				fr: "Retirez à Wailmer tous ses États Spéciaux ainsi que 4 marqueurs de dégât (si Wailmer a moins de dégâts que cela, retirez-les lui tous). Wailmer est maintenant Endormi.",
-				de: "Remove all Special Conditions and 4 damage counters from Wailmer. (all if there are less than 4). Wailmer is now Asleep."
+				de: "Entferne alle Speziellen Zustände und 4 Schadensmarken von Wailmer (entferne alle, wenn weniger als 4 auf Wailmer liegen). Wailmer schläft jetzt."
 			},
 
 		},
@@ -49,12 +49,12 @@ const card: Card = {
 			name: {
 				en: "Water Gun",
 				fr: "Pistolet à O",
-				de: "Water Gun"
+				de: "Aquaknarre"
 			},
 			effect: {
 				en: "This attack does 20 damage plus 10 more damage for each Water Energy attached to Wailmer but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way.",
 				fr: "Cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  attachée à Wailmer qui n'a pas été utilisée pour payer le coût en Énergie de cette attaque. Vous ne pouvez pas ajouter plus de 20 dégâts de cette façon.",
-				de: "This attack does 20 damage plus 10 more damage for each  Energy attached to Wailmer but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+				de: "Dieser Angriff fügt 20 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Wailmer angelegt {W}-Energie zu, die nicht zum Zahlen der Energiekosten für diesen Angriff verwendet wurde. Es lassen sich so nicht mehr als 20 Schadenspunkte hinzufügen."
 			},
 			damage: "20+",
 

--- a/data/EX/Ruby & Sapphire/5.ts
+++ b/data/EX/Ruby & Sapphire/5.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Skitty",
-		fr: "Skitty"
+		fr: "Skitty",
+		de: "Eneco"
 	},
 
 	stage: "Stage1",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Energy Draw",
 				fr: "Pioche d'énergie",
-				de: "Energy Draw"
+				de: "Ruf nach Energie"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may discard 1 Energy card from your hand. Then draw up to 3 cards from your deck. This power can't be used if Delcatty is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez défausser une carte Énergie de votre main. Ensuite, vous pouvez piocher jusqu'à trois cartes dans votre deck. Ce pouvoir ne peut être utilisé si Delcatty est affecté par un État Spécial.",
-				de: "Once during your turn (before your attack), your may discard 1 Energy card from your hand. Then draw up to 3 cards from your deck. This power can't be used if Delcatty is affected by a Special Condition."
+				de: "Während deines Zuges (vor deinem Angriff) kannst du einmal 1 Energiekarte von deiner Hand abwerfen. Ziehe danach bis zu 3 Karten von deinem Deck. Diese Poké-Power kann nicht angewendet werden, falls Enekoro von einem Speziellen Zustand betroffen ist."
 			}
 		},
 	],
@@ -52,12 +53,12 @@ const card: Card = {
 			name: {
 				en: "Max Energy Source",
 				fr: "Source d'énergie maximale",
-				de: "Max Energy Source"
+				de: "Maximale Energie"
 			},
 			effect: {
 				en: "Does 10 damage times the amount of Energy attached to all of your Active Pokémon.",
 				fr: "Inflige 10 dégâts pour chaque Énergie attachée à vos Pokémon Actifs.",
-				de: "Does 10 damage times the amount of Energy attached to all of your Active Pokémon."
+				de: "Dieser Angriff fügt für jede Energie, die an allen deinen Aktiven Pokémon angelegt ist, 10 Schadenspunkte zu."
 			},
 			damage: "10×",
 

--- a/data/EX/Ruby & Sapphire/53.ts
+++ b/data/EX/Ruby & Sapphire/53.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, each Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le ou les deux Pokémon Défenseurs sont maintenant Paralysés.",
-				de: "Wirf eine Münze. Bei 'Kopf' sind alle Verteidigenden Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ sind alle Verteidigenden Pokémon jetzt gelähmt."
 			},
 
 		},

--- a/data/EX/Ruby & Sapphire/57.ts
+++ b/data/EX/Ruby & Sapphire/57.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Fling",
 				fr: "Lancer",
-				de: "Fling"
+				de: "Austoben"
 			},
 			effect: {
 				en: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon.",
 				fr: "Votre adversaire échange le Pokémon Défenseur contre un des Pokémon de son Banc.",
-				de: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon."
+				de: "Dein Gegner tauscht sein Aktives Pokémon gegen 1 seiner Pokémon auf der Bank aus."
 			},
 
 		},
@@ -48,7 +48,7 @@ const card: Card = {
 			name: {
 				en: "Low Kick",
 				fr: "Balayage",
-				de: "Low Kick"
+				de: "Kick"
 			},
 
 			damage: 30,

--- a/data/EX/Ruby & Sapphire/58.ts
+++ b/data/EX/Ruby & Sapphire/58.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 

--- a/data/EX/Ruby & Sapphire/59.ts
+++ b/data/EX/Ruby & Sapphire/59.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 

--- a/data/EX/Ruby & Sapphire/6.ts
+++ b/data/EX/Ruby & Sapphire/6.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Cascoon",
-		fr: "Blindalys"
+		fr: "Blindalys",
+		de: "Panekon"
 	},
 
 	stage: "Stage2",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Protective Dust",
 				fr: "Poussière protectrice",
-				de: "Protective Dust"
+				de: "Schützender Staub"
 			},
 			effect: {
 				en: "Prevent all effects of attacks, except damage, done to Dustox by the Attacking Pokémon.",
 				fr: "Prévenez tous les effets d'attaques, excepté les dégâts, infligés à Papinox par le Pokémon Attaquant.",
-				de: "Prevent all effects of attacks, except damage, done to Dustox by the Attacking Pokémon."
+				de: "Verhindere alle Effekte von Angriffen außer Schaden, die Pudox von dem Angreifenden Pokémon zugefügt werden."
 			}
 		},
 	],
@@ -53,12 +54,12 @@ const card: Card = {
 			name: {
 				en: "Toxic",
 				fr: "Toxik",
-				de: "Toxic"
+				de: "Toxin"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned. Put 2 damage counters instead of 1 on the Defending Pokémon between turns.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné. Placez deux marqueurs de dégât sur le Pokémon Défenseur entre les deux tours.",
-				de: "The Defending Pokémon is now Poisoned. Put 2 damage counters instead of 1 on the defending Pokémon between turns."
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet. Lege zwischen den Zügen 2 Schadensmarken anstelle von 1 Schadensmarke auf das Verteidigende Pokémon."
 			},
 
 		},
@@ -71,7 +72,7 @@ const card: Card = {
 			name: {
 				en: "Gust",
 				fr: "Tornade",
-				de: "Gust"
+				de: "Windstoß"
 			},
 
 			damage: 50,

--- a/data/EX/Ruby & Sapphire/60.ts
+++ b/data/EX/Ruby & Sapphire/60.ts
@@ -50,7 +50,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez trois pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de face.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl 'Kopf' zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10×",
 

--- a/data/EX/Ruby & Sapphire/61.ts
+++ b/data/EX/Ruby & Sapphire/61.ts
@@ -50,7 +50,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, each Defending Pokémon is now Burned.",
 				fr: "Lancez une pièce. Si c'est face, chaque Pokémon Défenseur est maintenant Brûlé.",
-				de: "Wirf eine Münze. Bei 'Kopf' sind alle Verteidigenden Pokémon jetzt verbrannt."
+				de: "Wirf eine Münze. Bei „Kopf“ sind alle Verteidigenden Pokémon jetzt verbrannt."
 			},
 
 		},

--- a/data/EX/Ruby & Sapphire/62.ts
+++ b/data/EX/Ruby & Sapphire/62.ts
@@ -50,7 +50,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage to each Defending Pokémon, and each Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts à chaque Pokémon Défenseur et les Paralysent.",
-				de: "Wirf eine Münze. Bei 'Kopf' fügt dieser Angriff allen Verteidigenden Pokémon 10 Schadenspunkte zu und alle Verteidigenden Pokémon sind jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff allen Verteidigenden Pokémon 10 Schadenspunkte zu und alle Verteidigenden Pokémon sind jetzt gelähmt."
 			},
 
 		},

--- a/data/EX/Ruby & Sapphire/64.ts
+++ b/data/EX/Ruby & Sapphire/64.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, choose 1 card from your opponent's hand without looking and discard it.",
 				fr: "Lancez une pièce. Si c'est face, choisissez une carte de la main de votre adversaire sans la regarder et défaussez-la.",
-				de: "Wirf eine Münze. Bei 'Kopf' wähle 1 zufällige Karte von der Hand deines Gegners. Dein Gegner legt diese Karte auf seinen Ablagestapel."
+				de: "Wirf eine Münze. Bei „Kopf“ wähle 1 zufällige Karte von der Hand deines Gegners. Dein Gegner legt diese Karte auf seinen Ablagestapel."
 			},
 
 		},

--- a/data/EX/Ruby & Sapphire/65.ts
+++ b/data/EX/Ruby & Sapphire/65.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Shadow Bind",
 				fr: "Étreinte d'ombre",
-				de: "Shadow Bind"
+				de: "Schattenbindung"
 			},
 			effect: {
 				en: "The Defending Pokémon can't retreat until the end of your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas battre en retraite tant que le prochain tour de votre adversaire n'est pas terminé.",
-				de: "The Defending Pokémon can't retreat until the end of your opponent's next turn."
+				de: "Das Verteidigende Pokémon kann sich im nächsten Zug deines Gegners nicht zurückziehen."
 			},
 			damage: 10,
 

--- a/data/EX/Ruby & Sapphire/66.ts
+++ b/data/EX/Ruby & Sapphire/66.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Wirf eine Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt verwirrt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: 10,
 

--- a/data/EX/Ruby & Sapphire/67.ts
+++ b/data/EX/Ruby & Sapphire/67.ts
@@ -31,7 +31,7 @@ const card: Card = {
 			name: {
 				en: "Headbutt",
 				fr: "Coup d'boule",
-				de: "Headbutt"
+				de: "Kopfnuss"
 			},
 
 			damage: 10,
@@ -45,12 +45,12 @@ const card: Card = {
 			name: {
 				en: "Hypnoblast",
 				fr: "Hypnoblast",
-				de: "Hypnoblast"
+				de: "Hypnoschuss"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
-				de: "The Defending Pokémon is now Asleep."
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 			damage: 20,
 

--- a/data/EX/Ruby & Sapphire/68.ts
+++ b/data/EX/Ruby & Sapphire/68.ts
@@ -31,7 +31,7 @@ const card: Card = {
 			name: {
 				en: "Pound",
 				fr: "Écras'face",
-				de: "Pound"
+				de: "Pfund"
 			},
 
 			damage: 10,
@@ -45,12 +45,12 @@ const card: Card = {
 			name: {
 				en: "Link Blast",
 				fr: "Explosion en série",
-				de: "Link Blast"
+				de: "Vereinigende Explosion"
 			},
 			effect: {
 				en: "If Ralts and the Defending Pokémon have a different amount of Energy attached to them, this attack's base damage is 10 instead of 40.",
 				fr: "Si Tarsal et le Pokémon Défenseur ont un total d'Énergie différent, les dégâts de base de cette attaque sont de 10 et non de 40.",
-				de: "If Ralts and the Defending Pokémon have a different amount of Energy attached to them, this attack's base damage is 10 instead of 40."
+				de: "Wenn an Trasla und dem Verteidigenden Pokémon unterschiedlich viel Energie angelegt ist, beträgt der Grundschaden dieses Angriffs 10 statt 40."
 			},
 			damage: 40,
 

--- a/data/EX/Ruby & Sapphire/69.ts
+++ b/data/EX/Ruby & Sapphire/69.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Sleep Powder",
 				fr: "Poudre dodo",
-				de: "Sleep Powder"
+				de: "Schlafpuder"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
-				de: "The Defending Pokémon is now Asleep."
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 			damage: 10,
 

--- a/data/EX/Ruby & Sapphire/7.ts
+++ b/data/EX/Ruby & Sapphire/7.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Kirlia",
-		fr: "Kirlia"
+		fr: "Kirlia",
+		de: "Kirlia"
 	},
 
 	stage: "Stage2",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Psy Shadow",
 				fr: "Ombre psy",
-				de: "Psy Shadow"
+				de: "Psischatten"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may search your deck for a Psychic Energy card and attach it to 1 of your Pokémon. Put 2 damage counters on that Pokémon. Shuffle your deck afterward. This power can't be used if Gardevoir is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez choisir dans votre deck une carte Énergie  et l'attacher à un de vos Pokémon. Placez deux marqueurs de dégât sur ce Pokémon. Mélangez ensuite votre deck. Ce pouvoir ne peut être utilisé si Gardevoir est affecté par un État Spécial.",
-				de: "Once during your turn (before your attack), you may search your Deck for a  Energy card and attach it to 1 of your Pokémon. Put 2 damage counters on that Pokémon. Shuffle your Deck afterward. This power can't be used if Gardevoir is affected by a Special Condition."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du dein Deck nach einer {P}-Energiekarte durchsuchen und an 1 deiner Pokémon anlegen. Lege 2 Schadensmarken auf dieses Pokémon. Mische dein Deck danach. Diese Poké-Power kann nicht benutzt werden, wenn Guardevoir von einem Speziellen Zustand betroffen ist."
 			}
 		},
 	],
@@ -52,12 +53,12 @@ const card: Card = {
 			name: {
 				en: "Energy Burst",
 				fr: "Explosion d'énergie",
-				de: "Energy Burst"
+				de: "Energieausbruch"
 			},
 			effect: {
 				en: "Does 10 damage times the total amount of Energy attached to Gardevoir and the Defending Pokémon.",
 				fr: "Inflige 10 dégâts pour chaque carte Énergie attachée à Gardevoir et au Pokémon Défenseur.",
-				de: "Does 10 damage times the total amount of Energy attached to Gardevoir and the Defending Pokémon."
+				de: "Dieser Angriff fügt für jede Energie, die an Guardevoir und dem Verteidigenden Pokémon angelegt ist, 10 Schadenspunkte zu."
 			},
 			damage: "10×",
 

--- a/data/EX/Ruby & Sapphire/70.ts
+++ b/data/EX/Ruby & Sapphire/70.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Attach a basic Energy card from your hand to 1 of your Pokémon.",
 				fr: "Attachez une carte Énergie de base de votre main à un de vos Pokémon.",
-				de: "Lege 1 Basis Energiekarte an 1 deiner Pokémon an."
+				de: "Lege 1 Basis-Energiekarte an 1 deiner Pokémon an."
 			},
 
 		},

--- a/data/EX/Ruby & Sapphire/71.ts
+++ b/data/EX/Ruby & Sapphire/71.ts
@@ -50,7 +50,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, l'attaque est sans effet.",
-				de: "Wirf eine Münze. Bei 'Zahl' hat dieser Angriff keine Auswirkungen."
+				de: "Wirf eine Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 30,
 

--- a/data/EX/Ruby & Sapphire/73.ts
+++ b/data/EX/Ruby & Sapphire/73.ts
@@ -50,7 +50,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, discard a Fire Energy card attached to Torchic.",
 				fr: "Lancez une pièce. Si c'est pile, défaussez une carte Énergie  attachée à Poussifeu.",
-				de: "Wirf eine Münze. Entferne bei \"Zahl\" eine -Energiekarte von Flemmli."
+				de: "Wirf eine Münze. Entferne bei „Zahl“ eine {R}-Energiekarte von Flemmli."
 			},
 			damage: 30,
 

--- a/data/EX/Ruby & Sapphire/74.ts
+++ b/data/EX/Ruby & Sapphire/74.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Burned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Brûlé.",
-				de: "Wirf eine Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt verbrannt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verbrannt."
 			},
 
 		},

--- a/data/EX/Ruby & Sapphire/75.ts
+++ b/data/EX/Ruby & Sapphire/75.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Empoisonné.",
-				de: "Wirf eine Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt vergiftet."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet."
 			},
 
 		},

--- a/data/EX/Ruby & Sapphire/77.ts
+++ b/data/EX/Ruby & Sapphire/77.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, l'attaque est sans effet.",
-				de: "Wirf eine Münze. Bei 'Zahl' hat dieser Angriff keine Auswirkungen."
+				de: "Wirf eine Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 20,
 

--- a/data/EX/Ruby & Sapphire/78.ts
+++ b/data/EX/Ruby & Sapphire/78.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Search your deck for Silcoon and Beautifly, or Cascoon and Dustox cards. Show 1 card or both cards of a pair to your opponent and put them into your hand. Shuffle your deck afterward.",
 				fr: "Cherchez dans votre deck les Pokémon Armulys et Charmillon ou Blindalys et Papinox. Montrez à votre adversaire la ou les cartes composant une paire et placez-les dans votre main. Mélangez ensuite votre deck.",
-				de: "Durchsuche dein Deck nach Schaloko oder Papinella oder Panekon und Pudox. Zeige deinem Gegner 1 oder beide Karten des gewählten Paars und nimm sie auf deine Hand. Mische dein Deck danach."
+				de: "Durchsuche dein Deck nach Schaloko und Papinella oder Panekon und Pudox. Zeige deinem Gegner 1 oder beide Karten des gewählten Paars und nimm sie auf deine Hand. Mische dein Deck danach."
 			},
 
 		},

--- a/data/EX/Ruby & Sapphire/79.ts
+++ b/data/EX/Ruby & Sapphire/79.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez trois pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de face.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl 'Kopf' zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10×",
 

--- a/data/EX/Ruby & Sapphire/8.ts
+++ b/data/EX/Ruby & Sapphire/8.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Makuhita",
-		fr: "Makuhita"
+		fr: "Makuhita",
+		de: "Makuhita"
 	},
 
 	stage: "Stage1",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Super Slap Push",
 				fr: "Super gifle",
-				de: "Super Slap Push"
+				de: "Super Stoß"
 			},
 			effect: {
 				en: "Does 20 damage to each Defending Pokémon.",
 				fr: "Inflige 20 dégâts à chaque Pokémon Défenseur.",
-				de: "Does 20 damage to each Defending Pokémon."
+				de: "Dieser Angriff fügt allen Verteidigenden Pokémon 20 Schadenspunkte zu."
 			},
 
 		},
@@ -54,12 +55,12 @@ const card: Card = {
 			name: {
 				en: "Mega Throw",
 				fr: "Mega lancer",
-				de: "Mega Throw"
+				de: "Mega Wurf"
 			},
 			effect: {
 				en: "If the Defending Pokémon is a Pokémon-ex, this attack does 40 damage plus 40 more damage.",
 				fr: "Si le Pokémon Défenseur est un Pokémon-ex, cette attaque lui inflige 80 dégâts.",
-				de: "If the Defending Pokémon is a Pokémon-ex, this attack does 40 damage plus 40 more damage."
+				de: "Wenn das Verteidigende Pokémon ein Pokémon-ex ist, fügt dieser Angriff 40 Schadenspunkte plus 40 weitere Schadenspunkte zu."
 			},
 			damage: "40+",
 

--- a/data/EX/Ruby & Sapphire/80.ts
+++ b/data/EX/Ruby & Sapphire/80.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "Flip a coin. If heads, choose 1 Energy card attached to 1 of your opponent's Pokémon and discard it.",
 		fr: "Lancez une pièce. Si c'est face, choisissez une carte Énergie attachée à un des Pokémon de votre adversaire et défaussez-la.",
-		de: "Wirf eine Münze. Wähle bei 'Kopf' 1 Energiekarte, die an ein Pokémon deines Gegners angelegt ist, und lege sie auf seinen Ablagestapel."
+		de: "Wirf eine Münze. Wähle bei „Kopf“ 1 Energiekarte, die an 1 Pokémon deines Gegners angelegt ist, und lege sie auf seinen Ablagestapel."
 	},
 
 

--- a/data/EX/Ruby & Sapphire/81.ts
+++ b/data/EX/Ruby & Sapphire/81.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "Flip 3 coins. For each heads, put a Basic Energy card from your discard pile into your hand. If you don't have that many basic Energy cards in your discard pile, put all of them into your hand.",
 		fr: "Lancez trois pièces. Chaque fois que c'est face, prenez une carte Énergie de base de votre pile de défausse, montrez-la à votre adversaire et placez-la dans votre main. Si vous n'avez pas suffisamment de cartes Énergie dans votre pile de défausse, placez toutes vos cartes Énergie dans votre main.",
-		de: "Flip 3 coins. For each heads, put a basic Energy card from your discard pile into your hand. If you don't have that many basic Energy cards in your discard pile, put all of them into your hand."
+		de: "Wirf 3 Münzen. Nimm für jeden „Kopf“ eine Basis-Energiekarte von deinem Ablagestapel auf deine Hand. Falls du nicht genug Basis-Energiekarten in deinem Ablagestapel hast, nimm so viele wie möglich auf deine Hand."
 	},
 
 

--- a/data/EX/Ruby & Sapphire/82.ts
+++ b/data/EX/Ruby & Sapphire/82.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "Move a basic Energy card attached to 1 of your Pokémon to another of your Pokémon.",
 		fr: "Prenez une carte Énergie de base attachée à un de vos Pokémon et attachez-la à un autre de vos Pokémon.",
-		de: "Move a basic Energy card attached to 1 of your Pokémon to another of your Pokémon."
+		de: "Nimm eine Basis-Energiekarte von 1 deiner Pokémon und lege sie an ein anderes deiner Pokémon an."
 	},
 
 

--- a/data/EX/Ruby & Sapphire/83.ts
+++ b/data/EX/Ruby & Sapphire/83.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Search your deck for up to 3 different types of basic Energy cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward.",
 		fr: "Choisissez dans votre deck jusqu'à trois cartes Énergie de base différentes, montrez-les à votre adversaire et placez-les dans votre main. Mélangez ensuite votre deck.",
-		de: "Search your deck for up to 3 different types of basic Energy cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Durchsuche dein Deck nach bis zu 3 verschiedenen Sorten von Basis-Energiekarten, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 	},
 
 

--- a/data/EX/Ruby & Sapphire/84.ts
+++ b/data/EX/Ruby & Sapphire/84.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "Attach Lum Berry to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card. At any time between turns, if the Pokémon this card is attached to is affected by any Special Conditions, remove all of them. Then discard Lum Berry.",
 		fr: "Attachez Baie Prine à un de vos Pokémon qui n'a pas déjà d'Outil Pokémon. Si ce Pokémon est mis K.O., défaussez-cette carte.\n\nÀ la fin de chaque tour, si le Pokémon auquel cette carte est attachée possède des États Spéciaux, retirez-les lui tous. Ensuite, défaussez Baie Prine.[1]",
-		de: "Wenn zu irgendeinem Zeitpunkt zwischen den Zügen das Pokémon, an dem die Prunusbeere angelegt ist, von einem Speziellen Zustand betroffen ist, verlieren alle Speziellen Zustände auf diesem Pokémon ihre Wirkung. Lege Prunusbeere danach auf deinen Ablagestapel."
+		de: "Lege Prunusbeere an 1 deiner Pokémon an, das keine Pokémon-Ausrüstung hat. Wenn das Pokémon kampfunfähig gemacht wird, lege Prunusbeere auf den Ablagestapel. Wenn zu irgendeinem Zeitpunkt zwischen den Zügen das Pokémon, an dem die Prunusbeere angelegt ist, von einem Speziellen Zustand betroffen ist, verlieren alle Speziellen Zustände auf diesem Pokémon ihre Wirkung. Lege Prunusbeere danach auf deinen Ablagestapel."
 	},
 
 

--- a/data/EX/Ruby & Sapphire/85.ts
+++ b/data/EX/Ruby & Sapphire/85.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "Attach Oran Berry to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card. At any time between turns, if the Pokémon this card is attached to has at least 2 damage counters on it, remove 2 damage counters from it. Then discard Oran Berry.",
 		fr: "Attachez Baie Oran à un de vos Pokémon qui n'a pas déjà d'Outil Pokémon. Si ce Pokémon est mis K.O, défaussez cette carte.\n\nN'importe quand entre deux tours, si le Pokémon auquel cette carte est attachée possède au moins deux marqueurs de dégât, retirez-les lui. Ensuite, défaussez Baie Oran.",
-		de: "At any time between turns, if the Pokémon this card is attached to has at least 2 damage counters on it, remove 2 damage counters from it. Then discard Oran Berry."
+		de: "Lege Sinelbeere an 1 deiner Pokémon an, das keine Pokémon-Ausrüstung hat. Wenn das Pokémon kampfunfähig gemacht wird, lege Sinelbeere auf den Ablagestapel. Wenn zu irgendeinem Zeitpunkt zwischen den Zügen auf dem Pokémon, an dem die Sinelbeere angelegt ist, mindestens 2 Schadensmarken liegen, entferne 2 Schadensmarken von dem Pokémon. Lege Sinelbeere danach auf deinen Ablagestapel."
 	},
 
 

--- a/data/EX/Ruby & Sapphire/86.ts
+++ b/data/EX/Ruby & Sapphire/86.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "Flip a coin. If heads, search your deck for a Basic Pokémon or Evolution card, show it to your opponent and put it into your hand. Shuffle your deck afterward.",
 		fr: "Lancez une pièce. Si c'est face, choisissez dans votre deck un Pokémon de base ou une carte Évolution, montrez la carte à votre adversaire et placez-la dans votre main. Mélangez ensuite votre deck.",
-		de: "Wirf eine Münze. Bei \"Kopf\" durchsuche dein Deck nach einer Basis-Pokémon-Karte oder einer Evolutionskarte, zeige die Karte deinem Gegner und nimm sie auf deine Hand. Mische dein Deck danach."
+		de: "Wirf eine Münze. Bei „Kopf“ durchsuche dein Deck nach einer Basis-Pokémon-Karte oder einer Evolutionskarte, zeige die Karte deinem Gegner und nimm sie auf deine Hand. Mische dein Deck danach."
 	},
 
 

--- a/data/EX/Ruby & Sapphire/87.ts
+++ b/data/EX/Ruby & Sapphire/87.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "Flip a coin. If heads, your opponent switches 1 of his or her Active Pokémon with 1 of his or her Benched Pokémon.",
 		fr: "Lancez une pièce. Si c'est face, votre adversaire doit échanger un de ses Pokémon Actifs contre un des Pokémon de son Banc.",
-		de: "Flip a coin. If heads, your opponent switches 1 of his or her Active Pokémon with 1 of his or her Benched Pokémon."
+		de: "Wirf eine Münze. Bei „Kopf“ tauscht der Gegner 1 seiner Aktiven Pokémon gegen ein Pokémon auf seiner Bank aus."
 	},
 
 

--- a/data/EX/Ruby & Sapphire/88.ts
+++ b/data/EX/Ruby & Sapphire/88.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "Look at the top 3 cards of your deck, and choose a Basic Pokémon, Evolution card, or Energy card. Show it to your opponent and put it into your hand. Put the 2 other cards back on top of your deck in any order.",
 		fr: "Regardez les trois cartes placées au-dessus de votre deck et choisissez un Pokémon de base, une carte Évolution ou une carte Énergie. Montrez-la à votre adversaire et placez-la dans votre main. Remettez les deux autres cartes dans votre deck dans n'importe quel ordre.",
-		de: "Look at the top 3 cards of your deck, and choose a basic Pokémon, Evolution card, or Energy card. Show it to your opponent and put it into your hand. Put the 2 other cards back on top of your deck in any other."
+		de: "Schau dir die obersten 3 Karten deines Decks an. Wähle aus den 3 Karten eine Basis-Pokémon-Karte, Evolutionskarte oder Energiekarte. Zeige sie deinem Gegner und nimm sie auf die Hand. Die anderen 2 Karten legst du in beliebiger Reihenfolge auf dein Deck."
 	},
 
 

--- a/data/EX/Ruby & Sapphire/89.ts
+++ b/data/EX/Ruby & Sapphire/89.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Draw cards from your deck until you have 6 cards in your hand.",
 		fr: "Piochez des cartes dans votre deck jusqu'à ce que vous ayez six cartes en main.",
-		de: "Ziehe so lange Karten von deinem Deck, bis du 6 Karten auf deiner Hand hast."
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Ziehe so lange Karten von deinem Deck, bis du 6 Karten auf der Hand hast."
 	},
 
 

--- a/data/EX/Ruby & Sapphire/9.ts
+++ b/data/EX/Ruby & Sapphire/9.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Electrike",
-		fr: "Dynavolt"
+		fr: "Dynavolt",
+		de: "Frizelbliz"
 	},
 
 	stage: "Stage1",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Attract Current",
 				fr: "Courant électrique",
-				de: "Attract Current"
+				de: "Stromanziehung"
 			},
 			effect: {
 				en: "Search your deck for a Lightning Energy card and attach it to 1 of your Pokémon. Shuffle your deck afterward.",
 				fr: "Choisissez dans votre deck une carte Énergie  et attachez-la à un de vos Pokémon. Mélangez ensuite votre deck.",
-				de: "Search your deck for a  Energy card amd attach it to 1 of your Pokémon. Shuffle your deck afterward."
+				de: "Durchsuche dein Deck nach einer {L}-Energiekarte und lege sie an 1 deiner Pokémon an. Mische dein Deck danach."
 			},
 			damage: 10,
 
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Thunder Jolt",
 				fr: "Secousse tonnerre",
-				de: "Thunder Jolt"
+				de: "Erschütternder Donner"
 			},
 			effect: {
 				en: "Flip a coin. If tails, Manectric does 10 damage to itself.",
 				fr: "Lancez une pièce. Si c'est pile, Elecsprint s'inflige 10 dégâts.",
-				de: "Flip a coin. If tails, Manectric does 10 damage to itself."
+				de: "Wirf eine Münze. Bei „Zahl“ fügt sich Voltenso selbst 10 Schadenspunkte zu."
 			},
 			damage: 50,
 

--- a/data/EX/Ruby & Sapphire/91.ts
+++ b/data/EX/Ruby & Sapphire/91.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "Remove 2 damage counters from 1 of your Pokémon (remove 1 damage counter if that Pokémon has only 1).",
 		fr: "Retirez jusqu'à deux marqueurs de dégât à l'un de vos Pokémon.",
-		de: "Entferne 2 Schadensmarken von 1 deiner Pokémon (1 falls dieses nur 1 hat)."
+		de: "Entferne 2 Schadensmarken von 1 deiner Pokémon (1 falls dieses Pokémon nur 1 hat)."
 	},
 
 

--- a/data/EX/Ruby & Sapphire/93.ts
+++ b/data/EX/Ruby & Sapphire/93.ts
@@ -16,7 +16,7 @@ const card: Card = {
 
 	effect: {
 		en: "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect unless the Attacking Pokémon is Darkness or has Dark in its name. Darkness Energy provides Darkness Energy. (Doesn't count as a basic Energy card.)",
-		de: "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect unless the Attacking Pokémon is  or has Dark in its name. Darkness Energy provides  Energy. (Doesn't count as a basic Energy card.)",
+		de: "Falls das Pokémon, an das Finsternis-Energie angelegt ist, mit einem Angriff Schadenspunkte zufügt (bevor Schwäche und Resistenz verrechnet wurden), fügt der Angriff 10 weitere Schadenspunkte zu. Dieser Effekt wirkt nur, wenn die Finsternis-Energie an einem Pokémon vom Typ {D} oder einem Pokémon, das „Dunkel“ im Namen hat, angelegt ist. Finsternis-Energie liefert {D}-Energie .(Zählt nicht als Basis-Energiekarte.)",
 		fr: "Si le Pokémon auquel Énergie Obscurité est attachée attaque, cette attaque inflige 10 dégâts supplémentaires aux Pokémon Actifs (avant application de la Faiblesse et de la Résistance). Ne tenez pas compte de cet effet si le Pokémon Attaquant n'est pas Obscurité ou si son nom ne contient pas le mot Obscur. Énergie Obscurité fournit une Énergie Obscurité. (Elle ne compte pas comme Énergie de base)."
 	},
 

--- a/data/EX/Ruby & Sapphire/97.ts
+++ b/data/EX/Ruby & Sapphire/97.ts
@@ -55,7 +55,8 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 40 damage plus 20 more damage.",
-				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 60 dégâts."
+				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 60 dégâts.",
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 40 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "40+",
 

--- a/data/EX/Ruby & Sapphire/98.ts
+++ b/data/EX/Ruby & Sapphire/98.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts.",
-				de: "Wirf eine Münze. Bei Kopf fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -56,7 +56,7 @@ const card: Card = {
 			effect: {
 				en: "This attack's damage is not affected by Resistance.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Résistance.",
-				de: "Der Schaden dieses Angriff wird nicht durch die Resistenz des Verteidigenden Pokémon verringert."
+				de: "Der Schaden dieses Angriffs wird nicht durch die Resistenz des Verteidigenden Pokémon verringert."
 			},
 			damage: 50,
 

--- a/data/EX/Ruby & Sapphire/99.ts
+++ b/data/EX/Ruby & Sapphire/99.ts
@@ -32,12 +32,12 @@ const card: Card = {
 			name: {
 				en: "Energy Ball",
 				fr: "Boule d'énergie",
-				de: "Energy Ball"
+				de: "Energieball"
 			},
 			effect: {
 				en: "Does 10 damage plus 10 more damage for each Energy attached to Lapras ex but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way.",
 				fr: "Inflige 10 points de dégât plus 10 points de dégât supplémentaires pour chaque Énergie attachée à Lokhlass Ex qui n'a pas été utilisée pour payer le coût en Énergie de cette attaque. Vous ne pouvez pas ajouter plus de 20 dégâts de cette façon.",
-				de: "Does 10 damage plu 10 more damage for each Energy attached to Lapras ex but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+				de: "Dieser Angriff fügt 10 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Lapras ex angelegte Energie zu, die nicht zum Zahlen der Energiekosten für diesen Angriff verwendet wurde. Es lassen sich so nicht mehr als 20 Schadenspunkte hinzufügen."
 			},
 			damage: "10+",
 
@@ -51,12 +51,12 @@ const card: Card = {
 			name: {
 				en: "Confuse Ray",
 				fr: "Onde folie",
-				de: "Confuse Ray"
+				de: "Konfustrahl"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Confused.",
 				fr: "Le Pokémon Défenseur est maintenant Confus.",
-				de: "The Defending Pokémon is now Confused."
+				de: "Das Verteidigende Pokémon ist jetzt verwirrt."
 			},
 			damage: 30,
 


### PR DESCRIPTION
## Add missing German translations for ex1

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
