### PR TITLE
(fix) Remove fr Prism Star rule text stored as an attack on sm8 Ditto

### DIFF
--- a/data/Sun & Moon/Lost Thunder/154.ts
+++ b/data/Sun & Moon/Lost Thunder/154.ts
@@ -50,17 +50,6 @@ const card: Card = {
 		},
 	],
 
-	attacks: [
-		{
-
-			name: {
-				fr: "Règle pour les cartes  (Prisme Étoile)",
-			},
-
-
-		},
-	],
-
 	weaknesses: [
 		{
 			type: "Fighting",


### PR DESCRIPTION
Ditto ◇ (Lost Thunder 154) has no attacks — only its Almighty Evolution ability. The card's `attacks` array held a single entry whose only content was a French name, and that name is the Prism Star rule-box caption ("Règle pour les cartes (Prisme Étoile)"), not an attack. This removes the bogus entry; a repo-wide search found no other card with this pattern.