### PR TITLE
Add missing German translations for 2024sv

### DIFF
--- a/data/McDonald's Collection/McDonald's Collection 2024/1.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2024/1.ts
@@ -37,10 +37,12 @@ const card: Card = {
 		{
 			type: "Ability",
 			name: {
-				en: "Battle Sense"
+				en: "Battle Sense",
+				de: "Kampfsinn"
 			},
 			effect: {
-				en: "Once during your turn, you may look at the top 3 cards of your deck and put 1 of them into your hand. Discard the other cards."
+				en: "Once during your turn, you may look at the top 3 cards of your deck and put 1 of them into your hand. Discard the other cards.",
+				de: "Einmal während deines Zuges kannst du dir die obersten 3 Karten deines Decks anschauen und 1 davon auf deine Hand nehmen. Lege die anderen Karten auf deinen Ablagestapel."
 			}
 		}
 	],
@@ -50,10 +52,12 @@ const card: Card = {
 			cost: ["Fire", "Fire"],
 			name: {
 				en: "Royal Blaze",
+				de: "Königsflamme"
 			},
 			damage: "100+",
 			effect: {
 				en: "This attack does 50 more damage for each Leon card in your discard pile.",
+				de: "Diese Attacke fügt für jede Delion-Karte in deinem Ablagestapel 50 Schadenspunkte mehr zu."
 			},
 		},
 	],

--- a/data/McDonald's Collection/McDonald's Collection 2024/10.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2024/10.ts
@@ -37,10 +37,12 @@ const card: Card = {
 		{
 			type: "Ability",
 			name: {
-				en: "Tri Howl"
+				en: "Tri Howl",
+				de: "Dreifacher Jauler"
 			},
 			effect: {
-				en: "Once during your turn, you may look at the top 3 cards of your deck and attach any number of Energy cards you find there to your Pokémon in any way you like. Discard the other cards."
+				en: "Once during your turn, you may look at the top 3 cards of your deck and attach any number of Energy cards you find there to your Pokémon in any way you like. Discard the other cards.",
+				de: "Einmal während deines Zuges kannst du dir die obersten 3 Karten deines Decks anschauen und beliebig viele Energiekarten, die du dort findest, beliebig an deine Pokémon anlegen. Lege die anderen Karten auf deinen Ablagestapel."
 			}
 		}
 	],
@@ -50,6 +52,7 @@ const card: Card = {
 			cost: ["Darkness", "Darkness", "Colorless"],
 			name: {
 				en: "Dark Cutter",
+				de: "Dunkler Zerschneider"
 			},
 			damage: 160,
 		}

--- a/data/McDonald's Collection/McDonald's Collection 2024/11.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2024/11.ts
@@ -29,9 +29,11 @@ const card: Card = {
 			cost: ["Darkness"],
 			name: {
 				en: "Vengeance Fletching",
+				de: "Rachegefieder"
 			},
 			effect: {
-				en: "This attack does 10 more damage for each Ancient card in your discard pile."
+				en: "This attack does 10 more damage for each Ancient card in your discard pile.",
+				de: "Diese Attacke fügt für jede Vergangenheitskarte in deinem Ablagestapel 10 Schadenspunkte mehr zu."
 			},
 			damage: "70+",
 		},
@@ -39,6 +41,7 @@ const card: Card = {
 			cost: ["Darkness", "Colorless", "Colorless", "Colorless"],
 			name: {
 				en: "Speed Wing",
+				de: "Turboschwinge"
 			},
 			damage: 120,
 		},

--- a/data/McDonald's Collection/McDonald's Collection 2024/12.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2024/12.ts
@@ -37,10 +37,12 @@ const card: Card = {
 		{
 			type: "Ability",
 			name: {
-				en: "Jet Cruise"
+				en: "Jet Cruise",
+				de: "Jet-Cruisen"
 			},
 			effect: {
-				en: "Your Pokémon in play have no Retreat Cost."
+				en: "Your Pokémon in play have no Retreat Cost.",
+				de: "Deine Pokémon im Spiel haben keine Rückzugskosten."
 			}
 		}
 	],
@@ -50,10 +52,12 @@ const card: Card = {
 			cost: ["Water", "Lightning", "Colorless"],
 			name: {
 				en: "Dragon Pulse",
+				de: "Drachenpuls"
 			},
 			damage: 180,
 			effect: {
 				en: "Discard the top 2 cards of your deck.",
+				de: "Lege die obersten 2 Karten deines Decks auf deinen Ablagestapel."
 			},
 		},
 	],

--- a/data/McDonald's Collection/McDonald's Collection 2024/13.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2024/13.ts
@@ -29,9 +29,11 @@ const card: Card = {
 			cost: ["Colorless"],
 			name: {
 				en: "Continuous Steps",
+				de: "Dauerschritte"
 			},
 			effect: {
-				en: "Flip a coin until you get tails. This attack does 30 damage for each heads."
+				en: "Flip a coin until you get tails. This attack does 30 damage for each heads.",
+				de: "Wirf so lange 1 Münze, bis zum ersten Mal das Ergebnis Zahl kommt. Diese Attacke fügt 30 Schadenspunkte pro Kopf zu."
 			},
 			damage: "30x",
 		}

--- a/data/McDonald's Collection/McDonald's Collection 2024/14.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2024/14.ts
@@ -38,16 +38,19 @@ const card: Card = {
 			damage: 30,
 			effect: {
 				en: "During your opponent's next turn, the Defending Pokémon can't retreat.",
+				de: "Während des nächsten Zuges deines Gegners kann sich das Verteidigende Pokémon nicht zurückziehen."
 			},
 		},
 		{
 			cost: ["Colorless", "Colorless", "Colorless"],
 			name: {
 				en: "Power Blast",
+				de: "Powerschuss"
 			},
 			damage: 120,
 			effect: {
 				en: "Discard an Energy from this Pokémon.",
+				de: "Lege 1 Energie von diesem Pokémon auf deinen Ablagestapel."
 			},
 		},
 	],

--- a/data/McDonald's Collection/McDonald's Collection 2024/15.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2024/15.ts
@@ -29,6 +29,7 @@ const card: Card = {
 			cost: ["Colorless"],
 			name: {
 				en: "Gentle Slap",
+				de: "Sanfter Hieb"
 			},
 			damage: 20,
 		},
@@ -36,10 +37,12 @@ const card: Card = {
 			cost: ["Colorless", "Colorless", "Colorless"],
 			name: {
 				en: "Raging Cannon",
+				de: "Wutkanone"
 			},
 			damage: "100+",
 			effect: {
 				en: "If all your Benched Pokémon have at least 1 damage counter on them, this attack does 120 more damage.",
+				de: "Wenn auf allen Pokémon auf deiner Bank mindestens 1 Schadensmarke liegt, fügt diese Attacke 120 Schadenspunkte mehr zu."
 			},
 		},
 	],

--- a/data/McDonald's Collection/McDonald's Collection 2024/2.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2024/2.ts
@@ -29,15 +29,18 @@ const card: Card = {
 			cost: ["Lightning"],
 			name: {
 				en: "Charge",
+				de: "Ladevorgang"
 			},
 			effect: {
-				en: "Search your deck for a Basic Lightning Energy card and attach it to this Pokémon. Then, shuffle your deck."
+				en: "Search your deck for a Basic Lightning Energy card and attach it to this Pokémon. Then, shuffle your deck.",
+				de: "Durchsuche dein Deck nach 1 Basis-{L}-Energiekarte und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
 			}
 		},
 		{
 			cost: ["Lightning", "Lightning", "Colorless"],
 			name: {
 				en: "Pika Punch",
+				de: "Pikahieb"
 			},
 			damage: 50,
 		},

--- a/data/McDonald's Collection/McDonald's Collection 2024/3.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2024/3.ts
@@ -29,6 +29,7 @@ const card: Card = {
 			cost: ["Colorless", "Colorless"],
 			name: {
 				en: "Sharp Fang",
+				de: "Scharfe Fänge"
 			},
 			damage: 30,
 		},
@@ -36,9 +37,11 @@ const card: Card = {
 			cost: ["Lightning", "Lightning", "Colorless"],
 			name: {
 				en: "Lightning Laser",
+				de: "Blitzlaser"
 			},
 			effect: {
 				en: "This attack also does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
+				de: "Diese Attacke fügt auch 1 Pokémon auf der Bank deines Gegners 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 90,
 		},

--- a/data/McDonald's Collection/McDonald's Collection 2024/4.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2024/4.ts
@@ -29,6 +29,7 @@ const card: Card = {
 			cost: ["Psychic"],
 			name: {
 				en: "Pound",
+				de: "Klaps"
 			},
 			damage: 20
 		},
@@ -36,9 +37,11 @@ const card: Card = {
 			cost: ["Colorless", "Colorless"],
 			name: {
 				en: "Let's All Rollout",
+				de: "Gemeinsamer Walzer"
 			},
 			effect: {
 				en: "This attack does 20 more damage for each of your Benched Pokémon that has the Let's Rollout Attack.",
+				de: "Diese Attacke fügt für jedes Pokémon auf deiner Bank, das die Attacke Gemeinsamer Walzer hat, 20 Schadenspunkte zu."
 			},
 			damage: "20x",
 		},

--- a/data/McDonald's Collection/McDonald's Collection 2024/5.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2024/5.ts
@@ -29,6 +29,7 @@ const card: Card = {
 			cost: ["Psychic"],
 			name: {
 				en: "Stampede",
+				de: "Zertrampeln"
 			},
 			damage: 10,
 		},
@@ -36,6 +37,7 @@ const card: Card = {
 			cost: ["Psychic", "Colorless"],
 			name: {
 				en: "Magical Shot",
+				de: "Magischer Schuss"
 			},
 			damage: 30,
 		},

--- a/data/McDonald's Collection/McDonald's Collection 2024/6.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2024/6.ts
@@ -38,15 +38,18 @@ const card: Card = {
 			cost: ["Psychic"],
 			name: {
 				en: "Dragon Launcher",
+				de: "Drachenschleuder"
 			},
 			effect: {
-				en: "Discard a number of your Benched Dreepy up to the number of your opponent's Pokémon in play. Then, for each Dreepy you discarded in this way, choose 1 of your opponent's Pokémon and do 100 damage to it. You can't choose the same Pokémon more than once. This damage isn't affected by Weakness or Resistance"
+				en: "Discard a number of your Benched Dreepy up to the number of your opponent's Pokémon in play. Then, for each Dreepy you discarded in this way, choose 1 of your opponent's Pokémon and do 100 damage to it. You can't choose the same Pokémon more than once. This damage isn't affected by Weakness or Resistance",
+				de: "Lege bis zu so viele deiner Grolldra, wie dein Gegner Pokémon im Spiel hat, von deiner Bank auf deinen Ablagestapel. Wähle anschließend für jedes auf diese Weise abgelegte Grolldra 1 Pokémon deines Gegners und füge jenem Pokémon 100 Schadenspunkte zu. Du kannst dasselbe Pokémon nicht mehr als einmal wählen. Dieser Schaden wird durch Schwäche und Resistenz nicht verändert."
 			}
 		},
 		{
 			cost: ["Psychic", "Colorless"],
 			name: {
 				en: "Spooky Shot",
+				de: "Spukschuss"
 			},
 			damage: 120,
 		},

--- a/data/McDonald's Collection/McDonald's Collection 2024/7.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2024/7.ts
@@ -38,6 +38,7 @@ const card: Card = {
 			cost: ["Colorless", "Colorless"],
 			name: {
 				en: "Beat",
+				de: "Verprügler"
 			},
 			damage: 30,
 		},
@@ -45,10 +46,12 @@ const card: Card = {
 			cost: ["Fighting", "Colorless", "Colorless"],
 			name: {
 				en: "Fickle Impact",
+				de: "Launischer Einschlag"
 			},
 			damage: 180,
 			effect: {
 				en: "If you have exactly 2, 4, or 6 Prize cards remaining, this attack does nothing.",
+				de: "Wenn du genau 2, 4 oder 6 verbleibende Preiskarten hast, hat diese Attacke keine Auswirkungen."
 			},
 		},
 	],

--- a/data/McDonald's Collection/McDonald's Collection 2024/8.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2024/8.ts
@@ -29,6 +29,7 @@ const card: Card = {
 			cost: ["Colorless", "Colorless", "Colorless"],
 			name: {
 				en: "Claw Clash",
+				de: "Klauenschlitzer"
 			},
 			damage: 70,
 		},
@@ -36,10 +37,12 @@ const card: Card = {
 			cost: ["Fighting", "Fighting", "Fighting", "Colorless"],
 			name: {
 				en: "Wild Impact",
+				de: "Tobende Fänge"
 			},
 			damage: 190,
 			effect: {
 				en: "Discard 3 Energy from this Pokémon.",
+				de: "Lege 3 Energien von diesem Pokémon auf deinen Ablagestapel."
 			},
 		},
 	],

--- a/data/McDonald's Collection/McDonald's Collection 2024/9.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2024/9.ts
@@ -38,18 +38,22 @@ const card: Card = {
 			cost: ["Darkness"],
 			name: {
 				en: "Blindside",
+				de: "Aus heiterem Himmel"
 			},
 			effect: {
-				en: "This attack does 60 damage to 1 of your opponent's Pokémon that has any damage counters on it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				en: "This attack does 60 damage to 1 of your opponent's Pokémon that has any damage counters on it. (Don't apply Weakness and Resistance for Benched Pokémon.)",
+				de: "Diese Attacke fügt 1 Pokémon deines Gegners, auf dem mindestens 1 Schadensmarke liegt, 60 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 		},
 		{
 			cost: ["Darkness", "Colorless", "Colorless"],
 			name: {
 				en: "Moon Mirage",
+				de: "Mondillusion"
 			},
 			effect: {
-				en: "Your opponent's Active Pokémon is now Confused."
+				en: "Your opponent's Active Pokémon is now Confused.",
+				de: "Das Aktive Pokémon deines Gegners ist jetzt verwirrt."
 			},
 			damage: 80,
 		},


### PR DESCRIPTION
## Add missing German translations for 2024sv

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
