### PR TITLE
Add missing German translations for tk-bw-e

### DIFF
--- a/data/Trainer kits/BW trainer Kit (Excadrill)/1.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/1.ts
@@ -31,11 +31,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Pickup",
-			fr: "Ramassage"
+			fr: "Ramassage",
+			de: "Mitnahme"
 		},
 		effect: {
 			en: "Put an Item card from your discard pile into your hand.",
-			fr: "Prenez une carte Objet dans votre pile de défausse et ajoutez-la à votre main."
+			fr: "Prenez une carte Objet dans votre pile de défausse et ajoutez-la à votre main.",
+			de: "Nimm 1 Itemkarte von deinem Ablagestapel auf deine Hand."
 		}
 	}, {
 		cost: [
@@ -43,7 +45,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Bite",
-			fr: "Morsure"
+			fr: "Morsure",
+			de: "Biss"
 		},
 		damage: 10
 	}],
@@ -54,7 +57,8 @@ const card: Card = {
 	}],
 
 	description: {
-		en: "It faces strong opponents with great courage. But, when at a disadvantage in a fight, this intelligent Pokémon flees."
+		en: "It faces strong opponents with great courage. But, when at a disadvantage in a fight, this intelligent Pokémon flees.",
+		de: "Ein kluges Pokémon, das sich zwar tapfer auch starken Gegnern zum Kampf stellt, aber unfaire Begegnungen zu meiden weiß."
 	},
 
 	retreat: 1,

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/11.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/11.ts
@@ -30,7 +30,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Pound",
-			fr: "Écras'Face"
+			fr: "Écras'Face",
+			de: "Pfund"
 		},
 		damage: 30
 	}],
@@ -44,7 +45,8 @@ const card: Card = {
 
 
 	description: {
-		en: "It fights by swinging a piece of lumber around. It is close to evolving when it can handle the lumber without difficulty."
+		en: "It fights by swinging a piece of lumber around. It is close to evolving when it can handle the lumber without difficulty.",
+		de: "Greift Gegner mit einem Holzbalken an. Fällt es ihm leicht, den schweren Balken zu tragen, ist seine Entwicklung nah."
 	},
 
 	retreat: 1,

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/12.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/12.ts
@@ -30,11 +30,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Doubleslap",
-			fr: "Torgnoles"
+			fr: "Torgnoles",
+			de: "Duplexhieb"
 		},
 		effect: {
 			en: "Flip 2 coins. This attack does 30 damage times the number of heads.",
-			fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face."
+			fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
+			de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 		},
 		damage: "30x"
 	}],
@@ -48,7 +50,8 @@ const card: Card = {
 
 
 	description: {
-		en: "It touches others with the feelers on its ears, using the sound of their heartbeats to tell how they are feeling."
+		en: "It touches others with the feelers on its ears, using the sound of their heartbeats to tell how they are feeling.",
+		de: "Berührt es jemanden mit den Fühlern an seinen Ohren, erfährt es durch den Herzschlag der Person, wie es ihr geht."
 	},
 
 	retreat: 2,

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/13.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/13.ts
@@ -29,11 +29,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Hone Claws",
-			fr: "Aiguisage"
+			fr: "Aiguisage",
+			de: "Klauenwetzer"
 		},
 		effect: {
 			en: "During your next turn, each of this Pokémon's attacks does 30 more damage (before applying Weakness and Ressistance).",
-			fr: "Pendant votre prochain tour, chaque attaque de ce Pokémon inflige 30 dégâts supplémentaires (avant application de la Faiblesse et de la Résistance)."
+			fr: "Pendant votre prochain tour, chaque attaque de ce Pokémon inflige 30 dégâts supplémentaires (avant application de la Faiblesse et de la Résistance).",
+			de: "Während deines nächsten Zuges fügt jeder Angriff dieses Pokémon 30 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 		}
 	}, {
 		cost: [
@@ -41,7 +43,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Scratch",
-			fr: "Griffe"
+			fr: "Griffe",
+			de: "Kratzer"
 		},
 		damage: 10
 	}],
@@ -60,7 +63,8 @@ const card: Card = {
 	}],
 
 	description: {
-		en: "It can dig through the ground at a speed of 30 mph. It could give a car running aboveground a good race."
+		en: "It can dig through the ground at a speed of 30 mph. It could give a car running aboveground a good race.",
+		de: "Es gräbt sich mit 50 km/h durch das Erdreich und kann beinahe schon mit den Autos an der Oberfläche Schritt halten."
 	},
 
 	retreat: 2,

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/14.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/14.ts
@@ -39,11 +39,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Bulk Up",
-			fr: "Gonflette"
+			fr: "Gonflette",
+			de: "Protzer"
 		},
 		effect: {
 			en: "During your next turn, each of this Pokémon's attacks does 20 more damage (before applying Weakness and Resistance).",
-			fr: "Lors de votre prochain tour, chaque attaque de ce Pokémon inflige 20 dégâts supplémentaires (avant application de la Faiblesse et de la Résistance)."
+			fr: "Lors de votre prochain tour, chaque attaque de ce Pokémon inflige 20 dégâts supplémentaires (avant application de la Faiblesse et de la Résistance).",
+			de: "Während deines nächsten Zuges fügt jeder Angriff dieses Pokémon 20 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 		}
 	}, {
 		cost: [
@@ -53,7 +55,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Pound",
-			fr: "Écras'Face"
+			fr: "Écras'Face",
+			de: "Pfund"
 		},
 		damage: 60
 	}],
@@ -64,7 +67,8 @@ const card: Card = {
 	}],
 
 	description: {
-		en: "They strengthen their bodies by carrying steel beams. They show off their big muscles to their friends."
+		en: "They strengthen their bodies by carrying steel beams. They show off their big muscles to their friends.",
+		de: "Zu Trainingszwecken trägt es immer einen Stahlträger bei sich. Unter Kollegen gibt es nur zu gern mit seinen Muskeln an."
 	},
 
 	retreat: 2,

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/17.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/17.ts
@@ -40,7 +40,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Metal Claw",
-			fr: "Griffe Acier"
+			fr: "Griffe Acier",
+			de: "Metallklaue"
 		},
 
 		damage: 30
@@ -52,11 +53,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Drill Run",
-			fr: "Tunnelier"
+			fr: "Tunnelier",
+			de: "Schlagbohrer"
 		},
 		effect: {
 			en: "Discard an Energy attached to the Defending Pokémon.",
-			fr: "Défaussez une Énergie attachée au Pokémon Défenseur."
+			fr: "Défaussez une Énergie attachée au Pokémon Défenseur.",
+			de: "Lege 1 an das Verteidigende Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
 		},
 		damage: 80
 	}],
@@ -72,7 +75,8 @@ const card: Card = {
 	}],
 
 	description: {
-		en: "It can help in tunnel construction. Its drill has evolved into steel strong enough to bore through iron plates."
+		en: "It can help in tunnel construction. Its drill has evolved into steel strong enough to bore through iron plates.",
+		de: "Seine zu Stahl weiterentwickelten Bohrer kriegen selbst Eisenplatten klein. Im Tunnelbau ist es ein absolutes Ass."
 	},
 
 	retreat: 2,

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/18.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/18.ts
@@ -30,11 +30,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Doubleslap",
-			fr: "Torgnoles"
+			fr: "Torgnoles",
+			de: "Duplexhieb"
 		},
 		effect: {
 			en: "Flip 2 coins. This attack does 30 damage times the number of heads.",
-			fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face."
+			fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
+			de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 		},
 		damage: "30x"
 	}],
@@ -48,7 +50,8 @@ const card: Card = {
 
 
 	description: {
-		en: "It touches others with the feelers on its ears, using the sound of their heartbeats to tell how they are feeling."
+		en: "It touches others with the feelers on its ears, using the sound of their heartbeats to tell how they are feeling.",
+		de: "Berührt es jemanden mit den Fühlern an seinen Ohren, erfährt es durch den Herzschlag der Person, wie es ihr geht."
 	},
 
 	retreat: 2,

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/19.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/19.ts
@@ -40,11 +40,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Collect",
-			fr: "Collectionner"
+			fr: "Collectionner",
+			de: "Sammeln"
 		},
 		effect: {
 			en: "Draw 3 cards.",
-			fr: "Piochez 3 cartes."
+			fr: "Piochez 3 cartes.",
+			de: "Ziehe 3 Karten."
 		}
 	}, {
 		cost: [
@@ -54,7 +56,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Bite",
-			fr: "Morsure"
+			fr: "Morsure",
+			de: "Biss"
 		},
 		damage: 50
 	}],
@@ -65,7 +68,8 @@ const card: Card = {
 	}],
 
 	description: {
-		en: "It loyally follows its Trainer's orders. For ages, they have helped Trainers raise Pokémon."
+		en: "It loyally follows its Trainer's orders. For ages, they have helped Trainers raise Pokémon.",
+		de: "Folgt treu den Befehlen seines Trainers. Schon seit jeher ist es als rechte Hand der Pokémon-Trainer bekannt."
 	},
 
 	retreat: 1,

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/25.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/25.ts
@@ -29,11 +29,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Hone Claws",
-			fr: "Aiguisage"
+			fr: "Aiguisage",
+			de: "Klauenwetzer"
 		},
 		effect: {
 			en: "During your next turn, each of this Pokémon's attacks does 30 more damage (before applying Weakness and Ressistance).",
-			fr: "Pendant votre prochain tour, chaque attaque de ce Pokémon inflige 30 dégâts supplémentaires (avant application de la Faiblesse et de la Résistance)."
+			fr: "Pendant votre prochain tour, chaque attaque de ce Pokémon inflige 30 dégâts supplémentaires (avant application de la Faiblesse et de la Résistance).",
+			de: "Während deines nächsten Zuges fügt jeder Angriff dieses Pokémon 30 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 		}
 	}, {
 		cost: [
@@ -41,7 +43,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Scratch",
-			fr: "Griffe"
+			fr: "Griffe",
+			de: "Kratzer"
 		},
 		damage: 10
 	}],
@@ -57,7 +60,8 @@ const card: Card = {
 	}],
 
 	description: {
-		en: "It can dig through the ground at a speed of 30 mph. It could give a car running aboveground a good race."
+		en: "It can dig through the ground at a speed of 30 mph. It could give a car running aboveground a good race.",
+		de: "Es gräbt sich mit 50 km/h durch das Erdreich und kann beinahe schon mit den Autos an der Oberfläche Schritt halten."
 	},
 
 	retreat: 2,

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/27.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/27.ts
@@ -31,11 +31,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Pickup",
-			fr: "Ramassage"
+			fr: "Ramassage",
+			de: "Mitnahme"
 		},
 		effect: {
 			en: "Put an Item card from your discard pile into your hand.",
-			fr: "Prenez une carte Objet dans votre pile de défausse et ajoutez-la à votre main."
+			fr: "Prenez une carte Objet dans votre pile de défausse et ajoutez-la à votre main.",
+			de: "Nimm 1 Itemkarte von deinem Ablagestapel auf deine Hand."
 		}
 	}, {
 		cost: [
@@ -43,7 +45,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Bite",
-			fr: "Morsure"
+			fr: "Morsure",
+			de: "Biss"
 		},
 		damage: 10
 	}],
@@ -54,7 +57,8 @@ const card: Card = {
 	}],
 
 	description: {
-		en: "It faces strong opponents with great courage. But, when at a disadvantage in a fight, this intelligent Pokémon flees."
+		en: "It faces strong opponents with great courage. But, when at a disadvantage in a fight, this intelligent Pokémon flees.",
+		de: "Ein kluges Pokémon, das sich zwar tapfer auch starken Gegnern zum Kampf stellt, aber unfaire Begegnungen zu meiden weiß."
 	},
 
 	retreat: 1,

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/29.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/29.ts
@@ -30,7 +30,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Pound",
-			fr: "Écras'Face"
+			fr: "Écras'Face",
+			de: "Pfund"
 		},
 		damage: 30
 	}],
@@ -44,7 +45,8 @@ const card: Card = {
 
 
 	description: {
-		en: "It fights by swinging a piece of lumber around. It is close to evolving when it can handle the lumber without difficulty."
+		en: "It fights by swinging a piece of lumber around. It is close to evolving when it can handle the lumber without difficulty.",
+		de: "Greift Gegner mit einem Holzbalken an. Fällt es ihm leicht, den schweren Balken zu tragen, ist seine Entwicklung nah."
 	},
 
 	retreat: 1,

--- a/data/Trainer kits/BW trainer Kit (Excadrill)/30.ts
+++ b/data/Trainer kits/BW trainer Kit (Excadrill)/30.ts
@@ -40,7 +40,8 @@ const card: Card = {
 		],
 		name: {
 			en: "Metal Claw",
-			fr: "Griffe Acier"
+			fr: "Griffe Acier",
+			de: "Metallklaue"
 		},
 
 		damage: 30
@@ -52,11 +53,13 @@ const card: Card = {
 		],
 		name: {
 			en: "Drill Run",
-			fr: "Tunnelier"
+			fr: "Tunnelier",
+			de: "Schlagbohrer"
 		},
 		effect: {
 			en: "Discard an Energy attached to the Defending Pokémon.",
-			fr: "Défaussez une Énergie attachée au Pokémon Défenseur."
+			fr: "Défaussez une Énergie attachée au Pokémon Défenseur.",
+			de: "Lege 1 an das Verteidigende Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
 		},
 		damage: 80
 	}],
@@ -72,7 +75,8 @@ const card: Card = {
 	}],
 
 	description: {
-		en: "It can help in tunnel construction. Its drill has evolved into steel strong enough to bore through iron plates."
+		en: "It can help in tunnel construction. Its drill has evolved into steel strong enough to bore through iron plates.",
+		de: "Seine zu Stahl weiterentwickelten Bohrer kriegen selbst Eisenplatten klein. Im Tunnelbau ist es ein absolutes Ass."
 	},
 
 	retreat: 2,


### PR DESCRIPTION
## Add missing German translations for tk-bw-e

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
