### PR TITLE
Add missing German translations for swsh4.5sv

### DIFF
--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV001.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV001.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "At a distance, it launches its sharp feathers while flying about. If the enemy gets too close, Rowlet switches tactics and delivers vicious kicks."
+		en: "At a distance, it launches its sharp feathers while flying about. If the enemy gets too close, Rowlet switches tactics and delivers vicious kicks.",
+		de: "Während es durch die Lüfte fliegt, schleudert es scharfe Federn auf seine Ziele. Wenn Gegner ihm zu nahe kommen, greift es mit heftigen Tritten an."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV002.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV002.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Brindibou",
-		en: "Rowlet"
+		en: "Rowlet",
+		de: "Bauz"
 	},
 
 	attacks: [{
@@ -49,7 +50,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It throws one knifelike feather after another at its enemies, and each one precisely strikes a weak point. These feathers are known as blade quills."
+		en: "It throws one knifelike feather after another at its enemies, and each one precisely strikes a weak point. These feathers are known as blade quills.",
+		de: "Es bombardiert seine Feinde mit messerscharfen Federn, die man „Flügelklingen“ nennt, und trifft mit jedem Wurf zielsicher ihre Schwachstellen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV003.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV003.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Efflèche",
-		en: "Dartrix"
+		en: "Dartrix",
+		de: "Arboretoss"
 	},
 
 	abilities: [{
@@ -80,7 +81,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "As if wielding a bow, it launches the arrow quills hidden among the feathers of its wings. Decidueye's shots never miss."
+		en: "As if wielding a bow, it launches the arrow quills hidden among the feathers of its wings. Decidueye's shots never miss.",
+		de: "Dieses Pokémon kann die Federn seiner Flügel wie Pfeile abschießen. Hat es sein Ziel angepeilt, trifft es garantiert."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV004.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV004.ts
@@ -53,7 +53,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "When it uses its special stick to strike up a beat, the sound waves produced carry revitalizing energy to the plants and flowers in the area."
+		en: "When it uses its special stick to strike up a beat, the sound waves produced carry revitalizing energy to the plants and flowers in the area.",
+		de: "Der Rhythmus, den es mit seinem besonderen Schlägel erzeugt, verbreitet Schallwellen, die Pflanzen neue Vitalität verleihen können."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV005.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV005.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Ouistempo",
-		en: "Grookey"
+		en: "Grookey",
+		de: "Chimpep"
 	},
 
 	abilities: [{
@@ -71,7 +72,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "The faster a Thwackey can beat out a rhythm with its two sticks, the more respect it wins from its peers."
+		en: "The faster a Thwackey can beat out a rhythm with its two sticks, the more respect it wins from its peers.",
+		de: "Je wilder der Beat, den ein Chimstix mit seinen zwei Schlägeln erzeugt, desto mehr wird es von seinen Artgenossen respektiert."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV006.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV006.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Badabouin",
-		en: "Thwackey"
+		en: "Thwackey",
+		de: "Chimstix"
 	},
 
 	abilities: [{
@@ -43,7 +44,7 @@ const card: Card = {
 			es: "Una vez durante tu turno, puedes buscar en tu baraja hasta 2 cartas de Energía Grass y unirlas a 1 de tus Pokémon. Después, baraja las cartas de tu baraja.",
 			it: "Una sola volta durante il tuo turno, puoi cercare nel tuo mazzo fino a due carte Energia Grass e assegnarle a uno dei tuoi Pokémon. Poi rimischia le carte del tuo mazzo.",
 			pt: "Uma vez durante o seu turno, você poderá procurar por até 2 cartas de Energia Grass no seu baralho e ligá-las a 1 dos seus Pokémon. Em seguida, embaralhe o seu baralho.",
-			de: "Einmal während deines Zuges kannst du dein Deck nach bis zu 2 Grass-Energiekarten durchsuchen und sie an 1 deiner Pokémon anlegen. Mische anschließend dein Deck."
+			de: "Einmal während deines Zuges kannst du dein Deck nach bis zu 2 {G}-Energiekarten durchsuchen und sie an 1 deiner Pokémon anlegen. Mische anschließend dein Deck."
 		}
 	}],
 
@@ -71,7 +72,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "By drumming, it taps into the power of its special tree stump. The roots of the stump follow its direction in battle."
+		en: "By drumming, it taps into the power of its special tree stump. The roots of the stump follow its direction in battle.",
+		de: "Es kontrolliert die Macht seines speziellen Baumstumpfes durch Trommeln. Im Kampf manipuliert es damit Wurzeln."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV007.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV007.ts
@@ -44,7 +44,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Often found in gardens, this Pokémon has hairs on its body that it uses to assess its surroundings."
+		en: "Often found in gardens, this Pokémon has hairs on its body that it uses to assess its surroundings.",
+		de: "Dieses Pokémon trifft man oft auf Feldern an. Mit den Haaren, die an seinem Körper wachsen, spürt es, was in der Umgebung vor sich geht."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV008.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV008.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Larvadar",
-		en: "Blipbug"
+		en: "Blipbug",
+		de: "Sensect"
 	},
 
 	attacks: [{
@@ -69,7 +70,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "As it grows inside its shell, it uses its psychic abilities to monitor the outside world and prepare for evolution."
+		en: "As it grows inside its shell, it uses its psychic abilities to monitor the outside world and prepare for evolution.",
+		de: "Im Inneren seines Panzers wächst es. Während es sich auf die Entwicklung vorbereitet, prüft es mit seinen Psycho-Kräften, was im Freien geschieht."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV009.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV009.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Coléodôme",
-		en: "Dottler"
+		en: "Dottler",
+		de: "Keradar"
 	},
 
 	abilities: [{
@@ -63,7 +64,7 @@ const card: Card = {
 			es: "Este ataque hace 30 puntos de daño más por cada Energía Psychic unida a este Pokémon.",
 			it: "Questo attacco infligge 30 danni in più per ogni Energia Psychic assegnata a questo Pokémon.",
 			pt: "Este ataque causa 30 pontos de dano a mais para cada Energia Psychic ligada a este Pokémon.",
-			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte Psychic-Energie 30 Schadenspunkte mehr zu."
+			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte {P}-Energie 30 Schadenspunkte mehr zu."
 		},
 
 		damage: "90+",
@@ -80,7 +81,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "It emits psychic energy to observe and study what's around it—and what's around it can include things over six miles away."
+		en: "It emits psychic energy to observe and study what's around it—and what's around it can include things over six miles away.",
+		de: "Indem es Psycho-Kräfte ausstrahlt, erfasst es die Umgebung. Seine Observation umfasst dabei einen beeindruckenden Umkreis von 10 km."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV010.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV010.ts
@@ -64,7 +64,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It whirls around in the wind while singing a joyous song. This delightful display has charmed many into raising this Pokémon."
+		en: "It whirls around in the wind while singing a joyous song. This delightful display has charmed many into raising this Pokémon.",
+		de: "Viele Leute werden ihre Trainer, weil sie es niedlich finden, wie diese Pokémon in sanften Brisen herumwirbeln und voller Freude singen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV011.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV011.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Tournicoton",
-		en: "Gossifleur"
+		en: "Gossifleur",
+		de: "Cottini"
 	},
 
 	attacks: [{
@@ -41,7 +42,7 @@ const card: Card = {
 			es: "Busca en tu baraja hasta 3 cartas de Energía Grass y únelas a tus Pokémon en Banca de la manera que desees. Después, baraja las cartas de tu baraja.",
 			it: "Cerca nel tuo mazzo fino a tre carte Energia Grass e assegnale ai tuoi Pokémon in panchina nel modo che preferisci. Poi rimischia le carte del tuo mazzo.",
 			pt: "Procure por até 3 cartas de Energia Grass no seu baralho e ligue-as aos seus Pokémon no Banco como desejar. Em seguida, embaralhe o seu baralho.",
-			de: "Durchsuche dein Deck nach bis zu 3 Grass-Energiekarten und lege sie beliebig an die Pokémon auf deiner Bank an. Mische anschließend dein Deck."
+			de: "Durchsuche dein Deck nach bis zu 3 {G}-Energiekarten und lege sie beliebig an die Pokémon auf deiner Bank an. Mische anschließend dein Deck."
 		},
 
 		cost: ["Colorless"]
@@ -69,7 +70,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "The cotton on the head of this Pokémon can be spun into a glossy, gorgeous yarn—a Galar regional specialty."
+		en: "The cotton on the head of this Pokémon can be spun into a glossy, gorgeous yarn—a Galar regional specialty.",
+		de: "Aus dem Flaum auf seinem Kopf werden wunderschöne, glänzende Fäden gesponnen. Die Galar-Region ist bekannt für dieses Produkt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV012.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV012.ts
@@ -52,7 +52,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It spends its entire life inside an apple. It hides from its natural enemies, bird Pokémon, by pretending it's just an apple and nothing more."
+		en: "It spends its entire life inside an apple. It hides from its natural enemies, bird Pokémon, by pretending it's just an apple and nothing more.",
+		de: "Es verbringt sein ganzes Leben im Inneren eines Apfels. Um sich vor Vogel-Pokémon, seinen Fressfeinden, zu schützen, imitiert es einen Apfel."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV013.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV013.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Verpom",
-		en: "Applin"
+		en: "Applin",
+		de: "Knapfel"
 	},
 
 	abilities: [{
@@ -80,7 +81,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It ate a sour apple, and that induced its evolution. In its cheeks, it stores an acid capable of causing chemical burns."
+		en: "It ate a sour apple, and that induced its evolution. In its cheeks, it stores an acid capable of causing chemical burns.",
+		de: "Nach dem Verzehr eines sauren Apfels hat es sich entwickelt. In den Backentaschen speichert es eine saure Substanz, die zu Verbrennungen führt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV014.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV014.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Verpom",
-		en: "Applin"
+		en: "Applin",
+		de: "Knapfel"
 	},
 
 	abilities: [{
@@ -71,7 +72,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Eating a sweet apple caused its evolution. A nectarous scent wafts from its body, luring in the bug Pokémon it preys on."
+		en: "Eating a sweet apple caused its evolution. A nectarous scent wafts from its body, luring in the bug Pokémon it preys on.",
+		de: "Nach dem Verzehr eines süßen Apfels hat es sich entwickelt. Es verströmt einen süßen Duft und lockt damit sein Futter an: Käfer-Pokémon."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV015.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV015.ts
@@ -53,7 +53,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It has special pads on the backs of its feet, and one on its nose. Once it's raring to fight, these pads radiate tremendous heat."
+		en: "It has special pads on the backs of its feet, and one on its nose. Once it's raring to fight, these pads radiate tremendous heat.",
+		de: "Ist es kampfbereit, verströmt es von seiner Nasenspitze und von den Ballen an seinen Läufen Hitze."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV016.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV016.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Flambino",
-		en: "Scorbunny"
+		en: "Scorbunny",
+		de: "Hopplo"
 	},
 
 	attacks: [{
@@ -41,7 +42,7 @@ const card: Card = {
 			es: "Busca en tu baraja 1 carta de Energía Fire y únela a este Pokémon. Después, baraja las cartas de tu baraja.",
 			it: "Cerca nel tuo mazzo una carta Energia Fire e assegnala a questo Pokémon. Poi rimischia le carte del tuo mazzo.",
 			pt: "Procure por 1 carta de Energia Fire no seu baralho e ligue-a a este Pokémon. Em seguida, embaralhe o seu baralho.",
-			de: "Durchsuche dein Deck nach 1 Fire-Energiekarte und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
+			de: "Durchsuche dein Deck nach 1 {R}-Energiekarte und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
 		},
 
 		damage: 20,
@@ -70,7 +71,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It kicks berries right off the branches of trees and then juggles them with its feet, practicing its footwork."
+		en: "It kicks berries right off the branches of trees and then juggles them with its feet, practicing its footwork.",
+		de: "Es pflückt Beeren von Ästen, ohne seine Hände zu benutzen, und jongliert sie mit den Füßen. Damit trainiert es seine Fußfertigkeiten."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV017.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV017.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Lapyro",
-		en: "Raboot"
+		en: "Raboot",
+		de: "Kickerlo"
 	},
 
 	abilities: [{
@@ -43,7 +44,7 @@ const card: Card = {
 			es: "Una vez durante tu turno, cuando este Pokémon se mueve de tu Banca al Puesto Activo, puedes unirle hasta 2 cartas de Energía Fire de tu pila de descartes.",
 			it: "Una sola volta durante il tuo turno, quando questo Pokémon si sposta dalla tua panchina in posizione attiva, puoi assegnargli fino a due carte Energia Fire dalla tua pila degli scarti.",
 			pt: "Uma vez durante o seu turno, quando este Pokémon for movido do seu Banco para o Campo Ativo, você poderá ligar até 2 cartas de Energia Fire da sua pilha de descarte a ele.",
-			de: "Einmal während deines Zuges, wenn dieses Pokémon von deiner Bank in die Aktive Position wechselt, kannst du bis zu 2 Fire-Energiekarten aus deinem Ablagestapel an es anlegen."
+			de: "Einmal während deines Zuges, wenn dieses Pokémon von deiner Bank in die Aktive Position wechselt, kannst du bis zu 2 {R}-Energiekarten aus deinem Ablagestapel an es anlegen."
 		}
 	}],
 
@@ -80,7 +81,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "It's skilled at both offense and defense, and it gets pumped up when cheered on. But if it starts showboating, it could put itself in a tough spot."
+		en: "It's skilled at both offense and defense, and it gets pumped up when cheered on. But if it starts showboating, it could put itself in a tough spot.",
+		de: "Jubel für besonders gelungene Spielzüge schüren seinen Enthusiasmus. Spielt es aber zu sehr für die Publikumswirkung, geht dies oft nach hinten los."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV018.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV018.ts
@@ -56,7 +56,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It stores flammable gas in its body and uses it to generate heat. The yellow sections on its belly get particularly hot."
+		en: "It stores flammable gas in its body and uses it to generate heat. The yellow sections on its belly get particularly hot.",
+		de: "Mit dem entzündlichen Gas in seinem Körper erzeugt es Hitze. Die gelben Stellen an seinem Bauch werden besonders heiß."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV019.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV019.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Grillepattes",
-		en: "Sizzlipede"
+		en: "Sizzlipede",
+		de: "Thermopod"
 	},
 
 	attacks: [{
@@ -41,7 +42,7 @@ const card: Card = {
 			es: "Por cada Energía Fire unida a este Pokémon, descarta la primera carta de la baraja de tu rival.",
 			it: "Per ogni Energia Fire assegnata a questo Pokémon, scarta la prima carta del mazzo del tuo avversario.",
 			pt: "Para cada Energia Fire ligada a este Pokémon, descarte a carta de cima do baralho do seu oponente.",
-			de: "Lege für jede an dieses Pokémon angelegte Fire-Energie die oberste Karte vom Deck deines Gegners auf seinen Ablagestapel."
+			de: "Lege für jede an dieses Pokémon angelegte {R}-Energie die oberste Karte vom Deck deines Gegners auf seinen Ablagestapel."
 		},
 
 		cost: ["Fire"]
@@ -78,7 +79,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "When it heats up, its body temperature reaches about 1,500 degrees Fahrenheit. It lashes its body like a whip and launches itself at enemies."
+		en: "When it heats up, its body temperature reaches about 1,500 degrees Fahrenheit. It lashes its body like a whip and launches itself at enemies.",
+		de: "Wenn es Hitze erzeugt, beträgt seine Temperatur etwa 800 ºC. Es bewegt seinen Körper wie eine Peitsche, um dann den Gegner anzuspringen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV020.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV020.ts
@@ -64,7 +64,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Its talent is tap-dancing. It can also manipulate temperatures to create a floor of ice, which this Pokémon can kick up to use as a barrier."
+		en: "Its talent is tap-dancing. It can also manipulate temperatures to create a floor of ice, which this Pokémon can kick up to use as a barrier.",
+		de: "Dieser begabte Stepptänzer erzeugt am Boden mit kalter Luft eine Barriere aus Eis und richtet sie zu seinem Schutz mit den Füßen auf."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV021.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV021.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "M. Mime de Galar",
-		en: "Galarian Mr. Mime"
+		en: "Galarian Mr. Mime",
+		de: "Galar-Pantimos"
 	},
 
 	abilities: [{
@@ -80,7 +81,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It's highly skilled at tap-dancing. It waves its cane of ice in time with its graceful movements."
+		en: "It's highly skilled at tap-dancing. It waves its cane of ice in time with its graceful movements.",
+		de: "Dieser begnadete Stepptänzer schwingt einen aus Eis geformten Gehstock und gibt mit leichtem Fuß seinen Tanz zum Besten."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV022.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV022.ts
@@ -48,7 +48,7 @@ const card: Card = {
 			es: "Pon 2 Energías Water unidas a este Pokémon en tu mano.",
 			it: "Prendi due Energie Water assegnate a questo Pokémon e aggiungile alle carte che hai in mano.",
 			pt: "Coloque 2 Energias Water ligadas a este Pokémon na sua mão.",
-			de: "Nimm 2 an dieses Pokémon angelegte Water-Energien auf deine Hand."
+			de: "Nimm 2 an dieses Pokémon angelegte {W}-Energien auf deine Hand."
 		},
 
 		damage: 130,
@@ -65,7 +65,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Said to be the embodiment of north winds, it can instantly purify filthy, murky water."
+		en: "Said to be the embodiment of north winds, it can instantly purify filthy, murky water.",
+		de: "Man sagt, es sei die Wiedergeburt des Nordwindes. Es kann verschmutztes Wasser im Nu reinigen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV023.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV023.ts
@@ -53,7 +53,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It lived in snowy areas for so long that its fire sac cooled off and atrophied. It now has an organ that generates cold instead."
+		en: "It lived in snowy areas for so long that its fire sac cooled off and atrophied. It now has an organ that generates cold instead.",
+		de: "Seit es in kälteren Gefilden lebt, hat sich sein innerer Flammensack zurückgebildet. Stattdessen wuchs ein Organ heran, das eiskalte Luft erzeugt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV024.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV024.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Darumarond de Galar",
-		en: "Galarian Darumaka"
+		en: "Galarian Darumaka",
+		de: "Galar-Flampion"
 	},
 
 	attacks: [{
@@ -79,7 +80,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "On days when blizzards blow through, it comes down to where people live. It stashes food in the snowball on its head, taking it home for later."
+		en: "On days when blizzards blow through, it comes down to where people live. It stashes food in the snowball on its head, taking it home for later.",
+		de: "Es lagert Futter in dem Schneeball auf seinem Kopf und trägt es nach Hause. Bei Schneestürmen steigt es zu den Siedlungen der Menschen hinab."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV025.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV025.ts
@@ -44,7 +44,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "When scared, this Pokémon cries. Its tears pack the chemical punch of 100 onions, and attackers won't be able to resist weeping."
+		en: "When scared, this Pokémon cries. Its tears pack the chemical punch of 100 onions, and attackers won't be able to resist weeping.",
+		de: "Hat es Angst, vergießt es Tränen, die Reizstoffe enthalten, welche andere ebenfalls zum Weinen bringen. Sie sind so stark wie 100 Zwiebeln."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV026.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV026.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Larméléon",
-		en: "Sobble"
+		en: "Sobble",
+		de: "Memmeon"
 	},
 
 	abilities: [{
@@ -43,7 +44,7 @@ const card: Card = {
 			es: "Cuando juegas este Pokémon de tu mano para hacer evolucionar a 1 de tus Pokémon durante tu turno, puedes buscar en tu baraja hasta 2 cartas de Entrenador, enseñarlas y ponerlas en tu mano. Después, baraja las cartas de tu baraja.",
 			it: "Quando giochi questo Pokémon dalla tua mano per far evolvere uno dei tuoi Pokémon durante il tuo turno, puoi cercare nel tuo mazzo fino a due carte Allenatore, mostrarle e aggiungerle a quelle che hai in mano. Poi rimischia le carte del tuo mazzo.",
 			pt: "Quando você jogar este Pokémon da sua mão para evoluir 1 dos seus Pokémon durante o seu turno, você poderá procurar por até 2 cartas de Treinador no seu baralho, revelá-las e colocá-las na sua mão. Em seguida, embaralhe o seu baralho.",
-			de: "Wenn du dieses Pokémon aus deiner Hand spielst, um 1 deiner Pokémon während deines Zuges zu entwickeln, kannst du dein Deck nach bis zu 2 Trainerkarten durchsuchen, sie deinem Gegner zeigen und sie auf deine Hand nehmen. Mische anschließend dein Deck."
+			de: "Wenn du dieses Pokémon aus deiner Hand spielst, um 1 deiner Pokémon während deines Zuges zu entwickeln, kannst du dein Deck nach 1 Trainerkarte durchsuchen, sie deinem Gegner zeigen und sie auf deine Hand nehmen. Mische anschließend dein Deck."
 		}
 	}],
 
@@ -71,7 +72,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "A clever combatant, this Pokémon battles using water balloons created with moisture secreted from its palms."
+		en: "A clever combatant, this Pokémon battles using water balloons created with moisture secreted from its palms.",
+		de: "Das Sekret, das aus seinen Handflächen austritt, formt es zu Wasserkugeln. Diese nutzt es im Kampf für taktisch ausgeklügelte Angriffe."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV027.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV027.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Arrozard",
-		en: "Drizzile"
+		en: "Drizzile",
+		de: "Phlegleon"
 	},
 
 	abilities: [{
@@ -80,7 +81,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "It has many hidden capabilities, such as fingertips that can shoot water and a membrane on its back that it can use to glide through the air."
+		en: "It has many hidden capabilities, such as fingertips that can shoot water and a membrane on its back that it can use to glide through the air.",
+		de: "Zu seinen vielen geheimen Talenten gehört es, Wasser aus den Fingern zu schießen und mit der Membran am Rücken durch die Lüfte zu segeln."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV028.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV028.ts
@@ -56,7 +56,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It starts off battles by attacking with its rock-hard horn, but as soon as the opponent flinches, this Pokémon bites down and never lets go."
+		en: "It starts off battles by attacking with its rock-hard horn, but as soon as the opponent flinches, this Pokémon bites down and never lets go.",
+		de: "Im Kampf greift es mit dem steinharten Horn auf seinem Kopf an. Schreckt der Gegner zurück, schnappt es zu und lässt nicht wieder los."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV029.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV029.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Khélocrok",
-		en: "Chewtle"
+		en: "Chewtle",
+		de: "Kamehaps"
 	},
 
 	attacks: [{
@@ -41,7 +42,7 @@ const card: Card = {
 			es: "Este ataque hace 30 puntos de daño más por cada Colorless en el Coste de Retirada del Pokémon Activo de tu rival.",
 			it: "Questo attacco infligge 30 danni in più per ogni Colorless nel costo di ritirata del Pokémon attivo del tuo avversario.",
 			pt: "Este ataque causa 30 pontos de dano a mais para cada Colorless no custo de Recuo do Pokémon Ativo do seu oponente.",
-			de: "Diese Attacke fügt für jedes Colorless in den Rückzugskosten des Aktiven Pokémon deines Gegners 30 Schadenspunkte mehr zu."
+			de: "Diese Attacke fügt für jedes {C} in den Rückzugskosten des Aktiven Pokémon deines Gegners 30 Schadenspunkte mehr zu."
 		},
 
 		damage: "60+",
@@ -79,7 +80,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "This Pokémon rapidly extends its retractable neck to sink its sharp fangs into distant enemies and take them down."
+		en: "This Pokémon rapidly extends its retractable neck to sink its sharp fangs into distant enemies and take them down.",
+		de: "Sein streckbarer Hals ermöglicht es ihm, auch entfernte Gegner zu erreichen, die es dann mit seinen scharfen Zähnen ausschaltet."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV030.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV030.ts
@@ -57,7 +57,7 @@ const card: Card = {
 			es: "Este ataque hace 20 puntos de daño más por cada Energía Water unida a este Pokémon.",
 			it: "Questo attacco infligge 20 danni in più per ogni Energia Water assegnata a questo Pokémon.",
 			pt: "Este ataque causa 20 pontos de dano a mais para cada Energia Water ligada a este Pokémon.",
-			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte Water-Energie 20 Schadenspunkte mehr zu."
+			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte {W}-Energie 20 Schadenspunkte mehr zu."
 		},
 
 		damage: "50+",
@@ -79,7 +79,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It's so strong that it can knock out some opponents in a single hit, but it also may forget what it's battling midfight."
+		en: "It's so strong that it can knock out some opponents in a single hit, but it also may forget what it's battling midfight.",
+		de: "Es ist so stark, dass es seine Gegner mit einem Angriff vernichten könnte, aber zerstreut wie es ist, vergisst es öfters, wen es gerade bekämpft."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV031.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV031.ts
@@ -44,7 +44,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "If it sees any movement around it, this Pokémon charges for it straightaway, leading with its sharply pointed jaw. It's very proud of that jaw."
+		en: "If it sees any movement around it, this Pokémon charges for it straightaway, leading with its sharply pointed jaw. It's very proud of that jaw.",
+		de: "Sein spitz zulaufender Kiefer ist sein ganzer Stolz. Erblickt es etwas, das sich auch nur ein bisschen bewegt, setzt es geradewegs zum Stoßangriff an."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV032.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV032.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Embrochet",
-		en: "Arrokuda"
+		en: "Arrokuda",
+		de: "Pikuda"
 	},
 
 	attacks: [{
@@ -53,7 +54,7 @@ const card: Card = {
 			es: "Descarta 2 cartas de Energía Water de tu mano. Si no lo haces, este ataque no hace nada.",
 			it: "Scarta due carte Energia Water che hai in mano. Se non lo fai, questo attacco non ha effetto.",
 			pt: "Descarte 2 cartas de Energia Water da sua mão. Se não fizer isto, este ataque não fará nada.",
-			de: "Lege 2 Water-Energiekarten aus deiner Hand auf deinen Ablagestapel. Wenn du das nicht machst, hat diese Attacke keine Auswirkungen."
+			de: "Lege 2 {W}-Energiekarten aus deiner Hand auf deinen Ablagestapel. Wenn du das nicht machst, hat diese Attacke keine Auswirkungen."
 		},
 
 		damage: 130,
@@ -70,7 +71,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "This Pokémon has a jaw that's as sharp as a spear and as strong as steel. Apparently Barraskewda's flesh is surprisingly tasty, too."
+		en: "This Pokémon has a jaw that's as sharp as a spear and as strong as steel. Apparently Barraskewda's flesh is surprisingly tasty, too.",
+		de: "Sein Kiefer ist spitz wie ein Speer und hart wie Stahl. Außerdem soll Barrakiefa überraschend deliziös sein."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV033.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV033.ts
@@ -52,7 +52,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It spits out thread imbued with a frigid sort of energy and uses it to tie its body to branches, disguising itself as an icicle while it sleeps."
+		en: "It spits out thread imbued with a frigid sort of energy and uses it to tie its body to branches, disguising itself as an icicle while it sleeps.",
+		de: "Es spinnt einen eiskalten Faden, mit dem es sich an einen Ast hängt. Dabei tut es so, als wäre es ein Eiszapfen, um in Ruhe schlafen zu können."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV034.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV034.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Frissonille",
-		en: "Snom"
+		en: "Snom",
+		de: "Snomnom"
 	},
 
 	abilities: [{
@@ -43,7 +44,7 @@ const card: Card = {
 			es: "Todas las veces que quieras durante tu turno, puedes unir 1 carta de Energía Water de tu mano a 1 de tus Pokémon Water en Banca.",
 			it: "Durante il tuo turno, puoi assegnare a uno dei tuoi Pokémon Water in panchina una carta Energia Water dalla tua mano tutte le volte che vuoi.",
 			pt: "Quantas vezes desejar durante o seu turno, você poderá ligar 1 carta de Energia Water da sua mão a 1 dos seus Pokémon Water no Banco.",
-			de: "Beliebig oft während deines Zuges kannst du 1 Water-Energiekarte aus deiner Hand an 1 Water-Pokémon auf deiner Bank anlegen."
+			de: "Beliebig oft während deines Zuges kannst du 1 {W}-Energiekarte aus deiner Hand an 1 {W}-Pokémon auf deiner Bank anlegen."
 		}
 	}],
 
@@ -71,7 +72,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It shows no mercy to any who desecrate fields and mountains. It will fly around on its icy wings, causing a blizzard to chase offenders away."
+		en: "It shows no mercy to any who desecrate fields and mountains. It will fly around on its icy wings, causing a blizzard to chase offenders away.",
+		de: "Verwüstet jemand Felder und Berge, vergibt es ihm niemals. Es bestraft den Täter, indem es mit seinen kalten Flügeln einen Schneesturm erzeugt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV035.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV035.ts
@@ -75,7 +75,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It drifted in on the flow of ocean waters from a frigid place. It keeps its head iced constantly to make sure it stays nice and cold."
+		en: "It drifted in on the flow of ocean waters from a frigid place. It keeps its head iced constantly to make sure it stays nice and cold.",
+		de: "Es kam von einem extrem kalten Ort, indem es sich treiben ließ und schließlich angespült wurde. Es kühlt unablässig sein Gesicht mit Eis."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV036.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV036.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Fossile Rare",
-		en: "Rare Fossil"
+		en: "Rare Fossil",
+		de: "Seltenes Fossil"
 	},
 
 	abilities: [{
@@ -71,7 +72,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Powerful legs and jaws made it the apex predator of its time. Its own overhunting of its prey was what drove it to extinction."
+		en: "Powerful legs and jaws made it the apex predator of its time. Its own overhunting of its prey was what drove it to extinction.",
+		de: "Dank der enormen Kraft seiner Beine und seines Kiefers war es in der Urzeit unbesiegbar, doch es fing seine Beute restlos weg und starb daher aus."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV037.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV037.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Fossile Rare",
-		en: "Rare Fossil"
+		en: "Rare Fossil",
+		de: "Seltenes Fossil"
 	},
 
 	attacks: [{
@@ -79,7 +80,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Though it's able to capture prey by freezing its surroundings, it has trouble eating the prey afterward because its mouth is on top of its head."
+		en: "Though it's able to capture prey by freezing its surroundings, it has trouble eating the prey afterward because its mouth is on top of its head.",
+		de: "Es fängt seine Beute, indem es seine Umgebung einfriert, doch da sich sein Maul oben auf seinem Kopf befindet, ist Fressen für es sehr umständlich."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV038.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV038.ts
@@ -75,7 +75,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "One boy's invention led to the development of many different machines that take advantage of Rotom's unique capabilities."
+		en: "One boy's invention led to the development of many different machines that take advantage of Rotom's unique capabilities.",
+		de: "Die Erfindung eines jungen Tüftlers hat zu der Herstellung verschiedener Geräte geführt, die das Potenzial von Rotom nutzen können."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV039.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV039.ts
@@ -64,7 +64,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "This Pokémon is very popular as a herding dog in the Galar region. As it runs, it generates electricity from the base of its tail."
+		en: "This Pokémon is very popular as a herding dog in the Galar region. As it runs, it generates electricity from the base of its tail.",
+		de: "Beim Rennen erzeugt es Elektrizität in seinem Schwanzansatz. In der Galar-Region erfreut es sich bei Hirten großer Beliebtheit."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV040.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV040.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Voltoutou",
-		en: "Yamper"
+		en: "Yamper",
+		de: "Voldi"
 	},
 
 	attacks: [{
@@ -79,7 +80,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "This Pokémon generates electricity and channels it into its legs to keep them going strong. Boltund can run nonstop for three full days."
+		en: "This Pokémon generates electricity and channels it into its legs to keep them going strong. Boltund can run nonstop for three full days.",
+		de: "Es generiert Strom und lässt ihn zur Unterstützung beim Rennen in seine Beine fließen. Dadurch kann es drei Tage und Nächte ohne Pause rennen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV041.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV041.ts
@@ -56,7 +56,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It stores poison in an internal poison sac and secretes that poison through its skin. If you touch this Pokémon, a tingling sensation follows."
+		en: "It stores poison in an internal poison sac and secretes that poison through its skin. If you touch this Pokémon, a tingling sensation follows.",
+		de: "Das Gift aus dem Giftsack in seinem Körper sondert es über die Haut ab. Berührt man es, bekommt man einen lähmenden Schock verpasst."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV042.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV042.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Toxizap",
-		en: "Toxel"
+		en: "Toxel",
+		de: "Toxel"
 	},
 
 	attacks: [{
@@ -78,7 +79,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "When this Pokémon sounds as if it's strumming a guitar, it's actually clawing at the protrusions on its chest to generate electricity."
+		en: "When this Pokémon sounds as if it's strumming a guitar, it's actually clawing at the protrusions on its chest to generate electricity.",
+		de: "Wenn es am Fortsatz an seiner Brust kratzt und dadurch Strom erzeugt, dann erklingt in der Umgebung ein Ton wie von einer Gitarre."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV043.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV043.ts
@@ -53,7 +53,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It feeds on seaweed, using its teeth to scrape it off rocks. Electric current flows from the tips of its spines."
+		en: "It feeds on seaweed, using its teeth to scrape it off rocks. Electric current flows from the tips of its spines.",
+		de: "Aus den Spitzen seiner Stacheln setzt es Elektrizität frei. Mit seinen scharfen Zähnen schabt es Algen von Steinen ab und frisst sie."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV044.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV044.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "As it eats the seeds stored up in its pocket-like pouches, this Pokémon is not just satisfying its constant hunger. It's also generating electricity."
+		en: "As it eats the seeds stored up in its pocket-like pouches, this Pokémon is not just satisfying its constant hunger. It's also generating electricity.",
+		de: "Dieses immerzu hungrige Pokémon frisst Samen, die es in seinen beutelartigen Taschen verwahrt, und produziert so Elektrizität."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV045.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV045.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Fossile Rare",
-		en: "Rare Fossil"
+		en: "Rare Fossil",
+		de: "Seltenes Fossil"
 	},
 
 	attacks: [{
@@ -79,7 +80,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "In ancient times, it was unbeatable thanks to its powerful lower body, but it went extinct anyway after it depleted all its plant-based food sources."
+		en: "In ancient times, it was unbeatable thanks to its powerful lower body, but it went extinct anyway after it depleted all its plant-based food sources.",
+		de: "Dank seines kräftigen Unterkörpers war es in der Urzeit unbesiegbar, doch es fraß seine Pflanzennahrung restlos auf und starb daher aus."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV046.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV046.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Fossile Rare",
-		en: "Rare Fossil"
+		en: "Rare Fossil",
+		de: "Seltenes Fossil"
 	},
 
 	abilities: [{
@@ -71,7 +72,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "The shaking of its freezing upper half is what generates its electricity. It has a hard time walking around."
+		en: "The shaking of its freezing upper half is what generates its electricity. It has a hard time walking around.",
+		de: "Durch das Zittern seines gefrorenen Oberkörpers entsteht Elektrizität. Das Laufen fällt ihm äußerst schwer."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV047.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV047.ts
@@ -58,7 +58,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "This Pokémon will look into your eyes and read the contents of your heart. If it finds evil there, it promptly hides away."
+		en: "This Pokémon will look into your eyes and read the contents of your heart. If it finds evil there, it promptly hides away.",
+		de: "Ein Blick in die Augen seines Gegenübers reicht ihm, um seine Absichten zu erkennen. Vor Leuten, die böse Gedanken hegen, läuft es sofort davon."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV048.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV048.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Ponyta de Galar",
-		en: "Galarian Ponyta"
+		en: "Galarian Ponyta",
+		de: "Galar-Ponita"
 	},
 
 	abilities: [{
@@ -85,7 +86,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Brave and prideful, this Pokémon dashes airily through the forest, its steps aided by the psychic power stored in the fur on its fetlocks."
+		en: "Brave and prideful, this Pokémon dashes airily through the forest, its steps aided by the psychic power stored in the fur on its fetlocks.",
+		de: "Dieses kühne, stolze Pokémon speichert im Fell über seinen Hufen Psycho-Kräfte, dank deren es leichtfüßig durch die Wälder galoppiert."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV049.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV049.ts
@@ -57,7 +57,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Watch your step when wandering areas oceans once covered. What looks like a stone could be this Pokémon, and it will curse you if you kick it."
+		en: "Watch your step when wandering areas oceans once covered. What looks like a stone could be this Pokémon, and it will curse you if you kick it.",
+		de: "Man findet es oft an Orten, die vor langer Zeit vom Meer bedeckt waren. Wer es mit einem Stein verwechselt und herumkickt, wird verflucht."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV050.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV050.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Corayon de Galar",
-		en: "Galarian Corsola"
+		en: "Galarian Corsola",
+		de: "Galar-Corasonn"
 	},
 
 	abilities: [{
@@ -85,7 +86,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Its shell is overflowing with its heightened otherworldly energy. The ectoplasm serves as protection for this Pokémon's core spirit."
+		en: "Its shell is overflowing with its heightened otherworldly energy. The ectoplasm serves as protection for this Pokémon's core spirit.",
+		de: "In ihm wuchs eine mysteriöse Kraft und so löste es sich von seinem Panzer los. Sein geisterhaftes Ektoplasma schützt die Seele im Kern."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV051.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV051.ts
@@ -53,7 +53,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Its upper whiskers are sensors that survey its surroundings. Its lower whiskers are organs that shoot electricity."
+		en: "Its upper whiskers are sensors that survey its surroundings. Its lower whiskers are organs that shoot electricity.",
+		de: "Seine oberen Schnurrhaare dienen ihm als Sensoren zum Abtasten der Umgebung. Seine unteren Schnurrhaare erzeugen Elektrizität."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV052.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV052.ts
@@ -57,7 +57,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "This Pokémon is said to have been born when a lonely spirit possessed a cold, leftover cup of tea."
+		en: "This Pokémon is said to have been born when a lonely spirit possessed a cold, leftover cup of tea.",
+		de: "Es heißt, eine einsame Seele habe Besitz von einer abgestellten, kalten Tasse Schwarztee ergriffen und sei zu diesem Pokémon geworden."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV053.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV053.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Théffroi",
-		en: "Sinistea"
+		en: "Sinistea",
+		de: "Fatalitee"
 	},
 
 	abilities: [{
@@ -85,7 +86,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "This species lives in antique teapots. Most pots are forgeries, but on rare occasions, an authentic work is found."
+		en: "This species lives in antique teapots. Most pots are forgeries, but on rare occasions, an authentic work is found.",
+		de: "Sie lassen sich in alten Teekannen nieder. Die meisten dieser Kannen sind billige Fälschungen, aber es gibt auch ein paar sehr seltene Originale."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV054.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV054.ts
@@ -69,7 +69,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Via the protrusion on its head, it senses other creatures' emotions. If you don't have a calm disposition, it will never warm up to you."
+		en: "Via the protrusion on its head, it senses other creatures' emotions. If you don't have a calm disposition, it will never warm up to you.",
+		de: "Mit dem Fortsatz an seinem Kopf kann es die Gefühle von Lebewesen wahrnehmen. Es öffnet nur geruhsam veranlagten Leuten sein Herz."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV055.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV055.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Bibichut",
-		en: "Hatenna"
+		en: "Hatenna",
+		de: "Brimova"
 	},
 
 	attacks: [{
@@ -83,7 +84,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "No matter who you are, if you bring strong emotions near this Pokémon, it will silence you violently."
+		en: "No matter who you are, if you bring strong emotions near this Pokémon, it will silence you violently.",
+		de: "Empfindet jemand starke Emotionen, bringt es ihn auf gewaltsame Art zum Schweigen, egal, um wen es sich dabei handelt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV056.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV056.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Chapotus",
-		en: "Hattrem"
+		en: "Hattrem",
+		de: "Brimano"
 	},
 
 	abilities: [{
@@ -84,7 +85,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "It emits psychic power strong enough to cause headaches as a deterrent to the approach of others."
+		en: "It emits psychic power strong enough to cause headaches as a deterrent to the approach of others.",
+		de: "Die starken Psycho-Kräfte, die es ausstrahlt, rufen Kopfschmerzen hervor. So hält es andere Lebewesen von sich fern."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV057.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV057.ts
@@ -64,7 +64,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "This Pokémon was born from sweet-smelling particles in the air. Its body is made of cream."
+		en: "This Pokémon was born from sweet-smelling particles in the air. Its body is made of cream.",
+		de: "Sein Körper besteht aus Sahne. Es entstand aus einer Ansammlung süßer Geruchspartikel in der Luft."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV058.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV058.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Crèmy",
-		en: "Milcery"
+		en: "Milcery",
+		de: "Hokumil"
 	},
 
 	attacks: [{
@@ -78,7 +79,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "When it trusts a Trainer, it will treat them to berries it's decorated with cream."
+		en: "When it trusts a Trainer, it will treat them to berries it's decorated with cream.",
+		de: "Es macht einem Trainer, dem es vertraut, mit Beeren samt Sahnedekoration eine Freude."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV059.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV059.ts
@@ -78,7 +78,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "These intelligent Pokémon touch horns with each other to share information between them."
+		en: "These intelligent Pokémon touch horns with each other to share information between them.",
+		de: "Ein äußerst intelligentes Pokémon, das mit seinen Artgenossen kommuniziert, indem es die Hörner eines anderen Exemplars mit seinen berührt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV060.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV060.ts
@@ -58,7 +58,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "After being reborn as a ghost Pokémon, Dreepy wanders the areas it used to inhabit back when it was alive in prehistoric seas."
+		en: "After being reborn as a ghost Pokémon, Dreepy wanders the areas it used to inhabit back when it was alive in prehistoric seas.",
+		de: "In der Urzeit lebte es im Meer. Nun ist es als Geister-Pokémon wiedererwacht und irrt rastlos durch seinen früheren Lebensraum."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV061.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV061.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Fantyrm",
-		en: "Dreepy"
+		en: "Dreepy",
+		de: "Grolldra"
 	},
 
 	attacks: [{
@@ -74,7 +75,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It's capable of flying faster than 120 mph. It battles alongside Dreepy and dotes on them until they successfully evolve."
+		en: "It's capable of flying faster than 120 mph. It battles alongside Dreepy and dotes on them until they successfully evolve.",
+		de: "Beim Fliegen ist es bis zu 200 km/h schnell. Es kämpft gemeinsam mit Grolldra und kümmert sich bis zu dessen Entwicklung um es."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV062.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV062.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Dispareptil",
-		en: "Drakloak"
+		en: "Drakloak",
+		de: "Phandra"
 	},
 
 	abilities: [{
@@ -85,7 +86,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "When it isn't battling, it keeps Dreepy in the holes on its horns. Once a fight starts, it launches the Dreepy like supersonic missiles."
+		en: "When it isn't battling, it keeps Dreepy in the holes on its horns. Once a fight starts, it launches the Dreepy like supersonic missiles.",
+		de: "Es transportiert Grolldra in den Löchern an seinen Hörnern. Kommt es zum Kampf, schießt es diese mit Mach-Geschwindigkeit ab."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV063.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV063.ts
@@ -65,7 +65,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "The Farfetch'd of the Galar region are brave warriors, and they wield thick, tough leeks in battle."
+		en: "The Farfetch'd of the Galar region are brave warriors, and they wield thick, tough leeks in battle.",
+		de: "Dies ist die in Galar ansässige Form von Porenta. Dieser tapfere Krieger schwingt im Kampf eine dicke, robuste Lauchstange."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV064.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV064.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Canarticho de Galar",
-		en: "Galarian Farfetch'd"
+		en: "Galarian Farfetch'd",
+		de: "Galar-Porenta"
 	},
 
 	attacks: [{
@@ -70,7 +71,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Only Farfetch'd that have survived many battles can attain this evolution. When this Pokémon's leek withers, it will retire from combat."
+		en: "Only Farfetch'd that have survived many battles can attain this evolution. When this Pokémon's leek withers, it will retire from combat.",
+		de: "Porenta, die viele Schlachten überstanden haben, entwickeln sich zu Lauchzelot. Verwelkt seine Lauchstange, zieht es sich vom Kämpfen zurück."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV065.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV065.ts
@@ -53,7 +53,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "A clay slab with cursed engravings took possession of a Yamask. The slab is said to be absorbing the Yamask's dark power."
+		en: "A clay slab with cursed engravings took possession of a Yamask. The slab is said to be absorbing the Yamask's dark power.",
+		de: "Eine Tontafel, auf der ein Fluch eingeritzt wurde, hat Besitz von diesem Makabaja ergriffen. Man sagt, es ziehe seine Kraft aus dem Groll anderer."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV066.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV066.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Tutafeh de Galar",
-		en: "Galarian Yamask"
+		en: "Galarian Yamask",
+		de: "Galar-Makabaja"
 	},
 
 	attacks: [{
@@ -78,7 +79,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "A powerful curse was woven into an ancient painting. After absorbing the spirit of a Yamask, the painting began to move."
+		en: "A powerful curse was woven into an ancient painting. After absorbing the spirit of a Yamask, the painting began to move.",
+		de: "Eine antike Malerei, die mit einem mächtigen Fluch versehen wurde, nahm die Seele eines Makabaja auf und erwachte zum Leben."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV067.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV067.ts
@@ -44,7 +44,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Most of its body has the same composition as coal. Fittingly, this Pokémon was first discovered in coal mines about 400 years ago."
+		en: "Most of its body has the same composition as coal. Fittingly, this Pokémon was first discovered in coal mines about 400 years ago.",
+		de: "Es wurde vor circa 400 Jahren in einer Kohlemine entdeckt. Sein Körper besteht fast aus denselben Komponenten wie Steinkohle."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV068.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV068.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Charbi",
-		en: "Rolycoly"
+		en: "Rolycoly",
+		de: "Klonkett"
 	},
 
 	attacks: [{
@@ -61,7 +62,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It forms coal inside its body. Coal dropped by this Pokémon once helped fuel the lives of people in the Galar region."
+		en: "It forms coal inside its body. Coal dropped by this Pokémon once helped fuel the lives of people in the Galar region.",
+		de: "Es produziert Steinkohle in seinem Körper. Die von ihm abfallende Kohle wurde früher in der Galar-Region fürs tägliche Leben genutzt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV069.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV069.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Wagomine",
-		en: "Carkol"
+		en: "Carkol",
+		de: "Wagong"
 	},
 
 	abilities: [{
@@ -43,7 +44,7 @@ const card: Card = {
 			es: "Una vez durante tu turno, puedes unir 1 carta de Energía Fire, 1 carta de Energía Fighting o 1 de cada una de tu pila de descartes a tus Pokémon de la manera que desees.",
 			it: "Una sola volta durante il tuo turno, puoi assegnare ai tuoi Pokémon una carta Energia Fire, una carta Energia Fighting o entrambe dalla tua pila degli scarti nel modo che preferisci.",
 			pt: "Uma vez durante o seu turno, você poderá ligar 1 carta de Energia Fire, 1 carta de Energia Fighting, ou 1 de cada da sua pilha de descarte aos seus Pokémon como desejar.",
-			de: "Einmal während deines Zuges kannst du 1 Fire-Energiekarte, 1 Fighting-Energiekarte oder von beiden 1 aus deinem Ablagestapel beliebig an deine Pokémon anlegen."
+			de: "Einmal während deines Zuges kannst du 1 {R}-Energiekarte, 1 {F}-Energiekarte oder von beiden 1 aus deinem Ablagestapel beliebig an deine Pokémon anlegen."
 		}
 	}],
 
@@ -71,7 +72,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "It's usually peaceful, but the vandalism of mines enrages it. Offenders will be incinerated with flames that reach 2,700 degrees Fahrenheit."
+		en: "It's usually peaceful, but the vandalism of mines enrages it. Offenders will be incinerated with flames that reach 2,700 degrees Fahrenheit.",
+		de: "Meist ist es friedfertig, aber wenn Menschen eine Mine zugrunde richten, sieht es rot und verbrennt sie mit 1 500 ºC  heißen Flammen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV070.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV070.ts
@@ -52,7 +52,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It spews sand from its nostrils. While the enemy is blinded, it burrows into the ground to hide."
+		en: "It spews sand from its nostrils. While the enemy is blinded, it burrows into the ground to hide.",
+		de: "Aus seinen Nasenlöchern verschießt es Sand. Sobald der Feind dadurch nichts mehr sieht, versteckt es sich flugs unter der Erde."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV071.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV071.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Dunaja",
-		en: "Silicobra"
+		en: "Silicobra",
+		de: "Salanga"
 	},
 
 	attacks: [{
@@ -70,7 +71,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Its unique style of coiling allows it to blast sand out of its sand sac more efficiently."
+		en: "Its unique style of coiling allows it to blast sand out of its sand sac more efficiently.",
+		de: "Es rollt sich auf diese eigentümliche Weise zusammen, damit es den Sand aus seinem Sandbeutel effizienter verschießen kann."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV072.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV072.ts
@@ -53,7 +53,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It's very curious, but its means of investigating things is to try to punch them with its tentacles. The search for food is what brings it onto land."
+		en: "It's very curious, but its means of investigating things is to try to punch them with its tentacles. The search for food is what brings it onto land.",
+		de: "Zur Futtersuche kommt es an Land. Es ist sehr neugierig, weshalb es alles, was es sieht, zunächst einmal mit seinen Tentakeln haut."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV073.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV073.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Poulpaf",
-		en: "Clobbopus"
+		en: "Clobbopus",
+		de: "Klopptopus"
 	},
 
 	attacks: [{
@@ -41,7 +42,7 @@ const card: Card = {
 			es: "Hasta que este Grapploct deje el Puesto Activo, los ataques del Pokémon Defensor cuestan ColorlessColorless más, y el Pokémon Defensor no puede retirarse. Este efecto no puede aplicarse más de una vez.",
 			it: "Finché questo Grapploct è in posizione attiva, il costo degli attacchi del Pokémon difensore aumenta di ColorlessColorless e il Pokémon difensore non può ritirarsi. Questo effetto non può essere applicato più di una volta.",
 			pt: "Até este Grapploct sair do Campo Ativo, o custo dos ataques do Pokémon Defensor será ColorlessColorless a mais e o Pokémon Defensor não poderá recuar. Este efeito não pode ser aplicado mais de uma vez.",
-			de: "Bis dieses Kaocto die Aktive Position verlässt, erhöhen sich die Kosten der Attacken des Verteidigenden Pokémon um ColorlessColorless und das Verteidigende Pokémon kann sich nicht zurückziehen. Dieser Effekt kann nicht mehr als einmal angewandt werden."
+			de: "Bis dieses Kaocto die Aktive Position verlässt, erhöhen sich die Kosten der Attacken des Verteidigenden Pokémon um {C}{C} und das Verteidigende Pokémon kann sich nicht zurückziehen. Dieser Effekt kann nicht mehr als einmal angewandt werden."
 		},
 
 		cost: ["Fighting", "Fighting"]
@@ -78,7 +79,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "A body made up of nothing but muscle makes the grappling moves this Pokémon performs with its tentacles tremendously powerful."
+		en: "A body made up of nothing but muscle makes the grappling moves this Pokémon performs with its tentacles tremendously powerful.",
+		de: "Sein Körper besteht gänzlich aus Muskeln. Die schiere Stärke seines Würgegriffs, bei dem es seine Tentakel einsetzt, ist sagenhaft."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV074.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV074.ts
@@ -73,7 +73,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Five of them are troopers, and one is the brass. The brass's orders are absolute."
+		en: "Five of them are troopers, and one is the brass. The brass's orders are absolute.",
+		de: "Dieses Pokémon besteht aus fünf Untergebenen und einem Anführer. Die Befehle des Anführers werden nie in Frage gestellt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV075.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV075.ts
@@ -65,7 +65,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It stands in grasslands, watching the sun's descent from zenith to horizon. This Pokémon has a talent for delivering dynamic kicks."
+		en: "It stands in grasslands, watching the sun's descent from zenith to horizon. This Pokémon has a talent for delivering dynamic kicks.",
+		de: "Es verweilt auf weitläufigen Wiesen und beobachtet den Lauf der Sonne. Dynamische Trittangriffe sind sein Spezialgebiet."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV076.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV076.ts
@@ -52,7 +52,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Its body is full of poisonous gas. It floats into garbage dumps, seeking out the fumes of raw, rotting trash."
+		en: "Its body is full of poisonous gas. It floats into garbage dumps, seeking out the fumes of raw, rotting trash.",
+		de: "Sein Körper ist zum Bersten voll mit Giftgas. Angelockt vom fauligen Geruch verrottender Abfälle, lungert es auf Müllhalden herum."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV077.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV077.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Smogo",
-		en: "Koffing"
+		en: "Koffing",
+		de: "Smogon"
 	},
 
 	abilities: [{
@@ -79,7 +80,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "This Pokémon consumes particles that contaminate the air. Instead of leaving droppings, it expels clean air."
+		en: "This Pokémon consumes particles that contaminate the air. Instead of leaving droppings, it expels clean air.",
+		de: "Es saugt Schmutzpartikel aus der Atmosphäre und scheidet sie dann anstelle von Exkrementen in Form von sauberer Luft wieder aus."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV078.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV078.ts
@@ -75,7 +75,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Thought to be the oldest form of Zigzagoon, it moves in zigzags and wreaks havoc upon its surroundings."
+		en: "Thought to be the oldest form of Zigzagoon, it moves in zigzags and wreaks havoc upon its surroundings.",
+		de: "Es hinterlässt überall ein riesiges Chaos, indem es sich im Zickzack bewegt. Hierbei handelt es sich offenbar um die älteste Form von Zigzachs."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV079.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV079.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Zigzaton de Galar",
-		en: "Galarian Zigzagoon"
+		en: "Galarian Zigzagoon",
+		de: "Galar-Zigzachs"
 	},
 
 	attacks: [{
@@ -70,7 +71,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "This very aggressive Pokémon will recklessly challenge opponents stronger than itself."
+		en: "This very aggressive Pokémon will recklessly challenge opponents stronger than itself.",
+		de: "Es ist sehr angriffslustig und schreckt auch nicht davor zurück, sich mit Gegnern anzulegen, die ihm haushoch überlegen sind."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV080.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV080.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Linéon de Galar",
-		en: "Galarian Linoone"
+		en: "Galarian Linoone",
+		de: "Galar-Geradaks"
 	},
 
 	abilities: [{
@@ -80,7 +81,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "It evolved after experiencing numerous fights. While crossing its arms, it lets out a shout that would make any opponent flinch."
+		en: "It evolved after experiencing numerous fights. While crossing its arms, it lets out a shout that would make any opponent flinch.",
+		de: "Durch das Austragen unzähliger Kämpfe hat es sich entwickelt. Formt es mit den Armen ein „X“ und stößt einen Schrei aus, verschreckt das jeden."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV081.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV081.ts
@@ -52,7 +52,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Aided by the soft pads on its feet, it silently raids the food stores of other Pokémon. It survives off its ill-gotten gains."
+		en: "Aided by the soft pads on its feet, it silently raids the food stores of other Pokémon. It survives off its ill-gotten gains.",
+		de: "Es stibitzt Futter, das andere Pokémon gefunden haben. Dank der samtweichen Ballen an seinen Pfoten ist sein Gang lautlos."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV082.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV082.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Goupilou",
-		en: "Nickit"
+		en: "Nickit",
+		de: "Kleptifux"
 	},
 
 	attacks: [{
@@ -70,7 +71,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It secretly marks potential targets with a scent. By following the scent, it stalks its targets and steals from them when they least expect it."
+		en: "It secretly marks potential targets with a scent. By following the scent, it stalks its targets and steals from them when they least expect it.",
+		de: "Es markiert heimlich die Beute, auf die es ein Auge geworfen hat. Dann folgt es dem Geruch und stiehlt sie, wenn sich die Gelegenheit bietet."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV083.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV083.ts
@@ -56,7 +56,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Through its nose, it sucks in the emanations produced by people and Pokémon when they feel annoyed. It thrives off this negative energy."
+		en: "Through its nose, it sucks in the emanations produced by people and Pokémon when they feel annoyed. It thrives off this negative energy.",
+		de: "Es wird kräftiger, indem es die von unzufriedenen Menschen und Pokémon ausgestoßene negative Energie einatmet."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV084.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV084.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Grimalin",
-		en: "Impidimp"
+		en: "Impidimp",
+		de: "Bähmon"
 	},
 
 	attacks: [{
@@ -70,7 +71,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "When it gets down on all fours as if to beg for forgiveness, it's trying to lure opponents in so that it can stab them with its spear-like hair."
+		en: "When it gets down on all fours as if to beg for forgiveness, it's trying to lure opponents in so that it can stab them with its spear-like hair.",
+		de: "Es nutzt eine Taktik, bei der es sich niederwirft und vorgibt, sich zu entschuldigen, nur um dann mit seinem speerartigen Haar zuzustoßen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV085.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV085.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Fourbelin",
-		en: "Morgrem"
+		en: "Morgrem",
+		de: "Pelzebub"
 	},
 
 	abilities: [{
@@ -43,7 +44,7 @@ const card: Card = {
 			es: "Mientras este Pokémon esté en el Puesto Activo, los ataques del Pokémon Activo de tu rival cuestan Colorless más.",
 			it: "Fintanto che questo Pokémon è in posizione attiva, il costo degli attacchi del Pokémon attivo del tuo avversario aumenta di Colorless.",
 			pt: "Enquanto este Pokémon estiver no Campo Ativo, os ataques do Pokémon Ativo do seu oponente custam Colorless a mais.",
-			de: "Solange dieses Pokémon in der Aktiven Position ist, erhöhen sich die Kosten der Attacken des Aktiven Pokémon deines Gegners um Colorless."
+			de: "Solange dieses Pokémon in der Aktiven Position ist, erhöhen sich die Kosten der Attacken des Aktiven Pokémon deines Gegners um {C}."
 		}
 	}],
 
@@ -80,7 +81,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "With the hair wrapped around its body helping to enhance its muscles, this Pokémon can overwhelm even Machamp."
+		en: "With the hair wrapped around its body helping to enhance its muscles, this Pokémon can overwhelm even Machamp.",
+		de: "Wickelt es seine Haare um den ganzen Körper, verstärkt dies seine Muskelkraft. Das macht es so stark, dass es sogar Machomei bezwingen könnte."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV086.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV086.ts
@@ -71,7 +71,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Living with a savage, seafaring people has toughened this Pokémon's body so much that parts of it have turned to iron."
+		en: "Living with a savage, seafaring people has toughened this Pokémon's body so much that parts of it have turned to iron.",
+		de: "Das Leben bei einem kriegerischen Seefahrervolk hat es stärker gemacht. Manche Stellen an seinem Körper wandelten sich dabei zu Eisen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV087.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV087.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Miaouss de Galar",
-		en: "Galarian Meowth"
+		en: "Galarian Meowth",
+		de: "Galar-Mauzi"
 	},
 
 	abilities: [{
@@ -43,7 +44,7 @@ const card: Card = {
 			es: "Los ataques de tus Pokémon Metal hacen 20 puntos de daño más al Pokémon Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
 			it: "Gli attacchi dei tuoi Pokémon Metal infliggono 20 danni in più al Pokémon attivo del tuo avversario, prima di aver applicato debolezza e resistenza.",
 			pt: "Os ataques dos seus Pokémon Metal causam 20 pontos de dano a mais ao Pokémon Ativo do seu oponente (antes de aplicar Fraqueza e Resistência).",
-			de: "Die Attacken deiner Metal-Pokémon fügen dem Aktiven Pokémon deines Gegners 20 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
+			de: "Die Attacken deiner {M}-Pokémon fügen dem Aktiven Pokémon deines Gegners 20 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
 		}
 	}],
 
@@ -76,7 +77,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "What appears to be an iron helmet is actually hardened hair. This Pokémon lives for the thrill of battle."
+		en: "What appears to be an iron helmet is actually hardened hair. This Pokémon lives for the thrill of battle.",
+		de: "Die Haare auf seinem Kopf haben sich zu etwas verhärtet, das an einen eisernen Helm erinnert. Es ist von Natur aus kriegerisch veranlagt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV088.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV088.ts
@@ -80,7 +80,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Living in mud with a high iron content has given it a strong steel body."
+		en: "Living in mud with a high iron content has given it a strong steel body.",
+		de: "Das Leben inmitten von stark eisenhaltigem Schlamm führte dazu, dass es einen robusten Körper aus Stahl entwickelte."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV089.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV089.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Bleuseille",
-		en: "Corvisquire"
+		en: "Corvisquire",
+		de: "Kranoviz"
 	},
 
 	attacks: [{
@@ -75,7 +76,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "This Pokémon reigns supreme in the skies of the Galar region. The black luster of its steel body could drive terror into the heart of any foe."
+		en: "This Pokémon reigns supreme in the skies of the Galar region. The black luster of its steel body could drive terror into the heart of any foe.",
+		de: "Niemand wagt es, ihm den Himmel über Galar streitig zu machen. Sein schwarz glänzendes, stählernes Äußeres schüchtert jeden Gegner ein."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV090.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV090.ts
@@ -49,7 +49,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It digs up the ground with its trunk. It's also very strong, being able to carry loads of over five tons without any problem at all."
+		en: "It digs up the ground with its trunk. It's also very strong, being able to carry loads of over five tons without any problem at all.",
+		de: "Dieses Pokémon verfügt über eine Stärke, mit der es problemlos fünf Tonnen stemmen kann. Es nutzt seinen Rüssel, um in der Erde zu graben."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV091.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV091.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Charibari",
-		en: "Cufant"
+		en: "Cufant",
+		de: "Kupfanti"
 	},
 
 	abilities: [{
@@ -85,7 +86,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "They came over from another region long ago and worked together with humans. Their green skin is resistant to water."
+		en: "They came over from another region long ago and worked together with humans. Their green skin is resistant to water.",
+		de: "Seine grüne Haut ist wasserresistent. Es kam vor langer Zeit aus einer anderen Region und verrichtete mit den Menschen Arbeiten."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV092.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV092.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			es: "Une 1 carta de Energía Metal de tu pila de descartes a 1 de tus Pokémon.",
 			it: "Assegna a uno dei tuoi Pokémon una carta Energia Metal dalla tua pila degli scarti.",
 			pt: "Ligue 1 carta de Energia Metal da sua pilha de descarte a 1 dos seus Pokémon.",
-			de: "Lege 1 Metal-Energiekarte aus deinem Ablagestapel an 1 deiner Pokémon an."
+			de: "Lege 1 {M}-Energiekarte aus deinem Ablagestapel an 1 deiner Pokémon an."
 		},
 
 		damage: 30,
@@ -70,7 +70,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Its body resembles polished metal, and it's both lightweight and strong. The only drawback is that it rusts easily."
+		en: "Its body resembles polished metal, and it's both lightweight and strong. The only drawback is that it rusts easily.",
+		de: "Sein an aufpoliertes Metall erinnernder Körper ist nicht nur leicht, sondern auch robust. Er hat jedoch den Nachteil, schnell zu rosten."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV093.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV093.ts
@@ -73,7 +73,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "The way it brushes away grime with its tail can be helpful when cleaning. But its focus on spotlessness can make cleaning more of a hassle."
+		en: "The way it brushes away grime with its tail can be helpful when cleaning. But its focus on spotlessness can make cleaning more of a hassle.",
+		de: "Es entfernt Schmutz mit seinem Schweif. Beim Hausputz ist es eine große Hilfe, aber sein Putzfimmel kann auch anstrengend werden."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV094.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV094.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Chinchidou",
-		en: "Minccino"
+		en: "Minccino",
+		de: "Picochilla"
 	},
 
 	abilities: [{
@@ -80,7 +81,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Its body secretes oil that this Pokémon spreads over its nest as a coating to protect it from dust. Cinccino won't tolerate even a speck of the stuff."
+		en: "Its body secretes oil that this Pokémon spreads over its nest as a coating to protect it from dust. Cinccino won't tolerate even a speck of the stuff.",
+		de: "Es ist sehr reinlich und duldet nicht mal das kleinste Staubkorn. Es beschichtet sein Nest mit dem Öl, das sein Körper absondert."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV095.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV095.ts
@@ -49,7 +49,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "They are better at swimming than flying, and they happily eat their favorite food, peat moss, as they dive underwater."
+		en: "They are better at swimming than flying, and they happily eat their favorite food, peat moss, as they dive underwater.",
+		de: "Es schwimmt besser, als es fliegen kann. Am liebsten taucht es ins kühle Nass ab, um Torfmoos, seine Leibspeise, zu essen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV096.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV096.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Couaneton",
-		en: "Ducklett"
+		en: "Ducklett",
+		de: "Piccolente"
 	},
 
 	abilities: [{
@@ -85,7 +86,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Swanna start to dance at dusk. The one dancing in the middle is the leader of the flock."
+		en: "Swanna start to dance at dusk. The one dancing in the middle is the leader of the flock.",
+		de: "Wenn der Morgen dämmert, fangen sie an zu tanzen. Das Swaroness in der Mitte führt die Gruppe an."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV097.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV097.ts
@@ -53,7 +53,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It excels at digging holes. Using its ears, it can dig a nest 33 feet deep in one night."
+		en: "It excels at digging holes. Using its ears, it can dig a nest 33 feet deep in one night.",
+		de: "Mit den Ohren schaufelt es Löcher. Es braucht nur eine Nacht, um einen 10 m tiefen Bau zu graben."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV098.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV098.ts
@@ -66,7 +66,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It knows the forest inside and out. If it comes across a wounded Pokémon, Oranguru will gather medicinal herbs to treat it."
+		en: "It knows the forest inside and out. If it comes across a wounded Pokémon, Oranguru will gather medicinal herbs to treat it.",
+		de: "Es kennt jeden Winkel des Waldes. Trifft es ein verletztes Pokémon, findet es in Windeseile das passende Heilkraut und schreitet zur Behandlung."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV099.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV099.ts
@@ -56,7 +56,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Found throughout the Galar region, this Pokémon becomes uneasy if its cheeks are ever completely empty of berries."
+		en: "Found throughout the Galar region, this Pokémon becomes uneasy if its cheeks are ever completely empty of berries.",
+		de: "Es ist überall in der Galar-Region anzutreffen. Hat es keine Beeren, die es in seinen beiden Backen horten kann, wird es unruhig."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV100.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV100.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Rongourmand",
-		en: "Skwovet"
+		en: "Skwovet",
+		de: "Raffel"
 	},
 
 	abilities: [{
@@ -71,7 +72,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It stashes berries in its tail—so many berries that they fall out constantly. But this Pokémon is a bit slow-witted, so it doesn't notice the loss."
+		en: "It stashes berries in its tail—so many berries that they fall out constantly. But this Pokémon is a bit slow-witted, so it doesn't notice the loss.",
+		de: "Es hortet in seinem Schweif Beeren. Versucht es, zu viele unterzubringen, fallen sie heraus. Da es jedoch nicht allzu clever ist, bemerkt es das nicht."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV101.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV101.ts
@@ -61,7 +61,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It will bravely challenge any opponent, no matter how powerful. This Pokémon benefits from every battle—even a defeat increases its strength a bit."
+		en: "It will bravely challenge any opponent, no matter how powerful. This Pokémon benefits from every battle—even a defeat increases its strength a bit.",
+		de: "Es ist von Natur aus sehr mutig und fordert daher jeden noch so starken Feind heraus. Selbst wenn es den Kürzeren zieht, dient dies seinem Training."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV102.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV102.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Minisange",
-		en: "Rookidee"
+		en: "Rookidee",
+		de: "Meikro"
 	},
 
 	attacks: [{
@@ -75,7 +76,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Smart enough to use tools in battle, these Pokémon have been seen picking up rocks and flinging them or using ropes to wrap up enemies."
+		en: "Smart enough to use tools in battle, these Pokémon have been seen picking up rocks and flinging them or using ropes to wrap up enemies.",
+		de: "Es weiß Objekte geschickt einzusetzen. So greift und wirft es zum Beispiel kleine Steine mit seinen Krallen oder wickelt Seile um Gegner."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV103.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV103.ts
@@ -53,7 +53,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "If its fleece grows too long, Wooloo won't be able to move. Cloth made with the wool of this Pokémon is surprisingly strong."
+		en: "If its fleece grows too long, Wooloo won't be able to move. Cloth made with the wool of this Pokémon is surprisingly strong.",
+		de: "Werden seine Haare zu lang, kann es sich nicht mehr bewegen. Der aus Wollys Wolle gewobene Stoff ist unglaublich robust."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV104.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV104.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Moumouton",
-		en: "Wooloo"
+		en: "Wooloo",
+		de: "Wolly"
 	},
 
 	attacks: [{
@@ -79,7 +80,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Its majestic horns are meant only to impress the opposite gender. They never see use in battle."
+		en: "Its majestic horns are meant only to impress the opposite gender. They never see use in battle.",
+		de: "Seine prächtig gewachsenen Hörner dienen dazu, dem anderen Geschlecht zu imponieren. Es nutzt sie nicht als Waffe."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV105.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV105.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			es: "Busca en tu baraja hasta 2 Pokémon Grass Básicos y ponlos en tu Banca. Después, baraja las cartas de tu baraja.",
 			it: "Cerca nel tuo mazzo fino a due Pokémon Base Grass e mettili nella tua panchina. Poi rimischia le carte del tuo mazzo.",
 			pt: "Procure por até 2 Pokémon Grass Básicos no seu baralho e coloque-os no seu Banco. Em seguida, embaralhe o seu baralho.",
-			de: "Durchsuche dein Deck nach bis zu 2 Basis-Grass-Pokémon und lege sie auf deine Bank. Mische anschließend dein Deck."
+			de: "Durchsuche dein Deck nach bis zu 2 Basis-{G}-Pokémon und lege sie auf deine Bank. Mische anschließend dein Deck."
 		},
 
 		cost: ["Grass"]

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV106.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV106.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Gorythmic-V",
-		en: "Rillaboom V"
+		en: "Rillaboom V",
+		de: "Gortrom V"
 	},
 
 	attacks: [{
@@ -53,7 +54,7 @@ const card: Card = {
 			es: "Puedes descartar hasta 3 Energías Grass de este Pokémon. Si lo haces, este ataque hace 50 puntos de daño más por cada carta que hayas descartado de esta manera.",
 			it: "Puoi scartare fino a tre Energie Grass da questo Pokémon. Se lo fai, questo attacco infligge 50 danni in più per ogni carta che hai scartato in questo modo.",
 			pt: "Você pode descartar até 3 Energias Grass deste Pokémon. Se fizer isto, este ataque causará 50 pontos de dano a mais para cada carta descartada desta forma.",
-			de: "Du kannst bis zu 3 Grass-Energien von diesem Pokémon auf deinen Ablagestapel legen. Wenn du das machst, fügt diese Attacke für jede auf diese Weise abgelegte Karte 50 Schadenspunkte mehr zu."
+			de: "Du kannst bis zu 3 {G}-Energien von diesem Pokémon auf deinen Ablagestapel legen. Wenn du das machst, fügt diese Attacke für jede auf diese Weise abgelegte Karte 50 Schadenspunkte mehr zu."
 		},
 
 		damage: "130+",

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV107.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV107.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Dracaufeu-V",
-		en: "Charizard V"
+		en: "Charizard V",
+		de: "Glurak V"
 	},
 
 	attacks: [{

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV109.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV109.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Scolocendre-V",
-		en: "Centiskorch V"
+		en: "Centiskorch V",
+		de: "Infernopod V"
 	},
 
 	attacks: [{
@@ -41,7 +42,7 @@ const card: Card = {
 			es: "Este ataque hace 40 puntos de daño más por cada Energía Fire unida a este Pokémon. Si has infligido daño con este ataque, puedes unir 1 carta de Energía Fire de tu pila de descartes a este Pokémon.",
 			it: "Questo attacco infligge 40 danni in più per ogni Energia Fire assegnata a questo Pokémon. Sei hai inflitto dei danni con questo attacco, puoi assegnare a questo Pokémon una carta Energia Fire dalla tua pila degli scarti.",
 			pt: "Este ataque causa 40 pontos de dano a mais para cada Energia Fire ligada a este Pokémon. Se tiver causado qualquer dano com este ataque, você poderá ligar 1 carta de Energia Fire da sua pilha de descarte a este Pokémon.",
-			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte Fire-Energie 40 Schadenspunkte mehr zu. Wenn du mit dieser Attacke Schaden zugefügt hast, kannst du 1 Fire-Energiekarte aus deinem Ablagestapel an dieses Pokémon anlegen."
+			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte {R}-Energie 40 Schadenspunkte mehr zu. Wenn du mit dieser Attacke Schaden zugefügt hast, kannst du 1 {R}-Energiekarte aus deinem Ablagestapel an dieses Pokémon anlegen."
 		},
 
 		damage: "40+",

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV110.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV110.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			es: "Une 1 carta de Energía Water de tu mano a este Pokémon. Si lo haces, cámbialo por 1 de tus Pokémon en Banca.",
 			it: "Assegna a questo Pokémon una carta Energia Water dalla tua mano. Se lo fai, scambialo con uno della tua panchina.",
 			pt: "Ligue 1 carta de Energia Water da sua mão a este Pokémon. Se fizer isto, troque-o por 1 dos seus Pokémon no Banco.",
-			de: "Lege 1 Water-Energiekarte aus deiner Hand an dieses Pokémon an. Wenn du das machst, tausche es gegen 1 Pokémon auf deiner Bank aus."
+			de: "Lege 1 {W}-Energiekarte aus deiner Hand an dieses Pokémon an. Wenn du das machst, tausche es gegen 1 Pokémon auf deiner Bank aus."
 		},
 
 		cost: ["Colorless"]
@@ -56,7 +56,7 @@ const card: Card = {
 			es: "Pon 2 Energías Water unidas a este Pokémon en tu mano.",
 			it: "Prendi due Energie Water assegnate a questo Pokémon e aggiungile alle carte che hai in mano.",
 			pt: "Coloque 2 cartas de Energia Water ligadas a este Pokémon na sua mão.",
-			de: "Nimm 2 an dieses Pokémon angelegte Water-Energien auf deine Hand."
+			de: "Nimm 2 an dieses Pokémon angelegte {W}-Energien auf deine Hand."
 		},
 
 		damage: 210,

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV111.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV111.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Lokhlass-V",
-		en: "Lapras V"
+		en: "Lapras V",
+		de: "Lapras V"
 	},
 
 	attacks: [{
@@ -41,7 +42,7 @@ const card: Card = {
 			es: "Este ataque hace 30 puntos de daño más por cada Energía Water unida a este Pokémon.",
 			it: "Questo attacco infligge 30 danni in più per ogni Energia Water assegnata a questo Pokémon.",
 			pt: "Este ataque causa 30 pontos de dano a mais para cada Energia Water ligada a este Pokémon.",
-			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte Water-Energie 30 Schadenspunkte mehr zu."
+			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte {W}-Energie 30 Schadenspunkte mehr zu."
 		},
 
 		damage: "90+",

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV113.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV113.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Salarsen-V",
-		en: "Toxtricity V"
+		en: "Toxtricity V",
+		de: "Riffex V"
 	},
 
 	attacks: [{

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV116.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV116.ts
@@ -48,7 +48,7 @@ const card: Card = {
 			es: "Pon 2 Energías Darkness unidas a este Pokémon en tu mano.",
 			it: "Prendi due Energie Darkness assegnate a questo Pokémon e aggiungile alle carte che hai in mano.",
 			pt: "Coloque 2 Energias Darkness ligadas a este Pokémon na sua mão.",
-			de: "Nimm 2 an dieses Pokémon angelegte Darkness-Energien auf deine Hand."
+			de: "Nimm 2 an dieses Pokémon angelegte {D}-Energien auf deine Hand."
 		},
 
 		damage: 200,

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV117.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV117.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Angoliath-V",
-		en: "Grimmsnarl V"
+		en: "Grimmsnarl V",
+		de: "Olangaar V"
 	},
 
 	attacks: [{
@@ -41,7 +42,7 @@ const card: Card = {
 			es: "Este ataque hace 50 puntos de daño más por cada Energía Darkness adicional unida a este Pokémon (además de las del coste de este ataque). No puedes añadir más de 100 puntos de daño de esta manera.",
 			it: "Questo attacco infligge 50 danni in più per ogni Energia Darkness extra assegnata a questo Pokémon, in aggiunta a quelle del costo di questo attacco. Non puoi aggiungere più di 100 danni in questo modo.",
 			pt: "Este ataque causa 50 pontos de dano a mais para cada Energia Darkness adicional ligada a este Pokémon (além do custo deste ataque). Você não pode adicionar mais de 100 pontos de dano desta forma.",
-			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte extra Darkness-Energie (zusätzlich zu den Kosten dieser Attacke) 50 Schadenspunkte mehr zu. Du kannst auf diese Weise höchstens 100 Schadenspunkte mehr zufügen."
+			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte extra {D}-Energie (zusätzlich zu den Kosten dieser Attacke) 50 Schadenspunkte mehr zu. Du kannst auf diese Weise höchstens 100 Schadenspunkte mehr zufügen."
 		},
 
 		damage: "170+",

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV119.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV119.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Métamorph-V",
-		en: "Ditto V"
+		en: "Ditto V",
+		de: "Ditto V"
 	},
 
 	attacks: [{

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV121.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV121.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			es: "Puedes unir 1 carta de Energía Darkness de tu mano a 1 de tus Pokémon en Banca.",
 			it: "Puoi assegnare a uno dei tuoi Pokémon in panchina una carta Energia Darkness dalla tua mano.",
 			pt: "Você pode ligar 1 carta de Energia Darkness da sua mão a 1 dos seus Pokémon no Banco.",
-			de: "Du kannst 1 Darkness-Energiekarte aus deiner Hand an 1 Pokémon auf deiner Bank anlegen."
+			de: "Du kannst 1 {D}-Energiekarte aus deiner Hand an 1 Pokémon auf deiner Bank anlegen."
 		},
 
 		damage: 30,

--- a/data/Sword & Shield/Shining Fates Shiny Vault/SV122.ts
+++ b/data/Sword & Shield/Shining Fates Shiny Vault/SV122.ts
@@ -22,7 +22,8 @@ const card: Card = {
 
 	evolveFrom: {
 		fr: "Éthernatos-V",
-		en: "Eternatus V"
+		en: "Eternatus V",
+		de: "Endynalos V"
 	},
 
 	abilities: [{
@@ -43,7 +44,7 @@ const card: Card = {
 			es: "Si todos tus Pokémon en juego son de tipo Darkness, puedes tener hasta 8 Pokémon en tu Banca y no puedes poner Pokémon no Darkness en juego. (Si esta habilidad deja de funcionar, descarta Pokémon de tu Banca hasta que tengas 5).",
 			it: "Se tutti i tuoi Pokémon in gioco sono di tipo Darkness, puoi avere fino a otto Pokémon nella tua panchina e non puoi mettere in gioco Pokémon che non siano di tipo Darkness. Se questa abilità smette di funzionare, scarta i Pokémon dalla tua panchina fino ad averne cinque.",
 			pt: "Se todos os seus Pokémon em jogo forem de tipo Darkness, você poderá ter até 8 Pokémon no seu Banco e não poderá colocar Pokémon que não sejam de tipo Darkness em jogo (se esta Habilidade parar de funcionar, descarte Pokémon até ter 5 no seu Banco).",
-			de: "Wenn alle deine Pokémon im Spiel vom Typ Darkness sind, kannst du bis zu 8 Pokémon auf deiner Bank haben und Pokémon, die keine Darkness-Pokémon sind, nicht ins Spiel bringen. (Wenn diese Fähigkeit nicht mehr aktiv ist, lege so lange Pokémon von deiner Bank auf deinen Ablagestapel, bis du  5 hast.)"
+			de: "Wenn alle deine Pokémon im Spiel vom Typ {D} sind, kannst du bis zu 8 Pokémon auf deiner Bank haben und Pokémon, die keine {D}-Pokémon sind, nicht ins Spiel bringen. (Wenn diese Fähigkeit nicht mehr aktiv ist, lege so lange Pokémon von deiner Bank auf deinen Ablagestapel, bis du 5 hast.)"
 		}
 	}],
 
@@ -63,7 +64,7 @@ const card: Card = {
 			es: "Este ataque hace 30 puntos de daño por cada uno de tus Pokémon Darkness en juego.",
 			it: "Questo attacco infligge 30 danni per ogni tuo Pokémon Darkness in gioco.",
 			pt: "Este ataque causa 30 pontos de dano para cada um dos seus Pokémon Darkness em jogo.",
-			de: "Diese Attacke fügt für jedes deiner Darkness-Pokémon im Spiel 30 Schadenspunkte zu."
+			de: "Diese Attacke fügt für jedes deiner {D}-Pokémon im Spiel 30 Schadenspunkte zu."
 		},
 
 		damage: "30×",


### PR DESCRIPTION
## Add missing German translations for swsh4.5sv

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
