### PR TITLE
Add missing German translations for swsh3.5

### DIFF
--- a/data/Sword & Shield/Champion's Path/10.ts
+++ b/data/Sword & Shield/Champion's Path/10.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Sizzlipede",
-		fr: "Grillepattes"
+		fr: "Grillepattes",
+		de: "Thermopod"
 	},
 
 	attacks: [
@@ -95,7 +96,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "When it heats up, its body temperature reaches about 1,500 degrees Fahrenheit. It lashes its body like a whip and launches itself at enemies."
+		en: "When it heats up, its body temperature reaches about 1,500 degrees Fahrenheit. It lashes its body like a whip and launches itself at enemies.",
+		de: "Wenn es Hitze erzeugt, beträgt seine Temperatur etwa 800 ºC. Es bewegt seinen Körper wie eine Peitsche, um dann den Gegner anzuspringen."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/11.ts
+++ b/data/Sword & Shield/Champion's Path/11.ts
@@ -62,7 +62,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "With its sturdy jaws and fangs, it can easily chomp wooden boats to splinters. It fights with Basculin over food."
+		en: "With its sturdy jaws and fangs, it can easily chomp wooden boats to splinters. It fights with Basculin over food.",
+		de: "Mit seinem robusten Kiefer und starken Zähnen zerbeißt es mühelos Holzboote. Es streitet mit Barschuft um Futter."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/12.ts
+++ b/data/Sword & Shield/Champion's Path/12.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Carvanha",
-		fr: "Carvanha"
+		fr: "Carvanha",
+		de: "Kanivanha"
 	},
 
 	attacks: [
@@ -74,7 +75,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It drinks in seawater and jets it from its rear to propel itself. It's very sensitive to the scent of blood."
+		en: "It drinks in seawater and jets it from its rear to propel itself. It's very sensitive to the scent of blood.",
+		de: "Es schwimmt, indem es das Meerwasser, das es trinkt, aus seinem Hinterteil ausstößt. Für den Geruch von Blut ist es sehr empfänglich."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/13.ts
+++ b/data/Sword & Shield/Champion's Path/13.ts
@@ -41,7 +41,7 @@ const card: Card = {
 				es: "Une hasta 3 cartas de Energía Water de tu pila de descartes a este Pokémon.",
 				it: "Assegna a questo Pokémon fino a tre carte Energia Water dalla tua pila degli scarti.",
 				pt: "Ligue até 3 cartas de Energia Water da sua pilha de descarte a este Pokémon.",
-				de: "Lege bis zu 3 Water-Energiekarten aus deinem Ablagestapel an dieses Pokémon an."
+				de: "Lege bis zu 3 {W}-Energiekarten aus deinem Ablagestapel an dieses Pokémon an."
 			},
 
 		},

--- a/data/Sword & Shield/Champion's Path/15.ts
+++ b/data/Sword & Shield/Champion's Path/15.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Drednaw V",
-		fr: "Torgamord-V"
+		fr: "Torgamord-V",
+		de: "Kamalm V"
 	},
 
 	abilities: [

--- a/data/Sword & Shield/Champion's Path/17.ts
+++ b/data/Sword & Shield/Champion's Path/17.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Gardevoir V",
-		fr: "Gardevoir-V"
+		fr: "Gardevoir-V",
+		de: "Guardevoir V"
 	},
 
 	attacks: [

--- a/data/Sword & Shield/Champion's Path/18.ts
+++ b/data/Sword & Shield/Champion's Path/18.ts
@@ -86,7 +86,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Via the protrusion on its head, it senses other creatures' emotions. If you don't have a calm disposition, it will never warm up to you."
+		en: "Via the protrusion on its head, it senses other creatures' emotions. If you don't have a calm disposition, it will never warm up to you.",
+		de: "Mit dem Fortsatz an seinem Kopf kann es die Gefühle von Lebewesen wahrnehmen. Es öffnet nur geruhsam veranlagten Leuten sein Herz."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/19.ts
+++ b/data/Sword & Shield/Champion's Path/19.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Hatenna",
-		fr: "Bibichut"
+		fr: "Bibichut",
+		de: "Brimova"
 	},
 
 	attacks: [
@@ -90,7 +91,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "No matter who you are, if you bring strong emotions near this Pokémon, it will silence you violently."
+		en: "No matter who you are, if you bring strong emotions near this Pokémon, it will silence you violently.",
+		de: "Empfindet jemand starke Emotionen, bringt es ihn auf gewaltsame Art zum Schweigen, egal, um wen es sich dabei handelt."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/2.ts
+++ b/data/Sword & Shield/Champion's Path/2.ts
@@ -68,7 +68,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Its poison stinger is very powerful. Its bright-colored body is intended to warn off its enemies."
+		en: "Its poison stinger is very powerful. Its bright-colored body is intended to warn off its enemies.",
+		de: "Sein Giftstachel ist gefährlich. Sein hellleuchtender Körper soll Feinde abschrecken."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/20.ts
+++ b/data/Sword & Shield/Champion's Path/20.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Hattrem",
-		fr: "Chapotus"
+		fr: "Chapotus",
+		de: "Brimano"
 	},
 
 	abilities: [
@@ -103,7 +104,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "It emits psychic power strong enough to cause headaches as a deterrent to the approach of others."
+		en: "It emits psychic power strong enough to cause headaches as a deterrent to the approach of others.",
+		de: "Die starken Psycho-Kräfte, die es ausstrahlt, rufen Kopfschmerzen hervor. So hält es andere Lebewesen von sich fern."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/23.ts
+++ b/data/Sword & Shield/Champion's Path/23.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Alcremie V",
-		fr: "Charmilly-V"
+		fr: "Charmilly-V",
+		de: "Pokusan V"
 	},
 
 	weaknesses: [
@@ -52,7 +53,7 @@ const card: Card = {
 			es: "Por cada uno de tus Pokémon en Banca, busca en tu baraja 1 carta de Energía Psychic y únela a ese Pokémon. Después, baraja las cartas de tu baraja.",
 			it: "Cerca nel tuo mazzo una carta Energia Psychic per ogni Pokémon nella tua panchina e assegnala a quel Pokémon. Poi rimischia le carte del tuo mazzo.",
 			pt: "Para cada um dos seus Pokémon no Banco, procure por 1 carta de Energia Psychic no seu baralho e ligue-a àquele Pokémon. Em seguida, embaralhe o seu baralho.",
-			de: "Durchsuche für jedes Pokémon auf deiner Bank dein Deck nach 1 Psychic-Energiekarte und lege sie an jenes Pokémon an. Mische anschließend dein Deck."
+			de: "Durchsuche für jedes Pokémon auf deiner Bank dein Deck nach 1 {P}-Energiekarte und lege sie an jenes Pokémon an. Mische anschließend dein Deck."
 		},
 
 		cost: ["Colorless"]

--- a/data/Sword & Shield/Champion's Path/24.ts
+++ b/data/Sword & Shield/Champion's Path/24.ts
@@ -86,7 +86,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Its whole body is composed of muscles. Even though it's the size of a human child, it can hurl 100 grown-ups."
+		en: "Its whole body is composed of muscles. Even though it's the size of a human child, it can hurl 100 grown-ups.",
+		de: "Sein ganzer Körper besteht aus Muskeln. Auch wenn es nur so groß wie ein Menschenkind ist, kann es 100 Erwachsene jonglieren."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/25.ts
+++ b/data/Sword & Shield/Champion's Path/25.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Machop",
-		fr: "Machoc"
+		fr: "Machoc",
+		de: "Machollo"
 	},
 
 	attacks: [
@@ -92,7 +93,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Its muscular body is so powerful, it must wear a power-save belt to be able to regulate its motions."
+		en: "Its muscular body is so powerful, it must wear a power-save belt to be able to regulate its motions.",
+		de: "Dieses Pokémon ist superstark. Es kann sich nur mit einem kraftregulierenden Gürtel bewegen."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/26.ts
+++ b/data/Sword & Shield/Champion's Path/26.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Machoke",
-		fr: "Machopeur"
+		fr: "Machopeur",
+		de: "Maschock"
 	},
 
 	attacks: [
@@ -48,7 +49,7 @@ const card: Card = {
 				es: "Este ataque hace 20 puntos de daño por cada Pokémon Fighting en tu pila de descartes.",
 				it: "Questo attacco infligge 20 danni per ogni Pokémon Fighting nella tua pila degli scarti.",
 				pt: "Este ataque causa 20 pontos de dano para cada Pokémon Fighting na sua pilha de descarte.",
-				de: "Diese Attacke fügt für jedes Fighting-Pokémon in deinem Ablagestapel 20 Schadenspunkte zu."
+				de: "Diese Attacke fügt für jedes {F}-Pokémon in deinem Ablagestapel 20 Schadenspunkte zu."
 			},
 			damage: "20×",
 
@@ -100,7 +101,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "It quickly swings its four arms to rock its opponents with ceaseless punches and chops from all angles."
+		en: "It quickly swings its four arms to rock its opponents with ceaseless punches and chops from all angles.",
+		de: "Es verwendet seine vier Arme, um seine Gegner unermüdlich mit schnellen Schlägen aus allen Winkeln einzudecken."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/28.ts
+++ b/data/Sword & Shield/Champion's Path/28.ts
@@ -61,7 +61,7 @@ const card: Card = {
 				es: "Descarta 1 Energía Fighting de este Pokémon.",
 				it: "Scarta un'Energia Fighting da questo Pokémon.",
 				pt: "Descarte 1 Energia Fighting deste Pokémon.",
-				de: "Lege 1 Fighting-Energie von diesem Pokémon auf deinen Ablagestapel."
+				de: "Lege 1 {F}-Energie von diesem Pokémon auf deinen Ablagestapel."
 			},
 			damage: 130,
 
@@ -88,7 +88,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Some say it can change to an even more powerful form when battling those who threaten the ecosystem."
+		en: "Some say it can change to an even more powerful form when battling those who threaten the ecosystem.",
+		de: "Im Kampf gegen all jene, die das Ökosystem in Gefahr bringen, nimmt es angeblich eine noch mächtigere Form an."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/29.ts
+++ b/data/Sword & Shield/Champion's Path/29.ts
@@ -85,7 +85,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "When it rubs the rocks on its neck against you, that's proof of its love for you. However, the rocks are sharp, so the gesture is quite painful!"
+		en: "When it rubs the rocks on its neck against you, that's proof of its love for you. However, the rocks are sharp, so the gesture is quite painful!",
+		de: "Reibt es seinen steinernen Fellkragen an einem Trainer, ist das ein Zeichen seiner Zuneigung. Da er jedoch scharf ist, besteht Verletzungsgefahr."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/3.ts
+++ b/data/Sword & Shield/Champion's Path/3.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Weedle",
-		fr: "Aspicot"
+		fr: "Aspicot",
+		de: "Hornliu"
 	},
 
 	attacks: [
@@ -67,7 +68,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "While awaiting evolution, it hides from predators under leaves and in nooks of branches."
+		en: "While awaiting evolution, it hides from predators under leaves and in nooks of branches.",
+		de: "Während es auf seine Entwicklung wartet, versteckt es sich unter Blättern und zwischen Ästen."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/30.ts
+++ b/data/Sword & Shield/Champion's Path/30.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Rockruff",
-		fr: "Rocabot"
+		fr: "Rocabot",
+		de: "Wuffels"
 	},
 
 	attacks: [
@@ -92,7 +93,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "The rocks in its mane are sharper than a knife. Fragments that break off are treasured as good luck charms."
+		en: "The rocks in its mane are sharper than a knife. Fragments that break off are treasured as good luck charms.",
+		de: "Seine steinerne Mähne ist schärfer als ein Messer. Abgebrochene Stücke gelten als wertvolle Glücksbringer."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/31.ts
+++ b/data/Sword & Shield/Champion's Path/31.ts
@@ -61,7 +61,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Most of its body has the same composition as coal. Fittingly, this Pokémon was first discovered in coal mines about 400 years ago."
+		en: "Most of its body has the same composition as coal. Fittingly, this Pokémon was first discovered in coal mines about 400 years ago.",
+		de: "Es wurde vor circa 400 Jahren in einer Kohlemine entdeckt. Sein Körper besteht fast aus denselben Komponenten wie Steinkohle."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/33.ts
+++ b/data/Sword & Shield/Champion's Path/33.ts
@@ -79,7 +79,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "The eggs of bird Pokémon are its favorite food. It swallows eggs whole, so sometimes an egg gets stuck, and Ekans faints."
+		en: "The eggs of bird Pokémon are its favorite food. It swallows eggs whole, so sometimes an egg gets stuck, and Ekans faints.",
+		de: "Die Eier von Vogel-Pokémon, sein Leibgericht, verschlingt es am Stück. Bleibt ihm eines in der Kehle stecken, verliert es kurz das Bewusstsein."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/34.ts
+++ b/data/Sword & Shield/Champion's Path/34.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Ekans",
-		fr: "Abo"
+		fr: "Abo",
+		de: "Rettan"
 	},
 
 	attacks: [
@@ -84,7 +85,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "After stunning its opponents with the pattern on its stomach, it quickly wraps them up in its body and waits for them to stop moving."
+		en: "After stunning its opponents with the pattern on its stomach, it quickly wraps them up in its body and waits for them to stop moving.",
+		de: "Es schüchtert seinen Gegner mit dem Muster auf seinem Bauch ein und nimmt ihn dann in den Würgegriff, bis es keinen Widerstand mehr spürt."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/35.ts
+++ b/data/Sword & Shield/Champion's Path/35.ts
@@ -69,7 +69,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Its restlessness has it constantly running around. If it sees another Pokémon, it will purposely run into them in order to start a fight."
+		en: "Its restlessness has it constantly running around. If it sees another Pokémon, it will purposely run into them in order to start a fight.",
+		de: "Es tollt rastlos umher. Begegnet es einem anderen Pokémon, rempelt es dieses absichtlich an, um einen Streit anzuzetteln."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/36.ts
+++ b/data/Sword & Shield/Champion's Path/36.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Galarian Zigzagoon",
-		fr: "Zigzaton de Galar"
+		fr: "Zigzaton de Galar",
+		de: "Galar-Zigzachs"
 	},
 
 	attacks: [
@@ -75,7 +76,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It uses its long tongue to taunt opponents. Once the opposition is enraged, this Pokémon hurls itself at the opponent, tackling them forcefully."
+		en: "It uses its long tongue to taunt opponents. Once the opposition is enraged, this Pokémon hurls itself at the opponent, tackling them forcefully.",
+		de: "Mit seiner langen Zunge provoziert es seine Beute, bis diese vor Wut kocht. Danach rammt es sie mit voller Wucht."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/37.ts
+++ b/data/Sword & Shield/Champion's Path/37.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Galarian Linoone",
-		fr: "Linéon de Galar"
+		fr: "Linéon de Galar",
+		de: "Galar-Geradaks"
 	},
 
 	abilities: [
@@ -98,7 +99,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "Its voice is staggering in volume. Obstagoon has a tendency to take on a threatening posture and shout—this move is known as Obstruct."
+		en: "Its voice is staggering in volume. Obstagoon has a tendency to take on a threatening posture and shout—this move is known as Obstruct.",
+		de: "Es verfügt über eine beeindruckende Stimmkraft. Sein von Schreien begleitetes Drohverhalten nennt man auch „Abblocker“."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/38.ts
+++ b/data/Sword & Shield/Champion's Path/38.ts
@@ -63,7 +63,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "The elderly call it the disaster Pokémon and detest it, but interest in its power to predict disasters is on the rise."
+		en: "The elderly call it the disaster Pokémon and detest it, but interest in its power to predict disasters is on the rise.",
+		de: "Alte Leute verabscheuen es als das Desaster-Pokémon, aber seine Fähigkeit, Katastrophen vorherzusagen, findet immer mehr Anerkennung."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/39.ts
+++ b/data/Sword & Shield/Champion's Path/39.ts
@@ -86,7 +86,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It steals things from people just to amuse itself with their frustration. A rivalry exists between this Pokémon and Nickit."
+		en: "It steals things from people just to amuse itself with their frustration. A rivalry exists between this Pokémon and Nickit.",
+		de: "Es bestiehlt liebend gerne Leute, um sich an ihrer Frustration zu erfreuen. Mit Kleptifux verbindet es eine tiefe Rivalität."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/4.ts
+++ b/data/Sword & Shield/Champion's Path/4.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Kakuna",
-		fr: "Coconfort"
+		fr: "Coconfort",
+		de: "Kokuna"
 	},
 
 	attacks: [
@@ -74,7 +75,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "May appear in a swarm. Flies at violent speeds, all the while stabbing with the toxic stinger on its rear."
+		en: "May appear in a swarm. Flies at violent speeds, all the while stabbing with the toxic stinger on its rear.",
+		de: "Es kann in Schwärmen auftauchen. Während seines rasanten Fluges sticht es mit dem Giftstachel an seinem Hinterteil zu."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/40.ts
+++ b/data/Sword & Shield/Champion's Path/40.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Purrloin",
-		fr: "Chacripan"
+		fr: "Chacripan",
+		de: "Felilou"
 	},
 
 	abilities: [
@@ -91,7 +92,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Don't be fooled by its gorgeous fur and elegant figure. This is a moody and vicious Pokémon."
+		en: "Don't be fooled by its gorgeous fur and elegant figure. This is a moody and vicious Pokémon.",
+		de: "Man wird schnell von seinem schönen Fell und seiner Anmut verleitet, aber es ist ein sehr launisches und gewalttätiges Pokémon."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/41.ts
+++ b/data/Sword & Shield/Champion's Path/41.ts
@@ -79,7 +79,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "If it locks eyes with you, watch out! Nothing and no one is safe from the reckless headbutts of this troublesome Pokémon."
+		en: "If it locks eyes with you, watch out! Nothing and no one is safe from the reckless headbutts of this troublesome Pokémon.",
+		de: "Zurrokex deuten Blickkontakt als Einladung, ihr Gegenüber mit Kopfnüssen anzugreifen. Vorsicht ist also geboten."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/42.ts
+++ b/data/Sword & Shield/Champion's Path/42.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Scraggy",
-		fr: "Baggiguane"
+		fr: "Baggiguane",
+		de: "Zurrokex"
 	},
 
 	attacks: [
@@ -99,7 +100,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "As halfhearted as this Pokémon's kicks may seem, they pack enough power to shatter Conkeldurr's concrete pillars."
+		en: "As halfhearted as this Pokémon's kicks may seem, they pack enough power to shatter Conkeldurr's concrete pillars.",
+		de: "Selbst seine halbherzigen Tritte sind stark genug, um die Betonpfeiler eines Meistagrif zu zertrümmern."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/43.ts
+++ b/data/Sword & Shield/Champion's Path/43.ts
@@ -70,7 +70,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Its favorite places are unsanitary ones. If you leave trash lying around, you could even find one of these Pokémon living in your room."
+		en: "Its favorite places are unsanitary ones. If you leave trash lying around, you could even find one of these Pokémon living in your room.",
+		de: "Es liebt schmutzige Orte. Angeblich zieht es auch in menschliche Behausungen ein, wenn man zu viel Müll herumliegen lässt."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/44.ts
+++ b/data/Sword & Shield/Champion's Path/44.ts
@@ -86,7 +86,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It spins while making its luminescent spots flash. These spots allow it to communicate with others by using different patterns of light."
+		en: "It spins while making its luminescent spots flash. These spots allow it to communicate with others by using different patterns of light.",
+		de: "Es dreht sich und lässt dabei Punkte auf seinem Körper blinken. Durch bestimmte Lichtmuster kann es mit seinen Artgenossen kommunizieren."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/45.ts
+++ b/data/Sword & Shield/Champion's Path/45.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Inkay",
-		fr: "Sepiatop"
+		fr: "Sepiatop",
+		de: "Iscalar"
 	},
 
 	attacks: [
@@ -100,7 +101,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Gazing at its luminescent spots will quickly induce a hypnotic state, putting the observer under Malamar's control."
+		en: "Gazing at its luminescent spots will quickly induce a hypnotic state, putting the observer under Malamar's control.",
+		de: "Blickt man in das Licht, das es mit seinem Körper erzeugt, wird man sofort hypnotisiert und steht danach unter der Kontrolle von Calamanero."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/46.ts
+++ b/data/Sword & Shield/Champion's Path/46.ts
@@ -85,7 +85,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Aided by the soft pads on its feet, it silently raids the food stores of other Pokémon. It survives off its ill-gotten gains."
+		en: "Aided by the soft pads on its feet, it silently raids the food stores of other Pokémon. It survives off its ill-gotten gains.",
+		de: "Es stibitzt Futter, das andere Pokémon gefunden haben. Dank der samtweichen Ballen an seinen Pfoten ist sein Gang lautlos."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/47.ts
+++ b/data/Sword & Shield/Champion's Path/47.ts
@@ -77,7 +77,7 @@ const card: Card = {
 			es: "Este ataque hace 40 puntos de daño más por cada Energía Metal unida a este Pokémon.",
 			it: "Questo attacco infligge 40 danni in più per ogni Energia Metal assegnata a questo Pokémon.",
 			pt: "Este ataque causa 40 pontos de dano a mais para cada Energia Metal ligada a este Pokémon.",
-			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte Metal-Energie 40 Schadenspunkte mehr zu."
+			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte {M}-Energie 40 Schadenspunkte mehr zu."
 		},
 
 		damage: "10+",

--- a/data/Sword & Shield/Champion's Path/48.ts
+++ b/data/Sword & Shield/Champion's Path/48.ts
@@ -69,7 +69,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It constantly grooms its cotton-like wings. It takes a shower to clean itself if it becomes dirty."
+		en: "It constantly grooms its cotton-like wings. It takes a shower to clean itself if it becomes dirty.",
+		de: "Ständig pflegt es seine watteartigen Flügel. Falls es schmutzig wird, nimmt es eine Dusche, um sich zu putzen."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/49.ts
+++ b/data/Sword & Shield/Champion's Path/49.ts
@@ -25,7 +25,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Swablu",
-		fr: "Tylton"
+		fr: "Tylton",
+		de: "Wablu"
 	},
 
 	abilities: [
@@ -97,7 +98,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "On sunny days, it flies freely through the sky and blends into the clouds. It sings in a beautiful soprano."
+		en: "On sunny days, it flies freely through the sky and blends into the clouds. It sings in a beautiful soprano.",
+		de: "Bei gutem Wetter mischt es sich unter die Wolken und genießt die Freiheit. Es hat eine entzückende Sopranstimme."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/50.ts
+++ b/data/Sword & Shield/Champion's Path/50.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Une 1 carta de Energía Básica de tu mano a 1 de tus Pokémon en Banca.",
 		it: "Assegna a uno dei tuoi Pokémon in panchina una carta Energia base dalla tua mano.",
 		pt: "Ligue 1 carta de Energia básica da sua mão a 1 dos seus Pokémon no Banco.",
-		de: "Lege 1 Basis-Energiekarte aus deiner Hand an 1 Pokémon auf deiner Bank an."
+		de: "Lege 1 Basis-Energiekarte aus deiner Hand an 1 Pokémon auf deiner Bank an. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Champion's Path/51.ts
+++ b/data/Sword & Shield/Champion's Path/51.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Elimina todas las Condiciones Especiales de tu Pokémon Activo.",
 		it: "Rimuovi tutte le Condizioni Speciali dal tuo Pokémon Attivo.",
 		pt: "Remova todas as Condições Especiais do seu Pokémon Ativo.",
-		de: "Alle Speziellen Zustände auf deinen Aktiven Pokémon verlieren ihre Wirkung."
+		de: "Dein Aktives Pokémon erholt sich von allen Speziellen Zuständen. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Champion's Path/52.ts
+++ b/data/Sword & Shield/Champion's Path/52.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mira las 7 primeras cartas de tu baraja. Puedes enseñar 1 Pokémon que encuentres entre ellas y ponerlo en tu mano. Pon el resto de las cartas de nuevo en tu baraja y barájalas todas.",
 		it: "Guarda le prime sette carte del tuo mazzo. Puoi mostrare un Pokémon presente tra esse e aggiungerlo alle carte che hai in mano. Poi rimischia le altre carte nel tuo mazzo.",
 		pt: "Olhe as 7 cartas de cima do seu baralho. Você poderá revelar 1 Pokémon que encontrar lá e colocá-lo em sua mão. Embaralhe as demais cartas de volta no seu baralho.",
-		de: "Schau dir die obersten 7 Karten deines Decks an. Du kannst 1 Pokémon, das du dort findest, deinem Gegner zeigen und auf deine Hand nehmen. Mische die anderen Karten zurück in dein Deck."
+		de: "Schau dir die obersten 7 Karten deines Decks an. Du kannst 1 Pokémon, das du dort findest, deinem Gegner zeigen und auf deine Hand nehmen. Mische die anderen Karten zurück in dein Deck. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Champion's Path/53.ts
+++ b/data/Sword & Shield/Champion's Path/53.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba 3 cartas.",
 		it: "Pesca tre carte.",
 		pt: "Compre 3 cartas.",
-		de: "Ziehe 3 Karten."
+		de: "Ziehe 3 Karten. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Champion's Path/54.ts
+++ b/data/Sword & Shield/Champion's Path/54.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cura 120 puntos de daño a 1 de tus Pokémon que tenga por lo menos 2 Energías unidas a él. Si has curado algún punto de daño de esta manera, descarta 2 Energías de ese Pokémon.",
 		it: "Cura uno dei tuoi Pokémon che ha almeno due Energie assegnate da 120 danni. Se hai curato dei danni in questo modo, scarta due Energie da quel Pokémon.",
 		pt: "Cure 120 pontos de dano de 1 dos seus Pokémon que tiver pelo menos 2 Energias ligadas a ele. Se você curou qualquer dano desta forma, descarte 2 Energias daquele Pokémon.",
-		de: "Heile 120 Schadenspunkte bei 1 deiner Pokémon, an das mindestens 2 Energien angelegt sind. Wenn du auf diese Weise Schaden geheilt hast, lege 2 Energien von jenem Pokémon auf deinen Ablagestapel."
+		de: "Heile 120 Schadenspunkte bei 1 deiner Pokémon, an das mindestens 2 Energien angelegt sind. Wenn du auf diese Weise Schaden geheilt hast, lege 2 Energien von jenem Pokémon auf deinen Ablagestapel. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Champion's Path/55.ts
+++ b/data/Sword & Shield/Champion's Path/55.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon las cartas de tu mano en tu baraja y barájalas todas. Después, roba 4 cartas. Si tu Pokémon Activo es tu único Pokémon en juego, roba 8 cartas en vez de 4.",
 		it: "Rimischia le carte che hai in mano nel tuo mazzo. Poi pesca quattro carte. Se il tuo Pokémon attivo è il tuo unico Pokémon in gioco, invece pescane otto.",
 		pt: "Embaralhe a sua mão no seu baralho. Em seguida, compre 4 cartas. Se o seu Pokémon Ativo for o seu único Pokémon em jogo, compre 8 cartas ao invés de 4.",
-		de: "Mische deine Handkarten in dein Deck. Ziehe anschließend 4 Karten. Wenn dein Aktives Pokémon dein einziges Pokémon im Spiel ist, ziehe stattdessen 8 Karten."
+		de: "Mische deine Handkarten in dein Deck. Ziehe anschließend 4 Karten. Wenn dein Aktives Pokémon dein einziges Pokémon im Spiel ist, ziehe stattdessen 8 Karten. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Champion's Path/56.ts
+++ b/data/Sword & Shield/Champion's Path/56.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cada jugador baraja las cartas de su mano y las pone en la parte inferior de su baraja. Si cualquiera de los jugadores pone alguna carta en la parte inferior de su baraja de esta manera, robas 5 cartas, y tu rival roba 4 cartas.",
 		it: "Ciascun giocatore rimischia le carte che ha in mano e le mette in fondo al proprio mazzo. Se almeno un giocatore ha messo delle carte in fondo al proprio mazzo in questo modo, tu peschi cinque carte e il tuo avversario ne pesca quattro.",
 		pt: "Cada jogador embaralha a própria mão e coloca-a como as cartas de baixo do próprio baralho. Se qualquer um dos jogadores tiver colocado qualquer carta como a carta de baixo do próprio baralho desta forma, você comprará 5 cartas e seu oponente comprará 4 cartas.",
-		de: "Jeder Spieler mischt seine Handkarten und legt sie unter sein Deck. Wenn ein oder beide Spieler auf diese Weise mindestens 1 Karte unter ihr Deck gelegt haben, ziehst du 5 Karten und dein Gegner zieht 4 Karten."
+		de: "Jeder Spieler mischt seine Handkarten und legt sie unter sein Deck. Wenn ein oder beide Spieler auf diese Weise mindestens 1 Karte unter ihr Deck gelegt haben, ziehst du 5 Karten und dein Gegner zieht 4 Karten. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Champion's Path/57.ts
+++ b/data/Sword & Shield/Champion's Path/57.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta hasta 2 cartas de tu mano y roba 2 cartas por cada carta que hayas descartado de esta manera.",
 		it: "Scarta fino a due carte che hai in mano e pesca due carte per ogni carta che hai scartato in questo modo.",
 		pt: "Descarte até 2 cartas da sua mão e compre 2 cartas para cada carta descartada desta forma.",
-		de: "Lege bis zu 2 Karten aus deiner Hand auf deinen Ablagestapel und ziehe 2 Karten für jede auf diese Weise auf deinen Ablagestapel gelegte Karte."
+		de: "Lege bis zu 2 Karten aus deiner Hand auf deinen Ablagestapel und ziehe 2 Karten für jede auf diese Weise auf deinen Ablagestapel gelegte Karte. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Champion's Path/58.ts
+++ b/data/Sword & Shield/Champion's Path/58.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja 1 carta de Energía y 1 carta de Pokémon Darkness, enséñalas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo una carta Energia e un Pokémon Darkness, mostrali e aggiungili alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por 1 carta de Energia e 1 Pokémon Darkness no seu baralho, revele-os e coloque-os na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach 1 Energiekarte und 1 Darkness-Pokémon, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach 1 Energiekarte und 1 {D}-Pokémon, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Champion's Path/59.ts
+++ b/data/Sword & Shield/Champion's Path/59.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Lanza una moneda. Si sale cara, busca en tu mazo un Pokémon, enséñaselo a tu rival y ponlo en tu mano. Baraja tu mazo después.",
 		it: "Lancia una moneta. Se esce testa, cerca nel tuo mazzo un Pokémon, mostralo al tuo avversario e aggiungilo alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Lance uma moeda. Se der “cara”, procure um Pokémon no seu deck, mostre-o ao seu oponente e coloque-o na sua mão. Em seguida, embaralhe seu deck.",
-		de: "Wirf 1 Münze. Durchsuche bei „Kopf“ dein Deck nach 1 Pokémon-Karte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische anschließend dein Deck."
+		de: "Wirf 1 Münze. Durchsuche bei Kopf dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Champion's Path/6.ts
+++ b/data/Sword & Shield/Champion's Path/6.ts
@@ -85,7 +85,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "While young, it has six gorgeous tails. When it grows, several new tails are sprouted."
+		en: "While young, it has six gorgeous tails. When it grows, several new tails are sprouted.",
+		de: "In seiner Jugend hat es sechs hinreißende Schweife. Während es wächst, kommen noch weitere neue Schweife hinzu."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/60.ts
+++ b/data/Sword & Shield/Champion's Path/60.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cura 60 puntos de daño a 1 de tus Pokémon, y este se recupera de todas las Condiciones Especiales.",
 		it: "Cura uno dei tuoi Pokémon da 60 danni. Quel Pokémon guarisce da tutte le condizioni speciali.",
 		pt: "Cure 60 pontos de dano de 1 dos seus Pokémon e aquele Pokémon se recupera de quaisquer Condições Especiais.",
-		de: "Heile 60 Schadenspunkte bei 1 deiner Pokémon, und es erholt sich von allen Speziellen Zuständen."
+		de: "Heile 60 Schadenspunkte bei 1 deiner Pokémon, und es erholt sich von allen Speziellen Zuständen. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Champion's Path/61.ts
+++ b/data/Sword & Shield/Champion's Path/61.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cura 30 puntos de daño a 1 de tus Pokémon.",
 		it: "Cura uno dei tuoi Pokémon da 30 danni.",
 		pt: "Cura 30 de danos de 1 Pokémon seu.",
-		de: "Heile 30 Schadenspunkte bei 1 deiner Pokémon."
+		de: "Heile 30 Schadenspunkte bei 1 deiner Pokémon. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Champion's Path/62.ts
+++ b/data/Sword & Shield/Champion's Path/62.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta las cartas de tu mano y roba 7 cartas.",
 		it: "Scarta le carte che hai in mano e pesca sette carte.",
 		pt: "Descarte a sua mão e compre 7 cartas.",
-		de: "Lege deine Handkarten auf deinen Ablagestapel und ziehe 7 Karten."
+		de: "Lege deine Handkarten auf deinen Ablagestapel und ziehe 7 Karten. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",
@@ -36,7 +36,8 @@ const card: Card = {
 	},
 
 	description: {
-		en: "Professor's Research (Magnolia)"
+		en: "Professor's Research (Magnolia)",
+		de: "Forschung des Professors (Prof. Magnolica)"
 	}
 }
 

--- a/data/Sword & Shield/Champion's Path/63.ts
+++ b/data/Sword & Shield/Champion's Path/63.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba cartas hasta que tengas 6 cartas en tu mano. Tu turno termina.",
 		it: "Pesca fino ad avere sei carte in mano. Il tuo turno finisce.",
 		pt: "Compre cartas até ter 6 cartas na sua mão. O seu turno acaba.",
-		de: "Ziehe so lange Karten, bis du 6 Karten auf deiner Hand hast. Dein Zug endet."
+		de: "Ziehe so lange Karten, bis du 6 Karten auf deiner Hand hast. Dein Zug endet. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Champion's Path/64.ts
+++ b/data/Sword & Shield/Champion's Path/64.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mira las 5 primeras cartas de tu baraja, elige 1 de ellas y pon el resto de las cartas de nuevo en tu baraja y barájalas todas. Después, pon la carta que has elegido en la parte superior de tu baraja.",
 		it: "Guarda le prime cinque carte del tuo mazzo, scegline una e rimischia le altre carte nel tuo mazzo. Poi metti la carta che hai scelto in cima al tuo mazzo.",
 		pt: "Olhe as 5 cartas de cima do seu baralho, escolha 1 delas e embaralhe as demais cartas de volta no seu baralho. Em seguida, coloque a carta escolhida como a carta de cima do seu baralho.",
-		de: "Schau dir die obersten 5 Karten deines Decks an, wähle 1 von ihnen und mische die anderen Karten zurück in dein Deck. Lege anschließend die von dir gewählte Karte oben auf dein Deck."
+		de: "Schau dir die obersten 5 Karten deines Decks an, wähle 1 von ihnen und mische die anderen Karten zurück in dein Deck. Lege anschließend die von dir gewählte Karte oben auf dein Deck. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Champion's Path/65.ts
+++ b/data/Sword & Shield/Champion's Path/65.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 2 cartas de Pokémon Básico o hasta 2 cartas de Energía Básica, enséñalas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo fino a due Pokémon Base o due carte Energia base, mostrali e aggiungili alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por até 2 Pokémon Básicos ou até 2 cartas de Energia básica no seu baralho, revele-os e coloque-os na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach bis zu 2 Basis-Pokémon oder bis zu 2 Basis-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach bis zu 2 Basis-Pokémon oder bis zu 2 Basis-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Champion's Path/66.ts
+++ b/data/Sword & Shield/Champion's Path/66.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cura 80 puntos de puntos de daño a 1 de tus Pokémon que tenga por lo menos 1 Energía Psychic unida a él. Si has curado algún punto de daño de esta manera, descarta 1 Energía Psychic de ese Pokémon.",
 		it: "Cura uno dei tuoi Pokémon che ha almeno un'Energia Psychic assegnata da 80 danni. Se hai curato dei danni in questo modo, scarta un'Energia Psychic da quel Pokémon.",
 		pt: "Cure 80 pontos de dano de 1 dos seus Pokémon que tiver pelo menos 1 Energia Psychic ligada a ele. Se você curou qualquer dano desta forma, descarte 1 Energia Psychic daquele Pokémon.",
-		de: "Heile 80 Schadenspunkte bei 1 deiner Pokémon, an das mindestens 1 Psychic-Energie angelegt ist. Wenn du auf diese Weise Schaden geheilt hast, lege 1 Psychic-Energie von jenem Pokémon auf deinen Ablagestapel."
+		de: "Heile 80 Schadenspunkte bei 1 deiner Pokémon, an das mindestens 1 {P}-Energie angelegt ist. Wenn du auf diese Weise Schaden geheilt hast, lege 1 {P}-Energie von jenem Pokémon auf deinen Ablagestapel. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Champion's Path/67.ts
+++ b/data/Sword & Shield/Champion's Path/67.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon 1 Energía unida a 1 de los Pokémon de tu rival en su mano.",
 		it: "Prendi un'Energia assegnata a uno dei Pokémon del tuo avversario e aggiungila alle carte che ha in mano.",
 		pt: "Coloque 1 Energia ligada a 1 dos Pokémon do seu oponente na mão dele(a).",
-		de: "Gib deinem Gegner 1 an eins seiner Pokémon angelegte Energie auf seine Hand."
+		de: "Gib deinem Gegner 1 an eins seiner Pokémon angelegte Energie auf seine Hand. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Champion's Path/68.ts
+++ b/data/Sword & Shield/Champion's Path/68.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Una vez durante el turno de cada jugador, ese jugador puede buscar en su baraja 1 Pokémon Grass Evolución, enseñarlo y ponerlo en su mano. Después, ese jugador baraja las cartas de su baraja.",
 		it: "Una sola volta durante il turno di ciascun giocatore, quel giocatore può cercare nel suo mazzo un Pokémon Evoluzione Grass, mostrarlo e aggiungerlo alle carte che ha in mano. Poi quel giocatore rimischia le carte del suo mazzo.",
 		pt: "Uma vez durante o turno de cada jogador, aquele jogador poderá procurar por 1 Pokémon Grass de Evolução no próprio baralho, revelá-lo e colocá-lo na própria mão. Em seguida, aquele jogador embaralha o próprio baralho.",
-		de: "Einmal während des Zuges jedes Spielers kann jener Spieler sein Deck nach 1 Entwicklungs-Grass-Pokémon durchsuchen, es seinem Gegner zeigen und auf seine Hand nehmen. Anschließend mischt jener Spieler sein Deck."
+		de: "Einmal während des Zuges jedes Spielers kann jener Spieler sein Deck nach 1 Entwicklungs-{G}-Pokémon durchsuchen, es seinem Gegner zeigen und auf seine Hand nehmen. Anschließend mischt jener Spieler sein Deck. Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte auf den Ablagestapel, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit demselben Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 
 	trainerType: "Stadium",

--- a/data/Sword & Shield/Champion's Path/7.ts
+++ b/data/Sword & Shield/Champion's Path/7.ts
@@ -85,7 +85,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "When it shares the infinite energy it creates, that being's entire body will be overflowing with power."
+		en: "When it shares the infinite energy it creates, that being's entire body will be overflowing with power.",
+		de: "Jeder, dem Victini seine grenzenlose Energie zuteilwerden lässt, strotzt nur so vor Kraft."
 	},
 
 	thirdParty: {

--- a/data/Sword & Shield/Champion's Path/73.ts
+++ b/data/Sword & Shield/Champion's Path/73.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba 3 cartas.",
 		it: "Pesca tre carte.",
 		pt: "Compre 3 cartas.",
-		de: "Ziehe 3 Karten."
+		de: "Ziehe 3 Karten. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Champion's Path/74.ts
+++ b/data/Sword & Shield/Champion's Path/74.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Charizard V",
-		fr: "Dracaufeu-V"
+		fr: "Dracaufeu-V",
+		de: "Glurak V"
 	},
 
 	attacks: [

--- a/data/Sword & Shield/Champion's Path/75.ts
+++ b/data/Sword & Shield/Champion's Path/75.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Drednaw V",
-		fr: "Torgamord-V"
+		fr: "Torgamord-V",
+		de: "Kamalm V"
 	},
 
 	abilities: [

--- a/data/Sword & Shield/Champion's Path/76.ts
+++ b/data/Sword & Shield/Champion's Path/76.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Gardevoir V",
-		fr: "Gardevoir-V"
+		fr: "Gardevoir-V",
+		de: "Guardevoir V"
 	},
 
 	attacks: [

--- a/data/Sword & Shield/Champion's Path/77.ts
+++ b/data/Sword & Shield/Champion's Path/77.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon las cartas de tu mano en tu baraja y barájalas todas. Después, roba 4 cartas. Si tu Pokémon Activo es tu único Pokémon en juego, roba 8 cartas en vez de 4.",
 		it: "Rimischia le carte che hai in mano nel tuo mazzo. Poi pesca quattro carte. Se il tuo Pokémon attivo è il tuo unico Pokémon in gioco, invece pescane otto.",
 		pt: "Embaralhe a sua mão no seu baralho. Em seguida, compre 4 cartas. Se o seu Pokémon Ativo for o seu único Pokémon em jogo, compre 8 cartas ao invés de 4.",
-		de: "Mische deine Handkarten in dein Deck. Ziehe anschließend 4 Karten. Wenn dein Aktives Pokémon dein einziges Pokémon im Spiel ist, ziehe stattdessen 8 Karten."
+		de: "Mische deine Handkarten in dein Deck. Ziehe anschließend 4 Karten. Wenn dein Aktives Pokémon dein einziges Pokémon im Spiel ist, ziehe stattdessen 8 Karten. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Champion's Path/78.ts
+++ b/data/Sword & Shield/Champion's Path/78.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja 1 carta de Energía y 1 carta de Pokémon Darkness, enséñalas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo una carta Energia e un Pokémon Darkness, mostrali e aggiungili alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por 1 carta de Energia e 1 Pokémon Darkness no seu baralho, revele-os e coloque-os na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach 1 Energiekarte und 1 Darkness-Pokémon, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach 1 Energiekarte und 1 {D}-Pokémon, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Champion's Path/8.ts
+++ b/data/Sword & Shield/Champion's Path/8.ts
@@ -43,7 +43,7 @@ const card: Card = {
 				es: "Une hasta 2 cartas de Energía Fire de tu pila de descartes a 1 de tus Pokémon en Banca.",
 				it: "Assegna a uno dei tuoi Pokémon in panchina fino a due carte Energia Fire dalla tua pila degli scarti.",
 				pt: "Ligue até 2 cartas de Energia Fire da sua pilha de descarte a 1 dos seus Pokémon no Banco.",
-				de: "Lege bis zu 2 Fire-Energiekarten aus deinem Ablagestapel an 1 Pokémon auf deiner Bank an."
+				de: "Lege bis zu 2 {R}-Energiekarten aus deinem Ablagestapel an 1 Pokémon auf deiner Bank an."
 			},
 			damage: 90,
 

--- a/data/Sword & Shield/Champion's Path/80.ts
+++ b/data/Sword & Shield/Champion's Path/80.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cura 80 puntos de puntos de daño a 1 de tus Pokémon que tenga por lo menos 1 Energía Psychic unida a él. Si has curado algún punto de daño de esta manera, descarta 1 Energía Psychic de ese Pokémon.",
 		it: "Cura uno dei tuoi Pokémon che ha almeno un'Energia Psychic assegnata da 80 danni. Se hai curato dei danni in questo modo, scarta un'Energia Psychic da quel Pokémon.",
 		pt: "Cure 80 pontos de dano de 1 dos seus Pokémon que tiver pelo menos 1 Energia Psychic ligada a ele. Se você curou qualquer dano desta forma, descarte 1 Energia Psychic daquele Pokémon.",
-		de: "Heile 80 Schadenspunkte bei 1 deiner Pokémon, an das mindestens 1 Psychic-Energie angelegt ist. Wenn du auf diese Weise Schaden geheilt hast, lege 1 Psychic-Energie von jenem Pokémon auf deinen Ablagestapel."
+		de: "Heile 80 Schadenspunkte bei 1 deiner Pokémon, an das mindestens 1 {P}-Energie angelegt ist. Wenn du auf diese Weise Schaden geheilt hast, lege 1 {P}-Energie von jenem Pokémon auf deinen Ablagestapel. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Champion's Path/9.ts
+++ b/data/Sword & Shield/Champion's Path/9.ts
@@ -80,7 +80,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It stores flammable gas in its body and uses it to generate heat. The yellow sections on its belly get particularly hot."
+		en: "It stores flammable gas in its body and uses it to generate heat. The yellow sections on its belly get particularly hot.",
+		de: "Mit dem entzündlichen Gas in seinem Körper erzeugt es Hitze. Die gelben Stellen an seinem Bauch werden besonders heiß."
 	},
 
 	thirdParty: {


### PR DESCRIPTION
## Add missing German translations for swsh3.5

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
