### PR TITLE
Add missing German translations for pl4

### DIFF
--- a/data/Platinum/Arceus/1.ts
+++ b/data/Platinum/Arceus/1.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Charmeleon"
+		en: "Charmeleon",
+		de: "Glutexo"
 	},
 
 	stage: "Stage2",
@@ -35,7 +36,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Each of Charizard's attacks does 10 more damage for each Fire Pokémon on your Bench to your opponent's Active Pokémon (before applying Weakness and Resistance).",
-				de: "Jeder Angriff von Glurak fügt den Aktiven Pokémon deines Gegners für jedes -Pokémon auf deiner Bank 10 zusätzliche Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
+				de: "Jeder Angriff von Glurak fügt den Aktiven Pokémon deines Gegners für jedes {R}-Pokémon auf deiner Bank 10 zusätzliche Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 			}
 		},
 	],
@@ -65,7 +66,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard a Fire Energy attached to Charizard.",
-				de: "Lege 1 -Energie, die an Glurak angelegt ist, auf deinen Ablagestapel."
+				de: "Lege 1 {R}-Energie, die an Glurak angelegt ist, auf deinen Ablagestapel."
 			},
 			damage: 80,
 

--- a/data/Platinum/Arceus/10.ts
+++ b/data/Platinum/Arceus/10.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Tangela"
+		en: "Tangela",
+		de: "Tangela"
 	},
 
 	stage: "Stage1",
@@ -80,7 +81,8 @@ const card: Card = {
 	retreat: 3,
 
 	description: {
-		en: "Its arms are made of plants that bind themselves to things. They grow back right away if cut."
+		en: "Its arms are made of plants that bind themselves to things. They grow back right away if cut.",
+		de: "Seine Arme bestehen aus Ranken, die sich an Dinge klammern und nach dem Abschneiden sofort nachwachsen."
 	},
 
 	variants: [		{

--- a/data/Platinum/Arceus/11.ts
+++ b/data/Platinum/Arceus/11.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Croagunk"
+		en: "Croagunk",
+		de: "Glibunkel"
 	},
 
 	stage: "Stage1",
@@ -53,7 +54,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "If Toxicroak has any Psychic Energy attached to it, the Defending Pokémon is now Poisoned. If Toxicroak has any Fighting Energy attached to it, this attack does 30 damage plus 30 more damage.",
-				de: "Wenn an Toxiquak mindestens 1 -Energie angelegt ist, ist das Verteidigende Pokémon jetzt vergiftet. Wenn an Toxiquak mindestens 1 -Energie angelegt ist, fügt dieser Angriff 30 Schadenspunkte plus 30 weitere Schadenspunkte zu."
+				de: "Wenn an Toxiquak mindestens 1 {P}-Energie angelegt ist, ist das Verteidigende Pokémon jetzt vergiftet. Wenn an Toxiquak mindestens 1 {F}-Energie angelegt ist, fügt dieser Angriff 30 Schadenspunkte plus 30 weitere Schadenspunkte zu."
 			},
 			damage: "30+",
 
@@ -70,7 +71,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It has a poison sac at its throat. When it croaks, the stored poison is churned for more potency."
+		en: "It has a poison sac at its throat. When it croaks, the stored poison is churned for more potency.",
+		de: "Verfügt über einen Giftsack an seiner Kehle. Quakt es, schäumt das Gift und wird so noch stärker."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/12.ts
+++ b/data/Platinum/Arceus/12.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If heads, search your discard pile for an Energy card and attach it to Zapdos G.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" durchsuche deinen Ablagestapel nach 1 Energiekarte und lege sie an Zapdos G an."
+				de: "Wirf 1 Münze. Bei „Kopf“ durchsuche deinen Ablagestapel nach 1 Energiekarte und lege sie an Zapdos G an."
 			},
 			damage: 10,
 
@@ -50,7 +50,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "You may discard all Lightning attached to Zapdos G. If you do, this attack's base damage is 80 instead of 40.",
-				de: "Du kannst alle -Energien von Zapdos G entfernen und auf deinen Ablagestapel legen. Wenn du das machst, beträgt der Grundschaden dieses Angriffs 80 Schadenspunkte anstelle von 40 Schadenspunkten."
+				de: "Du kannst alle {L}-Energien von Zapdos G entfernen und auf deinen Ablagestapel legen. Wenn du das machst, beträgt der Grundschaden dieses Angriffs 80 Schadenspunkte anstelle von 40 Schadenspunkten."
 			},
 			damage: 40,
 

--- a/data/Platinum/Arceus/13.ts
+++ b/data/Platinum/Arceus/13.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Old Amber"
+		en: "Old Amber",
+		de: "Altbernstein"
 	},
 
 	stage: "Stage1",
@@ -52,7 +53,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy card attached to the Defending Pokémon.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" lege 1 Energiekarte, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
+				de: "Wirf 1 Münze. Bei „Kopf“ lege 1 Energiekarte, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
 			},
 			damage: 30,
 
@@ -76,7 +77,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "A Pokémon that roamed the skies in the dinosaur era. Its teeth are like saw blades."
+		en: "A Pokémon that roamed the skies in the dinosaur era. Its teeth are like saw blades.",
+		de: "Dieses PKMN flog zu Zeiten der Dinosaurier am Himmel. Seine Zähne sind wie Sägeblätter."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/14.ts
+++ b/data/Platinum/Arceus/14.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Bronzor"
+		en: "Bronzor",
+		de: "Bronzel"
 	},
 
 	stage: "Stage1",
@@ -38,7 +39,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon that has any damage counters on it. This attack does 40 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				de: "Wähle 1 Pokémon deines Gegners, auf den bereits mindestens 1 Schadensmarke liegt. Dieser Angriff fügt dem gewählten Pokémon 40 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Wähle 1 Pokémon deines Gegners, auf dem bereits mindestens 1 Schadensmarke liegt. Dieser Angriff fügt dem gewählten Pokémon 40 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -78,7 +79,8 @@ const card: Card = {
 	retreat: 3,
 
 	description: {
-		en: "It brought rains by opening portals to another world. It was revered as a bringer of plentiful harvests."
+		en: "It brought rains by opening portals to another world. It was revered as a bringer of plentiful harvests.",
+		de: "Ihm wurden reiche Ernten zugeschrieben, da es durch Portale in andere Welten Regenfälle brachte."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/15.ts
+++ b/data/Platinum/Arceus/15.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Cherubi"
+		en: "Cherubi",
+		de: "Kikugi"
 	},
 
 	stage: "Stage1",
@@ -35,7 +36,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "If any of your Grass Pokémon or Fire Pokémon would be damaged by an attack, reduce that damage by 10 (after applying Weakness and Resistance).",
-				de: "Schaden, der deinen - oder -Pokémon durch Angriffe zugefügt würde, wird um 10 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
+				de: "Schaden, der deinen {G}- oder {R}-Pokémon durch Angriffe zugefügt würde, wird um 10 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			}
 		},
 	],
@@ -52,7 +53,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt verwirrt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: 30,
 
@@ -76,7 +77,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "If it senses strong sunlight, it opens its folded petals to absorb the sun's rays with its whole body."
+		en: "If it senses strong sunlight, it opens its folded petals to absorb the sun's rays with its whole body.",
+		de: "Spürt es Sonnenlicht, öffnet es seine Blütenblätter und nimmt die Energie der Sonnenstrahlen auf."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/16.ts
+++ b/data/Platinum/Arceus/16.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Haunter"
+		en: "Haunter",
+		de: "Alpollo"
 	},
 
 	stage: "Stage2",
@@ -75,7 +76,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "The leer that floats in darkness belongs to a Gengar delighting in casting curses on people."
+		en: "The leer that floats in darkness belongs to a Gengar delighting in casting curses on people.",
+		de: "Der heimtückische Blick im Dunkel gehört einem GENGAR, das sich freut, Flüche auszustoßen."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/17.ts
+++ b/data/Platinum/Arceus/17.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Haunter"
+		en: "Haunter",
+		de: "Alpollo"
 	},
 
 	stage: "Stage2",
@@ -76,7 +77,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "The leer that floats in darkness belongs to a Gengar delighting in casting curses on people."
+		en: "The leer that floats in darkness belongs to a Gengar delighting in casting curses on people.",
+		de: "Der heimtückische Blick im Dunkel gehört einem GENGAR, das sich freut, Flüche auszustoßen."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/18.ts
+++ b/data/Platinum/Arceus/18.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Snorunt"
+		en: "Snorunt",
+		de: "Schneppke"
 	},
 
 	stage: "Stage1",
@@ -55,7 +56,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff jedem Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff jedem Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 50,
 
@@ -72,7 +73,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It prevents prey from escaping by instantaneously freezing moisture in the air."
+		en: "It prevents prey from escaping by instantaneously freezing moisture in the air.",
+		de: "Es verhindert, dass Beute flieht, indem es die Feuchtigkeit in der Luft augenblicklich einfriert."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/19.ts
+++ b/data/Platinum/Arceus/19.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Graveler"
+		en: "Graveler",
+		de: "Georok"
 	},
 
 	stage: "Stage2",
@@ -52,7 +53,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard as many Fighting Energy cards as you like from your hand. The attack does 30 damage times the number of Fighting Energy cards you discarded.",
-				de: "Lege beliebig viele -Energiekarten von deiner Hand auf den Ablagestapel. Dieser Angriff fügt für jede auf dieser Weise auf den Ablagestapel gelegte -Energiekarte 30 Schadenspunkte zu."
+				de: "Lege beliebig viele {F}-Energiekarten von deiner Hand auf deinen Ablagestapel. Dieser Angriff fügt für jede auf diese Weise auf den Ablagestapel gelegte {F}-Energiekarte 30 Schadenspunkte zu."
 			},
 			damage: "30×",
 

--- a/data/Platinum/Arceus/2.ts
+++ b/data/Platinum/Arceus/2.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Snorunt"
+		en: "Snorunt",
+		de: "Schneppke"
 	},
 
 	stage: "Stage1",
@@ -35,7 +36,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Once during your turn, when you play Froslass from your hand to evolve 1 of your Pokémon, you may search your deck for any 1 card and put it into your hand. Shuffle your deck afterward.",
-				de: "Einmal während deines Zuges, wenn du Frosdedje von deiner Hand spielst, um 1 deiner Pokémon zu entwickeln, kannst du dein Deck nach 1 belibigen Karte durchsuchen und sie auf die Hand nehmen. Mische dein Deck danach."
+				de: "Einmal während deines Zuges, wenn du Frosdedje von deiner Hand spielst, um 1 deiner Pokémon zu entwickeln, kannst du dein Deck nach 1 beliebigen Karte durchsuchen und sie auf die Hand nehmen. Mische dein Deck danach."
 			}
 		},
 	],
@@ -69,7 +70,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It freezes prey by blowing its -58 degrees F breath. It is said to then secretly display its prey."
+		en: "It freezes prey by blowing its -58 degrees F breath. It is said to then secretly display its prey.",
+		de: "Friert Beute durch seinen - 50 Grad kalten Atem ein. Es soll diese Beute dann heimlich ausstellen."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/20.ts
+++ b/data/Platinum/Arceus/20.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Makuhita"
+		en: "Makuhita",
+		de: "Makuhita"
 	},
 
 	stage: "Stage1",
@@ -74,7 +75,8 @@ const card: Card = {
 	retreat: 4,
 
 	description: {
-		en: "It loves to match power with big-bodied Pokémon. It can knock a truck flying with its arm thrusts."
+		en: "It loves to match power with big-bodied Pokémon. It can knock a truck flying with its arm thrusts.",
+		de: "Es liebt das Kräftemessen mit großen PKMN. Mit seinem Armwurf kann es LKW durch die Luft werfen."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/21.ts
+++ b/data/Platinum/Arceus/21.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Buneary"
+		en: "Buneary",
+		de: "Haspiror"
 	},
 
 	stage: "Stage1",
@@ -69,7 +70,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "The ears appear to be delicate. If they are touched roughly, it kicks with its graceful legs."
+		en: "The ears appear to be delicate. If they are touched roughly, it kicks with its graceful legs.",
+		de: "Es hat sehr empfindliche Ohren. Fasst man sie zu rau an, wird es mit seinen grazilen Beinen zutreten."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/22.ts
+++ b/data/Platinum/Arceus/22.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Electrike"
+		en: "Electrike",
+		de: "Frizelbliz"
 	},
 
 	stage: "Stage1",
@@ -77,7 +78,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "It discharges electricity from its mane. It creates a thundercloud overhead to drop lightning bolts."
+		en: "It discharges electricity from its mane. It creates a thundercloud overhead to drop lightning bolts.",
+		de: "Aus seiner Mähne entlädt es Elektrizität. Es generiert eine Gewitterwolke, aus der es Blitze entlädt."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/23.ts
+++ b/data/Platinum/Arceus/23.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Omanyte"
+		en: "Omanyte",
+		de: "Amonitas"
 	},
 
 	stage: "Stage2",
@@ -38,7 +39,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Evolved Pokémon. Remove the highest Stage Evolution card from that Pokémon and have your opponent shuffle that card into his or her deck.",
-				de: "Wähle 1 Pokémon deines Gegners. Entferne die höchste Evolutionskarte vom gewählten Pokémon, dein Gegner mischt diese Karte in sein Deck zurück."
+				de: "Wähle 1 entwickeltes Pokémon deines Gegners. Entferne die höchste Evolutionskarte vom gewählten Pokémon, dein Gegner mischt diese Karte in sein Deck zurück."
 			},
 
 		},
@@ -70,7 +71,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It is thought that this Pokémon became extinct because its spiral shell grew too large."
+		en: "It is thought that this Pokémon became extinct because its spiral shell grew too large.",
+		de: "Man geht davon aus, dass das PKMN ausgestorben ist, weil seine spiralförmige Schale zu groß wurde."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/24.ts
+++ b/data/Platinum/Arceus/24.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Wingull"
+		en: "Wingull",
+		de: "Wingull"
 	},
 
 	stage: "Stage1",
@@ -56,7 +57,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin until you get tails. For each heads, discard an Energy card attached to the Defending Pokémon.",
-				de: "Wirf solange 1 Münze bis zum ersten Mal das Ergebnis \"Zahl\" kommt. Lege pro \"Kopf\" eine an das Verteidigende Pokémon angelegt Energiekarte auf den Ablagestapel deines Gegners."
+				de: "Wirf so lange 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Lege pro „Kopf“ eine an das Verteidigende Pokémon angelegte Energiekarte auf den Ablagestapel deines Gegners."
 			},
 			damage: 70,
 
@@ -80,7 +81,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It is a messenger of the skies, carrying small Pokémon and eggs to safety in its bill."
+		en: "It is a messenger of the skies, carrying small Pokémon and eggs to safety in its bill.",
+		de: "Ein Bote der Lüfte. Bringt Eier und kleine Pokémon in seinem Schnabel in Sicherheit."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/25.ts
+++ b/data/Platinum/Arceus/25.ts
@@ -68,7 +68,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "The electric sacs in its cheeks are small. If even a little electricity leaks, it becomes shocked."
+		en: "The electric sacs in its cheeks are small. If even a little electricity leaks, it becomes shocked.",
+		de: "Tritt auch nur eine geringe Menge Elektrizität aus seinen Backen aus, bekommt es einen Schlag."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/26.ts
+++ b/data/Platinum/Arceus/26.ts
@@ -31,7 +31,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Once during your turn, when you put Porygon-Z G from your hand onto your Bench, you may search your discard pile for up to 2 Pokémon Tool cards, show them to your opponent, and shuffle them into your deck.",
-				de: "Einmal während deines Zuges kannst du, wenn du Porygon-Z G von deiner Hand auf die Bank legst, deinen Ablagestapel nach bis zu 2 Pokémon-Ausrüstungs-Karten durchsuchen, sie deinem Gegner zeigen und in dein Deck mischen."
+				de: "Einmal während deines Zuges kannst du, wenn du Porygon-Z G von deiner Hand auf deine Bank legst, deinen Ablagestapel nach bis zu 2 Pokémon-Ausrüstungs-Karten durchsuchen, sie deinem Gegner zeigen und in dein Deck mischen."
 			}
 		},
 	],
@@ -49,7 +49,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 40 more damage.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 20 Schadenspunkte plus 40 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 40 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 

--- a/data/Platinum/Arceus/27.ts
+++ b/data/Platinum/Arceus/27.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Pikachu"
+		en: "Pikachu",
+		de: "Pikachu"
 	},
 
 	stage: "Stage1",
@@ -54,7 +55,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard a Lightning Energy card attached to Raichu.",
-				de: "Entferne 1 -Energiekarte, die an Raichu angelegt ist, und lege sie auf den Ablagestapel."
+				de: "Entferne 1 {L}-Energiekarte, die an Raichu angelegt ist, und lege sie auf deinen Ablagestapel."
 			},
 			damage: 70,
 
@@ -78,7 +79,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Its tail discharges electricity into the ground, protecting it from getting shocked."
+		en: "Its tail discharges electricity into the ground, protecting it from getting shocked.",
+		de: "Es entlädt Elektrizität in den Boden, um sich auf diese Weise vor elektrischen Schlägen zu schüzten."
 	},
 
 	thirdParty: {

--- a/data/Platinum/Arceus/28.ts
+++ b/data/Platinum/Arceus/28.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Ponyta"
+		en: "Ponyta",
+		de: "Ponita"
 	},
 
 	stage: "Stage1",
@@ -65,7 +66,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 50 damage plus 20 more damage.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 50 Schadenspunkte plus 20 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 50 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "50+",
 

--- a/data/Platinum/Arceus/29.ts
+++ b/data/Platinum/Arceus/29.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Rattata"
+		en: "Rattata",
+		de: "Rattfratz"
 	},
 
 	stage: "Stage1",
@@ -37,7 +38,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Look at your opponent's hand, choose a Supporter card you find there, and discard it. Then, use the effect of that card as the effect of this attack.",
-				de: "Schau dir die Handkarten deines Gegners an, wähle 1 Unterstüzerkarte, die du dort gefunden hast, und lege sie auf den Ablagestapel deines Gegners. Danach nutze den Effekt der gewählten Karte als Effekt dieses Angriffs."
+				de: "Schau dir die Handkarten deines Gegners an, wähle 1 Unterstützerkarte, die du dort gefunden hast, und lege sie auf den Ablagestapel deines Gegners. Danach nutze den Effekt der gewählten Karte als Effekt dieses Angriffs."
 			},
 
 		},
@@ -66,7 +67,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "It whittles its constantly growing fangs by gnawing on hard things. It can chew apart cinder walls."
+		en: "It whittles its constantly growing fangs by gnawing on hard things. It can chew apart cinder walls.",
+		de: "Es wetzt seine ständig wachsenden Zähne an harten Dingen. Es kann Wände aus Beton zernagen."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/3.ts
+++ b/data/Platinum/Arceus/3.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard the top 3 cards of your deck. This attack does 60 damage plus 20 more damage for each Fire or Metal Energy card you discarded.",
-				de: "Lege die obersten 3 Karten deines Decks auf deinen Ablagestapel. Dieser Angriff fügt 60 Schadenspunkte plus 20 weitere Schadenspunkte für jede auf diese Weise auf den Ablagestapel gelegte - oder -Energiekarte zu."
+				de: "Lege die obersten 3 Karten deines Decks auf deinen Ablagestapel. Dieser Angriff fügt 60 Schadenspunkte plus 20 weitere Schadenspunkte für jede auf diese Weise auf den Ablagestapel gelegte {R}- oder {M}-Energiekarte zu."
 			},
 			damage: "60+",
 
@@ -69,7 +69,8 @@ const card: Card = {
 	retreat: 3,
 
 	description: {
-		en: "Its body is made of rugged steel. However, it is partially melted in spots because of its own heat."
+		en: "Its body is made of rugged steel. However, it is partially melted in spots because of its own heat.",
+		de: "Sein Körper besteht aus Stahl, hat aber aufgrund der eigenen Temperatur geschmolzene Stellen."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/30.ts
+++ b/data/Platinum/Arceus/30.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Grovyle"
+		en: "Grovyle",
+		de: "Reptain"
 	},
 
 	stage: "Stage2",
@@ -35,7 +36,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "When you attach a Grass Energy card from your hand to Sceptile, remove 2 damage counters from Sceptile.",
-				de: "Wenn du 1 -Energiekarte von deiner Hand an Gewaldro anlegst, entferne 2 Schadensmarken von Gewaldro."
+				de: "Wenn du 1 {G}-Energiekarte von deiner Hand an Gewaldro anlegst, entferne 2 Schadensmarken von Gewaldro."
 			}
 		},
 	],
@@ -51,7 +52,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Does 20 damage times the amount of Grass Energy attached to Sceptile.",
-				de: "Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl der an Gewaldro angelegten -Energien zu."
+				de: "Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl der an Gewaldro angelegten {G}-Energien zu."
 			},
 			damage: "20×",
 

--- a/data/Platinum/Arceus/31.ts
+++ b/data/Platinum/Arceus/31.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Grovyle"
+		en: "Grovyle",
+		de: "Reptain"
 	},
 
 	stage: "Stage2",
@@ -54,7 +55,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 70 damage times the number of heads.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 70 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 70 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "70×",
 
@@ -78,7 +79,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "The leaves that grow on its arms can slice down thick trees. It is without peer in jungle combat."
+		en: "The leaves that grow on its arms can slice down thick trees. It is without peer in jungle combat.",
+		de: "Die Blätter an seinen Armen können dicke Bäume fällen. Im Dschungelkampf gibt es kein stärkeres PKMN."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/33.ts
+++ b/data/Platinum/Arceus/33.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Bronzor"
+		en: "Bronzor",
+		de: "Bronzel"
 	},
 
 	stage: "Stage1",
@@ -53,7 +54,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy card attached to the Defending Pokémon.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" lege 1 Energiekarte, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
+				de: "Wirf 1 Münze. Bei „Kopf“ lege 1 Energiekarte, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
 			},
 			damage: 50,
 
@@ -77,7 +78,8 @@ const card: Card = {
 	retreat: 3,
 
 	description: {
-		en: "It brought rains by opening portals to another world. It was revered as a bringer of plentiful harvests."
+		en: "It brought rains by opening portals to another world. It was revered as a bringer of plentiful harvests.",
+		de: "Ihm wurden reiche Ernten zugeschrieben, da es durch Portale in andere Welten Regenfälle brachte."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/34.ts
+++ b/data/Platinum/Arceus/34.ts
@@ -71,7 +71,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "There are researchers who believe this Pokémon reflected like a mirror in the distant past."
+		en: "There are researchers who believe this Pokémon reflected like a mirror in the distant past.",
+		de: "Manche Forscher glauben, dass dieses Pokémon in der Vergangenheit wie ein Spiegel reflektierte."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/35.ts
+++ b/data/Platinum/Arceus/35.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Charmander"
+		en: "Charmander",
+		de: "Glumanda"
 	},
 
 	stage: "Stage1",
@@ -38,7 +39,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 30 damage times the number of heads.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "30×",
 
@@ -69,7 +70,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "In the rocky mountains where Charmeleon live, their fiery tails shine at night like stars."
+		en: "In the rocky mountains where Charmeleon live, their fiery tails shine at night like stars.",
+		de: "GLUTEXO leben in den Bergen. Die Flammen auf ihren Schweifspitzen leuchten in der Nacht wie Sterne."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/36.ts
+++ b/data/Platinum/Arceus/36.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 
@@ -73,7 +73,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Born from gases, anyone would faint if engulfed by its gaseous body, which contains poison."
+		en: "Born from gases, anyone would faint if engulfed by its gaseous body, which contains poison.",
+		de: "Eingehüllt in seinen gasförmigen, Gift enthaltenden Körper würde jeder in Ohnmacht fallen."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/37.ts
+++ b/data/Platinum/Arceus/37.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Geodude"
+		en: "Geodude",
+		de: "Kleinstein"
 	},
 
 	stage: "Stage1",
@@ -76,7 +77,8 @@ const card: Card = {
 	retreat: 3,
 
 	description: {
-		en: "It rolls on mountain paths to move. Once it builds momentum, no Pokémon can stop it without difficulty."
+		en: "It rolls on mountain paths to move. Once it builds momentum, no Pokémon can stop it without difficulty.",
+		de: "Rollt auf Bergpfaden, um sich fortzubewegen. Hat es erst mal Schwung geholt, kann man es kaum bremsen."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/38.ts
+++ b/data/Platinum/Arceus/38.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Treecko"
+		en: "Treecko",
+		de: "Geckarbor"
 	},
 
 	stage: "Stage1",
@@ -37,7 +38,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Grovyle during your opponent's next turn.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" verhindere während des nächsten Zuges deines Gegners alle Effekte eines Angriffs, einschließlich Schaden, die Reptain zugefügt würden."
+				de: "Wirf 1 Münze. Bei „Kopf“ verhindere während des nächsten Zuges deines Gegners alle Effekte eines Angriffs, einschließlich Schaden, die Reptain zugefügt würden."
 			},
 
 		},
@@ -73,7 +74,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It lives in dense jungles. While closing in on its prey, it leaps from branch to branch."
+		en: "It lives in dense jungles. While closing in on its prey, it leaps from branch to branch.",
+		de: "Es lebt im dichten Dschungel. Es springt von Ast zu Ast, wenn es sich einer Beute nähert."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/39.ts
+++ b/data/Platinum/Arceus/39.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Treecko"
+		en: "Treecko",
+		de: "Geckarbor"
 	},
 
 	stage: "Stage1",
@@ -38,7 +39,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 10 more damage.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -76,7 +77,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It lives in dense jungles. While closing in on its prey, it leaps from branch to branch."
+		en: "It lives in dense jungles. While closing in on its prey, it leaps from branch to branch.",
+		de: "Es lebt im dichten Dschungel. Es springt von Ast zu Ast, wenn es sich einer Beute nähert."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/4.ts
+++ b/data/Platinum/Arceus/4.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Kabuto"
+		en: "Kabuto",
+		de: "Kabuto"
 	},
 
 	stage: "Stage2",
@@ -71,7 +72,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It is thought that this Pokémon came onto land because its prey adapted to life on land."
+		en: "It is thought that this Pokémon came onto land because its prey adapted to life on land.",
+		de: "Man geht davon aus, dass dieses PKMN an Land kam, weil seine Beute ebenfalls irgendwann an Land kam."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/40.ts
+++ b/data/Platinum/Arceus/40.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If heads, during your opponent's next turn, if Gulpin would be Knocked Out by damage from an attack, Gulpin is not Knocked Out and its remaining HP becomes 10 instead.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" wird Schluppuck, wenn es im nächsten Zug deines Gegners durch Schaden eines Angriffs kampfunfähig würde, nicht kampfunfähig und hat stattdessen 10 verbliebene KP."
+				de: "Wirf 1 Münze. Bei „Kopf“ wird Schluppuck, wenn es im nächsten Zug deines Gegners durch Schaden eines Angriffs kampfunfähig würde, nicht kampfunfähig und hat stattdessen 10 verbliebene KP."
 			},
 
 		},
@@ -61,7 +61,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "Almost all of its body is its stomach. Its harsh digestive juices quickly dissolve anything it swallows."
+		en: "Almost all of its body is its stomach. Its harsh digestive juices quickly dissolve anything it swallows.",
+		de: "Sein Körper besteht fast nur aus Magen. Seine starken Verdauungssäfte zersetzen alles sehr schnell."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/41.ts
+++ b/data/Platinum/Arceus/41.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Gastly"
+		en: "Gastly",
+		de: "Nebulak"
 	},
 
 	stage: "Stage1",
@@ -75,7 +76,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It likes to lurk in the dark and tap shoulders with a gaseous hand. Its touch causes endless shuddering."
+		en: "It likes to lurk in the dark and tap shoulders with a gaseous hand. Its touch causes endless shuddering.",
+		de: "Lauert in der Dunkelheit. Die Berührung seiner gasförmigen Hand erzeugt endloses Schaudern."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/42.ts
+++ b/data/Platinum/Arceus/42.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Gastly"
+		en: "Gastly",
+		de: "Nebulak"
 	},
 
 	stage: "Stage1",
@@ -74,7 +75,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It likes to lurk in the dark and tap shoulders with a gaseous hand. Its touch causes endless shuddering."
+		en: "It likes to lurk in the dark and tap shoulders with a gaseous hand. Its touch causes endless shuddering.",
+		de: "Lauert in der Dunkelheit. Die Berührung seiner gasförmigen Hand erzeugt endloses Schaudern."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/43.ts
+++ b/data/Platinum/Arceus/43.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Shinx"
+		en: "Shinx",
+		de: "Sheinux"
 	},
 
 	stage: "Stage1",
@@ -51,7 +52,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard all Lightning Energy attached to Luxio. Flip a coin for each Energy card you discarded. This attack does 40 damage times the number of heads.",
-				de: "Entferne alle -Energien von Luxio und lege sie auf deinen Ablagestapel. Wirf für jede auf diese Weise auf deinen Ablagestapel gelegte Energiekarte 1 Münze. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Entferne alle {L}-Energien von Luxio und lege sie auf deinen Ablagestapel. Wirf für jede auf diese Weise auf deinen Ablagestapel gelegte Energiekarte 1 Münze. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "40×",
 
@@ -75,7 +76,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Strong electricity courses through the tips of its sharp claws. A light scratch causes fainting in foes."
+		en: "Strong electricity courses through the tips of its sharp claws. A light scratch causes fainting in foes.",
+		de: "Durch die Spitzen seiner scharfen Krallen strömt Elektrizität. Selbst kleine Kratzer verursachen Ohnmacht."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/44.ts
+++ b/data/Platinum/Arceus/44.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Electrike"
+		en: "Electrike",
+		de: "Frizelbliz"
 	},
 
 	stage: "Stage1",
@@ -70,7 +71,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "It discharges electricity from its mane. It creates a thundercloud overhead to drop lightning bolts."
+		en: "It discharges electricity from its mane. It creates a thundercloud overhead to drop lightning bolts.",
+		de: "Aus seiner Mähne entlädt es Elektrizität. Es generiert eine Gewitterwolke, aus der es Blitze entlädt."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/45.ts
+++ b/data/Platinum/Arceus/45.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Wingull"
+		en: "Wingull",
+		de: "Wingull"
 	},
 
 	stage: "Stage1",
@@ -37,7 +38,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Does 20 damage plus 10 more damage for each Water Energy attached to Pelipper.",
-				de: "Dieser Angriff fügt 20 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Pelipper angelegte -Energie zu."
+				de: "Dieser Angriff fügt 20 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Pelipper angelegte {W}-Energie zu."
 			},
 			damage: "20+",
 
@@ -75,7 +76,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It is a messenger of the skies, carrying small Pokémon and eggs to safety in its bill."
+		en: "It is a messenger of the skies, carrying small Pokémon and eggs to safety in its bill.",
+		de: "Ein Bote der Lüfte. Bringt Eier und kleine Pokémon in seinem Schnabel in Sicherheit."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/46.ts
+++ b/data/Platinum/Arceus/46.ts
@@ -62,7 +62,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "As a newborn, it can barely stand. However, through galloping, its legs are made tougher and faster."
+		en: "As a newborn, it can barely stand. However, through galloping, its legs are made tougher and faster.",
+		de: "Neugeboren kann es kaum stehen. Durch das Galoppieren werden seine Beine aber schneller und kräftiger."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/47.ts
+++ b/data/Platinum/Arceus/47.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Ponyta"
+		en: "Ponyta",
+		de: "Ponita"
 	},
 
 	stage: "Stage1",
@@ -65,7 +66,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "When at an all-out gallop, its blazing mane sparkles, enhancing its beautiful appearance."
+		en: "When at an all-out gallop, its blazing mane sparkles, enhancing its beautiful appearance.",
+		de: "In vollem Galopp funkelt seine leuchtende Mähne, was wiederum seine Schönheit unterstreicht."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/48.ts
+++ b/data/Platinum/Arceus/48.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Bagon"
+		en: "Bagon",
+		de: "Kindwurm"
 	},
 
 	stage: "Stage1",
@@ -37,7 +38,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If heads, prevent all damage done to Shelgon during your opponent's next turn.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" verhindere allen Schaden, der Draschel im nächsten Zug deines Gegners durch Angriffe zugefügt würde."
+				de: "Wirf 1 Münze. Bei „Kopf“ verhindere allen Schaden, der Draschel im nächsten Zug deines Gegners durch Angriffe zugefügt würde."
 			},
 
 		},
@@ -53,7 +54,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "If Shelgon has any basic Fire Energy and any basic Water Energy attached to it, this attack does 40 damage plus 20 more damage.",
-				de: "Wenn mindestens 1 -Basis-Energiekarte und 1 -Basis-Energiekarte an Draschel angelegt sind, fügt dieser Angriff 40 Schadenspunkte plus 20 weitere Schadenspunkte zu."
+				de: "Wenn mindestens 1 {R}-Basis-Energiekarte und 1 {W}-Basis-Energiekarte an Draschel angelegt sind, fügt dieser Angriff 40 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "40+",
 
@@ -70,7 +71,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Within its rugged shell, its cells have begun changing. The shell peels off the instant it evolves."
+		en: "Within its rugged shell, its cells have begun changing. The shell peels off the instant it evolves.",
+		de: "Die Zellen seines Panzers fingen an, sich zu verändern. Er fällt ab, sobald sich das PKMN entwickelt."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/49.ts
+++ b/data/Platinum/Arceus/49.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Burmy Plant Cloak"
+		en: "Burmy Plant Cloak",
+		de: "Burmy Pflanzenumhang"
 	},
 
 	stage: "Stage1",
@@ -71,7 +72,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "When evolving, its body takes in surrounding materials. As a result, there are many body variations."
+		en: "When evolving, its body takes in surrounding materials. As a result, there are many body variations.",
+		de: "Es nimmt während der Entwicklung Dinge aus der Umgebung auf, daher gibt es viele Variationen von ihm."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/5.ts
+++ b/data/Platinum/Arceus/5.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Luxio"
+		en: "Luxio",
+		de: "Luxio"
 	},
 
 	stage: "Stage2",
@@ -37,7 +38,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
-				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 30,
 
@@ -54,7 +55,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "If Luxray has a Pokémon Tool card attached to it, you may do 100 damage instead of 60 to the Defending Pokémon. If you do, discard that Pokémon Tool card.",
-				de: "Wenn an Luxtra 1 Pokémon-Ausrüstung angelegt ist, kannst du diesen Angiff dem Verteidigenden Pokémon 100 Schadenspunkte anstelle von 60 Schadenspunkten zufügen lassen. Wenn du das machst, lege die Pokémon-Ausrüstung auf deinen Ablagestapel."
+				de: "Wenn an Luxtra 1 Pokémon-Ausrüstung angelegt ist, kannst du diesen Angriff dem Verteidigenden Pokémon 100 Schadenspunkte anstelle von 60 Schadenspunkten zufügen lassen. Wenn du das machst, lege die Pokémon-Ausrüstung auf deinen Ablagestapel."
 			},
 			damage: 60,
 
@@ -76,7 +77,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "It can see clearly through walls to track down its prey and seek its lost young."
+		en: "It can see clearly through walls to track down its prey and seek its lost young.",
+		de: "Es kann durch Wände sehen und spürt auf diese Weise Beute und verlorengegangene Junge auf."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/50.ts
+++ b/data/Platinum/Arceus/50.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Burmy Sandy Cloak"
+		en: "Burmy Sandy Cloak",
+		de: "Burmy Sandumhang"
 	},
 
 	stage: "Stage1",
@@ -75,7 +76,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "When evolving, its body takes in surrounding materials. As a result, there are many body variations."
+		en: "When evolving, its body takes in surrounding materials. As a result, there are many body variations.",
+		de: "Es nimmt während der Entwicklung Dinge aus der Umgebung auf, daher gibt es viele Variationen von ihm."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/51.ts
+++ b/data/Platinum/Arceus/51.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Burmy Trash Cloak"
+		en: "Burmy Trash Cloak",
+		de: "Burmy Lumpenumhang"
 	},
 
 	stage: "Stage1",
@@ -76,7 +77,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "When evolving, its body takes in surrounding materials. As a result, there are many body variations."
+		en: "When evolving, its body takes in surrounding materials. As a result, there are many body variations.",
+		de: "Es nimmt während der Entwicklung Dinge aus der Umgebung auf, daher gibt es viele Variationen von ihm."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/52.ts
+++ b/data/Platinum/Arceus/52.ts
@@ -46,7 +46,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Burned.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt verbrannt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verbrannt."
 			},
 			damage: 20,
 
@@ -63,7 +63,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Dreaming of one day flying, it practices by leaping off cliffs every day."
+		en: "Dreaming of one day flying, it practices by leaping off cliffs every day.",
+		de: "Es träumt davon, eines Tages fliegen zu können und springt daher jeden Tag von hohen Klippen."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/53.ts
+++ b/data/Platinum/Arceus/53.ts
@@ -50,7 +50,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 30 damage times the number of heads.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "30×",
 

--- a/data/Platinum/Arceus/54.ts
+++ b/data/Platinum/Arceus/54.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Asleep.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" schläft das Verteidigende Pokémon jetzt."
+				de: "Wirf 1 Münze. Bei „Kopf“ schläft das Verteidigende Pokémon jetzt."
 			},
 			damage: 10,
 
@@ -70,7 +70,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "There are researchers who believe this Pokémon reflected like a mirror in the distant past."
+		en: "There are researchers who believe this Pokémon reflected like a mirror in the distant past.",
+		de: "Manche Forscher glauben, dass dieses Pokémon in der Vergangenheit wie ein Spiegel reflektierte."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/55.ts
+++ b/data/Platinum/Arceus/55.ts
@@ -49,7 +49,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Its ears are always rolled up. They can be forcefully extended to shatter even a large boulder."
+		en: "Its ears are always rolled up. They can be forcefully extended to shatter even a large boulder.",
+		de: "Seine Ohren sind immer aufgerollt. Mit ihnen kann es selbst große Felsbrocken zertrümmern."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/56.ts
+++ b/data/Platinum/Arceus/56.ts
@@ -62,7 +62,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Even if it is born where there are no cocooning materials, it somehow always ends up with a cloak."
+		en: "Even if it is born where there are no cocooning materials, it somehow always ends up with a cloak.",
+		de: "Es erschafft sich immer irgendwie einen schützenden Umhang, selbst wenn es kaum Materialien findet."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/57.ts
+++ b/data/Platinum/Arceus/57.ts
@@ -62,7 +62,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Even if it is born where there are no cocooning materials, it somehow always ends up with a cloak."
+		en: "Even if it is born where there are no cocooning materials, it somehow always ends up with a cloak.",
+		de: "Es erschafft sich immer irgendwie einen schützenden Umhang, selbst wenn es kaum Materialien findet."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/58.ts
+++ b/data/Platinum/Arceus/58.ts
@@ -62,7 +62,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Even if it is born where there are no cocooning materials, it somehow always ends up with a cloak."
+		en: "Even if it is born where there are no cocooning materials, it somehow always ends up with a cloak.",
+		de: "Es erschafft sich immer irgendwie einen schützenden Umhang, selbst wenn es kaum Materialien findet."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/59.ts
+++ b/data/Platinum/Arceus/59.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Search your deck for a Fire Basic Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
-				de: "Durchsuche dein Deck nach 1 -Basis-Pokémon-Karte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
+				de: "Durchsuche dein Deck nach 1 {R}-Basis-Pokémon-Karte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 			},
 
 		},
@@ -62,7 +62,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "The fire on the tip of its tail is a measure of its life. If healthy, its tail burns intensely."
+		en: "The fire on the tip of its tail is a measure of its life. If healthy, its tail burns intensely.",
+		de: "Lodert die Flamme auf seinem Schweifspitz hell, ist GLUMANDA gesund."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/6.ts
+++ b/data/Platinum/Arceus/6.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Burmy"
+		en: "Burmy",
+		de: "Burmy"
 	},
 
 	stage: "Stage1",
@@ -71,7 +72,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "While it loves floral honey, it won't gather any itself. Instead, it plots to steal some from Combee."
+		en: "While it loves floral honey, it won't gather any itself. Instead, it plots to steal some from Combee.",
+		de: "Es liebt Honig, sammelt ihn aber nicht, sondern stiehlt den Honig, der von WADRIBIE gesammelt wurde."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/60.ts
+++ b/data/Platinum/Arceus/60.ts
@@ -67,7 +67,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "The small ball is not only filled with nutrients, it is also tasty. Starly try to peck it off."
+		en: "The small ball is not only filled with nutrients, it is also tasty. Starly try to peck it off.",
+		de: "Der kleine Ball ist nicht nur voller Nährstoffe, sondern auch noch schmackhaft. STARALILI pickt oft danach."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/61.ts
+++ b/data/Platinum/Arceus/61.ts
@@ -62,7 +62,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It rarely fights fairly, but that is strictly to ensure survival. It is popular as a mascot."
+		en: "It rarely fights fairly, but that is strictly to ensure survival. It is popular as a mascot.",
+		de: "Aufgrund seines starken Überlebensdrangs kämpft es selten fair. Beliebt als Maskottchen."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/62.ts
+++ b/data/Platinum/Arceus/62.ts
@@ -46,7 +46,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If tails, Electrike does 10 damage to itself.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" fügt Frizelbliz sich selbst 10 Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Zahl“ fügt Frizelbliz sich selbst 10 Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -70,7 +70,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Using electricity stored in its fur, it stimulates its muscles to heighten its reaction speed."
+		en: "Using electricity stored in its fur, it stimulates its muscles to heighten its reaction speed.",
+		de: "Die Elektrizität, die es im Fell speichert, nutzt es, um seine Muskeln zu stimulieren."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/63.ts
+++ b/data/Platinum/Arceus/63.ts
@@ -54,7 +54,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Using electricity stored in its fur, it stimulates its muscles to heighten its reaction speed."
+		en: "Using electricity stored in its fur, it stimulates its muscles to heighten its reaction speed.",
+		de: "Die Elektrizität, die es im Fell speichert, nutzt es, um seine Muskeln zu stimulieren."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/64.ts
+++ b/data/Platinum/Arceus/64.ts
@@ -67,7 +67,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Born from gases, anyone would faint if engulfed by its gaseous body, which contains poison."
+		en: "Born from gases, anyone would faint if engulfed by its gaseous body, which contains poison.",
+		de: "Eingehüllt in seinen gasförmigen, Gift enthaltenden Körper würde jeder in Ohnmacht fallen."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/65.ts
+++ b/data/Platinum/Arceus/65.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin until you get tails. This attack does 10 damage times the number of heads.",
-				de: "Wirf so lange 1 Münze, bis zum ersten Mal das Ergebnis \"Zahl\" kommt. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf so lange 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10×",
 
@@ -57,7 +57,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "At rest, it looks just like a rock. Carelessly stepping on it will make it swing its fists angrily."
+		en: "At rest, it looks just like a rock. Carelessly stepping on it will make it swing its fists angrily.",
+		de: "Ruhend sieht es fast wie ein Felsen aus. Tritt man auf KLEINSTEIN, wird es wütend mit den Fäusten wirbeln."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/66.ts
+++ b/data/Platinum/Arceus/66.ts
@@ -62,7 +62,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Almost all of its body is its stomach. Its harsh digestive juices quickly dissolve anything it swallows."
+		en: "Almost all of its body is its stomach. Its harsh digestive juices quickly dissolve anything it swallows.",
+		de: "Sein Körper besteht fast nur aus Magen. Seine starken Verdauungssäfte zersetzen alles sehr schnell."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/67.ts
+++ b/data/Platinum/Arceus/67.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Dome Fossil"
+		en: "Dome Fossil",
+		de: "Domfossil"
 	},
 
 	stage: "Stage1",
@@ -66,7 +67,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It is thought to have inhabited beaches 300 million years ago. It is protected by a stiff shell."
+		en: "It is thought to have inhabited beaches 300 million years ago. It is protected by a stiff shell.",
+		de: "Man geht davon aus, dass dieses PKMN vor 300 Millionen Jahren die Strände bevölkerte."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/68.ts
+++ b/data/Platinum/Arceus/68.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
-				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 
 		},
@@ -62,7 +62,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It toughens its body by slamming into thick trees. Many snapped trees can be found near its nest."
+		en: "It toughens its body by slamming into thick trees. Many snapped trees can be found near its nest.",
+		de: "Es stärkt seinen Körper, indem es gegen Bäume rennt. In seiner Nähe finden sich viele umgekippte Bäume."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/69.ts
+++ b/data/Platinum/Arceus/69.ts
@@ -48,7 +48,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 10 more damage.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -65,7 +65,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "When endangered, it may protect itself by raising its magnetism and drawing iron objects to its body."
+		en: "When endangered, it may protect itself by raising its magnetism and drawing iron objects to its body.",
+		de: "Es schützt sich bei Gefahr durch Gegenstände aus Eisen, die es mit erhöhtem Magnetismus an sich zieht."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/7.ts
+++ b/data/Platinum/Arceus/7.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Nosepass"
+		en: "Nosepass",
+		de: "Nasgnet"
 	},
 
 	stage: "Stage1",
@@ -69,7 +70,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 50 damage plus 30 more damage.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 50 Schadenspunkte plus 30 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 50 Schadenspunkte plus 30 weitere Schadenspunkte zu."
 			},
 			damage: "50+",
 

--- a/data/Platinum/Arceus/70.ts
+++ b/data/Platinum/Arceus/70.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Helix Fossil"
+		en: "Helix Fossil",
+		de: "Helixfossil"
 	},
 
 	stage: "Stage1",
@@ -37,7 +38,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Draw 3 cards.",
-				de: "Ziehe 3 Karten"
+				de: "Ziehe 3 Karten."
 			},
 
 		},
@@ -52,7 +53,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -69,7 +70,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "A Pokémon that was resurrected from a fossil using modern science. It swam in ancient seas."
+		en: "A Pokémon that was resurrected from a fossil using modern science. It swam in ancient seas.",
+		de: "Dieses PKMN wurde von der modernen Wissenschaft aus einem Fossil geschaffen. Es lebte im urzeitlichen Meer."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/71.ts
+++ b/data/Platinum/Arceus/71.ts
@@ -47,7 +47,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard all Lightning Energy attached to Pikachu and then choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				de: "Entferne alle -Energien von Pikachu und lege sie auf deinen Ablagestapel; wähle danach 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 40 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Entferne alle {L}-Energien von Pikachu und lege sie auf deinen Ablagestapel; wähle danach 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 40 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -70,7 +70,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It occasionally uses an electric shock to recharge a fellow Pikachu that is in a weakened state."
+		en: "It occasionally uses an electric shock to recharge a fellow Pikachu that is in a weakened state.",
+		de: "Es verwendet hin und wieder Elektrizität, um ein anderes, geschwächtes PIKACHU aufzuladen."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/72.ts
+++ b/data/Platinum/Arceus/72.ts
@@ -46,7 +46,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: 10,
 
@@ -63,7 +63,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "As a newborn, it can barely stand. However, through galloping, its legs are made tougher and faster."
+		en: "As a newborn, it can barely stand. However, through galloping, its legs are made tougher and faster.",
+		de: "Neugeboren kann es kaum stehen. Durch das Galoppieren werden seine Beine aber schneller und kräftiger."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/73.ts
+++ b/data/Platinum/Arceus/73.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 30,
 
@@ -48,7 +48,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "Cautious in the extreme, its hardy vitality lets it live in any kind of environment."
+		en: "Cautious in the extreme, its hardy vitality lets it live in any kind of environment.",
+		de: "Es strotzt vor Lebenskraft und kann in jeder Umgebung leben. Es ist extrem vorsichtig."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/74.ts
+++ b/data/Platinum/Arceus/74.ts
@@ -46,7 +46,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy card attached to the Defending Pokémon.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" lege 1 Energiekarte, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
+				de: "Wirf 1 Münze. Bei „Kopf“ lege 1 Energiekarte, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
 			},
 			damage: 20,
 
@@ -70,7 +70,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "The extension and contraction of its muscles generates electricity. It glows when in trouble."
+		en: "The extension and contraction of its muscles generates electricity. It glows when in trouble.",
+		de: "Es erzeugt Elektrizität durch das Strecken und Zusammenziehen seiner Muskeln. Bei Bedrohung glüht es."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/75.ts
+++ b/data/Platinum/Arceus/75.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 
 		},
@@ -48,7 +48,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 
@@ -65,7 +65,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It is said that several Snorunt gather under giant leaves and live together in harmony."
+		en: "It is said that several Snorunt gather under giant leaves and live together in harmony.",
+		de: "Gerüchten zufolge sammeln sich SCHNEPPKE unter riesigen Blättern und leben dort friedlich zusammen."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/76.ts
+++ b/data/Platinum/Arceus/76.ts
@@ -73,7 +73,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "The blue vines shrouding its body are covered in a growth of fine hair. It is known to be ticklish."
+		en: "The blue vines shrouding its body are covered in a growth of fine hair. It is known to be ticklish.",
+		de: "Die blauen Ranken an seinem Körper sind von feinen Haaren bedeckt. Es gilt zudem als kitzlig."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/77.ts
+++ b/data/Platinum/Arceus/77.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 30,
 
@@ -73,7 +73,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "The blue vines shrouding its body are covered in a growth of fine hair. It is known to be ticklish."
+		en: "The blue vines shrouding its body are covered in a growth of fine hair. It is known to be ticklish.",
+		de: "Die blauen Ranken an seinem Körper sind von feinen Haaren bedeckt. Es gilt zudem als kitzlig."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/78.ts
+++ b/data/Platinum/Arceus/78.ts
@@ -34,7 +34,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 10 more damage.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -58,7 +58,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "The soles of its feet are covered by countless tiny spikes, enabling it to walk on walls and ceilings."
+		en: "The soles of its feet are covered by countless tiny spikes, enabling it to walk on walls and ceilings.",
+		de: "Seine Fußsohlen sind mit kleinen Stacheln bedeckt, so dass es an Wänden und Decken Halt findet."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/79.ts
+++ b/data/Platinum/Arceus/79.ts
@@ -67,7 +67,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "The soles of its feet are covered by countless tiny spikes, enabling it to walk on walls and ceilings."
+		en: "The soles of its feet are covered by countless tiny spikes, enabling it to walk on walls and ceilings.",
+		de: "Seine Fußsohlen sind mit kleinen Stacheln bedeckt, so dass es an Wänden und Decken Halt findet."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/8.ts
+++ b/data/Platinum/Arceus/8.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Shelgon"
+		en: "Shelgon",
+		de: "Draschel"
 	},
 
 	stage: "Stage2",

--- a/data/Platinum/Arceus/80.ts
+++ b/data/Platinum/Arceus/80.ts
@@ -70,7 +70,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It soars high in the sky, riding on updrafts like a glider. It carries food tucked in its bill."
+		en: "It soars high in the sky, riding on updrafts like a glider. It carries food tucked in its bill.",
+		de: "Es nutzt Aufwinde, um hoch oben in den Lüften zu schweben. Es trägt Futter in seinem Schnabel umher."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/81.ts
+++ b/data/Platinum/Arceus/81.ts
@@ -54,7 +54,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It soars high in the sky, riding on updrafts like a glider. It carries food tucked in its bill."
+		en: "It soars high in the sky, riding on updrafts like a glider. It carries food tucked in its bill.",
+		de: "Es nutzt Aufwinde, um hoch oben in den Lüften zu schweben. Es trägt Futter in seinem Schnabel umher."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/83.ts
+++ b/data/Platinum/Arceus/83.ts
@@ -14,7 +14,7 @@ const card: Card = {
 
 	effect: {
 		en: "Attach Bench Shield to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card. As long as the Pokémon this card is attached to is on your Bench, prevent all damage done to that Pokémon by attacks (both yours and your opponent's).",
-		de: "Solange sich das Pokémon, an das diese Karte angelegt ist, auf deiner Bank befindet, verhindere allen Schaden, der diesem Pokémon durch Angriffe (deine und die deines Gegners) zugefügt würde."
+		de: "Lege Bank-Schutzschild an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn dieses Pokémon kampfunfähig wird, lege Bank-Schutzschild auf den Ablagestapel. Solange sich das Pokémon, an das diese Karte angelegt ist, auf deiner Bank befindet, verhindere allen Schaden, der diesem Pokémon durch Angriffe (deine und die deines Gegners) zugefügt würde."
 	},
 
 	trainerType: "Tool",

--- a/data/Platinum/Arceus/84.ts
+++ b/data/Platinum/Arceus/84.ts
@@ -14,7 +14,7 @@ const card: Card = {
 
 	effect: {
 		en: "Attach Buffer Piece to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card. Any damage done to the Pokémon this card is attached to by an opponent's attack is reduced by 20 (after applying Weakness and Resistance). At the end of your opponent's turn after you played Buffer Piece, discard Buffer Piece.",
-		de: "Schaden, der dem Pokémon, an das Dämpfender Talisman angelegt ist, durch einen gegnerischen Angriff zugefügt wird, wird um 20 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden). Nachdem du Dämpfender Talisman ausgespielt hast, lege Dämpfender Talisman am Ende des nächsten Zuges deines Gegners auf den Ablagestapel."
+		de: "Lege Dämpfender Talisman an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn dieses Pokémon kampfunfähig wird, lege Dämpfender Talisman auf den Ablagestapel. Schaden, der dem Pokémon, an das Dämpfender Talisman angelegt ist, durch einen gegnerischen Angriff zugefügt wird, wird um 20 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden). Nachdem du Dämpfender Talisman ausgespielt hast, lege Dämpfender Talisman am Ende des nächsten Zuges deines Gegners auf den Ablagestapel."
 	},
 
 	trainerType: "Tool",

--- a/data/Platinum/Arceus/85.ts
+++ b/data/Platinum/Arceus/85.ts
@@ -14,7 +14,7 @@ const card: Card = {
 
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Search your deck for up to 3 Pokémon Tool cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward.",
-		de: "Durchsuche dein Deck nach bis zu 3 Pokémon-Ausrüstungs-Karten, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Durchsuche dein Deck nach bis zu 3 Pokémon-Ausrüstungs-Karten, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 	},
 
 	trainerType: "Supporter",

--- a/data/Platinum/Arceus/86.ts
+++ b/data/Platinum/Arceus/86.ts
@@ -14,7 +14,7 @@ const card: Card = {
 
 	effect: {
 		en: "Flip 3 coins. For each heads, put a basic Energy card from your discard pile into your hand. If you don't have that many basic Energy cards in your discard pile, put all of them into your hand.",
-		de: "Wirf 3 Münzen. Nimm für jedes Mal, wenn die Münze \"Kopf\" gezeigt hat, eine Basis-Energiekarte von deinem Ablagestapel auf deine Hand. Falls du nicht genug Basis-Energiekarten in deinem Ablagestapel hast, nimm so viele wie möglich auf deine Hand."
+		de: "Wirf 3 Münzen. Nimm für jedes Mal, wenn die Münze „Kopf“ gezeigt hat, eine Basis-Energiekarte von deinem Ablagestapel auf deine Hand. Falls du nicht genug Basis-Energiekarten in deinem Ablagestapel hast, nimm so viele wie möglich auf deine Hand."
 	},
 
 	trainerType: "Item",

--- a/data/Platinum/Arceus/87.ts
+++ b/data/Platinum/Arceus/87.ts
@@ -14,7 +14,7 @@ const card: Card = {
 
 	effect: {
 		en: "Attach Expert Belt to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card. The Pokémon this card is attached to gets +20 HP and that Pokémon's attacks do 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance). When the Pokémon this card is attached to is Knocked Out, your opponent takes 1 more Prize card.",
-		de: "Das Pokémon, an das diese Karte angelegt ist, erhält +20 KP und die Angriffe dieses Pokémon fügen den Aktiven Pokémon deines Gegners 20 zusätzliche Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden). Wenn das Pokémon, an das diese Karte angelegt ist, kampfunfähig wird, nimmt dein Gegner 1 zusätzlichen Preis."
+		de: "Lege Expertengurt an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn dieses Pokémon kampfunfähig wird, lege Expertengurt auf den Ablagestapel. Das Pokémon, an das diese Karte angelegt ist, erhält +20 KP und die Angriffe dieses Pokémon fügen den Aktiven Pokémon deines Gegners 20 zusätzliche Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden). Wenn das Pokémon, an das diese Karte angelegt ist, kampfunfähig wird, nimmt dein Gegner 1 zusätzlichen Preis."
 	},
 
 	trainerType: "Tool",

--- a/data/Platinum/Arceus/88.ts
+++ b/data/Platinum/Arceus/88.ts
@@ -14,7 +14,7 @@ const card: Card = {
 
 	effect: {
 		en: "Attach Lucky Egg to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card. When the Pokémon this card is attached to is Knocked Out by damage from an opponent's attack, draw cards until you have 7 cards in your hand.",
-		de: "Wenn das Pokémon, an das diese Karte angelegt ist, durch Schaden eines gegnerischen Angriffs kampfunfähig wird, ziehe so viele Karten, bis du 7 Karten auf deiner Hand hast."
+		de: "Lege Glücks-Ei an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn dieses Pokémon kampfunfähig wird, lege Glücks-Ei auf den Ablagestapel. Wenn das Pokémon, an das diese Karte angelegt ist, durch Schaden eines gegnerischen Angriffs kampfunfähig wird, ziehe so viele Karten, bis du 7 Karten auf deiner Hand hast."
 	},
 
 	trainerType: "Tool",

--- a/data/Platinum/Arceus/89.ts
+++ b/data/Platinum/Arceus/89.ts
@@ -14,7 +14,7 @@ const card: Card = {
 
 	effect: {
 		en: "Play Old Amber as if it were a Colorless Basic Pokémon. (Old Amber counts as a Trainer card as well, but if Old Amber is Knocked Out, this counts as a Knocked Out Pokémon.) Old Amber can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Old Amber from play. (This doesn't count as a Knocked Out Pokémon.)",
-		de: "Spiele Altbernstein wie ein -Basis-Pokémon. (Altbernstein zählt gleichzeitig als Trainerkarte, aber wenn Altbernstein kampfunfähig wird, zählt es als kampfunfähiges Pokémon.) Altbernstein kann nicht von Speziellen Zuständen betroffen werden und sich nicht zurückziehen. In deinem Zug (vor deinem Angriff) kannst du Altbernstein auf deinen Ablagestapel legen. (Dies zählt nicht als kampfunfähig gemachtes Pokémon.)"
+		de: "Spiele Altbernstein wie ein {C}-Basis-Pokémon. (Altbernstein zählt gleichzeitig als Trainerkarte, aber wenn Altbernstein kampfunfähig wird, zählt es als kampfunfähiges Pokémon.) Altbernstein kann nicht von Speziellen Zuständen betroffen werden und sich nicht zurückziehen. In deinem Zug (vor deinem Angriff) kannst du Altbernstein auf deinen Ablagestapel legen. (Dies zählt nicht als kampfunfähig gemachtes Pokémon.)"
 	},
 
 	trainerType: "Item",

--- a/data/Platinum/Arceus/9.ts
+++ b/data/Platinum/Arceus/9.ts
@@ -21,7 +21,8 @@ const card: Card = {
 	],
 
 	evolveFrom: {
-		en: "Gulpin"
+		en: "Gulpin",
+		de: "Schluppuck"
 	},
 
 	stage: "Stage1",
@@ -70,7 +71,8 @@ const card: Card = {
 	retreat: 3,
 
 	description: {
-		en: "It swallows anything whole. It sweats toxic fluids from its follicles to douse foes."
+		en: "It swallows anything whole. It sweats toxic fluids from its follicles to douse foes.",
+		de: "Es verschluckt alles in einem Stück und sondert giftige Stoffe ab, mit denen es Gegner besprüht."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/90.ts
+++ b/data/Platinum/Arceus/90.ts
@@ -14,7 +14,7 @@ const card: Card = {
 
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Draw 3 cards. Then, choose a card from your hand and put it on the bottom of your deck.",
-		de: "Ziehe 3 Karten. Danach wähle 1 Karte von deiner Hand und lege sie unter dein Deck."
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Ziehe 3 Karten. Danach wähle 1 Karte von deiner Hand und lege sie unter dein Deck."
 	},
 
 	trainerType: "Supporter",

--- a/data/Platinum/Arceus/91.ts
+++ b/data/Platinum/Arceus/91.ts
@@ -15,7 +15,7 @@ const card: Card = {
 
 	effect: {
 		en: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card. During each player's turn, the player may move an Energy card attached to 1 of his or her Benched Pokémon to his or her Active Arceus as often as he or she likes.",
-		de: "Beliebig oft während seines Zuges kann jeder Spieler 1 Energiekarte von 1 Pokémon auf seiner Bank entfernen und an sein Aktives Arceus anlegen."
+		de: "Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadion-Karte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen. Beliebig oft während seines Zuges kann jeder Spieler 1 Energiekarte von 1 Pokémon auf seiner Bank entfernen und an sein Aktives Arceus anlegen."
 	},
 
 	trainerType: "Stadium",

--- a/data/Platinum/Arceus/92.ts
+++ b/data/Platinum/Arceus/92.ts
@@ -14,7 +14,7 @@ const card: Card = {
 
 	effect: {
 		en: "Play Dome Fossil as if it were a Colorless Basic Pokémon. (Dome Fossil counts as a Trainer card as well, but if Dome Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Dome Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Dome Fossil from play. (This doesn't count as a Knocked Out Pokémon.)",
-		de: "Spiele Domfossil wie ein -Basis-Pokémon. (Domfossil zählt gleichzeitig als Trainerkarte, aber wenn Domfossil kampfunfähig wird, zählt es als kampfunfähiges Pokémon.) Domfossil kann nicht von Speziellen Zuständen betroffen werden und sich nicht zurückziehen. In deinem Zug (vor deinem Angriff) kannst du Domfossil auf deinen Ablagestapel legen. (Dies zählt nicht als kampfunfähig gemachtes Pokémon.)"
+		de: "Spiele Domfossil wie ein {C}-Basis-Pokémon. (Domfossil zählt gleichzeitig als Trainerkarte, aber wenn Domfossil kampfunfähig wird, zählt es als kampfunfähiges Pokémon.) Domfossil kann nicht von Speziellen Zuständen betroffen werden und sich nicht zurückziehen. In deinem Zug (vor deinem Angriff) kannst du Domfossil auf deinen Ablagestapel legen. (Dies zählt nicht als kampfunfähig gemachtes Pokémon.)"
 	},
 
 	abilities: [

--- a/data/Platinum/Arceus/93.ts
+++ b/data/Platinum/Arceus/93.ts
@@ -14,7 +14,7 @@ const card: Card = {
 
 	effect: {
 		en: "Play Helix Fossil as if it were a Colorless Basic Pokémon. (Helix Fossil counts as a Trainer card as well, but if Helix Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Helix Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Helix Fossil from play. (This doesn't count as a Knocked Out Pokémon.)",
-		de: "Spiele Helixfossil wie ein -Basis-Pokémon. (Helixfossil zählt gleichzeitig als Trainerkarte, aber wenn Helixfossil kampfunfähig wird, zählt es als kampfunfähiges Pokémon.) Helixfossil kann nicht von Speziellen Zuständen betroffen werden und sich nicht zurückziehen. In deinem Zug (vor deinem Angriff) kannst du Helixfossil auf deinen Ablagestapel legen. (Dies zählt nicht als kampfunfähig gemachtes Pokémon.)"
+		de: "Spiele Helixfossil wie ein {C}-Basis-Pokémon. (Helixfossil zählt gleichzeitig als Trainerkarte, aber wenn Helixfossil kampfunfähig wird, zählt es als kampfunfähiges Pokémon.) Helixfossil kann nicht von Speziellen Zuständen betroffen werden und sich nicht zurückziehen. In deinem Zug (vor deinem Angriff) kannst du Helixfossil auf deinen Ablagestapel legen. (Dies zählt nicht als kampfunfähig gemachtes Pokémon.)"
 	},
 
 	abilities: [

--- a/data/Platinum/Arceus/95.ts
+++ b/data/Platinum/Arceus/95.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack's base damage is 50 instead of 100.",
 				fr: "Lancez une pièce. Si c'est pile, les dégâts de base de cette attaque sont de 50 au lieu de 100.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" beträgt der Grundschaden dieses Angriffs 50 Schadenspunkte anstelle von 100 Schadenspunkten."
+				de: "Wirf 1 Münze. Bei „Zahl“ beträgt der Grundschaden dieses Angriffs 50 Schadenspunkte anstelle von 100 Schadenspunkten."
 			},
 			damage: 100,
 

--- a/data/Platinum/Arceus/96.ts
+++ b/data/Platinum/Arceus/96.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Discard a Lightning Energy and a Psychic Energy attached to Arceus.",
 				fr: "Défaussez une Énergie Lightning et une Énergie Psychic attachée à Arceus.",
-				de: "Lege 1 -Energie und 1 -Energie, die an Arceus angelegt sind, auf deinen Ablagestapel."
+				de: "Lege 1 {L}-Energie und 1 {P}-Energie, die an Arceus angelegt sind, auf deinen Ablagestapel."
 			},
 			damage: 100,
 

--- a/data/Platinum/Arceus/99.ts
+++ b/data/Platinum/Arceus/99.ts
@@ -30,7 +30,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may flip a coin. If heads, remove 4 damage counters from 1 of your Pokémon. This power can't be used if Tangrowth is affected by a Special Condition.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 Münze werfen. Bei \"Kopf\" entferne 4 Schadensmarken von 1 deiner Pokémon. Diese Poké-Power kann nicht benutzt werden, wenn Tangoloss von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 Münze werfen. Bei „Kopf“ entferne 4 Schadensmarken von 1 deiner Pokémon. Diese Poké-Power kann nicht benutzt werden, wenn Tangoloss von einem Speziellen Zustand betroffen ist."
 			}
 		},
 	],
@@ -45,7 +45,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Search your discard pile for as many Grass Energy cards as you like and attach them to your Pokémon in any way you like.",
-				de: "Durchsuche deinen Ablagestapel nach beliebig vielen -Energiekarten und lege sie in beliebiger Verteilung an deine Pokémon an."
+				de: "Durchsuche deinen Ablagestapel nach beliebig vielen {G}-Energiekarten und lege sie in beliebiger Verteilung an deine Pokémon an."
 			},
 
 		},

--- a/data/Platinum/Arceus/AR1.ts
+++ b/data/Platinum/Arceus/AR1.ts
@@ -61,7 +61,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It is told in mythology that this Pokémon was born before the universe even existed."
+		en: "It is told in mythology that this Pokémon was born before the universe even existed.",
+		de: "Die Mythologie erzählt, dass dieses PKMN geboren wurde, bevor das Universum überhaupt existierte."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/AR2.ts
+++ b/data/Platinum/Arceus/AR2.ts
@@ -61,7 +61,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It is said to have emerged from an egg in a place where there was nothing, then shaped the world."
+		en: "It is said to have emerged from an egg in a place where there was nothing, then shaped the world.",
+		de: "Man sagt, es sei im Nichts aus einem Ei geschlüpft und habe dann die Welt geformt."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/AR3.ts
+++ b/data/Platinum/Arceus/AR3.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, discard 2 Energy attached to Arceus.",
 				fr: "Lancez une pièce. Si c'est pile, défaussez 2 Énergies attachées à Arceus.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" entferne 2 Energien, die an Arceus angelegt sind, und lege sie auf deinen Ablagestapel."
+				de: "Wirf 1 Münze. Bei „Zahl“ entferne 2 Energien, die an Arceus angelegt sind, und lege sie auf deinen Ablagestapel."
 			},
 			damage: 80,
 
@@ -55,7 +55,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It is described in mythology as the Pokémon that shaped the universe with its 1,000 arms."
+		en: "It is described in mythology as the Pokémon that shaped the universe with its 1,000 arms.",
+		de: "Die Mythologie nennt dieses PKMN als Former des Universums, wobei es seine tausend Arme eingesetzt hat."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/AR4.ts
+++ b/data/Platinum/Arceus/AR4.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "This attack's damage isn't affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Résistance, les Poké-Powers, les Poké-Bodies ou tout autre effet sur le Pokémon Défenseur.",
-				de: "Resistenz, Poké-Power, Poké-Body und alle anderen Effekte auf den Verteidigenden Pokémon haben keine Auswirkungen auf die Schadenspunkte dieses Angriffs."
+				de: "Resistenz, Poké-Power, Poké-Body und alle anderen Effekte auf dem Verteidigenden Pokémon haben keine Auswirkungen auf die Schadenspunkte dieses Angriffs."
 			},
 			damage: 50,
 
@@ -55,7 +55,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It is told in mythology that this Pokémon was born before the universe even existed."
+		en: "It is told in mythology that this Pokémon was born before the universe even existed.",
+		de: "Die Mythologie erzählt, dass dieses PKMN geboren wurde, bevor das Universum überhaupt existierte."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/AR5.ts
+++ b/data/Platinum/Arceus/AR5.ts
@@ -34,7 +34,7 @@ const card: Card = {
 			effect: {
 				en: "If you have 6 Arceus in play and each of them is a different type, search your deck for up to 6 basic Energy cards. Attach each of those Energy cards to a different Pokémon you have in play. Shuffle your deck afterward.",
 				fr: "Si vous avez 6 Arceus en jeu et que chacun de ces Arceus est de type différent, choisissez jusqu'à 6 cartes Énergie de base dans votre deck. Attachez chacune de ces cartes Énergie à un autre Pokémon que vous avez en jeu. Ensuite, mélangez votre deck.",
-				de: "Wenn du 6 Arceus jeweils unterschiedlichen Typs im Spiel hast, durchsuche dein Deck nach bis zu 6 Basis-Energiekarten. Lege jeder dieser Energiekarten an ein anderes deiner Pokémon im Spiel an. Mische dein Deck danach."
+				de: "Wenn du 6 Arceus jeweils unterschiedlichen Typs im Spiel hast, durchsuche dein Deck nach bis zu 6 Basis-Energiekarten. Lege jede dieser Energiekarten an ein anderes deiner Pokémon im Spiel an. Mische dein Deck danach."
 			},
 
 		},
@@ -68,7 +68,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It is said to have emerged from an egg in a place where there was nothing, then shaped the world."
+		en: "It is said to have emerged from an egg in a place where there was nothing, then shaped the world.",
+		de: "Man sagt, es sei im Nichts aus einem Ei geschlüpft und habe dann die Welt geformt."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/AR6.ts
+++ b/data/Platinum/Arceus/AR6.ts
@@ -61,7 +61,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It is described in mythology as the Pokémon that shaped the universe with its 1,000 arms."
+		en: "It is described in mythology as the Pokémon that shaped the universe with its 1,000 arms.",
+		de: "Die Mythologie nennt dieses PKMN als Former des Universums, wobei es seine tausend Arme eingesetzt hat."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/AR7.ts
+++ b/data/Platinum/Arceus/AR7.ts
@@ -55,7 +55,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It is told in mythology that this Pokémon was born before the universe even existed."
+		en: "It is told in mythology that this Pokémon was born before the universe even existed.",
+		de: "Die Mythologie erzählt, dass dieses PKMN geboren wurde, bevor das Universum überhaupt existierte."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/AR8.ts
+++ b/data/Platinum/Arceus/AR8.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à chacun de vos Pokémon de Banc. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Dieser Angriff fügt jeden Pokémon auf deiner Bank 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Dieser Angriff fügt jedem Pokémon auf deiner Bank 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 60,
 
@@ -62,7 +62,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It is said to have emerged from an egg in a place where there was nothing, then shaped the world."
+		en: "It is said to have emerged from an egg in a place where there was nothing, then shaped the world.",
+		de: "Man sagt, es sei im Nichts aus einem Ei geschlüpft und habe dann die Welt geformt."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/AR9.ts
+++ b/data/Platinum/Arceus/AR9.ts
@@ -62,7 +62,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It is described in mythology as the Pokémon that shaped the universe with its 1,000 arms."
+		en: "It is described in mythology as the Pokémon that shaped the universe with its 1,000 arms.",
+		de: "Die Mythologie nennt dieses PKMN als Former des Universum, wobei es seine tausend Arme eingesetzt hat."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/SH10.ts
+++ b/data/Platinum/Arceus/SH10.ts
@@ -47,7 +47,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip 2 coins. If either of them is tails, this attack does nothing.",
-				de: "Wirf 2 Münzen. Wenn mindestens eine Münze \"Zahl\" gezeigt hat, hat dieser Angriff keine Auswirkungen."
+				de: "Wirf 2 Münzen. Wenn mindestens eine Münze „Zahl“ gezeigt hat, hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 40,
 
@@ -64,7 +64,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Dreaming of one day flying, it practices by leaping off cliffs every day."
+		en: "Dreaming of one day flying, it practices by leaping off cliffs every day.",
+		de: "Es träumt davon, eines Tages fliegen zu können und springt daher jeden Tag von hohen Klippen."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/SH11.ts
+++ b/data/Platinum/Arceus/SH11.ts
@@ -48,7 +48,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard all Fire Energy attached to Ponyta.",
-				de: "Entferne alle -Energien von Ponita und lege sie auf deinen Ablagestapel."
+				de: "Entferne alle {R}-Energien von Ponita und lege sie auf deinen Ablagestapel."
 			},
 			damage: 50,
 
@@ -65,7 +65,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "As a newborn, it can barely stand. However, through galloping, its legs are made tougher and faster."
+		en: "As a newborn, it can barely stand. However, through galloping, its legs are made tougher and faster.",
+		de: "Neugeboren kann es kaum stehen. Durch das Galoppieren werden seine Beine aber schneller und kräftiger."
 	},
 
 	variants: [

--- a/data/Platinum/Arceus/SH12.ts
+++ b/data/Platinum/Arceus/SH12.ts
@@ -71,7 +71,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "The extension and contraction of its muscles generates electricity. It glows when in trouble."
+		en: "The extension and contraction of its muscles generates electricity. It glows when in trouble.",
+		de: "Es erzeugt Elektrizität durch das Strecken und Zusammenziehen seiner Muskeln. Bei Bedrohung glüht es."
 	},
 
 	variants: [


### PR DESCRIPTION
## Add missing German translations for pl4

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
