### PR TITLE
Add missing German translations for ecard1

### DIFF
--- a/data/E-Card/Expedition Base Set/1.ts
+++ b/data/E-Card/Expedition Base Set/1.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Kadabra",
-		fr: "Kadabra"
+		fr: "Kadabra",
+		de: "Kadabra"
 	},
 
 	stage: "Stage2",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn, instead of Alakazam's normal attack, you may choose 1 of your opponent's Pokémon's attacks. Alakazam copies that attack including its Energy costs and anything else required in order to use that attack, such as discarding Energy cards. (No matter what type that Pokémon is, Alakazam's type is still Psychic.) This power can't be used if Alakazam is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour, à la place de l'attaque normale d'Alakazam, vous pouvez choisir une attaque d'un des Pokémon de votre adversaire. Alakazam copie cette attaque, y compris son coût d'Énergie et toute autre action requise pour utiliser cette attaque, comme par exemple, se défausser de cartes Énergie. (Quel que soit le type de l'autre Pokémon, Alakazam est toujours de type Psy.) Ce pouvoir ne peut pas être utilisé si Alakazam est affecté par un État spécial.",
-				de: "Einmal während deines Zuges kannst du anstatt Simsalas normalen Angriff 1 der Angriffe der Pokémon deines Gegners wählen. Simsala kopiert diesen Angriff (einschließlich der Energiekosten und allem anderen, was du tun musst, um diesen Angriff zu verwenden). (Unabhängig vom Typ dieses Pokémon bleibt Simsalas Typ Psycho.) Diese Fähigkeit kann nicht verwendet werden, falls Simsala von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges kannst du anstatt Simsalas normalem Angriff 1 der Angriffe der Pokémon deines Gegners wählen. Simsala kopiert diesen Angriff (einschließlich der Energiekosten und allem anderen, was du tun musst, um diesen Angriff zu verwenden). (Unabhängig vom Typ dieses Pokémon bleibt Simsalas Typ Psycho.) Diese Fähigkeit kann nicht verwendet werden, falls Simsala von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],

--- a/data/E-Card/Expedition Base Set/10.ts
+++ b/data/E-Card/Expedition Base Set/10.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Diglett",
-		fr: "Taupiqueur"
+		fr: "Taupiqueur",
+		de: "Digda"
 	},
 
 	stage: "Stage1",
@@ -36,7 +37,7 @@ const card: Card = {
 			name: {
 				en: "Mud Slap",
 				fr: "Coud'boue",
-				de: "Mud Slap"
+				de: "Lehmschelle"
 			},
 
 			damage: 20,
@@ -51,12 +52,12 @@ const card: Card = {
 			name: {
 				en: "Magnitude",
 				fr: "Ampleur",
-				de: "Magnitude"
+				de: "Intensität"
 			},
 			effect: {
 				en: "Does 10 damage to each Benched Pokémon (yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à chaque Pokémon du Banc (le vôtre et celui de votre adversaire). (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon du Banc.)",
-				de: "Does 10 damage to each Benched Pokémon (yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Fügt allen Pokémon auf der Bank 10 Schadenspunkte zu (deinen und den gegnerischen). (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 40,
 

--- a/data/E-Card/Expedition Base Set/101.ts
+++ b/data/E-Card/Expedition Base Set/101.ts
@@ -31,7 +31,7 @@ const card: Card = {
 			name: {
 				en: "Shining Fingers",
 				fr: "Doigts brillants",
-				de: "Leuchtender Finger"
+				de: "Leuchtende Finger"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",

--- a/data/E-Card/Expedition Base Set/102.ts
+++ b/data/E-Card/Expedition Base Set/102.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl 'Kopf' zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 

--- a/data/E-Card/Expedition Base Set/103.ts
+++ b/data/E-Card/Expedition Base Set/103.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
-				de: "Wirf eine Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Wirf eine Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 
 			damage: 30,

--- a/data/E-Card/Expedition Base Set/104.ts
+++ b/data/E-Card/Expedition Base Set/104.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Singe",
 				fr: "Roussir",
-				de: "Singe"
+				de: "Versengung"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Burned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Brûlé.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Burned."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verbrannt."
 			},
 
 		},
@@ -48,12 +48,12 @@ const card: Card = {
 			name: {
 				en: "Quick Attack",
 				fr: "Vive-attaque",
-				de: "Quick Attack"
+				de: "Ruckzuckhieb"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires.",
-				de: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 

--- a/data/E-Card/Expedition Base Set/105.ts
+++ b/data/E-Card/Expedition Base Set/105.ts
@@ -50,7 +50,7 @@ const card: Card = {
 			effect: {
 				en: "Discard a Fire Energy card attached to Cyndaquil.",
 				fr: "Défaussez-vous d'une carte Énergie  attachée à Héricendre.",
-				de: "Lege 1 an Feurigel angelegte -Energiekarte auf deinen Ablagestapel."
+				de: "Lege 1 an Feurigel angelegte {R}-Energiekarte auf deinen Ablagestapel."
 			},
 			damage: 30,
 

--- a/data/E-Card/Expedition Base Set/106.ts
+++ b/data/E-Card/Expedition Base Set/106.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10×",
 

--- a/data/E-Card/Expedition Base Set/107.ts
+++ b/data/E-Card/Expedition Base Set/107.ts
@@ -45,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
-				de: "Wirf eine Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Wirf eine Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 
 			damage: 40,

--- a/data/E-Card/Expedition Base Set/108.ts
+++ b/data/E-Card/Expedition Base Set/108.ts
@@ -32,13 +32,13 @@ const card: Card = {
 			name: {
 				en: "Poison Sting",
 				fr: "Dard-venin",
-				de: "Poison Sting"
+				de: "Giftstachel"
 			},
 
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Empoisonné.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Poisoned."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet."
 			},
 
 			damage: 10,

--- a/data/E-Card/Expedition Base Set/109.ts
+++ b/data/E-Card/Expedition Base Set/109.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Bad Dream",
 				fr: "Mauvais rêve",
-				de: "Bad Dream"
+				de: "Schlechter Traum"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Asleep. If tails, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Endormi. Si c'est pile, le Pokémon Défenseur est maintenant Confus.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Asleep. If tails, the Defending Pokémon is now Confused."
+				de: "Wirf eine Münze. Bei „Kopf“ schläft das Verteidigende Pokémon jetzt. Bei „Zahl“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 
 		},

--- a/data/E-Card/Expedition Base Set/11.ts
+++ b/data/E-Card/Expedition Base Set/11.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Spearow",
-		fr: "Piafabec"
+		fr: "Piafabec",
+		de: "Habitak"
 	},
 
 	stage: "Stage1",
@@ -63,7 +64,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
-				de: "Wirf eine Münze. Bei 'Zahl' hat dieser Angriff keine Wirkung."
+				de: "Wirf eine Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 
 			damage: 50,

--- a/data/E-Card/Expedition Base Set/112.ts
+++ b/data/E-Card/Expedition Base Set/112.ts
@@ -28,12 +28,12 @@ const card: Card = {
 		name: {
 			en: "Sleep Powder",
 			fr: "Poudre dodo",
-			de: "Dornkanone"
+			de: "Schlafpuder"
 		},
 		effect: {
 			en: "Flip a coin. If heads, the Defending Pokémon is now Asleep.",
 			fr: "Le Pokémon Défenseur est maintenant Endormi.",
-			de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl 'Kopf' zu."
+			de: "Das Verteidigende Pokémon schläft jetzt."
 		},
 		damage: "20x",
 

--- a/data/E-Card/Expedition Base Set/114.ts
+++ b/data/E-Card/Expedition Base Set/114.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt verwirrt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 
 		},

--- a/data/E-Card/Expedition Base Set/117.ts
+++ b/data/E-Card/Expedition Base Set/117.ts
@@ -50,7 +50,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 

--- a/data/E-Card/Expedition Base Set/118.ts
+++ b/data/E-Card/Expedition Base Set/118.ts
@@ -32,12 +32,12 @@ const card: Card = {
 			name: {
 				en: "Flail",
 				fr: "Fléau",
-				de: "Flail"
+				de: "Dreschflegel"
 			},
 			effect: {
 				en: "This attack does 10 damage times the number of damage counters on Magikarp.",
 				fr: "Inflige 10 dégâts multipliés par le nombre de marqueurs de dégâts sur Magicarpe.",
-				de: "This attack does 10 damage times the number of damage counters on Magikarp."
+				de: "Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl an Schadensmarken auf Karpador zu."
 			},
 			damage: "10×",
 

--- a/data/E-Card/Expedition Base Set/119.ts
+++ b/data/E-Card/Expedition Base Set/119.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 

--- a/data/E-Card/Expedition Base Set/12.ts
+++ b/data/E-Card/Expedition Base Set/12.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Croconaw",
-		fr: "Crocrodil"
+		fr: "Crocrodil",
+		de: "Tyracroc"
 	},
 
 	stage: "Stage2",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Major Tsunami",
 				fr: "Terrible tsunami",
-				de: "Major Tsunami"
+				de: "Größerer Tsunami"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), if Feraligatr is your Active Pokémon and if your opponent has any Benched Pokémon, your opponent switches his or her Active Pokémon with 1 of his or her Benched Pokémon. Either way, if you have any Benched Pokémon, switch Feraligatr with 1 of them. This power can't be used if Feraligatr is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), si Aligatueur est votre Pokémon Actif et si votre adversaire a des Pokémon sur son Banc, il échange l'un d'eux contre son Pokémon Actif. Quel que soit le cas, si vous avez des Pokémon sur votre Banc, échangez l'un d'eux contre Aligatueur. Ce pouvoir ne peut pas être utilisé si Aligatueur est affecté par un État spécial.",
-				de: "Once during your turn (before your attack), if Feraligatr is your Active Pokémon and if your opponent has any Benched Pokémon, your opponent switches his or her Active Pokémon with 1 of his or her Benched Pokémon. Either way, if you have any Benched Pokémon, switch Feraligatr with 1 of them. This power can't be used if Feraligatr is affected by a Special Condition."
+				de: "Einmal während deines Zuges (vor deinem Angriff), falls Impergator dein Aktives Pokémon ist und dein Gegner mindestens ein Pokémon auf der Bank hat, tauscht dein Gegner sein Aktives Pokémon mit 1 seiner Pokémon auf der Bank. Unabhängig davon: Falls du mindestens 1 Pokémon auf deiner Bank hast, tausche 1 von diesen mit Impergator. Diese Fähigkeit kann nicht verwendet werden, falls Impergator von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -56,13 +57,13 @@ const card: Card = {
 			name: {
 				en: "Rending Jaws",
 				fr: "Coud'mâchoire",
-				de: "Rending Jaws"
+				de: "Reißkiefer"
 			},
 
 			effect: {
 				en: "If here are no damage counters on the Defending Pokémon, this attack's base damage is 40 instead of 70.",
 				fr: "S'il n'y a aucun marqueur de dégâts sur le Pokémon Défenseur, cette attaque inflige 40 dégâts de base au lieu de 70.",
-				de: "If there are now damage counters on the Defending Pokémon, this attack's base damage is 40 instead of 70."
+				de: "Falls auf dem Verteidigenden Pokémon keine Schadensmarken sind, ist der Basisschaden dieses Angriffs 40 anstatt 70."
 			},
 
 			damage: 70,

--- a/data/E-Card/Expedition Base Set/120.ts
+++ b/data/E-Card/Expedition Base Set/120.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 

--- a/data/E-Card/Expedition Base Set/121.ts
+++ b/data/E-Card/Expedition Base Set/121.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Double Scratch",
 				fr: "Double griffe",
-				de: "Double Scratch"
+				de: "Doppelkratzer"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de faces.",
-				de: "Flip 2 coins. This attack does 10 damage times the number of heads."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10×",
 
@@ -49,12 +49,12 @@ const card: Card = {
 			name: {
 				en: "Pay Day",
 				fr: "Jackpot",
-				de: "Pay Day"
+				de: "Zahltag"
 			},
 			effect: {
 				en: "Flip a coin. If heads, draw a card.",
 				fr: "Lancez une pièce. Si c'est face, piochez une carte.",
-				de: "Flip a coin. If heads, draw a card."
+				de: "Wirf eine Münze. Ziehe bei „Kopf“ eine Karte."
 			},
 			damage: 10,
 

--- a/data/E-Card/Expedition Base Set/123.ts
+++ b/data/E-Card/Expedition Base Set/123.ts
@@ -51,7 +51,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10×",
 

--- a/data/E-Card/Expedition Base Set/124.ts
+++ b/data/E-Card/Expedition Base Set/124.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 
 		},

--- a/data/E-Card/Expedition Base Set/126.ts
+++ b/data/E-Card/Expedition Base Set/126.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Burned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Brûlé.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt verbrannt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verbrannt."
 			},
 
 		},

--- a/data/E-Card/Expedition Base Set/127.ts
+++ b/data/E-Card/Expedition Base Set/127.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 

--- a/data/E-Card/Expedition Base Set/128.ts
+++ b/data/E-Card/Expedition Base Set/128.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires.",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 

--- a/data/E-Card/Expedition Base Set/129.ts
+++ b/data/E-Card/Expedition Base Set/129.ts
@@ -31,7 +31,7 @@ const card: Card = {
 			name: {
 				en: "Irongrip",
 				fr: "Poigne de fer",
-				de: "Eisener Griff"
+				de: "Eiserner Griff"
 			},
 
 			damage: 10,
@@ -50,7 +50,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 

--- a/data/E-Card/Expedition Base Set/13.ts
+++ b/data/E-Card/Expedition Base Set/13.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Haunter",
-		fr: "Spectrum"
+		fr: "Spectrum",
+		de: "Alpollo"
 	},
 
 	stage: "Stage2",

--- a/data/E-Card/Expedition Base Set/130.ts
+++ b/data/E-Card/Expedition Base Set/130.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
-				de: "Wirf eine Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Wirf eine Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 
 			damage: 20,

--- a/data/E-Card/Expedition Base Set/131.ts
+++ b/data/E-Card/Expedition Base Set/131.ts
@@ -51,7 +51,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl 'Kopf' zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 

--- a/data/E-Card/Expedition Base Set/132.ts
+++ b/data/E-Card/Expedition Base Set/132.ts
@@ -31,7 +31,7 @@ const card: Card = {
 			name: {
 				en: "Headbutt",
 				fr: "Coup d'boule",
-				de: "Headbutt"
+				de: "Kopfnuss"
 			},
 
 			damage: 10,
@@ -45,12 +45,12 @@ const card: Card = {
 			name: {
 				en: "Bubblebeam",
 				fr: "Bulles d'O",
-				de: "Bubblebeam"
+				de: "Blubbstrahl"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 

--- a/data/E-Card/Expedition Base Set/133.ts
+++ b/data/E-Card/Expedition Base Set/133.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
-				de: "Wirf eine Münze. Bei 'Zahl' hat dieser Angriff keine Auswirkungen."
+				de: "Wirf eine Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 
 			damage: 30,

--- a/data/E-Card/Expedition Base Set/134.ts
+++ b/data/E-Card/Expedition Base Set/134.ts
@@ -50,7 +50,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl 'Kopf' zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 

--- a/data/E-Card/Expedition Base Set/135.ts
+++ b/data/E-Card/Expedition Base Set/135.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 
 		},

--- a/data/E-Card/Expedition Base Set/137.ts
+++ b/data/E-Card/Expedition Base Set/137.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. If you have any cards in your hand, shuffle 1 of them into your deck, then draw 3 cards.",
 		fr: "Si vous avez des cartes dans votre main, mélangez-en une à votre deck et piochez ensuite 3 cartes.",
-		de: "Falls du mindestens eine Karte auf deiner Hand hast, mische 1 davon in dein Deck und ziehe dann 3 Karten.",
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Falls du mindestens eine Karte auf deiner Hand hast, mische 1 davon in dein Deck und ziehe dann 3 Karten.",
 	},
 
 	variants: [

--- a/data/E-Card/Expedition Base Set/138.ts
+++ b/data/E-Card/Expedition Base Set/138.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Shuffle your hand into your deck. Then, count the number of cards in your opponent's hand and draw that many cards.",
 		fr: "Mélangez votre main avec votre deck. Comptez ensuite le nombre de cartes dans la main de votre adversaire et piochez autant de cartes.",
-		de: "Mische deine Hand in dein Deck. Zähle dann die Anzahl an Karten auf der Hand deines Gegners und ziehe so viele Karten.",
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Mische deine Hand in dein Deck. Zähle dann die Anzahl an Karten auf der Hand deines Gegners und ziehe so viele Karten.",
 	},
 
 	variants: [

--- a/data/E-Card/Expedition Base Set/139.ts
+++ b/data/E-Card/Expedition Base Set/139.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "Flip 2 coins. For each heads, search your deck for a Basic Pokémon card other than a Baby Pokémon card, show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
 		fr: "Lancez 2 pièces. Pour chaque face, cherchez une carte Pokémon de base dans votre deck, montrez-la à votre adversaire et placez-la dans votre main. Mélangez ensuite votre deck.",
-		de: "Flip 2 coins. For each heads, search your deck for a Basic Pokémon card other than a Baby Pokémon card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
+		de: "Wirf 2 Münzen. Durchsuche für jeden „Kopf“ dein Deck nach einer Basis-Pokémonkarte (allerdings keiner Baby-Pokémonkarte), zeige sie deinem Gegner und nimm sie auf deine Hand. Mische dein Deck danach."
 	},
 
 	variants: [

--- a/data/E-Card/Expedition Base Set/14.ts
+++ b/data/E-Card/Expedition Base Set/14.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Graveler",
-		fr: "Gravalanch"
+		fr: "Gravalanch",
+		de: "Georok"
 	},
 
 	stage: "Stage2",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Rock Body",
 				fr: "Corps roc",
-				de: "Rock Body"
+				de: "Steinkörper"
 			},
 			effect: {
 				en: "All damage done by attacks to Golem is reduced by 10 (after applying Weakness and Resistance).",
 				fr: "Tous les dégâts infligés par des attaques sur Grolem sont réduits de 10 (après application de la Faiblesse et de la Résistance).",
-				de: "All damage done by attacks to Golem is reduced by 10 (after applying Weakness and Resistance.)"
+				de: "Aller Schaden, der Geowaz von Angriffen zugefügt wird, wird um 10 reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 		},
 	],
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Rock Tumble",
 				fr: "Roule-pierre",
-				de: "Rock Tumble"
+				de: "Rollende Felsen"
 			},
 			effect: {
 				en: "Don't apply Resistance.",
 				fr: "N'appliquez pas la Résistance.",
-				de: "Don't apply Resistance."
+				de: "Wende Resistenz nicht an."
 			},
 			damage: 60,
 

--- a/data/E-Card/Expedition Base Set/140.ts
+++ b/data/E-Card/Expedition Base Set/140.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Flip a coin. If heads, choose 1 Energy card attached to 1 of your opponent's Pokémon and discard it.",
 		fr: "Lancez une pièce. Si c'est face, choisissez une carte Énergie attachée à l'un des Pokémon de votre adversaire et obligez-le à s'en défausser.",
-		de: "Wirf eine Münze. Wähle bei 'Kopf' 1 Energiekarte, die an ein Pokémon deines Gegners angelegt ist, und lege sie auf seinen Ablagestapel."
+		de: "Wirf eine Münze. Wähle bei „Kopf“ 1 Energiekarte, die an ein Pokémon deines Gegners angelegt ist, und lege sie auf seinen Ablagestapel."
 	},
 
 	variants: [

--- a/data/E-Card/Expedition Base Set/141.ts
+++ b/data/E-Card/Expedition Base Set/141.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Flip 3 coins. For each heads, put a Basic Energy card from your discard pile into your hand. If you don't have that many basic Energy cards in your discard pile, put all of them into your hand.",
 		fr: "Lancez 3 pièces. Pour chaque face, ajoutez une carte Énergie de votre pile de défausse à votre main. Si vous n'avez pas suffisamment de cartes Énergie de base dans votre pile de défausse, ajoutez-les toutes à votre main.",
-		de: "Wirf 3 Münzen. Nimm für jeden 'Kopf' eine Basis-Energiekarte von deinem Ablagestapel auf deine Hand. Falls du nicht genug Basis-Energiekarten in deinem Ablagestapel hast, nimm so viele wie möglich auf deine Hand."
+		de: "Wirf 3 Münzen. Nimm für jeden „Kopf“ eine Basis-Energiekarte von deinem Ablagestapel auf deine Hand. Falls du nicht genug Basis-Energiekarten in deinem Ablagestapel hast, nimm so viele wie möglich auf deine Hand."
 	},
 
 	variants: [

--- a/data/E-Card/Expedition Base Set/142.ts
+++ b/data/E-Card/Expedition Base Set/142.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Flip a coin until you get tails. For each heads, draw 2 cards.",
 		fr: "Lancez une pièce jusqu'à obtenir pile. Pour chaque face, piochez 2 cartes.",
-		de: "Flip a coin until you get tails. For each heads, draw 2 cards.",
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Wirf eine Münze, bis du das erste Mal „Zahl“ wirfst. Ziehe für jeden „Kopf“ 2 Karten.",
 	},
 
 	variants: [

--- a/data/E-Card/Expedition Base Set/143.ts
+++ b/data/E-Card/Expedition Base Set/143.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Look at 7 cards from the top of your deck. You may choose a Basic Pokémon or Evolution card from those cards, show it your opponent, and put it into your hand. Shuffle the rest into your deck.",
 		fr: "Regardez les 7 cartes du dessus de votre deck. Parmi ces cartes, vous pouvez choisir une carte de Pokémon de base ou d'Évolution. Montrez-la à votre adversaire et ajoutez-la à votre main. Mélangez le reste à votre deck.",
-		de: "Look at 7 cards from the top of your deck. You may choose a Basic Pokémon or Evolution card from those cards, show it your opponent, and put it into your hand. Shuffle the rest into your deck."
+		de: "Schaue dir die sieben obersten Karten deines Decks an. Du kannst von diesen Karten eine Basis-Pokémonkarte oder eine Entwicklungskarte nehmen, sie deinem Gegner zeigen und auf deine Hand nehmen. Mische die anderen Karten in dein Deck."
 	},
 
 	variants: [

--- a/data/E-Card/Expedition Base Set/144.ts
+++ b/data/E-Card/Expedition Base Set/144.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Attach this card to 1 of your Pokémon in play. That Pokémon may use this card's attack instead of its own. At the end of your turn, discard Multi Technical Machine 01.",
 		fr: "Attachez cette carte à l'un de vos Pokémon en jeu. Ce Pokémon peut utiliser l'attaque de cette carte à la place de la sienne. À la fin de votre tour, défaussez-vous de Machine multi-technique 01.",
-		de: "Lege diese Karte an 1 deiner Pokémon im Spiel an. Dieses Pokémon kann den Angriff dieser Karte anstatt seiner eigenen verwenden. Lege am Ende deines Zuges Vielzweckmaschine 01 auf deinen Ablagestapel."
+		de: "Lege diese Karte an 1 deiner Pokémon im Spiel an. Diese Pokémon kann den Angriff dieser Karte anstatt seiner eigenen verwenden. Lege am Ende deines Zuges Vielzweckmaschine 01 auf deinen Ablagestapel."
 	},
 
 	attacks: [

--- a/data/E-Card/Expedition Base Set/145.ts
+++ b/data/E-Card/Expedition Base Set/145.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Remove all damage counters from 1 of your Pokémon. Then discard all Energy cards attached to it, if any.",
 		fr: "Retirez tous les marqueurs de dégâts d'un de vos Pokémon. Défaussez -vous ensuite de toutes les cartes Énergie qui lui sont attachées, s'il en possède.",
-		de: "Entferne alle Schadensmarken von einem deiner Pokémon. Lege dann alle an es angelegten Energiekarten auf deinen Ablagestapel.",
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Entferne alle Schadensmarken von einem deiner Pokémon. Lege dann alle an es angelegten Energiekarten auf deinen Ablagestapel.",
 	},
 
 	variants: [

--- a/data/E-Card/Expedition Base Set/147.ts
+++ b/data/E-Card/Expedition Base Set/147.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Flip a coin. If heads, shuffle 2 Energy cards from your discard pile into your deck (1 if you have only 1).",
 		fr: "Lancez une pièce. Si c'est face, mélangez 2 cartes Énergie de votre pile de défausse à votre deck (1 seule si vous n'en avez qu'une).",
-		de: "Wirf eine Münze. Mische bei 'Kopf' 2 Energiekarten aus deinem Ablagestapel in dein Deck (1, wenn du nur 1 hast)."
+		de: "Wirf eine Münze. Mische bei „Kopf“ 2 Energiekarten aus deinem Ablagestapel in dein Deck (1, wenn du nur 1 hast)."
 	},
 
 	variants: [

--- a/data/E-Card/Expedition Base Set/149.ts
+++ b/data/E-Card/Expedition Base Set/149.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Shuffle your hand into your deck, then draw 5 cards.",
 		fr: "Mélangez votre main à votre deck. Piochez ensuite 5 cartes.",
-		de: "Mische deine Hand in dein Deck, und ziehe dann 5 Karten.",
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Mische deine Hand in dein Deck, und ziehe dann 5 Karten.",
 	},
 
 	variants: [

--- a/data/E-Card/Expedition Base Set/15.ts
+++ b/data/E-Card/Expedition Base Set/15.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Krabby",
-		fr: "Krabby"
+		fr: "Krabby",
+		de: "Krabby"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
-				de: "Wirf eine Münze. Bei 'Zahl' hat dieser Angriff keine Auswirkungen."
+				de: "Wirf eine Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 
 			damage: 70,

--- a/data/E-Card/Expedition Base Set/150.ts
+++ b/data/E-Card/Expedition Base Set/150.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "Attach Strength Charm to 1 of your Pokémon that doesn't have a Pokémon Tool attached to it. Whenever an attack from the Pokémon that Strength Charm is attached to does damage (after applying Weakness and Resistance), the attack does 10 more damage. At the end of your turn in which this happens, discard Strength Charm.",
 		fr: "Attachez Fétiche de force à un de vos Pokémon qui n'a pas d'Outil Pokémon attaché à lui.\n\nÀ chaque fois qu'une attaque du Pokémon sur lequel est attachée Fétiche de force inflige des dégâts (après application de la Faiblesse et de la Résistance), cette attaque inflige 10 dégâts supplémentaires. À la fin de votre tour où cet effet a lieu, défaussez-vous de Fétiche de force.",
-		de: "Falls das Pokémon, an das das Stärke-Amulett angelegt ist, mit einem Angriff Schaden zufügt (nachdem Schwäche und Resistenz verrechnet wurden), fügt der Angriff 10 weitere Schadenspunkte zu. Lege am Ende des Zuges, in dem dies geschieht, das Stärke-Amulett auf den Ablagestapel."
+		de: "Lege das Stärke-Amulett an eines deiner Pokémon an, das keine Pokémon-Ausrüstung hat. Falls das Pokémon, an das Stärke-Amulett angelegt ist, mit einem Angriff Schaden zufügt (nachdem Schwäche und Resistenz verrechnet wurden), fügt der Angriff 10 weitere Schadenspunkte zu. Lege am Ende des Zuges, in dem dies geschieht, das Stärke-Amulett auf deinen Ablagestapel."
 	},
 
 	variants: [

--- a/data/E-Card/Expedition Base Set/151.ts
+++ b/data/E-Card/Expedition Base Set/151.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Flip a coin. If heads, return 1 of your Pokémon and all cards attached to it to your hand.",
 		fr: "Lancez une pièce. Si c'est face, reprenez 1 de vos Pokémon et toutes les cartes qui lui sont attachées dans votre main.",
-		de: "Wirf eine Münze. Nimm bei 'Kopf' eines deiner Pokémon und alle daran angelegten Karten zurück auf deine Hand."
+		de: "Wirf eine Münze. Nimm bei „Kopf“ eines deiner Pokémon und alle daran angelegten Karten zurück auf deine Hand."
 	},
 
 	variants: [

--- a/data/E-Card/Expedition Base Set/155.ts
+++ b/data/E-Card/Expedition Base Set/155.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Choose 1 of your Pokémon. Flip 2 coins. Remove 2 damage counters times the number of heads from that Pokémon. If the Pokémon has fewer damage counters than that, remove all of them.",
 		fr: "Choisissez 1 de vos Pokémon. Lancez 2 pièces. Retirez de ce Pokémon 2 marqueurs de dégâts multipliés par le nombre de faces. Si le Pokémon a moins de marqueurs de dégâts, retirez-les tous.",
-		de: "Wähle eines deiner Pokémon. Wirf 2 Münzen. Entferne zwei Schadensmarken mal der Anzahl \"Kopf\" von diesem Pokémon. Falls das Pokémon weniger Schadensmarken hat, entferne alle."
+		de: "Wähle eines deiner Pokémon. Wirf zwei Münzen. Entferne zwei Schadensmarken mal der Anzahl „Kopf“ von diesem Pokémon. Falls das Pokémon weniger Schadensmarken hat, entferne alle."
 	},
 
 	variants: [

--- a/data/E-Card/Expedition Base Set/157.ts
+++ b/data/E-Card/Expedition Base Set/157.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Switch your Active Pokémon with 1 of your Benched Pokémon.",
 		fr: "Échangez votre Pokémon Actif contre l'un des Pokémon de votre Banc.",
-		de: "Tausche dein Aktives Pokémon mit 1 der Pokémon auf der Bank aus."
+		de: "Tausche dein Aktives Pokémon mit 1 der Pokémon auf deiner Bank aus."
 	},
 
 	variants: [

--- a/data/E-Card/Expedition Base Set/159.ts
+++ b/data/E-Card/Expedition Base Set/159.ts
@@ -16,7 +16,7 @@ const card: Card = {
 
 	effect: {
 		en: "Damage done by attacks to the Pokémon Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). If the Pokémon Metal Energy is attached to isn't Metal, whenever it damages a Pokémon by an attack, reduce that damage by 10 (after applying Weakness and Resistance). Metal Energy provides Metal Energy. (Doesn't count as a basic Energy card.)",
-		de: "Schaden, der dem Pokémon, an das Metall-Energie angelegt ist, durch Angriffe zugefügt wird, wird um 10 reduziert (nachdem Schwäche und Resistenz verrechnet wurden). Falls das Pokémon, an das Metall-Energie angelegt ist, nicht vom Typ  ist, reduziere den Schaden jedesmal um 10, wenn es einem Pokémon mit einem Angriff Schaden zufügt (nachdem Schwäche und Resistenz verrechnet wurden). Metall-Energie liefert -Energie. (Zählt nicht als Basis-Energiekarte.)",
+		de: "Schaden, der dem Pokémon, an das Metall-Energie angelegt ist, durch Angriffe zugefügt wird, wird um 10 reduziert (nachdem Schwäche und Resistenz verrechnet wurden). Falls das Pokémon, an das Metall-Energie angelegt ist, nicht von Typ {D} ist, reduziere den Schaden jedesmal um 10, wenn es einem Pokémon mit einem Angriff Schaden zufügt (nachdem Schwäche und Resistenz verrechnet wurden). Metall-Energie liefert {D}-Energie. (Zählt nicht als Basis-Energiekarte.)",
 		fr: "Des dégâts infligés au Pokémon lors d'une attaque au Pokémon sur lequel Énergie Métal est attachée sont réduits de 10 (après application de la Faiblesse et de la Résistance). Si le Pokémon sur lequel Énergie Métal est attachée n'est pas Métal, à chaque fois qu'il inflige des dégâts à un Pokémon lors d'une attaque, réduisez ces dégâts de 10 (après application de la Faiblesse et de la Résistance).",
 	},
 

--- a/data/E-Card/Expedition Base Set/16.ts
+++ b/data/E-Card/Expedition Base Set/16.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Machoke",
-		fr: "Machopeur"
+		fr: "Machopeur",
+		de: "Maschock"
 	},
 
 	stage: "Stage2",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Terraforming",
 				fr: "Terraformage",
-				de: "Terraforming"
+				de: "Erdumwälzung"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may look at the top 4 cards of your deck and rearrange them as you like. This power can't be used if Machamp is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez regarder les 4 cartes du dessus de votre deck et les remettre dans l'ordre que vous désirez. Ce pouvoir ne peut pas être utilisé si Mackogneur est affecté par un État spécial.",
-				de: "Once during your turn (before you attack), you may look at the top 4 cards of your deck and rearrange them as you like. This power can`t be used if Machamp is affected by a Special Condition."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du dir die obersten 4 Karten deines Decks ansehen und sie in beliebiger Reihenfolge zurücklegen. Diese Fähigkeit kann nicht verwendet werden, falls Machomei von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Iron Fist",
 				fr: "Poing de fer",
-				de: "Iron Fist"
+				de: "Eisenfaust"
 			},
 			effect: {
 				en: "Count the number of Pokémon you have in play with damage counters on them. Flip a coin. If heads, this attack does 50 damage plus 10 more damage for each of those Pokémon.",
 				fr: "Comptez le nombre de vos Pokémon en jeu ayant des marqueurs de dégâts. Lancez une pièce. Si c'est face, cette attaque inflige 50 dégâts plus 10 dégâts supplémentaires pour chacun de ces Pokémon.",
-				de: "Count the number of Pokémon you have in play with damage counters on them. Flip a coin. If heads, this attack does 50 damage plus 10 more damage for each of those Pokémon."
+				de: "Zähle die Anzahl der Pokémon, die du im Spiel hast und auf denen Schadensmarken liegen. Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 50 Schadenspunkte plus weitere 10 Schadenspunkte für jedes dieser Pokémon zu."
 			},
 			damage: "50+",
 

--- a/data/E-Card/Expedition Base Set/17.ts
+++ b/data/E-Card/Expedition Base Set/17.ts
@@ -48,7 +48,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, put a basic Energy card from your discard pile into your hand.",
 				fr: "Lancez une pièce. Si c'est face, ajoutez une carte Énergie de votre pile de défausse à votre main.",
-				de: "Wirf eine Münze. Nimm bei 'Kopf' eine Basis-Energiekarte von deinem Ablagestapel auf deine Hand."
+				de: "Wirf eine Münze. Nimm bei „Kopf“ eine Basis-Energiekarte von deinem Ablagestapel auf deine Hand."
 			},
 
 		},

--- a/data/E-Card/Expedition Base Set/18.ts
+++ b/data/E-Card/Expedition Base Set/18.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Bayleef",
-		fr: "Macronium"
+		fr: "Macronium",
+		de: "Lorblatt"
 	},
 
 	stage: "Stage2",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may flip a coin. If heads, remove 1 damage counter from each of your Pokémon that has any. This power can't be used if Meganium is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez lancer une pièce. Si c'est face, retirez un marqueur de dégât de chacun de vos Pokémon ayant des marqueurs de dégâts. Ce pouvoir ne peut pas être utilisé si Meganium est affecté par un État spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du eine Münze werfen. Entferne bei \"Kopf\" von jedem deiner Pokémon, auf dem Schadensmarken liegen, 1 der Schadensmarken. Diese Fähigkeit kann nicht verwendet werden, falls Meganie von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du eine Münze werfen. Entferne bei „Kopf“ von jedem deiner Pokémon, auf dem Schadensmarken liegen, 1 der Schadensmarken. Diese Fähigkeit kann nicht verwendet werden, falls Meganie von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],

--- a/data/E-Card/Expedition Base Set/2.ts
+++ b/data/E-Card/Expedition Base Set/2.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Flaaffy",
-		fr: "Lainergie"
+		fr: "Lainergie",
+		de: "Waaty"
 	},
 
 	stage: "Stage2",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "As often as you like during your turn (before your attack), you may take a basic Energy card attached to 1 of your Benched Pokémon and attach it to your Active Pokémon. This power can't be used if Ampharos is affected by a Special Condition.",
 				fr: "Aussi souvent que vous le désirez pendant votre tour (avant votre attaque), vous pouvez prendre une carte Énergie de base attachée à l'un des Pokémon de votre Banc et l'attacher à votre Pokémon Actif. Ce pouvoir ne peut pas être utilisé si Pharamp est affecté par un État spécial.",
-				de: "Du darft in deinem Zug so oft, wie du willst (vor deinem Angriff), eine Basis-Energiekarte, die an 1 deiner Pokémon auf der Bank angelegt ist, nehmen und an dein Aktives Pokémon anlegen. Diese Fähigkeit kann nicht verwendet werden, falls Ampharos von einem Speziellen Zustand betroffen ist."
+				de: "Du darfst in deinem Zug so oft, wie du willst (vor deinem Angriff), eine Basis-Energiekarte, die an 1 deiner Pokémon auf der Bank angelegt ist, nehmen und an dein Aktives Pokémon anlegen. Diese Fähigkeit kann nicht verwendet werden, falls Ampharos von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "You may discard all Lightning Energy cards attached to Ampharos. If you do, this attack's base damage is 80 instead of 40.",
 				fr: "Vous pouvez vous défausser de toutes les cartes Énergie  attachées à Pharamp. Si vous faites ainsi, cette attaque inflige 80 dégâts de base au lieu de 40.",
-				de: "Du kannst alle -Energiekarten, die an Ampharos angelegt sind, auf deinen Ablagestapel legen. Falls du dies tust, ist der Basisschaden dieses Angriffs 80 anstatt 40."
+				de: "Du kannst alle {L}-Energiekarten, die an Ampharos angelegt sind, auf deinen Ablagestapel legen. Falls du dies tust, ist der Basisschaden dieses Angriffs 80 anstatt 40."
 			},
 
 			damage: 40,

--- a/data/E-Card/Expedition Base Set/20.ts
+++ b/data/E-Card/Expedition Base Set/20.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Asleep.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Endormi.",
-				de: "Wirf eine Münze. Bei 'Kopf' schläft das Verteidigende Pokémon jetzt."
+				de: "Wirf eine Münze. Bei „Kopf“ schläft das Verteidigende Pokémon jetzt."
 			},
 
 		},
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "This attack does 20 damage plus 10 more damage for each Energy card attached to the Defending Pokémon.",
 				fr: "Cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires pour chaque carte Énergie attachée au Pokémon Défenseur.",
-				de: "Dieser Angriff fügt 20 Schadenspunkte plus zusätzlich 10 Schadenspunkte für jede an das Verteidigende Pokémon angelegte Energiekarte zu."
+				de: "Dieser Angriff fügt 20 Schadenspunkte plus zusätzliche 10 Schadenspunkte für jede an das Verteidigende Pokémon angelegte Energiekarte zu."
 			},
 			damage: "20+",
 

--- a/data/E-Card/Expedition Base Set/21.ts
+++ b/data/E-Card/Expedition Base Set/21.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Vulpix",
-		fr: "Goupix"
+		fr: "Goupix",
+		de: "Vulpix"
 	},
 
 	stage: "Stage1",
@@ -37,12 +38,12 @@ const card: Card = {
 			name: {
 				en: "Mislead",
 				fr: "Tromperie",
-				de: "Mislead"
+				de: "Irreführen"
 			},
 			effect: {
 				en: "Flip 2 coins. If either of them is heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez 2 pièces. Si vous obtenez au moins une face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Flip 2 coins. If either of them is heads, the Defending Pokémon is now Confused."
+				de: "Wirf 2 Münzen. Falls mindestens eine von ihnen „Kopf“ zeigt, ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 
 		},
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Ethereal Flame",
 				fr: "Flamme éthérée",
-				de: "Ethereal Flame"
+				de: "Ätherflamme"
 			},
 			effect: {
 				en: "Discard all Fire Energy cards attached to Ninetales. This attack does 30 damage plus 20 more damage for each card discarded this way.",
 				fr: "Défaussez-vous de toutes les cartes Énergie  attachées à Feunard. Cette carte inflige 30 dégâts plus 20 dégâts supplémentaires pour chaque carte défaussée de cette manière.",
-				de: "Discard all  Energy cards attached to Ninetales. This attack does 30 damage plus 20 more damage for each card discarded this way."
+				de: "Lege alle an Vulnona angelegten {R}-Energiekarten auf deinen Ablagestapel. Dieser Angriff fügt 30 Schadenspunkte plus 20 weitere Schadenspunkte für jede auf diese Weise abgeworfene Karte zu."
 			},
 			damage: "30+",
 

--- a/data/E-Card/Expedition Base Set/23.ts
+++ b/data/E-Card/Expedition Base Set/23.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pidgeotto",
-		fr: "Roucoups"
+		fr: "Roucoups",
+		de: "Tauboga"
 	},
 
 	stage: "Stage2",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), if Pidgeot is your Active Pokémon, you may shuffle 1 of your Benched Pokémon and all cards attached to it into your deck. This power can't be used if Pidgeot is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), si Roucarnage est votre Pokémon Actif, vous pouvez mélanger un des Pokémon de votre Banc et toutes les cartes qui lui sont attachées à votre deck. Ce pouvoir ne peut être utilisé si Roucarnage est affecté par un État spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, falls Tauboss dein aktives Pokémon ist, 1 der Pokémon auf deiner Bank und alle daran angelegten Karten in dein Deck mischen. Diese Fähigkeit kann nicht verwendet werden, falls Tauboss von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, falls Tauboss dein Aktives Pokémon ist, 1 der Pokémon auf deiner Bank und alle daran angelegten Karten in dein Deck mischen. Diese Fähigkeit kann nicht verwendet werden, falls Tauboss von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -59,7 +60,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 30 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts plus 30 dégâts supplémentaires.",
-				de: "Wirf eine Münze. Bei 'Kopf' fügt dieser Angriff 20 Schadenspunkte plus 30 weitere Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 30 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 

--- a/data/E-Card/Expedition Base Set/24.ts
+++ b/data/E-Card/Expedition Base Set/24.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Poliwhirl",
-		fr: "Têtarte"
+		fr: "Têtarte",
+		de: "Quaputzi"
 	},
 
 	stage: "Stage2",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Plunge",
 				fr: "Plongeon",
-				de: "Plunge"
+				de: "Untertauchen"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), if Poliwrath is on your Bench, you may flip a coin. If heads, take all Energy cards attached to your Active Pokémon, if any, and attach them to Poliwrath. Then switch Poliwrath with your Active Pokémon.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), si Tartard est sur votre Banc, vous pouvez lancer une pièce. Si c'est face, prenez toutes les cartes Énergie attachées à votre Pokémon Actif, s'il en possède, et attachez-les à Tartard. Échangez ensuite Tartard contre votre Pokémon Actif.",
-				de: "Once during your turn (before your attack), if Poliwrath is on your Bench, you may flip a coin. If heads, take all Energy cards attached to your Active Pokémon, if any, and attach them to Poliwrath. Then switch Poliwrath with your Active Pokémon."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, falls Quappo auf deiner Bank ist, eine Münze werfen. Nimm bei „Kopf“ alle an dein Aktives Pokémon angelegte Energiekarten, falls vorhanden, und lege sie an Quappo an. Tausche dann Quappo mit deinem aktiven Pokémon."
 			},
 		},
 	],
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Water Punch",
 				fr: "Poing d'O",
-				de: "Water Punch"
+				de: "Wasserhieb"
 			},
 			effect: {
 				en: "Flip a number of coins equal to the amount of Water Energy attached to Poliwrath. This attack does 40 damage plus 10 more damage for each heads.",
 				fr: "Lancez un nombre de pièces équivalent au nombre d'Énergie  attachées à Tartard. Cette attaque inflige 40 dégâts plus 10 dégâts supplémentaires pour chaque face.",
-				de: "Flip a number of coins equal to the amount of  Energy attached to Poliwrath. This attack does 40 damage plus 10 more damage for each heads."
+				de: "Wirf so viele Münzen, wie {W}-Energie an Quappo angelegt ist. Dieser Angriff fügt 40 Schadenspunkte plus 10 weitere Schadenspunkte pro geworfenem „Kopf“ zu."
 			},
 			damage: "40+",
 

--- a/data/E-Card/Expedition Base Set/25.ts
+++ b/data/E-Card/Expedition Base Set/25.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pikachu",
-		fr: "Pikachu"
+		fr: "Pikachu",
+		de: "Pikachu"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "If there are any Lightning Energy cards in your discard pile, flip a coin. If heads, attach 1 of them to Raichu.",
 				fr: "Si vous avez des cartes Énergie  dans votre pile de défausse, lancez une pièce. Si c'est face, attachez l'une d'elles à Raichu.",
-				de: "Wenn mindestens eine -Energiekarte in deinem Ablagestapel ist, wirf eine Münze. Lege bei 'Kopf' 1 davon an Raichu an."
+				de: "Wenn mindestens eine {L}-Energiekarte in deinem Ablagestapel ist, wirf eine Münze. Lege bei „Kopf“ 1 davon an Raichu an."
 			},
 			damage: 10,
 
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Discard all Lightning Energy cards attached to Raichu or this attack does nothing.",
 				fr: "Défaussez-vous de toutes les cartes Énergie  attachées à Raichu ou cette attaque ne fait rien.",
-				de: "Lege alle an Raichu angelegten -Energiekarten auf deinen Ablagestapel, oder dieser Angriff hat keine Auswirkung."
+				de: "Lege alle an Raichu angelegten {L}-Energiekarten auf deinen Ablagestapel, oder dieser Angriff hat keine Auswirkungen."
 			},
 			damage: 60,
 

--- a/data/E-Card/Expedition Base Set/26.ts
+++ b/data/E-Card/Expedition Base Set/26.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Ponyta",
-		fr: "Ponyta"
+		fr: "Ponyta",
+		de: "Ponita"
 	},
 
 	stage: "Stage1",
@@ -37,12 +38,12 @@ const card: Card = {
 			name: {
 				en: "Overrun",
 				fr: "Dépassement",
-				de: "Überennen"
+				de: "Überrennen"
 			},
 			effect: {
 				en: "If your opponent has any Benched Pokémon, flip a coin. If heads, choose 1 of them and this attack does 10 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Si votre adversaire a des Pokémon sur son Banc, lancez une pièce. Si c'est face, choisissez-en un et cette attaque lui inflige 10 dégâts. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon du Banc.)",
-				de: "Falls dein gegner mindestens ein Pokémon auf der Bank hat, wirf eine Münze. Wähle bei \"Kopf\" 1 von diesen, und dieser Angriff fügt diesem Pokémon 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei dem Pokémon auf der Bank nicht an)"
+				de: "Falls dein Gegner mindestens ein Pokémon auf der Bank hat, wirf eine Münze. Wähle bei „Kopf“ 1 von diesen und dieser Angriff fügt diesem Pokémon 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 20,
 

--- a/data/E-Card/Expedition Base Set/27.ts
+++ b/data/E-Card/Expedition Base Set/27.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires.",
-				de: "Wirf eine Münze. Bei 'Kopf' fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -58,7 +58,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
-				de: "Wirf eine Münze. Bei 'Zahl' hat dieser Angriff keine Auswirkungen."
+				de: "Wirf eine Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 
 			damage: 50,

--- a/data/E-Card/Expedition Base Set/28.ts
+++ b/data/E-Card/Expedition Base Set/28.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Quilava",
-		fr: "Feurisson"
+		fr: "Feurisson",
+		de: "Igelavar"
 	},
 
 	stage: "Stage2",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may count the total number of Energy cards attached to all of your Pokémon and all of your opponent's Pokémon. If your opponent has more total Energy cards attached, you may search your deck for 1 Fire Energy card and attach it to 1 of your Benched Pokémon, if any. Shuffle your deck afterward. This power can't be used if Typhlosion is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez compter le nombre total de cartes Énergie attachées à tous vos Pokémon et à tous ceux de votre adversaire. Si au total, votre adversaire a plus de cartes Énergie attachées que vous, vous pouvez chercher dans votre deck 1 carte Énergie  et l'attacher à l'un des Pokémon de votre Banc, si vous en possédez. Mélangez ensuite votre deck. Ce pouvoir ne peut pas être utilisé si Typhlosion est affecté par un État spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du zählen, wie viele Energiekarten an alle deine Pokémon angelegt sind und wie viele an alle Pokémon deines Gegners. Wenn an die Pokémon deines Gegners mehr Energiekarten angelegt sind, kannst du dein Deck nach 1 -Energiekarte durchsuchen und diese, falls du Pokémon auf deiner Bank hast, an 1 dieser Pokémon anlegen. Mische dein Deck danach. Diese Fähigkeit kann nicht verwendet werden, falls Tornupto von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du zählen, wie viele Energiekarten insgesamt an alle deine Pokémon angelegt sind und wie viele an alle Pokémon deines Gegners. Wenn an die Pokémon deines Gegners mehr Energiekarten angelegt sind, kannst du dein Deck nach 1 {R}-Energiekarte durchsuchen und diese, falls du Pokémon auf deiner Bank hast, an 1 dieser Pokémon anlegen. Mische dein Deck danach. Diese Fähigkeit kann nicht verwendet werden, falls Tornupto von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Burned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Brûlé.",
-				de: "Wirf eine Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt verbrannt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verbrannt."
 			},
 			damage: 50,
 

--- a/data/E-Card/Expedition Base Set/29.ts
+++ b/data/E-Card/Expedition Base Set/29.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pupitar",
-		fr: "Ymphect"
+		fr: "Ymphect",
+		de: "Pupitar"
 	},
 
 	stage: "Stage2",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "All Energy attached to Tyranitar is Darkness Energy instead of its usual type.",
 				fr: "Toutes les cartes Énergie attachées à Tyranocif sont d'Énergie  au lieu de leur type habituel.",
-				de: "Alle Energie, die an Despotar angelegt ist, ist anstatt ihrem normalen Typ -Energie."
+				de: "Alle Energie, die an Despotar angelegt ist, ist anstatt ihrem normalen Typ {D}-Energie."
 			},
 		},
 	],
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 50 damage plus 10 more damage and does 10 damage to each of your opponent's Benched Pokémon, if any. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 50 dégâts plus 10 dégâts supplémentaires et inflige 10 dégâts à chaque Pokémon du Banc de votre adversaire, s'il en possède. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon du Banc.)",
-				de: "Wirf eine Münze. Bei 'Kopf' fügt dieser Angriff 50 Schadenspunkte plus 10 weitere Schadenspunkte zu und außerdem jedem Pokémon auf der Bank deines Gegners 10 Schadenspunkte, falls vorhanden. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 50 Schadenspunkte plus 10 weitere Schadenspunkte zu und außerdem jedem Pokémon auf der Bank deines Gegners 10 Schadenspunkte, falls vorhanden. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: "50+",
 

--- a/data/E-Card/Expedition Base Set/3.ts
+++ b/data/E-Card/Expedition Base Set/3.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Ekans",
-		fr: "Abo"
+		fr: "Abo",
+		de: "Rettan"
 	},
 
 	stage: "Stage1",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Poison Spray",
 				fr: "Jet-venin",
-				de: "Poison Spray"
+				de: "Giftspray"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné.",
-				de: "The Defending Pokémon is now Poisoned."
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet."
 			}
 		},
 		{
@@ -52,12 +53,12 @@ const card: Card = {
 			name: {
 				en: "Poison Reaction",
 				fr: "Allergie poison",
-				de: "Poison Reaction"
+				de: "Gifteinwirkung"
 			},
 			effect: {
 				en: "If the Defending Pokémon is Poisoned, this attack does 20 damage plus 20 more damage.",
 				fr: "Si le Pokémon Défenseur est Empoisonné, cette attaque inflige 20 dégâts plus 20 dégâts supplémentaires.",
-				de: "If the Defending Pokémon is Poisoned, this attack does 20 damage plus 20 more damage."
+				de: "Wenn das Verteidigende Pokémon vergiftet ist, fügt dieser Angriff 20 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 

--- a/data/E-Card/Expedition Base Set/30.ts
+++ b/data/E-Card/Expedition Base Set/30.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Ivysaur",
-		fr: "Herbizarre"
+		fr: "Herbizarre",
+		de: "Bisaknosp"
 	},
 
 	stage: "Stage2",
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 40,
 

--- a/data/E-Card/Expedition Base Set/31.ts
+++ b/data/E-Card/Expedition Base Set/31.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Gloom",
-		fr: "Ortide"
+		fr: "Ortide",
+		de: "Duflor"
 	},
 
 	stage: "Stage2",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may flip a coin. If heads, the Defending Pokémon is now Poisoned. This power can't be used if Vileplume is affected by a Special Condition.",
 				fr: "Une fois pendant votre tour (avant votre attaque), vous pouvez lancer une pièce. Si c'est face, le Pokémon Défenseur est maintenant Empoisonné. Ce pouvoir ne peut pas être utilisé si Raflésia est affecté par un État spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du eine Münze werfen. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt vergiftet. Diese Fähigkeit kann nicht verwendet werden, falls Giflor von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du eine Münze werfen. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet. Diese Fähigkeit kann nicht verwendet werden, falls Giflor von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -58,7 +59,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 30 damage times the number of heads. Vileplume is now Confused.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de faces. Raflésia est maintenant Confus.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl \"Kopf\" zu. Giflor ist jetzt verwirrt."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu. Giflor ist jetzt verwirrt."
 			},
 			damage: "30×",
 

--- a/data/E-Card/Expedition Base Set/32.ts
+++ b/data/E-Card/Expedition Base Set/32.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Koffing",
-		fr: "Smogo"
+		fr: "Smogo",
+		de: "Smogon"
 	},
 
 	stage: "Stage1",
@@ -37,12 +38,12 @@ const card: Card = {
 			name: {
 				en: "Foul Gas",
 				fr: "Gaz infect",
-				de: "Foul Gas"
+				de: "Fäulnisgas"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned. If tails, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Empoisonné. Si c'est pile, le Pokémon Défenseur est maintenant Confus.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Poisoned. If tails, the Defending Pokémon is now Confused."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet. Bei „Zahl“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 
 		},
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Misfire",
 				fr: "Raté",
-				de: "Misfire"
+				de: "Fehlschuss"
 			},
 			effect: {
 				en: "Flip a coin. If tails, put 6 damage counters on Weezing.",
 				fr: "Lancez une pièce. Si c'est face, placez 6 marqueurs de dégâts sur Smogogo.",
-				de: "Flip a coin. If tails, put 6 damage counters on Weezing."
+				de: "Wirf eine Münze. Lege bei „Zahl“ 6 Schadensmarken auf Smogmog."
 			},
 			damage: 60,
 

--- a/data/E-Card/Expedition Base Set/33.ts
+++ b/data/E-Card/Expedition Base Set/33.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Kadabra",
-		fr: "Kadabra"
+		fr: "Kadabra",
+		de: "Kadabra"
 	},
 
 	stage: "Stage2",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn, instead of Alakazam's normal attack, you may choose 1 of your opponent's Pokémon's attacks. Alakazam copies that attack including its Energy costs and anything else required in order to use that attack, such as discarding Energy cards. (No matter what type that Pokémon is, Alakazam's type is still Psychic.) This power can't be used if Alakazam is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour, à la place de l'attaque normale d'Alakazam, vous pouvez choisir une attaque d'un des Pokémon de votre adversaire. Alakazam copie cette attaque, y compris son coût d'Énergie et toute autre action requise pour utiliser cette attaque, comme par exemple, se défausser de cartes Énergie. (Quel que soit le type de l'autre Pokémon, Alakazam est toujours de type Psy.) Ce pouvoir ne peut pas être utilisé si Alakazam est affecté par un État spécial.",
-				de: "Einmal während deines Zuges kannst duanstatt Simsalas normalen Angriff 1 der Angriffen der Pokémon deines Gegners wählen. Simsala kopiert diesen Angriff (einschließlich der Energiekosten und allem anderen, was du tun musst, um diesen Angriff zu verwenden).(Unabhängig vom Typ dieses Pokémon bleibt Simsalas Typ Psycho.) Diese Fähigkeit kann nicht verwendet werden, falls Simsala von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges kannst du anstatt Simsalas normalem Angriff 1 der Angriffe der Pokémon deines Gegners wählen. Simsala kopiert diesen Angriff (einschließlich der Energiekosten und allem anderen, was du tun musst, um diesen Angriff zu verwenden). (Unabhängig vom Typ dieses Pokémon bleibt Simsalas Typ Psycho.) Diese Fähigkeit kann nicht verwendet werden, falls Simsala von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],

--- a/data/E-Card/Expedition Base Set/34.ts
+++ b/data/E-Card/Expedition Base Set/34.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Flaaffy",
-		fr: "Lainergie"
+		fr: "Lainergie",
+		de: "Waaty"
 	},
 
 	stage: "Stage2",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "As often as you like during your turn (before your attack), you may take a basic Energy card attached to 1 of your Benched Pokémon and attach it to your Active Pokémon. This power can't be used if Ampharos is affected by a Special Condition.",
 				fr: "Aussi souvent que vous le désirez pendant votre tour (avant votre attaque), vous pouvez prendre une carte Énergie de base attachée à l'un des Pokémon de votre Banc et l'attacher à votre Pokémon Actif. Ce pouvoir ne peut pas être utilisé si Pharamp est affecté par un État spécial.",
-				de: "Du darft in deinem Zug so oft, wie du willst (vor deinem Angriff), eine Basis-Energiekarte, die an 1 deiner Pokémon auf der Bank angelegt ist, nehmen und an dein Aktives Pokémon anlegen. Diese Fähigkeit kann nicht verwendet werden, falls Ampharos von einem Speziellen Zustand betroffen ist."
+				de: "Du darfst in deinem Zug so oft, wie du willst (vor deinem Angriff), eine Basis-Energiekarte, die an 1 deiner Pokémon auf der Bank angelegt ist, nehmen und an dein Aktives Pokémon anlegen. Diese Fähigkeit kann nicht verwendet werden, falls Ampharos von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "You may discard all Lightning Energy cards attached to Ampharos. If you do, this attack's base damage is 80 instead of 40.",
 				fr: "Vous pouvez vous défausser de toutes les cartes Énergie  attachées à Pharamp. Si vous faites ainsi, cette attaque inflige 80 dégâts de base au lieu de 40.",
-				de: "Du kannst alle -Energiekarten, die an Ampharos angelegt sind, auf deinen Ablagestapel legen. Falls du dies tust, ist der Basisschaden dieses Angriffs 80 anstatt 40."
+				de: "Du kannst alle {L}-Energiekarten, die an Ampharos angelegt sind, auf deinen Ablagestapel legen. Falls du dies tust, ist der Basisschaden dieses Angriffs 80 anstatt 40."
 			},
 
 			damage: 40,

--- a/data/E-Card/Expedition Base Set/35.ts
+++ b/data/E-Card/Expedition Base Set/35.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Poison Spray",
 				fr: "Jet-venin",
-				de: "Poison Spray"
+				de: "Giftspray"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné.",
-				de: "The Defending Pokémon is now Poisoned."
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet."
 			}
 
 		},
@@ -48,12 +48,12 @@ const card: Card = {
 			name: {
 				en: "Poison Reaction",
 				fr: "Allergie poison",
-				de: "Poison Reaction"
+				de: "Gifteinwirkung"
 			},
 			effect: {
 				en: "If the Defending Pokémon is Poisoned, this attack does 20 damage plus 20 more damage.",
 				fr: "Si le Pokémon Défenseur est Empoisonné, cette attaque inflige 20 dégâts plus 20 dégâts supplémentaires.",
-				de: "If the Defending Pokémon is Poisoned, this attack does 20 damage plus 20 more damage."
+				de: "Wenn das Verteidigende Pokémon vergiftet ist, fügt dieser Angriff 20 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 

--- a/data/E-Card/Expedition Base Set/36.ts
+++ b/data/E-Card/Expedition Base Set/36.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Wartortle",
-		fr: "Carabaffe"
+		fr: "Carabaffe",
+		de: "Schillok"
 	},
 
 	stage: "Stage2",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 40 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque fait 40 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl 'Kopf' zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "40×",
 

--- a/data/E-Card/Expedition Base Set/37.ts
+++ b/data/E-Card/Expedition Base Set/37.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Jet Stream",
 				fr: "Force courant",
-				de: "Jet Stream"
+				de: "Düsenstrahl"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), if Blastoise is your Active Pokémon, you may flip a coin. If heads, discard an Energy card attached to Blastoise, if any. Then, if there are any Energy cards attached to the Defending Pokémon, choose 1 of them and discard it. This power can't be used if Blastoise is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), si Tortank est votre Pokémon Actif, vous pouvez lancer une pièce. Si c'est face, défaussez-vous d'une carte Énergie attachée à Tortank, s'il en possède une. Ensuite, s'il y a des cartes Énergie attachées au Pokémon Défenseur, choisissez-en une et obligez votre adversaire à s'en défausser. Ce pouvoir ne peut pas être utilisé si Tortank est affecté par un État spécial.",
-				de: "Once during your turn (before you attack), if Blastoise is your Active Pokémon, you may flip a coin. If heads, discard an Energy card attached to Blastoise. Then, if there any Energy cards attached to the Defending Pokémon, choose 1 of them and discard it. This power can't be used if Blaistoise is affected by a Special Condition."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, falls Turtok dein Aktives Pokémon ist, eine Münze werfen. Lege bei „Kopf“ eine an Turtok angelegte Energiekarte auf deinen Ablagestapel, falls vorhanden. Wenn dann mindestens eine Energiekarte an das Verteidigende Pokémon angelegt ist, wähle 1 davon und lege sie auf den Ablagestapel deines Gegners. Diese Fähigkeit kann nicht verwendet werden, falls Turtok von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -49,12 +49,12 @@ const card: Card = {
 			name: {
 				en: "Energy Cannon",
 				fr: "Canon à énergie",
-				de: "Energy Cannon"
+				de: "Energiekanone"
 			},
 			effect: {
 				en: "Does 40 damage plus 10 more damage for each Energy attached to Blastoise but not used to pay for this attack's Energy Cost. You can't add more than 20 damage in this way.",
 				fr: "Inflige 40 dégâts plus 10 dégâts supplémentaires pour chaque Énergie attachée à Tortank en plus du coût en Énergie de cette attaque. Vous ne pouvez pas ajouter plus de 20 dégâts de cette façon.",
-				de: "Does 40 damage plus 10 more damage for each Energy attached to Blastoise but not used to pay for this attack's energy cost. You can't add more then 20 damage in this way."
+				de: "Fügt 40 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Turtok angelegte Energie, die nicht zum Zahlen der Energiekosten für diesen Angriff verwendet wird, zu. Du kannst auf diese Weise höchstens 20 weitere Schadenspunkte zufügen."
 			},
 			damage: "40+",
 

--- a/data/E-Card/Expedition Base Set/38.ts
+++ b/data/E-Card/Expedition Base Set/38.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Metapod",
-		fr: "Chrysacier"
+		fr: "Chrysacier",
+		de: "Safcon"
 	},
 
 	stage: "Stage2",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Miraculous Powder",
 				fr: "Poudre miraculeuse",
-				de: "Miraculous Powder"
+				de: "Wundersames Puder"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may remove all Special Conditions from your Active Pokémon. This power can't be used if Butterfree is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez annuler tous les États spéciaux sur votre Pokémon Actif. Ce pouvoir ne peut pas être utilisé si Papilusion est affecté par un État spécial.",
-				de: "Once during your turn (before your attack), you may remove all Special Conditions from your Active Pokémon. This power can't be used if Butterfree is affected by a Special Condition."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du alle Speziellen Zustände von deinem Aktiven Pokémon entfernen. Diese Fähigkeit kann nicht verwendet werden, falls Smettbo von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -54,12 +55,12 @@ const card: Card = {
 			name: {
 				en: "Spiral Drain",
 				fr: "Spirale",
-				de: "Spiral Drain"
+				de: "Spiralsauger"
 			},
 			effect: {
 				en: "Flip a coin. If heads, remove 2 damage counters from Butterfree.",
 				fr: "Lancez une pièce. Si c'est face, retirez 2 marqueurs de dégâts sur Papilusion.",
-				de: "Flip a coin. If heads, remove 2 damage counters from Butterfree."
+				de: "Wirf eine Münze. Entferne bei „Kopf“ 2 Schadensmarken von Smettbo."
 			},
 			damage: 40,
 

--- a/data/E-Card/Expedition Base Set/39.ts
+++ b/data/E-Card/Expedition Base Set/39.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Charmeleon",
-		fr: "Reptincel"
+		fr: "Reptincel",
+		de: "Glutexo"
 	},
 
 	stage: "Stage2",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
-				de: "Wirf eine Münze. Bei Zahl hat dieser Angriff keine Auswirkungen."
+				de: "Wirf eine Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 
 			damage: 40,
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "Discard 1 Fire Energy card attached to Charizard.",
 				fr: "Défaussez-vous d'une carte Énergie  attachée à Dracaufeu.",
-				de: "Lege 1 an Glurak angelegte  Energiekarte auf deinen Ablagestapel."
+				de: "Lege 1 an Glurak angelegte {R}-Energiekarte auf deinen Ablagestapel."
 			},
 			damage: 60,
 

--- a/data/E-Card/Expedition Base Set/4.ts
+++ b/data/E-Card/Expedition Base Set/4.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Wartortle",
-		fr: "Carabaffe"
+		fr: "Carabaffe",
+		de: "Schillok"
 	},
 
 	stage: "Stage2",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Jet Stream",
 				fr: "Force courant",
-				de: "Jet Stream"
+				de: "Düsenstrahl"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), if Blastoise is your Active Pokémon, you may flip a coin. If heads, discard an Energy card attached to Blastoise, if any. Then, if there are any Energy cards attached to the Defending Pokémon, choose 1 of them and discard it. This power can't be used if Blastoise is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), si Tortank est votre Pokémon Actif, vous pouvez lancer une pièce. Si c'est face, défaussez-vous d'une carte Énergie attachée à Tortank, s'il en possède une. Ensuite, s'il y a des cartes Énergie attachées au Pokémon Défenseur, choisissez-en une et obligez votre adversaire à s'en défausser. Ce pouvoir ne peut pas être utilisé si Tortank est affecté par un État spécial.",
-				de: "Once during your turn (before you attack), if Blastoise is your Active Pokémon, you may flip a coin. If heads, discard an Energy card attached to Blastoise. Then, if there any Energy cards attached to the Defending Pokémon, choose 1 of them and discard it. This power can't be used if Blaistoise is affected by a Special Condition."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, falls Turtok dein Aktives Pokémon ist, eine Münze werfen. Lege bei „Kopf“ eine an Turtok angelegte Energiekarte auf deinen Ablagestapel, falls vorhanden. Wenn dann mindestens eine Energiekarte an das Verteidigende Pokémon angelegt ist, wähle 1 davon und lege sie auf den Ablagestapel deines Gegners. Diese Fähigkeit kann nicht verwendet werden, falls Turtok von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -54,12 +55,12 @@ const card: Card = {
 			name: {
 				en: "Energy Cannon",
 				fr: "Canon à énergie",
-				de: "Energy Cannon"
+				de: "Energiekanone"
 			},
 			effect: {
 				en: "Does 40 damage plus 10 more damage for each Energy attached to Blastoise but not used to pay for this attack's Energy Cost. You can't add more than 20 damage in this way.",
 				fr: "Inflige 40 dégâts plus 10 dégâts supplémentaires pour chaque Énergie attachée à Tortank en plus du coût en Énergie de cette attaque. Vous ne pouvez pas ajouter plus de 20 dégâts de cette façon.",
-				de: "Does 40 damage plus 10 more damage for each Energy attached to Blastoise but not used to pay for this attack's energy cost. You can't add more then 20 damage in this way."
+				de: "Fügt 40 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Turtok angelegte Energie, die nicht zum Zahlen der Energiekosten für diesen Angriff verwendet wird, zu. Du kannst auf diese Weise höchstens 20 weitere Schadenspunkte zufügen."
 			},
 			damage: "40+",
 

--- a/data/E-Card/Expedition Base Set/40.ts
+++ b/data/E-Card/Expedition Base Set/40.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Charmeleon",
-		fr: "Reptincel"
+		fr: "Reptincel",
+		de: "Glutexo"
 	},
 
 	stage: "Stage2",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Burning Energy",
 				fr: "Énergie brûlante",
-				de: "Burning Energy"
+				de: "Energieverbrennung"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may turn all basic Energy attached to all of your Pokémon into Fire Energy for the rest of the turn. This power can't be used if Charizard is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez changer toutes les Énergies de base attachées à tous vos Pokémon en Énergie  pour le reste du tour. Ce pouvoir ne peut pas être utilisé si Dracaufeu est affecté par un État spécial.",
-				de: "Once during your turn (before your attack), you may turn all basic Energy attached to all of your Pokémonn into  Energy for the rest of the turn. This power can´t be used if Charizard is affected by a Special Condition"
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du alle Basis-Energie, die an alle deine Pokémon angelegt ist, bis zum Ende des Zuges in {R}-Energie umwandeln. Diese Fähigkeit kann nicht verwendet werden, falls Glurak von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Scorching Whirlwind",
 				fr: "Tourbillon brûlant",
-				de: "Scorching Whirlwind"
+				de: "Sengender Wirbelwind"
 			},
 			effect: {
 				en: "Flip 2 coins. If 1 of them is tails, discard 2 Energy cards attached to Charizard. If both are tails, discard all Energy cards attached to Charizard.",
 				fr: "Lancez 2 pièces. Si vous obtenez 1 pile, défaussez-vous de 2 cartes Énergie attachées à Dracaufeu. Si vous obtenez 2 piles, défaussez-vous de toutes les cartes Énergie attachées à Dracaufeu.",
-				de: "Flip 2 coins. If 1 of them is tails, discard 2Energy cards attached to Charizard. If both are tails, discard all Energy cards attached to Charizard."
+				de: "Wirf 2 Münzen. Falls 1 davon „Zahl“ zeigt, lege 2 an Glurak angelegte Energiekarten auf deinen Ablagestapel. Falls beide „Zahl“ zeigen, lege alle an Glurak angelegten Energiekarten auf deinen Ablagestapel."
 			},
 			damage: 120,
 

--- a/data/E-Card/Expedition Base Set/41.ts
+++ b/data/E-Card/Expedition Base Set/41.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Clefairy",
-		fr: "Mélofée"
+		fr: "Mélofée",
+		de: "Piepi"
 	},
 
 	stage: "Stage1",
@@ -58,7 +59,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 20 times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl 'Kopf' zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 

--- a/data/E-Card/Expedition Base Set/42.ts
+++ b/data/E-Card/Expedition Base Set/42.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Shellder",
-		fr: "Kokiyas"
+		fr: "Kokiyas",
+		de: "Muschas"
 	},
 
 	stage: "Stage1",
@@ -42,7 +43,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 4 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 4 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 4 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl 'Kopf' zu."
+				de: "Wirf 4 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 

--- a/data/E-Card/Expedition Base Set/43.ts
+++ b/data/E-Card/Expedition Base Set/43.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Dragonair",
-		fr: "Draco"
+		fr: "Draco",
+		de: "Dragonir"
 	},
 
 	stage: "Stage2",
@@ -65,7 +66,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 40 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque fait 40 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "40×",
 

--- a/data/E-Card/Expedition Base Set/44.ts
+++ b/data/E-Card/Expedition Base Set/44.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Diglett",
-		fr: "Taupiqueur"
+		fr: "Taupiqueur",
+		de: "Digda"
 	},
 
 	stage: "Stage1",
@@ -36,7 +37,7 @@ const card: Card = {
 			name: {
 				en: "Mud Slap",
 				fr: "Coud'boue",
-				de: "Mud Slap"
+				de: "Lehmschelle"
 			},
 
 			damage: 20,
@@ -51,12 +52,12 @@ const card: Card = {
 			name: {
 				en: "Magnitude",
 				fr: "Ampleur",
-				de: "Magnitude"
+				de: "Intensität"
 			},
 			effect: {
 				en: "Does 10 damage to each Benched Pokémon (yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à chaque Pokémon du Banc (le vôtre et celui de votre adversaire). (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon du Banc.)",
-				de: "Does 10 damage to each Benched Pokémon (yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Fügt allen Pokémon auf der Bank 10 Schadenspunkte zu (deinen und den gegnerischen). (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 40,
 

--- a/data/E-Card/Expedition Base Set/45.ts
+++ b/data/E-Card/Expedition Base Set/45.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Spearow",
-		fr: "Piafabec"
+		fr: "Piafabec",
+		de: "Habitak"
 	},
 
 	stage: "Stage1",
@@ -63,7 +64,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
-				de: "Wirf eine Münze. Bei 'Zahl' hat dieser Angriff keine Auswirkungen."
+				de: "Wirf eine Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 
 			damage: 50,

--- a/data/E-Card/Expedition Base Set/46.ts
+++ b/data/E-Card/Expedition Base Set/46.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Croconaw",
-		fr: "Crocrodil"
+		fr: "Crocrodil",
+		de: "Tyracroc"
 	},
 
 	stage: "Stage2",
@@ -36,7 +37,7 @@ const card: Card = {
 			name: {
 				en: "Slash",
 				fr: "Tranche",
-				de: "Slash"
+				de: "Schlitzer"
 			},
 
 			damage: 20,
@@ -51,12 +52,12 @@ const card: Card = {
 			name: {
 				en: "Double Claw",
 				fr: "Combo-griffe",
-				de: "Double Claw"
+				de: "Doppelkralle"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 30 damage plus 20 more damage for each heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts plus 20 dégâts supplémentaires pour chaque face.",
-				de: "Flip 2 coins. This attack does 30 damage plus 20 more damage for each heads."
+				de: "Wirf zwei Münzen. Dieser Angriff fügt 30 Schadenspunkte plus 20 weitere Schadenspunkte pro geworfenem „Kopf“ zu."
 			},
 			damage: "30+",
 

--- a/data/E-Card/Expedition Base Set/47.ts
+++ b/data/E-Card/Expedition Base Set/47.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Croconaw",
-		fr: "Crocrodil"
+		fr: "Crocrodil",
+		de: "Tyracroc"
 	},
 
 	stage: "Stage2",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Major Tsunami",
 				fr: "Terrible tsunami",
-				de: "Major Tsunami"
+				de: "Größerer Tsunami"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), if Feraligatr is your Active Pokémon and if your opponent has any Benched Pokémon, your opponent switches his or her Active Pokémon with 1 of his or her Benched Pokémon. Either way, if you have any Benched Pokémon, switch Feraligatr with 1 of them. This power can't be used if Feraligatr is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), si Aligatueur est votre Pokémon Actif et si votre adversaire a des Pokémon sur son Banc, il échange l'un d'eux contre son Pokémon Actif. Quel que soit le cas, si vous avez des Pokémon sur votre Banc, échangez l'un d'eux contre Aligatueur. Ce pouvoir ne peut pas être utilisé si Aligatueur est affecté par un État spécial.",
-				de: "Once during your turn (before your attack), if Feraligatr is your Active Pokémon and if your opponent has any Benched Pokémon, your opponent switches his or her Active Pokémon with 1 of his or her Benched Pokémon. Either way, if you have any Benched Pokémon, switch Feraligatr with 1 of them. This power can't be used if Feraligatr is affected by a Special Condition."
+				de: "Einmal während deines Zuges (vor deinem Angriff), falls Impergator dein Aktives Pokémon ist und dein Gegner mindestens ein Pokémon auf der Bank hat, tauscht dein Gegner sein Aktives Pokémon mit 1 seiner Pokémon auf der Bank. Unabhängig davon: Falls du mindestens 1 Pokémon auf deiner Bank hast, tausche 1 von diesen mit Impergator. Diese Fähigkeit kann nicht verwendet werden, falls Impergator von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -56,13 +57,13 @@ const card: Card = {
 			name: {
 				en: "Rending Jaws",
 				fr: "Coud'mâchoire",
-				de: "Rending Jaws"
+				de: "Reißkiefer"
 			},
 
 			effect: {
 				en: "If here are no damage counters on the Defending Pokémon, this attack's base damage is 40 instead of 70.",
 				fr: "S'il n'y a aucun marqueur de dégâts sur le Pokémon Défenseur, cette attaque inflige 40 dégâts de base au lieu de 70.",
-				de: "If there are now damage counters on the Defending Pokémon, this attack's base damage is 40 instead of 70."
+				de: "Falls auf dem Verteidigenden Pokémon keine Schadensmarken sind, ist der Basisschaden dieses Angriffs 40 anstatt 70."
 			},
 
 			damage: 70,

--- a/data/E-Card/Expedition Base Set/48.ts
+++ b/data/E-Card/Expedition Base Set/48.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Haunter",
-		fr: "Spectrum"
+		fr: "Spectrum",
+		de: "Alpollo"
 	},
 
 	stage: "Stage2",

--- a/data/E-Card/Expedition Base Set/49.ts
+++ b/data/E-Card/Expedition Base Set/49.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Graveler",
-		fr: "Gravalanch"
+		fr: "Gravalanch",
+		de: "Georok"
 	},
 
 	stage: "Stage2",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Rock Body",
 				fr: "Corps roc",
-				de: "Rock Body"
+				de: "Steinkörper"
 			},
 			effect: {
 				en: "All damage done by attacks to Golem is reduced by 10 (after applying Weakness and Resistance).",
 				fr: "Tous les dégâts infligés par des attaques sur Grolem sont réduits de 10 (après application de la Faiblesse et de la Résistance).",
-				de: "All damage done by attacks to Golem is reduced by 10 (after applying Weakness and Resistance.)"
+				de: "Aller Schaden, der Geowaz von Angriffen zugefügt wird, wird um 10 reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 		},
 	],
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Rock Tumble",
 				fr: "Roule-pierre",
-				de: "Rock Tumble"
+				de: "Rollende Felsen"
 			},
 			effect: {
 				en: "Don't apply Resistance.",
 				fr: "N'appliquez pas la Résistance.",
-				de: "Don't apply Resistance."
+				de: "Wende Resistenz nicht an."
 			},
 			damage: 60,
 

--- a/data/E-Card/Expedition Base Set/5.ts
+++ b/data/E-Card/Expedition Base Set/5.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Metapod",
-		fr: "Chrysacier"
+		fr: "Chrysacier",
+		de: "Safcon"
 	},
 
 	stage: "Stage2",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Miraculous Powder",
 				fr: "Poudre miraculeuse",
-				de: "Miraculous Powder"
+				de: "Wundersames Puder"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may remove all Special Conditions from your Active Pokémon. This power can't be used if Butterfree is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez annuler tous les États spéciaux sur votre Pokémon Actif. Ce pouvoir ne peut pas être utilisé si Papilusion est affecté par un État spécial.",
-				de: "Once during your turn (before your attack), you may remove all Special Conditions from your Active Pokémon. This power can't be used if Butterfree is affected by a Special Condition."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du alle Speziellen Zustände von deinem Aktiven Pokémon entfernen. Diese Fähigkeit kann nicht verwendet werden, falls Smettbo von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -54,12 +55,12 @@ const card: Card = {
 			name: {
 				en: "Spiral Drain",
 				fr: "Sangsue spirale",
-				de: "Spiral Drain"
+				de: "Spiralsauger"
 			},
 			effect: {
 				en: "Flip a coin. If heads, remove 2 damage counters from Butterfree.",
 				fr: "Lancez une pièce. Si c'est face, retirez 2 marqueurs de dégâts sur Papilusion.",
-				de: "Flip a coin. If heads, remove 2 damage counters from Butterfree."
+				de: "Wirf eine Münze. Entferne bei „Kopf“ 2 Schadensmarken von Smettbo."
 			},
 			damage: 40,
 

--- a/data/E-Card/Expedition Base Set/50.ts
+++ b/data/E-Card/Expedition Base Set/50.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Krabby",
-		fr: "Krabby"
+		fr: "Krabby",
+		de: "Krabby"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
-				de: "Wirf eine Münze. Bei 'Zahl' hat dieser Angriff keine Auswirkungen."
+				de: "Wirf eine Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 
 			damage: 70,

--- a/data/E-Card/Expedition Base Set/51.ts
+++ b/data/E-Card/Expedition Base Set/51.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Machoke",
-		fr: "Machopeur"
+		fr: "Machopeur",
+		de: "Maschock"
 	},
 
 	stage: "Stage2",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Terraforming",
 				fr: "Terraformage",
-				de: "Terraforming"
+				de: "Erdumwälzung"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may look at the top 4 cards of your deck and rearrange them as you like. This power can't be used if Machamp is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez regarder les 4 cartes du dessus de votre deck et les remettre dans l'ordre que vous désirez. Ce pouvoir ne peut pas être utilisé si Mackogneur est affecté par un État spécial.",
-				de: "Once during your turn (before you attack), you may look at the top 4 cards of your deck and rearrange them as you like. This power can`t be used if Machamp is affected by a Special Condition."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du dir die obersten 4 Karten deines Decks ansehen und sie in beliebiger Reihenfolge zurücklegen. Diese Fähigkeit kann nicht verwendet werden, falls Machomei von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Iron Fist",
 				fr: "Poing de fer",
-				de: "Iron Fist"
+				de: "Eisenfaust"
 			},
 			effect: {
 				en: "Count the number of Pokémon you have in play with damage counters on them. Flip a coin. If heads, this attack does 50 damage plus 10 more damage for each of those Pokémon.",
 				fr: "Comptez le nombre de vos Pokémon en jeu ayant des marqueurs de dégâts. Lancez une pièce. Si c'est face, cette attaque inflige 50 dégâts plus 10 dégâts supplémentaires pour chacun de ces Pokémon.",
-				de: "Count the number of Pokémon you have in play with damage counters on them. Flip a coin. If heads, this attack does 50 damage plus 10 more damage for each of those Pokémon."
+				de: "Zähle die Anzahl der Pokémon, die du im Spiel hast und auf denen Schadensmarken liegen. Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 50 Schadenspunkte plus weitere 10 Schadenspunkte für jedes dieser Pokémon zu."
 			},
 			damage: "50+",
 

--- a/data/E-Card/Expedition Base Set/52.ts
+++ b/data/E-Card/Expedition Base Set/52.ts
@@ -48,7 +48,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, put a basic Energy card from your discard pile into your hand.",
 				fr: "Lancez une pièce. Si c'est face, ajoutez une carte Énergie de votre pile de défausse à votre main.",
-				de: "Wirf eine Münze. Nimm bei 'Kopf' eine Basis-Energiekarte von deinem Ablagestapel auf deine Hand."
+				de: "Wirf eine Münze. Nimm bei „Kopf“ eine Basis-Energiekarte von deinem Ablagestapel auf deine Hand."
 			},
 
 		},

--- a/data/E-Card/Expedition Base Set/53.ts
+++ b/data/E-Card/Expedition Base Set/53.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Bayleef",
-		fr: "Macronium"
+		fr: "Macronium",
+		de: "Lorblatt"
 	},
 
 	stage: "Stage2",

--- a/data/E-Card/Expedition Base Set/54.ts
+++ b/data/E-Card/Expedition Base Set/54.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Bayleef",
-		fr: "Macronium"
+		fr: "Macronium",
+		de: "Lorblatt"
 	},
 
 	stage: "Stage2",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may flip a coin. If heads, remove 1 damage counter from each of your Pokémon that has any. This power can't be used if Meganium is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez lancer une pièce. Si c'est face, retirez un marqueur de dégât de chacun de vos Pokémon ayant des marqueurs de dégâts. Ce pouvoir ne peut pas être utilisé si Meganium est affecté par un État spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du eine Münze werfen. Entferne bei \"Kopf\" von jedem deiner Pokémon, auf dem Schadensmarken liegen, 1 der Schadensmarken. Diese Fähigkeit kann nicht verwendet werden, falls Meganie von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du eine Münze werfen. Entferne bei „Kopf“ von jedem deiner Pokémon, auf dem Schadensmarken liegen, 1 der Schadensmarken. Diese Fähigkeit kann nicht verwendet werden, falls Meganie von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],

--- a/data/E-Card/Expedition Base Set/56.ts
+++ b/data/E-Card/Expedition Base Set/56.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Asleep.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Endormi.",
-				de: "Wirf eine Münze. Bei 'Kopf' schläft das Verteidigende Pokémon jetzt."
+				de: "Wirf eine Münze. Bei „Kopf“ schläft das Verteidigende Pokémon jetzt."
 			},
 
 		},
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "This attack does 20 damage plus 10 more damage for each Energy card attached to the Defending Pokémon.",
 				fr: "Cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires pour chaque carte Énergie attachée au Pokémon Défenseur.",
-				de: "Dieser Angriff fügt 20 Schadenspunkte plus zusätzlich 10 Schadenspunkte für jede an das Verteidigende Pokémon angelegte Energiekarte zu."
+				de: "Dieser Angriff fügt 20 Schadenspunkte plus zusätzliche 10 Schadenspunkte für jede an das Verteidigende Pokémon angelegte Energiekarte zu."
 			},
 			damage: "20+",
 

--- a/data/E-Card/Expedition Base Set/57.ts
+++ b/data/E-Card/Expedition Base Set/57.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Vulpix",
-		fr: "Goupix"
+		fr: "Goupix",
+		de: "Vulpix"
 	},
 
 	stage: "Stage1",
@@ -37,12 +38,12 @@ const card: Card = {
 			name: {
 				en: "Mislead",
 				fr: "Tromperie",
-				de: "Mislead"
+				de: "Irreführen"
 			},
 			effect: {
 				en: "Flip 2 coins. If either of them is heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez 2 pièces. Si vous obtenez au moins une face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Flip 2 coins. If either of them is heads, the Defending Pokémon is now Confused."
+				de: "Wirf 2 Münzen. Falls mindestens eine von ihnen „Kopf“ zeigt, ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 
 		},
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Ethereal Flame",
 				fr: "Flamme éthérée",
-				de: "Ethereal Flame"
+				de: "Ätherflamme"
 			},
 			effect: {
 				en: "Discard all Fire Energy cards attached to Ninetales. This attack does 30 damage plus 20 more damage for each card discarded this way.",
 				fr: "Défaussez-vous de toutes les cartes Énergie  attachées à Feunard. Cette carte inflige 30 dégâts plus 20 dégâts supplémentaires pour chaque carte défaussée de cette manière.",
-				de: "Discard all  Energy cards attached to Ninetales. This attack does 30 damage plus 20 more damage for each card discarded this way."
+				de: "Lege alle an Vulnona angelegten {R}-Energiekarten auf deinen Ablagestapel. Dieser Angriff fügt 30 Schadenspunkte plus 20 weitere Schadenspunkte für jede auf diese Weise abgeworfene Karte zu."
 			},
 			damage: "20+",
 

--- a/data/E-Card/Expedition Base Set/59.ts
+++ b/data/E-Card/Expedition Base Set/59.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pidgeotto",
-		fr: "Roucoups"
+		fr: "Roucoups",
+		de: "Tauboga"
 	},
 
 	stage: "Stage2",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), if Pidgeot is your Active Pokémon, you may shuffle 1 of your Benched Pokémon and all cards attached to it into your deck. This power can't be used if Pidgeot is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), si Roucarnage est votre Pokémon Actif, vous pouvez mélanger un des Pokémon de votre Banc et toutes les cartes qui lui sont attachées à votre deck. Ce pouvoir ne peut être utilisé si Roucarnage est affecté par un État spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, falls auboss dein Aktives Pokémon ist, 1 der Pokémon auf der Bank und alle daran angelegten Karten in dein Deck mischen. Diese Fähigkeit kann nicht verwendet werden, falls Tauboss von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, falls Tauboss dein Aktives Pokémon ist, 1 der Pokémon auf deiner Bank und alle daran angelegten Karten in dein Deck mischen. Diese Fähigkeit kann nicht verwendet werden, falls Tauboss von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -59,7 +60,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 30 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts plus 30 dégâts supplémentaires.",
-				de: "Wirf eine Münze. Bei 'Kopf' fügt dieser Angriff 20 Schadenspunkte plus 30 weitere Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 30 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 

--- a/data/E-Card/Expedition Base Set/6.ts
+++ b/data/E-Card/Expedition Base Set/6.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Charmeleon",
-		fr: "Reptincel"
+		fr: "Reptincel",
+		de: "Glutexo"
 	},
 
 	stage: "Stage2",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Burning Energy",
 				fr: "Énergie brûlante",
-				de: "Burning Energy"
+				de: "Energieverbrennung"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may turn all basic Energy attached to all of your Pokémon into Fire Energy for the rest of the turn. This power can't be used if Charizard is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez changer toutes les Énergies de base attachées à tous vos Pokémon en Énergie  pour le reste du tour. Ce pouvoir ne peut pas être utilisé si Dracaufeu est affecté par un État spécial.",
-				de: "Once during your turn (before your attack), you may turn all basic Energy attached to all of your Pokémonn into  Energy for the rest of the turn. This power can´t be used if Charizard is affected by a Special Condition"
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du alle Basis-Energie, die an alle deine Pokémon angelegt ist, bis zum Ende des Zuges in {R}-Energie umwandeln. Diese Fähigkeit kann nicht verwendet werden, falls Glurak von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Scorching Whirlwind",
 				fr: "Tourbillon brûlant",
-				de: "Scorching Whirlwind"
+				de: "Sengender Wirbelwind"
 			},
 			effect: {
 				en: "Flip 2 coins. If 1 of them is tails, discard 2 Energy cards attached to Charizard. If both are tails, discard all Energy cards attached to Charizard.",
 				fr: "Lancez 2 pièces. Si vous obtenez 1 pile, défaussez-vous de 2 cartes Énergie attachées à Dracaufeu. Si vous obtenez 2 piles, défaussez-vous de toutes les cartes Énergie attachées à Dracaufeu.",
-				de: "Flip 2 coins. If 1 of them is tails, discard 2Energy cards attached to Charizard. If both are tails, discard all Energy cards attached to Charizard."
+				de: "Wirf 2 Münzen. Falls 1 davon „Zahl“ zeigt, lege 2 an Glurak angelegte Energiekarten auf deinen Ablagestapel. Falls beide „Zahl“ zeigen, lege alle an Glurak angelegten Energiekarten auf deinen Ablagestapel."
 			},
 			damage: 120,
 

--- a/data/E-Card/Expedition Base Set/60.ts
+++ b/data/E-Card/Expedition Base Set/60.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Poliwhirl",
-		fr: "Têtarte"
+		fr: "Têtarte",
+		de: "Quaputzi"
 	},
 
 	stage: "Stage2",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Plunge",
 				fr: "Plongeon",
-				de: "Plunge"
+				de: "Untertauchen"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), if Poliwrath is on your Bench, you may flip a coin. If heads, take all Energy cards attached to your Active Pokémon, if any, and attach them to Poliwrath. Then switch Poliwrath with your Active Pokémon.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), si Tartard est sur votre Banc, vous pouvez lancer une pièce. Si c'est face, prenez toutes les cartes Énergie attachées à votre Pokémon Actif, s'il en possède, et attachez-les à Tartard. Échangez ensuite Tartard contre votre Pokémon Actif.",
-				de: "Once during your turn (before your attack), if Poliwrath is on your Bench, you may flip a coin. If heads, take all Energy cards attached to your Active Pokémon, if any, and attach them to Poliwrath. Then switch Poliwrath with your Active Pokémon."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, falls Quappo auf deiner Bank ist, eine Münze werfen. Nimm bei „Kopf“ alle an dein Aktives Pokémon angelegte Energiekarten, falls vorhanden, und lege sie an Quappo an. Tausche dann Quappo mit deinem aktiven Pokémon."
 			},
 		},
 	],
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Water Punch",
 				fr: "Poing d'O",
-				de: "Water Punch"
+				de: "Wasserhieb"
 			},
 			effect: {
 				en: "Flip a number of coins equal to the amount of Water Energy attached to Poliwrath. This attack does 40 damage plus 10 more damage for each heads.",
 				fr: "Lancez un nombre de pièces équivalent au nombre d'Énergie  attachées à Tartard. Cette attaque inflige 40 dégâts plus 10 dégâts supplémentaires pour chaque face.",
-				de: "Flip a number of coins equal to the amount of  Energy attached to Poliwrath. This attack does 40 damage plus 10 more damage for each heads."
+				de: "Wirf so viele Münzen, wie {W}-Energie an Quappo angelegt ist. Dieser Angriff fügt 40 Schadenspunkte plus 10 weitere Schadenspunkte pro geworfenem „Kopf“ zu."
 			},
 			damage: "40+",
 

--- a/data/E-Card/Expedition Base Set/61.ts
+++ b/data/E-Card/Expedition Base Set/61.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pikachu",
-		fr: "Pikachu"
+		fr: "Pikachu",
+		de: "Pikachu"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "If there are any Lightning Energy cards in your discard pile, flip a coin. If heads, attach 1 of them to Raichu.",
 				fr: "Si vous avez des cartes Énergie  dans votre pile de défausse, lancez une pièce. Si c'est face, attachez l'une d'elles à Raichu.",
-				de: "Wenn mindestens eine -Energiekarte in deinem Ablagestapel ist, wirf eine Münze. Lege bei 'Kopf' 1 davon an Raichu an."
+				de: "Wenn mindestens eine {L}-Energiekarte in deinem Ablagestapel ist, wirf eine Münze. Lege bei „Kopf“ 1 davon an Raichu an."
 			},
 			damage: 10,
 
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Discard all Lightning Energy cards attached to Raichu or this attack does nothing.",
 				fr: "Défaussez-vous de toutes les cartes Énergie  attachées à Raichu ou cette attaque ne fait rien.",
-				de: "Lege alle an Raichu angelegten -Energiekarten auf deinen Ablagestapel, oder dieser Angriff hat keine Auswirkung."
+				de: "Lege alle an Raichu angelegten {L}-Energiekarten auf deinen Ablagestapel, oder dieser Angriff hat keine Auswirkungen."
 			},
 			damage: 60,
 

--- a/data/E-Card/Expedition Base Set/62.ts
+++ b/data/E-Card/Expedition Base Set/62.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Ponyta",
-		fr: "Ponyta"
+		fr: "Ponyta",
+		de: "Ponita"
 	},
 
 	stage: "Stage1",
@@ -42,7 +43,7 @@ const card: Card = {
 			effect: {
 				en: "If your opponent has any Benched Pokémon, flip a coin. If heads, choose 1 of them and this attack does 10 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Si votre adversaire a des Pokémon sur son Banc, lancez une pièce. Si c'est face, choisissez-en un et cette attaque lui inflige 10 dégâts. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon du Banc.)",
-				de: "Falls dein Gegner mindestens ein Pokémon auf der Bank hat, wirf eine Münze. Wähle bei \"Kopf\" 1 von diesen, und dieser Angriff fügt diesem Pokémon 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Falls dein Gegner mindestens ein Pokémon auf der Bank hat, wirf eine Münze. Wähle bei „Kopf“ 1 von diesen und dieser Angriff fügt diesem Pokémon 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 20,
 

--- a/data/E-Card/Expedition Base Set/63.ts
+++ b/data/E-Card/Expedition Base Set/63.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires.",
-				de: "Wirf eine Münze. Bei 'Kopf' fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -58,7 +58,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
-				de: "Wirf eine Münze. Bei 'Zahl' hat dieser Angriff keine Auswirkungen."
+				de: "Wirf eine Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 
 			damage: 50,

--- a/data/E-Card/Expedition Base Set/64.ts
+++ b/data/E-Card/Expedition Base Set/64.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Quilava",
-		fr: "Feurisson"
+		fr: "Feurisson",
+		de: "Igelavar"
 	},
 
 	stage: "Stage2",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires.",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Benched Pokémon, if any. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts à chaque Pokémon du Banc de votre adversaire, s'il en possède. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon du Banc.)",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff jedem Pokémon auf der gegnerischen Bank 10 Schadenspunkte zu, falls vorhanden. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff jedem Pokémon auf der gegnerischen Bank 10 Schadenspunkte zu, falls vorhanden. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 40,
 

--- a/data/E-Card/Expedition Base Set/65.ts
+++ b/data/E-Card/Expedition Base Set/65.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Quilava",
-		fr: "Feurisson"
+		fr: "Feurisson",
+		de: "Igelavar"
 	},
 
 	stage: "Stage2",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may count the total number of Energy cards attached to all of your Pokémon and all of your opponent's Pokémon. If your opponent has more total Energy cards attached, you may search your deck for 1 Fire Energy card and attach it to 1 of your Benched Pokémon, if any. Shuffle your deck afterward. This power can't be used if Typhlosion is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez compter le nombre total de cartes Énergie attachées à tous vos Pokémon et à tous ceux de votre adversaire. Si au total, votre adversaire a plus de cartes Énergie attachées que vous, vous pouvez chercher dans votre deck 1 carte Énergie  et l'attacher à l'un des Pokémon de votre Banc, si vous en possédez. Mélangez ensuite votre deck. Ce pouvoir ne peut pas être utilisé si Typhlosion est affecté par un État spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du zählen, wie viele Energiekarten an alle deine Pokémon angelegt sind und wie viele an alle Pokémon deines Gegners. Wenn an die Pokémon deines Gegners mehr Energiekarten angelegt sind, kannst du dein Deck nach 1 -Energiekarte durchsuchen und diese, falls du Pokémon auf deiner Bank hast, an 1 dieser Pokémon anlegen. Mische dein Deck danach. Diese Fähigkeit kann nicht verwendet werden, falls Tornupto von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du zählen, wie viele Energiekarten insgesamt an alle deine Pokémon angelegt sind und wie viele an alle Pokémon deines Gegners. Wenn an die Pokémon deines Gegners mehr Energiekarten angelegt sind, kannst du dein Deck nach 1 {R}-Energiekarte durchsuchen und diese, falls du Pokémon auf deiner Bank hast, an 1 dieser Pokémon anlegen. Mische dein Deck danach. Diese Fähigkeit kann nicht verwendet werden, falls Tornupto von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Burned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Brûlé.",
-				de: "Wirf eine Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt verbrannt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verbrannt."
 			},
 			damage: 50,
 

--- a/data/E-Card/Expedition Base Set/66.ts
+++ b/data/E-Card/Expedition Base Set/66.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pupitar",
-		fr: "Ymphect"
+		fr: "Ymphect",
+		de: "Pupitar"
 	},
 
 	stage: "Stage2",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "All Energy attached to Tyranitar is Darkness Energy instead of its usual type.",
 				fr: "Toutes les cartes Énergie attachées à Tyranocif sont d'Énergie  au lieu de leur type habituel.",
-				de: "Alle Energie, die an Despotar angelegt ist, ist anstatt ihrem normalen Typ -Energie."
+				de: "Alle Energie, die an Despotar angelegt ist, ist anstatt ihrem normalen Typ {D}-Energie."
 			},
 		},
 	],
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 50 damage plus 10 more damage and does 10 damage to each of your opponent's Benched Pokémon, if any. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 50 dégâts plus 10 dégâts supplémentaires et inflige 10 dégâts à chaque Pokémon du Banc de votre adversaire, s'il en possède. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon du Banc.)",
-				de: "Wirf eine Münze. Bei 'Kopf' fügt dieser Angriff 50 Schadenspunkte plus 10 weitere Schadenspunkte zu und außerdem jedem Pokémon auf der Bank deines Gegners 10 Schadenspunkte, falls vorhanden. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 50 Schadenspunkte plus 10 weitere Schadenspunkte zu und außerdem jedem Pokémon auf der Bank deines Gegners 10 Schadenspunkte, falls vorhanden. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: "50+",
 

--- a/data/E-Card/Expedition Base Set/67.ts
+++ b/data/E-Card/Expedition Base Set/67.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Ivysaur",
-		fr: "Herbizarre"
+		fr: "Herbizarre",
+		de: "Bisaknosp"
 	},
 
 	stage: "Stage2",
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 30 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl 'Kopf' zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "30×",
 

--- a/data/E-Card/Expedition Base Set/68.ts
+++ b/data/E-Card/Expedition Base Set/68.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Ivysaur",
-		fr: "Herbizarre"
+		fr: "Herbizarre",
+		de: "Bisaknosp"
 	},
 
 	stage: "Stage2",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), if you attach an Energy card to your Active Pokémon as part of your turn, you may attach an additional Energy card to that Pokémon at the same time. This power can't be used if Venusaur is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), si vous attachez une carte Énergie de votre main à votre Pokémon Actif en tant qu'action de votre tour, vous pouvez attacher une carte Énergie supplémentaire à ce Pokémon. Ce pouvoir ne peut pas être utilisé si Florizarre est affecté par un État spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff)kannst du, falls du als Bestandteil deines Zuges eine Energiekarte an dein Aktives Pokémon gelegt hast, gleichzeitig eine zusätzliche Energiekarte an dieses Pokémon anlegen. Diese Fähigkeit kann nicht verwendet werden, falls Bisaflor von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, falls du als Bestandteil deines Zuges eine Energiekarte aus deiner Hand an dein Aktives Pokémon angelegt hast, gleichzeitig eine zusätzliche Energiekarte an dieses Pokémon anlegen. Diese Fähigkeit kann nicht verwendet werden, falls Bisaflor von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 40,
 

--- a/data/E-Card/Expedition Base Set/69.ts
+++ b/data/E-Card/Expedition Base Set/69.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Gloom",
-		fr: "Ortide"
+		fr: "Ortide",
+		de: "Duflor"
 	},
 
 	stage: "Stage2",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may flip a coin. If heads, the Defending Pokémon is now Poisoned. This power can't be used if Vileplume is affected by a Special Condition.",
 				fr: "Une fois pendant votre tour (avant votre attaque), vous pouvez lancer une pièce. Si c'est face, le Pokémon Défenseur est maintenant Empoisonné. Ce pouvoir ne peut pas être utilisé si Raflésia est affecté par un État spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du eine Münze werfen. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt vergiftet. Diese Fähigkeit kann nicht verwendet werden, falls Giflor von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du eine Münze werfen. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet. Diese Fähigkeit kann nicht verwendet werden, falls Giflor von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -58,7 +59,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 30 damage times the number of heads. Vileplume is now Confused.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de faces. Raflésia est maintenant Confus.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl \"Kopf\" zu. Giflor ist jetzt verwirrt."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu. Giflor ist jetzt verwirrt."
 			},
 			damage: "30×",
 

--- a/data/E-Card/Expedition Base Set/7.ts
+++ b/data/E-Card/Expedition Base Set/7.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Clefairy",
-		fr: "Mélofée"
+		fr: "Mélofée",
+		de: "Piepi"
 	},
 
 	stage: "Stage1",
@@ -58,7 +59,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 20 times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 

--- a/data/E-Card/Expedition Base Set/70.ts
+++ b/data/E-Card/Expedition Base Set/70.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Koffing",
-		fr: "Smogo"
+		fr: "Smogo",
+		de: "Smogon"
 	},
 
 	stage: "Stage1",
@@ -37,12 +38,12 @@ const card: Card = {
 			name: {
 				en: "Foul Gas",
 				fr: "Gaz infect",
-				de: "Foul Gas"
+				de: "Fäulnisgas"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned. If tails, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Empoisonné. Si c'est pile, le Pokémon Défenseur est maintenant Confus.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Poisoned. If tails, the Defending Pokémon is now Confused."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet. Bei „Zahl“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 
 		},
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Misfire",
 				fr: "Raté",
-				de: "Misfire"
+				de: "Fehlschuss"
 			},
 			effect: {
 				en: "Flip a coin. If tails, put 6 damage counters on Weezing.",
 				fr: "Lancez une pièce. Si c'est face, placez 6 marqueurs de dégâts sur Smogogo.",
-				de: "Flip a coin. If tails, put 6 damage counters on Weezing."
+				de: "Wirf eine Münze. Lege bei „Zahl“ 6 Schadensmarken auf Smogmog."
 			},
 			damage: 60,
 

--- a/data/E-Card/Expedition Base Set/71.ts
+++ b/data/E-Card/Expedition Base Set/71.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Chikorita",
-		fr: "Germignon"
+		fr: "Germignon",
+		de: "Endivie"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt verwirrt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 
 		},

--- a/data/E-Card/Expedition Base Set/72.ts
+++ b/data/E-Card/Expedition Base Set/72.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, remove 2 damage counters from 1 of your Pokémon (1 if it has only 1).",
 				fr: "Lancez une pièce. Si c'est face, retirez 2 marqueurs de dégâts d'un de vos Pokémon (1 seul s'il n'en a qu'un).",
-				de: "Wirf eine Münze. Entferne bei 'Kopf' 2 Schadensmarken von 1 deiner Pokémon (1, wenn es nur 1 hat)."
+				de: "Wirf eine Münze. Entferne bei „Kopf“ 2 Schadensmarken von 1 deiner Pokémon (1, wenn es nur 1 hat)."
 			},
 
 		},
@@ -57,7 +57,7 @@ const card: Card = {
 			effect: {
 				en: "Count the number of Pokémon on your Bench. This attack does 10 times that number of damage to the Defending Pokémon, and Chansey does 10 times that number of damage to itself.",
 				fr: "Comptez le nombre de Pokémon sur votre Banc. Cette attaque inflige 10 fois ce nombre de dégâts au Pokémon Défenseur, et Leveinard s'inflige 10 fois ce nombre de dégâts.",
-				de: "Zähle die Anzahl der Pokémon auf deiner Bank. Dieser Angriff fügt 10mal diese Zahl dem Verteidigenden Pokémon an Schaden zu, und Chaneira fügt sich selber 10mal diese Zahl an Schaden zu."
+				de: "Zähle die Anzahl der Pokémon auf deiner Bank. Dieser Angriff fügt 10mal diese Zahl dem verteidigenden Pokémon an Schaden zu, und Chaneira fügt sich selber 10mal diese Zahl an Schaden zu."
 			},
 
 			damage: "10×",

--- a/data/E-Card/Expedition Base Set/73.ts
+++ b/data/E-Card/Expedition Base Set/73.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Charmander",
-		fr: "Salamèche"
+		fr: "Salamèche",
+		de: "Glumanda"
 	},
 
 	stage: "Stage1",
@@ -42,7 +43,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Discard 1 Fire Energy card attached to Charmeleon.",
 				fr: "Défaussez-vous d'une carte Énergie  attachée à Reptincel.",
-				de: "Lege 1 an Glutexo angelegte -Energiekarte auf deinen Ablagestapel."
+				de: "Lege 1 an Glutexo angelegte {R}-Energiekarte auf deinen Ablagestapel."
 			},
 			damage: 50,
 

--- a/data/E-Card/Expedition Base Set/74.ts
+++ b/data/E-Card/Expedition Base Set/74.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Totodile",
-		fr: "Kaiminus"
+		fr: "Kaiminus",
+		de: "Karnimani"
 	},
 
 	stage: "Stage1",

--- a/data/E-Card/Expedition Base Set/75.ts
+++ b/data/E-Card/Expedition Base Set/75.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Dratini",
-		fr: "Minidraco"
+		fr: "Minidraco",
+		de: "Dratini"
 	},
 
 	stage: "Stage1",
@@ -48,7 +49,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin until you get tails. This attack does 20 damage times the number of heads.",
 				fr: "Lancez une pièce jusqu'à obtenir pile. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf eine Münze, bis du das erste Mal \"Zahl\" wirfst. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf eine Münze, bis du das erste Mal „Zahl“ wirfst. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 

--- a/data/E-Card/Expedition Base Set/76.ts
+++ b/data/E-Card/Expedition Base Set/76.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Search your deck for a basic Energy card and attach it to Electabuzz. Shuffle your deck afterward.",
 				fr: "Vous pouvez chercher une carte Énergie de base et l'attacher à Élektek. Mélangez ensuite votre deck.",
-				de: "Du kannst dein Deck nach einer Basis-Energiekarte durchsuchen und an Elektek anlegen. Mische dein Deck danach."
+				de: "Du kannst dein Deck nach einer Basis-Energiekarte durchsuchen und sie an Elektek anlegen. Mische dein Deck danach."
 			},
 
 		},

--- a/data/E-Card/Expedition Base Set/77.ts
+++ b/data/E-Card/Expedition Base Set/77.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Mareep",
-		fr: "Wattouat"
+		fr: "Wattouat",
+		de: "Voltilamm"
 	},
 
 	stage: "Stage1",
@@ -57,7 +58,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, Flaaffy does 20 damage to itself.",
 				fr: "Lancez une pièce. Si c'est pile, Lainergie s'inflige 20 dégâts.",
-				de: "Wirf eine Münze. Bei 'Zahl' fügt sich Waaty selber 20 Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Zahl“ fügt sich Waaty selber 20 Schadenspunkte zu."
 			},
 			damage: 50,
 

--- a/data/E-Card/Expedition Base Set/78.ts
+++ b/data/E-Card/Expedition Base Set/78.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Oddish",
-		fr: "Mystherbe"
+		fr: "Mystherbe",
+		de: "Myrapla"
 	},
 
 	stage: "Stage1",

--- a/data/E-Card/Expedition Base Set/79.ts
+++ b/data/E-Card/Expedition Base Set/79.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Geodude",
-		fr: "Racaillou"
+		fr: "Racaillou",
+		de: "Kleinstein"
 	},
 
 	stage: "Stage1",

--- a/data/E-Card/Expedition Base Set/8.ts
+++ b/data/E-Card/Expedition Base Set/8.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Shellder",
-		fr: "Kokiyas"
+		fr: "Kokiyas",
+		de: "Muschas"
 	},
 
 	stage: "Stage1",
@@ -42,7 +43,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 4 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 4 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 4 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl 'Kopf' zu."
+				de: "Wirf 4 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 

--- a/data/E-Card/Expedition Base Set/80.ts
+++ b/data/E-Card/Expedition Base Set/80.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Gastly",
-		fr: "Fantominus"
+		fr: "Fantominus",
+		de: "Nebulak"
 	},
 
 	stage: "Stage1",
@@ -37,12 +38,12 @@ const card: Card = {
 			name: {
 				en: "Nightmare",
 				fr: "Cauchemar",
-				de: "Nightmare"
+				de: "Nachtmahr"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
-				de: "The Defending Pokémon is now Asleep."
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 			damage: 20,
 
@@ -56,13 +57,13 @@ const card: Card = {
 			name: {
 				en: "Dream Eater",
 				fr: "Dévorêve",
-				de: "Dream Eater"
+				de: "Traumfresser"
 			},
 
 			effect: {
 				en: "If the Defending Pokémon isn't Asleep, this attack does nothing.",
 				fr: "Si le Pokémon Défenseur n'est pas Endormi, cette attaque ne fait rien.",
-				de: "If the Defending Pokémon isn't Asleep, this attack does nothing."
+				de: "Falls das Verteidigende Pokémon nicht schläft, hat dieser Angriff keine Auswirkungen."
 			},
 
 			damage: 50,

--- a/data/E-Card/Expedition Base Set/81.ts
+++ b/data/E-Card/Expedition Base Set/81.ts
@@ -31,7 +31,7 @@ const card: Card = {
 			name: {
 				en: "Smash Kick",
 				fr: "Coud'pattes",
-				de: "Smash Kick"
+				de: "Schmetterkick"
 			},
 
 			damage: 10,
@@ -46,12 +46,12 @@ const card: Card = {
 			name: {
 				en: "Stretch Kick",
 				fr: "Allonge",
-				de: "Stretch Kick"
+				de: "Streckkick"
 			},
 			effect: {
 				en: "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 30 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Si votre adversaire a des Pokémon sur son Banc, choisissez l'un d'eux et cette attaque lui inflige 30 dégâts. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon du Banc.)",
-				de: "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 30 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Falls dein Gegner mindestens ein Pokémon auf der Bank hat, wähle 1 von diesen, und dieser Angriff fügt ihm 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			}
 
 		},

--- a/data/E-Card/Expedition Base Set/82.ts
+++ b/data/E-Card/Expedition Base Set/82.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Bulbasaur",
-		fr: "Bulbizarre"
+		fr: "Bulbizarre",
+		de: "Bisasam"
 	},
 
 	stage: "Stage1",

--- a/data/E-Card/Expedition Base Set/83.ts
+++ b/data/E-Card/Expedition Base Set/83.ts
@@ -32,12 +32,12 @@ const card: Card = {
 			name: {
 				en: "Ice Punch",
 				fr: "Poinglace",
-				de: "Ice Punch"
+				de: "Eishieb"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 
@@ -51,12 +51,12 @@ const card: Card = {
 			name: {
 				en: "Powder Snow",
 				fr: "Poudreuse",
-				de: "Powder Snow"
+				de: "Pulverschnee"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
-				de: "The Defending Pokémon is now Asleep."
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 			damage: 20,
 

--- a/data/E-Card/Expedition Base Set/84.ts
+++ b/data/E-Card/Expedition Base Set/84.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Abra",
-		fr: "Abra"
+		fr: "Abra",
+		de: "Abra"
 	},
 
 	stage: "Stage1",
@@ -58,7 +59,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt verwirrt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: 20,
 

--- a/data/E-Card/Expedition Base Set/85.ts
+++ b/data/E-Card/Expedition Base Set/85.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Machop",
-		fr: "Machoc"
+		fr: "Machoc",
+		de: "Machollo"
 	},
 
 	stage: "Stage1",

--- a/data/E-Card/Expedition Base Set/86.ts
+++ b/data/E-Card/Expedition Base Set/86.ts
@@ -32,12 +32,12 @@ const card: Card = {
 			name: {
 				en: "Flaming Punch",
 				fr: "Poing de flammes",
-				de: "Flaming Punch"
+				de: "Flammender Hieb"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Burned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Brûlé.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Burned."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verbrannt."
 			},
 			damage: 10,
 
@@ -51,12 +51,12 @@ const card: Card = {
 			name: {
 				en: "Thrash",
 				fr: "Mania",
-				de: "Thrash"
+				de: "Fuchtler"
 			},
 			effect: {
 				en: "Flip a coin. If heads this attack does 30 damage plus 10 more damage. If tails, Magmar does 10 damage to itself.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts plus 10 dégâts supplémentaires. Si c'est pile, Magmar s'inflige 10 dégâts.",
-				de: "Flip a coin. If heads, this attack does 30 damage plus 10 more damage. If tails, Magmar does 10 damage to itself."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 30 Schadenspunkte plus 10 weitere Schadenspunkte zu. Bei „Zahl“ fügt sich Magmar selber 10 Schadenspunkte zu."
 			},
 			damage: "30+",
 

--- a/data/E-Card/Expedition Base Set/87.ts
+++ b/data/E-Card/Expedition Base Set/87.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Caterpie",
-		fr: "Chenipan"
+		fr: "Chenipan",
+		de: "Raupy"
 	},
 
 	stage: "Stage1",

--- a/data/E-Card/Expedition Base Set/88.ts
+++ b/data/E-Card/Expedition Base Set/88.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pidgey",
-		fr: "Roucool"
+		fr: "Roucool",
+		de: "Taubsi"
 	},
 
 	stage: "Stage1",

--- a/data/E-Card/Expedition Base Set/89.ts
+++ b/data/E-Card/Expedition Base Set/89.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Poliwag",
-		fr: "Ptitard"
+		fr: "Ptitard",
+		de: "Quapsel"
 	},
 
 	stage: "Stage1",
@@ -57,7 +58,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei 'Kopf'ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 30,
 

--- a/data/E-Card/Expedition Base Set/9.ts
+++ b/data/E-Card/Expedition Base Set/9.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Dragonair",
-		fr: "Draco"
+		fr: "Draco",
+		de: "Dragonir"
 	},
 
 	stage: "Stage2",
@@ -59,7 +60,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 40 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque fait 40 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "40×",
 

--- a/data/E-Card/Expedition Base Set/90.ts
+++ b/data/E-Card/Expedition Base Set/90.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Larvitar",
-		fr: "Embrylex"
+		fr: "Embrylex",
+		de: "Larvitar"
 	},
 
 	stage: "Stage1",

--- a/data/E-Card/Expedition Base Set/91.ts
+++ b/data/E-Card/Expedition Base Set/91.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Cyndaquil",
-		fr: "Héricendre"
+		fr: "Héricendre",
+		de: "Feurigel"
 	},
 
 	stage: "Stage1",
@@ -42,7 +43,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Burned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Brûlé.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt verbrannt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verbrannt."
 			},
 			damage: 20,
 

--- a/data/E-Card/Expedition Base Set/92.ts
+++ b/data/E-Card/Expedition Base Set/92.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Squirtle",
-		fr: "Carapuce"
+		fr: "Carapuce",
+		de: "Schiggy"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl 'Kopf' zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10×",
 

--- a/data/E-Card/Expedition Base Set/93.ts
+++ b/data/E-Card/Expedition Base Set/93.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt verwirrt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 
 		},

--- a/data/E-Card/Expedition Base Set/94.ts
+++ b/data/E-Card/Expedition Base Set/94.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Empoisonné.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt vergiftet."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet."
 			},
 
 			damage: 10,

--- a/data/E-Card/Expedition Base Set/96.ts
+++ b/data/E-Card/Expedition Base Set/96.ts
@@ -50,7 +50,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 

--- a/data/E-Card/Expedition Base Set/97.ts
+++ b/data/E-Card/Expedition Base Set/97.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10×",
 

--- a/data/E-Card/Expedition Base Set/98.ts
+++ b/data/E-Card/Expedition Base Set/98.ts
@@ -45,12 +45,12 @@ const card: Card = {
 			name: {
 				en: "Searing Flame",
 				fr: "Flammes ardentes",
-				de: "Sengende Flammen"
+				de: "Sengende Flamme"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Burned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Brûlé.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt verbrannt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verbrannt."
 			},
 			damage: 10,
 

--- a/data/E-Card/Expedition Base Set/99.ts
+++ b/data/E-Card/Expedition Base Set/99.ts
@@ -53,7 +53,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 


### PR DESCRIPTION
## Add missing German translations for ecard1

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
