### PR TITLE
Add missing German translations for dp1

### DIFF
--- a/data/Diamond & Pearl/Diamond & Pearl/1.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/1.ts
@@ -82,7 +82,8 @@ const card: Card = {
 
 	description: {
 		en: "It has the power to control time. It appears in Sinnoh-region myths as an ancient deity.",
-		fr: "Il peut contrôler le temps. Les mythes de Sinnoh en parlent comme d'une divinité ancienne."
+		fr: "Il peut contrôler le temps. Les mythes de Sinnoh en parlent comme d'une divinité ancienne.",
+		de: "Es besitzt die Macht, die Zeit zu kontrollieren. In den Mythen von Sinnoh erscheint es als Gottheit."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/10.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/10.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Misdreavus",
 		fr: "Feuforêve",
+		de: "Traunfugil"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Count the number of your Pokémon that have any damage counters on them. Put that many damage counters on the Defending Pokémon.",
 				fr: "Comptabilisez le nombre de vos Pokémon possédant des marqueurs de dégât. Placez autant de marqueurs de dégât sur le Pokémon Défenseur.",
-				de: "Zähle die anzahl deiner Pokémon, auf denen Schadensmarken liegen. Lege die gleiche Anzahl Schadensmarken auf das Verteidigende Pokémon."
+				de: "Zähle die Anzahl deiner Pokémon, auf denen Schadensmarken liegen. Lege die gleiche Anzahl Schadensmarken auf das Verteidigende Pokémon."
 			},
 
 		},
@@ -86,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "Its cries sound like incantations. Those hearing it are tormented by headaches and hallucinations.",
+		de: "Seine Rufe klingen wie Beschwörungen. Die, die sie hören, kriegen Kopfschmerzen und Halluzinationen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/100.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/100.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl 'Kopf' zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10x",
 
@@ -80,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "It feeds on eggs stolen from nests. Its sharply hooked claws rip vulnerable spots on prey.",
-		fr: "Il se nourrit d'œufs volés dans des nids. Ses griffes crochues percent les défenses de l'ennemi."
+		fr: "Il se nourrit d'œufs volés dans des nids. Ses griffes crochues percent les défenses de l'ennemi.",
+		de: "Es ernährt sich von Eiern, die es aus Nestern stiehlt. Beute greift es mit seinen scharfen Krallen an."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/101.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/101.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -77,7 +77,8 @@ const card: Card = {
 
 	description: {
 		en: "They flock in great numbers. Though small, they flap their wings with great power.",
-		fr: "Ils volent en nombre. Bien que minuscule, il bat des ailes avec une vigueur impressionnante."
+		fr: "Ils volent en nombre. Bien que minuscule, il bat des ailes avec une vigueur impressionnante.",
+		de: "Ihr Schwarm ist stets groß. Obwohl es kleine PKMN sind, schwingen sie ihre Flügel mit enormer Kraft."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/102.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/102.ts
@@ -77,7 +77,8 @@ const card: Card = {
 
 	description: {
 		en: "It protects itself by spraying a noxious fluid from its rear. The stench lingers for 24 hours.",
-		fr: "Il se protège en expulsant un fluide nocif par son derrière. La puanteur dure 24 heures."
+		fr: "Il se protège en expulsant un fluide nocif par son derrière. La puanteur dure 24 heures.",
+		de: "Um sich zu schützen, versprüht es eine Substanz aus seinem Hinterleib, die 24 Stunden stinkt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/103.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/103.ts
@@ -70,7 +70,8 @@ const card: Card = {
 
 	description: {
 		en: "Made from soil, the shell on its back hardens when it drinks water. It lives along lakes.",
-		fr: "La coquille sur son dos est faite de terre. Elle durcit lorsqu'il s'abreuve. Il vit le long des lacs."
+		fr: "La coquille sur son dos est faite de terre. Elle durcit lorsqu'il s'abreuve. Il vit le long des lacs.",
+		de: "Es besteht aus Erdreich. Trinkt es Wasser, verhärtet sich der Panzer auf seinem Rücken. Es lebt an Seen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/104.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/104.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei 'Kopf' fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 10,
 
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "It loves to eat leaves. If it is attacked by a STARLY, it will defend itself with its spiked rear.",
-		fr: "Il adore manger des feuilles. Si un Etourmi l'attaque, il riposte avec les piquants de son postérieur."
+		fr: "Il adore manger des feuilles. Si un Etourmi l'attaque, il riposte avec les piquants de son postérieur.",
+		de: "Es isst am liebsten Blätter. Wird es von einem STARALILI angegriffen, verteidigt es sich mit Stacheln."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/106.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/106.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Flip 3 coins. For each heads, put a basic Energy card from your discard pile into your hand. If you don't have that many basic Energy cards in your discard pile, put all of them into your hand.",
 		fr: "Lancez trois pièces. Chaque fois que c'est face, prenez une carte Énergie de base dans votre pile de défausse, montrez-la à votre adversaire et placez-la dans votre main. Si vous n'avez pas suffisamment de cartes Énergie dans votre pile de défausse, placez toutes vos cartes Énergie dans votre main.",
-		de: "Wirf 3 Münzen. Nimme für jedes Mal, wenn die Münze 'Kopf' gezeigt hat, eine Basis-Energiekarte von deinem Ablagestapel auf deine Hand. Falls du nicht genug Basis-Energiekarten in deinem Ablagestapel hast, nimm so viele wie möglich auf deine Hand."
+		de: "Wirf 3 Münzen. Nimm für jedes Mal, wenn die Münze „Kopf“ gezeigt hat, eine Basis-Energiekarte von deinem Ablagestapel auf deine Hand. Falls du nicht genug Basis-Energiekarten in deinem Ablagestapel hast, nimm so viele wie möglich auf deine Hand."
 	},
 
 	trainerType: "Item",

--- a/data/Diamond & Pearl/Diamond & Pearl/108.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/108.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Choose 1 of your Pokémon. Flip 2 coins. If both are heads, remove all damage counters from that Pokémon. If both are tails, discard all Energy cards attached to that Pokémon.",
 		fr: "Choisissez 1 de vos Pokémon. Lancez 2 pièces. Si ce sont deux faces, retirez à ce Pokémon tous ses marqueurs de dégât. Si ce sont deux piles, défaussez toutes les cartes Énergie attachées à ce Pokémon.",
-		de: "Wähle 1 deiner Pokémon. Wirf 2 Münzen. Wenn beide 'Kopf' gezeigt haben, entferne alle Schadensmarken von diesem Pokémon. Wenn beide 'Zahl' gezeigt haben, lege alle Energiekarten, die an dieses Pokémon angelegt sind, auf deinen Ablagestapel."
+		de: "Wähle 1 deiner Pokémon. Wirf 2 Münzen. Wenn beide „Kopf“ gezeigt haben, entferne alle Schadensmarken von diesem Pokémon. Wenn beide „Zahl“ gezeigt haben, lege alle Energiekarten, die an dieses Pokémon angelegt sind, auf deinen Ablagestapel."
 	},
 
 	trainerType: "Item",

--- a/data/Diamond & Pearl/Diamond & Pearl/109.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/109.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Attach PlusPower to 1 of your Pokémon. Discard this card at the end of your turn. If the Pokémon PlusPower is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance).",
 		fr: "Attachez PlusPower à 1 de vos Pokémon. Défaussez cette carte à la fin de votre tour. Pokémon auquel PlusPower est attachée attaque, cette attaque inflige 10 dégâts supplémentaires au Pokémon Actif (avant application de la Faiblesse et de la Résistance).",
-		de: "Lege PlusPower an 1 deiner Pokémon an und lege die Karte am Ende deines Zuges auf deinen Ablagestapel.Falls das Pokémon, an das PlusPower angelegt ist, angreift, fügt der Angriff den Aktiven Pokémon 10 weitere Schadesnpunkte zu (bevor Schwäche und Resistenz verrechnet werden).",
+		de: "Lege PlusPower an 1 deiner Pokémon an und lege die Karte am Ende deines Zugs auf deinen Ablagestapel. Falls das Pokémon, an das PlusPower angelegt ist, angreift, fügt der Angriff den Aktiven Pokémon 10 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden).",
 	},
 
 	trainerType: "Item",

--- a/data/Diamond & Pearl/Diamond & Pearl/11.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/11.ts
@@ -57,7 +57,7 @@ const card: Card = {
 			effect: {
 				en: "You may flip a coin. If heads, discard all Energy attached to Palkia and put the Defending Pokémon and all cards attached to it on top of your opponent's deck. Your opponent shuffles his or her deck afterward.",
 				fr: "Vous pouvez lancer une pièce. Si c'est face, défaussez toutes les Énergies attachées à Palkia et placez le Pokémon Défenseur ainsi que toutes les cartes qui lui sont attachées au dessus du deck de votre adversaire. Ensuite, votre adversaire mélange son deck.",
-				de: "Du kannst 1 Münze werfen. Bei 'Kopf' lege alle Energien, die an Palkia angelegt sind, auf deinen Ablagestapel. Danach lege das Verteidigende Pokémon und alle an es angelegten Karten auf das Deck deines Gegners. Dein Gegner mischt sein Deck danach."
+				de: "Du kannst 1 Münze werfen. Bei „Kopf“ lege alle Energien, die an Palkia angelegt sind, auf deinen Ablagestapel. Danach lege das Verteidigende Pokémon und alle an es angelegten Karten auf das Deck deines Gegners. Dein Gegner mischt sein Deck danach."
 			},
 			damage: 40,
 
@@ -75,7 +75,8 @@ const card: Card = {
 
 	description: {
 		en: "It has the ability to distort space. It is described as a deity in Sinnoh-region mythology.",
-		fr: "Il peut modeler l'espace. Les mythes de Sinnoh en parlent comme d'une divinité ancienne."
+		fr: "Il peut modeler l'espace. Les mythes de Sinnoh en parlent comme d'une divinité ancienne.",
+		de: "Es hat die Macht, den Raum zu krümmen. In den Mythen von Sinnoh erscheint es als Gottheit."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/110.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/110.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Flip a coin. If heads, search your deck for a Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
 		fr: "Lancez une pièce. Si c'est face, choisissez 1 Pokémon dans votre deck, montrez-le à votre adversaire et placez-le dans votre main. Ensuite, mélangez votre deck.",
-		de: "Wirf 1 Münze. Bei \"Kopf\" durchsuche dein Deck nach einer Basis-Pokémon-Karte oder einer Evolutionskarte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
+		de: "Wirf 1 Münze. Bei „Kopf“ durchsuche dein Deck nach einer Pokémon-Karte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 	},
 
 	trainerType: "Item",

--- a/data/Diamond & Pearl/Diamond & Pearl/112.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/112.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Choose 1 card in your hand and shuffle the rest of your cards into your deck. Then, draw 4 cards. (If this is the only card in your hand, you can't play this card.)",
 		fr: "Choisissez 1 carte de votre main et mélangez le reste de vos cartes à votre deck. Ensuite, piochez 4 cartes. (Si c'est la seule carte que vous ayez en main, vous ne pouvez pas jouer cette carte.)",
-		de: "Wähle 1 Karte auf deiner Hand und mische alle anderen Karten auf deiner Hand zurück in dein Deck. Ziehe danach 4 Karten. (Wenn diese Karte die einzige Karte auf deiner Hand ist, kannst du sie nicht spielen.)"
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Wähle 1 Karte auf deiner Hand und mische alle anderen Karten auf deiner Hand zurück in dein Deck. Ziehe danach 4 Karten. (Wenn diese Karte die einzige Karte auf deiner Hand ist, kannst du sie nicht spielen.)"
 	},
 
 	trainerType: "Supporter",

--- a/data/Diamond & Pearl/Diamond & Pearl/113.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/113.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Reveal the top 5 cards of your deck. Your opponent chooses 3 of those cards. Put those cards into your hand and put other 2 cards on top of your deck. Shuffle your deck afterward.",
 		fr: "Retournez les 5 cartes du dessus de votre deck. Votre adversaire choisit 3 de ces cartes. Placez ces cartes dans votre main et placez les 2 autres cartes au dessus de votre deck. Ensuite, mélangez votre deck.",
-		de: "Decke die obersten 5 Karten deines Decks auf. Dein Gegner wählt 3 von diesen Karten. Nimm die gewählten Karten auf die Hand und lege die restlichen 2 Karten zurück auf dein Deck. Mische dein Deck danach."
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Decke die obersten 5 Karten deines Decks auf. Dein Gegner wählt 3 von diesen Karten. Nimm die gewählten Karten auf die Hand und lege die restlichen 2 Karten zurück auf dein Deck. Mische dein Deck danach."
 	},
 
 	trainerType: "Supporter",

--- a/data/Diamond & Pearl/Diamond & Pearl/114.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/114.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card. Once during each player's turn, the player may flip a coin until he or she gets tails. For each heads, that player draws a card.",
 		fr: "Une seule fois lors du tour de chaque joueur, le joueur peut lancer une pièce jusqu'à ce qu'il ou elle obtienne pile. Pour chaque face, ce joueur pioche une carte.",
-		de: "Einmal während seines Zuges kann jeder Spieler so lange 1 Münze werfen, bis zum ersten Mal das Ergebnis 'Zahl' kommt. Für jedes Mal, wenn die Münze 'Kopf' gezeigt hat, zieht dieser Spieler eine Karte."
+		de: "Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadion-Karte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen. Einmal während seines Zuges kann jeder Spieler so lange 1 Münze werfen, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Für jedes Mal, wenn die Münze „Kopf“ gezeigt hat, zieht dieser Spieler eine Karte."
 	},
 
 	trainerType: "Stadium",

--- a/data/Diamond & Pearl/Diamond & Pearl/115.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/115.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Flip a coin. If heads, return 1 of your Pokémon and all cards attached to it to your hand.",
 		fr: "Lancez une pièce. Si c'est face, reprenez dans votre main 1 de vos Pokémon ainsi que toutes les cartes qui lui sont attachées.",
-		de: "Wirf 1 Münze. Nimm bei 'Kopf' 1 deiner Pokémon und alle daran angelegten Karten zurück auf die Hand."
+		de: "Wirf 1 Münze. Nimm bei „Kopf“ 1 deiner Pokémon und alle daran angelegten Karten zurück auf die Hand."
 	},
 
 	trainerType: "Item",

--- a/data/Diamond & Pearl/Diamond & Pearl/12.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/12.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Rhydon",
 		fr: "Rhinoféros",
+		de: "Rizeros"
 	},
 
 	stage: "Stage2",
@@ -86,7 +87,8 @@ const card: Card = {
 
 	description: {
 		en: "It puts rocks in holes in its palms and uses its muscles to shoot them. Geodude are shot at rare times.",
-		fr: "Il bande ses muscles pour projeter des pierres ou des Racaillou depuis le creux de ses paumes."
+		fr: "Il bande ses muscles pour projeter des pierres ou des Racaillou depuis le creux de ses paumes.",
+		de: "Es legt Steine in die Löcher seiner Hände und wirft sie mit Muskelkraft. Sogar GEOROK werden verwendet."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/121.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/121.ts
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Search your discard pile for 8 Fire Energy cards, show them to your opponent, and shuffle them into your deck. (This attack does nothing if you don't have 8 Fire Energy cards in your discard pile.)",
 				fr: "Choisissez dans votre pile de défausse 8 cartes Énergie Fire, montrez-les à votre adversaire et mélangez-les à votre deck. (Cette attaque est sans effet si vous n'avez pas 8 cartes Énergie Fire dans votre pile de défausse.)",
-				de: "Durchsuche deinen Ablagestapel nach 8 -Energiekarten, zeige sie deinem Gegner und mische sie in dein Deck. (Dieser Angriff hat keine Auswirklungen, wenn weniger als 8 -Energiekarten auf deinem Ablagestapel liegen.)"
+				de: "Durchsuche deinen Ablagestapel nach 8 {R}-Energiekarten, zeige sie deinem Gegner und mische sie in dein Deck. (Dieser Angriff hat keine Auswirkungen, wenn weniger als 8 {R}-Energiekarten auf deinem Ablagestapel liegen.)"
 			},
 			damage: 150,
 

--- a/data/Diamond & Pearl/Diamond & Pearl/122.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/122.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), if you have more Prize cards left than your opponent, you may choose 1 of your opponent's Benched Pokémon and switch it with 1 of the Defending Pokémon. This power can't be used if Torterra is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), si vous possédez plus de cartes Récompense que votre adversaire, vous pouvez choisir 1 des Pokémon de Banc de votre adversaire et l'échanger avec 1 des Pokémon Défenseurs. Ce pouvoir ne peut pas être utilisé si Torterra est affecté par un État Spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) wenn du mehr Preise übrig hast als dein Gegner, kannst du 1 Pokémon auf der Bank deines Gegners wählen und es gegen 1 Verteidigendes Pokémon austauschen. Diese Poke-Power kann nicht benutzt werden, wenn Chelterrar von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff), wenn du mehr Preise übrig hast als dein Gegner, kannst du 1 Pokémon auf der Bank deines Gegners wählen und es gegen 1 Verteidigendes Pokémon austauschen. Diese Poké-Power kann nicht benutzt werden, wenn Chelterrar von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -57,7 +57,7 @@ const card: Card = {
 			effect: {
 				en: "Does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Torterra does 30 damage to itself.",
 				fr: "Inflige 30 dégâts à 1 des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.) Torterra s'inflige 30 dégâts.",
-				de: "Dieser Angriff fügt 1 Pokémon auf der Bank deines Gegners 30 Schadenspunkte zu. (Wende Schwäche und Resistenz auf der Bank nicht an.) Chelterrar fügt sich selbst 30 Schadenspunkte zu."
+				de: "Dieser Angriff fügt 1 Pokémon auf der Bank deines Gegners 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.) Chelterrar fügt sich selbst 30 Schadenspunkte zu."
 			},
 			damage: 100,
 

--- a/data/Diamond & Pearl/Diamond & Pearl/13.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/13.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Roselia",
 		fr: "Roselia",
+		de: "Roselia"
 	},
 
 	stage: "Stage1",
@@ -81,7 +82,8 @@ const card: Card = {
 
 	description: {
 		en: "It attracts prey with a sweet aroma, then downs it with thorny whips hidden in its arms.",
-		fr: "Il attire ses proies avec son doux parfum et les achève grâce aux fouets d'épines de ses bras."
+		fr: "Il attire ses proies avec son doux parfum et les achève grâce aux fouets d'épines de ses bras.",
+		de: "Mit einem süßen Duft lockt es Beute an, die es dann mit den dornigen Ranken in seinen Armen schlägt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/14.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/14.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Nuzleaf",
 		fr: "Pifeuil",
+		de: "Blanas"
 	},
 
 	stage: "Stage2",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may flip a coin. If heads, choose 1 Evolved Pokémon on your opponent's Bench, remove the highest Stage Evolution card from that Pokémon, and put it back into his or her hand. This power can't be used if Shiftry is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), si Tengalice est votre Pokémon Actif, vous pouvez lancer une pièce. Si c'est face, choisissez 1 Pokémon Évolué sur le Banc de votre adversaire, retirez-lui la carte Évolution au niveau le plus élevé et replacez-la dans sa main. Ce pouvoir ne peut pas être utilisé si Tengalice est affecté par un État Spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff), wenn Tengulist dein Aktives Pokémon ist, kannst du 1 Münze werfen. Entferne die höchste Evolutionsstufe vom gewählten Pokémon. Dein Gegner nimmt diese Karte zurück auf die Hand. Diese Poke-Power kann nicht benutzt werden, wenn Tengulist von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff), wenn Tengulist dein Aktives Pokémon ist, kannst du 1 Münze werfen. Bei „Kopf“ wähle 1 entwickeltes Pokémon auf der Bank deines Gegners. Entferne die höchste Evolutionskarte vom gewählten Pokémon. Dein Gegner nimmt diese Karte zurück auf die Hand. Diese Poké-Power kann nicht benutzt werden, wenn Tengulist von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 50 damage plus 20 more damage for each heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 50 dégâts plus 20 dégâts supplémentaires pour chaque face.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 50 Schadenspunkte plus 20 Schadenspunkte mal der Anzahl 'Kopf' zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 50 Schadenspunkte plus 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "50+",
 
@@ -86,7 +87,8 @@ const card: Card = {
 
 	description: {
 		en: "By flapping its leafy fan, it can whip up gusts of 100 ft/second that can level houses.",
-		fr: "D'un coup de sa feuille éventail, il génère des bourrasques de 30 m/s capables de souffler une maison."
+		fr: "D'un coup de sa feuille éventail, il génère des bourrasques de 30 m/s capables de souffler une maison.",
+		de: "Seine großen Fächer erzeugen Böen, die eine Geschwindigkeit von 30 m/sek erreichen können."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/15.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/15.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Stunky",
 		fr: "Moufouette",
+		de: "Skunkapuh"
 	},
 
 	stage: "Stage1",
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned. Put 2 damage counters instead of 1 on the Defending Pokémon between turns.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Empoisonné. Placez 2 marqueurs de dégât au lieu d'1 sur le Pokémon Défenseur entre deux tours.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt vergiftet. Lege zwischen den Zügen 2 Schadensmarken anstelle von 1 Schadensmarke auf das Verteidigende Pokémon."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet. Lege zwischen den Zügen 2 Schadensmarken anstelle von 1 Schadensmarke auf das Verteidigende Pokémon."
 			},
 			damage: 30,
 
@@ -87,7 +88,8 @@ const card: Card = {
 
 	description: {
 		en: "It sprays a vile-smelling fluid from the tip of its tail to attack. Its range is over 160 feet.",
-		fr: "Il attaque en projetant un liquide fétide du bout de sa queue. Il peut tirer à 50 mètres."
+		fr: "Il attaque en projetant un liquide fétide du bout de sa queue. Il peut tirer à 50 mètres.",
+		de: "Über seine Schweifspitze versprüht es eine übelriechende Substanz. Die Reichweite liegt bei über 50 Metern."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/16.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/16.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Staravia",
 		fr: "Etourvol",
+		de: "Staravia"
 	},
 
 	stage: "Stage2",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing. If heads, prevent all damage done to Staraptor by attacks (both yours and your opponent's) until the end of your next turn.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet. Si c'est face, prévenez tous les dégâts infligés à Etouraptor par des attaques (les vôtres et celles de votre adversaire) jusqu'à la fin de votre prochain tour.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen. Bei \"Kopf\" verhindere alle Schadenspunkte, die Staraptor durch Angriffe von Pokémon (deine und die deines Gegners) bis zum Ende deines nächsten Zuges zugefügt werden."
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen. Bei „Kopf“ verhindere alle Schadenspunkte, die Staraptor durch Angriffe von Pokémon (deine und die deines Gegners) bis zum Ende deines nächsten Zuges zugefügt werden."
 			},
 			damage: 30,
 
@@ -63,7 +64,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, Staraptor does 100 damage to itself.",
 				fr: "Lancez une pièce. Si c'est pile, Etouraptor s'inflige 100 dégâts.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" fügt sich Staraptor selbst 100 Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Zahl“ fügt sich Staraptor selbst 100 Schadenspunkte zu."
 			},
 			damage: 100,
 
@@ -86,7 +87,8 @@ const card: Card = {
 
 	description: {
 		en: "It has a savage nature. It will courageously challenge foes that are much larger.",
-		fr: "Un Pokémon sauvage qui a le courage de défier des ennemis beaucoup plus grands que lui."
+		fr: "Un Pokémon sauvage qui a le courage de défier des ennemis beaucoup plus grands que lui.",
+		de: "Es hat ein wildes Wesen. Mutig fordert es immer wieder Gegner heraus, die viel größer sind."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/17.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/17.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Grotle",
 		fr: "Boskara",
+		de: "Chelcarain"
 	},
 
 	stage: "Stage2",
@@ -45,7 +46,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 30,
 
@@ -65,7 +66,7 @@ const card: Card = {
 			effect: {
 				en: "Remove 2 damage counters from each of your Grass Pokémon.",
 				fr: "Retirez 2 marqueurs de dégât à chacun de vos Pokémon Grass.",
-				de: "Entferne 2 Schadensmarken von jedem deiner -Pokémon."
+				de: "Entferne 2 Schadensmarken von jedem deiner {G}-Pokémon."
 			},
 			damage: 60,
 
@@ -83,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "Small Pokémon occasionally gather on its unmoving back to begin building their nests.",
+		de: "Kleine PKMN fangen manchmal an, auf dem bewegungslosen Rücken Nester zu bauen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/18.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/18.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Marill",
 		fr: "Marill",
+		de: "Marill"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, prevent all damage done to Azumarill during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, prévenez tous dégâts infligés à Azumarill lors du prochain tour de votre adversaire.",
-				de: "Wirf eine Müntze. Bei \"Kopf\" verhindere alle Schaden, der Azumarill während des nächsten Zuges deines Gegners zugefügt wird."
+				de: "Wirf 1 Münze. Bei „Kopf“ verhindere allen Schaden, der Azumarill während des nächsten Zuges deines Gegners zugefügt wird."
 			},
 
 		},
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "If Azumarill has 3 or more Energy attached to it, this attack does 40 damage plus 20 more damage. If Azurill is anywhere under Azumarill, flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Si Azumarill possède au moins 3 Énergies, cette attaque inflige 40 dégâts plus 20 dégâts supplémentaires. Si Azurill se trouve sous Azumarill, lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wenn an Azumarill 3 oder mehr Energien angelegt sind, fügt dieser Angriff 40 Schadenspunkte plus 20 weitere Schadenspunkte zu. Wenn Azurill sich an beliebiger Stelle unter Azumarill befindet, wirf 1 Müntze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wenn an Azumarill 3 oder mehr Energien angelegt sind, fügt dieser Angriff 40 Schadenspunkte plus 20 weitere Schadenspunkte zu. Wenn Azurill sich an beliebiger Stelle unter Azumarill befindet, wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: "40+",
 
@@ -78,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives in rivers and lakes. In water, its coloring and patterns trick the vision of foes.",
+		de: "Es lebt in Flüssen und Seen. Im Wasser verwirrt es seine Gegner durch seine Farbe und Muster."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/19.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/19.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Silcoon",
 		fr: "Armulys",
+		de: "Schaloko"
 	},
 
 	stage: "Stage2",
@@ -89,7 +90,8 @@ const card: Card = {
 
 	description: {
 		en: "It has an aggressive nature. It stabs prey with its long, narrow mouth to drain the prey's fluids.",
-		fr: "Il est très agressif. Il pique sa proie avec son long museau étroit et absorbe sa vitalité."
+		fr: "Il est très agressif. Il pique sa proie avec son long museau étroit et absorbe sa vitalité.",
+		de: "Es besitzt ein aggressives Wesen. Es sticht seinen Rüssel in seine Beute und saugt sie aus."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/2.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/2.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Dusclops",
 		fr: "Teraclope",
+		de: "Zwirrklop"
 	},
 
 	stage: "Stage2",
@@ -85,7 +86,8 @@ const card: Card = {
 
 	description: {
 		en: "The antenna on its head captures radio waves from the world of spirits that command it to take people there.",
-		fr: "L'antenne sur sa tête capte les ondes radio du monde des esprits lui ordonnant d'y porter des gens."
+		fr: "L'antenne sur sa tête capte les ondes radio du monde des esprits lui ordonnant d'y porter des gens.",
+		de: "Die Antenne auf seinem Kopf empfängt Radiowellen aus einer anderen Dimension."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/20.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/20.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Bidoof",
 		fr: "Keunotor",
+		de: "Bidiza"
 	},
 
 	stage: "Stage1",
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "It makes its nest by damming streams with bark and mud. It is known as an industrious worker.",
-		fr: "Il construit des barrages de boue et d'écorce le long des fleuves. C'est un ouvrier de renom."
+		fr: "Il construit des barrages de boue et d'écorce le long des fleuves. C'est un ouvrier de renom.",
+		de: "Es baut sein Nest, indem es in Flüssen Dämme aus Schlamm und Ästen baut. Ein fleißiger Arbeiter."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/21.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/21.ts
@@ -57,7 +57,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed and discard an Energy card attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé et défaussez alors une carte Énergie attachée au Pokémon Défenseur.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" lege eine Energiekarte, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners und das Verteidigende Pokémon ist jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ lege eine Energiekarte, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners und das Verteidigende Pokémon ist jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -82,7 +82,8 @@ const card: Card = {
 
 	description: {
 		en: "It attracts prey with its sweet-smelling saliva, then chomps down. It takes a whole day to eat prey.",
-		fr: "Il attire sa proie avec sa salive odorante avant de la croquer. Il lui faut une journée pour l'avaler."
+		fr: "Il attire sa proie avec sa salive odorante avant de la croquer. Il lui faut une journée pour l'avaler.",
+		de: "Sein süßlich riechender Speichel zieht Beute an, die es frisst. Es braucht einen Tag, sie zu fressen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/22.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/22.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Clefairy",
 		fr: "Melofée",
+		de: "Piepi"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 30 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Müntzen. Dieser Angrif fügt 30 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "30x",
 
@@ -63,7 +64,7 @@ const card: Card = {
 			effect: {
 				en: "Choose 1 of the Defending Pokémon's attacks. Metronome copies that attack except for its Energy cost. (You must still do anything else in order to use that attack.) Clefable performs that attack.",
 				fr: "Choisissez 1 des attaques du Pokémon Défenseur. Métronome copie cette attaque, son Coût en Énergie excepté. (Vous devez toujours faire ce que l'attaque indique.) Melodelfe utilise cette attaque.",
-				de: "Wähle 1 Angriff des Verteidigenden Pokémon. Metronom kopiert diesen Angriff, mit Ausnahme der Energiekosten. (Du musst immer noch alles zun, was verlangt wird, um diesen Angriff durchzuführen). Pixi führt diesen Angriff aus."
+				de: "Wähle 1 Angriff des Verteidigenden Pokémon. Metronom kopiert diesen Angriff, mit Ausnahme der Energiekosten. (Du musst immer noch alles tun, was verlangt wird, um diesen Angriff durchzuführen.) Pixi führt diesen Angriff aus."
 			},
 
 		},
@@ -80,7 +81,8 @@ const card: Card = {
 
 	description: {
 		en: "Rarely seen by people, it is said to be drawn by the full moon to play at deserted lakes.",
-		fr: "Il joue au bord des lacs déserts les soirs de pleine lune. Rares sont ceux qui l'ont aperçu."
+		fr: "Il joue au bord des lacs déserts les soirs de pleine lune. Rares sont ceux qui l'ont aperçu.",
+		de: "Man bekommt es selten zu sehen. Bei Vollmond soll es an den Ufern einsam gelegener Seen spielen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/23.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/23.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Skorupi",
 		fr: "Drapion",
+		de: "Pionskora"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts plus 20 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei 'Kopf' fügt dieser Angriff 20 Schadenspunkte plus 20 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -81,7 +82,8 @@ const card: Card = {
 
 	description: {
 		en: "It has the power in its clawed arms to make scrap of a car. The tips of its claws release poison.",
-		fr: "Il peut réduire une voiture en pièces avec ses pinces. Le bout de ses pinces contient du poison."
+		fr: "Il peut réduire une voiture en pièces avec ses pinces. Le bout de ses pinces contient du poison.",
+		de: "In seinen Armen steckt so viel Kraft, dass es mit seinen giftigen Krallen Autos zerquetschen kann."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/24.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/24.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Drifloon",
 		fr: "Baudrive",
+		de: "Driftlon"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Search your discard pile for up to 5 in any combination of Pokémon and Supporter cards. Show them to your opponent and shuffle them into your deck.",
 				fr: "Choisissez dans votre pile de défausse n'importe quelle combinaison de jusqu'à 5 Pokémon et cartes Supporter. Montrez-les à votre adversaire et mélangez-les à votre deck.",
-				de: "Durchsuche deinen Ablagestapel nach bis zu 5 Karten in beliebiger Kombination aus Pokémon und Unterstützungskarten. Zeige sie deinem Gegener und mische sie in dein Deck."
+				de: "Durchsuche deinen Ablagestapel nach bis zu 5 Karten in beliebiger Kombination aus Pokémon- und Unterstützerkarten. Zeige sie deinem Gegner und mische sie in dein Deck."
 			},
 
 		},
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à chaque Pokémon de Banc (les vôtres et ceux de votre adversaire). (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Dieser Angriff fügt allen Pokémon auf der Bank (deinen und deines Gegners) 10 Schadenspunkte zu. (Wenn Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Dieser Angriff fügt allen Pokémon auf der Bank (deinen und denen deines Gegners) 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 60,
 
@@ -84,7 +85,8 @@ const card: Card = {
 
 	description: {
 		en: "It's drowzy in daytime, but flies off in the evening in big groups. No one knows where they go.",
-		fr: "Il somnole la journée et s'envole en grands groupes le soir venu. Nul ne sait où ils vont."
+		fr: "Il somnole la journée et s'envole en grands groupes le soir venu. Nul ne sait où ils vont.",
+		de: "Tagsüber treibt es faul vor sich hin, nachts fliegt es mit anderen umher. Niemand weiß wohin."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/25.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/25.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cascoon",
 		fr: "Blindalys",
+		de: "Panekon"
 	},
 
 	stage: "Stage2",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Müntze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 30,
 
@@ -64,7 +65,7 @@ const card: Card = {
 			effect: {
 				en: "The Defending Pokémon is now Poisoned. Put 2 damage counters instead of 1 on the Defending Pokémon between turns.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné. Placez 2 marqueurs de dégât au lieu d'1 sur le Pokémon Défenseur entre deux tours.",
-				de: "Das Verteidigende Pokémon ist jetzt vergiftet. Lege zwischen den Zügen 2 Schadensmarken anstelle von 1 Schadensmarke auf das Verteidigende Pokémon"
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet. Lege zwischen den Zügen 2 Schadensmarken anstelle von 1 Schadensmarke auf das Verteidigende Pokémon."
 			},
 			damage: 50,
 
@@ -82,7 +83,8 @@ const card: Card = {
 
 	description: {
 		en: "A nocturnal Pokémon. Drawn by streetlights, they messily eat the leaves of trees lining boulevards.",
-		fr: "Ce Pokémon nocturne est attiré par les lueurs de la ville et aime les feuilles des arbres urbains."
+		fr: "Ce Pokémon nocturne est attiré par les lueurs de la ville et aime les feuilles des arbres urbains.",
+		de: "Nachtaktives PKMN, das vom Licht der Stadt angezogen wird und dort die Blätter der Bäume frisst."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/26.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/26.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Buizel",
 		fr: "Mustébouée",
+		de: "Bamelin"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, défaussez une Énergie attachée au Pokémon Défenseur.",
-				de: "Wirf 1 Münze. Bei 'Kopf' lege eine Energie, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
+				de: "Wirf 1 Münze. Bei „Kopf“ lege eine Energie, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
 			},
 			damage: 30,
 
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "Does 40 damage plus 20 more damage for each Water Energy attached to Floatzel but not used to pay for this attack's Energy cost. You can't add more than 40 damage in this way.",
 				fr: "Inflige 40 dégâts plus 20 dégâts supplémentaires pour chaque Énergie Water attachée à Mustéflott qui n'a pas été utilisée pour payer le Coût en Énergie de cette attaque. Vous ne pouvez pas ajouter plus de 40 dégâts de cette façon.",
-				de: "Dieser Angriff fügt 40 Schadenspunkte plus 20 weitere Schadenpunkte für jede an Bojelin angelegte -Energie zu, die nicht zum Bezahlen der Energiekosten für diesen Angriff verwendet wurde. Es lassen sich so nicht mehr als 40 Schadenspunkte hinzufügen."
+				de: "Dieser Angriff fügt 40 Schadenspunkte plus 20 weitere Schadenspunkte für jede an Bojelin angelegte {W}-Energie zu, die nicht zum Bezahlen der Energiekosten für diesen Angriff verwendet wurde. Es lassen sich so nicht mehr als 40 Schadenspunkte hinzufügen."
 			},
 			damage: "40+",
 
@@ -80,7 +81,8 @@ const card: Card = {
 
 	description: {
 		en: "It floats using its well-developed floatation sac. It assists in the rescues of drowning people.",
-		fr: "Il flotte grâce à sa bouée très développée. Il vole au secours des gens sur le point de se noyer."
+		fr: "Il flotte grâce à sa bouée très développée. Il vole au secours des gens sur le point de se noyer.",
+		de: "Es treibt mithilfe einer Art Rettungsring auf dem Wasser und hilft dem, der zu ertrinken droht."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/27.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/27.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Haunter",
 		fr: "Spectrum",
+		de: "Alpollo"
 	},
 
 	stage: "Stage2",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, put damage counters on the Defending Pokémon until it is 10 HP away from being Knocked Out.",
 				fr: "Lancez une pièce. Si c'est face, placez des marqueurs de dégât sur le Pokémon Défenseur jusqu'à ce qu'il ne soit plus qu'à 10 PV d'être mis K.O.",
-				de: "Wirf 1 Münze. Bei 'Kopf' lege so viele Schadensmarken auf das Verteidigende Pokémon, dass es nur noch 10 Schadenspunkte davon entfernt ist, kampfunfähig zu sein."
+				de: "Wirf 1 Münze. Bei „Kopf“ lege so viele Schadensmarken auf das Verteidigende Pokémon, dass es nur noch 10 Schadenspunkte davon entfernt ist, kampfunfähig zu sein."
 			},
 
 		},
@@ -85,7 +86,8 @@ const card: Card = {
 
 	description: {
 		en: "It hides in shadows. It is said that if Gengar is hiding, it cools that area by nearly 10 degrees F.",
-		fr: "On dit que lorsqu'Ectoplasma se cache dans l'ombre, la température alentour chute de 5°C."
+		fr: "On dit que lorsqu'Ectoplasma se cache dans l'ombre, la température alentour chute de 5°C.",
+		de: "Es versteckt sich im Schatten. Man sagt, wenn sich ein GENGAR versteckt, kühlt es sich um 5 Grad ab."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/28.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/28.ts
@@ -56,7 +56,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 damage plus 30 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts plus 30 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei 'Kopf' fügt dieser Angriff 30 Schadenspunkte plus 30 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 Schadenspunkte plus 30 weitere Schadenspunkte zu."
 			},
 			damage: "30+",
 
@@ -74,7 +74,8 @@ const card: Card = {
 
 	description: {
 		en: "It gathers in forests to search for tree sap, its favorite food. It's strong enough to hurl foes.",
-		fr: "Il arpente la forêt en quête de sève, son mets favori. Il est assez fort pour projeter l'ennemi."
+		fr: "Il arpente la forêt en quête de sève, son mets favori. Il est assez fort pour projeter l'ennemi.",
+		de: "Auf der Suche nach Baumsaft durchstreift es die Wälder. Es ist stark genug, um Gegner wegzuschleudern."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/29.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/29.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Hippopotas",
 		fr: "Hippopotas",
+		de: "Hippopotas"
 	},
 
 	stage: "Stage1",
@@ -90,7 +91,8 @@ const card: Card = {
 
 	description: {
 		en: "It blasts internally stored sand from ports on its body to create a towering twister for attack.",
-		fr: "Il emmagasine du sable qu'il expulse en tornades par les pores de sa peau pour attaquer."
+		fr: "Il emmagasine du sable qu'il expulse en tornades par les pores de sa peau pour attaquer.",
+		de: "Es wirbelt im Körper gespeicherten Sand durch Öffnungen und generiert so einen Sandwirbelsturm."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/3.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/3.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Electabuzz",
 		fr: "Elektek",
+		de: "Elektek"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "As often as you like during your turn (before your attack), if Elekid is anywhere under Electivire, you may move a Lightning Energy attached to 1 of your Pokémon to Electivire. This power can't be used if Electivire is affected by a Special Condition.",
 				fr: "Autant de fois que vous le voulez lors de votre tour (avant votre attaque), si Elekid se trouve sous Elekable, vous pouvez déplacer une Énergie Lightning attachée à votre Pokémon et la placer sur Elekable. Ce pouvoir ne peut pas être utilisé si Elekable est affecté par un État Spécial.",
-				de: "Beliebig oft,während deines Zuges (vor deinem Angriff) kannst du, wenn Elekid sich an beliebiger Stelle unter Elevoltek befindet, 1  Energie, die an 1 deiner Pokémon angelegt ist, an Elevoltek anlegen. Diese Poke-Power kann nicht benutz werden, wenn Elevoltek von einem Speziellen Zustand betrofen ist."
+				de: "Beliebig oft während deines Zuges (vor deinem Angriff) kannst du, wenn Elekid sich an beliebiger Stelle unter Elevoltek befindet, 1 {L}-Energie, die an 1 deiner Pokémon angelegt ist, an Elevoltek anlegen. Diese Poké-Power kann nicht benutzt werden, wenn Elevoltek von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "You may discard all  Lightning Energy attached to Electivire. If you do, this attack's base damage is 120 instead of 60.",
 				fr: "Vous pouvez défausser toutes les Énergies Lightning attachées à Elekable. Les dégâts de base de cette attaque sont alors de 120 au lieu de 60.",
-				de: "Du kannst alle  Energien, die an Elevoltek angelegt sind, auf deinen Ablagestapel legen. Wenn du das machst, beträgt der Grundschaden dieses Angriffs 120 Schadenspunkte anstelle von 60 Schadenspunkten."
+				de: "Du kannst alle {L}-Energien, die an Elevoltek angelegt sind, auf deinen Ablagestapel legen. Wenn du das machst, beträgt der Grundschaden dieses Angriffs 120 Schadenspunkte anstelle von 60 Schadenspunkten."
 			},
 			damage: 60,
 
@@ -87,7 +88,8 @@ const card: Card = {
 
 	description: {
 		en: "It pushes the tips of its two tails against the foe, then lets loose with over 20,000 volts of power.",
-		fr: "Il place le bout de ses deux queues sur son ennemi et libère une décharge de 20 000 volts."
+		fr: "Il place le bout de ses deux queues sur son ennemi et libère une décharge de 20 000 volts.",
+		de: "Es berührt den Gegner mit seinen beiden Schweifspitzen und entlädt dann über 20 000 Volt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/30.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/30.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Buneary",
 		fr: "Laporeille",
+		de: "Haspiror"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin until you get tails. Remove a number of damage counters equal to the number of heads from 1 of your Pokémon.",
 				fr: "Lancez une pièce jusqu'à ce que vous obteniez pile. Retirez à 1 de vos Pokémon autant de marqueurs de dégât que vous obtenez de faces.",
-				de: "Wirf so lange 1 Münze, bis zum ersten Mal das Ergebnis 'Zahl' kommt. Entferne für jedes Mal, wenn die Münze 'Kopf' gezeigt hat, 1 Schadensmarke von 1 deiner Pokémon."
+				de: "Wirf so lange 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Entferne für jedes Mal, wenn die Münze „Kopf“ gezeigt hat, 1 Schadensmarke von 1 deiner Pokémon."
 			},
 
 		},
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "An extremely cautious Pokémon. It cloaks its body with its fluffy ear fur when it senses danger.",
-		fr: "Un Pokémon extrêmement prudent. Il couvre son corps de ses oreilles pelucheuses en cas de danger."
+		fr: "Un Pokémon extrêmement prudent. Il couvre son corps de ses oreilles pelucheuses en cas de danger.",
+		de: "Ein sehr vorsichtiges PKMN. Nimmt es Gefahr wahr, schützt es seinen Körper mit seinen weichen Ohren."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/31.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/31.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Machoke",
 		fr: "Machopeur",
+		de: "Maschock"
 	},
 
 	stage: "Stage2",
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 60 damage plus 30 more damage and the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 60 dégâts plus 30 dégâts supplémentaires et le Pokémon Défenseur est maintenant Confus.",
-				de: "Wirf 1 Münze. Bei 'Kopf' fügt dieser Angriff 60 Schadenspunkte plus 30 weitere Schadenspunkte zu und das Verteidigende Pokémon ist jetzt verwirrt."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 60 Schadenspunkte plus 30 weitere Schadenspunkte zu und das Verteidigende Pokémon ist jetzt verwirrt."
 			},
 			damage: "60+",
 
@@ -80,7 +81,8 @@ const card: Card = {
 
 	description: {
 		en: "It punches with its four arms at blinding speed. It can launch 1,000 punches in two seconds.",
-		fr: "Ses quatre bras frappent à une vitesse aveuglante. Il peut porter 1000 coups en deux secondes."
+		fr: "Ses quatre bras frappent à une vitesse aveuglante. Il peut porter 1000 coups en deux secondes.",
+		de: "Mit seinen vier Armen schlägt es blitzschnell zu. Es kann in zwei Sekunden 1 000-mal zuschlagen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/32.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/32.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Meditite",
 		fr: "Meditikka",
+		de: "Meditie"
 	},
 
 	stage: "Stage1",
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "Through yoga training, it has honed its sixth sense. Its movements are elegant.",
-		fr: "Il a développé son sixième sens grâce au yoga. Ses mouvements sont gracieux."
+		fr: "Il a développé son sixième sens grâce au yoga. Ses mouvements sont gracieux.",
+		de: "Mit Yoga-Training hat es seinen 6. Sinn geschärft. Seine Bewegungen sind sehr elegant."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/33.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/33.ts
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "Discard 2 cards from your hand. (If you can't discard 2 cards, this attack does nothing.) Flip 2 coins. This attack does 30 damage times the number of heads.",
 				fr: "Défaussez 2 cartes de votre main. (Si vous ne pouvez pas défausser 2 cartes, cette attaque est sans effet.) Lancez 2 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de faces.",
-				de: "Lege 2 Karten von deiner Hand auf deinen Ablagestapel. (Wenn du keine 2 Karten auf den Ablagestapel legen kannst, hat dieser Angriff keine Auswirkungen.) Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl 'Kopf' zu."
+				de: "Lege 2 Karten von deiner Hand auf deinen Ablagestapel. (Wenn du keine 2 Karten auf den Ablagestapel legen kannst, hat dieser Angriff keine Auswirkungen.) Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "30x",
 
@@ -72,7 +72,8 @@ const card: Card = {
 
 	description: {
 		en: "It wolfs down its weight in food once a day, swallowing food whole with almost no chewing.",
-		fr: "Il avale son poids en nourriture chaque jour. Il avale tout sans prendre le temps de mâcher."
+		fr: "Il avale son poids en nourriture chaque jour. Il avale tout sans prendre le temps de mâcher.",
+		de: "Einmal am Tag verschlingt es eine Nahrungsmenge, die seinem Gewicht entspricht. Und das ohne zu kauen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/34.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/34.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Hoothoot",
 		fr: "Hoothoot",
+		de: "Hoothoot"
 	},
 
 	stage: "Stage1",
@@ -38,12 +39,12 @@ const card: Card = {
 			name: {
 				en: "See Beyond",
 				fr: "Clairvoyant",
-				de: "Weitansicht"
+				de: "Weitsicht"
 			},
 			effect: {
 				en: "Choose a card from your hand and put it as a Prize card face up. Then, choose 1 of your face-down Prize cards without looking and put it into your hand. This attack does nothing if all of your Prize cards are face up.",
 				fr: "Choisissez une carte de votre main et placez-la comme carte Récompense, face retournée. Choisissez alors 1 de vos cartes Récompense se trouvant face cachée et placez-la dans votre main. Cette attaque est sans effet si toutes vos cartes Récompense sont retournées.",
-				de: "Wähle eine Karte von deiner Hand und spiele sie offen als Preis. Wenn du das machst, wähle einen deiner verdeckten Preise, ohne ihn vorher anzusehen, und nimm ihn auf die Hand. Dieser Angriff hat keine Auwirkung, wenn bereits alle deine Preise offen liegen."
+				de: "Wähle eine Karte von deiner Hand und spiele sie offen als Preis. Wenn du das machst, wähle einen deiner verdeckten Preise, ohne ihn vorher anzusehen, und nimm ihn auf die Hand. Dieser Angriff hat keine Auswirkungen, wenn bereits alle deine Preise offen liegen."
 			},
 
 		},
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "If you have the same number of cards in your hand as your opponent, this attack does 30 damage plus 50 more damage.",
 				fr: "Si vous avez le même nombre de cartes en main que votre adversaire, cette attaque inflige 30 dégâts plus 50 dégâts supplémentaires.",
-				de: "Wenn du die gleiche anzahl Karten auf der Hand hast wie dein Gegner fügt dieser Angriff 30 Schadenspunkte plus 50 weitere Schadenspunkte zu."
+				de: "Wenn du die gleiche Anzahl Karten auf der Hand hast wie dein Gegner, fügt dieser Angriff 30 Schadenspunkte plus 50 weitere Schadenspunkte zu."
 			},
 			damage: "30+",
 
@@ -86,7 +87,8 @@ const card: Card = {
 
 	description: {
 		en: "Its eyes are special. They can pick out objects as long as there is the tiniest amount of light.",
-		fr: "Ses yeux sont particuliers. La plus petite source de lumière leur permet de distinguer les objets."
+		fr: "Ses yeux sont particuliers. La plus petite source de lumière leur permet de distinguer les objets.",
+		de: "Seine Augen sind etwas Besonderes. Sie können selbst bei schwächstem Licht alles erkennen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/35.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/35.ts
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, Pachirisu does 10 damage to itself.",
 				fr: "Lancez une pièce. Si c'est pile, Pachirisu s'inflige 10 dégâts.",
-				de: "Wirf 1 Müntze. Bei \"Zahl\" fügt sich Pachirisu selbst 10 Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Zahl“ fügt sich Pachirisu selbst 10 Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -79,7 +79,8 @@ const card: Card = {
 
 	description: {
 		en: "It makes fur balls that crackle with static electricity. It stores them with berries in tree holes.",
-		fr: "Il roule des boules de poils pleines d'électricité statique et les range dans des souches avec des Baies."
+		fr: "Il roule des boules de poils pleines d'électricité statique et les range dans des souches avec des Baies.",
+		de: "Es bildet ein Fellknäuel, der vor statischer Energie knistert. Es speichert die Energie in Bäumen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/36.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/36.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Glameow",
 		fr: "Chaglam",
+		de: "Charmian"
 	},
 
 	stage: "Stage1",
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 50,
 
@@ -80,7 +81,8 @@ const card: Card = {
 
 	description: {
 		en: "It is a brazen brute that barges its way into another Pokémon's nest and claims it as its own.",
-		fr: "Cette brute arrogante n'hésite pas à voler le nid d'autres Pokémon pour s'y installer."
+		fr: "Cette brute arrogante n'hésite pas à voler le nid d'autres Pokémon pour s'y installer.",
+		de: "Dieses PKMN ist ein Grobian, der sich in die Nester anderer PKMN einnistet und sie sich damit aneignet."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/37.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/37.ts
@@ -75,7 +75,8 @@ const card: Card = {
 
 	description: {
 		en: "Its stomach can digest any kind of food, even if it happens to be moldy or rotten.",
-		fr: "Son estomac peut digérer n'importe quel type de nourriture, même quand elle est moisie ou pourrie."
+		fr: "Son estomac peut digérer n'importe quel type de nourriture, même quand elle est moisie ou pourrie.",
+		de: "Sein Magen kann jede Art von Nahrung verdauen, selbst wenn sie verschimmelt und verdorben ist."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/38.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/38.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Onix",
 		fr: "Onix",
+		de: "Onix"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 30 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "30x",
 
@@ -88,7 +89,8 @@ const card: Card = {
 
 	description: {
 		en: "Tempered underground under high pressure and heat, its body is harder than any metal.",
-		fr: "Grâce à la température élevée et la haute pression souterraines, son corps est plus dur que le métal."
+		fr: "Grâce à la température élevée et la haute pression souterraines, son corps est plus dur que le métal.",
+		de: "Hoher Druck und hohe Temperaturen haben seinen Körper härter als Stahl werden lassen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/39.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/39.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Combee",
 		fr: "Apitrini",
+		de: "Wadribie"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Discard a Grass Energy attached to Vespiquen and remove all damage counters from 1 of your Benched Grass Pokémon.",
 				fr: "Défaussez une Énergie Grass attachée à Apireine et retirez à 1 de vos Pokémon de Banc Grass tous ses marqueurs de dégât.",
-				de: "Lege eine -Energie, die an Honweisel angelegt ist, auf deinen Ablagestapel und entferne danach alle Schadensmarken von 1 -Pokémon auf deiner Bank."
+				de: "Lege eine {G}-Energie, die an Honweisel angelegt ist, auf deinen Ablagestapel und entferne danach alle Schadensmarken von 1 {G}-Pokémon auf deiner Bank."
 			},
 
 		},
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Does 10 damage times the number of Grass Pokémon in play (both yours and your opponent's).",
 				fr: "Inflige 10 dégâts multipliés par le nombre de Pokémon Grass en jeu (les vôtres et ceux de votre adversaire).",
-				de: "Dieser Angriff fügt 10 Schadenspunkte für jedes -Pokémon im Spiel zu (deine und die deines Gegners)."
+				de: "Dieser Angriff fügt 10 Schadenspunkte für jedes {G}-Pokémon im Spiel zu (deine und die deines Gegners)."
 			},
 			damage: "10x",
 
@@ -86,7 +87,8 @@ const card: Card = {
 
 	description: {
 		en: "Its abdomen is a honeycomb for grubs. It raises its grubs on honey collected by COMBEE.",
-		fr: "Son abdomen est un rayon où vivent ses larves, élevées avec le nectar récolté par Apitrini."
+		fr: "Son abdomen est un rayon où vivent ses larves, élevées avec le nectar récolté par Apitrini.",
+		de: "Ihr Bauch ist die Wabe für die Larven. Sie füttert ihre Larven mit dem Honig, den WADRIBIE sammelt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/4.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/4.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Prinplup",
 		fr: "Prinplouf",
+		de: "Pliprin"
 	},
 
 	stage: "Stage2",
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts à 1 des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Wirf 1 Münze. Bei 'Kopf' fügt dieser Angriff 1 Pokémon auf der Bank deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 1 Pokémon auf der Bank deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 70,
 
@@ -80,7 +81,8 @@ const card: Card = {
 
 	description: {
 		en: "The three horns that extend from its beak attest to its power. The leader has the biggest horns.",
-		fr: "Les trois cornes de son bec sont le symbole de sa force. Celles du chef sont plus grosses que les autres."
+		fr: "Les trois cornes de son bec sont le symbole de sa force. Celles du chef sont plus grosses que les autres.",
+		de: "Die 3 Hörner, die aus dem Schnabel wachsen, stehen für Kraft. Ein Anführer hat die größten Hörner."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/40.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/40.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Sneasel",
 		fr: "Farfuret",
+		de: "Sniebel"
 	},
 
 	stage: "Stage1",
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Does 10 damage times the total amount of Darkness Energy attached to all of your Pokémon.",
 				fr: "Inflige 10 dégâts multipliés par le nombre d'Énergies Darkness attachées à tous vos Pokémon.",
-				de: "Dieser Angriff fügt für jede -Energie, die an deine Pokémon angelegt ist, 10 Schadenspunkte zu."
+				de: "Dieser Angriff fügt für jede {D}-Energie, die an deine Pokémon angelegt ist, 10 Schadenspunkte zu."
 			},
 			damage: "10x",
 
@@ -86,7 +87,8 @@ const card: Card = {
 
 	description: {
 		en: "They live in cold regions, forming groups of four or five that hunt prey with impressive coordination.",
-		fr: "Ils vivent par groupe de 4 ou 5 en région froide et chassent de façon très organisée."
+		fr: "Ils vivent par groupe de 4 ou 5 en région froide et chassent de façon très organisée.",
+		de: "Es lebt in kalten Gebieten in Gruppen von 4 oder 5 PKMN, die bei der Jagd großes Geschick zeigen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/41.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/41.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, move all damage counters from Wobbuffet to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, déplacez tous les marqueurs de dégât de Qulbutoké sur le Pokémon Défenseur.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" entferne alle Schadensmarken von Woingenau und lege sie auf das Verteidigende Pokémon."
+				de: "Wirf 1 Münze. Bei „Kopf“ entferne alle Schadensmarken von Woingenau und lege sie auf das Verteidigende Pokémon."
 			},
 
 		},
@@ -56,7 +56,8 @@ const card: Card = {
 
 	description: {
 		en: "It desperately tries to keep its black tail hidden. It is said to be proof the tail hides a secret.",
-		fr: "Il cherche désespérément à cacher sa queue noire. Certains pensent qu'elle renferme un secret."
+		fr: "Il cherche désespérément à cacher sa queue noire. Certains pensent qu'elle renferme un secret.",
+		de: "Verzweifelt versucht es, seinen schwarzen Schweif zu verstecken. Er soll ein Geheimnis enthalten."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/42.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/42.ts
@@ -69,7 +69,8 @@ const card: Card = {
 
 	description: {
 		en: "It grows strong by pushing up against others en masse. It loves eating sweet fruit.",
-		fr: "Il se muscle en bousculant ses semblables lors de mêlées. Il raffole des fruits sucrés."
+		fr: "Il se muscle en bousculant ses semblables lors de mêlées. Il raffole des fruits sucrés.",
+		de: "Es wird stärker, indem es andere ständig anrempelt. Es liebt Süßigkeiten."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/43.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/43.ts
@@ -69,7 +69,8 @@ const card: Card = {
 
 	description: {
 		en: "Over the winter, it closes its bud and endures the cold. In spring, the bud opens and releases pollen.",
-		fr: "En hiver, son bourgeon se referme pour résister au froid. Il s'ouvre au printemps et libère du pollen."
+		fr: "En hiver, son bourgeon se referme pour résister au froid. Il s'ouvre au printemps et libère du pollen.",
+		de: "Im Winter schließt es die Knospe. Im Frühjahr öffnet es die Knospe und gibt Pollen ab."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/44.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/44.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Wurmple",
 		fr: "Chenipotte",
+		de: "Waumpel"
 	},
 
 	stage: "Stage1",
@@ -78,7 +79,8 @@ const card: Card = {
 
 	description: {
 		en: "It is hot inside its cocoon. All the cells in its body create the energy for it to evolve.",
-		fr: "Il est au chaud dans son cocon. Ses cellules produisent l'énergie nécessaire à son évolution."
+		fr: "Il est au chaud dans son cocon. Ses cellules produisent l'énergie nécessaire à son évolution.",
+		de: "In seinem Kokon ist es heiß. Seine Körperzellen produzieren die Hitze, damit es sich entwickeln kann."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/45.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/45.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cherubi",
 		fr: "Ceribou",
+		de: "Kikugi"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt verwirrt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: 20,
 
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 20 more damage and remove 3 damage counters from Cherrim.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts plus 20 dégâts supplémentaires et retirez à Ceriflor 3 marqueurs de dégât.",
-				de: "Wirf 1 Münze. Bei 'Kopf' fügt dieser Angriff 20 Schadenspunkte plus 20 weitere Schadenspunkte zu und entferne 3 Schadensmarken von Kinoso."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 20 weitere Schadenspunkte zu und entferne 3 Schadensmarken von Kinoso."
 			},
 			damage: "20+",
 
@@ -86,7 +87,8 @@ const card: Card = {
 
 	description: {
 		en: "It blooms during times of strong sunlight. It tries to make up for everything it endured as a bud.",
-		fr: "Il fleurit lorsque le soleil est au beau fixe. Il cherche à prendre sa revanche sur une vie de bourgeon."
+		fr: "Il fleurit lorsque le soleil est au beau fixe. Il cherche à prendre sa revanche sur une vie de bourgeon.",
+		de: "In Zeiten mit viel Sonnenschein blüht es auf. Es holt nach, was ihm als Knospe verwehrt blieb."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/46.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/46.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, put 1 of your Benched Pokémon and all cards attached to on top of your deck. Shuffle your deck afterward.",
 				fr: "Lancez une pièce. Si c'est face, placez 1 de vos Pokémon de Banc et toutes les cartes qui lui sont attachées au dessus de votre deck. Ensuite, mélangez votre deck.",
-				de: "Wirf 1 Münze. Bei 'Kopf' lege 1 der Pokémon auf deiner Bank und alle an es angelegten Karten auf dein Deck. Mische dein Deck danach."
+				de: "Wirf 1 Münze. Bei „Kopf“ lege 1 der Pokémon auf deiner Bank und alle an es angelegten Karten auf dein Deck. Mische dein Deck danach."
 			},
 
 		},
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused and can't retreat during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus et ne peut pas battre en retraite lors du prochain tour de votre adversaire.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt verwirrt und kann sich im nächsten Zug deines Gegners nicht zurückziehen."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt und kann sich im nächsten Zug deines Gegners nicht zurückziehen."
 			},
 			damage: 10,
 
@@ -80,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon formed by the spirits of people and Pokémon. It loves damp, humid seasons.",
-		fr: "Un Pokémon né de l'esprit des gens et des Pokémon. Il aime les saisons chaudes et humides."
+		fr: "Un Pokémon né de l'esprit des gens et des Pokémon. Il aime les saisons chaudes et humides.",
+		de: "Ein PKMN, entstanden aus den Gefühlen von Menschen und PKMN. Es mag feuchte Jahreszeiten."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/47.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/47.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Duskull",
 		fr: "Skélénox",
+		de: "Zwirrlicht"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, put 2 damage counters on each of your opponent's Pokémon. If tails, put 2 damage counters on 1 of your Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, placez 2 marqueurs de dégât sur chacun des Pokémon de votre adversaire. Si c'est pile, placez 2 marqueurs de dégât sur 1 de vos Pokémon.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" lege 2 Schadensmarken auf jedes Pokémon deines Gegners. Bei \"Zahl\" lege 2 Schadensmarken auf 1 deiner Pokémon."
+				de: "Wirf 1 Münze. Bei „Kopf“ lege 2 Schadensmarken auf jedes Pokémon deines Gegners. Bei „Zahl“ lege 2 Schadensmarken auf 1 deiner Pokémon."
 			},
 
 		},
@@ -86,7 +87,8 @@ const card: Card = {
 
 	description: {
 		en: "Its body is hollow. It is said that those who look into its body are sucked into the void.",
-		fr: "Son corps est creux. On raconte que celui qui regarde à l'intérieur finira aspiré par le néant."
+		fr: "Son corps est creux. On raconte que celui qui regarde à l'intérieur finira aspiré par le néant.",
+		de: "Sein Körper ist hohl. Man sagt, dass diejenigen, die in den Körper blicken, hineingezogen werden."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/48.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/48.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Search your deck for a Lightning Energy card, show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
 				fr: "Cherchez dans votre deck une carte Énergie Lightning, montrez-la à votre adversaire et placez-la dans votre main. Ensuite, mélangez votre deck.",
-				de: "Durchsuche dein Deck nach einer -Energiekarte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
+				de: "Durchsuche dein Deck nach einer {L}-Energiekarte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 			},
 
 		},
@@ -76,7 +76,8 @@ const card: Card = {
 
 	description: {
 		en: "It generates electricity by whirling its arms. However, it can't store the energy it makes.",
-		fr: "Il génère de l'électricité en battant des bras, mais il n'a aucun moyen de stocker cette énergie."
+		fr: "Il génère de l'électricité en battant des bras, mais il n'a aucun moyen de stocker cette énergie.",
+		de: "Es bewegt seine Arme und generiert damit Elektrizität. Diese kann es aber nicht speichern."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/49.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/49.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Turtwig",
 		fr: "Tortipouss",
+		de: "Chelast"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Search your deck for a Grass Energy card and attach it to 1 of your Pokémon. Shuffle your deck afterward.",
 				fr: "Cherchez dans votre deck une carte Énergie Grass, et attachez-la à 1 de vos Pokémon. Ensuite, mélangez votre deck.",
-				de: "Durchsuche dein Deck nach einer -Energiekarte und lege sie an 1 deiner Pokémon an. Mische dein Deck danach."
+				de: "Durchsuche dein Deck nach einer {G}-Energiekarte und lege sie an 1 deiner Pokémon an. Mische dein Deck danach."
 			},
 
 		},
@@ -82,7 +83,8 @@ const card: Card = {
 
 	description: {
 		en: "It lives along water in forests. In the daytime, it leaves the forest to sunbathe its treed shell.",
-		fr: "Il vit en forêt près de l'eau. En journée, il la quitte pour dorer sa carapace feuillue au soleil."
+		fr: "Il vit en forêt près de l'eau. En journée, il la quitte pour dorer sa carapace feuillue au soleil.",
+		de: "Es lebt in der Nähe von Wasser in Wäldern. Tagsüber verlässt es diese, um ein Sonnenbad zu nehmen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/5.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/5.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Monferno",
 		fr: "Chimpenfeu",
+		de: "Panpyro"
 	},
 
 	stage: "Stage2",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin until you get tails. This attack does 30 damage times the number of heads.",
 				fr: "Lancez une pièce jusqu'à ce que vous obteniez pile. Cette attaque inflige 30 dégâts multipliés par le nombre de faces.",
-				de: "Wirf so lange 1 Münze, bis zum ersten Mal das Ergebnis \"Zahl\" kommt. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl \"Kopf\" zu"
+				de: "Wirf so lange 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "30x",
 
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Discard all Fire Energy attached to Infernape.",
 				fr: "Défaussez toutes les Énergies Fire attachées à Simiabraz.",
-				de: "Entferne alle an Panferno angelegten  Energien und lege sie auf deinen Ablagestapel"
+				de: "Entferne alle an Panferno angelegten {R}-Energien und lege sie auf deinen Ablagestapel."
 			},
 			damage: 90,
 
@@ -77,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "It uses a special kind of martial arts involving all its limbs. Its fire never goes out.",
+		de: "Es kämpft auf besondere Art, indem es alle Gliedmaßen einsetzt. Sein Feuer erlöscht nie."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/50.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/50.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gastly",
 		fr: "Fantominus",
+		de: "Nebulak"
 	},
 
 	stage: "Stage1",
@@ -83,7 +84,8 @@ const card: Card = {
 
 	description: {
 		en: "It can slip through any obstacle. It lurks inside walls to keep an eye on its foes.",
-		fr: "Il peut traverser n'importe quel obstacle. Il rôde dans les murs pour surveiller ses ennemis."
+		fr: "Il peut traverser n'importe quel obstacle. Il rôde dans les murs pour surveiller ses ennemis.",
+		de: "Es kann sich durch jedes Hindernis bewegen. Es versteckt sich in Wänden, um Gegner zu beobachten."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/51.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/51.ts
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
 				fr: "Si le Pokémon Défenseur essaye d'attaquer lors du prochain tour de votre adversaire, votre adversaire lance une pièce. Si c'est pile, cette attaque est sans effet.",
-				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei 'Zahl' hat dieser Angriff keine Auswirkungen."
+				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 10,
 
@@ -79,7 +79,8 @@ const card: Card = {
 
 	description: {
 		en: "It lives in arid places. Instead of perspiration, it expels grainy sand from its body.",
-		fr: "Il vit dans des endroits arides. Il exsude du sable granuleux au lieu de transpirer."
+		fr: "Il vit dans des endroits arides. Il exsude du sable granuleux au lieu de transpirer.",
+		de: "Es lebt in ausgetrockneten Gebieten. Statt zu schwitzen, sondert sein Körper Sand ab."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/52.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/52.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Shinx",
 		fr: "Lixy",
+		de: "Sheinux"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 30 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 30 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei 'Kopf' fügt dieser Angriff 10 Schadenspunkte plus 30 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 30 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 30,
 
@@ -84,7 +85,8 @@ const card: Card = {
 
 	description: {
 		en: "Its claws loose electricity with enough amperage to cause fainting. They live in small groups.",
-		fr: "L'électricité libérée par ses griffes peut assommer l'ennemi. Il vit en petits groupes."
+		fr: "L'électricité libérée par ses griffes peut assommer l'ennemi. Il vit en petits groupes.",
+		de: "Seine Krallen geben Elektrizität ab, die stark genug ist, jemanden bewusstlos zu machen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/53.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/53.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Machop",
 		fr: "Machoc",
+		de: "Machollo"
 	},
 
 	stage: "Stage1",
@@ -77,7 +78,8 @@ const card: Card = {
 
 	description: {
 		en: "MACHOKE's boundless power is very dangerous, so it wears a belt that suppresses its energy.",
-		fr: "La force herculéenne du Machopeur est très dangereuse. Il utilise une ceinture pour contenir son énergie."
+		fr: "La force herculéenne du Machopeur est très dangereuse. Il utilise une ceinture pour contenir son énergie.",
+		de: "MASCHOCKs unbegrenzte Kraft ist gefährlich, daher trägt es einen Gürtel, der die Kraft unterdrückt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/54.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/54.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Magnemite",
 		fr: "Magneti",
+		de: "Magnetilo"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20x",
 
@@ -88,7 +89,8 @@ const card: Card = {
 
 	description: {
 		en: "It is actually three MAGNEMITE linked by magnetism. A group can set off a magnetic storm.",
-		fr: "Il est formé de trois Magneti liés par magnétisme. En groupe, ils déclenchent un orage magnétique."
+		fr: "Il est formé de trois Magneti liés par magnétisme. En groupe, ils déclenchent un orage magnétique.",
+		de: "Eigentlich sind es drei MAGNETILO, die durch Magnetismus verbunden sind."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/55.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/55.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Search your deck for a  grass Basic Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
 				fr: "Cherchez dans votre deck un Pokémon de Base Water, montrez-le à votre adversaire et placez-le dans votre main. Ensuite, mélangez votre deck.",
-				de: "Durchsuche dein Deck nach einer -Basis-Pokémon-Karte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
+				de: "Durchsuche dein Deck nach einer {W}-Basis-Pokémon-Karte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 			},
 
 		},
@@ -76,7 +76,8 @@ const card: Card = {
 
 	description: {
 		en: "A friendly Pokémon that captures the subtle flows of seawater using its two antennae.",
-		fr: "Un Pokémon amical qui analyse les mouvements subtils de l'eau de mer grâce à ses deux antennes."
+		fr: "Un Pokémon amical qui analyse les mouvements subtils de l'eau de mer grâce à ses deux antennes.",
+		de: "Ein freundliches PKMN, das mit seinen zwei Antennen die Strömungen des Meeres erkennt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/56.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/56.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Chimchar",
 		fr: "Ouisticram",
+		de: "Panflam"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Search your discard pile for a Fire Energy card and attach it to Monferno.",
 				fr: "Chercher dans votre pile de défausse une carte Énergie Fire et attachez-la à Chimpenfeu.",
-				de: "Durchsuche deinen Ablagestapel nach einer -Energiekarte und lege sie an Panpyro an."
+				de: "Durchsuche deinen Ablagestapel nach einer {R}-Energiekarte und lege sie an Panpyro an."
 			},
 			damage: 30,
 
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl 'Kopf' zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20x",
 
@@ -77,7 +78,8 @@ const card: Card = {
 
 	description: {
 		en: "To intimidate attackers, it stretches the fire on its tail to make itself appear bigger.",
-		fr: "Pour intimider ses agresseurs, il gonfle les flammes de sa queue pour paraître plus grand."
+		fr: "Pour intimider ses agresseurs, il gonfle les flammes de sa queue pour paraître plus grand.",
+		de: "Um Angreifer abzuschrecken, verstärkt es das Feuer auf seinem Schweif, wodurch es größer wirkt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/57.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/57.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Seedot",
 		fr: "Grainipiot",
+		de: "Samurzel"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy card attached to 1 of your opponent's Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, défaussez une carte Énergie attachée à 1 des Pokémon de votre adversaire.",
-				de: "Wirf 1 Münze. Bei 'Kopf' lege 1 Energiekarte, die an 1 gegnerisches Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
+				de: "Wirf 1 Münze. Bei „Kopf“ lege 1 Energiekarte, die an 1 gegnerisches Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
 			},
 
 		},
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet.",
-				de: "Wirf 1 Münze. Bei 'Zahl' hat dieser Angriff keine Auswirkungen."
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 40,
 
@@ -85,7 +86,8 @@ const card: Card = {
 
 	description: {
 		en: "The sound of its grass flute makes its listeners uneasy. It lives deep in forests.",
-		fr: "Le son de sa flûte d'herbe déstabilise l'auditeur. Il vit au plus profond des forêts."
+		fr: "Le son de sa flûte d'herbe déstabilise l'auditeur. Il vit au plus profond des forêts.",
+		de: "Der Ton seiner Grasflöte beunruhigt die, die ihn hören. Es lebt tief in den Wäldern."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/58.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/58.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Piplup",
 		fr: "Tiplouf",
+		de: "Plinfa"
 	},
 
 	stage: "Stage1",
@@ -77,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives alone, away from others. Apparently, every one of them believes it is the most important.",
+		de: "Es lebt allein, entfernt von anderen. Jedes von ihnen denkt, es sei das bedeutendste unter ihnen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/59.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/59.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Ponyta",
 		fr: "Ponyta",
+		de: "Ponita"
 	},
 
 	stage: "Stage1",
@@ -63,7 +64,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, discard a Fire Energy attached to Rapidash and this attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Lancez une pièce. Si c'est pile, défaussez une Énergie Fire attachée à Galopa et cette attaque inflige 10 dégâts à chacun des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Wirf 1 Münze. Bei \"Zahl\" lege eine -Energie, die an Gallopa angelegt ist, auf deinen Ablagestapel und dieser Angriff fügt jedem Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Wirf 1 Münze. Bei „Zahl“ lege eine {R}-Energie, die an Gallopa angelegt ist, auf deinen Ablagestapel und dieser Angriff fügt jedem Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 50,
 
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "It gallops at nearly 150 mph. With its mane blazing ferociously, it races as if it were an arrow.",
-		fr: "Son galop dépasse les 240 km/h. Il file comme une flèche, laissant flotter sa crinière ardente."
+		fr: "Son galop dépasse les 240 km/h. Il file comme une flèche, laissant flotter sa crinière ardente.",
+		de: "Seine Mähne lodert auf, wenn es mit 240 km/h pfeilschnell galoppiert."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/6.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/6.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Riolu",
 		fr: "Riolu",
+		de: "Riolu"
 	},
 
 	stage: "Stage1",
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 20 dégâts à 1 des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Dieser Angriff fügt 1 Pokémon auf der Bank deines Gegeners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Dieser Angriff fügt 1 Pokémon auf der Bank deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 40,
 
@@ -79,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It has the ability to sense the auras of all things. It understands human speech.",
+		de: "Es besitzt die Fähigkeit, die Aura aller Dinge zu spüren. Es versteht die menschliche Sprache."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/60.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/60.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Rhyhorn",
 		fr: "Rhinocorne",
+		de: "Rihorn"
 	},
 
 	stage: "Stage1",
@@ -39,7 +40,7 @@ const card: Card = {
 			name: {
 				en: "Storm Up",
 				fr: "La tempête se lève",
-				de: "Losstürme"
+				de: "Losstürmen"
 			},
 			effect: {
 				en: "If there is any Stadium card in play, this attack does 30 damage plus 20 more damage. Discard that Stadium card.",
@@ -88,7 +89,8 @@ const card: Card = {
 
 	description: {
 		en: "Its brain developed after it stood up on its hind legs. Its drill horn bores tunnels through solid rock.",
-		fr: "Son cerveau s'est développé depuis qu'il tient debout. Sa corne peut traverser la pierre la plus dure."
+		fr: "Son cerveau s'est développé depuis qu'il tient debout. Sa corne peut traverser la pierre la plus dure.",
+		de: "Sein Gehirn entwickelt sich, wenn es sich auf die Hinterbeine stellt. Mit dem Horn bohrt es durch Gestein."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/61.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/61.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet.",
-				de: "Wirf 1 Münze. Bei 'Zahl' hat dieser Angriff keine Auswirkungen."
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 30,
 
@@ -56,7 +56,8 @@ const card: Card = {
 
 	description: {
 		en: "The aura that emanates from its body intensifies to alert others if it is afraid or sad.",
-		fr: "Son aura s'intensifie pour prévenir son entourage quand il a peur ou qu'il est triste."
+		fr: "Son aura s'intensifie pour prévenir son entourage quand il a peur ou qu'il est triste.",
+		de: "Die Aura, die dieses PKMN umgibt, verstärkt sich, wenn es zeigen will, dass es ängstlich oder traurig ist."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/62.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/62.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Goldeen",
 		fr: "Poissirène",
+		de: "Goldini"
 	},
 
 	stage: "Stage1",
@@ -76,7 +77,8 @@ const card: Card = {
 
 	description: {
 		en: "It makes its nest by hollowing out boulders in streams with its horn. It defends its eggs with its life.",
-		fr: "Il niche dans des rochers du ruisseau qu'il évide avec sa corne. Il donnerait sa vie pour ses œufs."
+		fr: "Il niche dans des rochers du ruisseau qu'il évide avec sa corne. Il donnerait sa vie pour ses œufs.",
+		de: "Es baut Nester, indem es Steine im Fluss mit seinem Horn aushöhlt. Es verteidigt seine Eier mit dem Leben."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/63.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/63.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Wurmple",
 		fr: "Chenipotte",
+		de: "Waumpel"
 	},
 
 	stage: "Stage1",
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon can't attack during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur ne peut pas attaquer lors du prochain tour de votre adversaire.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" kann das Verteidigende Pokémon im nächsten Zug deines Gegners nicht angreifen."
+				de: "Wirf 1 Münze. Bei „Kopf“ kann das Verteidigende Pokémon im nächsten Zug deines Gegners nicht angreifen."
 			},
 			damage: 20,
 
@@ -78,7 +79,8 @@ const card: Card = {
 
 	description: {
 		en: "It anchors itself by wrapping twigs with the silk from its body. It motionlessly awaits evolution.",
-		fr: "Il s'accroche en enroulant sa soie autour des branches. Il reste immobile en attendant d'évoluer."
+		fr: "Il s'accroche en enroulant sa soie autour des branches. Il reste immobile en attendant d'évoluer.",
+		de: "Es bindet sich mit Seidenfäden an Ästen fest und wartet so starr auf seine Entwicklung."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/64.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/64.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Starly",
 		fr: "Etourmi",
+		de: "Staralili"
 	},
 
 	stage: "Stage1",
@@ -85,7 +86,8 @@ const card: Card = {
 
 	description: {
 		en: "It flies around forests and fields in search of bug Pokémon. It stays within a huge flock.",
-		fr: "Il survole les forêts et les champs en quête de Pokémon Insecte. Ils forment de grandes volées."
+		fr: "Il survole les forêts et les champs en quête de Pokémon Insecte. Ils forment de grandes volées.",
+		de: "Auf der Suche nach Käfer-PKMN fliegt es über Wiesen und Wälder. Es bleibt in einem großen Schwarm."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/65.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/65.ts
@@ -68,7 +68,8 @@ const card: Card = {
 
 	description: {
 		en: "Shaped like ancient writing, it is a huge mystery whether language or UNOWN came first.",
-		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou de Zarbi est apparu en premier."
+		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou de Zarbi est apparu en premier.",
+		de: "Seine Form sieht aus wie antike Schrift. Was war zuerst da? Die Sprache oder ICOGNITO?"
 	},
 
 	variants: [

--- a/data/Diamond & Pearl/Diamond & Pearl/66.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/66.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), if Unown B is on your Bench, you may flip a coin. If heads, discard all cards attached to any 1 of your Unown and shuffle that Pokémon back into your deck.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), si Zarbi B est sur votre Banc, vous pouvez lancer une pièce. Si c'est face, défaussez toutes les cartes attachées à 1 de vos Zarbis et mélanger ce Pokémon à votre deck.",
-				de: "Einmal während deines Zuges (vor deinem Angriff), wenn Icognito B auf deiner Bank liegt, kannst du 1 Münze werfen. Bei \"Kopf\" lege alle Karten, die an 1 deiner Icognito angelegt sind, auf deinen Ablagestapel und mische danach dieses Pokémon in dein Deck."
+				de: "Einmal während deines Zuges (vor deinem Angriff), wenn Icognito B auf deiner Bank liegt, kannst du 1 Münze werfen. Bei „Kopf“ lege alle Karten, die an 1 deiner Icognito angelegt sind, auf deinen Ablagestapel und mische danach dieses Pokémon in dein Deck."
 			},
 		},
 	],
@@ -68,7 +68,8 @@ const card: Card = {
 
 	description: {
 		en: "Shaped like ancient writing, it is a huge mystery whether language or UNOWN came first.",
-		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou de Zarbi est apparu en premier."
+		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou de Zarbi est apparu en premier.",
+		de: "Seine Form sieht aus wie antike Schrift. Was war zuerst da? Die Sprache oder ICOGNITO?"
 	},
 
 	variants: [

--- a/data/Diamond & Pearl/Diamond & Pearl/67.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/67.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), if Unown C is on your Bench, you may flip a coin. If heads, search your deck for any 1 Unown and put it onto your Bench. Shuffle your deck afterward.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), si Zarbi C est sur votre Banc, vous pouvez lancer une pièce. Si c'est face, choisissez dans votre deck 1 Zarbi et placez-le sur votre Banc. Ensuite, mélangez votre deck.",
-				de: "Einmal während deines Zuges (vor deinem Angriff), wenn Icognito C auf deiner Bank liegt, kannst du 1 Münze werfen. Bei \"Kopf\" durchsuche dein Deck nach 1 Icognito-Karte und lege sie auf deine Bank. Mische dein Deck danach."
+				de: "Einmal während deines Zuges (vor deinem Angriff), wenn Icognito C auf deiner Bank liegt, kannst du 1 Münze werfen. Bei „Kopf“ durchsuche dein Deck nach 1 Icognito-Karte und lege sie auf deine Bank. Mische dein Deck danach."
 			},
 		},
 	],
@@ -68,7 +68,8 @@ const card: Card = {
 
 	description: {
 		en: "Shaped like ancient writing, it is a huge mystery whether language or UNOWN came first.",
-		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou de Zarbi est apparu en premier."
+		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou de Zarbi est apparu en premier.",
+		de: "Seine Form sieht aus wie antike Schrift. Was war zuerst da? Die Sprache oder ICOGNITO?"
 	},
 
 	variants: [

--- a/data/Diamond & Pearl/Diamond & Pearl/68.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/68.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), if Unown D is on your Bench, you may flip a coin. If heads, each player may draw a card. (You draw your card first.)",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), si Zarbi D est sur votre Banc, vous pouvez lancer une pièce. Si c'est face, chaque joueur peut piocher une carte. (Vous piochez votre carte en premier.)",
-				de: "Einmal während deines Zuges (vor deinem Angriff), wenn Icognito D auf deiner Bank liegt, kannst du 1 Münze werfen. Bei 'Kopf' kann jeder Spieler eine Karte ziehen. (Du ziehst deine Karte zuerst.)"
+				de: "Einmal während deines Zuges (vor deinem Angriff), wenn Icognito D auf deiner Bank liegt, kannst du 1 Münze werfen. Bei „Kopf“ kann jeder Spieler eine Karte ziehen. (Du ziehst deine Karte zuerst.)"
 			},
 		},
 	],
@@ -68,7 +68,8 @@ const card: Card = {
 
 	description: {
 		en: "Shaped like ancient writing, it is a huge mystery whether language or UNOWN came first.",
-		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou de Zarbi est apparu en premier."
+		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou de Zarbi est apparu en premier.",
+		de: "Seine Form sieht aus wie antike Schrift. Was war zuerst da? Die Sprache oder ICOGNITO?"
 	},
 
 	variants: [

--- a/data/Diamond & Pearl/Diamond & Pearl/69.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/69.ts
@@ -69,7 +69,8 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon that lives by water. It moves quickly on land by bouncing on its big tail.",
-		fr: "Un Pokémon qui vit près de l'eau. Au sol, il se déplace rapidement en rebondissant sur sa grosse queue"
+		fr: "Un Pokémon qui vit près de l'eau. Au sol, il se déplace rapidement en rebondissant sur sa grosse queue",
+		de: "Dieses PKMN lebt am Wasser. An Land bewegt es sich schnell, indem es auf seinem großen Schweif hüpft."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/7.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/7.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Luxio",
 		fr: "Luxio",
+		de: "Luxio"
 	},
 
 	stage: "Stage2",
@@ -62,7 +63,7 @@ const card: Card = {
 			effect: {
 				en: "Move all Lightning Energy attached to Luxray to 1 of your Benched Pokémon. (Ignore this effect if you don't have any Benched Pokémon.)",
 				fr: "Déplacez toutes les Énergies Lightning attachées à Luxray sur 1 de vos Pokémon de Banc. (Ignorez cet effet si vous n'avez pas de Pokémon de Banc.)",
-				de: "Entferne alle an Luxtra angelegten -Energien und lege sie an 1 Pokémon auf deiner Bank an. (Dieser Effekt hat keine Auswirkungen, wenn du keine Pokémon auf der Bank hast.)"
+				de: "Entferne alle an Luxtra angelegten {L}-Energien und lege sie an 1 Pokémon auf deiner Bank an. (Dieser Effekt hat keine Auswirkungen, wenn du keine Pokémon auf der Bank hast.)"
 			},
 			damage: 80,
 
@@ -87,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It has eyes that can see through anything. It spots and captures prey hiding behind objects.",
+		de: "Mit seinen Augen kann es durch alles hindurch sehen. So findet es auch Beute, die sich versteckt hat."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/70.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/70.ts
@@ -71,7 +71,8 @@ const card: Card = {
 
 	description: {
 		en: "With nerves of steel, nothing can perturb it. It is more agile and active than it appears.",
-		fr: "Rien ne peut perturber ses nerfs d'acier. Il est plus agile et énergique qu'il n'y paraît."
+		fr: "Rien ne peut perturber ses nerfs d'acier. Il est plus agile et énergique qu'il n'y paraît.",
+		de: "Es hat Nerven wie Drahtseile, nichts kann es erschüttern. Es ist agiler und aktiver, als es scheint."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/71.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/71.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, your opponent can't play any Trainer cards from his or her hand during your opponent's next turn, and any damage done to Bonsly by attacks is reduced by 30 (after applying Weakness and Resistance).",
 				fr: "Lancez une pièce. Si c'est face, votre adversaire ne peut pas jouer de cartes Dresseur de sa main lors de son prochain tour et tous dégâts infligés à Manzai par des attaques sont réduits de 30 (après application de la Faiblesse et de la Résistance).",
-				de: "Wirf 1 Münze. Bei \"Kopf\" kann dein Gegner in seinem nächsten Zug keine Trainerkarten von seiner Hand spielen und aller Schaden, der Mobai durch gegnerische Angriffe zugefügt wird, wird um 30 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
+				de: "Wirf 1 Münze. Bei „Kopf“ kann dein Gegner in seinem nächsten Zug keine Trainerkarten von seiner Hand spielen und aller Schaden, der Mobai durch gegnerische Angriffe zugefügt wird, wird um 30 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 
 		},
@@ -69,7 +69,8 @@ const card: Card = {
 
 	description: {
 		en: "It looks as if it is always crying. It is actually adjusting its body's fluid levels by eliminating excess.",
-		fr: "On dirait qu'il pleure constamment. En fait, il régule ses fluides corporels en éliminant le surplus."
+		fr: "On dirait qu'il pleure constamment. En fait, il régule ses fluides corporels en éliminant le surplus.",
+		de: "Es sieht aus, als würde es immer weinen. Dabei reguliert es nur seinen Wasserhaushalt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/72.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/72.ts
@@ -56,7 +56,8 @@ const card: Card = {
 
 	description: {
 		en: "It has a flotation sac that is like an inflatable collar. It floats on water with its head out.",
-		fr: "Sa bouée est pareille à un collier gonflable. Quand il flotte, il garde la tête à l'air libre."
+		fr: "Sa bouée est pareille à un collier gonflable. Quand il flotte, il garde la tête à l'air libre.",
+		de: "Es hat eine Art Rettungsring um den Hals. Wenn es schwimmt, gerät sein Kopf niemals unter Wasser."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/73.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/73.ts
@@ -70,7 +70,8 @@ const card: Card = {
 
 	description: {
 		en: "It slams foes by sharply uncoiling its rolled ears. It stings enough to make a grown-up cry in pain.",
-		fr: "Il frappe l'ennemi en déroulant violemment ses oreilles. Cela peut faire pleurer un adulte."
+		fr: "Il frappe l'ennemi en déroulant violemment ses oreilles. Cela peut faire pleurer un adulte.",
+		de: "Es entrollt seine Ohren sehr schnell, um seine Gegner schmerzhaft zu schlagen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/74.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/74.ts
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt verwirrt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: 10,
 
@@ -79,7 +79,8 @@ const card: Card = {
 
 	description: {
 		en: "It can learn and speak human words. If they gather, they all learn the same saying.",
-		fr: "On peut lui enseigner quelques mots. S'il s'agit d'un groupe, ils retiendront les mêmes phrases."
+		fr: "On peut lui enseigner quelques mots. S'il s'agit d'un groupe, ils retiendront les mêmes phrases.",
+		de: "Es kann die menschliche Sprache lernen. Versammeln sie sich, bringen sie sich alle dasselbe bei."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/75.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/75.ts
@@ -80,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "The small ball holds the nutrients needed for evolution. Apparently, it is very sweet and tasty.",
-		fr: "La petite boule renferme les délicieux nutriments sucrés dont il a besoin pour évoluer."
+		fr: "La petite boule renferme les délicieux nutriments sucrés dont il a besoin pour évoluer.",
+		de: "Das kleine Bällchen enthält alles, was es für die Entwicklung braucht. Es ist süß und lecker."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/76.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/76.ts
@@ -50,7 +50,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, discard a Fire Energy attached to Chimchar.",
 				fr: "Lancez une pièce. Si c'est pile, défaussez une Énergie Fire attachée à Ouisticram.",
-				de: "Wirf 1 Münze. Bei 'Zahl' lege eine -Energie, die an Panflam angelegt ist, auf deinen Ablagestapel."
+				de: "Wirf 1 Münze. Bei „Zahl“ lege eine {R}-Energie, die an Panflam angelegt ist, auf deinen Ablagestapel."
 			},
 			damage: 30,
 
@@ -68,7 +68,8 @@ const card: Card = {
 
 	description: {
 		en: "It agilely scales sheer cliffs to live atop craggy mountains. Its fire is put out when it sleeps.",
-		fr: "Il escalade prestement les falaises escarpées et vit sur les sommets. Sa flamme s'éteint quand il dort."
+		fr: "Il escalade prestement les falaises escarpées et vit sur les sommets. Sa flamme s'éteint quand il dort.",
+		de: "Es klettert behände steile Felsen hinauf, um auf Bergen zu leben. Sein Feuer ist aus, wenn es schläft."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/77.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/77.ts
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "Thought to live with others on quiet mountains, it is popular for its adorable nature.",
-		fr: "Tout le monde craque pour cet adorable Pokémon. Il vit en groupe dans le calme des montagnes."
+		fr: "Tout le monde craque pour cet adorable Pokémon. Il vit en groupe dans le calme des montagnes.",
+		de: "Es ist bekannt für sein liebenswertes Wesen. Man sagt, es lebt in der Stille der Berge."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/78.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/78.ts
@@ -69,7 +69,8 @@ const card: Card = {
 
 	description: {
 		en: "Its silhouette is like a star. It is believed to arrive riding on shooting stars.",
-		fr: "Sa silhouette rappelle une étoile. On dit qu'il descend sur terre en chevauchant une étoile filante."
+		fr: "Sa silhouette rappelle une étoile. On dit qu'il descend sur terre en chevauchant une étoile filante.",
+		de: "Seine Silhouette sieht aus wie ein Stern. Man sagt, es würde auf Sternschnuppen reisen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/79.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/79.ts
@@ -76,7 +76,8 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon formed by three others. It busily carries sweet floral honey to VESPIQUEN.",
-		fr: "Un Pokémon qui en regroupe trois autres. Il est toujours occupé à apporter du nectar à Apireine."
+		fr: "Un Pokémon qui en regroupe trois autres. Il est toujours occupé à apporter du nectar à Apireine.",
+		de: "Ein PKMN, geformt aus 3 einzelnen PKMN. Fleißig bringt es Blütenhonig zu HONWEISEL."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/8.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/8.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Magneton",
 		fr: "Magneton",
+		de: "Magneton"
 	},
 
 	stage: "Stage2",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "If you have any Metal Energy attached to your Active Pokémon, the Retreat Cost for that Pokémon is 0.",
 				fr: "Si votre Pokémon Actif possède des Énergies Metal, son Coût de retraite est de 0.",
-				de: "Wenn an dein Aktives Pokémon mindestens 1  Energie angelegt ist, hat dieses Pokémon Rückzugskosten 0."
+				de: "Wenn an dein Aktives Pokémon mindestens 1 {M}-Energie angelegt ist, hat dieses Pokémon Rückzugskosten 0."
 			},
 		},
 	],
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Does 50 damage plus 10 more damage for each Metal Energy attached to Magnezone.",
 				fr: "Inflige 50 dégâts plus 10 dégâts supplémentaires pour chaque Énergie Metal attachée à Magnézone.",
-				de: "Dieser Angrif fügt 50 Schadenspunkte plus 10 weitere Schadenspunkte für jede  Energie, die an Magnezone angelegt ist, zu."
+				de: "Dieser Angriff fügt 50 Schadenspunkte plus 10 weitere Schadenspunkte für jede {M}-Energie, die an Magnezone angelegt ist, zu."
 			},
 			damage: "50+",
 
@@ -86,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "It evolved from exposure to a special magnetic field. Three units generate magnetism.",
+		de: "Es entwickelte sich, als es einem besonderen Magnetfeld ausgesetzt wurde."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/80.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/80.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, choisissez 1 des attaques du Pokémon Défenseur. Ce Pokémon ne peut pas utiliser cette attaque lors du prochain tour de votre adversaire.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" wähle 1 Angriff des Verteidigenden Pokémon. Dieses Pokémon kann den gewählten Angriff im nächsten Zug deines Gegners nicht einsetzen."
+				de: "Wirf 1 Münze. Bei „Kopf“ wähle 1 Angriff des Verteidigenden Pokémon. Dieses Pokémon kann den gewählten Angriff im nächsten Zug deines Gegners nicht einsetzen."
 			},
 
 		},
@@ -80,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "It doggedly pursues its prey wherever it goes. However, the chase is abandoned at sunrise.",
-		fr: "Il poursuit assidûment sa proie, où qu'elle aille. Il n'abandonne sa traque qu'au lever du soleil."
+		fr: "Il poursuit assidûment sa proie, où qu'elle aille. Il n'abandonne sa traque qu'au lever du soleil.",
+		de: "Verbissen verfolgt es seine Beute überallhin. Doch sobald die Sonne aufgeht, ist die Jagd vorbei."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/81.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/81.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 damage plus 10 more damage. If tails, Electabuzz does 10 damage to itself.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts plus 10 dégâts supplémentaires. Si c'est pile, Elektek s'inflige 10 dégâts.",
-				de: "Wirf 1 Münze. Bei 'Kopf' fügt dieser Angriff 30 Schadenspunkte plus 10 weitere Schadenspunkte zu. Bei 'Zahl' fügt sich Elektek selbst 10 Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 Schadenspunkte plus 10 weitere Schadenspunkte zu. Bei „Zahl“ fügt sich Elektek selbst 10 Schadenspunkte zu."
 			},
 			damage: "30+",
 
@@ -57,7 +57,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed. If Electabuzz is evolved from Elekid, this attack does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé. Si Elektek évolue d'Elekid, cette attaque inflige 20 dégâts à 1 des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt. Wenn Elektek sich aus Elekid entwickelt hat, fügt dieser Angriff 1 Pokémon auf der Bank deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt. Wenn Elektek sich aus Elekid entwickelt hat, fügt dieser Angriff 1 Pokémon auf der Bank deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 20,
 
@@ -82,7 +82,8 @@ const card: Card = {
 
 	description: {
 		en: "Half of all blackouts occur when this Pokémon appears at power plants and eats electricity.",
-		fr: "Ce Pokémon dévore l'électricité des centrales. Il est responsable de la majorité des coupures de courant."
+		fr: "Ce Pokémon dévore l'électricité des centrales. Il est responsable de la majorité des coupures de courant.",
+		de: "Die Hälfte aller Stromausfälle wird durch dieses PKMN ausgelöst, das in E-Werken Elektrizität frisst."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/82.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/82.ts
@@ -62,7 +62,8 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon's body is 95% made up of gases, which are blown away by strong gusts of wind.",
-		fr: "Le corps de ce Pokémon est composé de gaz à 95%. Une bourrasque suffit à le disperser."
+		fr: "Le corps de ce Pokémon est composé de gaz à 95%. Une bourrasque suffit à le disperser.",
+		de: "Der Körper des Pokémon besteht zu 95 % aus Gasen, die fortgeweht werden, wenn starker Wind geht."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/83.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/83.ts
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet.",
-				de: "Wirf 1 Münze. Bei 'Zahl' hat dieser Angriff keine Auswirkungen."
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 30,
 
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "It claws if displeased and purrs when affectionate. Its fickleness if very popular among some.",
-		fr: "Il griffe quand il est en colère et ronronne quand il est heureux. Certains aiment ce côté lunatique."
+		fr: "Il griffe quand il est en colère et ronronne quand il est heureux. Certains aiment ce côté lunatique.",
+		de: "Es schlägt mit Krallen zu oder schnurrt, je nachdem, ob es gerade wütend oder zutraulich ist."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/84.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/84.ts
@@ -70,7 +70,8 @@ const card: Card = {
 
 	description: {
 		en: "It swims elegantly by flittering its tail as if it were a dress. It has the look of a queen.",
-		fr: "Il nage élégamment en agitant sa nageoire caudale comme si c'était une robe. Il a l'allure d'une reine."
+		fr: "Il nage élégamment en agitant sa nageoire caudale comme si c'était une robe. Il a l'allure d'une reine.",
+		de: "Es schwimmt elegant und bewegt seine Hinterflosse wie ein Kleid. Es sieht aus wie eine Königin."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/85.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/85.ts
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet.",
-				de: "Wirf 1 Münze. Bei 'Zahl' hat dieser Angriff keine Auswirkungen."
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 30,
 
@@ -80,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "It always stands on one foot. Even when attacked, it does not brace itself using both feet.",
-		fr: "Il se tient toujours sur un pied. Il ne prend jamais appui sur les deux, même en cas d'attaque."
+		fr: "Il se tient toujours sur un pied. Il ne prend jamais appui sur les deux, même en cas d'attaque.",
+		de: "Es steht ständig auf einem Fuß. Selbst wenn es angreift, stellt es sich nicht auf beide Beine."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/86.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/86.ts
@@ -52,7 +52,8 @@ const card: Card = {
 
 	description: {
 		en: "It hefts a GRAVELER repeatedly to strengthen its entire body. It uses every type of martial arts.",
-		fr: "Il muscle son corps en soulevant régulièrement un Gravalanch. Il est rompu à tous les arts martiaux."
+		fr: "Il muscle son corps en soulevant régulièrement un Gravalanch. Il est rompu à tous les arts martiaux.",
+		de: "Es hebt GEOROK hoch, um seinen Körper zu trainieren. Außerdem übt es sich in jeder Art v. Kampfsport."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/87.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/87.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt verwirrt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 
 		},
@@ -80,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "The units at its sides generate electromagnetic waves that keep it airborne. It feeds on electricity.",
-		fr: "Ses extrémités génèrent les vagues électromagnétiques qui le font voler. Il se nourrit d'électricité."
+		fr: "Ses extrémités génèrent les vagues électromagnétiques qui le font voler. Il se nourrit d'électricité.",
+		de: "Die Vorrichtungen an seinem Körper generieren elektromagnetische Wellen, die es schweben lassen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/88.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/88.ts
@@ -74,7 +74,8 @@ const card: Card = {
 
 	description: {
 		en: "Using its tail as a float, it dives underwater. It likes eating plants that grow on river bottoms.",
-		fr: "Il plonge sous l'eau en utilisant sa queue comme un flotteur. Il aime les plantes du fond des rivières."
+		fr: "Il plonge sous l'eau en utilisant sa queue comme un flotteur. Il aime les plantes du fond des rivières.",
+		de: "Seinen Schweif verwendet es als eine Art Rettungsring, wenn es taucht. Es liebt Wasserpflanzen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/89.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/89.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Meditite during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, prévenez tous les effets d'une attaque, dégâts inclus, infligés à Meditikka lors du prochain tour de votre adversaire.",
-				de: "Wirf 1 Münze. Verhindere bei 'Kopf' während des nächsten Zuges deines Gegners alle Effekte eines Angriffs, einschließlich Schaden, die Meditie zugefügt werden."
+				de: "Wirf 1 Münze. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte eines Angriffs, einschließlich Schaden, die Meditie zugefügt werden."
 			},
 
 		},
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "It eats just one berry a day. By enduring hunger, its spirit is tempered and made sharper.",
-		fr: "Il ne mange qu'une Baie par jour. La faim lui a forgé une volonté de fer."
+		fr: "Il ne mange qu'une Baie par jour. La faim lui a forgé une volonté de fer.",
+		de: "Es isst gerade mal eine Beere am Tag. Durch Hunger wird sein Geist ruhiger und schärfer."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/9.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/9.ts
@@ -73,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "Born on a cold seafloor, it will swim great distances to return to its birthplace.",
+		de: "Geboren auf dem Meeresboden, legt es große Entfernungen zurück, um dorthin zurückzukehren."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/90.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/90.ts
@@ -71,7 +71,8 @@ const card: Card = {
 
 	description: {
 		en: "It habitually mimics foes. Once mimicked, the foe cannot take its eyes off this Pokémon.",
-		fr: "Il imite ses ennemis. Une fois imités, ils ne peuvent plus quitter ce Pokémon des yeux."
+		fr: "Il imite ses ennemis. Une fois imités, ils ne peuvent plus quitter ce Pokémon des yeux.",
+		de: "Es ahmt seinen Gegner nach. Der kann den Blick danach nicht von ihm abwenden."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/91.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/91.ts
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt verwirrt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: 20,
 
@@ -80,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "It loves to sneak up on people late at night, then startle them with its shrieklike cry.",
-		fr: "Il adore se faufiler derrière les gens la nuit pour les effrayer avec son cri strident."
+		fr: "Il adore se faufiler derrière les gens la nuit pour les effrayer avec son cri strident.",
+		de: "Es liebt es, sich nachts an andere heranzuschleichen und sie mit einem schrillen Schrei zu erschrecken."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/92.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/92.ts
@@ -69,7 +69,8 @@ const card: Card = {
 
 	description: {
 		en: "When it travels underground, it causes rumbling and tremors. It can move at 50 mph.",
-		fr: "Il provoque des secousses sismiques en creusant. Il peut atteindre les 80 km/h."
+		fr: "Il provoque des secousses sismiques en creusant. Il peut atteindre les 80 km/h.",
+		de: "Wenn es sich unter dem Boden mit bis zu 80 km/h bewegt, verursacht es Erschütterungen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/93.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/93.ts
@@ -50,7 +50,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei 'Kopf' fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -68,7 +68,8 @@ const card: Card = {
 
 	description: {
 		en: "Because it is very proud, it hates accepting food from people. Its thick down guards it from cold.",
-		fr: "Il est fier et déteste accepter la nourriture qu'on lui offre. Son pelage épais le protège du froid."
+		fr: "Il est fier et déteste accepter la nourriture qu'on lui offre. Son pelage épais le protège du froid.",
+		de: "Es ist sehr stolz und nimmt daher kein Futter von anderen an. Seine dicken Daunen schützen vor Kälte."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/94.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/94.ts
@@ -66,7 +66,8 @@ const card: Card = {
 
 	description: {
 		en: "About an hour after birth, its fiery mane and tail grow out, giving it an impressive appearance.",
-		fr: "La crinière et la queue ardentes lui donnant sa superbe poussent une heure après sa naissance."
+		fr: "La crinière et la queue ardentes lui donnant sa superbe poussent une heure après sa naissance.",
+		de: "Bereits eine Stunde nach seiner Geburt wachsen seine feurige Mähne und sein feuriger Schweif."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/95.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/95.ts
@@ -77,7 +77,8 @@ const card: Card = {
 
 	description: {
 		en: "Its body is clad in a thick hide, and its tackles topple buildings. Unfortunately, it is not smart.",
-		fr: "Sa peau est très épaisse et sa charge peut détruire un immeuble. Dommage qu'il soit stupide."
+		fr: "Sa peau est très épaisse et sa charge peut détruire un immeuble. Dommage qu'il soit stupide.",
+		de: "Sein Körper ist von einer dicken Haut umgeben und es kann wackelige Gebäude zum Einsturz bringen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/96.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/96.ts
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "ROSELIA raised on clean drinking water are known to grow vividly colored flowers.",
-		fr: "Les Roselia élevés avec une eau claire et potable font de ravissantes fleurs bariolées."
+		fr: "Les Roselia élevés avec une eau claire et potable font de ravissantes fleurs bariolées.",
+		de: "ROSELIA, die mit klarem Wasser aufgezogen wurden, bekommen Blüten in leuchtenden Farben."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/97.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/97.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, during your opponent's next turn, if Seedot would be Knocked Out by damage from an attack, Seedot is not Knocked Out and its remaining HP becomes 10 instead.",
 				fr: "Lancez une pièce. Si c'est face, lors du prochain tour de votre adversaire, si Grainipiot doit être mis K.O par des dégâts infligés par une attaque, il n'est pas mis K.O et ses PV restants sont de 10.",
-				de: "Wirf 1 Münze. Bei 'Kopf' wird Samurzel im nächsten Zug deines Gegners, wenn er durch Schaden eines Angriffs kampfunfähig würde, nicht kampfunfähig und hat stattdessen 10 verbliebene KP."
+				de: "Wirf 1 Münze. Bei „Kopf“ wird Samurzel im nächsten Zug deines Gegners, wenn er durch Schaden eines Angriffs kampfunfähig würde, nicht kampfunfähig und hat stattdessen 10 verbliebene KP."
 			},
 
 		},
@@ -76,7 +76,8 @@ const card: Card = {
 
 	description: {
 		en: "When it dangles from a tree branch, it looks just like an acorn. It enjoys scaring other Pokémon.",
-		fr: "Il ressemble à un gland pendu à une branche. Il adore effrayer les autres Pokémon."
+		fr: "Il ressemble à un gland pendu à une branche. Il adore effrayer les autres Pokémon.",
+		de: "Es sieht aus wie eine Eichel, die am Baum hängt. Es liebt es, andere PKMN zu erschrecken."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/98.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/98.ts
@@ -63,7 +63,8 @@ const card: Card = {
 
 	description: {
 		en: "All of its fur dazzles if danger is sensed. It flees while the foe is momentarily blinded.",
-		fr: "Sa fourrure étincelle en cas de danger. Il profite du fait que l'ennemi est aveuglé pour s'enfuir."
+		fr: "Sa fourrure étincelle en cas de danger. Il profite du fait que l'ennemi est aveuglé pour s'enfuir.",
+		de: "In Gefahr blendet es seinen Gegner mit seinem Fell und flieht, während der Gegner einen Moment blind ist."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Diamond & Pearl/99.ts
+++ b/data/Diamond & Pearl/Diamond & Pearl/99.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Empoisonné.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt vergiftet."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet."
 			},
 
 		},
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 4 coins. This attack does 10 damage time the number of heads.",
 				fr: "Lancez 4 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 4 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl 'Kopf' zu."
+				de: "Wirf 4 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10x",
 
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "It grips prey with its tail claws and injects poison. It tenaciously hangs on until the poison takes.",
-		fr: "Il saisit sa proie avec les pinces de sa queue, lui injecte un poison et la retient jusqu'à ce qu'il agisse."
+		fr: "Il saisit sa proie avec les pinces de sa queue, lui injecte un poison et la retient jusqu'à ce qu'il agisse.",
+		de: "Es greift seine Beute mit den Krallen an seinem Schweif und vergiftet sie. Dann wartet es ab..."
 	},
 
 	thirdParty: {


### PR DESCRIPTION
## Add missing German translations for dp1

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
