### PR TITLE
Add missing German translations for ex3

### DIFF
--- a/data/EX/Dragon/1.ts
+++ b/data/EX/Dragon/1.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Bad News",
 				fr: "Mauvaises nouvelles",
-				de: "Bad News"
+				de: "Böse Neuigkeiten"
 			},
 			effect: {
 				en: "If the number of cards in your opponent's hand is at least 6, choose a number of cards there, without looking, until your opponent has 5 cards left. Have your opponent discard the cards you chose.",
 				fr: "Si votre adversaire a au moins six cartes en main, choisissez sans regarder suffisamment de cartes pour qu'il ne lui reste plus que cinq cartes. Votre adversaire défausse les cartes que vous avez choisi.",
-				de: "If the number of cards in your opponent's hand is at least 6, choose a number of cards there, without looking, until your opponent has 5 cards left. Have your opponent discard the cards you chose."
+				de: "Falls dein Gegner mindestens 6 Karten auf der Hand hat, wähle (ohne sie vorher anzusehen) so viele seiner Handkarten, dass dein Gegner nur noch 5 Karten auf der Hand hat. Dein Gegner legt die gewählten Karten auf seinen Ablagestapel."
 			},
 
 		},
@@ -48,12 +48,12 @@ const card: Card = {
 			name: {
 				en: "Prize Count",
 				fr: "Compteur de Récompense",
-				de: "Prize Count"
+				de: "Preiszähler"
 			},
 			effect: {
 				en: "If you have more Prize cards left than your opponent, this attack does 20 damage plus 20 more damage.",
 				fr: "S'il vous reste plus de cartes Récompense que votre adversaire, cette attaque inflige 40 dégâts.",
-				de: "If you have more Prize cards left than your opponent, this attack does 20 damage plus 20 more damage."
+				de: "Falls du mehr Preise übrig hast als dein Gegner, fügt dieser Angriff 20 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 

--- a/data/EX/Dragon/10.ts
+++ b/data/EX/Dragon/10.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Shelgon",
-		fr: "Drackhaus"
+		fr: "Drackhaus",
+		de: "Draschel"
 	},
 
 	stage: "Stage2",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), if Salamence is your Active Pokémon, you may switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. This power can't be used if Salamence is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), si Drattak est votre Pokémon Actif, vous pouvez échanger un des Pokémon du Banc de votre adversaire contre un des Pokémon Défenseurs. Votre adversaire choisit le Pokémon Défenseur à échanger. Ce pouvoir ne peut pas être utilisé si Drattak est affecté par un État spécial.",
-				de: "Du kannst diese Pokémon-Power einmal während deines Zuges (vor deinem Angriff) anwenden, falls Brutalanda dein Aktives Pokémon ist. Tausche 1 Verteidigendes Pokémon mit 1 der Pokémon auf der Bank deines gegners aus. Dein gegner wählt aus, welches Verteidigende Pokémon getauscht wird. Diese Poke-Power kann nicht verwendet werden, falls Brutalanda von einem Speziellen Zustand betroffen ist."
+				de: "Du kannst diese Poké-Power einmal während deines Zuges (vor deinem Angriff) anwenden, falls Brutalanda dein Aktives Pokémon ist. Tausche 1 Verteidigendes Pokémon mit 1 der Pokémon auf der Bank deines Gegners aus. Dein Gegner wählt aus, welches Verteidigende Pokémon getauscht wird. Diese Poké-Power kann nicht verwendet werden, falls Brutalanda von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -58,7 +59,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Salamence during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, pendant le prochain tour de votre adversaire, prévenez tous les effets d'attaque, y compris les dégâts, infligés à Drattak.",
-				de: "Wirf 1 Münze. Verhindere bei Kopf während des nächsten Zuges deines Gegners alle Effekte von Angriffen (einschließlich Schaden), die Brutalanda zugefügt werden."
+				de: "Wirf 1 Münze. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte von Angriffen (einschließlich Schaden), die Brutalanda zugefügt werden."
 			},
 			damage: 20,
 

--- a/data/EX/Dragon/100.ts
+++ b/data/EX/Dragon/100.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Charmeleon",
-		fr: "Reptincel"
+		fr: "Reptincel",
+		de: "Glutexo"
 	},
 
 	stage: "Stage2",
@@ -37,12 +38,12 @@ const card: Card = {
 			name: {
 				en: "Collect Fire",
 				fr: "Quête du feu",
-				de: "Collect Fire"
+				de: "Feuersammeln"
 			},
 			effect: {
 				en: "Flip a coin. If heads, search your discard pile for 2 Fire Energy cards and attach them to Charizard (1 if there is only 1).",
 				fr: "Lancez une pièce. Si c'est face, cherchez dans votre pile de défausse deux cartes Énergie  (ou une s'il n'y en a qu'une) et attachez-les à Dracaufeu.",
-				de: "Flip a coin. If heads, search your dicard pile for 2  Energy cards and attach them to Charizard (1 if there is only 1)."
+				de: "Wirf 1 Münze. Durchsuche bei „Kopf“ deinen Ablagestapel nach 2 {R}-Energiekarten und lege sie an Glurak an (1 falls nur 1 vorhanden)."
 			},
 			damage: 30,
 
@@ -57,12 +58,12 @@ const card: Card = {
 			name: {
 				en: "Flame Pillar",
 				fr: "Colonne de flamme",
-				de: "Flame Pillar"
+				de: "Flammensäule"
 			},
 			effect: {
 				en: "You may discard a Fire Energy card attached to Charizard. If you do, choose 1 of your opponent's Benched Pokémon and do 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Vous pouvez défausser une carte Énergie  attachée à Dracaufeu. Vous pouvez alors choisir un des Pokémon de Banc de votre adversaire et lui infliger 30 dégâts. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc.)",
-				de: "You may discard a  Energy card attached to Charizard, If you do, choose 1 of your opponent's Benched Pokémon and do 30 damage to that Pokémon. (Don't apply Weakness and resistance for Benched Pokémon.)"
+				de: "Du darfst 1 an Glurak abgelegte {R}-Energie auf deinen Ablagestapel legen, wenn du diesen Angriff einsetzt. Wenn du das machst, wähle 1 Pokémon auf der Bank deines Gegners und dieser Angriff fügt ihm 30 Schadenspunkte zu. (Schwäche und Resistenz für Pokémon auf der Bank nicht anwenden.)"
 			},
 			damage: 60,
 

--- a/data/EX/Dragon/11.ts
+++ b/data/EX/Dragon/11.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Nincada",
-		fr: "Ningale"
+		fr: "Ningale",
+		de: "Nincada"
 	},
 
 	stage: "Stage1",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Wonder Guard",
 				fr: "Garde mystik",
-				de: "Wonder Guard"
+				de: "Wunderwache"
 			},
 			effect: {
 				en: "Prevent all effects of attacks, including damage, done to Shedinja by your opponent's Evolved Pokémon and Pokémon-ex.",
 				fr: "Prévenez tous les effets d'une attaque, dégâts inclus, infligés à Munja par les Pokémon-ex et les Pokémon Evolués de votre adversaire.",
-				de: "Prevent all effects of attacks, including damage, done to Shedinja by your opponent's Evolved Pokémon and Pokémon-ex."
+				de: "Verhindere alle Effekte von Angriffen inklusive Schaden, die Ninjatom von gegnerischen entwickelten Pokémon und Pokémon-ex zugefügt werden."
 			},
 		},
 	],
@@ -52,12 +53,12 @@ const card: Card = {
 			name: {
 				en: "Damage Curse",
 				fr: "La malédiction des dégâts",
-				de: "Damage Curse"
+				de: "Schadensfluch"
 			},
 			effect: {
 				en: "Put 1 damage counter, plus 1 more damage counter for each damage counter on Shedinja, on the Defending Pokémon.",
 				fr: "Placez un marqueur de dégât sur le Pokémon Défenseur, plus un marqueur supplémentaire pour chaque marqueur de dégât sur Munja.",
-				de: "Put 1 damage counter, plus 1 more damage counter for each damage counter on Shedinja, on the Defending Pokémon."
+				de: "Lege 1 Schadensmarke plus 1 weitere Schadensmarke für jede Schadensmarke auf Ninjatom auf das Verteidigende Pokémon."
 			},
 
 		},

--- a/data/EX/Dragon/12.ts
+++ b/data/EX/Dragon/12.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Power Generation",
 				fr: "Générateur de pouvoir",
-				de: "Power Generation"
+				de: "Kräftige Generation"
 			},
 			effect: {
 				en: "Search your discard pile for up to 2 basic Energy cards, show them to your opponent, and put them into your hand.",
 				fr: "Choisissez dans votre pile de défausse jusqu'à deux cartes Énergie de base, montrez-les à votre adversaire et placez-les dans votre main.",
-				de: "Search your discard pile for up 2 basic Energy cards, show them to your opponent, and put them into your hand."
+				de: "Durchsuche deinen Ablagestapel nach bis zu 2 Basis-Energiekarten, zeige sie deinem Gegner und nimm sie auf die Hand."
 			},
 
 		},
@@ -47,12 +47,12 @@ const card: Card = {
 			name: {
 				en: "Scorching Smoke",
 				fr: "Fumée brûlante",
-				de: "Scorching Smoke"
+				de: "Versengender Rauch"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Burned. Flip a coin. If tails, discard a Fire Energy card attached to Torkoal.",
 				fr: "Le Pokémon Défenseur est maintenant Brûlé. Lancez une pièce. Si c'est pile, défaussez une carte Énergie  attachée à Chartor.",
-				de: "The Defending Pokémon is now Burned. Flip a coin. If tails, dicard a  Energy card attached to Torkoal"
+				de: "Das Verteidigende Pokémon ist jetzt verbrannt. Wirf 1 Münze. Bei „Zahl“ lege 1 an Qurtel angelegt {R}-Energiekarte auf deinen Ablagestapel."
 			},
 
 		},

--- a/data/EX/Dragon/13.ts
+++ b/data/EX/Dragon/13.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Corphish",
-		fr: "Écrapince"
+		fr: "Écrapince",
+		de: "Krebscorps"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Empoisonné.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt vergiftet."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet."
 			},
 			damage: 10,
 

--- a/data/EX/Dragon/14.ts
+++ b/data/EX/Dragon/14.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Dratini",
-		fr: "Minidraco"
+		fr: "Minidraco",
+		de: "Dratini"
 	},
 
 	stage: "Stage1",
@@ -37,12 +38,12 @@ const card: Card = {
 			name: {
 				en: "Dazzle Blast",
 				fr: "Explosion de lumière",
-				de: "Dazzle Blast"
+				de: "Blendende Explosion"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Confused."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: 20,
 
@@ -56,12 +57,12 @@ const card: Card = {
 			name: {
 				en: "Healing Wave",
 				fr: "Vague guérisseuse",
-				de: "Healing Wave"
+				de: "Heilungswelle"
 			},
 			effect: {
 				en: "Remove 1 damage counter from each of your Active Pokémon.",
 				fr: "Retirez un marqueur de dégât à chacun de vos Pokémon Actifs.",
-				de: "Remove 1 damage counter from each of your Active Pokémon."
+				de: "Entferne 1 Schadensmarke von allen deinen Aktiven Pokémon."
 			},
 			damage: 30,
 

--- a/data/EX/Dragon/15.ts
+++ b/data/EX/Dragon/15.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Vibrava",
-		fr: "Vibraninf"
+		fr: "Vibraninf",
+		de: "Vibrava"
 	},
 
 	stage: "Stage2",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Whenever Flygon would be damaged by your opponent's attack (after applying Weakness and Resistance), flip a coin. If heads, reduce that damage by 20.",
 				fr: "Lorsqu'une attaque de votre adversaire inflige des dégâts à Libegon (après application de la Faiblesse et de la Résistance), lancez une pièce. Si c'est face, les dégâts sont réduits de 20.",
-				de: "Immer wenn Libelldra durch einen generischen Angriff Schaden zugefügt würde (nachdem Schwäche und Resistenz verrechnet wurden), wirf 1 Münze. Bei 'Kopf' wird der Schaden um 20 Schadenspunkte reduziert."
+				de: "Immer wenn Libelldra durch einen gegnerischen Angriff Schaden zugefügt würde (nachdem Schwäche und Resistenz verrechnet wurden), wirf 1 Münze. Bei „Kopf“ wird der Schaden um 20 Schadenspunkte reduziert."
 			},
 		},
 	],
@@ -59,7 +60,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, discard an Energy card attached to Flygon.",
 				fr: "Lancez une pièce. Si c'est face, défaussez une carte Énergie attachée à Libegon.",
-				de: "Wirf 1 Münze. Entferne bei 'Zahl' 1 Energiekarte von Libelldra."
+				de: "Wirf 1 Münze. Entferne bei „Zahl“ 1 Energiekarte von Libelldra."
 			},
 			damage: 60,
 

--- a/data/EX/Dragon/16.ts
+++ b/data/EX/Dragon/16.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Synchronized Search",
 				fr: "Recherche synchronisée",
-				de: "Synchronized Search"
+				de: "Synchronsuche"
 			},
 			effect: {
 				en: "If Girafarig and the Defending Pokémon have the same amount of Energy attached to them, pick any 1 card from your deck and put it into your hand. Shuffle your deck afterward.",
 				fr: "Si Girafarig et le Pokémon Défenseur possèdent le même total en Énergie, choisissez une carte dans votre deck, montrez-la à votre adversaire et placez-la dans votre main. Ensuite, mélangez votre deck.",
-				de: "If Girafarig and the Defending Pokémon have the same amount of Energy attached to them, pick any 1 card from your deck and put it into your hand. Shuffle your deck afterward."
+				de: "Falls an Girafarig und dem Verteidigenden Pokémon gleich viel Energie angelegt ist, wähle 1 Karte aus deinem Deck und nimm sie auf deine Hand."
 			},
 
 		},
@@ -48,12 +48,12 @@ const card: Card = {
 			name: {
 				en: "Breaking Impact",
 				fr: "Impact dévastateur",
-				de: "Breaking Impact"
+				de: "Brechender Einfluss"
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon. This attack does 10 damage for each Colorless Energy in that Pokémon's Retreat Cost to that Pokémon (after applying effects to the Retreat Cost). (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Choisissez un des Pokémon de votre adversaire. Cette attaque lui inflige 10 dégâts pour chaque Énergie  de son Coût de retraite (après application des effets sur le Coût de retraite). (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc).",
-				de: "Choose 1 of your opponent's Pokémon. This attack does 10 damage for each  Energy in that Pokémon's Retreat Cost to that Pokémon (after applying effects to the Retreat Cost). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Wähle 1 gegnerisches Pokémon. Dieser Angriff fügt 10 Schadenspunkte für jede {C}-Energie in den Rückzugskosten des gewählten Pokémon zu (nachdem alle Effekte auf die Rückzugskosten verrechnet wurden). (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},

--- a/data/EX/Dragon/17.ts
+++ b/data/EX/Dragon/17.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Magnemite",
-		fr: "Magnéti"
+		fr: "Magnéti",
+		de: "Magnetilo"
 	},
 
 	stage: "Stage1",

--- a/data/EX/Dragon/18.ts
+++ b/data/EX/Dragon/18.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Nincada",
-		fr: "Ningale"
+		fr: "Ningale",
+		de: "Nincada"
 	},
 
 	stage: "Stage1",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Loose Shell",
 				fr: "Carapace branlante",
-				de: "Loose Shell"
+				de: "Loser Panzer"
 			},
 			effect: {
 				en: "Once during your turn, when you play Ninjask from your hand to evolve 1 of your Pokémon, you may search your deck for Shedinja and put it onto your Bench. Treat the new Benched Pokémon as a Basic Pokémon. Shuffle your deck afterward.",
 				fr: "Une seule fois pendant votre tour, lorsque vous placez Ninjask de votre main sur un de vos Pokémon pour le faire évoluer, vous pouvez chercher Munja dans votre deck et le placer sur votre Banc. Traitez le nouveau Pokémon du Banc comme un Pokémon de base. Ensuite, mélangez votre deck.",
-				de: "Once during your turn, when you play Ninjask from your hand to evolve 1 of your Pokémon, you may search your deck for Shedinja and put it onto your Bench. Treat the new Benched Pokémon as a Basic Pokémon. Shuffle your deck afterward."
+				de: "Einmal während deines Zuges, wenn du Ninjask von deiner Hand spielst um 1 deiner Pokémon zu entwickeln, kannst du dein Deck nach Ninjatom durchsuchen und auf deine Bank legen. Behandle das neue Pokémon wie ein Basis-Pokémon. Mische dein Deck danach."
 			},
 		},
 	],
@@ -53,12 +54,12 @@ const card: Card = {
 			name: {
 				en: "Quick Touch",
 				fr: "Touche rapide",
-				de: "Quick Touch"
+				de: "Schnelle Berührung"
 			},
 			effect: {
 				en: "You may switch Ninjask with 1 of your Benched Pokémon. If you do, you may move any number of Grass Energy cards attached to Ninjask to the new Active Pokémon.",
 				fr: "Vous pouvez échanger Ninjask contre un des Pokémon de votre Banc. Vous pouvez alors attacher au nouveau Pokémon Actif autant de cartes Énergie  attachées à Ninjask que vous le voulez.",
-				de: "You may switch Ninjask with 1 of your Benched Pokémon. If you do, you may move any number of  Enegry cards attached to Ninjask to the new Active Pokémon."
+				de: "Du kannst Ninjask gegen 1 Pokémon auf deiner Bank austauschen. Wenn du das machst, kannst du beliebig viele an Ninjask angelegte {G}-Energiekarten an das neue Aktive Pokémon anlegen."
 			},
 			damage: 30,
 

--- a/data/EX/Dragon/19.ts
+++ b/data/EX/Dragon/19.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Shelgon",
-		fr: "Drackhaus"
+		fr: "Drackhaus",
+		de: "Draschel"
 	},
 
 	stage: "Stage2",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Intimidating Fang",
 				fr: "Croc intimidant",
-				de: "Intimidating Fang"
+				de: "Beeindruckende Fangzähne"
 			},
 			effect: {
 				en: "As long as Salamence is your Active Pokémon, any damage done to your Pokémon by an opponent's attack is reduced by 10 (before applying Weakness and Resistance).",
 				fr: "Tant que Drattak est votre Pokémon Actif, les dégâts qui lui sont infligés par une attaque de votre adversaire sont réduits de 10 (avant application de la Faiblesse et de la Résistance).",
-				de: "As long as Salamence is your Active Pokémon, any damage done to your Pokémon by an opponent's attack is reduced by 10 (before applying Weakness and Resistance)."
+				de: "Solange Brutalanda dein Aktives Pokémon ist, wird aller Schaden, der deinen Pokémon durch gegnerische Angriffe zugefügt wird, um 10 Schadenspunkte reduziert (bevor Schwäche und Resistenz verrechnet wurden)."
 			},
 		},
 	],
@@ -54,12 +55,12 @@ const card: Card = {
 			name: {
 				en: "Dragon Flame",
 				fr: "Flamme de dragon",
-				de: "Dragon Flame"
+				de: "Drachenflamme"
 			},
 			effect: {
 				en: "You may discard an Energy card attached to Salamence. If you do, this attack does 40 damage plus 20 more damage.",
 				fr: "Vous pouvez défausser une carte Énergie attachée à Drattak. Cette attaque inflige alors 60 dégâts.",
-				de: "You may discard an Energy card attached to Salamence. If you do, this attack does 40 damage plus 20 more damage."
+				de: "Du kannst 1 Energiekarte, die an Brutalanda angelegt ist, auf den Ablagestapel legen. Wenn du das machst, fügt dieser Angriff 40 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "40+",
 

--- a/data/EX/Dragon/2.ts
+++ b/data/EX/Dragon/2.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Swablu",
-		fr: "Tylton"
+		fr: "Tylton",
+		de: "Wablu"
 	},
 
 	stage: "Stage1",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Dragon Dance",
 				fr: "Danse de dragon",
-				de: "Dragon Dance"
+				de: "Drachentanz"
 			},
 			effect: {
 				en: "During your next turn, if any of your current Active Pokémon does damage to any Defending Pokémon, this attack does 40 more damage (before applying Weakness and Resistance).",
 				fr: "Lors de votre prochain tour, si un de vos Pokémon Actifs inflige des dégâts à un des Pokémon Défenseurs, cette attaque inflige 40 dégâts supplémentaires (avant application de la Faiblesse et de la Résistance).",
-				de: "During your next turn, if any of your current Active Pokémon does damage to any Defending Pokémon, the attack does 40 more damage (before applying Weakness and Resistance)."
+				de: "Falls eines deiner jetzigen Aktiven Pokémon im nächsten Zug einem Verteidigenden Pokémon Schaden zufügt, fügt der Angriff 40 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet wurden)."
 			},
 
 		},
@@ -53,12 +54,12 @@ const card: Card = {
 			name: {
 				en: "Dragon Song",
 				fr: "Chanson de dragon",
-				de: "Dragon Song"
+				de: "Drachenlied"
 			},
 			effect: {
 				en: "Each Defending Pokémon is now Asleep.",
 				fr: "Chaque Pokémon Défenseur est maintenant Endormi.",
-				de: "Each Defending Pokémon is now Asleep."
+				de: "Alle Verteidigenden Pokémon schlafen jetzt."
 			},
 			damage: 30,
 

--- a/data/EX/Dragon/20.ts
+++ b/data/EX/Dragon/20.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Bagon",
-		fr: "Draby"
+		fr: "Draby",
+		de: "Kindwurm"
 	},
 
 	stage: "Stage1",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Scrunch",
 				fr: "Compresse",
-				de: "Scrunch"
+				de: "Zähneknirschen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, prevent all damage done to Shelgon during your opponent's next turn. (Any other effects of attacks still happen.)",
 				fr: "Lancez une pièce. Si c'est face, prévenez tous les dégâts infligés à Drackhaus lors du prochain tour de votre adversaire. (Tous les autres effets sont appliqués.)",
-				de: "Flip a coin. If heads, prevent all damage done to Shelgon during your opponent's next turn. (Any other effects of attacks still happen.)"
+				de: "Wirf 1 Münze. Bei „Kopf“, verhindere alle Schadenspunkte, die Draschel während des nächsten Zuges deines Gegners durch Angriffe zugefügt werden."
 			},
 
 		},
@@ -54,7 +55,7 @@ const card: Card = {
 			name: {
 				en: "Rolling Attack",
 				fr: "Attaque qui roule",
-				de: "Rolling Attack"
+				de: "Rollender Angriff"
 			},
 
 			damage: 50,

--- a/data/EX/Dragon/21.ts
+++ b/data/EX/Dragon/21.ts
@@ -53,7 +53,7 @@ const card: Card = {
 			effect: {
 				en: "Count the amount of Energy attached to all of your Pokémon and all of your opponent's Pokémon. If your Pokémon have less Energy than your opponent's, this attack does 20 damage plus 30 more damage.",
 				fr: "Comptabilisez le nombre d'Énergies attachées à tous vos Pokémon ainsi qu'à tous les Pokémon de votre adversaire. Si vos Pokémon possèdent moins d'Énergies que ceux de votre adversaire, cette attaque inflige 50 dégâts.",
-				de: "Vergleiche wieviel Energie an allen deinen Pokémon und allen gegnerischen Pokémon angelegt ist. Wenn an deinen Pokémon weniger Energie angelegt ist als an den gegnerischen Pokémon, fügt dieser Angriff 20 Schadenspunkte plus 30 weitere Schadenspunkte zu."
+				de: "Vergleiche wieviel Energie an allen deinen Pokémon und an allen gegnerischen Pokémon angelegt ist. Wenn an deinen Pokémon weniger Energie angelegt ist als an den gegnerischen Pokémon, fügt dieser Angriff 20 Schadenspunkte plus 30 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 

--- a/data/EX/Dragon/22.ts
+++ b/data/EX/Dragon/22.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Trapinch",
-		fr: "Kraknoix"
+		fr: "Kraknoix",
+		de: "Knacklion"
 	},
 
 	stage: "Stage1",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Quick Charge",
 				fr: "Attaque rapide",
-				de: "Quick Charge"
+				de: "Schneller Ladevorgang"
 			},
 			effect: {
 				en: "Search your deck for up to 3 different types of basic Energy cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward.",
 				fr: "Choisissez dans votre deck jusqu'à trois types de cartes Énergie de base différents, montrez-les à votre adversaire et placez-les dans votre main. Ensuite, mélangez votre deck.",
-				de: "Search your deck for up to 3 different types of basic Energy cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
+				de: "Durchsuche dein Deck nach bis zu 3 unterschiedlichen Basis-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische dein Deck danach."
 			},
 
 		},
@@ -53,12 +54,12 @@ const card: Card = {
 			name: {
 				en: "Dragon Spark",
 				fr: "Étincelle de dragon",
-				de: "Dragon Spark"
+				de: "Drachenfunke"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts à chacun des Pokémon de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc).",
-				de: "Flip a coin. If heads, this attack does 20 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance to Benched Pokémon.)"
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff allen gegnerischen Pokémon 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},

--- a/data/EX/Dragon/23.ts
+++ b/data/EX/Dragon/23.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Paralyzing Gaze",
 				fr: "Regard paralysant",
-				de: "Paralyzing Gaze"
+				de: "Lähmender Blick"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 
 		},
@@ -48,7 +48,7 @@ const card: Card = {
 			name: {
 				en: "Combustion",
 				fr: "Fournaise",
-				de: "Combustion"
+				de: "Glühen"
 			},
 
 			damage: 20,

--- a/data/EX/Dragon/24.ts
+++ b/data/EX/Dragon/24.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Numel",
-		fr: "Chamallot"
+		fr: "Chamallot",
+		de: "Camaub"
 	},
 
 	stage: "Stage1",
@@ -42,7 +43,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Burned.",
 				fr: "Lancez une pièce. Si c'est face, Le Pokémon Défenseur est maintenant Brûlé.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt verbrannt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verbrannt."
 			},
 			damage: 20,
 

--- a/data/EX/Dragon/25.ts
+++ b/data/EX/Dragon/25.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Torchic",
-		fr: "Poussifeu"
+		fr: "Poussifeu",
+		de: "Flemmli"
 	},
 
 	stage: "Stage1",
@@ -42,7 +43,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts.",
-				de: "Wirf 1 Münze. Bei 'Kopf' fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 

--- a/data/EX/Dragon/26.ts
+++ b/data/EX/Dragon/26.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Remove 2 damage counters from 1 of your Pokémon (remove 1 if there is only 1).",
 				fr: "Retirez deux marqueurs de dégât à un de vos Pokémon (ou un s'il n'y en a qu'un).",
-				de: "Entferne 2 Schadensmarken von einem deiner Pokémon (1 falls nur 1 vorhanden)."
+				de: "Entferne 2 Schadensmarken von einem deiner Pokémon (falls 1 nur 1 vorhanden)."
 			},
 
 		},

--- a/data/EX/Dragon/27.ts
+++ b/data/EX/Dragon/27.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Mareep",
-		fr: "Wattouat"
+		fr: "Wattouat",
+		de: "Voltilamm"
 	},
 
 	stage: "Stage1",

--- a/data/EX/Dragon/28.ts
+++ b/data/EX/Dragon/28.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pineco",
-		fr: "Pomdepik"
+		fr: "Pomdepik",
+		de: "Tannza"
 	},
 
 	stage: "Stage1",
@@ -37,12 +38,12 @@ const card: Card = {
 			name: {
 				en: "Double Metal Ball",
 				fr: "Double boule métallique",
-				de: "Double Metal Ball"
+				de: "Doppel Metallball"
 			},
 			effect: {
 				en: "Put 2 damage counters on each Defending Pokémon.",
 				fr: "Placez deux marqueurs de dégât sur chaque Pokémon Défenseur.",
-				de: "Put 2 damage counters on each Defending Pokémon."
+				de: "Lege 2 Schadensmarken auf alle Verteidigenden Pokémon."
 			},
 
 		},
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Backspin",
 				fr: "Retour arrière",
-				de: "Backspin"
+				de: "Wegdrehen"
 			},
 			effect: {
 				en: "After your attack, you may discard 1 Energy card attached to Forretress. If you do, switch Forretress with 1 of your Benched Pokémon.",
 				fr: "Après votre attaque, vous pouvez défausser une carte Énergie attachée à Foretress. Vous pouvez alors échanger Foretress avec un des Pokémon de votre Banc.",
-				de: "After your attack, you may discard 1 Energy card attached to Forretress. If you do, swich Forretress with 1 of your benched Pokémon."
+				de: "Nach deinem Angriff kannst du 1 an Forstellka angelegte Energiekarte auf deinen Ablagestapel legen. Wenn du das machst, tausche Forstellka gegen ein Pokémon auf deiner Bank aus."
 			},
 			damage: 40,
 

--- a/data/EX/Dragon/29.ts
+++ b/data/EX/Dragon/29.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Geodude",
-		fr: "Racaillou"
+		fr: "Racaillou",
+		de: "Kleinstein"
 	},
 
 	stage: "Stage1",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Grind",
 				fr: "Écrase",
-				de: "Grind"
+				de: "Zermahlen"
 			},
 			effect: {
 				en: "Does 10 damage times the amount of Energy attached to Graveler.",
 				fr: "Inflige 10 dégâts multipliés par le nombre d'Énergies attachées à Gravalanch.",
-				de: "Does 10 damage times the amount of Energy attached to Graveler."
+				de: "Fügt für jede an Georok angelegte Energie 10 Schadenspunkte zu."
 			},
 			damage: "10×",
 
@@ -57,13 +58,13 @@ const card: Card = {
 			name: {
 				en: "Big Explosion",
 				fr: "Grosse explosion",
-				de: "Big Explosion"
+				de: "Große Explosion"
 			},
 
 			effect: {
 				en: "Does 80 damage to each Active Pokémon (both yours and your opponent's).",
 				fr: "Inflige 80 dégâts à chaque Pokémon Actif (les vôtres et ceux de votre adversaire).",
-				de: "Does 80 damage to each Active Pokémon (both yours and your opponent's)."
+				de: "Fügt allen Aktiven Pokémon (deinen und den gegnerischen) 80 Schadenspunkte zu."
 			},
 
 			damage: "10x"

--- a/data/EX/Dragon/3.ts
+++ b/data/EX/Dragon/3.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Corphish",
-		fr: "Écrapince"
+		fr: "Écrapince",
+		de: "Krebscorps"
 	},
 
 	stage: "Stage1",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "As long as Crawdaunt is your Active Pokémon, when any of your Active Pokémon does damage to the Defending Pokémon, the attack does 10 more damage (before applying Weakness and Resistance).",
 				fr: "Tant que Colhomard est votre Pokémon Actif, dès qu'un de vos Pokémon Actifs inflige des dégâts aux Pokémon Défenseurs, cette attaque inflige 10 dégâts supplémentaires (avant application de la Faiblesse et de la Résistance).",
-				de: "Wenn Krebutack dein Aktives Pokémon ist und eins deiner Aktiven Pokémon einem verteidigenden Pokémon Schaden zufügt, fügt der Angriff 10 weitere Schadenspunkte zu. (bevor Schwäche und Resistenz verrechnet wurden.)"
+				de: "Wenn Krebutack dein Aktives Pokémon ist und eins deiner Aktiven Pokémon einem Verteidigenden Pokémon Schaden zufügt, fügt der Angriff 10 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet wurden)."
 			},
 		},
 	],

--- a/data/EX/Dragon/30.ts
+++ b/data/EX/Dragon/30.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Geodude",
-		fr: "Racaillou"
+		fr: "Racaillou",
+		de: "Kleinstein"
 	},
 
 	stage: "Stage1",
@@ -37,12 +38,12 @@ const card: Card = {
 			name: {
 				en: "Magnitude",
 				fr: "Ampleur",
-				de: "Magnitude"
+				de: "Intensität"
 			},
 			effect: {
 				en: "Does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à chacun des Pokémon du Banc (les vôtres et ceux de votre adversaire). (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc.)",
-				de: "Does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Fügt allen Pokémon auf der Bank 10 Schadenspunkte zu (deinen und den gegnerischen). (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 20,
 
@@ -56,7 +57,7 @@ const card: Card = {
 			name: {
 				en: "Rollout",
 				fr: "Roulade",
-				de: "Rollout"
+				de: "Walzer"
 			},
 
 			damage: 40,

--- a/data/EX/Dragon/31.ts
+++ b/data/EX/Dragon/31.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Treecko",
-		fr: "Arcko"
+		fr: "Arcko",
+		de: "Geckarbor"
 	},
 
 	stage: "Stage1",
@@ -37,12 +38,12 @@ const card: Card = {
 			name: {
 				en: "Fury Cutter",
 				fr: "Taillade",
-				de: "Fury Cutter"
+				de: "Zornklinge"
 			},
 			effect: {
 				en: "Flip 4 coins. If all of them are heads, this attack does 10 damage plus 60 more damage. If not, this attack does 10 damage plus 10 more damage for each heads.",
 				fr: "Lancez quatre pièces. Si ce sont quatre faces, cette attaque inflige 10 dégâts plus 60 dégâts supplémentaires. Sinon, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires multipliés par le nombre de faces.",
-				de: "Flip 4 coins. If all of them are heads, this attack does 10 damage plus 60 more damage. If not, this attack does 10 damage plus 10 more damage for each heads."
+				de: "Wirf 4 Münzen. Bei 4 mal „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 60 weitere Schadenspunkte zu. Ansonsten fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10+",
 

--- a/data/EX/Dragon/32.ts
+++ b/data/EX/Dragon/32.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Magikarp",
-		fr: "Magicarpe"
+		fr: "Magicarpe",
+		de: "Karpador"
 	},
 
 	stage: "Stage1",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Dragon Crush",
 				fr: "Écras'dragon",
-				de: "Dragon Crush"
+				de: "Drachenmalmer"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage to each Defending Pokémon. Discard an Energy card from each Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts à chaque Pokémon Défenseur. Défaussez une carte Énergie de chacun de ces Pokémon.",
-				de: "Flip a coin. If heads, this attack does 10 damage to each Defending Pokémon. Discard an Energy from each Defending Pokémon."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff allen Verteidigenden Pokémon 10 Schadenspunkte zu. Lege eine Energiekarte von jedem Verteidigenden Pokémon auf den Ablagestapel deines Gegners."
 			},
 
 		},
@@ -56,12 +57,12 @@ const card: Card = {
 			name: {
 				en: "Aqua Sonic",
 				fr: "Aquasonique",
-				de: "Aqua Sonic"
+				de: "Aquaschall"
 			},
 			effect: {
 				en: "This attack's damage is not affected by Resistance.",
 				fr: "Les dégâts infligés par cette attaque ne sont pas affectés par la Résistance.",
-				de: "This attack's damage is not affected by Resistence."
+				de: "Der Schaden dieses Angriffs wird durch die Resistenz des Verteidigenden Pokémon nicht verringert."
 			},
 			damage: 80,
 

--- a/data/EX/Dragon/33.ts
+++ b/data/EX/Dragon/33.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage times the number of damage counters on Horsea.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts pour chaque marqueur de dégât sur Hypotrempe.",
-				de: "Wirf 1 Münze. Bei 'Kopf' fügt dieser Angriff für jede Schadensmarke auf Seeper 10 Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff für jede Schadensmarke auf Seeper 10 Schadenspunkte zu."
 			},
 			damage: "10×",
 
@@ -53,7 +53,7 @@ const card: Card = {
 			effect: {
 				en: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
 				fr: "Si le Pokémon Défenseur essaye d'attaquer lors du prochain tour de votre adversaire, celui-ci lance une pièce. Si c'est pile, cette attaque est sans effet.",
-				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners anzugreifen versucht, wirft dein Gegner 1 Münze. Bei 'Zahl' hat dieser Angriff keine Auswirkungen."
+				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners anzugreifen versucht, wirft dein Gegner 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 10,
 

--- a/data/EX/Dragon/34.ts
+++ b/data/EX/Dragon/34.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Houndour",
-		fr: "Malosse"
+		fr: "Malosse",
+		de: "Hunduster"
 	},
 
 	stage: "Stage1",
@@ -37,12 +38,12 @@ const card: Card = {
 			name: {
 				en: "Feint Attack",
 				fr: "Feinte",
-				de: "Feint Attack"
+				de: "Finte"
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, or any other effects on that Pokémon.",
 				fr: "Choisissez un des Pokémon de votre adversaire. Cette attaque lui inflige 20 dégâts. Les dégâts de cette attaque ne sont pas affectés par la Faiblesse, la Résistance, les Poké-Powers, les Poké-Bodies ou tout autre effet.",
-				de: "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. This attack's damage isn't affected by Weakness, resistance, Poke-Powers, Poke-Bodies, or any other effects on that Pokémon."
+				de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt diesem Pokémon 20 Schadenspunkte zu. Schwäche, Resistenz, Poké-Power, Poké-Body und alle anderen Effekte auf dem Verteidigenden Pokémon haben keine Auswirkungen auf die Schadenspunkte dieses Angriffs."
 			},
 
 		},
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Flamethrower",
 				fr: "Lance-flammes",
-				de: "Flamethrower"
+				de: "Flammenwurf"
 			},
 			effect: {
 				en: "Discard a Fire Energy card attached to Houndoom.",
 				fr: "Défaussez une carte Énergie  attachée à Démolosse.",
-				de: "Discard a  Energy card attached to Houndoom."
+				de: "Entferne 1 {R}-Energiekarte von Hundemon und lege sie auf den Ablagestapel."
 			},
 			damage: 50,
 

--- a/data/EX/Dragon/35.ts
+++ b/data/EX/Dragon/35.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Magnemite",
-		fr: "Magnéti"
+		fr: "Magnéti",
+		de: "Magnetilo"
 	},
 
 	stage: "Stage1",
@@ -57,7 +58,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 20 damage plus 20 more damage for each heads.",
 				fr: "Lancez trois pièces. Cette attaque inflige 20 dégâts plus 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte plus 20 Schadenspunkte mal der Anzahl 'Kopf' zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte plus 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20+",
 

--- a/data/EX/Dragon/36.ts
+++ b/data/EX/Dragon/36.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Mudkip",
-		fr: "Gobou"
+		fr: "Gobou",
+		de: "Hydropi"
 	},
 
 	stage: "Stage1",

--- a/data/EX/Dragon/37.ts
+++ b/data/EX/Dragon/37.ts
@@ -31,7 +31,7 @@ const card: Card = {
 			name: {
 				en: "Punch",
 				fr: "Koud'poing",
-				de: "Punch"
+				de: "Boxhieb"
 			},
 
 			damage: 10,
@@ -45,12 +45,12 @@ const card: Card = {
 			name: {
 				en: "Meditate",
 				fr: "Yoga",
-				de: "Meditate"
+				de: "Meditation"
 			},
 			effect: {
 				en: "Does 10 damage plus 10 more damage for each damage counter on the Defending Pokémon.",
 				fr: "Inflige 10 dégâts plus 10 dégâts supplémentaires pour chaque marqueur de dégât sur le Pokémon Défenseur.",
-				de: "Does 10 damage plus 10 more damage for each damage counter on the Defending Pokémon."
+				de: "Fügt 10 Schadenspunkte plus 10 weitere Schadenspunkte für jede Schadensmarke auf dem Verteidigenden Pokémon zu."
 			},
 			damage: "10+",
 

--- a/data/EX/Dragon/38.ts
+++ b/data/EX/Dragon/38.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Nincada",
-		fr: "Ningale"
+		fr: "Ningale",
+		de: "Nincada"
 	},
 
 	stage: "Stage1",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Supersonic",
 				fr: "Ultrason",
-				de: "Supersonic"
+				de: "Superschall"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Flip a coin. If heads, the Defending ´Pokémon is now Confused."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon verwirrt."
 			},
 			damage: 10,
 
@@ -54,12 +55,12 @@ const card: Card = {
 			name: {
 				en: "Sonic Wing",
 				fr: "Aile supersonique",
-				de: "Sonic Wing"
+				de: "Überschallflügel"
 			},
 			effect: {
 				en: "This attack's damage is not affected by Resistance.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Résistance.",
-				de: "This attack's damage is not affected by Resistance."
+				de: "Der Schaden dieses Angriffs wird durch die Resistenz des Verteidigenden Pokémon nicht verringert."
 			},
 			damage: 30,
 

--- a/data/EX/Dragon/39.ts
+++ b/data/EX/Dragon/39.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Horsea",
-		fr: "Hypotrempe"
+		fr: "Hypotrempe",
+		de: "Seeper"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Does 20 damage plus 10 more damage for each Energy attached to Seadra but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way.",
 				fr: "Inflige 20 dégâts plus 20 dégâts supplémentaires pour chaque Énergie attachée à Hypocéan qui n'a pas été utilisée pour payer le Coût en Énergie de cette attaque. Vous ne pouvez pas ajouter plus de 20 dégâts de cette façon.",
-				de: "Dieser Angriff fügt 20 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Seemon angelegte Energie zu, die nicht zum Zahlen der Energiekosten für diesen Angriff verwendet wurden. Es lassen sich so nicht mehr als 20 Schadenspunkte hinzufügen."
+				de: "Dieser Angriff fügt 20 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Seemon angelegte Energie zu, die nicht zum Zahlen der Energiekosten für diesen Angriff verwendet wurde. Es lassen sich so nicht mehr als 20 Schadenspunkte hinzufügen."
 			},
 			damage: "20+",
 
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Choisissez un des Pokémon de votre adversaire : cette attaque inflige 30 dégâts à ce Pokémon. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc.)",
-				de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der bank nicht an)"
+				de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},

--- a/data/EX/Dragon/4.ts
+++ b/data/EX/Dragon/4.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Vibrava",
-		fr: "Vibraninf"
+		fr: "Vibraninf",
+		de: "Vibrava"
 	},
 
 	stage: "Stage2",
@@ -37,12 +38,12 @@ const card: Card = {
 			name: {
 				en: "Energy Shower",
 				fr: "Averse d'énergie",
-				de: "Energy Shower"
+				de: "Energiedusche"
 			},
 			effect: {
 				en: "Attach any number of basic Energy cards from your hand to your Pokémon in any way you like.",
 				fr: "Choisissez dans votre main autant de cartes Énergie de base que vous le voulez et attachez-les à vos Pokémon de la façon que vous voulez.",
-				de: "Attach any number of basic Energy cards from your hand to your Pokémon in any way you like."
+				de: "Lege beliebig viele Basis-Energiekarten von deiner Hand an deine Pokémon an."
 			},
 
 		},
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Rainbow Burn",
 				fr: "Brûlure arcenciel",
-				de: "Rainbow Burn"
+				de: "Regenbogenfeuer"
 			},
 			effect: {
 				en: "Does 30 damage plus 10 more damage for each type of basic Energy card attached to Flygon.",
 				fr: "Inflige 30 dégâts plus 10 dégâts supplémentaires pour chaque type de carte Énergie de base attaché à Libegon.",
-				de: "Does 30 damage plus 10 more damage for each type of basic Energy attached to Flygon."
+				de: "Dieser Angriff fügt 30 Schadenspunkte plus 10 weitere Schadenspunkte für jede unterschiedliche Sorte Basis-Energiekarten, die an Libelldra angelegt sind, zu."
 			},
 			damage: "30+",
 

--- a/data/EX/Dragon/40.ts
+++ b/data/EX/Dragon/40.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Horsea",
-		fr: "Hypotrempe"
+		fr: "Hypotrempe",
+		de: "Seeper"
 	},
 
 	stage: "Stage1",
@@ -42,7 +43,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Seadra during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, pendant le prochain tour de votre adversaire, prévenez tous les effets d'attaque, y compris les dégâts, infligés à Hypocéan.",
-				de: "Wirf 1 Münze. Verhindere bei 'Kopf' während des nächsten Zuges deines Gegners alle Effekte von Angriffen (einschließlich Schaden), die Seemon zugefügt werden."
+				de: "Wirf 1 Münze. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte von Angriffen (einschließlich Schaden), die Seemon zugefügt werden."
 			},
 			damage: 20,
 

--- a/data/EX/Dragon/41.ts
+++ b/data/EX/Dragon/41.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Bagon",
-		fr: "Draby"
+		fr: "Draby",
+		de: "Kindwurm"
 	},
 
 	stage: "Stage1",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "As long as Shelgon has any basic Energy cards attached to it, damage done to Shelgon by an opponent's attack is reduced by 10 (after applying Weakness and Resistance).",
 				fr: "Tant que Drackhaus possède des cartes Énergie de base, les dégâts qui lui sont infligés par une attaque de votre adversaire sont réduits de 10 (après application de la Faiblesse et de la Résistance).",
-				de: "Solange mindestens 1 Basis-Energiekarte an Draschel angelegt ist, wird jeder Schaden, der Draschel durch gegnerische Angriffe zugefügt wird, um 10 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurde)."
+				de: "Solange mindestens 1 Basis-Energiekarte an Draschel angelegt ist, wird jeder Schaden, der Draschel durch gegnerische Angriffe zugefügt wird, um 10 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 		},
 	],

--- a/data/EX/Dragon/42.ts
+++ b/data/EX/Dragon/42.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Bagon",
-		fr: "Draby"
+		fr: "Draby",
+		de: "Kindwurm"
 	},
 
 	stage: "Stage1",
@@ -37,12 +38,12 @@ const card: Card = {
 			name: {
 				en: "Granite Head",
 				fr: "Tête de granit",
-				de: "Granite Head"
+				de: "Granitkopf"
 			},
 			effect: {
 				en: "Damage done to Shelgon by an opponent's attack is reduced by 10 (after applying Weakness and Resistance) during your opponent's next turn.",
 				fr: "Les dégâts infligés à Drackhaus par une attaque de votre adversaire sont réduits de 10 lors du prochain tour de votre adversaire (après application de la Faiblesse et de la Résistance).",
-				de: "Damage done to Shelgon by an opponent's attack is reduced by 10 (after applying Weakness and Resistance) during your opponent's next turn."
+				de: "Im nächsten Zug deines Gegners wird Schaden, der Draschel durch generische Angriffe zugefügt wird, um 10 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 			damage: 20,
 
@@ -56,7 +57,7 @@ const card: Card = {
 			name: {
 				en: "Flare",
 				fr: "Enflammer",
-				de: "Flare"
+				de: "Flackern"
 			},
 
 			damage: 40,

--- a/data/EX/Dragon/43.ts
+++ b/data/EX/Dragon/43.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Hypnosis",
 				fr: "Hypnose",
-				de: "Hypnosis"
+				de: "Hypnose"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
-				de: "The Defending Pokémon is now Asleep."
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 
 		},
@@ -47,12 +47,12 @@ const card: Card = {
 			name: {
 				en: "Night Attack",
 				fr: "Attaque nocturne",
-				de: "Night Attack"
+				de: "Nachtangriff"
 			},
 			effect: {
 				en: "Put 1 damage counter on 1 of your opponent's Pokémon.",
 				fr: "Placez un marqueur de dégât sur un des Pokémon de votre adversaire.",
-				de: "Put 1 damage counter on 1 of your opponent's Pokémon."
+				de: "Lege 1 Schadensmarke auf 1 gegnerisches Pokémon."
 			},
 
 		},

--- a/data/EX/Dragon/44.ts
+++ b/data/EX/Dragon/44.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Powder Snow",
 				fr: "Poudreuse",
-				de: "Powder Snow"
+				de: "Pulverschnee"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
-				de: "The Defending Pokémon is now Asleep."
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 			damage: 10,
 

--- a/data/EX/Dragon/45.ts
+++ b/data/EX/Dragon/45.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Taillow",
-		fr: "Nirondelle"
+		fr: "Nirondelle",
+		de: "Schwalbini"
 	},
 
 	stage: "Stage1",
@@ -59,7 +60,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, choose 1 of your opponent's Pokémon. This attack does 50 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance.",
 				fr: "Lancez une pièce. Si c'est face, choisissez un des Pokémon de votre adversaire. Cette attaque lui inflige 50 dégâts. Les dégâts de cette attaque ne sont pas affectés par la Faiblesse ou la Résistance.",
-				de: "Wirf 1 Münze. Bei 'Kopf' wähle 1 gegnerisches Pokémon. Dieser Angriff fügt dem ausgewählten Pokémon 50 Schadenspunkte zu. Der Schaden dieses Angriffs wird durch die Schwäche und Resistenz des ausgewählten nicht verändert."
+				de: "Wirf 1 Münze. Bei „Kopf“ wähle 1 gegnerisches Pokémon. Dieser Angriff fügt dem ausgewählten Pokémon 50 Schadenspunkte zu. Der Schaden dieses Angriffs wird durch die Schwäche und Resistenz des ausgewählten nicht verändert."
 			},
 
 		},

--- a/data/EX/Dragon/46.ts
+++ b/data/EX/Dragon/46.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Trapinch",
-		fr: "Kraknoix"
+		fr: "Kraknoix",
+		de: "Knacklion"
 	},
 
 	stage: "Stage1",

--- a/data/EX/Dragon/47.ts
+++ b/data/EX/Dragon/47.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Trapinch",
-		fr: "Kraknoix"
+		fr: "Kraknoix",
+		de: "Knacklion"
 	},
 
 	stage: "Stage1",
@@ -57,7 +58,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 40 damage times the number of heads.",
 				fr: "Lancez deux pièces. Cette attaque inflige 40 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl 'Kopf' zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "40×",
 

--- a/data/EX/Dragon/48.ts
+++ b/data/EX/Dragon/48.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Barboach",
-		fr: "Barloche"
+		fr: "Barloche",
+		de: "Schmerbe"
 	},
 
 	stage: "Stage1",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Submerge",
 				fr: "Submerger",
-				de: "Submerge"
+				de: "Untertauchen"
 			},
 			effect: {
 				en: "As long as Whiscash is on your Bench, prevent all damage done to Whiscash by your opponent's attacks.",
 				fr: "Tant que Barbicha est sur votre Banc, prévenez tous les dégâts qui lui sont infligés par des attaques de votre adversaire.",
-				de: "As long as Whiscash is on your Bench, prevent all damage done to Whiscash by opponent's attacks."
+				de: "Solange sich Welsar auf deiner Bank befindet, verhindere allen Schaden, der Welsar durch gegnerische Angriffe zugefügt wird."
 			},
 		},
 	],
@@ -53,7 +54,7 @@ const card: Card = {
 			name: {
 				en: "Surf",
 				fr: "Surf",
-				de: "Surf"
+				de: "Surfer"
 			},
 
 			damage: 30,
@@ -69,12 +70,12 @@ const card: Card = {
 			name: {
 				en: "Magnitude",
 				fr: "Ampleur",
-				de: "Magnitude"
+				de: "Intensität"
 			},
 			effect: {
 				en: "Does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à chacun des Pokémon du Banc (les vôtres et ceux de votre adversaire). (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc.)",
-				de: "Does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Fügt allen Pokémon auf der Bank 10 Schadenspunkte zu (deinen und den gegnerischen). (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 60,
 

--- a/data/EX/Dragon/5.ts
+++ b/data/EX/Dragon/5.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Graveler",
-		fr: "Gravalanch"
+		fr: "Gravalanch",
+		de: "Georok"
 	},
 
 	stage: "Stage2",
@@ -38,12 +39,12 @@ const card: Card = {
 			name: {
 				en: "Rock Vengeance",
 				fr: "Grosse vengeance",
-				de: "Rock Vengeance"
+				de: "Steinrache"
 			},
 			effect: {
 				en: "Does 20 damage plus 10 more damage for each damage counter on all of your Active Pokémon.",
 				fr: "Inflige 20 dégâts plus 10 dégâts supplémentaires pour chaque marqueur de dégât sur vos Pokémon Actifs.",
-				de: "Does 20 damage plus 10 more damage for each each damage counter on all of your Active Pokémon."
+				de: "Fügt 20 Schadenspunkte plus 10 weitere Schadenspunkte für jede Schadensmarke auf allen deinen Aktiven Pokémon zu."
 			},
 			damage: "20+",
 
@@ -59,12 +60,12 @@ const card: Card = {
 			name: {
 				en: "Rock Slide",
 				fr: "Éboulement",
-				de: "Rock Slide"
+				de: "Steinhagel"
 			},
 			effect: {
 				en: "Does 20 damage to 2 of your opponent's Benched Pokémon (1 if there is only 1). (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 20 dégâts à deux des Pokémon du banc de votre adversaire (ou un s'il n'y en a qu'un). (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc).",
-				de: "Does 20 damage to 2 of your opponent's Benched Pokémon (1 if there is only 1). (Don't apply Weakness and resistance for Benched Pokémon.)"
+				de: "Fügt 2 gegnerischen Pokémon auf der Bank 20 Schadenspunkte zu (falls 1 nur 1 vorhanden). (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 60,
 

--- a/data/EX/Dragon/50.ts
+++ b/data/EX/Dragon/50.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Risky Kick",
 				fr: "Coup de pied risqué",
-				de: "Risky Kick"
+				de: "Risikokick"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet.",
-				de: "Flip a coin. If tails, this attack does nothing."
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 10,
 
@@ -49,12 +49,12 @@ const card: Card = {
 			name: {
 				en: "Dragon Eye",
 				fr: "Oeil de dragon",
-				de: "Dragon Eye"
+				de: "Drachenauge"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
-				de: "The Defending Pokémon is now Asleep."
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 			damage: 20,
 

--- a/data/EX/Dragon/52.ts
+++ b/data/EX/Dragon/52.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Poison Claws",
 				fr: "Griffes empoisonnées",
-				de: "Poison Claws"
+				de: "Giftkrallen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Empoisonné.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Poisoned."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet."
 			},
 
 		},
@@ -47,12 +47,12 @@ const card: Card = {
 			name: {
 				en: "Bubble",
 				fr: "Écume",
-				de: "Bubble"
+				de: "Blubber"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 

--- a/data/EX/Dragon/56.ts
+++ b/data/EX/Dragon/56.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts.",
-				de: "Wirf 1 Münze. Bei 'Kopf' fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 

--- a/data/EX/Dragon/57.ts
+++ b/data/EX/Dragon/57.ts
@@ -31,7 +31,7 @@ const card: Card = {
 			name: {
 				en: "Pound",
 				fr: "Écras'face",
-				de: "Pound"
+				de: "Pfund"
 			},
 
 			damage: 10,
@@ -44,12 +44,12 @@ const card: Card = {
 			name: {
 				en: "Poison Spurt",
 				fr: "Jet de poison",
-				de: "Poison Spurt"
+				de: "Giftspritzer"
 			},
 			effect: {
 				en: "Discard a Grass Energy card attached to Grimer. The Defending Pokémon is now Poisoned.",
 				fr: "Défaussez une carte Énergie  attachée à Tadmorv. Le Pokémon Défenseur est maintenant Empoisonné.",
-				de: "Discard a  Energy card attached to Grimer. The Defending Pokémon is now Poisoned."
+				de: "Entferne 1 {G}-Energiekarte von Sleima und lege sie auf den Ablagestapel. Das Verteidigende Pokémon ist jetzt vergiftet."
 			},
 
 		},

--- a/data/EX/Dragon/58.ts
+++ b/data/EX/Dragon/58.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 
 		},

--- a/data/EX/Dragon/6.ts
+++ b/data/EX/Dragon/6.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Spoink",
-		fr: "Spoink"
+		fr: "Spoink",
+		de: "Spoink"
 	},
 
 	stage: "Stage1",
@@ -37,12 +38,12 @@ const card: Card = {
 			name: {
 				en: "Psychic Boom",
 				fr: "Psycho-boom",
-				de: "Psychic Boom"
+				de: "Psychoknall"
 			},
 			effect: {
 				en: "Does 20 damage plus 10 more damage for each Energy attached to the Defending Pokémon.",
 				fr: "Inflige 20 dégâts plus 10 dégâts supplémentaires pour chaque Énergie attachée au Pokémon Défenseur.",
-				de: "Does 20 damage plus 10 more damage for each Energy attached to the Defending Pokémon."
+				de: "Fügt 20 Schadenspunkte plus 10 weitere Schadenspunkte für jede am Verteidigenden Pokémon angelegte Energie zu."
 			},
 			damage: "20+",
 
@@ -56,12 +57,12 @@ const card: Card = {
 			name: {
 				en: "Mind Trip",
 				fr: "Avoir l'esprit ailleurs",
-				de: "Mind Trip"
+				de: "Verstandesreise"
 			},
 			effect: {
 				en: "If Grumpig and the Defending Pokémon have the same amount of Energy attached to them, the Defending Pokémon is now Confused.",
 				fr: "Si Groret et le Pokémon Défenseur possèdent le même total en Énergie, le Pokémon Défenseur est maintenant Confus.",
-				de: "If grumpig and the Defending Pokémon have the same number off Energy attached to them, the Defending Pokémon is now Confused."
+				de: "Falls an Groink und dem Verteidigenden Pokémon gleich viel Energie angelegt ist, ist das Verteidigende jetzt verwirrt."
 			},
 			damage: 50,
 

--- a/data/EX/Dragon/63.ts
+++ b/data/EX/Dragon/63.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Thundershock",
 				fr: "Éclair",
-				de: "Thundershock"
+				de: "Donnerschock"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 

--- a/data/EX/Dragon/64.ts
+++ b/data/EX/Dragon/64.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 
 		},

--- a/data/EX/Dragon/65.ts
+++ b/data/EX/Dragon/65.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Does 10 damage plus 10 more damage for each Water Energy attached to Mudkip but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way.",
 				fr: "Cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  attachée à Gobou qui n'a pas été utilisée pour payer le coût en Énergie de cette attaque. Vous ne pouvez pas ajouter plus de 20 dégâts de cette façon.",
-				de: "Dieser Angriff fügt 10 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Hydropi angelegte -Energiekarte zu, die nicht zum Zahlen der Energiekosten für diesen Angriff verwendet wurde. Es lassen sich so nicht mehr als 20 Schadenspunkte hinzufügen."
+				de: "Dieser Angriff fügt 10 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Hydropi angelegte {W}-Energiekarte zu, die nicht zum Zahlen der Energiekosten für diesen Angriff verwendet wurde. Es lassen sich so nicht mehr als 20 Schadenspunkte hinzufügen."
 			},
 			damage: "10+",
 

--- a/data/EX/Dragon/66.ts
+++ b/data/EX/Dragon/66.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Empoisonné.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt vergiftet."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet."
 			},
 			damage: 10,
 

--- a/data/EX/Dragon/67.ts
+++ b/data/EX/Dragon/67.ts
@@ -50,7 +50,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez deux pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl 'Kopf' zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 

--- a/data/EX/Dragon/68.ts
+++ b/data/EX/Dragon/68.ts
@@ -34,7 +34,7 @@ const card: Card = {
 			effect: {
 				en: "After your attack, remove from Nincada the number of damage counters equal to the damage you did to the Defending Pokémon. If Nincada has fewer damage counters than that, remove all of them.",
 				fr: "Après votre attaque, retirez à Ningale autant de marqueurs de dégât que vous avez infligé de dégâts au Pokémon Défenseur. Si Ningale a moins de marqueurs de dégât que de dégâts infligés, retirez-les lui tous.",
-				de: "Nach dem Kampf entferne pro 10 Schadenspunkte, die Nincada dem Verteidigenden Pokémon zugefügt hat, 1 Schadensmarke von Nincada. Falls zu wenig Schadensmarken vorhanden sind, entferne alle."
+				de: "Nach dem Kampf entferne pro 10 Schadenspunkte, die Nincada dem Verteidigenden Pokémon zugefügt hat, 1 Schadensmarke von Nincada. Falls zuwenig Schadensmarken vorhanden sind, entferne alle."
 			},
 
 			cost: ["Grass"],

--- a/data/EX/Dragon/69.ts
+++ b/data/EX/Dragon/69.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei 'Kopf' fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 

--- a/data/EX/Dragon/7.ts
+++ b/data/EX/Dragon/7.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Chain of Events",
 				fr: "Réactions en chaîne",
-				de: "Chain of Events"
+				de: "Kette der Ereignisse"
 			},
 			effect: {
 				en: "As long as Minun is your Active Pokémon, whenever your other Active Pokémon, if any, attacks, you may use Cheer On after the first attack (you still need the necessary Energy to use Cheer On). You can't use Cheer On more than once in this way even if your other Active Pokémon has the Chain of Events Poké-Body.",
 				fr: "Tant que Negapi est votre Pokémon Actif, dès que votre autre Pokémon Actif, si vous en avez un, attaque, vous pouvez utiliser Encouragement après la première attaque (vous avez toujours besoin du nombre d'Énergies nécessaires pour utiliser Encouragement). Vous ne pouvez pas utiliser Encouragement plus d'une fois, même si votre autre Pokémon Actif possède le Poké-Body Réactions en chaîne.",
-				de: "As long as Minun is your Active Pokémon, whenever your other Active Pokémon, if any, attacks, you may use Cheer On, after the first attack (you still need the necessary Energy to use Cheer On). You can't use Cheer On more than once in this way even if your other Active Pokémon has the Chain of Events Poke-Body."
+				de: "Wenn Minun dein Aktives Pokémon ist und dein anderes Aktives Pokémon einen Angriff benutzt, kannst du Anfeuern nach dem ersten Angriff benutzen (nur wenn du die Energiekosten von Anfeuern bezahlen kannst). Du kannst Anfeuern auf diese Weise nicht häufiger als ein Mal benutzen, auch wenn dein anderes Aktives Pokémon auch den Kette der Ereignisse Poké-Body hat."
 			},
 		},
 	],
@@ -47,12 +47,12 @@ const card: Card = {
 			name: {
 				en: "Cheer On",
 				fr: "Encouragement",
-				de: "Cheer On"
+				de: "Anfeuern"
 			},
 			effect: {
 				en: "Remove 1 damage counter from each of your Pokémon (including Minun).",
 				fr: "Retirez un marqueur de dégât à chacun de vos Pokémon (Negapi inclus).",
-				de: "Remove 1 damage counter from each of your Pokémon (including Minun)."
+				de: "Entferne 1 Schadensmarke von allen deinen Pokémon (einschließlich Minun)."
 			},
 
 		},
@@ -64,12 +64,12 @@ const card: Card = {
 			name: {
 				en: "Special Circuit",
 				fr: "Circuit spécial",
-				de: "Special Circuit"
+				de: "Spezial Stromkreis"
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. If you choose Pokémon that has a Poké-Power or Poké-Body, this attack does 40 damage instead. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Choisissez un des Pokémon de votre adversaire. Cette attaque lui inflige 20 dégâts. Si vous choisissez un Pokémon possédant un Poké-Power ou un Poké-Body, cette attaque inflige 40 dégâts. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc).",
-				de: "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. If you choose Pokémon than has a Poke-Power or Poke-Body, this attack does 40 damage instead. (Don't apply Weakness and Resistance for benched Pokémon.)"
+				de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt diesem Pokémon 20 Schadenspunkte zu. Falls das ausgewählte Pokémon eine Poké-Power oder ein Poké-Body hat, fügt dieser Angriff stattdessen 40 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},

--- a/data/EX/Dragon/70.ts
+++ b/data/EX/Dragon/70.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			effect: {
 				en: "Discard a Fire Energy card attached to Numel and then discard an Energy card attached to the Defending Pokémon.",
 				fr: "Défaussez une carte Énergie  attachée à Chamallot puis une carte Énergie attachée au Pokémon Défenseur.",
-				de: "Lege 1 -Energiekarte von Camaub auf deinen Ablagestapel und lege danach eine Energiekarte vom Verteidigenden Pokémon auf den Ablagestapel deines Gegners."
+				de: "Lege 1 {R}-Energiekarte von Camaub auf deinen Ablagestapel und lege danach eine Energiekarte vom Verteidigenden Pokémon auf den Ablagestapel deines Gegners."
 			},
 			damage: 10,
 

--- a/data/EX/Dragon/72.ts
+++ b/data/EX/Dragon/72.ts
@@ -31,7 +31,7 @@ const card: Card = {
 			name: {
 				en: "Ram",
 				fr: "Charge",
-				de: "Ram"
+				de: "Ramme"
 			},
 
 			damage: 10,
@@ -45,12 +45,12 @@ const card: Card = {
 			name: {
 				en: "Luring Flame",
 				fr: "Flamme attrayante",
-				de: "Luring Flame"
+				de: "Verlockende Flamme"
 			},
 			effect: {
 				en: "Switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. The new Defending Pokémon is now Burned.",
 				fr: "Échangez un des Pokémon du Banc de votre adversaire avec le Pokémon Défenseur. Votre adversaire choisit le Pokémon Défenseur à échanger. Le nouveau Pokémon Défenseur est maintenant Brûlé.",
-				de: "Switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. Your opponent chooses the Defending Pokémon to switch. The new Defending Pokémon is now Burned."
+				de: "Tausche 1 Verteidigendes Pokémon mit 1 der Pokémon auf der Bank deines Gegners aus. Dein Gegner wählt aus, welches Verteidigende Pokémon getauscht wird. Das neue Verteidigende Pokémon ist jetzt verbrannt."
 			},
 
 		},

--- a/data/EX/Dragon/74.ts
+++ b/data/EX/Dragon/74.ts
@@ -31,7 +31,7 @@ const card: Card = {
 			name: {
 				en: "Hop",
 				fr: "Trempette",
-				de: "Hop"
+				de: "Hüpfer"
 			},
 
 			damage: 10,
@@ -45,12 +45,12 @@ const card: Card = {
 			name: {
 				en: "Psybeam",
 				fr: "Rafale psy",
-				de: "Psybeam"
+				de: "Psystrahl"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Confused."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: 10,
 

--- a/data/EX/Dragon/75.ts
+++ b/data/EX/Dragon/75.ts
@@ -53,7 +53,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 

--- a/data/EX/Dragon/76.ts
+++ b/data/EX/Dragon/76.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon.",
 				fr: "Votre adversaire échange le Pokémon Défenseur contre l'un des Pokémon de son Banc.",
-				de: "Dein gegner tauscht das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
+				de: "Dein Gegner tauscht das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
 			},
 
 		},

--- a/data/EX/Dragon/77.ts
+++ b/data/EX/Dragon/77.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts plus 20 dégâts supplémentaires.",
-				de: "Wirf eine Münze. Bei 'Kopf' fügt dieser Angriff 20 Schadenspunkte plus 20 weitere Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 

--- a/data/EX/Dragon/79.ts
+++ b/data/EX/Dragon/79.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 
 		},
@@ -53,7 +53,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei 'Kopf' fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 

--- a/data/EX/Dragon/8.ts
+++ b/data/EX/Dragon/8.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Chain of Events",
 				fr: "Réactions en chaîne",
-				de: "Chain of Events"
+				de: "Kette der Ereignisse"
 			},
 			effect: {
 				en: "As long as Plusle is your Active Pokémon, whenever your other Active Pokémon, if any, attacks, you may use Cheer On after the first attack (you still need the necessary Energy to use Cheer On). You can't use Cheer On more than once in this way even if your other Active Pokémon has the Chain of Events Poké-Body.",
 				fr: "Tant que Posipi est votre Pokémon Actif, dès que votre autre Pokémon Actif, si vous en avez un, attaque, vous pouvez utiliser Encouragement après la première attaque (vous avez toujours besoin du nombre d'Énergies nécessaires pour utiliser Encouragement). Vous ne pouvez pas utiliser Encouragement plus d'une fois, même si votre autre Pokémon Actif possède le Poké-Body Réactions en chaîne.",
-				de: "As long as Plusle is your Active Pokémon, whenever your other Active Pokémon, if any, attacks, you may use Cheer On, after the first attack (you still need the necessary Energy to use Cheer On). You can't use Cheer On more than once in this way even if your other Active Pokémon has the Chain of Events Poké-Body."
+				de: "Wenn Plusle dein Aktives Pokémon ist und dein anderes Aktives Pokémon einen Angriff benutzt, kannst du Anfeuern nach dem ersten Angriff benutzen (nur wenn du die Energiekosten von Anfeuern bezahlen kannst). Du kannst Anfeuern auf diese Weise nicht häufiger als ein Mal benutzen, auch wenn dein anderes Aktives Pokémon auch den Kette der Ereignisse Poké-Body hat."
 			},
 		},
 	],
@@ -47,12 +47,12 @@ const card: Card = {
 			name: {
 				en: "Cheer On",
 				fr: "Encouragement",
-				de: "Cheer On"
+				de: "Anfeuern"
 			},
 			effect: {
 				en: "Remove 1 damage counter from each of your Pokémon (including Plusle).",
 				fr: "Retirez un marqueur de dégât à chacun de vos Pokémon (Posipi inclus).",
-				de: "Remove 1 damage counter from each of your Pokémon (including Plusle)."
+				de: "Entferne 1 Schadensmarke von allen deinen Pokémon (einschließlich Plusle)."
 			},
 
 		},
@@ -64,12 +64,12 @@ const card: Card = {
 			name: {
 				en: "Extra Circuit",
 				fr: "Circuit supplémentaire",
-				de: "Extra Circuit"
+				de: "Extra Stromkreis"
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. If you choose Pokémon-ex, this attack does 40 damage instead. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Choisissez un des Pokémon de votre adversaire. Cette attaque lui inflige 20 dégâts. Si vous choisissez un Pokémon-ex, cette attaque inflige 40 dégâts. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc).",
-				de: "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. If you choose Pokémon-ex, this attack does 40 damage instead. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt diesem Pokémon 20 Schadenspunkte zu. Falls das ausgewählte Pokémon ein Pokémon-ex ist, fügt dieser Angriff stattdessen 40 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},

--- a/data/EX/Dragon/80.ts
+++ b/data/EX/Dragon/80.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts.",
-				de: "Wirf 1 Münze. Bei 'Kopf' fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 

--- a/data/EX/Dragon/81.ts
+++ b/data/EX/Dragon/81.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Search your deck for Grass Basic Pokémon and put as many of them as you like onto your Bench. Shuffle your deck afterward.",
 				fr: "Cherchez dans votre deck des Pokémon de base  et placez-en autant que vous le voulez sur votre Banc. Ensuite, mélangez votre deck.",
-				de: "Durchsuche dein Deck nach -Basis-Pokémon-Karten und lege beliebig viele von ihnen auf deine Bank. Mische dein Deck danach."
+				de: "Durchsuche dein Deck nach {G}-Basis-Pokémon-Karten und lege beliebige viele von ihnen auf deine Bank. Mische dein Deck danach."
 			},
 
 		},
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 

--- a/data/EX/Dragon/82.ts
+++ b/data/EX/Dragon/82.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "Attach Balloon Berry to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card. When the Pokémon Balloon Berry is attached to retreats, discard Balloon Berry instead of discarding Energy cards.",
 		fr: "Attachez Baie Ballon à un de vos Pokémon qui ne possède pas déjà d'Outil Pokémon. Si ce Pokémon est mis K.O, défaussez-la.\n\nLorsque le Pokémon auquel Baie Ballon est attachée bat en retraite, défaussez Baie Ballon plutôt que de défausser des cartes Énergie.",
-		de: "When the Pokémon Balloon Berry is attached to retreats, discard Balloon Berry instead of discarding Energy cards."
+		de: "Lege Ballonbeere an 1 deiner Pokémon an, das keine Pokémon-Ausrüstung hat. Wenn das Pokémon kampfunfähig gemacht wird, lege Ballonbeere auf den Ablagestapel. Wenn das Pokémon, an das Ballonbeere angelegt ist, sich zurückzieht, lege Ballonbeere auf deinen Ablagestapel, anstatt Energiekarten abzulegen."
 	},
 
 	variants: [

--- a/data/EX/Dragon/83.ts
+++ b/data/EX/Dragon/83.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "Attach Buffer Piece to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card. Damage done to the Pokémon Buffer Piece is attached to by an opponent's attack is reduced by 20 (after applying Weakness and Resistance). At the end of your opponent's turn after you played Buffer Piece, discard Buffer Piece.",
 		fr: "Attachez Pare-chocs à un de vos Pokémon qui ne possède pas déjà d'Outil Pokémon. Si ce Pokémon est mis K.O, défaussez-la.\n\nLes dégâts infligés par une attaque de votre adversaire au Pokémon auquel Pare-chocs est attachée sont réduits de 20 (après application de la Faiblesse et de la Résistance). À la fin du tour de votre adversaire, défaussez-la.",
-		de: "Damage done to the Pokémon Buffer Piece is attached to by an opponent's attack is reduced by 20 (after applying Weakness and Resistance). At the end of your opponent's turn after you played Buffer Piece, discard Buffer Piece."
+		de: "Lege Dämpfender Talisman an 1 deiner Pokémon an, das keine Pokémon-Ausrüstung hat. Wenn das Pokémon kampfunfähig gemacht wird, lege Dämpfender Talisman auf den Ablagestapel. Jeder Schaden, der dem Pokémon, an dem Dämpfender Talisman angelegt ist, durch Angriffe zugefügt wird, wird um 20 reduziert (nachdem Schwäche und Resistenz verrechntet wurden). Lege Dämpfender Talisman am Ende des nächsten Zuges deines Gegners (nachdem Dämpfender Talisman gespielt wurde) auf den Ablagestapel."
 	},
 
 	variants: [

--- a/data/EX/Dragon/84.ts
+++ b/data/EX/Dragon/84.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "Search your discard pile for basic Energy cards. You may either show 1 basic Energy card to your opponent and put it into your hand, or show 3 basic Energy cards to your opponent and shuffle them into your deck.",
 		fr: "Cherchez dans votre deck des cartes Énergie de base. Vous pouvez soit montrer une carte Énergie de base à votre adversaire et la placer dans votre main, soit montrer trois cartes Énergie de base à votre adversaire et les mélanger à votre deck.",
-		de: "Durchsuche deinen Ablagestapel nach Basis-Energiekarten. Wähle entweder 1 Basis Energiekarte, zeige sie deinem Gegner und nimm sie auf die Hand oder wähle 3 Basis Energiekarten, zeige sie deinem Gegner und mische sie in dein Deck."
+		de: "Durchsuche deinen Ablagestapel nach Basis-Energiekarten. Wähle entweder 1 Basis-Energiekarte, zeige sie deinem Gegner und nimm sie auf deine Hand oder wähle 3 Basis-Energiekarten, zeige sie deinem Gegner und mische sie in dein Deck."
 	},
 
 	variants: [

--- a/data/EX/Dragon/85.ts
+++ b/data/EX/Dragon/85.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. Each player pays Colorless less to retreat his or her Fire and Water Pokémon.",
 		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez -la si une autre carte Stade est mise en jeu.",
-		de: "Each players pays  less to retreat his or her  and  Pokémon.",
+		de: "Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadion-Karte ins Spiel kommt. Jeder Spieler bezahlt {C} weniger, um seine {R} und {W} Pokémon zurückzuziehen.",
 	},
 
 	variants: [

--- a/data/EX/Dragon/86.ts
+++ b/data/EX/Dragon/86.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. Each Grass and Lightning Pokémon in play (both yours and your opponent's) gets +10 HP.",
 		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez -la si une autre carte Stade est mise en jeu.",
-		de: "Each  and  Pokémon in play (both yours and your opponent's) gets +10HP.",
+		de: "Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadion-Karte ins Spiel kommt. Alle {G} und {L} Pokémon im Spiel (deine und die deines Gegners) erhalten + 10 KP.",
 	},
 
 	retreat: 0,

--- a/data/EX/Dragon/87.ts
+++ b/data/EX/Dragon/87.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Choose 1 of your Pokémon in play (excluding Pokémon-ex). Return that Pokémon and all cards attached to it to your hand.",
 		fr: "Choisissez un des Pokémon que vous avez en jeu (sauf les Pokémon-ex). Reprenez dans votre main ce Pokémon ainsi que toutes les cartes qui lui sont attachées.",
-		de: "Choose 1 of your Pokémon in play (excluding Pokémon-ex). Return that Pokémon and all cards attached to it to your hand.",
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Wähle 1 deiner Pokémon (außer Pokémon-ex). Nimm das ausgewählte Pokémon und alle daran angelegten Karten zurück auf deine Hand.",
 	},
 
 	variants: [

--- a/data/EX/Dragon/88.ts
+++ b/data/EX/Dragon/88.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Draw 3 cards. Then discard any 1 card from your hand.",
 		fr: "Piochez trois cartes. Ensuite, défaussez une carte de votre main.",
-		de: "Draw 3 cards. Then discard any 1 card from your hand.",
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Akives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Ziehe 3 Karten. Lege danach 1 Karte von deiner Hand auf deinen Ablagestapel.",
 	},
 
 	variants: [

--- a/data/EX/Dragon/89.ts
+++ b/data/EX/Dragon/89.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Flaaffy",
-		fr: "Lainergie"
+		fr: "Lainergie",
+		de: "Waaty"
 	},
 
 	suffix: "ex",
@@ -35,12 +36,12 @@ const card: Card = {
 			name: {
 				en: "Conductivity",
 				fr: "Conductivité",
-				de: "Conductivity"
+				de: "Leitfähigkeit"
 			},
 			effect: {
 				en: "As long as Ampharos ex is in play, whenever your opponent attaches an Energy card to his or her Pokémon from hand, put 1 damage counter on that Pokémon. You can't put more than 1 damage counter even if there is more than 1 Ampharos ex in play.",
 				fr: "Tant que Pharamp ex est en jeu, dès que votre adversaire attache une carte Énergie de sa main à un Pokémon, placez un marqueur de dégât sur ce Pokémon. Vous ne pouvez pas placer plus d'un marqueur de dégât même s'il y a plus d'un Pharamp ex en jeu.",
-				de: "As long as Ampharos ex is in play, whenever your opponent attaches an Energy card to his or her Pokémon from hand, put 1 damage counter on that Pokémon. You can't put more than 1 damage counter even if there is more than 1 Ampharos ex in play."
+				de: "Solange sich Ampharos ex im Spiel befindet, lege jedes Mal, wenn dein Gegner 1 Energiekarte an 1 seiner Pokémon von der Hand anlegt, 1 Schadensmarke auf das entsprechende Pokémon. Du kannst auf diese Weise nicht mehr als 1 Schadensmarke verteilen, auch wenn mehr als 1 Ampharos ex im Spiel ist."
 			},
 		},
 	],
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 40 damage plus 30 more damage. If tails, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 70 dégâts. Si c'est pile, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Flip a coin. If heads, this attack does 40 damage plus 30 more damage. If tails, the Defending Pokémon is now Paralyzed."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 40 Schadenspunkte plus 30 weitere Schadenspunkte zu. Bei „Zahl“ fügt dieser Angriff 40 Schadenspunkte zu, und das Verteidigende Pokémon ist jetzt gelähmt."
 			},
 			damage: "40+",
 

--- a/data/EX/Dragon/9.ts
+++ b/data/EX/Dragon/9.ts
@@ -34,7 +34,7 @@ const card: Card = {
 			effect: {
 				en: "Roselia can't be affected by any Special Conditions.",
 				fr: "Roselia ne peut pas être affectée par un État spécial.",
-				de: "Roselia kann nicht von speziellen Zuständen betroffen werden."
+				de: "Roselia kann nicht von Speziellen Zuständen betroffen werden."
 			},
 		},
 	],
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Attach up to 2 Grass Energy cards from your hand to your Pokémon in any way you like.",
 				fr: "Attachez jusqu'à deux cartes Énergie  de votre main à vos Pokémon de la façon que vous voulez.",
-				de: "Lege bis zu 2  Energiekarten von deiner Hand an deine Pokémon an."
+				de: "Lege bis zu 2 {G}-Energiekarten von deiner Hand an deine Pokémon an."
 			},
 
 		},
@@ -68,7 +68,7 @@ const card: Card = {
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
-				de: "Das verteidigende Pokémon schläft jetzt."
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 			damage: 10,
 

--- a/data/EX/Dragon/90.ts
+++ b/data/EX/Dragon/90.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Dragonair",
-		fr: "Draco"
+		fr: "Draco",
+		de: "Dragonir"
 	},
 
 	suffix: "ex",
@@ -35,12 +36,12 @@ const card: Card = {
 			name: {
 				en: "Call for Power",
 				fr: "Appel à la puissance",
-				de: "Call for Power"
+				de: "Kraftruf"
 			},
 			effect: {
 				en: "As often as you like during your turn, you may move an Energy card attached to 1 of your Pokémon to Dragonite ex. This power can't be used if Dragonite ex is affected by a Special Condition.",
 				fr: "Autant de fois que vous le voulez lors de votre tour, vous pouvez attacher à Dracolosse ex une carte Énergie attachée à un de vos Pokémon. Ce pouvoir ne peut pas être utilisé si Dracolosse ex est affecté par un État spécial.",
-				de: "As often as you like during your turn, you may mova an Energy card attached to 1 of your Pokémon to Dragonite ex. This power can't be used if Dragonite ex is affected by a Special Condition."
+				de: "Du kannst in deinem Zug so oft wie du willst eine an 1 deiner Pokémon angelegte Energiekarte an Dragoran ex anlegen. Diese Poké-Power kann nicht verwendet werden, falls Dragoran ex von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -54,12 +55,12 @@ const card: Card = {
 			name: {
 				en: "Dragon Wave",
 				fr: "Vague de dragon",
-				de: "Dragon Wave"
+				de: "Drachenwelle"
 			},
 			effect: {
 				en: "Discard a Water Energy card and a Lightning Energy card attached to Dragonite ex.",
 				fr: "Défaussez une carte Énergie  et une carte Énergie  attachée à Dracolosse ex.",
-				de: "Discard a  Energy card and a  card attached to Dragonite ex."
+				de: "Entferne 1 {W}-Energiekarte und 1 {L}-Energiekarte, die an Dragoran ex angelegt sind, und lege sie auf deinen Ablagestapel."
 			},
 			damage: 70,
 
@@ -74,12 +75,12 @@ const card: Card = {
 			name: {
 				en: "Giant Tail",
 				fr: "Longue queue",
-				de: "Giant Tail"
+				de: "Riesenschweif"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet.",
-				de: "Flip a coin. If tails, this attack does nothing."
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 120,
 

--- a/data/EX/Dragon/91.ts
+++ b/data/EX/Dragon/91.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Graveler",
-		fr: "Gravalanch"
+		fr: "Gravalanch",
+		de: "Georok"
 	},
 
 	suffix: "ex",
@@ -39,12 +40,12 @@ const card: Card = {
 			name: {
 				en: "Magnitude",
 				fr: "Ampleur",
-				de: "Magnitude"
+				de: "Intensität"
 			},
 			effect: {
 				en: "Does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à chacun des Pokémon du Banc (les vôtres et ceux de votre adversaire). (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc.)",
-				de: "Does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and resistance for Benched Pokémon.)"
+				de: "Fügt allen Pokémon auf der Bank 10 Schadenspunkte zu (deinen und den gegnerischen). (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 60,
 
@@ -60,12 +61,12 @@ const card: Card = {
 			name: {
 				en: "Double-edge",
 				fr: "Damoclès",
-				de: "Double-edge"
+				de: "Risikotackle"
 			},
 			effect: {
 				en: "Golem ex does 50 damage to itself.",
 				fr: "Grolem ex s'inflige 50 dégâts.",
-				de: "Golem ex does 50 damage to itself."
+				de: "Geowaz ex fügt sich selbst 50 Schadenspunkte zu."
 			},
 			damage: 120,
 

--- a/data/EX/Dragon/92.ts
+++ b/data/EX/Dragon/92.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Seadra",
-		fr: "Hypocéan"
+		fr: "Hypocéan",
+		de: "Seemon"
 	},
 
 	suffix: "ex",
@@ -37,12 +38,12 @@ const card: Card = {
 			name: {
 				en: "Genetic Memory",
 				fr: "Mémoire Génétique",
-				de: "Genetic Memory"
+				de: "Genetisches Gedächtnis"
 			},
 			effect: {
 				en: "Use any attack from Kingdra ex's Basic Pokémon card or Stage 1 Evolution card. (Kingdra ex doesn't have to pay for that attack's Energy cost.)",
 				fr: "Utilisez n'importe quelle attaque de la carte Pokémon de base ou de la carte Évolution Niveau 1 d'Hyporoi ex. (Hyporoi ex ne paye pas le Coût en Énergie de cette attaque).",
-				de: "Use any attack from Kindra ex's Basic Pokémon card or Stage 1 Evolution card. (Kindra ex doesn't have to pay for that attack's Energy cost.)"
+				de: "Du kannst alle Angriffe von Seedraking ex Basis-Pokémon-Karte oder Phase 1 Evolutionskarte verwenden. (Seedraking ex muss nicht die Energiekosten dieser Angriffe bezahlen.)"
 			},
 
 		},
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Hydrocannon",
 				fr: "Canon à O",
-				de: "Hydrocannon"
+				de: "Aquahaubitze"
 			},
 			effect: {
 				en: "Does 50 damage plus 20 more damage for each Water Energy attached to Kingdra ex but not used to pay for this attack's Energy cost. You can't add more than 40 damage in this way.",
 				fr: "Inflige 50 dégâts plus 20 dégâts supplémentaires pour chaque carte Énergie  attachée à Hyporoi ex qui n'a pas été utilisée pour payer le coût en Énergie de cette attaque. Vous ne pouvez pas ajouter plus de 40 dégâts de cette façon.",
-				de: "Does 50 damage plus 20 more damage for each  Energy attached to Kindra ex but not used to pay for this attack's Energy cost. You can't add more than 40 damage in this way."
+				de: "Dieser Angriff fügt 50 Schadenspunkte plus 20 weitere Schadenspunkte für jede an Seedraking ex angelegte {W}-Energie zu, die nicht zum Zahlen der Energiekosten für diesen Angriff verwendet wurde. Es lassen sich so nicht mehr als 40 Schadenspunkte hinzufügen."
 			},
 			damage: "50+",
 

--- a/data/EX/Dragon/93.ts
+++ b/data/EX/Dragon/93.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Asleep.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Endormi.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" schläft das Verteidigende Pokémon jetzt."
+				de: "Wirf 1 Münze. Bei „Kopf“ schläft das Verteidigende Pokémon jetzt."
 			},
 			damage: 10,
 
@@ -56,7 +56,7 @@ const card: Card = {
 			effect: {
 				en: "Discard a Fire Energy and a Water Energy attached to Latias ex.",
 				fr: "Défaussez une Énergie  et une Énergie  attachée à Latias ex.",
-				de: "Entferne 1 -Energie und 1 -Energie, die an Latias ex angelegt sind und lege sie auf deinen Ablagestapel."
+				de: "Entferne 1 {R}-Energie und 1 {W}-Energie, die an Latias ex angelegt sind und lege sie auf deinen Ablagestapel."
 			},
 			damage: 100,
 

--- a/data/EX/Dragon/94.ts
+++ b/data/EX/Dragon/94.ts
@@ -32,12 +32,12 @@ const card: Card = {
 			name: {
 				en: "Energy Stream",
 				fr: "Courant d'énergie",
-				de: "Energy Stream"
+				de: "Energiestrom"
 			},
 			effect: {
 				en: "Flip a coin. If heads, search your discard pile for a basic Energy card and attach it to Latios ex.",
 				fr: "Lancez une pièce. Si c'est face, cherchez dans votre deck une carte Énergie de base et attachez-la à Latios ex.",
-				de: "Flip a coin. If heads, search your discard pile for a basic Energy card and attach it to Latios ex."
+				de: "Wirf 1 Münze. Bei „Kopf“ durchsuche deinen Ablagestapel nach 1 Basis-Energiekarte und lege sie an Latios ex an."
 			},
 			damage: 10,
 
@@ -51,7 +51,7 @@ const card: Card = {
 			name: {
 				en: "Luster Purge",
 				fr: "Purge",
-				de: "Luster Purge"
+				de: "Schimmernde Reinigung"
 			},
 			effect: {
 				en: "Discard 3 Energy attached to Latios ex.",

--- a/data/EX/Dragon/95.ts
+++ b/data/EX/Dragon/95.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Slugma",
-		fr: "Limagma"
+		fr: "Limagma",
+		de: "Schneckmag"
 	},
 
 	suffix: "ex",
@@ -37,12 +38,12 @@ const card: Card = {
 			name: {
 				en: "Melting Mountain",
 				fr: "Montagne fondante",
-				de: "Melting Mountain"
+				de: "Schmelzender Berg"
 			},
 			effect: {
 				en: "Discard the top card from your deck. If that card is a basic Energy card, attach it to Magcargo ex.",
 				fr: "Défaussez la première carte de votre deck. Si cette carte est une carte Énergie de base, attachez-la à Volcaropod ex.",
-				de: "Discard the top card from your deck. If that card is a basic Energy card, attach it to Magcargo ex."
+				de: "Lege die oberste Karte von deinem Deck auf deinen Ablagestapel. Falls diese Karte eine Energiekarte ist, lege sie an Magcargo ex an."
 			},
 			damage: 20,
 
@@ -56,12 +57,12 @@ const card: Card = {
 			name: {
 				en: "Lava Flow",
 				fr: "Torrent de lave",
-				de: "Lava Flow"
+				de: "Lavaschub"
 			},
 			effect: {
 				en: "You may discard any number of basic Energy cards attached to Magcargo ex when you use this attack. If you do, this attack does 40 damage plus 20 more damage for each basic Energy card you discarded.",
 				fr: "Vous pouvez défausser autant de cartes Énergie de base attachées à Volcaropod ex que vous le voulez lorsque vous utilisez cette attaque. Cette attaque inflige alors 40 dégâts plus 20 dégâts supplémentaires pour chaque carte Énergie de base que vous défaussez.",
-				de: "You may discard any number of basic Energy card attached to Magcargo ex when you use this attack. If you do, this attack does 40 damage plus 20 more damage for each basic Energy card you discarded."
+				de: "Du kannst eine beliebige Anzahl an Magcargo ex angelegte Basis-Energiekarten auf deinen Ablagestapel legen, wenn du diesen Angriff verwendest. Wenn du das machst, fügt dieser Angriff 40 Schadenspunkte plus 20 weitere Schadenspunkte für jede auf diese Weise abgelegte Basis-Energiekarte zu."
 			},
 			damage: "40+",
 

--- a/data/EX/Dragon/96.ts
+++ b/data/EX/Dragon/96.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Grimer",
-		fr: "Tadmorv"
+		fr: "Tadmorv",
+		de: "Sleima"
 	},
 
 	suffix: "ex",
@@ -35,12 +36,12 @@ const card: Card = {
 			name: {
 				en: "Toxic Gas",
 				fr: "Gaz chimique",
-				de: "Toxic Gas"
+				de: "Giftgas"
 			},
 			effect: {
 				en: "As long as Muk ex is your Active Pokémon, ignore all Poké-Powers and Poké-Bodies other than Toxic Gas.",
 				fr: "Tant que Grotadmorv ex est votre Pokémon Actif, ignorez tous les Poké-Powers et les Poké-Bodies autres que Puanteur.",
-				de: "As long as Muk is your active Pokémon, ignore all Poke-Powers and Poke-Bodies other than Toxic Gas."
+				de: "Solange Sleimok ex dein Aktives Pokémon ist, ignoriere jede Poké-Power und jeden Poké-Body außer Giftgas."
 			},
 		},
 	],
@@ -53,12 +54,12 @@ const card: Card = {
 			name: {
 				en: "Poison Breath",
 				fr: "Haleine empoisonnée",
-				de: "Poison Breath"
+				de: "Gifthauch"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné.",
-				de: "The Defending Pokémon is now Poisoned"
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet."
 			},
 			damage: 10,
 
@@ -72,12 +73,12 @@ const card: Card = {
 			name: {
 				en: "Slimy Water",
 				fr: "Eau gluante",
-				de: "Slimy Water"
+				de: "Glitschiges Wasser"
 			},
 			effect: {
 				en: "Does 40 damage plus 10 more damage for each Colorless Energy in the Defending Pokémon's Retreat Cost (after applying effects to the Retreat Cost).",
 				fr: "Inflige 40 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  dans le Coût de retraite du Pokémon Défenseur (après application des effets sur le Coût de retraite).",
-				de: "Does 40 damage plus 10 more damage for each  Energy in the Defending Pokémon's Retreat Cost (after applying effects to the Retreat Cost)."
+				de: "Fügt 40 Schadenspunkte plus 10 weitere Schadenspunkte für jede {C}-Energie in den Rückzugskosten des Verteidigenden Pokémon (nachdem Effekte auf die Rückzugskosten verrechnet wurden)."
 			},
 			damage: "40+",
 

--- a/data/EX/Dragon/97.ts
+++ b/data/EX/Dragon/97.ts
@@ -32,12 +32,12 @@ const card: Card = {
 			name: {
 				en: "Spiral Growth",
 				fr: "Croissance en spirale",
-				de: "Spiral Growth"
+				de: "Spiralwachstum"
 			},
 			effect: {
 				en: "Flip a coin until you get tails. For each heads, search your discard pile for a basic Energy card and attach it to Rayquaza ex.",
 				fr: "Lancez une pièce jusqu'à ce que vous obteniez pile. Pour chaque face, cherchez dans votre deck une carte Énergie de base et attachez-la à Rayquaza ex.",
-				de: "Flip a coin until you get tails. For each heads, search your descard pile for a Energy card and attach it to Rayquaza ex."
+				de: "Wirf 1 Münze, bis du „Zahl“ wirfst. Jedesmal, wenn die Münze „Kopf“ zeigt, durchsuche deinen Ablagestapel nach 1 Basis-Energiekarte und lege sie an Rayquaza ex an."
 			},
 
 		},
@@ -49,12 +49,12 @@ const card: Card = {
 			name: {
 				en: "Dragon Burst",
 				fr: "Jet de dragon",
-				de: "Dragon Burst"
+				de: "Drachensalve"
 			},
 			effect: {
 				en: "Discard either all Fire Energy or all Lightning Energy attached to Rayquaza ex. This attack does 40 damage times the amount of Fire or Lightning Energy discarded.",
 				fr: "Défaussez soit toutes les Énergies  soit toutes les Énergies  attachées à Rayquaza ex. Cette attaque inflige 40 dégâts multipliés par le nombre d'Énergie  ou  défaussées.",
-				de: "Discard either all  Energy or all  Energy attached to Rayquaza ex. This attack does 40 damage times the amount of  or  Energy discarded."
+				de: "Entferne entweder jede {R}-Energie oder jede {L}-Energie, die an Rayquaza ex angelegt ist, und lege sie auf deinen Ablagestapel. Dieser Angriff fügt für jede auf diese Weise abgelegte Energie 40 Schadenspunkte zu."
 			},
 			damage: "40×",
 

--- a/data/EX/Dragon/98.ts
+++ b/data/EX/Dragon/98.ts
@@ -31,7 +31,7 @@ const card: Card = {
 			name: {
 				en: "Flare",
 				fr: "Intimidation",
-				de: "Flare"
+				de: "Flackern"
 			},
 
 			damage: 10,
@@ -45,12 +45,12 @@ const card: Card = {
 			name: {
 				en: "Rage",
 				fr: "Frénésie",
-				de: "Rage"
+				de: "Raserei"
 			},
 			effect: {
 				en: "Does 10 damage plus 10 more damage for each damage counter on Charmander.",
 				fr: "Inflige 10 dégâts plus 10 dégâts supplémentaires pour chaque marqueur de dégât sur Salamèche.",
-				de: "Does 10 damage plus 10 more damage for each damage counter on Charmander"
+				de: "Fügt 10 Schadenspunkte plus 10 weitere Schadenspunkte für jede Schadensmarke auf Glumanda zu."
 			},
 			damage: "10+",
 

--- a/data/EX/Dragon/99.ts
+++ b/data/EX/Dragon/99.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Charmander",
-		fr: "Salamèche"
+		fr: "Salamèche",
+		de: "Glumanda"
 	},
 
 	stage: "Stage1",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Smokescreen",
 				fr: "Brouillard",
-				de: "Smokescreen"
+				de: "Rauchwolke"
 			},
 			effect: {
 				en: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
 				fr: "Si le Pokémon Défenseur essaye d'attaquer lors du prochain tour de votre adversaire, celui-ci lance une pièce. Si c'est face, cette attaque est sans effet.",
-				de: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flip a coin. if tails, that attack does nothing."
+				de: "Falls das verteidigende Pokémon während des nächsten gegnerischen Zuges anzugreifen versucht, wirft dein Gegner 1 Münze. Bei „Zahl“ fügt dieser Angriff keine Schadenspunkte zu."
 			},
 			damage: 10,
 
@@ -54,12 +55,12 @@ const card: Card = {
 			name: {
 				en: "Fireworks",
 				fr: "Feux d'artifices",
-				de: "Fireworks"
+				de: "Feuerwerk"
 			},
 			effect: {
 				en: "Flip a coin. If tails, discard a Fire Energy card attached to Charmeleon.",
 				fr: "Lancez une pièce. Si c'est pile, défaussez une carte Énergie  attachée à Reptincel.",
-				de: "Flip a coin. If tails, discard a  Energy card attached to Charmeleon."
+				de: "Wirf 1 Münze. Entferne bei „Zahl“ eine {R}-Energiekarte von Glutexo."
 			},
 			damage: 40,
 


### PR DESCRIPTION
## Add missing German translations for ex3

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
