### PR TITLE
(fix) Repair German EX-era card names: ex hyphenation and missing δ

### DIFF
--- a/data/E-Card/Skyridge/134.ts
+++ b/data/E-Card/Skyridge/134.ts
@@ -4,7 +4,7 @@ import Set from '../Skyridge'
 const card: Card = {
 	name: {
 		en: "Mystery Plate β",
-		de: "Geheimnis-Schild ß"
+		de: "Geheimnis-Schild β"
 	},
 
 	illustrator: "Hiromichi Sugiyama",

--- a/data/E-Card/Skyridge/135.ts
+++ b/data/E-Card/Skyridge/135.ts
@@ -4,7 +4,7 @@ import Set from '../Skyridge'
 const card: Card = {
 	name: {
 		en: "Mystery Plate γ",
-		de: "Geheimes Schild γ"
+		de: "Geheimnis-Schild γ"
 	},
 
 	illustrator: "Hiromichi Sugiyama",

--- a/data/E-Card/Skyridge/137.ts
+++ b/data/E-Card/Skyridge/137.ts
@@ -4,7 +4,7 @@ import Set from '../Skyridge'
 const card: Card = {
 	name: {
 		en: "Mystery Zone",
-		de: "Geheimnis Zone"
+		de: "Geheimnis-Zone"
 	},
 
 	illustrator: "Ken Ikuji",

--- a/data/EX/Crystal Guardians/15.ts
+++ b/data/EX/Crystal Guardians/15.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Cacturne δ",
 		fr: "Cacturne δ",
-		de: "Noktuska"
+		de: "Noktuska δ"
 	},
 
 	illustrator: "Kouki Saitou",

--- a/data/EX/Crystal Guardians/18.ts
+++ b/data/EX/Crystal Guardians/18.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Fearow δ",
 		fr: "Rapasdepic δ",
-		de: "Ibitak"
+		de: "Ibitak δ"
 	},
 
 	illustrator: "Kouki Saitou",

--- a/data/EX/Crystal Guardians/19.ts
+++ b/data/EX/Crystal Guardians/19.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Grovyle δ",
 		fr: "Massko δ",
-		de: "Reptain"
+		de: "Reptain δ"
 	},
 
 	illustrator: "Masakazu Fukuda",

--- a/data/EX/Crystal Guardians/2.ts
+++ b/data/EX/Crystal Guardians/2.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Blastoise δ",
 		fr: "Tortank δ",
-		de: "Turtok"
+		de: "Turtok δ"
 	},
 
 	illustrator: "Masakazu Fukuda",

--- a/data/EX/Crystal Guardians/22.ts
+++ b/data/EX/Crystal Guardians/22.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Kingler δ",
 		fr: "Krabboss δ",
-		de: "Kingler"
+		de: "Kingler δ"
 	},
 
 	illustrator: "Masakazu Fukuda",

--- a/data/EX/Crystal Guardians/26.ts
+++ b/data/EX/Crystal Guardians/26.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Pelipper δ",
 		fr: "Bekipan δ",
-		de: "Pelipper"
+		de: "Pelipper δ"
 	},
 
 	illustrator: "Masakazu Fukuda",

--- a/data/EX/Crystal Guardians/30.ts
+++ b/data/EX/Crystal Guardians/30.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Charmeleon δ",
 		fr: "Reptincel δ",
-		de: "Glutexo"
+		de: "Glutexo δ"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Crystal Guardians/4.ts
+++ b/data/EX/Crystal Guardians/4.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Charizard δ",
 		fr: "Dracaufeu δ",
-		de: "Glurak"
+		de: "Glurak δ"
 	},
 
 	illustrator: "Kouki Saitou",

--- a/data/EX/Crystal Guardians/49.ts
+++ b/data/EX/Crystal Guardians/49.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Charmander δ",
 		fr: "Salamèche δ",
-		de: "Glumanda"
+		de: "Glumanda δ"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Crystal Guardians/6.ts
+++ b/data/EX/Crystal Guardians/6.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Ludicolo δ",
 		fr: "Ludicolo δ",
-		de: "Kappalores"
+		de: "Kappalores δ"
 	},
 
 	illustrator: "Masakazu Fukuda",

--- a/data/EX/Crystal Guardians/68.ts
+++ b/data/EX/Crystal Guardians/68.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Treecko δ",
 		fr: "Arcko δ",
-		de: "Geckarbor"
+		de: "Geckarbor δ"
 	},
 
 	illustrator: "Masakazu Fukuda",

--- a/data/EX/Crystal Guardians/89.ts
+++ b/data/EX/Crystal Guardians/89.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Aggron ex",
 		fr: "Galeking ex",
-		de: "Stolloss ex"
+		de: "Stolloss-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Crystal Guardians/90.ts
+++ b/data/EX/Crystal Guardians/90.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Blaziken ex",
 		fr: "Brasegali ex",
-		de: "Lohgock ex"
+		de: "Lohgock-ex"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Crystal Guardians/91.ts
+++ b/data/EX/Crystal Guardians/91.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Delcatty ex",
 		fr: "Delcatty ex",
-		de: "Enekoro ex"
+		de: "Enekoro-ex"
 	},
 
 	illustrator: "Shizurow",

--- a/data/EX/Crystal Guardians/92.ts
+++ b/data/EX/Crystal Guardians/92.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Exploud ex",
 		fr: "Brouhabam ex",
-		de: "Krawumms ex"
+		de: "Krawumms-ex"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Crystal Guardians/93.ts
+++ b/data/EX/Crystal Guardians/93.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Groudon ex",
 		fr: "Groudon ex",
-		de: "Groudon ex"
+		de: "Groudon-ex"
 	},
 
 	illustrator: "Takabon",

--- a/data/EX/Crystal Guardians/94.ts
+++ b/data/EX/Crystal Guardians/94.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Jirachi ex",
 		fr: "Jirachi ex",
-		de: "Jirachi ex"
+		de: "Jirachi-ex"
 	},
 
 	illustrator: "Shizurow",

--- a/data/EX/Crystal Guardians/95.ts
+++ b/data/EX/Crystal Guardians/95.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Kyogre ex",
 		fr: "Kyogre ex",
-		de: "Kyogre ex"
+		de: "Kyogre-ex"
 	},
 
 	illustrator: "Yasuki Watanabe",

--- a/data/EX/Crystal Guardians/96.ts
+++ b/data/EX/Crystal Guardians/96.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Sceptile ex δ",
 		fr: "Jungko ex δ",
-		de: "Gewaldro ex"
+		de: "Gewaldro-ex"
 	},
 
 	suffix: "ex",

--- a/data/EX/Crystal Guardians/96.ts
+++ b/data/EX/Crystal Guardians/96.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Sceptile ex δ",
 		fr: "Jungko ex δ",
-		de: "Gewaldro-ex"
+		de: "Gewaldro-ex δ"
 	},
 
 	suffix: "ex",

--- a/data/EX/Crystal Guardians/97.ts
+++ b/data/EX/Crystal Guardians/97.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Shiftry ex",
 		fr: "Tengalice ex",
-		de: "Tengulist ex"
+		de: "Tengulist-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Crystal Guardians/98.ts
+++ b/data/EX/Crystal Guardians/98.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Swampert ex",
 		fr: "Laggron ex",
-		de: "Sumpex ex"
+		de: "Sumpex-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Delta Species/1.ts
+++ b/data/EX/Delta Species/1.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Beedrill δ",
 		fr: "Dardargnan δ",
-		de: "Bibor"
+		de: "Bibor δ"
 	},
 
 	illustrator: "Masakazu Fukuda",

--- a/data/EX/Delta Species/10.ts
+++ b/data/EX/Delta Species/10.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Marowak δ",
 		fr: "Ossatueur δ",
-		de: "Knogga"
+		de: "Knogga δ"
 	},
 
 	illustrator: "Hajime Kusajima",

--- a/data/EX/Delta Species/108.ts
+++ b/data/EX/Delta Species/108.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Flareon ex",
 		fr: "Pyroli ex",
-		de: "Flamara ex"
+		de: "Flamara-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Delta Species/109.ts
+++ b/data/EX/Delta Species/109.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Jolteon ex",
 		fr: "Voltali ex",
-		de: "Blitza ex"
+		de: "Blitza-ex"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Delta Species/11.ts
+++ b/data/EX/Delta Species/11.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Metagross δ",
 		fr: "Metalosse δ",
-		de: "Metagross"
+		de: "Metagross δ"
 	},
 
 	illustrator: "Masakazu Fukuda",

--- a/data/EX/Delta Species/110.ts
+++ b/data/EX/Delta Species/110.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Vaporeon ex",
 		fr: "Aquali ex",
-		de: "Aquana ex"
+		de: "Aquana-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Delta Species/12.ts
+++ b/data/EX/Delta Species/12.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Mewtwo δ",
 		fr: "Mewtwo δ",
-		de: "Mewtu"
+		de: "Mewtu δ"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Delta Species/13.ts
+++ b/data/EX/Delta Species/13.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Rayquaza δ",
 		fr: "Rayquaza δ",
-		de: "Rayquaza"
+		de: "Rayquaza δ"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Delta Species/14.ts
+++ b/data/EX/Delta Species/14.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Salamence δ",
 		fr: "Drattak δ",
-		de: "Brutalanda"
+		de: "Brutalanda δ"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Delta Species/15.ts
+++ b/data/EX/Delta Species/15.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Starmie δ",
 		fr: "Staross δ",
-		de: "Starmie"
+		de: "Starmie δ"
 	},
 
 	illustrator: "Masakazu Fukuda",

--- a/data/EX/Delta Species/16.ts
+++ b/data/EX/Delta Species/16.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Tyranitar δ",
 		fr: "Tyranocif δ",
-		de: "Despotar"
+		de: "Despotar δ"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Delta Species/17.ts
+++ b/data/EX/Delta Species/17.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Umbreon δ",
 		fr: "Noctali δ",
-		de: "Nachtara"
+		de: "Nachtara δ"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Delta Species/18.ts
+++ b/data/EX/Delta Species/18.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Vaporeon δ",
 		fr: "Aquali δ",
-		de: "Aquana"
+		de: "Aquana δ"
 	},
 
 	illustrator: "Kouki Saitou",

--- a/data/EX/Delta Species/19.ts
+++ b/data/EX/Delta Species/19.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Azumarill δ",
 		fr: "Azumarill δ",
-		de: "Azumarill"
+		de: "Azumarill δ"
 	},
 
 	illustrator: "Atsuko Nishida",

--- a/data/EX/Delta Species/2.ts
+++ b/data/EX/Delta Species/2.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Crobat δ",
 		fr: "Nostenfer δ",
-		de: "Iksbat"
+		de: "Iksbat δ"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Delta Species/24.ts
+++ b/data/EX/Delta Species/24.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Mightyena δ",
 		fr: "Grahyena δ",
-		de: "Magnayen"
+		de: "Magnayen δ"
 	},
 
 	illustrator: "Hajime Kusajima",

--- a/data/EX/Delta Species/27.ts
+++ b/data/EX/Delta Species/27.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Sandslash δ",
 		fr: "Sablaireau δ",
-		de: "Sandamer"
+		de: "Sandamer δ"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Delta Species/3.ts
+++ b/data/EX/Delta Species/3.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Dragonite δ",
 		fr: "Dracolosse δ",
-		de: "Dragoran"
+		de: "Dragoran δ"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Delta Species/30.ts
+++ b/data/EX/Delta Species/30.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Starmie δ",
 		fr: "Staross δ",
-		de: "Starmie"
+		de: "Starmie δ"
 	},
 
 	illustrator: "Midori Harada",

--- a/data/EX/Delta Species/4.ts
+++ b/data/EX/Delta Species/4.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Espeon δ",
 		fr: "Mentali δ",
-		de: "Psiana"
+		de: "Psiana δ"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Delta Species/41.ts
+++ b/data/EX/Delta Species/41.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Dragonair δ",
 		fr: "Draco δ",
-		de: "Dragonir"
+		de: "Dragonir δ"
 	},
 
 	illustrator: "Hajime Kusajima",

--- a/data/EX/Delta Species/42.ts
+++ b/data/EX/Delta Species/42.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Dragonair δ",
 		fr: "Draco δ",
-		de: "Dragonir"
+		de: "Dragonir δ"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Delta Species/49.ts
+++ b/data/EX/Delta Species/49.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Metang δ",
 		fr: "Metang δ",
-		de: "Metang"
+		de: "Metang δ"
 	},
 
 	illustrator: "Hajime Kusajima",

--- a/data/EX/Delta Species/5.ts
+++ b/data/EX/Delta Species/5.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Flareon δ",
 		fr: "Pyroli δ",
-		de: "Flamara"
+		de: "Flamara δ"
 	},
 
 	illustrator: "Kouki Saitou",

--- a/data/EX/Delta Species/51.ts
+++ b/data/EX/Delta Species/51.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Pupitar δ",
 		fr: "Ymphect δ",
-		de: "Pupitar"
+		de: "Pupitar δ"
 	},
 
 	illustrator: "Masakazu Fukuda",

--- a/data/EX/Delta Species/53.ts
+++ b/data/EX/Delta Species/53.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Shelgon δ",
 		fr: "Drackhaus δ",
-		de: "Draschel"
+		de: "Draschel δ"
 	},
 
 	illustrator: "Masakazu Fukuda",

--- a/data/EX/Delta Species/54.ts
+++ b/data/EX/Delta Species/54.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Shelgon δ",
 		fr: "Drackhaus δ",
-		de: "Draschel"
+		de: "Draschel δ"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Delta Species/57.ts
+++ b/data/EX/Delta Species/57.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Bagon δ",
 		fr: "Draby δ",
-		de: "Kindwurm"
+		de: "Kindwurm δ"
 	},
 
 	illustrator: "Masakazu Fukuda",

--- a/data/EX/Delta Species/58.ts
+++ b/data/EX/Delta Species/58.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Bagon δ",
 		fr: "Draby δ",
-		de: "Kindwurm"
+		de: "Kindwurm δ"
 	},
 
 	illustrator: "Hajime Kusajima",

--- a/data/EX/Delta Species/59.ts
+++ b/data/EX/Delta Species/59.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Beldum δ",
 		fr: "Terhal δ",
-		de: "Tanhel"
+		de: "Tanhel δ"
 	},
 
 	illustrator: "Hajime Kusajima",

--- a/data/EX/Delta Species/6.ts
+++ b/data/EX/Delta Species/6.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Gardevoir δ",
 		fr: "Gardevoir δ",
-		de: "Guardevoir"
+		de: "Guardevoir δ"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Delta Species/65.ts
+++ b/data/EX/Delta Species/65.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Dratini δ",
 		fr: "Minidraco δ",
-		de: "Dratini"
+		de: "Dratini δ"
 	},
 
 	illustrator: "Hajime Kusajima",

--- a/data/EX/Delta Species/66.ts
+++ b/data/EX/Delta Species/66.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Dratini δ",
 		fr: "Minidraco δ",
-		de: "Dratini"
+		de: "Dratini δ"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Delta Species/68.ts
+++ b/data/EX/Delta Species/68.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Eevee δ",
 		fr: "Evoli δ",
-		de: "Evoli"
+		de: "Evoli δ"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Delta Species/7.ts
+++ b/data/EX/Delta Species/7.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Jolteon δ",
 		fr: "Voltali δ",
-		de: "Blitza"
+		de: "Blitza δ"
 	},
 
 	illustrator: "Kouki Saitou",

--- a/data/EX/Delta Species/73.ts
+++ b/data/EX/Delta Species/73.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Larvitar δ",
 		fr: "Embrylex δ",
-		de: "Larvitar"
+		de: "Larvitar δ"
 	},
 
 	illustrator: "Hajime Kusajima",

--- a/data/EX/Delta Species/8.ts
+++ b/data/EX/Delta Species/8.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Latias δ",
 		fr: "Latias δ",
-		de: "Latias"
+		de: "Latias δ"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Delta Species/9.ts
+++ b/data/EX/Delta Species/9.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Latios δ",
 		fr: "Latios δ",
-		de: "Latios"
+		de: "Latios δ"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Deoxys/100.ts
+++ b/data/EX/Deoxys/100.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Hariyama ex",
 		fr: "Hariyama ex",
-		de: "Hariyama ex"
+		de: "Hariyama-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Deoxys/101.ts
+++ b/data/EX/Deoxys/101.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Manectric ex",
 		fr: "Elecsprint ex",
-		de: "Voltenso ex"
+		de: "Voltenso-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Deoxys/102.ts
+++ b/data/EX/Deoxys/102.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Rayquaza ex",
 		fr: "Rayquaza ex",
-		de: "Rayquaza ex"
+		de: "Rayquaza-ex"
 	},
 
 	illustrator: "Shin-ichi Yoshikawa",

--- a/data/EX/Deoxys/103.ts
+++ b/data/EX/Deoxys/103.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Salamence ex",
 		fr: "Drattak ex",
-		de: "Brutalanda ex"
+		de: "Brutalanda-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Deoxys/104.ts
+++ b/data/EX/Deoxys/104.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Sharpedo ex",
 		fr: "Sharpedo ex",
-		de: "Tohaido ex"
+		de: "Tohaido-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Deoxys/108.ts
+++ b/data/EX/Deoxys/108.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Rocket's Raikou ex",
 		fr: "Raikou ex de Rocket",
-		de: "Rockets Raikou ex"
+		de: "Rockets Raikou-ex"
 	},
 
 	suffix: "ex",

--- a/data/EX/Deoxys/96.ts
+++ b/data/EX/Deoxys/96.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Crobat ex",
 		fr: "Nostenfer ex",
-		de: "Iksbat ex"
+		de: "Iksbat-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Deoxys/97.ts
+++ b/data/EX/Deoxys/97.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Deoxys ex",
 		fr: "Deoxys ex",
-		de: "Deoxys ex"
+		de: "Deoxys-ex"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Deoxys/98.ts
+++ b/data/EX/Deoxys/98.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Deoxys ex",
 		fr: "Deoxys ex",
-		de: "Deoxys ex"
+		de: "Deoxys-ex"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Deoxys/99.ts
+++ b/data/EX/Deoxys/99.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Deoxys ex",
 		fr: "Deoxys ex",
-		de: "Deoxys ex"
+		de: "Deoxys-ex"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Dragon Frontiers/1.ts
+++ b/data/EX/Dragon Frontiers/1.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Ampharos δ",
 		fr: "Pharamp δ",
-		de: "Ampharos"
+		de: "Ampharos δ"
 	},
 
 	illustrator: "Kagemaru Himeno",

--- a/data/EX/Dragon Frontiers/10.ts
+++ b/data/EX/Dragon Frontiers/10.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Snorlax δ",
 		fr: "Ronflex δ",
-		de: "Relaxo"
+		de: "Relaxo δ"
 	},
 
 	illustrator: "Masakazu Fukuda",

--- a/data/EX/Dragon Frontiers/11.ts
+++ b/data/EX/Dragon Frontiers/11.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Togetic δ",
 		fr: "Togetic δ",
-		de: "Togetic"
+		de: "Togetic δ"
 	},
 
 	illustrator: "Kouki Saitou",

--- a/data/EX/Dragon Frontiers/12.ts
+++ b/data/EX/Dragon Frontiers/12.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Typhlosion δ",
 		fr: "Typhlosion δ",
-		de: "Tornupto"
+		de: "Tornupto δ"
 	},
 
 	illustrator: "Hisao Nakamura",

--- a/data/EX/Dragon Frontiers/13.ts
+++ b/data/EX/Dragon Frontiers/13.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Arbok δ",
 		fr: "Arbok δ",
-		de: "Arbok"
+		de: "Arbok δ"
 	},
 
 	illustrator: "Hisao Nakamura",

--- a/data/EX/Dragon Frontiers/14.ts
+++ b/data/EX/Dragon Frontiers/14.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Cloyster δ",
 		fr: "Crustabri δ",
-		de: "Austos"
+		de: "Austos δ"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Dragon Frontiers/15.ts
+++ b/data/EX/Dragon Frontiers/15.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Dewgong δ",
 		fr: "Lamantine δ",
-		de: "Jugong"
+		de: "Jugong δ"
 	},
 
 	illustrator: "Atsuko Nishida",

--- a/data/EX/Dragon Frontiers/16.ts
+++ b/data/EX/Dragon Frontiers/16.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Gligar δ",
 		fr: "Scorplane δ",
-		de: "Skorgla"
+		de: "Skorgla δ"
 	},
 
 	illustrator: "Kagemaru Himeno",

--- a/data/EX/Dragon Frontiers/17.ts
+++ b/data/EX/Dragon Frontiers/17.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Jynx δ",
 		fr: "Lippoutou δ",
-		de: "Rossana"
+		de: "Rossana δ"
 	},
 
 	illustrator: "Ken Sugimori",

--- a/data/EX/Dragon Frontiers/18.ts
+++ b/data/EX/Dragon Frontiers/18.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Ledian δ",
 		fr: "Coxyclaque δ",
-		de: "Ledian"
+		de: "Ledian δ"
 	},
 
 	illustrator: "Hajime Kusajima",

--- a/data/EX/Dragon Frontiers/19.ts
+++ b/data/EX/Dragon Frontiers/19.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Lickitung δ",
 		fr: "Excelangue δ",
-		de: "Schlurp"
+		de: "Schlurp δ"
 	},
 
 	illustrator: "Masakazu Fukuda",

--- a/data/EX/Dragon Frontiers/2.ts
+++ b/data/EX/Dragon Frontiers/2.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Feraligatr δ",
 		fr: "Aligatueur δ",
-		de: "Impergator"
+		de: "Impergator δ"
 	},
 
 	illustrator: "Kouki Saitou",

--- a/data/EX/Dragon Frontiers/20.ts
+++ b/data/EX/Dragon Frontiers/20.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Mantine δ",
 		fr: "Demanta δ",
-		de: "Mantax"
+		de: "Mantax δ"
 	},
 
 	illustrator: "Sumiyoshi Kizuki",

--- a/data/EX/Dragon Frontiers/21.ts
+++ b/data/EX/Dragon Frontiers/21.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Quagsire δ",
 		fr: "Maraiste δ",
-		de: "Morlord"
+		de: "Morlord δ"
 	},
 
 	illustrator: "Sachiko Adachi",

--- a/data/EX/Dragon Frontiers/22.ts
+++ b/data/EX/Dragon Frontiers/22.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Seadra δ",
 		fr: "Hypocéan δ",
-		de: "Seemon"
+		de: "Seemon δ"
 	},
 
 	illustrator: "Sachiko Adachi",

--- a/data/EX/Dragon Frontiers/23.ts
+++ b/data/EX/Dragon Frontiers/23.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Tropius δ",
 		fr: "Tropius δ",
-		de: "Tropius"
+		de: "Tropius δ"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Dragon Frontiers/24.ts
+++ b/data/EX/Dragon Frontiers/24.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Vibrava δ",
 		fr: "Vibraninf δ",
-		de: "Vibrava"
+		de: "Vibrava δ"
 	},
 
 	illustrator: "Tomokazu Komiya",

--- a/data/EX/Dragon Frontiers/25.ts
+++ b/data/EX/Dragon Frontiers/25.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Xatu δ",
 		fr: "Xatu δ",
-		de: "Xatu"
+		de: "Xatu δ"
 	},
 
 	illustrator: "Kouki Saitou",

--- a/data/EX/Dragon Frontiers/26.ts
+++ b/data/EX/Dragon Frontiers/26.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Bayleef δ",
 		fr: "Macronium δ",
-		de: "Lorblatt"
+		de: "Lorblatt δ"
 	},
 
 	illustrator: "Kagemaru Himeno",

--- a/data/EX/Dragon Frontiers/27.ts
+++ b/data/EX/Dragon Frontiers/27.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Croconaw δ",
 		fr: "Crocrodil δ",
-		de: "Tyracroc"
+		de: "Tyracroc δ"
 	},
 
 	illustrator: "Yuka Morii",

--- a/data/EX/Dragon Frontiers/28.ts
+++ b/data/EX/Dragon Frontiers/28.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Dragonair δ",
 		fr: "Draco δ",
-		de: "Dragonir"
+		de: "Dragonir δ"
 	},
 
 	illustrator: "Kouki Saitou",

--- a/data/EX/Dragon Frontiers/29.ts
+++ b/data/EX/Dragon Frontiers/29.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Electabuzz δ",
 		fr: "Elektek δ",
-		de: "Elektek"
+		de: "Elektek δ"
 	},
 
 	illustrator: "Ken Sugimori",

--- a/data/EX/Dragon Frontiers/3.ts
+++ b/data/EX/Dragon Frontiers/3.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Heracross δ",
 		fr: "Scarhino δ",
-		de: "Skaraborn"
+		de: "Skaraborn δ"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Dragon Frontiers/30.ts
+++ b/data/EX/Dragon Frontiers/30.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Flaaffy δ",
 		fr: "Lainergie δ",
-		de: "Waaty"
+		de: "Waaty δ"
 	},
 
 	illustrator: "Yuka Morii",

--- a/data/EX/Dragon Frontiers/31.ts
+++ b/data/EX/Dragon Frontiers/31.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Horsea δ",
 		fr: "Hypotrempe δ",
-		de: "Seeper"
+		de: "Seeper δ"
 	},
 
 	illustrator: "Tomokazu Komiya",

--- a/data/EX/Dragon Frontiers/33.ts
+++ b/data/EX/Dragon Frontiers/33.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Kirlia δ",
 		fr: "Kirlia δ",
-		de: "Kirlia"
+		de: "Kirlia δ"
 	},
 
 	illustrator: "Kyoko Umemoto",

--- a/data/EX/Dragon Frontiers/34.ts
+++ b/data/EX/Dragon Frontiers/34.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Nidorina δ",
 		fr: "Nidorina δ",
-		de: "Nidorina"
+		de: "Nidorina δ"
 	},
 
 	illustrator: "Sumiyoshi Kizuki",

--- a/data/EX/Dragon Frontiers/35.ts
+++ b/data/EX/Dragon Frontiers/35.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Nidorino δ",
 		fr: "Nidorino δ",
-		de: "Nidorino"
+		de: "Nidorino δ"
 	},
 
 	illustrator: "Atsuko Nishida",

--- a/data/EX/Dragon Frontiers/36.ts
+++ b/data/EX/Dragon Frontiers/36.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Quilava δ",
 		fr: "Feurisson δ",
-		de: "Igelavar"
+		de: "Igelavar δ"
 	},
 
 	illustrator: "Midori Harada",

--- a/data/EX/Dragon Frontiers/37.ts
+++ b/data/EX/Dragon Frontiers/37.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Seadra δ",
 		fr: "Hypocéan δ",
-		de: "Seemon"
+		de: "Seemon δ"
 	},
 
 	illustrator: "Hisao Nakamura",

--- a/data/EX/Dragon Frontiers/38.ts
+++ b/data/EX/Dragon Frontiers/38.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Shelgon δ",
 		fr: "Drackhaus δ",
-		de: "Draschel"
+		de: "Draschel δ"
 	},
 
 	illustrator: "Kyoko Umemoto",

--- a/data/EX/Dragon Frontiers/39.ts
+++ b/data/EX/Dragon Frontiers/39.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Smeargle δ",
 		fr: "Queulorior δ",
-		de: "Farbeagle"
+		de: "Farbeagle δ"
 	},
 
 	illustrator: "Kagemaru Himeno",

--- a/data/EX/Dragon Frontiers/4.ts
+++ b/data/EX/Dragon Frontiers/4.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Meganium δ",
 		fr: "Meganium δ",
-		de: "Meganie"
+		de: "Meganie δ"
 	},
 
 	illustrator: "Sumiyoshi Kizuki",

--- a/data/EX/Dragon Frontiers/40.ts
+++ b/data/EX/Dragon Frontiers/40.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Swellow δ",
 		fr: "Heledelle δ",
-		de: "Schwalboss"
+		de: "Schwalboss δ"
 	},
 
 	illustrator: "Sumiyoshi Kizuki",

--- a/data/EX/Dragon Frontiers/41.ts
+++ b/data/EX/Dragon Frontiers/41.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Togepi δ",
 		fr: "Togepi δ",
-		de: "Togepi"
+		de: "Togepi δ"
 	},
 
 	illustrator: "Miki Tanaka",

--- a/data/EX/Dragon Frontiers/42.ts
+++ b/data/EX/Dragon Frontiers/42.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Vibrava δ",
 		fr: "Vibraninf δ",
-		de: "Vibrava"
+		de: "Vibrava δ"
 	},
 
 	illustrator: "Midori Harada",

--- a/data/EX/Dragon Frontiers/43.ts
+++ b/data/EX/Dragon Frontiers/43.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Bagon δ",
 		fr: "Draby δ",
-		de: "Kindwurm"
+		de: "Kindwurm δ"
 	},
 
 	illustrator: "Hajime Kusajima",

--- a/data/EX/Dragon Frontiers/44.ts
+++ b/data/EX/Dragon Frontiers/44.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Chikorita δ",
 		fr: "Germignon δ",
-		de: "Endivie"
+		de: "Endivie δ"
 	},
 
 	illustrator: "Yuka Morii",

--- a/data/EX/Dragon Frontiers/45.ts
+++ b/data/EX/Dragon Frontiers/45.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Cyndaquil δ",
 		fr: "Héricendre δ",
-		de: "Feurigel"
+		de: "Feurigel δ"
 	},
 
 	illustrator: "Atsuko Nishida",

--- a/data/EX/Dragon Frontiers/46.ts
+++ b/data/EX/Dragon Frontiers/46.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Dratini δ",
 		fr: "Minidraco δ",
-		de: "Dratini"
+		de: "Dratini δ"
 	},
 
 	illustrator: "Tomokazu Komiya",

--- a/data/EX/Dragon Frontiers/47.ts
+++ b/data/EX/Dragon Frontiers/47.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Ekans δ",
 		fr: "Abo δ",
-		de: "Rettan"
+		de: "Rettan δ"
 	},
 
 	illustrator: "Yuka Morii",

--- a/data/EX/Dragon Frontiers/48.ts
+++ b/data/EX/Dragon Frontiers/48.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Elekid δ",
 		fr: "Elekid δ",
-		de: "Elekid"
+		de: "Elekid δ"
 	},
 
 	illustrator: "Ken Sugimori",

--- a/data/EX/Dragon Frontiers/49.ts
+++ b/data/EX/Dragon Frontiers/49.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Feebas δ",
 		fr: "Barpau δ",
-		de: "Barschwa"
+		de: "Barschwa δ"
 	},
 
 	illustrator: "Yukiko Baba",

--- a/data/EX/Dragon Frontiers/5.ts
+++ b/data/EX/Dragon Frontiers/5.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Milotic δ",
 		fr: "Milobellus δ",
-		de: "Milotic"
+		de: "Milotic δ"
 	},
 
 	illustrator: "Midori Harada",

--- a/data/EX/Dragon Frontiers/50.ts
+++ b/data/EX/Dragon Frontiers/50.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Horsea δ",
 		fr: "Hypotrempe δ",
-		de: "Seeper"
+		de: "Seeper δ"
 	},
 
 	illustrator: "Hisao Nakamura",

--- a/data/EX/Dragon Frontiers/52.ts
+++ b/data/EX/Dragon Frontiers/52.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Larvitar δ",
 		fr: "Embrylex δ",
-		de: "Larvitar"
+		de: "Larvitar δ"
 	},
 
 	illustrator: "Kouki Saitou",

--- a/data/EX/Dragon Frontiers/53.ts
+++ b/data/EX/Dragon Frontiers/53.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Ledyba δ",
 		fr: "Coxy δ",
-		de: "Ledyba"
+		de: "Ledyba δ"
 	},
 
 	illustrator: "Kyoko Umemoto",

--- a/data/EX/Dragon Frontiers/54.ts
+++ b/data/EX/Dragon Frontiers/54.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Mareep δ",
 		fr: "Wattouat δ",
-		de: "Voltilamm"
+		de: "Voltilamm δ"
 	},
 
 	illustrator: "Sachiko Adachi",

--- a/data/EX/Dragon Frontiers/55.ts
+++ b/data/EX/Dragon Frontiers/55.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Natu δ",
 		fr: "Natu δ",
-		de: "Natu"
+		de: "Natu δ"
 	},
 
 	illustrator: "Yukiko Baba",

--- a/data/EX/Dragon Frontiers/56.ts
+++ b/data/EX/Dragon Frontiers/56.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Nidoran♀ δ",
 		fr: "Nidoran ♀ δ",
-		de: "Nidoran W"
+		de: "Nidoran W δ"
 	},
 	illustrator: "Hajime Kusajima",
 	rarity: "Common",

--- a/data/EX/Dragon Frontiers/57.ts
+++ b/data/EX/Dragon Frontiers/57.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Nidoran♂ δ",
 		fr: "Nidoran ♂ δ",
-		de: "Nidoran M"
+		de: "Nidoran M δ"
 	},
 	illustrator: "Midori Harada",
 	rarity: "Common",

--- a/data/EX/Dragon Frontiers/59.ts
+++ b/data/EX/Dragon Frontiers/59.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Pupitar δ",
 		fr: "Ymphect δ",
-		de: "Pupitar"
+		de: "Pupitar δ"
 	},
 
 	illustrator: "Kouki Saitou",

--- a/data/EX/Dragon Frontiers/6.ts
+++ b/data/EX/Dragon Frontiers/6.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Nidoking δ",
 		fr: "Nidoking δ",
-		de: "Nidoking"
+		de: "Nidoking δ"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Dragon Frontiers/61.ts
+++ b/data/EX/Dragon Frontiers/61.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Ralts δ",
 		fr: "Tarsal δ",
-		de: "Trasla"
+		de: "Trasla δ"
 	},
 
 	illustrator: "Kyoko Umemoto",

--- a/data/EX/Dragon Frontiers/62.ts
+++ b/data/EX/Dragon Frontiers/62.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Seel δ",
 		fr: "Otaria δ",
-		de: "Jurob"
+		de: "Jurob δ"
 	},
 
 	illustrator: "Hajime Kusajima",

--- a/data/EX/Dragon Frontiers/63.ts
+++ b/data/EX/Dragon Frontiers/63.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Shellder δ",
 		fr: "Kokiyas δ",
-		de: "Muschas"
+		de: "Muschas δ"
 	},
 
 	illustrator: "Hisao Nakamura",

--- a/data/EX/Dragon Frontiers/64.ts
+++ b/data/EX/Dragon Frontiers/64.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Smoochum δ",
 		fr: "Lippouti δ",
-		de: "Kussilla"
+		de: "Kussilla δ"
 	},
 
 	illustrator: "Miki Tanaka",

--- a/data/EX/Dragon Frontiers/65.ts
+++ b/data/EX/Dragon Frontiers/65.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Swablu δ",
 		fr: "Tylton δ",
-		de: "Wablu"
+		de: "Wablu δ"
 	},
 
 	illustrator: "Miki Tanaka",

--- a/data/EX/Dragon Frontiers/66.ts
+++ b/data/EX/Dragon Frontiers/66.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Taillow δ",
 		fr: "Nirondelle δ",
-		de: "Schwalbini"
+		de: "Schwalbini δ"
 	},
 
 	illustrator: "Miki Tanaka",

--- a/data/EX/Dragon Frontiers/67.ts
+++ b/data/EX/Dragon Frontiers/67.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Totodile δ",
 		fr: "Kaiminus δ",
-		de: "Karnimani"
+		de: "Karnimani δ"
 	},
 
 	illustrator: "Hisao Nakamura",

--- a/data/EX/Dragon Frontiers/68.ts
+++ b/data/EX/Dragon Frontiers/68.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Trapinch δ",
 		fr: "Kraknoix δ",
-		de: "Knacklion"
+		de: "Knacklion δ"
 	},
 
 	illustrator: "Midori Harada",

--- a/data/EX/Dragon Frontiers/69.ts
+++ b/data/EX/Dragon Frontiers/69.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Trapinch δ",
 		fr: "Kraknoix δ",
-		de: "Knacklion"
+		de: "Knacklion δ"
 	},
 
 	illustrator: "Yukiko Baba",

--- a/data/EX/Dragon Frontiers/7.ts
+++ b/data/EX/Dragon Frontiers/7.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Nidoqueen δ",
 		fr: "Nidoqueen δ",
-		de: "Nidoqueen"
+		de: "Nidoqueen δ"
 	},
 
 	illustrator: "Kouki Saitou",

--- a/data/EX/Dragon Frontiers/70.ts
+++ b/data/EX/Dragon Frontiers/70.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Vulpix δ",
 		fr: "Goupix δ",
-		de: "Vulpix"
+		de: "Vulpix δ"
 	},
 
 	illustrator: "Sachiko Adachi",

--- a/data/EX/Dragon Frontiers/71.ts
+++ b/data/EX/Dragon Frontiers/71.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Wooper δ",
 		fr: "Axoloto δ",
-		de: "Felino"
+		de: "Felino δ"
 	},
 
 	illustrator: "Tomokazu Komiya",

--- a/data/EX/Dragon Frontiers/8.ts
+++ b/data/EX/Dragon Frontiers/8.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Ninetales δ",
 		fr: "Feunard δ",
-		de: "Vulnona"
+		de: "Vulnona δ"
 	},
 
 	illustrator: "Hajime Kusajima",

--- a/data/EX/Dragon Frontiers/9.ts
+++ b/data/EX/Dragon Frontiers/9.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Pinsir δ",
 		fr: "Scarabrute δ",
-		de: "Pinsir"
+		de: "Pinsir δ"
 	},
 
 	illustrator: "Yukiko Baba",

--- a/data/EX/Dragon Frontiers/90.ts
+++ b/data/EX/Dragon Frontiers/90.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Altaria ex δ",
 		fr: "Altaria ex δ",
-		de: "Altaria ex"
+		de: "Altaria-ex"
 	},
 
 	suffix: "ex",

--- a/data/EX/Dragon Frontiers/90.ts
+++ b/data/EX/Dragon Frontiers/90.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Altaria ex δ",
 		fr: "Altaria ex δ",
-		de: "Altaria-ex"
+		de: "Altaria-ex δ"
 	},
 
 	suffix: "ex",

--- a/data/EX/Dragon Frontiers/91.ts
+++ b/data/EX/Dragon Frontiers/91.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Dragonite ex δ",
 		fr: "Dracolosse ex δ",
-		de: "Dragoran-ex"
+		de: "Dragoran-ex δ"
 	},
 
 	suffix: "ex",

--- a/data/EX/Dragon Frontiers/91.ts
+++ b/data/EX/Dragon Frontiers/91.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Dragonite ex δ",
 		fr: "Dracolosse ex δ",
-		de: "Dragoran ex"
+		de: "Dragoran-ex"
 	},
 
 	suffix: "ex",

--- a/data/EX/Dragon Frontiers/92.ts
+++ b/data/EX/Dragon Frontiers/92.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Flygon ex δ",
 		fr: "Libegon ex δ",
-		de: "Libelldra-ex"
+		de: "Libelldra-ex δ"
 	},
 
 	suffix: "ex",

--- a/data/EX/Dragon Frontiers/92.ts
+++ b/data/EX/Dragon Frontiers/92.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Flygon ex δ",
 		fr: "Libegon ex δ",
-		de: "Libelldra ex"
+		de: "Libelldra-ex"
 	},
 
 	suffix: "ex",

--- a/data/EX/Dragon Frontiers/93.ts
+++ b/data/EX/Dragon Frontiers/93.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Gardevoir ex δ",
 		fr: "Gardevoir ex δ",
-		de: "Guardevoir-ex"
+		de: "Guardevoir-ex δ"
 	},
 
 	suffix: "ex",

--- a/data/EX/Dragon Frontiers/93.ts
+++ b/data/EX/Dragon Frontiers/93.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Gardevoir ex δ",
 		fr: "Gardevoir ex δ",
-		de: "Guardevoir ex"
+		de: "Guardevoir-ex"
 	},
 
 	suffix: "ex",

--- a/data/EX/Dragon Frontiers/94.ts
+++ b/data/EX/Dragon Frontiers/94.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Kingdra ex δ",
 		fr: "Hyporoi ex δ",
-		de: "Seedraking-ex"
+		de: "Seedraking-ex δ"
 	},
 
 	suffix: "ex",

--- a/data/EX/Dragon Frontiers/94.ts
+++ b/data/EX/Dragon Frontiers/94.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Kingdra ex δ",
 		fr: "Hyporoi ex δ",
-		de: "Seedraking ex"
+		de: "Seedraking-ex"
 	},
 
 	suffix: "ex",

--- a/data/EX/Dragon Frontiers/95.ts
+++ b/data/EX/Dragon Frontiers/95.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Latias ex δ",
 		fr: "Latias ex δ",
-		de: "Latias ex"
+		de: "Latias-ex"
 	},
 
 	suffix: "ex",

--- a/data/EX/Dragon Frontiers/95.ts
+++ b/data/EX/Dragon Frontiers/95.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Latias ex δ",
 		fr: "Latias ex δ",
-		de: "Latias-ex"
+		de: "Latias-ex δ"
 	},
 
 	suffix: "ex",

--- a/data/EX/Dragon Frontiers/96.ts
+++ b/data/EX/Dragon Frontiers/96.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Latios ex δ",
 		fr: "Latios ex δ",
-		de: "Latios ex"
+		de: "Latios-ex"
 	},
 
 	suffix: "ex",

--- a/data/EX/Dragon Frontiers/96.ts
+++ b/data/EX/Dragon Frontiers/96.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Latios ex δ",
 		fr: "Latios ex δ",
-		de: "Latios-ex"
+		de: "Latios-ex δ"
 	},
 
 	suffix: "ex",

--- a/data/EX/Dragon Frontiers/97.ts
+++ b/data/EX/Dragon Frontiers/97.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Rayquaza ex δ",
 		fr: "Rayquaza ex δ",
-		de: "Rayquaza ex"
+		de: "Rayquaza-ex"
 	},
 
 	suffix: "ex",

--- a/data/EX/Dragon Frontiers/97.ts
+++ b/data/EX/Dragon Frontiers/97.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Rayquaza ex δ",
 		fr: "Rayquaza ex δ",
-		de: "Rayquaza-ex"
+		de: "Rayquaza-ex δ"
 	},
 
 	suffix: "ex",

--- a/data/EX/Dragon Frontiers/98.ts
+++ b/data/EX/Dragon Frontiers/98.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Salamence ex δ",
 		fr: "Drattak ex δ",
-		de: "Brutalanda-ex"
+		de: "Brutalanda-ex δ"
 	},
 
 	suffix: "ex",

--- a/data/EX/Dragon Frontiers/98.ts
+++ b/data/EX/Dragon Frontiers/98.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Salamence ex δ",
 		fr: "Drattak ex δ",
-		de: "Brutalanda ex"
+		de: "Brutalanda-ex"
 	},
 
 	suffix: "ex",

--- a/data/EX/Dragon Frontiers/99.ts
+++ b/data/EX/Dragon Frontiers/99.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Tyranitar ex δ",
 		fr: "Tyranocif ex δ",
-		de: "Despotar-ex"
+		de: "Despotar-ex δ"
 	},
 
 	suffix: "ex",

--- a/data/EX/Dragon Frontiers/99.ts
+++ b/data/EX/Dragon Frontiers/99.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Tyranitar ex δ",
 		fr: "Tyranocif ex δ",
-		de: "Despotar ex"
+		de: "Despotar-ex"
 	},
 
 	suffix: "ex",

--- a/data/EX/Dragon/89.ts
+++ b/data/EX/Dragon/89.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Ampharos ex",
 		fr: "Pharamp ex",
-		de: "Ampharos ex"
+		de: "Ampharos-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Dragon/90.ts
+++ b/data/EX/Dragon/90.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Dragonite ex",
 		fr: "Dracolosse ex",
-		de: "Dragoran ex"
+		de: "Dragoran-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Dragon/91.ts
+++ b/data/EX/Dragon/91.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Golem ex",
 		fr: "Grolem ex",
-		de: "Geowaz ex"
+		de: "Geowaz-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Dragon/92.ts
+++ b/data/EX/Dragon/92.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Kingdra ex",
 		fr: "Hyporoi ex",
-		de: "Seedraking ex"
+		de: "Seedraking-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Dragon/93.ts
+++ b/data/EX/Dragon/93.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Latias ex",
 		fr: "Latias ex",
-		de: "Latias ex"
+		de: "Latias-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Dragon/94.ts
+++ b/data/EX/Dragon/94.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Latios ex",
 		fr: "Latios ex",
-		de: "Latios ex"
+		de: "Latios-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Dragon/95.ts
+++ b/data/EX/Dragon/95.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Magcargo ex",
 		fr: "Volcaropod ex",
-		de: "Magcargo ex"
+		de: "Magcargo-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Dragon/96.ts
+++ b/data/EX/Dragon/96.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Muk ex",
 		fr: "Grotadmorv ex",
-		de: "Sleimok ex"
+		de: "Sleimok-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Dragon/97.ts
+++ b/data/EX/Dragon/97.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Rayquaza ex",
 		fr: "Rayquaza ex",
-		de: "Rayquaza ex"
+		de: "Rayquaza-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Emerald/100.ts
+++ b/data/EX/Emerald/100.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Registeel ex",
 		fr: "Registeel ex",
-		de: "Registeel ex"
+		de: "Registeel-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Emerald/90.ts
+++ b/data/EX/Emerald/90.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Altaria ex",
 		fr: "Altaria ex",
-		de: "Altaria ex"
+		de: "Altaria-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Emerald/91.ts
+++ b/data/EX/Emerald/91.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Cacturne ex",
 		fr: "Cacturne ex",
-		de: "Noktuska ex"
+		de: "Noktuska-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Emerald/92.ts
+++ b/data/EX/Emerald/92.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Camerupt ex",
 		fr: "Camerupt ex",
-		de: "Camerupt ex"
+		de: "Camerupt-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Emerald/93.ts
+++ b/data/EX/Emerald/93.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Deoxys ex",
 		fr: "Deoxys ex",
-		de: "Deoxys ex"
+		de: "Deoxys-ex"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Emerald/94.ts
+++ b/data/EX/Emerald/94.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Dusclops ex",
 		fr: "Teraclope ex",
-		de: "Zwirrklop ex"
+		de: "Zwirrklop-ex"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Emerald/95.ts
+++ b/data/EX/Emerald/95.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Medicham ex",
 		fr: "Charmina ex",
-		de: "Meditalis ex"
+		de: "Meditalis-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Emerald/96.ts
+++ b/data/EX/Emerald/96.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Milotic ex",
 		fr: "Milobellus ex",
-		de: "Milotic ex"
+		de: "Milotic-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Emerald/97.ts
+++ b/data/EX/Emerald/97.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Raichu ex",
 		fr: "Raichu ex",
-		de: "Raichu ex"
+		de: "Raichu-ex"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Emerald/98.ts
+++ b/data/EX/Emerald/98.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Regice ex",
 		fr: "Regice ex",
-		de: "Regice ex"
+		de: "Regice-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Emerald/99.ts
+++ b/data/EX/Emerald/99.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Regirock ex",
 		fr: "Regirock ex",
-		de: "Regirock ex"
+		de: "Regirock-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/FireRed & LeafGreen/104.ts
+++ b/data/EX/FireRed & LeafGreen/104.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Blastoise ex",
 		fr: "Tortank ex",
-		de: "Turtok ex"
+		de: "Turtok-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/FireRed & LeafGreen/105.ts
+++ b/data/EX/FireRed & LeafGreen/105.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Charizard ex",
 		fr: "Dracaufeu ex",
-		de: "Glurak ex"
+		de: "Glurak-ex"
 	},
 
 	illustrator: "Hiromichi Sugiyama",

--- a/data/EX/FireRed & LeafGreen/106.ts
+++ b/data/EX/FireRed & LeafGreen/106.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Clefable ex",
 		fr: "Mélodelfe ex",
-		de: "Pixi ex"
+		de: "Pixi-ex"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/FireRed & LeafGreen/107.ts
+++ b/data/EX/FireRed & LeafGreen/107.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Electrode ex",
 		fr: "Électrode ex",
-		de: "Lektrobal ex"
+		de: "Lektrobal-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/FireRed & LeafGreen/108.ts
+++ b/data/EX/FireRed & LeafGreen/108.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Gengar ex",
 		fr: "Ectoplasma ex",
-		de: "Gengar ex"
+		de: "Gengar-ex"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/FireRed & LeafGreen/109.ts
+++ b/data/EX/FireRed & LeafGreen/109.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Gyarados ex",
 		fr: "Léviator ex",
-		de: "Garados ex"
+		de: "Garados-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/FireRed & LeafGreen/110.ts
+++ b/data/EX/FireRed & LeafGreen/110.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Mr. Mime ex",
 		fr: "M. Mime ex",
-		de: "Pantimos ex"
+		de: "Pantimos-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/FireRed & LeafGreen/111.ts
+++ b/data/EX/FireRed & LeafGreen/111.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Mr. Mime ex",
 		fr: "M. Mime ex",
-		de: "Pantimos ex"
+		de: "Pantimos-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/FireRed & LeafGreen/112.ts
+++ b/data/EX/FireRed & LeafGreen/112.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Venusaur ex",
 		fr: "Florizarre ex",
-		de: "Bisaflor ex"
+		de: "Bisaflor-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/FireRed & LeafGreen/114.ts
+++ b/data/EX/FireRed & LeafGreen/114.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Articuno ex",
 		fr: "Artikodin ex",
-		de: "Arktos ex"
+		de: "Arktos-ex"
 	},
 
 	suffix: "ex",

--- a/data/EX/FireRed & LeafGreen/115.ts
+++ b/data/EX/FireRed & LeafGreen/115.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Moltres ex",
 		fr: "Sulfura ex",
-		de: "Lavados ex"
+		de: "Lavados-ex"
 	},
 
 	suffix: "ex",

--- a/data/EX/FireRed & LeafGreen/116.ts
+++ b/data/EX/FireRed & LeafGreen/116.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Zapdos ex",
 		fr: "Élector ex",
-		de: "Zapdos ex"
+		de: "Zapdos-ex"
 	},
 
 	suffix: "ex",

--- a/data/EX/Hidden Legends/100.ts
+++ b/data/EX/Hidden Legends/100.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Vileplume ex",
 		fr: "Rafflesia ex",
-		de: "Giflor ex"
+		de: "Giflor-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Hidden Legends/101.ts
+++ b/data/EX/Hidden Legends/101.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Wigglytuff ex",
 		fr: "Grodoudou ex",
-		de: "Knuddeluff ex"
+		de: "Knuddeluff-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Hidden Legends/93.ts
+++ b/data/EX/Hidden Legends/93.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Groudon ex",
 		fr: "Groudon ex",
-		de: "Groudon ex"
+		de: "Groudon-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Hidden Legends/94.ts
+++ b/data/EX/Hidden Legends/94.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Kyogre ex",
 		fr: "Kyogre ex",
-		de: "Kyogre ex"
+		de: "Kyogre-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Hidden Legends/95.ts
+++ b/data/EX/Hidden Legends/95.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Metagross ex",
 		fr: "Metalosse ex",
-		de: "Metagross ex"
+		de: "Metagross-ex"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Hidden Legends/96.ts
+++ b/data/EX/Hidden Legends/96.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Ninetales ex",
 		fr: "Feunard ex",
-		de: "Vulnona ex"
+		de: "Vulnona-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Hidden Legends/97.ts
+++ b/data/EX/Hidden Legends/97.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Regice ex",
 		fr: "Regice ex",
-		de: "Regice ex"
+		de: "Regice-ex"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Hidden Legends/98.ts
+++ b/data/EX/Hidden Legends/98.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Regirock ex",
 		fr: "Regirock ex",
-		de: "Regirock ex"
+		de: "Regirock-ex"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Hidden Legends/99.ts
+++ b/data/EX/Hidden Legends/99.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Registeel ex",
 		fr: "Registeel ex",
-		de: "Registeel ex"
+		de: "Registeel-ex"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Holon Phantoms/1.ts
+++ b/data/EX/Holon Phantoms/1.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Armaldo δ",
 		fr: "Armaldo δ",
-		de: "Armaldo"
+		de: "Armaldo δ"
 	},
 
 	illustrator: "Masakazu Fukuda",

--- a/data/EX/Holon Phantoms/10.ts
+++ b/data/EX/Holon Phantoms/10.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Kingdra δ",
 		fr: "Hyporoi δ",
-		de: "Seedraking"
+		de: "Seedraking δ"
 	},
 
 	illustrator: "Masakazu Fukuda",

--- a/data/EX/Holon Phantoms/100.ts
+++ b/data/EX/Holon Phantoms/100.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Mew ex",
 		fr: "Mew ex",
-		de: "Mew ex"
+		de: "Mew-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Holon Phantoms/101.ts
+++ b/data/EX/Holon Phantoms/101.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Mightyena ex",
 		fr: "Gradhyena ex",
-		de: "Magnayen ex"
+		de: "Magnayen-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Holon Phantoms/11.ts
+++ b/data/EX/Holon Phantoms/11.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Latias δ",
 		fr: "Latias δ",
-		de: "Latias"
+		de: "Latias δ"
 	},
 
 	illustrator: "Masakazu Fukuda",

--- a/data/EX/Holon Phantoms/12.ts
+++ b/data/EX/Holon Phantoms/12.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Latios δ",
 		fr: "Latios δ",
-		de: "Latios"
+		de: "Latios δ"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Holon Phantoms/13.ts
+++ b/data/EX/Holon Phantoms/13.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Omastar δ",
 		fr: "Amonistar δ",
-		de: "Amoroso"
+		de: "Amoroso δ"
 	},
 
 	illustrator: "Midori Harada",

--- a/data/EX/Holon Phantoms/14.ts
+++ b/data/EX/Holon Phantoms/14.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Pidgeot δ",
 		fr: "Roucarnage δ",
-		de: "Tauboss"
+		de: "Tauboss δ"
 	},
 
 	illustrator: "Kouki Saitou",

--- a/data/EX/Holon Phantoms/15.ts
+++ b/data/EX/Holon Phantoms/15.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Raichu δ",
 		fr: "Raichu δ",
-		de: "Raichu"
+		de: "Raichu δ"
 	},
 
 	illustrator: "Masakazu Fukuda",

--- a/data/EX/Holon Phantoms/16.ts
+++ b/data/EX/Holon Phantoms/16.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Rayquaza δ",
 		fr: "Rayquaza δ",
-		de: "Rayquaza"
+		de: "Rayquaza δ"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Holon Phantoms/17.ts
+++ b/data/EX/Holon Phantoms/17.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Vileplume δ",
 		fr: "Rafflesia δ",
-		de: "Giflor"
+		de: "Giflor δ"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Holon Phantoms/19.ts
+++ b/data/EX/Holon Phantoms/19.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Bellossom δ",
 		fr: "Joliflor δ",
-		de: "Blubella"
+		de: "Blubella δ"
 	},
 
 	illustrator: "Kagemaru Himeno",

--- a/data/EX/Holon Phantoms/2.ts
+++ b/data/EX/Holon Phantoms/2.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Cradily δ",
 		fr: "Vacilys δ",
-		de: "Wielie"
+		de: "Wielie δ"
 	},
 
 	illustrator: "Kouki Saitou",

--- a/data/EX/Holon Phantoms/21.ts
+++ b/data/EX/Holon Phantoms/21.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Latias δ",
 		fr: "Latias δ",
-		de: "Latias"
+		de: "Latias δ"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Holon Phantoms/22.ts
+++ b/data/EX/Holon Phantoms/22.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Latios δ",
 		fr: "Latios δ",
-		de: "Latios"
+		de: "Latios δ"
 	},
 
 	illustrator: "Masakazu Fukuda",

--- a/data/EX/Holon Phantoms/24.ts
+++ b/data/EX/Holon Phantoms/24.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Mewtwo δ",
 		fr: "Mewtwo δ",
-		de: "Mewtu"
+		de: "Mewtu δ"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Holon Phantoms/26.ts
+++ b/data/EX/Holon Phantoms/26.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Rayquaza δ",
 		fr: "Rayquaza δ",
-		de: "Rayquaza"
+		de: "Rayquaza δ"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Holon Phantoms/3.ts
+++ b/data/EX/Holon Phantoms/3.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Deoxys δ",
 		fr: "Deoxys δ",
-		de: "Deoxys"
+		de: "Deoxys δ"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Holon Phantoms/35.ts
+++ b/data/EX/Holon Phantoms/35.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Aerodactyl δ",
 		fr: "Ptera δ",
-		de: "Aerodactyl"
+		de: "Aerodactyl δ"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Holon Phantoms/37.ts
+++ b/data/EX/Holon Phantoms/37.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Chimecho δ",
 		fr: "Eoko δ",
-		de: "Palimpalim"
+		de: "Palimpalim δ"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Holon Phantoms/4.ts
+++ b/data/EX/Holon Phantoms/4.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Deoxys δ",
 		fr: "Deoxys δ",
-		de: "Deoxys"
+		de: "Deoxys δ"
 	},
 
 	illustrator: "Kagemaru Himeno",

--- a/data/EX/Holon Phantoms/41.ts
+++ b/data/EX/Holon Phantoms/41.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Exeggutor δ",
 		fr: "Noadkoko δ",
-		de: "Kokowei"
+		de: "Kokowei δ"
 	},
 
 	illustrator: "Midori Harada",

--- a/data/EX/Holon Phantoms/42.ts
+++ b/data/EX/Holon Phantoms/42.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Gloom δ",
 		fr: "Ortide δ",
-		de: "Duflor"
+		de: "Duflor δ"
 	},
 
 	illustrator: "Midori Harada",

--- a/data/EX/Holon Phantoms/43.ts
+++ b/data/EX/Holon Phantoms/43.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Golduck δ",
 		fr: "Akwakwak δ",
-		de: "Entoron"
+		de: "Entoron δ"
 	},
 
 	illustrator: "Midori Harada",

--- a/data/EX/Holon Phantoms/48.ts
+++ b/data/EX/Holon Phantoms/48.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Persian δ",
 		fr: "Persian δ",
-		de: "Snobilikat"
+		de: "Snobilikat δ"
 	},
 
 	illustrator: "Midori Harada",

--- a/data/EX/Holon Phantoms/49.ts
+++ b/data/EX/Holon Phantoms/49.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Pidgeotto δ",
 		fr: "Roucoups δ",
-		de: "Tauboga"
+		de: "Tauboga δ"
 	},
 
 	illustrator: "Atsuko Nishida",

--- a/data/EX/Holon Phantoms/5.ts
+++ b/data/EX/Holon Phantoms/5.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Deoxys δ",
 		fr: "Deoxys δ",
-		de: "Deoxys"
+		de: "Deoxys δ"
 	},
 
 	illustrator: "Kouki Saitou",

--- a/data/EX/Holon Phantoms/50.ts
+++ b/data/EX/Holon Phantoms/50.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Primeape δ",
 		fr: "Colossinge δ",
-		de: "Rasaff"
+		de: "Rasaff δ"
 	},
 
 	illustrator: "Hajime Kusajima",

--- a/data/EX/Holon Phantoms/52.ts
+++ b/data/EX/Holon Phantoms/52.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Seadra δ",
 		fr: "Hypocéan δ",
-		de: "Seemon"
+		de: "Seemon δ"
 	},
 
 	illustrator: "Kouki Saitou",

--- a/data/EX/Holon Phantoms/53.ts
+++ b/data/EX/Holon Phantoms/53.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Sharpedo δ",
 		fr: "Sharpedo δ",
-		de: "Tohaido"
+		de: "Tohaido δ"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Holon Phantoms/54.ts
+++ b/data/EX/Holon Phantoms/54.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Vibrava δ",
 		fr: "Vibraninf δ",
-		de: "Vibrava"
+		de: "Vibrava δ"
 	},
 
 	illustrator: "Masakazu Fukuda",

--- a/data/EX/Holon Phantoms/57.ts
+++ b/data/EX/Holon Phantoms/57.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Anorith δ",
 		fr: "Anorith δ",
-		de: "Anorith"
+		de: "Anorith δ"
 	},
 
 	illustrator: "Hajime Kusajima",

--- a/data/EX/Holon Phantoms/6.ts
+++ b/data/EX/Holon Phantoms/6.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Deoxys δ",
 		fr: "Deoxys δ",
-		de: "Deoxys"
+		de: "Deoxys δ"
 	},
 
 	illustrator: "Masakazu Fukuda",

--- a/data/EX/Holon Phantoms/61.ts
+++ b/data/EX/Holon Phantoms/61.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Carvanha δ",
 		fr: "Carvanha δ",
-		de: "Kanivanha"
+		de: "Kanivanha δ"
 	},
 
 	illustrator: "Kouki Saitou",

--- a/data/EX/Holon Phantoms/65.ts
+++ b/data/EX/Holon Phantoms/65.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Exeggcute δ",
 		fr: "Noeunoeuf δ",
-		de: "Owei"
+		de: "Owei δ"
 	},
 
 	illustrator: "Atsuko Nishida",

--- a/data/EX/Holon Phantoms/66.ts
+++ b/data/EX/Holon Phantoms/66.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Horsea δ",
 		fr: "Hypotrempe δ",
-		de: "Seeper"
+		de: "Seeper δ"
 	},
 
 	illustrator: "Atsuko Nishida",

--- a/data/EX/Holon Phantoms/67.ts
+++ b/data/EX/Holon Phantoms/67.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Kabuto δ",
 		fr: "Kabuto δ",
-		de: "Kabuto"
+		de: "Kabuto δ"
 	},
 
 	illustrator: "Hajime Kusajima",

--- a/data/EX/Holon Phantoms/68.ts
+++ b/data/EX/Holon Phantoms/68.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Lileep δ",
 		fr: "Lilia δ",
-		de: "Liliep"
+		de: "Liliep δ"
 	},
 
 	illustrator: "Kagemaru Himeno",

--- a/data/EX/Holon Phantoms/69.ts
+++ b/data/EX/Holon Phantoms/69.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Magikarp δ",
 		fr: "Magicarpe δ",
-		de: "Karpador"
+		de: "Karpador δ"
 	},
 
 	illustrator: "Midori Harada",

--- a/data/EX/Holon Phantoms/7.ts
+++ b/data/EX/Holon Phantoms/7.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Flygon δ",
 		fr: "Libegon δ",
-		de: "Libelldra"
+		de: "Libelldra δ"
 	},
 
 	illustrator: "Kagemaru Himeno",

--- a/data/EX/Holon Phantoms/70.ts
+++ b/data/EX/Holon Phantoms/70.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Mankey δ",
 		fr: "Férosinge δ",
-		de: "Menki"
+		de: "Menki δ"
 	},
 
 	illustrator: "Atsuko Nishida",

--- a/data/EX/Holon Phantoms/71.ts
+++ b/data/EX/Holon Phantoms/71.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Meowth δ",
 		fr: "Miaouss δ",
-		de: "Mauzi"
+		de: "Mauzi δ"
 	},
 
 	illustrator: "Kagemaru Himeno",

--- a/data/EX/Holon Phantoms/73.ts
+++ b/data/EX/Holon Phantoms/73.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Oddish δ",
 		fr: "Mystherbe δ",
-		de: "Myrapla"
+		de: "Myrapla δ"
 	},
 
 	illustrator: "Atsuko Nishida",

--- a/data/EX/Holon Phantoms/74.ts
+++ b/data/EX/Holon Phantoms/74.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Omanyte δ",
 		fr: "Amonita δ",
-		de: "Amonitas"
+		de: "Amonitas δ"
 	},
 
 	illustrator: "Kagemaru Himeno",

--- a/data/EX/Holon Phantoms/76.ts
+++ b/data/EX/Holon Phantoms/76.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Pichu δ",
 		fr: "Pichu δ",
-		de: "Pichu"
+		de: "Pichu δ"
 	},
 
 	illustrator: "Kouki Saitou",

--- a/data/EX/Holon Phantoms/77.ts
+++ b/data/EX/Holon Phantoms/77.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Pidgey δ",
 		fr: "Roucool δ",
-		de: "Taubsi"
+		de: "Taubsi δ"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Holon Phantoms/79.ts
+++ b/data/EX/Holon Phantoms/79.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Pikachu δ",
 		fr: "Pikachu δ",
-		de: "Pikachu"
+		de: "Pikachu δ"
 	},
 
 	illustrator: "Atsuko Nishida",

--- a/data/EX/Holon Phantoms/8.ts
+++ b/data/EX/Holon Phantoms/8.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Gyarados δ",
 		fr: "Leviator δ",
-		de: "Garados"
+		de: "Garados δ"
 	},
 
 	illustrator: "Hajime Kusajima",

--- a/data/EX/Holon Phantoms/81.ts
+++ b/data/EX/Holon Phantoms/81.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Psyduck δ",
 		fr: "Psykokwak δ",
-		de: "Enton"
+		de: "Enton δ"
 	},
 
 	illustrator: "Hajime Kusajima",

--- a/data/EX/Holon Phantoms/84.ts
+++ b/data/EX/Holon Phantoms/84.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Trapinch δ",
 		fr: "Kraknoix δ",
-		de: "Knacklion"
+		de: "Knacklion δ"
 	},
 
 	illustrator: "Hajime Kusajima",

--- a/data/EX/Holon Phantoms/9.ts
+++ b/data/EX/Holon Phantoms/9.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Kabutops δ",
 		fr: "Kabutops δ",
-		de: "Kabutops"
+		de: "Kabutops δ"
 	},
 
 	illustrator: "Masakazu Fukuda",

--- a/data/EX/Holon Phantoms/98.ts
+++ b/data/EX/Holon Phantoms/98.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "δ Rainbow Energy",
 		fr: "Énergie Multicolore δ",
-		de: "Delta Regenbogen-Energie"
+		de: "δ Regenbogen-Energie"
 	},
 
 	illustrator: "Takumi Akabane",

--- a/data/EX/Holon Phantoms/99.ts
+++ b/data/EX/Holon Phantoms/99.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Crawdaunt ex",
 		fr: "Colhomard ex",
-		de: "Krebutack ex"
+		de: "Krebutack-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Legend Maker/83.ts
+++ b/data/EX/Legend Maker/83.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Arcanine ex",
 		fr: "Arcanin ex",
-		de: "Arkani ex"
+		de: "Arkani-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Legend Maker/84.ts
+++ b/data/EX/Legend Maker/84.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Armaldo ex",
 		fr: "Armaldo ex",
-		de: "Armaldo ex"
+		de: "Armaldo-ex"
 	},
 
 	illustrator: "Kimiya Masago",

--- a/data/EX/Legend Maker/85.ts
+++ b/data/EX/Legend Maker/85.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Banette ex",
 		fr: "Branette ex",
-		de: "Banette ex"
+		de: "Banette-ex"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Legend Maker/86.ts
+++ b/data/EX/Legend Maker/86.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Dustox ex",
 		fr: "Papinox ex",
-		de: "Pudox ex"
+		de: "Pudox-ex"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Legend Maker/87.ts
+++ b/data/EX/Legend Maker/87.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Flygon ex",
 		fr: "Libegon ex",
-		de: "Libelldra ex"
+		de: "Libelldra-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Legend Maker/88.ts
+++ b/data/EX/Legend Maker/88.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Mew ex",
 		fr: "Mew ex",
-		de: "Mew ex"
+		de: "Mew-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Legend Maker/89.ts
+++ b/data/EX/Legend Maker/89.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Walrein ex",
 		fr: "Kaimorse ex",
-		de: "Walraisa ex"
+		de: "Walraisa-ex"
 	},
 
 	illustrator: "Kimiya Masago",

--- a/data/EX/Legend Maker/93.ts
+++ b/data/EX/Legend Maker/93.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Pikachu δ",
 		fr: "Pikachu δ",
-		de: "Pikachu"
+		de: "Pikachu δ"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Power Keepers/92.ts
+++ b/data/EX/Power Keepers/92.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Absol ex",
 		fr: "Absol ex",
-		de: "Absol ex"
+		de: "Absol-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Power Keepers/93.ts
+++ b/data/EX/Power Keepers/93.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Claydol ex",
 		fr: "Kaorine ex",
-		de: "Lepumentas ex"
+		de: "Lepumentas-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Power Keepers/94.ts
+++ b/data/EX/Power Keepers/94.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Flygon ex",
 		fr: "Libegon ex",
-		de: "Libelldra ex"
+		de: "Libelldra-ex"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Power Keepers/95.ts
+++ b/data/EX/Power Keepers/95.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Metagross ex",
 		fr: "Metalosse ex",
-		de: "Metagross ex"
+		de: "Metagross-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Power Keepers/96.ts
+++ b/data/EX/Power Keepers/96.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Salamence ex",
 		fr: "Drattak ex",
-		de: "Brutalanda ex"
+		de: "Brutalanda-ex"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Power Keepers/97.ts
+++ b/data/EX/Power Keepers/97.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Shiftry ex",
 		fr: "Tengalice ex",
-		de: "Tengulist ex"
+		de: "Tengulist-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Power Keepers/98.ts
+++ b/data/EX/Power Keepers/98.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Skarmory ex",
 		fr: "Airmure ex",
-		de: "Panzaeron ex"
+		de: "Panzaeron-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Power Keepers/99.ts
+++ b/data/EX/Power Keepers/99.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Walrein ex",
 		fr: "Kaimorse ex",
-		de: "Walraisa ex"
+		de: "Walraisa-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Ruby & Sapphire/100.ts
+++ b/data/EX/Ruby & Sapphire/100.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Magmar ex",
 		fr: "Magmar ex",
-		de: "Magmar ex"
+		de: "Magmar-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Ruby & Sapphire/101.ts
+++ b/data/EX/Ruby & Sapphire/101.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Mewtwo ex",
 		fr: "Mewtwo ex",
-		de: "Mewtu ex"
+		de: "Mewtu-ex"
 	},
 
 	illustrator: "Katsura Tabata",

--- a/data/EX/Ruby & Sapphire/102.ts
+++ b/data/EX/Ruby & Sapphire/102.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Scyther ex",
 		fr: "Insécateur ex",
-		de: "Sichlor ex"
+		de: "Sichlor-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Ruby & Sapphire/103.ts
+++ b/data/EX/Ruby & Sapphire/103.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Sneasel ex",
 		fr: "Farfuret ex",
-		de: "Sniebel ex"
+		de: "Sniebel-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Ruby & Sapphire/96.ts
+++ b/data/EX/Ruby & Sapphire/96.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Chansey ex",
 		fr: "Leveinard ex",
-		de: "Chaneira ex"
+		de: "Chaneira-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Ruby & Sapphire/97.ts
+++ b/data/EX/Ruby & Sapphire/97.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Electabuzz ex",
 		fr: "Elektek ex",
-		de: "Elektek ex"
+		de: "Elektek-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Ruby & Sapphire/98.ts
+++ b/data/EX/Ruby & Sapphire/98.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Hitmonchan ex",
 		fr: "Tygnon ex",
-		de: "Nockchan ex"
+		de: "Nockchan-ex"
 	},
 
 	illustrator: "Hiromichi Sugiyama",

--- a/data/EX/Ruby & Sapphire/99.ts
+++ b/data/EX/Ruby & Sapphire/99.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Lapras ex",
 		fr: "Lokhlass ex",
-		de: "Lapras ex"
+		de: "Lapras-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Sandstorm/100.ts
+++ b/data/EX/Sandstorm/100.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Wailord ex",
 		fr: "Wailord ex",
-		de: "Wailord ex"
+		de: "Wailord-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Sandstorm/94.ts
+++ b/data/EX/Sandstorm/94.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Aerodactyl ex",
 		fr: "Ptera ex",
-		de: "Aerodactyl ex"
+		de: "Aerodactyl-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Sandstorm/95.ts
+++ b/data/EX/Sandstorm/95.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Aggron ex",
 		fr: "Galeking ex",
-		de: "Stollos ex"
+		de: "Stollos-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Sandstorm/96.ts
+++ b/data/EX/Sandstorm/96.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Gardevoir ex",
 		fr: "Gardevoir ex",
-		de: "Guardevoir ex"
+		de: "Guardevoir-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Sandstorm/97.ts
+++ b/data/EX/Sandstorm/97.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Kabutops ex",
 		fr: "Kabutops ex",
-		de: "Kabutops ex"
+		de: "Kabutops-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Sandstorm/98.ts
+++ b/data/EX/Sandstorm/98.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Raichu ex",
 		fr: "Raichu ex",
-		de: "Raichu ex"
+		de: "Raichu-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Sandstorm/99.ts
+++ b/data/EX/Sandstorm/99.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Typhlosion ex",
 		fr: "Typhlosion ex",
-		de: "Tornupto ex"
+		de: "Tornupto-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Team Magma vs Team Aqua/89.ts
+++ b/data/EX/Team Magma vs Team Aqua/89.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Blaziken ex",
 		fr: "Brasegali ex",
-		de: "Lohgock ex"
+		de: "Lohgock-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Team Magma vs Team Aqua/90.ts
+++ b/data/EX/Team Magma vs Team Aqua/90.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Cradily ex",
 		fr: "Vacilys ex",
-		de: "Wielie ex"
+		de: "Wielie-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Team Magma vs Team Aqua/91.ts
+++ b/data/EX/Team Magma vs Team Aqua/91.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Entei ex",
 		fr: "Entei ex",
-		de: "Entei ex"
+		de: "Entei-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Team Magma vs Team Aqua/92.ts
+++ b/data/EX/Team Magma vs Team Aqua/92.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Raikou ex",
 		fr: "Raikou ex",
-		de: "Raikou ex"
+		de: "Raikou-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Team Magma vs Team Aqua/93.ts
+++ b/data/EX/Team Magma vs Team Aqua/93.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Sceptile ex",
 		fr: "Jungko ex",
-		de: "Gewaldro ex"
+		de: "Gewaldro-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Team Magma vs Team Aqua/94.ts
+++ b/data/EX/Team Magma vs Team Aqua/94.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Suicune ex",
 		fr: "Suicune ex",
-		de: "Suicune ex"
+		de: "Suicune-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Team Magma vs Team Aqua/95.ts
+++ b/data/EX/Team Magma vs Team Aqua/95.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Swampert ex",
 		fr: "Laggron ex",
-		de: "Sumpex ex"
+		de: "Sumpex-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Team Rocket Returns/100.ts
+++ b/data/EX/Team Rocket Returns/100.ts
@@ -4,7 +4,7 @@ import Set from '../Team Rocket Returns'
 const card: Card = {
 	name: {
 		en: "Rocket's Moltres ex",
-		de: "Rockets Lavados ex"
+		de: "Rockets Lavados-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Team Rocket Returns/101.ts
+++ b/data/EX/Team Rocket Returns/101.ts
@@ -4,7 +4,7 @@ import Set from '../Team Rocket Returns'
 const card: Card = {
 	name: {
 		en: "Rocket's Scizor ex",
-		de: "Rockets Scherox ex"
+		de: "Rockets Scherox-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Team Rocket Returns/102.ts
+++ b/data/EX/Team Rocket Returns/102.ts
@@ -4,7 +4,7 @@ import Set from '../Team Rocket Returns'
 const card: Card = {
 	name: {
 		en: "Rocket's Scyther ex",
-		de: "Rockets Sichlor ex"
+		de: "Rockets Sichlor-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Team Rocket Returns/103.ts
+++ b/data/EX/Team Rocket Returns/103.ts
@@ -4,7 +4,7 @@ import Set from '../Team Rocket Returns'
 const card: Card = {
 	name: {
 		en: "Rocket's Sneasel ex",
-		de: "Rockets Sniebel ex"
+		de: "Rockets Sniebel-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Team Rocket Returns/104.ts
+++ b/data/EX/Team Rocket Returns/104.ts
@@ -4,7 +4,7 @@ import Set from '../Team Rocket Returns'
 const card: Card = {
 	name: {
 		en: "Rocket's Snorlax ex",
-		de: "Rockets Relaxo ex"
+		de: "Rockets Relaxo-ex"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Team Rocket Returns/105.ts
+++ b/data/EX/Team Rocket Returns/105.ts
@@ -4,7 +4,7 @@ import Set from '../Team Rocket Returns'
 const card: Card = {
 	name: {
 		en: "Rocket's Suicune ex",
-		de: "Rockets Suicune ex"
+		de: "Rockets Suicune-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Team Rocket Returns/106.ts
+++ b/data/EX/Team Rocket Returns/106.ts
@@ -4,7 +4,7 @@ import Set from '../Team Rocket Returns'
 const card: Card = {
 	name: {
 		en: "Rocket's Zapdos ex",
-		de: "Rockets Zapdos ex"
+		de: "Rockets Zapdos-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Team Rocket Returns/96.ts
+++ b/data/EX/Team Rocket Returns/96.ts
@@ -4,7 +4,7 @@ import Set from '../Team Rocket Returns'
 const card: Card = {
 	name: {
 		en: "Rocket's Articuno ex",
-		de: "Rockets Arktos ex"
+		de: "Rockets Arktos-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Team Rocket Returns/97.ts
+++ b/data/EX/Team Rocket Returns/97.ts
@@ -4,7 +4,7 @@ import Set from '../Team Rocket Returns'
 const card: Card = {
 	name: {
 		en: "Rocket's Entei ex",
-		de: "Rockets Entei ex"
+		de: "Rockets Entei-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Team Rocket Returns/98.ts
+++ b/data/EX/Team Rocket Returns/98.ts
@@ -4,7 +4,7 @@ import Set from '../Team Rocket Returns'
 const card: Card = {
 	name: {
 		en: "Rocket's Hitmonchan ex",
-		de: "Rockets Nokchan ex"
+		de: "Rockets Nokchan-ex"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Team Rocket Returns/99.ts
+++ b/data/EX/Team Rocket Returns/99.ts
@@ -4,7 +4,7 @@ import Set from '../Team Rocket Returns'
 const card: Card = {
 	name: {
 		en: "Rocket's Mewtwo ex",
-		de: "Rockets Mewtu ex"
+		de: "Rockets Mewtu-ex"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Unseen Forces/101.ts
+++ b/data/EX/Unseen Forces/101.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Blissey ex",
 		fr: "Leuphorie ex",
-		de: "Heiteira ex"
+		de: "Heiteira-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Unseen Forces/102.ts
+++ b/data/EX/Unseen Forces/102.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Espeon ex",
 		fr: "Mentali ex",
-		de: "Psiana ex"
+		de: "Psiana-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Unseen Forces/103.ts
+++ b/data/EX/Unseen Forces/103.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Feraligatr ex",
 		fr: "Aligatueur ex",
-		de: "Impergator ex"
+		de: "Impergator-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Unseen Forces/104.ts
+++ b/data/EX/Unseen Forces/104.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Ho-Oh ex",
 		fr: "Ho-Oh ex",
-		de: "Ho-oh ex"
+		de: "Ho-oh-ex"
 	},
 
 	suffix: "ex",

--- a/data/EX/Unseen Forces/105.ts
+++ b/data/EX/Unseen Forces/105.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Lugia ex",
 		fr: "Lugia ex",
-		de: "Lugia ex"
+		de: "Lugia-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/EX/Unseen Forces/106.ts
+++ b/data/EX/Unseen Forces/106.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Meganium ex",
 		fr: "Meganium ex",
-		de: "Meganie ex"
+		de: "Meganie-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Unseen Forces/107.ts
+++ b/data/EX/Unseen Forces/107.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Politoed ex",
 		fr: "Tarpaud ex",
-		de: "Quaxo ex"
+		de: "Quaxo-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Unseen Forces/108.ts
+++ b/data/EX/Unseen Forces/108.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Scizor ex",
 		fr: "Cizayox ex",
-		de: "Scherox ex"
+		de: "Scherox-ex"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Unseen Forces/109.ts
+++ b/data/EX/Unseen Forces/109.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Steelix ex",
 		fr: "Steelix ex",
-		de: "Stahlos ex"
+		de: "Stahlos-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Unseen Forces/110.ts
+++ b/data/EX/Unseen Forces/110.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Typhlosion ex",
 		fr: "Typhlosion ex",
-		de: "Tornupto ex"
+		de: "Tornupto-ex"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Unseen Forces/111.ts
+++ b/data/EX/Unseen Forces/111.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Tyranitar ex",
 		fr: "Tyranocif ex",
-		de: "Despotar ex"
+		de: "Despotar-ex"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/EX/Unseen Forces/112.ts
+++ b/data/EX/Unseen Forces/112.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Umbreon ex",
 		fr: "Noctali ex",
-		de: "Nachtara ex"
+		de: "Nachtara-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/EX/Unseen Forces/116.ts
+++ b/data/EX/Unseen Forces/116.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Rocket's Persian ex",
 		fr: "Persian ex de Rocket",
-		de: "Rockets Snobilikat ex"
+		de: "Rockets Snobilikat-ex"
 	},
 
 	suffix: "ex",

--- a/data/EX/Unseen Forces/117.ts
+++ b/data/EX/Unseen Forces/117.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Celebi ex",
 		fr: "Celebi ex",
-		de: "Celebi ex"
+		de: "Celebi-ex"
 	},
 
 	suffix: "ex",

--- a/data/POP/POP Series 1/16.ts
+++ b/data/POP/POP Series 1/16.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Armaldo ex",
 		fr: "Armaldo ex",
-		de: "Armaldo ex"
+		de: "Armaldo-ex"
 	},
 
 	illustrator: "Hikaru Koike",

--- a/data/POP/POP Series 1/17.ts
+++ b/data/POP/POP Series 1/17.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Tyranitar ex",
 		fr: "Tyranocif ex",
-		de: "Despotar ex"
+		de: "Despotar-ex"
 	},
 
 	illustrator: "Hisao Nakamura",

--- a/data/POP/POP Series 2/17.ts
+++ b/data/POP/POP Series 2/17.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Celebi ex",
 		fr: "Celebi ex",
-		de: "Celebi ex"
+		de: "Celebi-ex"
 	},
 
 	illustrator: "Ryo Ueda",

--- a/data/POP/POP Series 3/17.ts
+++ b/data/POP/POP Series 3/17.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Ho-Oh ex",
 		fr: "Ho-Oh ex",
-		de: "Ho-oh ex"
+		de: "Ho-oh-ex"
 	},
 
 	illustrator: "Mitsuhiro Arita",

--- a/data/POP/POP Series 4/15.ts
+++ b/data/POP/POP Series 4/15.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Treecko δ",
 		fr: "Arcko δ",
-		de: "Geckarbor"
+		de: "Geckarbor δ"
 	},
 
 	illustrator: "Masakazu Fukuda",

--- a/data/POP/POP Series 4/17.ts
+++ b/data/POP/POP Series 4/17.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Deoxys ex",
 		fr: "Deoxys ex",
-		de: "Deoxys ex"
+		de: "Deoxys-ex"
 	},
 
 	illustrator: "Hiromichi Sugiyama",

--- a/data/POP/POP Series 4/2.ts
+++ b/data/POP/POP Series 4/2.ts
@@ -5,7 +5,7 @@ const card: Card = {
 	name: {
 		en: "Deoxys δ",
 		fr: "Deoxys δ",
-		de: "Deoxys"
+		de: "Deoxys δ"
 	},
 
 	illustrator: "Kouki Saitou",


### PR DESCRIPTION
Two systematic repairs to German card names, overlapping on the same lines in Dragon Frontiers and other sets, hence one PR.

**Hyphenate the ex suffix (144 names).** Official German and Pokemon page writes it hyphenated: the card face shows the "ex" logo without punctuation in any language, but German running text compounds with a hyphen — the German rule box on the cards themselves reads "Wenn dein Pokémon-ex …", and pokemon.com/de names cards accordingly ("Glurak-ex").

**Restore the δ sign (177 names).** The δ mark is part of the Delta Species card name in every language — the English data keeps it ("Beedrill δ") and the German printings show it — but the German names were added without it wholesale (#450), e.g. "Bibor" for "Beedrill δ".

**Skyridge Mystery Plates (3 names).** Found while sweeping for stray Greek letters: plate β was stored with the German eszett ("Geheimnis-Schild ß"), plate γ with a diverging base name ("Geheimes Schild γ"), and "Geheimnis Zone" without its hyphen — PokéWiki files all of them as "Geheimnis-Schild α/β/γ/δ" and "Geheimnis-Zone", matching the α/δ plates already stored that way.