### PR TITLE
Add missing German translations for bw7

### DIFF
--- a/data/Black & White/Boundaries Crossed/1.ts
+++ b/data/Black & White/Boundaries Crossed/1.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Absorb",
 				fr: "Vol-Vie",
+				de: "Absorber"
 			},
 			effect: {
 				en: "Heal 10 damage from this Pokémon.",
 				fr: "Soignez 10 dégâts à ce Pokémon.",
+				de: "Heile 10 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 10,
 
@@ -52,6 +54,7 @@ const card: Card = {
 			name: {
 				en: "Acid",
 				fr: "Acide",
+				de: "Säure"
 			},
 
 			damage: 20,
@@ -77,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It often plants its root feet in the ground during the day and sows seeds as it walks about at night.",
+		de: "Tagsüber verankert es sich mit seinen Wurzelfüßen im Boden. Nachts wandert es und verteilt Samen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/10.ts
+++ b/data/Black & White/Boundaries Crossed/10.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Call for Family",
 				fr: "Appel à la Famille",
+				de: "Familienruf"
 			},
 			effect: {
 				en: "Search your deck for 2 Basic Pokémon and put them onto your Bench. Shuffle your deck afterward.",
 				fr: "Cherchez 2 Pokémon de base dans votre deck et placez-les sur votre Banc. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 2 Basis-Pokémon und lege sie auf deine Bank. Mische anschließend dein Deck."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Leaf Drain",
 				fr: "Feuille Sangsue",
+				de: "Blattsauger"
 			},
 			effect: {
 				en: "Flip a coin. If heads, heal 30 damage from this Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, soignez 30 dégâts à ce Pokémon.",
+				de: "Wirf 1 Münze. Heile bei „Kopf“ 30 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 30,
 
@@ -72,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "The flowers all over its body burst into bloom if it is lovingly hugged and senses gratitude.",
+		de: "Wird es umarmt, empfindet es Dankbarkeit, was wiederum dazu führt, dass seine Blumen blühen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/100.ts
+++ b/data/Black & White/Boundaries Crossed/100.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Dual Claw",
 				fr: "Paire de Griffes",
+				de: "Doppelpranke"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -55,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Flash Freeze",
 				fr: "Tonnerre de Glace",
+				de: "Froststrahl"
 			},
 			effect: {
 				en: "Discard an Energy attached to this Pokémon.",
 				fr: "Défaussez une Énergie attachée à ce Pokémon.",
+				de: "Lege 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel."
 			},
 			damage: 100,
 
@@ -76,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "This legendary ice Pokémon waits for a hero to fill in the missing parts of its body with truth or ideals.",
+		de: "Ein Legendäres Eis-Pokémon, das auf den Helden wartet, der seinen verstümmelten Körper mit Wunsch und Wirklichkeit heilt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/101.ts
+++ b/data/Black & White/Boundaries Crossed/101.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Dragon Fang",
 				fr: "Croc de Dragon",
+				de: "Drachenzahn"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 60,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Freeze Shock",
 				fr: "Éclair Gelé",
+				de: "Frostvolt"
 			},
 			effect: {
 				en: "This Pokémon can't attack during your next turn.",
 				fr: "Ce Pokémon ne peut pas attaquer pendant votre prochain tour.",
+				de: "Dieses Pokémon kann während deines nächsten Zuges nicht angreifen."
 			},
 			damage: 150,
 

--- a/data/Black & White/Boundaries Crossed/102.ts
+++ b/data/Black & White/Boundaries Crossed/102.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Damage Rush",
 				fr: "Charge Destructrice",
+				de: "Schadensrausch"
 			},
 			effect: {
 				en: "Flip a coin until you get tails. This attack does 20 damage times the number of heads.",
 				fr: "Lancez une pièce jusqu'à ce que vous obteniez un côté pile. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -55,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Cold Fire",
 				fr: "Flammes de Glace",
+				de: "Eisbrand"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 40 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 40 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 40 weitere Schadenspunkte zu."
 			},
 			damage: 80,
 
@@ -76,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "This legendary ice Pokémon waits for a hero to fill in the missing parts of its body with truth or ideals.",
+		de: "Ein Legendäres Eis-Pokémon, das auf den Helden wartet, der seinen verstümmelten Körper mit Wunsch und Wirklichkeit heilt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/103.ts
+++ b/data/Black & White/Boundaries Crossed/103.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Dragon Stream",
 				fr: "Flux Draconique",
+				de: "Drachenströmung"
 			},
 			effect: {
 				en: "Flip a coin. If heads, attach a basic Energy card from your discard pile to this Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, attachez une carte Énergie de base de votre pile de défausse à ce Pokémon.",
+				de: "Wirf 1 Münze. Nimm bei „Kopf“ 1 Basis-Energiekarte von deinem Ablagestapel und lege sie an dieses Pokémon an."
 			},
 			damage: 60,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Ice Burn",
 				fr: "Feu Glacé",
+				de: "Frosthauch"
 			},
 			effect: {
 				en: "Discard 2 Fire Energy attached to this Pokémon. The Defending Pokémon is now Burned.",
 				fr: "Défaussez 2 Énergies Fire attachées à ce Pokémon. Le Pokémon Défenseur est maintenant Brûlé.",
+				de: "Lege 2 an dieses Pokémon angelegte {R}-Energien auf deinen Ablagestapel. Das Verteidigende Pokémon ist jetzt verbrannt."
 			},
 			damage: 150,
 

--- a/data/Black & White/Boundaries Crossed/104.ts
+++ b/data/Black & White/Boundaries Crossed/104.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Paralyzing Gaze",
 				fr: "Regard Paralysant",
+				de: "Lähmender Blick"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 
 		},
@@ -56,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "It searches for food all day. It gnaws on hard objects to wear down its fangs, which grow constantly during its lifetime.",
+		de: "Sucht den lieben langen Tag nach Futter. Da seine Nagezähne immer nachwachsen, wetzt es sie an harten Objekten ab."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/105.ts
+++ b/data/Black & White/Boundaries Crossed/105.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Rattata",
 		fr: "Rattata",
+		de: "Rattfratz"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Gnaw Through",
 				fr: "Grignotage",
+				de: "Durchnagen"
 			},
 			effect: {
 				en: "Discard a Pokémon Tool card attached to the Defending Pokémon.",
 				fr: "Défaussez une carte Outil Pokémon attachée au Pokémon Défenseur.",
+				de: "Lege 1 an das Verteidigende Pokémon angelegte Pokémon-Ausrüstung auf den Ablagestapel deines Gegners."
 			},
 
 		},
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Super Fang",
 				fr: "Croc Fatal",
+				de: "Superzahn"
 			},
 			effect: {
 				en: "Put damage counters on the Defending Pokémon until its remaining HP is 10.",
 				fr: "Placez des marqueurs de dégâts sur le Pokémon Défenseur jusqu'à ce qu'il ait 10 PV.",
+				de: "Lege so lang Schadensmarken auf das Verteidigende Pokémon, bis es noch 10 KP übrig hat."
 			},
 
 		},
@@ -77,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "With its long fangs, this surprisingly violent Pokémon can gnaw away even thick concrete with ease.",
+		de: "Ein überraschend brutales Pokémon. Seine langen Nagezähne sind äußerst stark und durchbrechen selbst Beton."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/106.ts
+++ b/data/Black & White/Boundaries Crossed/106.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Fake Out",
 				fr: "Bluff",
+				de: "Mogelhieb"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 20,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "It is nocturnal in nature. If it spots something shiny, its eyes glitter brightly.",
+		de: "Ein nachtaktives Pokémon. Sieht es etwas Schimmerndes, fangen seine Augen an zu glänzen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/107.ts
+++ b/data/Black & White/Boundaries Crossed/107.ts
@@ -35,10 +35,12 @@ const card: Card = {
 			name: {
 				en: "Hard Swing",
 				fr: "Gnon Vigoureux",
+				de: "Harter Hieb"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -63,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It can't live without the stalk it holds. That's why it defends the stalk from attackers with its life.",
+		de: "Ohne seinen Stock kann es nicht leben. Daher beschützt es den Stock mit seinem Leben."
 	},
 }
 

--- a/data/Black & White/Boundaries Crossed/108.ts
+++ b/data/Black & White/Boundaries Crossed/108.ts
@@ -61,6 +61,7 @@ const card: Card = {
 
 	description: {
 		en: "It can reconstitute its entire cellular structure to change into what it sees, but it returns to normal when it relaxes.",
+		de: "Ruht es sich nicht aus, kann es seine Zellstruktur so verändern, dass es sich in alles verwandeln kann, was es sieht."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/109.ts
+++ b/data/Black & White/Boundaries Crossed/109.ts
@@ -38,10 +38,12 @@ const card: Card = {
 			name: {
 				en: "Double Lariat",
 				fr: "Double Lasso",
+				de: "Doppel-Lasso"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 40 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 40 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 40,
 
@@ -56,6 +58,7 @@ const card: Card = {
 			name: {
 				en: "Rollout",
 				fr: "Roulade",
+				de: "Walzer"
 			},
 
 			damage: 60,
@@ -74,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "When its belly is full, it becomes too lethargic to even lift a finger, so it is safe to bounce on its belly.",
+		de: "Ist sein Magen voll, wird es sehr lethargisch. Nun kann man problemlos auf seinem Bauch umherspringen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/11.ts
+++ b/data/Black & White/Boundaries Crossed/11.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Vine Whip",
 				fr: "Fouet Lianes",
+				de: "Rankenhieb"
 			},
 
 			damage: 10,
@@ -49,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Cut",
 				fr: "Coupe",
+				de: "Zerschneider"
 			},
 
 			damage: 20,
@@ -67,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "It is very intelligent and calm. Being exposed to lots of sunlight makes its movements swifter.",
+		de: "Eine kühle Denkernatur. Bekommt es genügend Sonnenlicht ab, erhöht sich die Geschwindigkeit seiner Bewegungen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/110.ts
+++ b/data/Black & White/Boundaries Crossed/110.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Attract Smack",
 				fr: "Poutou Grisant",
+				de: "Köderklaps"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 10,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "It transforms the kindness and joy of others into happiness, which it stores in its shell.",
+		de: "Wandelt die Güte und Freude anderer in Glücksgefühle um, die es in seinem Panzer speichert."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/111.ts
+++ b/data/Black & White/Boundaries Crossed/111.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Double Draw",
 				fr: "Double Pioche",
+				de: "Zweifachzug"
 			},
 			effect: {
 				en: "Draw 2 cards.",
 				fr: "Piochez 2 cartes.",
+				de: "Ziehe 2 Karten."
 			},
 
 		},
@@ -50,10 +52,12 @@ const card: Card = {
 			name: {
 				en: "Dig",
 				fr: "Tunnel",
+				de: "Schaufler"
 			},
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, évitez tous les effets d'attaques (y compris les dégâts) infligés à ce Pokémon pendant le prochain tour de votre adversaire.",
+				de: "Wirf 1 Münze. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die diesem Pokémon zugefügt werden."
 			},
 			damage: 10,
 
@@ -71,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "It creates mazes in dark locations. When spotted, it flees into the ground by digging with its tail.",
+		de: "Es baut an dunklen Orten Labyrinthe. Wird es von jemandem entdeckt, gräbt es ein Loch und versucht zu entkommen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/112.ts
+++ b/data/Black & White/Boundaries Crossed/112.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Peck",
 				fr: "Picpic",
+				de: "Schnabel"
 			},
 
 			damage: 10,
@@ -61,6 +62,7 @@ const card: Card = {
 
 	description: {
 		en: "It has a gutsy spirit that makes it bravely take on tough foes. It flies in search of warm climates.",
+		de: "Es ist sehr mutig und stellt sich auch starken Gegnern. Es sucht ständig nach warmen Regionen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/113.ts
+++ b/data/Black & White/Boundaries Crossed/113.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 10,
@@ -49,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Double Slap",
 				fr: "Torgnoles",
+				de: "Duplexhieb"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -70,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "It shows its cute side by chasing its own tail until it gets dizzy.",
+		de: "Es zeigt gerne seine niedliche Seite, indem es seinen eigenen Schweif jagt, bis ihm schwindlig wird."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/114.ts
+++ b/data/Black & White/Boundaries Crossed/114.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Skitty",
 		fr: "Skitty",
+		de: "Eneco"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Gather Energy",
 				fr: "Récolte d'Énergie",
+				de: "Energie sammeln"
 			},
 			effect: {
 				en: "Search your deck for a basic Energy card and attach it to 1 of your Pokémon. Shuffle your deck afterward.",
 				fr: "Cherchez une carte Énergie de base dans votre deck et attachez-la à 1 de vos Pokémon. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach einer Basis-Energiekarte und lege sie an 1 deiner Pokémon an. Mische anschließend dein Deck."
 			},
 			damage: 30,
 
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Double Slap",
 				fr: "Torgnoles",
+				de: "Duplexhieb"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 30 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 30,
 
@@ -78,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "The reason it does not have a nest is that it simply searches for a clean, comfortable place then sleeps there.",
+		de: "Es hat kein festes Revier, weil es sich einfach immer ein gemütliches, sauberes Fleckchen zum Schlafen sucht."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/115.ts
+++ b/data/Black & White/Boundaries Crossed/115.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Whimsy Tackle",
 				fr: "Charge Bizarre",
+				de: "Launischer Tackle"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 30,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "No two Spinda have the same pattern of spots. Its tottering step fouls the aim of foes.",
+		de: "Das Muster eines Pandir ist wie ein Fingerabdruck. Sein Taumeln senkt die gegnerische Zielsicherheit."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/116.ts
+++ b/data/Black & White/Boundaries Crossed/116.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Pound",
 				fr: "Écras'Face",
+				de: "Pfund"
 			},
 
 			damage: 10,
@@ -49,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Smash Kick",
 				fr: "Coud'Pattes",
+				de: "Schmetterkick"
 			},
 
 			damage: 20,
@@ -67,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "By extending its rolled up ears and striking the ground, it can bound so high it surprises itself.",
+		de: "Es kann selbst kaum glauben, wie hoch es fliegt, wenn es seine aufgerollten Ohren mit großer Wucht zu Boden schnellt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/117.ts
+++ b/data/Black & White/Boundaries Crossed/117.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Buneary",
 		fr: "Laporeille",
+		de: "Haspiror"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Healing Melody",
 				fr: "Mélodie Apaisante",
+				de: "Heilende Melodie"
 			},
 			effect: {
 				en: "Flip a coin. If heads, heal 60 damage from each of your Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, soignez 60 dégâts à chacun de vos Pokémon.",
+				de: "Wirf 1 Münze. Heile bei „Kopf“ 60 Schadenspunkte bei jedem deiner Pokémon."
 			},
 
 		},
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Kick Away",
 				fr: "Coud'Pied Éjecteur",
+				de: "Wegkicken"
 			},
 			effect: {
 				en: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon.",
 				fr: "Votre adversaire échange le Pokémon Défenseur avec 1 de ses Pokémon de Banc.",
+				de: "Dein Gegner tauscht das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
 			},
 			damage: 60,
 
@@ -78,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "Extremely cautious, it quickly bounds off when it senses danger.",
+		de: "Es ist extrem vorsichtig. Wenn es Gefahr wittert, macht es sich mit flinken Sprüngen aus dem Staub."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/118.ts
+++ b/data/Black & White/Boundaries Crossed/118.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Patrol",
 				fr: "Patrouille",
+				de: "Streife"
 			},
 			effect: {
 				en: "Look at the top 3 cards of your deck and put them back on top of your deck in any order.",
 				fr: "Regardez les 3 cartes du dessus de votre deck et replacez-les sur le dessus de votre deck dans l'ordre de votre choix.",
+				de: "Schau dir die obersten 3 Karten deines Decks an und lege sie in beliebiger Reihenfolge zurück auf dein Deck."
 			},
 
 		},
@@ -56,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "Extremely cautious, one of them will always be on the lookout, but it won't notice a foe coming from behind.",
+		de: "Eines dieser vorsichtigen Pokémon steht immer vor ihrem Bau Wache. Nähert sich jedoch ein Feind von hinten, ist es aus."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/119.ts
+++ b/data/Black & White/Boundaries Crossed/119.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Patrat",
 		fr: "Ratentif",
+		de: "Nagelotz"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Hypnoblast",
 				fr: "Hypnoblast",
+				de: "Hypnoschuss"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 			damage: 20,
 
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Psych Up",
 				fr: "Boost",
+				de: "Psycho-Plus"
 			},
 			effect: {
 				en: "During your next turn, this Pokémon's Psych Up attack does 30 more damage (before applying Weakness and Resistance).",
 				fr: "Pendant votre prochain tour, l'attaque Boost de ce Pokémon inflige 30 dégâts supplémentaires (avant application de la Faiblesse et de la Résistance).",
+				de: "Während deines nächsten Zuges fügt die Attacke Psycho-Plus dieses Pokémon 30 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 			damage: 30,
 
@@ -78,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "Using luminescent matter, it makes its eyes and body glow and stuns attacking opponents.",
+		de: "Es kann mit einer körpereigenen Substanz seine Augen und seinen Torso aufleuchten lassen, um Gegner zu erschrecken."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/12.ts
+++ b/data/Black & White/Boundaries Crossed/12.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Snivy",
 		fr: "Vipélierre",
+		de: "Serpifeu"
 	},
 
 	stage: "Stage1",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Vine Whip",
 				fr: "Fouet Lianes",
+				de: "Rankenhieb"
 			},
 
 			damage: 20,
@@ -55,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Double Slash",
 				fr: "Double Lame",
+				de: "Doppelschlitzer"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 40 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 40 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 40,
 
@@ -76,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It moves along the ground as if sliding. Its swift movements befuddle its foes, and it then attacks with a vine whip.",
+		de: "Huscht beinahe gleitend über den Boden und täuscht Gegner mit agilen Manövern, bis es mithilfe seiner Efeurute obsiegt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/120.ts
+++ b/data/Black & White/Boundaries Crossed/120.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Roar",
 				fr: "Hurlement",
+				de: "Brüller"
 			},
 			effect: {
 				en: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon.",
 				fr: "Votre adversaire échange le Pokémon Défenseur avec 1 de ses Pokémon de Banc.",
+				de: "Dein Gegner tauscht das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
 			},
 
 		},
@@ -51,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
+				de: "Biss"
 			},
 
 			damage: 20,
@@ -69,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "Though it is a very brave Pokémon, it's also smart enough to check its foe's strength and avoid battle.",
+		de: "Ein tapferes Pokémon, das jedoch klug genug ist, seinen Gegner zu mustern, bevor es sich auf einen Kampf einlässt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/121.ts
+++ b/data/Black & White/Boundaries Crossed/121.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Lillipup",
 		fr: "Ponchiot",
+		de: "Yorkleff"
 	},
 
 	stage: "Stage1",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
+				de: "Biss"
 			},
 
 			damage: 20,
@@ -55,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Take Down",
 				fr: "Bélier",
+				de: "Bodycheck"
 			},
 			effect: {
 				en: "This Pokémon does 10 damage to itself.",
 				fr: "Ce Pokémon s'inflige 10 dégâts.",
+				de: "Dieses Pokémon fügt sich selbst 10 Schadenspunkte zu."
 			},
 			damage: 60,
 
@@ -76,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "This very loyal Pokémon helps trainers, and it also takes care of other Pokémon.",
+		de: "Dieses äußerst treue Pokémon geht nicht nur seinem Trainer zur Hand, sondern hilft auch anderen Pokémon."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/122.ts
+++ b/data/Black & White/Boundaries Crossed/122.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Herdier",
 		fr: "Ponchien",
+		de: "Terribark"
 	},
 
 	stage: "Stage2",
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Wild Tackle",
 				fr: "Tacle Brutal",
+				de: "Wilder Tackle"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this Pokémon does 20 damage to itself.",
 				fr: "Lancez une pièce. Si c'est pile, ce Pokémon s'inflige 20 dégâts.",
+				de: "Wirf 1 Münze. Bei „Zahl“ fügt sich dieses Pokémon selbst 20 Schadenspunkte zu."
 			},
 			damage: 90,
 
@@ -86,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "Being wrapped in its long fur is so comfortable that a person would be fine even overnight on a wintry mountain.",
+		de: "Sein langes Fell ist sehr bequem und kann einen Menschen eine ganze Nacht lang auf einem schneebedeckten Berg warmhalten."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/123.ts
+++ b/data/Black & White/Boundaries Crossed/123.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Razor Wind",
 				fr: "Coupe-Vent",
+				de: "Klingensturm"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 30,
 
@@ -65,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "This very forgetful Pokémon will wait for a new order from its Trainer even though it already has one.",
+		de: "Wartet oft vergeblich auf Anweisungen, obwohl es bereits einen Befehl erhalten hat. Ein sehr zerstreutes Pokémon."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/124.ts
+++ b/data/Black & White/Boundaries Crossed/124.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pidove",
 		fr: "Poichigeon",
+		de: "Dusselgurr"
 	},
 
 	stage: "Stage1",
@@ -43,10 +44,12 @@ const card: Card = {
 			name: {
 				en: "Air Slash",
 				fr: "Lame d'Air",
+				de: "Luftschnitt"
 			},
 			effect: {
 				en: "Discard an Energy attached to this Pokémon.",
 				fr: "Défaussez une Énergie attachée à ce Pokémon.",
+				de: "Lege 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel."
 			},
 			damage: 60,
 
@@ -71,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "No matter where in the world it goes, it knows where its nest is, so it never gets separated from its Trainer.",
+		de: "Findet selbst von der anderen Seite des Globus zu seinem Nest zurück. Nichts kann es von seinem Trainer trennen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/125.ts
+++ b/data/Black & White/Boundaries Crossed/125.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Tranquill",
 		fr: "Colombeau",
+		de: "Navitaub"
 	},
 
 	stage: "Stage2",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Wing Flick",
 				fr: "Battement d'Aile",
+				de: "Schwingenschlag"
 			},
 			effect: {
 				en: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon.",
 				fr: "Votre adversaire échange le Pokémon Défenseur avec 1 de ses Pokémon de Banc.",
+				de: "Dein Gegner tauscht das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
 			},
 			damage: 40,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Air Slash",
 				fr: "Lame d'Air",
+				de: "Luftschnitt"
 			},
 			effect: {
 				en: "Flip a coin. If tails, discard an Energy attached to this Pokémon.",
 				fr: "Lancez une pièce. Si c'est pile, défaussez une Énergie attachée à ce Pokémon.",
+				de: "Wirf 1 Münze. Lege bei „Zahl“ 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel."
 			},
 			damage: 80,
 
@@ -87,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "Males swing the plumage on their heads to threaten others, but females are better at flying.",
+		de: "Männchen schrecken Gegner ab, indem sie ihren Kopfschmuck schütteln. Weibchen verfügen über bessere Flugfertigkeiten."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/126.ts
+++ b/data/Black & White/Boundaries Crossed/126.ts
@@ -59,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Hip Bump",
 				fr: "Hanche Amortissante",
+				de: "Hüftschubser"
 			},
 			effect: {
 				en: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
 				fr: "Si le Pokémon Défenseur essaie d'attaquer pendant le prochain tour de votre adversaire, ce dernier lance une pièce. Si c’est pile, son attaque ne fait rien.",
+				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 30,
 
@@ -80,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "Using the feelers on its ears, it can tell how someone is feeling or when an egg might hatch.",
+		de: "Über die Fühler an seinen Ohren kann es ertasten, wie es einer Person geht oder wann ein Pokémon aus seinem Ei schlüpft."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/127.ts
+++ b/data/Black & White/Boundaries Crossed/127.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cada Pokémon Colorless en juego (tanto tuyos como de tu rival) obtiene 20 PV más.",
 		it: "Ciascun Pokémon Colorless in gioco, sia tuo che del tuo avversario, ha 20 PV in più.",
 		pt: "Cada Pokémon Colorless em jogo (tanto seu quanto do seu oponente) recebe +20 PS.",
-		de: "Jedes Colorless-Pokémon im Spiel (deine und die deines Gegners) erhält +20 KP."
+		de: "Jedes {C}-Pokémon im Spiel (deine und die deines Gegners) erhält +20 KP. Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 
 	trainerType: "Stadium",

--- a/data/Black & White/Boundaries Crossed/128.ts
+++ b/data/Black & White/Boundaries Crossed/128.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja una carta de Energía Básica, enséñala y ponla en tu mano. Baraja las cartas de tu baraja después.",
 		it: "Cerca nel tuo mazzo una carta Energia base, mostrala e aggiungila alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure em seu baralho um card de Energia básica, revele-o e coloque-o na sua mão. Em seguida, embaralhe seus cards.",
-		de: "Durchsuche dein Deck nach 1 Basis-Energiekarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach 1 Basis-Energiekarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Boundaries Crossed/129.ts
+++ b/data/Black & White/Boundaries Crossed/129.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mira las 7 primeras cartas de tu baraja. Puedes enseñar un Pokémon que encuentres entre ellas y ponerlo en tu mano. Pon el resto de cartas de nuevo en tu baraja y barájalas todas.",
 		it: "Guarda le prime sette carte del tuo mazzo. Puoi mostrare un Pokémon che hai trovato e aggiungerlo alle carte che hai in mano. Rimischia le altre carte nel tuo mazzo.",
 		pt: "Olhe os 7 cards de cima do seu baralho. Você poderá revelar um Pokémon que encontrar lá e colocá-lo em sua mão. Embaralhe os demais cards de volta.",
-		de: "Schau dir die obersten 7 Karten deines Decks an. Du kannst 1 Pokémon, das du dort gefunden hast, deinem Gegner zeigen und es auf deine Hand nehmen. Mische die anderen Karten zurück in dein Deck."
+		de: "Schau dir die obersten 7 Karten deines Decks an. Du kannst 1 Pokémon, das du dort gefunden hast, deinem Gegner zeigen und auf deine Hand nehmen. Mische die anderen Karten zurück in dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Boundaries Crossed/13.ts
+++ b/data/Black & White/Boundaries Crossed/13.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Servine",
 		fr: "Lianaja",
+		de: "Efoserp"
 	},
 
 	stage: "Stage2",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Double Slash",
 				fr: "Double Lame",
+				de: "Doppelschlitzer"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 50 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 50 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 50,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Mega Drain",
 				fr: "Méga-Sangsue",
+				de: "Megasauger"
 			},
 			effect: {
 				en: "Heal 30 damage from this Pokémon.",
 				fr: "Soignez 30 dégâts à ce Pokémon.",
+				de: "Heile 30 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 70,
 
@@ -80,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "It can stop its opponents' movements with just a glare. It takes in solar energy and boosts it internally.",
+		de: "Bringt Gegner mit einem einzigen kühlen Blick zum Erstarren. In seinem Inneren verstärkt es die Energie der Sonne."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/130.ts
+++ b/data/Black & White/Boundaries Crossed/130.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cada jugador roba o descarta cartas hasta tener 5 cartas en su mano. (Tu rival lo hace primero.)",
 		it: "Ciascun giocatore pesca o scarta carte fino ad avere cinque carte in mano. Inizia il tuo avversario.",
 		pt: "Cada jogador compra ou descarta cards até ter 5 cards na mão. (Seu oponente faz isso primeiro.)",
-		de: "Jeder Spieler muss so viele Karten ziehen oder ablegen, bis er 5 Karten auf der Hand hat. (Dein Gegner beginnt.)"
+		de: "Jeder Spieler muss so viele Karten ziehen oder ablegen, bis er 5 Karten auf der Hand hat. (Dein Gegner beginnt.) Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Black & White/Boundaries Crossed/131.ts
+++ b/data/Black & White/Boundaries Crossed/131.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Lanza una moneda. Si sale cara, busca en tu baraja un Pokémon, enséñalo y ponlo en tu mano. Baraja las cartas de tu baraja después.",
 		it: "Lancia una moneta. Se esce testa, cerca nel tuo mazzo un Pokémon, mostralo e aggiungilo alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Jogue uma moeda. Se sair cara, procure um Pokémon no seu deck, mostre-o e coloque-o na sua mão. Em seguida, embaralhe seus cards.",
-		de: "Wirf 1 Münze. Durchsuche bei „Kopf“ dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck."
+		de: "Wirf 1 Münze. Durchsuche bei „Kopf“ dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Boundaries Crossed/132.ts
+++ b/data/Black & White/Boundaries Crossed/132.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cura 30 puntos de daño a 1 de tus Pokémon.",
 		it: "Cura uno dei tuoi Pokémon da 30 danni.",
 		pt: "Cure 30 de danos de 1 dos seus Pokémon.",
-		de: "Heile 30 Schadenspunkte bei 1 deiner Pokémon."
+		de: "Heile 30 Schadenspunkte bei 1 deiner Pokémon. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Boundaries Crossed/133.ts
+++ b/data/Black & White/Boundaries Crossed/133.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Si el Pokémon al que está unida esta carta es tu Pokémon Activo y resulta dañado por el ataque de un rival (incluso si ese Pokémon queda Fuera de Combate), pon 2 contadores de daño en el Pokémon Atacante.",
 		it: "Se il Pokémon a cui è assegnata questa carta è il tuo Pokémon attivo e viene danneggiato da un attacco del tuo avversario, anche se viene messo K.O., metti due segnalini danno sul Pokémon attaccante.",
 		pt: "Se este card estiver ligado a seu Pokémon Ativo e ele for danificado pelo ataque de um oponente (mesmo se esse Pokémon for Nocauteado), coloque 2 marcadores de danos no Pokémon Atacante.",
-		de: "Wenn das Pokémon, an dem diese Karte angelegt ist, dein Aktives Pokémon ist und es durch einen gegnerischen Angriff Schaden erhält (auch wenn dieses Pokémon dadurch kampfunfähig wird), lege 2 Schadensmarken auf das Angreifende Pokémon."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn das Pokémon, an dem diese Karte angelegt ist, dein Aktives Pokémon ist und durch einen gegnerischen Angriff Schaden erhält (auch wenn dieses Pokémon dadurch kampfunfähig wird), lege 2 Schadensmarken auf das Angreifende Pokémon. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Black & White/Boundaries Crossed/134.ts
+++ b/data/Black & White/Boundaries Crossed/134.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja una carta de Entrenador, enséñala y ponla en tu mano. Baraja las cartas de tu baraja después.",
 		it: "Cerca nel tuo mazzo una carta Allenatore, mostrala e aggiungila alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure um card de Treinador em seu baralho, revele-o e coloque-o em sua mão. Em seguida, embaralhe seus cards.",
-		de: "Durchsuche dein Deck nach 1 Trainerkarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach 1 Trainerkarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Black & White/Boundaries Crossed/135.ts
+++ b/data/Black & White/Boundaries Crossed/135.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cambia a tu Pokémon Activo por 1 de tus Pokémon en Banca.",
 		it: "Scambia il tuo Pokémon attivo con uno dei tuoi Pokémon in panchina.",
 		pt: "Troque seu Pokémon Ativo por 1 dos Pokémon no seu Banco.",
-		de: "Tausche dein Aktives Pokémon gegen 1 Pokémon auf deiner Bank aus."
+		de: "Tausche dein Aktives Pokémon gegen 1 Pokémon auf deiner Bank aus. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Boundaries Crossed/136.ts
+++ b/data/Black & White/Boundaries Crossed/136.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon todas tus cartas de Premio boca arriba. (Esas cartas de Premio permanecerán boca arriba durante el resto de la partida.)",
 		it: "Gira tutte le tue carte Premio a faccia in su (rimarranno così per il resto della partita).",
 		pt: "Vire todos os seus cards de Prêmio com a face para cima. (Os cards de Prêmio permanecerão virados para cima pelo resto do jogo.)",
-		de: "Decke all deine Preiskarten auf. (Diese Preiskarten bleiben für den Rest des Spiels aufgedeckt.)"
+		de: "Decke all deine Preiskarten auf. (Diese Preiskarten bleiben für den Rest des Spiels aufgedeckt.) Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Boundaries Crossed/137.ts
+++ b/data/Black & White/Boundaries Crossed/137.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta 2 cartas de tu mano. (Si no puedes descartar 2 cartas, no puedes jugar esta carta.) Busca en tu baraja una carta y ponla en tu mano. Baraja las cartas de tu baraja después.",
 		it: "Scarta due delle carte che hai in mano (se non puoi scartare due carte, non potrai giocare questa carta). Cerca nel tuo mazzo una carta qualsiasi e aggiungila a quelle che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Descarte 2 cards da sua mão. (Se você não puder descartar 2 cards, não poderá jogar esse card.) Procure um card em seu baralho e coloque-o em sua mão. Em seguida, embaralhe seus cards.",
-		de: "Lege 2 Karten von deiner Hand auf deinen Ablagestapel. (Wenn du keine 2 Karten auf deinen Ablagestapel legen kannst, kannst du diese Karte nicht spielen.) Durchsuche dein Deck nach 1 Karte und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Dein Deck darf nicht mehr als 1 ASS-KLASSE-Karte enthalten. Lege 2 Karten von deiner Hand auf deinen Ablagestapel. (Wenn du keine 2 Karten auf deinen Ablagestapel legen kannst, kannst du diese Karte nicht spielen.) Durchsuche dein Deck nach 1 Karte und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Boundaries Crossed/138.ts
+++ b/data/Black & White/Boundaries Crossed/138.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Si esta carta está unida a Kyurem Blanco-EX, cada uno de sus ataques hace 50 puntos de daño más a los Pokémon Activos (antes de aplicar Debilidad y Resistencia).",
 		it: "Se questa carta è assegnata a Kyurem Bianco-EX, tutti i suoi attacchi infliggono 50 danni in più al Pokémon attivo, prima di aver applicato debolezza e resistenza.",
 		pt: "Se este card estiver ligado a Kyurem Branco-EX, cada um de seus ataques causará 50 de danos adicionais ao Pokémon Ativo (antes da aplicação de Fraqueza e Resistência) .",
-		de: "Wenn diese Karte an ein Weißes Kyurem-EX angelegt ist, fügen alle seine Angriffe den Aktiven Pokémon 50 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
+		de: "Dein Deck darf nicht mehr als 1 ASS-KLASSE-Karte enthalten. Wenn diese Karte an ein Weißes Kyurem-EX angelegt ist, fügen alle seine Angriffe den Aktiven Pokémon 50 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden). Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Black & White/Boundaries Crossed/139.ts
+++ b/data/Black & White/Boundaries Crossed/139.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Si esta carta está unida a Kyurem Negro-EX, sus PV máximos son 300.",
 		it: "Se questa carta è assegnata a Kyurem Nero-EX, i suoi PV massimi diventano 300.",
 		pt: "Se esse card estiver ligado a Kyurem Preto-EX, seu PS máximo será 300.",
-		de: "Wenn diese Karte an ein Schwarzes Kyurem-EX angelegt ist, verfügt es über 300 Grund-KP."
+		de: "Dein Deck darf nicht mehr als 1 ASS-KLASSE-Karte enthalten. Wenn diese Karte an Schwarzes Kyurem-EX angelegt ist, verfügt es über 300 Grund-KP. Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Black & White/Boundaries Crossed/14.ts
+++ b/data/Black & White/Boundaries Crossed/14.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Ram",
 				fr: "Collision",
+				de: "Ramme"
 			},
 
 			damage: 10,
@@ -61,6 +62,7 @@ const card: Card = {
 
 	description: {
 		en: "Perhaps because they feel more at ease in a group, they stick to others they find. They end up looking like a cloud.",
+		de: "Sind sie mit Freunden unterwegs, hängen sie eng aufeinander wie Wolken, wohl weil sie sich in der Gruppe sicherer fühlen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/140.ts
+++ b/data/Black & White/Boundaries Crossed/140.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cura 90 puntos de daño a tu Pokémon Activo.",
 		it: "Cura il tuo Pokémon attivo da 90 danni.",
 		pt: "Cure 90 de danos do seu Pokémon Ativo.",
-		de: "Heile 90 Schadenspunkte bei deinem Aktiven Pokémon."
+		de: "Dein Deck darf nicht mehr als 1 ASS-KLASSE-Karte enthalten. Heile 90 Schadenspunkte bei deinem Aktiven Pokémon. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Boundaries Crossed/141.ts
+++ b/data/Black & White/Boundaries Crossed/141.ts
@@ -56,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Wind Whisk",
 				fr: "Rafale Tranchante",
+				de: "Windbesen"
 			},
 			effect: {
 				en: "Switch this Pokémon with 1 of your Benched Pokémon.",
 				fr: "Échangez ce Pokémon avec 1 de vos Pokémon de Banc.",
+				de: "Tausche dieses Pokémon gegen 1 Pokémon auf deiner Bank aus."
 			},
 			damage: 60,
 

--- a/data/Black & White/Boundaries Crossed/142.ts
+++ b/data/Black & White/Boundaries Crossed/142.ts
@@ -56,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Secret Sword",
 				fr: "Lame Ointe",
+				de: "Mystoschwert"
 			},
 			effect: {
 				en: "Does 20 more damage for each Water Energy attached to this Pokémon.",
 				fr: "Inflige 20 dégâts supplémentaires pour chaque Énergie Water attachée à ce Pokémon.",
+				de: "Dieser Angriff fügt 20 weitere Schadenspunkte für jede an dieses Pokémon angelegte {W}-Energie zu."
 			},
 			damage: 50,
 

--- a/data/Black & White/Boundaries Crossed/143.ts
+++ b/data/Black & White/Boundaries Crossed/143.ts
@@ -57,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Psychic Protection",
 				fr: "Protection Psy",
+				de: "Psychoschützer"
 			},
 			effect: {
 				en: "During your opponent's next turn, this Pokémon has no Weakness.",
 				fr: "Pendant le prochain tour de votre adversaire, ce Pokémon n'a pas de Faiblesse.",
+				de: "Während des nächsten Zuges deines Gegners hat dieses Pokémon keine Schwäche."
 			},
 			damage: 90,
 

--- a/data/Black & White/Boundaries Crossed/144.ts
+++ b/data/Black & White/Boundaries Crossed/144.ts
@@ -34,10 +34,12 @@ const card: Card = {
 			name: {
 				en: "Hammerhead",
 				fr: "Massue",
+				de: "Hammerkopf"
 			},
 			effect: {
 				en: "Does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 30 dégâts à 1 des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 1 Pokémon auf der Bank deines Gegners 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 30,
 
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Land's Judgment",
 				fr: "Jugement Terrestre",
+				de: "Mach dich vom Acker"
 			},
 			effect: {
 				en: "You may discard all Fighting Energy attached to this Pokémon. If you do, this attack does 70 more damage.",
 				fr: "Vous pouvez défausser toutes les Énergies Fighting attachées à ce Pokémon. Dans ce cas, cette attaque inflige 70 dégâts supplémentaires.",
+				de: "Du kannst alle an dieses Pokémon angelegten {F}-Energien auf deinen Ablagestapel legen. Wenn du das machst, fügt dieser Angriff 70 weitere Schadenspunkte zu."
 			},
 			damage: 80,
 

--- a/data/Black & White/Boundaries Crossed/145.ts
+++ b/data/Black & White/Boundaries Crossed/145.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Dragon Fang",
 				fr: "Croc de Dragon",
+				de: "Drachenzahn"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 60,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Freeze Shock",
 				fr: "Éclair Gelé",
+				de: "Frostvolt"
 			},
 			effect: {
 				en: "This Pokémon can't attack during your next turn.",
 				fr: "Ce Pokémon ne peut pas attaquer pendant votre prochain tour.",
+				de: "Dieses Pokémon kann während deines nächsten Zuges nicht angreifen."
 			},
 			damage: 150,
 

--- a/data/Black & White/Boundaries Crossed/146.ts
+++ b/data/Black & White/Boundaries Crossed/146.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Dragon Stream",
 				fr: "Flux Draconique",
+				de: "Drachenströmung"
 			},
 			effect: {
 				en: "Flip a coin. If heads, attach a basic Energy card from your discard pile to this Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, attachez une carte Énergie de base de votre pile de défausse à ce Pokémon.",
+				de: "Wirf 1 Münze. Nimm bei „Kopf“ 1 Basis-Energiekarte von deinem Ablagestapel und lege sie an dieses Pokémon an."
 			},
 			damage: 60,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Ice Burn",
 				fr: "Feu Glacé",
+				de: "Frosthauch"
 			},
 			effect: {
 				en: "Discard 2 Fire Energy attached to this Pokémon. The Defending Pokémon is now Burned.",
 				fr: "Défaussez 2 Énergies Fire attachées à ce Pokémon. Le Pokémon Défenseur est maintenant Brûlé.",
+				de: "Lege 2 an dieses Pokémon angelegte {R}-Energien auf deinen Ablagestapel. Das Verteidigende Pokémon ist jetzt verbrannt."
 			},
 			damage: 150,
 

--- a/data/Black & White/Boundaries Crossed/147.ts
+++ b/data/Black & White/Boundaries Crossed/147.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba cartas hasta que tengas 6 cartas en tu mano.",
 		it: "Pesca fino ad avere sei carte in mano.",
 		pt: "Compre cards até ter 6 cards em sua mão.",
-		de: "Ziehe so viele Karten, bis du 6 Karten auf der Hand hast."
+		de: "Ziehe so viele Karten, bis du 6 Karten auf der Hand hast. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Black & White/Boundaries Crossed/148.ts
+++ b/data/Black & White/Boundaries Crossed/148.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba 3 cartas.",
 		it: "Pesca tre carte.",
 		pt: "Compre 3 cards.",
-		de: "Ziehe 3 Karten."
+		de: "Ziehe 3 Karten. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Black & White/Boundaries Crossed/149.ts
+++ b/data/Black & White/Boundaries Crossed/149.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja una carta de Entrenador, enséñala y ponla en tu mano. Baraja las cartas de tu baraja después.",
 		it: "Cerca nel tuo mazzo una carta Allenatore, mostrala e aggiungila alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure um card de Treinador em seu baralho, revele-o e coloque-o em sua mão. Em seguida, embaralhe seus cards.",
-		de: "Durchsuche dein Deck nach 1 Trainerkarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach 1 Trainerkarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Black & White/Boundaries Crossed/15.ts
+++ b/data/Black & White/Boundaries Crossed/15.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cottonee",
 		fr: "Doudouvet",
+		de: "Waumboll"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Fluffy Tag",
 				fr: "Accolade Duveteuse",
+				de: "Schlummerschlag"
 			},
 			effect: {
 				en: "Switch this Pokémon with 1 of your Benched Pokémon. During your next turn, the attacks of that Pokémon do 40 more damage to the Active Pokémon (before applying Weakness and Resistance).",
 				fr: "Échangez ce Pokémon avec 1 de vos Pokémon de Banc. Pendant votre prochain tour, les attaques du Pokémon échangé infligent 40 dégâts supplémentaires aux Pokémon Actifs (avant application de la Faiblesse et de la Résistance).",
+				de: "Tausche dieses Pokémon gegen 1 Pokémon auf deiner Bank aus. Während deines nächsten Zuges fügen die Angriffe dieses Pokémon den Aktiven Pokémon 40 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 
 		},
@@ -55,10 +58,12 @@ const card: Card = {
 			name: {
 				en: "Stun Spore",
 				fr: "Para-Spore",
+				de: "Stachelspore"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 20,
 
@@ -83,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "They appear along with whirlwinds. They pull pranks, such as moving furniture and leaving balls of cotton in homes.",
+		de: "Sie erscheinen mit Orkanböen und spielen den Leuten Streiche, indem sie in Häusern Möbel verrücken oder Watte verstreuen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/150.ts
+++ b/data/Black & White/Boundaries Crossed/150.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Golett",
 		fr: "Gringolem",
+		de: "Golbit"
 	},
 
 	stage: "Stage1",
@@ -43,10 +44,12 @@ const card: Card = {
 			name: {
 				en: "Devolution Punch",
 				fr: "Beigne Dés-évoluante",
+				de: "Rückentwicklungshieb"
 			},
 			effect: {
 				en: "Devolve the Defending Pokémon and put the highest Stage Evolution card on it into your opponent's hand.",
 				fr: "Faites dés-évoluer le Pokémon Défenseur et mettez sa carte Évolution de plus haut Niveau dans la main de votre adversaire.",
+				de: "Rückentwickle das Verteidigende Pokémon. Dein Gegner nimmt die höchste daraufliegende Evolutionskarte auf seine Hand."
 			},
 			damage: 60,
 
@@ -61,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Ghost Hammer",
 				fr: "Spectro Maillet",
+				de: "Geisterhammer"
 			},
 			effect: {
 				en: "During your opponent's next turn, this Pokémon has no Weakness.",
 				fr: "Pendant le prochain tour de votre adversaire, ce Pokémon n'a pas de Faiblesse.",
+				de: "Während des nächsten Zuges deines Gegners hat dieses Pokémon keine Schwäche."
 			},
 			damage: 90,
 
@@ -82,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "This extremely rare Pokémon is a different color than usual. It is very hard to find.",
+		de: "Dieses sehr seltene Pokémon hat eine andere Farbe als üblich. Es ist schwer zu finden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/151.ts
+++ b/data/Black & White/Boundaries Crossed/151.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Retaliate",
 				fr: "Vengeance",
+				de: "Heimzahlung"
 			},
 			effect: {
 				en: "If any of your Pokémon were Knocked Out by damage from an opponent's attack during his or her last turn, this attack does 60 more damage.",
 				fr: "Si l'un de vos Pokémon a été mis K.O. par les dégâts d'une attaque de votre adversaire pendant son dernier tour, cette attaque inflige 60 dégâts supplémentaires.",
+				de: "Falls eins deiner Pokémon während des letzten Zuges deines Gegners durch Schaden eines gegnerischen Angriffs kampfunfähig gemacht wurde, fügt dieser Angriff 60 weitere Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -54,6 +56,7 @@ const card: Card = {
 			name: {
 				en: "Land Crush",
 				fr: "Écras'Terre",
+				de: "Schollenbrecher"
 			},
 
 			damage: 90,
@@ -72,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "This extremely rare Pokémon is a different color than usual. It is very hard to find.",
+		de: "Dieses sehr seltene Pokémon hat eine andere Farbe als üblich. Es ist schwer zu finden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/152.ts
+++ b/data/Black & White/Boundaries Crossed/152.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Swablu",
 		fr: "Tylton",
+		de: "Wablu"
 	},
 
 	stage: "Stage1",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Los ataques de tus Pokémon Dragon hacen 20 puntos de daño más a los Pokémon Activos (antes de aplicar Debilidad y Resistencia).",
 				it: "Gli attacchi dei tuoi Pokémon Dragon infliggono 20 danni in più al Pokémon attivo, prima di aver applicato debolezza e resistenza.",
 				pt: "Os ataques do seu Pokémon Dragon causam 20 de danos adicionais ao Pokémon Ativo (antes da aplicação de Fraqueza e Resistência).",
-				de: "Die Angriffe deiner Dragon-Pokémon fügen den Aktiven Pokémon 20 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
+				de: "Die Angriffe deiner {N}-Pokémon fügen den Aktiven Pokémon 20 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 		},
 	],
@@ -65,6 +66,7 @@ const card: Card = {
 			name: {
 				en: "Glide",
 				fr: "Glissement",
+				de: "Gleiten"
 			},
 
 			damage: 40,
@@ -83,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "This extremely rare Pokémon is a different color than usual. It is very hard to find.",
+		de: "Dieses sehr seltene Pokémon hat eine andere Farbe als üblich. Es ist schwer zu finden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/153.ts
+++ b/data/Black & White/Boundaries Crossed/153.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Si el Pokémon al que está unida esta carta es tu Pokémon Activo y resulta dañado por el ataque de un rival (incluso si ese Pokémon queda Fuera de Combate), pon 2 contadores de daño en el Pokémon Atacante,",
 		it: "Se il Pokémon a cui è assegnata questa carta è il tuo Pokémon attivo e viene danneggiato da un attacco del tuo avversario, anche se viene messo K,O metti due segnalini danno sul Pokémon attaccante,",
 		pt: "Se este card estiver ligado a seu Pokémon Ativo e ele for danificado pelo ataque de um oponente (mesmo se esse Pokémon for Nocauteado), coloque 2 marcadores de danos no Pokémon Atacante.",
-		de: "Wenn das Pokémon, an dem diese Karte angelegt ist, dein Aktives Pokémon ist und es durch einen gegnerischen Angriff Schaden erhält (auch wenn dieses Pokémon dadurch kampfunfähig wird), lege 2 Schadensmarken auf das Angreifende Pokémon,"
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn das Pokémon, an dem diese Karte angelegt ist, dein Aktives Pokémon ist und durch einen gegnerischen Angriff Schaden erhält (auch wenn dieses Pokémon dadurch kampfunfähig wird), lege 2 Schadensmarken auf das Angreifende Pokémon. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Black & White/Boundaries Crossed/16.ts
+++ b/data/Black & White/Boundaries Crossed/16.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Sleep Powder",
 				fr: "Poudre Dodo",
+				de: "Schlafpuder"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Asleep.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Endormi.",
+				de: "Wirf 1 Münze. Bei „Kopf“ schläft das Verteidigende Pokémon jetzt."
 			},
 			damage: 10,
 
@@ -64,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "The leaves on its head grow right back even if they fall out. These bitter leaves refresh those who eat them.",
+		de: "Die Blätter auf seinem Kopf schmecken äußerst bitter, wirken aber erfrischend. Fallen sie aus, wachsen sie sofort nach."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/17.ts
+++ b/data/Black & White/Boundaries Crossed/17.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Petilil",
 		fr: "Chlorobule",
+		de: "Lilminip"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Return",
 				fr: "Retour",
+				de: "Rückkehr"
 			},
 			effect: {
 				en: "Draw cards until you have 6 cards in your hand.",
 				fr: "Piochez des cartes jusqu'à ce que vous ayez 6 cartes en main.",
+				de: "Ziehe so viele Karten, bis du 6 Karten auf deiner Hand hast."
 			},
 			damage: 20,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Magical Leaf",
 				fr: "Feuillemagik",
+				de: "Zauberblatt"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 more damage and heal 30 damage from this Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires et vous soignez 30 dégâts à ce Pokémon.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 weitere Schadenspunkte zu und heilt 30 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 50,
 
@@ -86,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "The fragrance of the garland on its head has a relaxing effect, but taking care of it is very difficult.",
+		de: "Der Duft, den der Blumenschmuck auf seinem Kopf absondert, wirkt beruhigend, aber es ist nicht gerade pflegeleicht."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/18.ts
+++ b/data/Black & White/Boundaries Crossed/18.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Draw In",
 				fr: "Aspiracartes",
+				de: "Ansaugen"
 			},
 			effect: {
 				en: "Attach 2 Fire Energy cards from your discard pile to this Pokémon.",
 				fr: "Attachez 2 cartes Énergie Fire de votre pile de défausse à ce Pokémon.",
+				de: "Lege 2 {R}-Energiekarten von deinem Ablagestapel an dieses Pokémon an."
 			},
 
 		},
@@ -51,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Flare",
 				fr: "Flamboiement",
+				de: "Flackern"
 			},
 
 			damage: 20,
@@ -69,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "The fire on the tip of its tail is a measure of its life. If healthy, its tail burns intensely.",
+		de: "Lodert die Flamme auf seiner Schweifspitze hell, ist Glumanda gesund."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/19.ts
+++ b/data/Black & White/Boundaries Crossed/19.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Charmander",
 		fr: "Salamèche",
+		de: "Glumanda"
 	},
 
 	stage: "Stage1",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Flare",
 				fr: "Flamboiement",
+				de: "Flackern"
 			},
 
 			damage: 20,
@@ -55,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Raging Claws",
 				fr: "Griffes Enragées",
+				de: "Wutklauen"
 			},
 			effect: {
 				en: "Does 10 more damage for each damage counter on this Pokémon.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque marqueur de dégâts placé sur ce Pokémon.",
+				de: "Dieser Angriff fügt 10 weitere Schadenspunkte für jede Schadensmarke auf diesem Pokémon zu."
 			},
 			damage: 50,
 
@@ -76,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "In the rocky mountains where Charmeleon live, their fiery tails shine at night like stars.",
+		de: "Glutexo leben in den Bergen. Die Flammen auf ihren Schweifspitzen leuchten in der Nacht wie Sterne."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/2.ts
+++ b/data/Black & White/Boundaries Crossed/2.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Oddish",
 		fr: "Mystherbe",
+		de: "Myrapla"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Foul Odor",
 				fr: "Odeur Fétide",
+				de: "Fäulnisgeruch"
 			},
 			effect: {
 				en: "Both this Pokémon and the Defending Pokémon are now Confused.",
 				fr: "Ce Pokémon et le Pokémon Défenseur sont maintenant Confus.",
+				de: "Dieses Pokémon und das Verteidigende Pokémon sind jetzt verwirrt."
 			},
 
 		},
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Poison Powder",
 				fr: "Poudre Toxik",
+				de: "Giftpuder"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné.",
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet."
 			},
 			damage: 40,
 
@@ -86,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "The honey it drools from its mouth smells so atrocious, it can curl noses more than a mile away.",
+		de: "Der Honig, den es abgibt, riecht so entsetzlich, dass sich sogar Nasen in 2 km Entfernung rümpfen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/20.ts
+++ b/data/Black & White/Boundaries Crossed/20.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Charmeleon",
 		fr: "Reptincel",
+		de: "Glutexo"
 	},
 
 	stage: "Stage2",
@@ -43,10 +44,12 @@ const card: Card = {
 			name: {
 				en: "Split Bomb",
 				fr: "Bombe Fendante",
+				de: "Splitterbombe"
 			},
 			effect: {
 				en: "This attack does 40 damage to 2 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige 40 dégâts à 2 des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 2 Pokémon deines Gegners 40 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -61,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Scorching Fire",
 				fr: "Feu Infernal",
+				de: "Versengendes Feuer"
 			},
 			effect: {
 				en: "Discard a Fire Energy attached to this Pokémon.",
 				fr: "Défaussez une Énergie Fire attachée à ce Pokémon.",
+				de: "Lege 1 an dieses Pokémon angelegte {R}-Energie auf deinen Ablagestapel."
 			},
 			damage: 150,
 
@@ -82,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said that Charizard's fire burns hotter if it has experienced harsh battles.",
+		de: "Man sagt, Gluraks Feuer lodert stärker, wenn es harte Kämpfe überstanden hat."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/21.ts
+++ b/data/Black & White/Boundaries Crossed/21.ts
@@ -38,10 +38,12 @@ const card: Card = {
 			name: {
 				en: "Flamethrower",
 				fr: "Lance-Flamme",
+				de: "Flammenwurf"
 			},
 			effect: {
 				en: "Discard an Energy attached to this Pokémon.",
 				fr: "Défaussez une Énergie attachée à ce Pokémon.",
+				de: "Lege 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel."
 			},
 			damage: 60,
 
@@ -59,6 +61,7 @@ const card: Card = {
 
 	description: {
 		en: "The magma in its body reaches 2,200 degrees F. Its hump gets smaller when it uses Fire-type moves.",
+		de: "In seinem Körper fließt 1 200 Grad heißes Magma. Nach Einsatz einer Feuer-Attacke schrumpft sein Höcker."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/22.ts
+++ b/data/Black & White/Boundaries Crossed/22.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Numel",
 		fr: "Chamallot",
+		de: "Camaub"
 	},
 
 	stage: "Stage1",
@@ -43,10 +44,12 @@ const card: Card = {
 			name: {
 				en: "Fire Shard",
 				fr: "Écharde de Feu",
+				de: "Feuerscherben"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Burned. Flip a coin. If heads, the Defending Pokémon is also Paralyzed.",
 				fr: "Le Pokémon Défenseur est maintenant Brûlé. Lancez une pièce. Si c'est face, le Pokémon Défenseur est aussi Paralysé.",
+				de: "Das Verteidigende Pokémon ist jetzt verbrannt. Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt auch paralysiert."
 			},
 			damage: 60,
 
@@ -61,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Flamethrower",
 				fr: "Lance-Flamme",
+				de: "Flammenwurf"
 			},
 			effect: {
 				en: "Discard an Energy attached to this Pokémon.",
 				fr: "Défaussez une Énergie attachée à ce Pokémon.",
+				de: "Lege 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel."
 			},
 			damage: 80,
 
@@ -82,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "The volcanoes on its back have a major eruption every 10 years–or whenever it becomes really angry.",
+		de: "Seine Vulkanhöcker brechen nur alle zehn Jahre aus oder wenn es richtig wütend ist."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/23.ts
+++ b/data/Black & White/Boundaries Crossed/23.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Collect",
 				fr: "Collecte",
+				de: "Sammeln"
 			},
 			effect: {
 				en: "Draw a card.",
 				fr: "Piochez une carte.",
+				de: "Ziehe 1 Karte."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Relentless Flames",
 				fr: "Flammes Incessantes",
+				de: "Unermüdliche Flammen"
 			},
 			effect: {
 				en: "Flip a coin until you get tails. This attack does 30 damage times the number of heads.",
 				fr: "Lancez une pièce jusqu'à ce que vous obteniez un côté pile. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 30,
 
@@ -72,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "It creates an unlimited supply of energy inside its body, which it shares with those who touch it.",
+		de: "Es erzeugt im Inneren seines Körpers grenzenlose Energie, die es mit jedem teilt, der mit ihm in Berührung kommt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/24.ts
+++ b/data/Black & White/Boundaries Crossed/24.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Flare",
 				fr: "Flamboiement",
+				de: "Flackern"
 			},
 
 			damage: 10,
@@ -49,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Rollout",
 				fr: "Roulade",
+				de: "Walzer"
 			},
 
 			damage: 20,
@@ -67,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "It blows fire through its nose. When it catches a cold, the fire becomes pitch-black smoke instead.",
+		de: "Es schießt Flammen aus seinem Rüssel. Ist es erkältet, kommt statt Feuer aber nur pechschwarzer Rauch zum Vorschein."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/25.ts
+++ b/data/Black & White/Boundaries Crossed/25.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Tepig",
 		fr: "Gruikui",
+		de: "Floink"
 	},
 
 	stage: "Stage1",
@@ -42,6 +43,7 @@ const card: Card = {
 			name: {
 				en: "Rollout",
 				fr: "Roulade",
+				de: "Walzer"
 			},
 
 			damage: 20,
@@ -56,10 +58,12 @@ const card: Card = {
 			name: {
 				en: "Firebreathing",
 				fr: "Souffle-Feu",
+				de: "Feuerhauch"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 40,
 
@@ -77,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Whatever it eats becomes fuel for the flame in its stomach. When it is angered, the intensity of the flame increases.",
+		de: "Nutzt Nahrung als Brennstoff, um das Feuer in seinem Magen zu schüren. Mit Wut im Bauch heizt es ungleich stärker."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/26.ts
+++ b/data/Black & White/Boundaries Crossed/26.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pignite",
 		fr: "Grotichon",
+		de: "Ferkokel"
 	},
 
 	stage: "Stage2",
@@ -43,10 +44,12 @@ const card: Card = {
 			name: {
 				en: "Firebreathing",
 				fr: "Souffle-Feu",
+				de: "Feuerhauch"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: 40,
 
@@ -61,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Fire Blast",
 				fr: "Déflagration",
+				de: "Feuersturm"
 			},
 			effect: {
 				en: "Discard an Energy attached to this Pokémon.",
 				fr: "Défaussez une Énergie attachée à ce Pokémon.",
+				de: "Lege 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel."
 			},
 			damage: 120,
 
@@ -82,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "It has mastered fast and powerful fighting moves. It grows a beard of fire.",
+		de: "Es trägt einen Backenbart aus Feuer und beherrscht Kampftechniken, die ebenso wuchtig wie schnell sind."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/27.ts
+++ b/data/Black & White/Boundaries Crossed/27.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Reckless Charge",
 				fr: "Attaque Imprudente",
+				de: "Waghalsiger Sturmangriff"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this Pokémon does 10 damage to itself.",
 				fr: "Lancez une pièce. Si c'est pile, ce Pokémon s'inflige 10 dégâts.",
+				de: "Wirf 1 Münze. Bei „Zahl“ fügt sich dieses Pokémon selbst 10 Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "When it sleeps, it pulls its limbs into its body and its internal fire goes down to 1,100 F.",
+		de: "Zum Schlafen zieht es Arme und Beine ein und senkt seine innere Körpertemperatur auf 600 Grad, um sich zu entspannen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/28.ts
+++ b/data/Black & White/Boundaries Crossed/28.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Darumaka",
 		fr: "Darumarond",
+		de: "Flampion"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Continuous Tumble",
 				fr: "Roulade Continue",
+				de: "Dauerrollen"
 			},
 			effect: {
 				en: "Flip a coin until you get tails. This attack does 20 damage times the number of heads.",
 				fr: "Lancez une pièce jusqu'à ce que vous obteniez un côté pile. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Damage Counterpunch",
 				fr: "Riposte Enragée",
+				de: "Konterklatsche"
 			},
 			effect: {
 				en: "If this Pokémon has any damage counters on it, this attack does 60 more damage.",
 				fr: "Si ce Pokémon a des marqueurs de dégâts, cette attaque inflige 60 dégâts supplémentaires.",
+				de: "Wenn auf diesem Pokémon bereits mindestens 1 Schadensmarke liegt, fügt dieser Angriff 60 weitere Schadenspunkte zu."
 			},
 			damage: 60,
 
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "When one is injured in a fierce battle, it hardens into a stone-like form. Then it meditates and sharpens its mind.",
+		de: "Nimmt es in einem heißen Kampf Schaden, wird es hart wie Stein und fällt in eine Trance, um seinen Verstand zu schärfen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/29.ts
+++ b/data/Black & White/Boundaries Crossed/29.ts
@@ -59,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Water Splash",
 				fr: "Éclaboussure",
+				de: "Wasserplatscher"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 10,
 
@@ -80,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It shelters itself in its shell then strikes back with spouts of water at every opportunity.",
+		de: "Es zieht sich in seinen Panzer zurück und greift dann mit Wasserstrahlen seine Gegner an."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/3.ts
+++ b/data/Black & White/Boundaries Crossed/3.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gloom",
 		fr: "Ortide",
+		de: "Duflor"
 	},
 
 	stage: "Stage2",
@@ -66,10 +67,12 @@ const card: Card = {
 			name: {
 				en: "Pollen Spray",
 				fr: "Crache-Pollen",
+				de: "Pollenspray"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep and Poisoned.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi et Empoisonné.",
+				de: "Das Verteidigende Pokémon schläft jetzt und ist vergiftet."
 			},
 			damage: 50,
 
@@ -94,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "Its petals are the largest in the world. As it walks, it scatters extremely allergenic pollen.",
+		de: "Es besitzt die größten Blätter der Welt. Es verteilt beim Gehen Pollen, die schreckliche Allergien auslösen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/30.ts
+++ b/data/Black & White/Boundaries Crossed/30.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Squirtle",
 		fr: "Carapuce",
+		de: "Schiggy"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Withdraw",
 				fr: "Repli",
+				de: "Panzerschutz"
 			},
 			effect: {
 				en: "Flip a coin. If heads, prevent all damage done to this Pokémon by attacks during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, évitez tous les dégâts infligés à ce Pokémon par des attaques pendant le prochain tour de votre adversaire.",
+				de: "Wirf 1 Münze. Bei „Kopf“ verhindere allen Schaden, der diesem Pokémon während des nächsten Zuges deines Gegners durch Angriffe zugefügt würde."
 			},
 
 		},
@@ -57,6 +60,7 @@ const card: Card = {
 			name: {
 				en: "Waterfall",
 				fr: "Cascade",
+				de: "Kaskade"
 			},
 
 			damage: 60,
@@ -75,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said to live 10,000 years. Its furry tail is popular as a symbol of longevity.",
+		de: "Man sagt, es werde 10 000 Jahre alt. Sein buschiger Schweif ist ein Symbol für langes Leben."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/31.ts
+++ b/data/Black & White/Boundaries Crossed/31.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Wartortle",
 		fr: "Carabaffe",
+		de: "Schillok"
 	},
 
 	stage: "Stage2",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Todas las veces que quieras durante tu turno (antes de tu ataque), puedes unir una carta de Energía Water de tu mano a 1 de tus Pokémon.",
 				it: "Durante il tuo turno, prima di attaccare, puoi assegnare a piacimento le carte Energia Water che hai in mano ai tuoi Pokémon.",
 				pt: "Tantas vezes quanto desejar em sua vez de jogar (antes de atacar), você poderá ligar um card de Energia Water da sua mão a 1 dos seus Pokémon.",
-				de: "Beliebig oft während deines Zuges (vor deinem Angriff) kannst du 1 Water-Energiekarte von deiner Hand an 1 deiner Pokémon anlegen."
+				de: "Beliebig oft während deines Zuges (vor deinem Angriff) kannst du 1 {W}-Energiekarte von deiner Hand an 1 deiner Pokémon anlegen."
 			},
 		},
 	],
@@ -66,10 +67,12 @@ const card: Card = {
 			name: {
 				en: "Hydro Pump",
 				fr: "Hydrocanon",
+				de: "Hydropumpe"
 			},
 			effect: {
 				en: "Does 10 more damage for each Water Energy attached to this Pokémon.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque Énergie Water attachée à ce Pokémon.",
+				de: "Dieser Angriff fügt 10 weitere Schadenspunkte für jede an dieses Pokémon angelegte {W}-Energie zu."
 			},
 			damage: 60,
 
@@ -87,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "The jets of water it spouts from the rocket cannons on its shell can punch through thick steel.",
+		de: "Der Wasserstrahl, der aus den Wasserdüsen schießt, kann sogar Stahlwände durchdringen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/32.ts
+++ b/data/Black & White/Boundaries Crossed/32.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Dazzle Dance",
 				fr: "Danse Éblouissante",
+				de: "Verwirrender Tanz"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 
 		},
@@ -56,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "Overwhelmed by enigmatic abilities, it suffers a constant headache. It sometimes uses mysterious powers.",
+		de: "Leidet unter stetigem Kopfschmerz, ausgelöst durch seltsame Kräfte, die es aber auch einsetzen kann."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/33.ts
+++ b/data/Black & White/Boundaries Crossed/33.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Firefighting",
 				fr: "Anti-Flammes",
+				de: "Feuerwehr"
 			},
 			effect: {
 				en: "Discard a Fire Energy attached to the Defending Pokémon.",
 				fr: "Défaussez une Énergie Fire attachée au Pokémon Défenseur.",
+				de: "Lege 1 an das Verteidigende Pokémon angelegte {R}-Energie auf den Ablagestapel deines Gegners."
 			},
 
 		},
@@ -56,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "When headaches stimulate its brain cells, which are usually inactive, it can use a mysterious power.",
+		de: "Werden die Zellen seines Hirns durch starke Kopfschmerzen stimuliert, erhält es geheimnisvolle Kräfte."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/34.ts
+++ b/data/Black & White/Boundaries Crossed/34.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Psyduck",
 		fr: "Psykokwak",
+		de: "Enton"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Confuse Ray",
 				fr: "Onde Folie",
+				de: "Konfustrahl"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Confused.",
 				fr: "Le Pokémon Défenseur est maintenant Confus.",
+				de: "Das Verteidigende Pokémon ist jetzt verwirrt."
 			},
 
 		},
@@ -56,6 +59,7 @@ const card: Card = {
 			name: {
 				en: "Water Gun",
 				fr: "Pistolet à O",
+				de: "Aquaknarre"
 			},
 
 			damage: 30,
@@ -74,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "It is seen swimming dynamically and elegantly using its well-developed limbs and flippers.",
+		de: "Die gut ausgeprägten Flossen ermöglichen einen sowohl eleganten als auch dynamischen Schwimmstil."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/35.ts
+++ b/data/Black & White/Boundaries Crossed/35.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Psyduck",
 		fr: "Psykokwak",
+		de: "Enton"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Amnesia",
 				fr: "Amnésie",
+				de: "Amnesie"
 			},
 			effect: {
 				en: "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn.",
 				fr: "Choisissez 1 des attaques du Pokémon Défenseur. Le Pokémon ciblé ne peut pas utiliser l'attaque choisie pendant le prochain tour de votre adversaire.",
+				de: "Wähle 1 Angriff des Verteidigenden Pokémon. Das Pokémon kann den gewählten Angriff während des nächsten Zuges deines Gegners nicht einsetzen."
 			},
 			damage: 20,
 
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Aquafall",
 				fr: "Aquasplash",
+				de: "Aquafall"
 			},
 			effect: {
 				en: "Discard all Energy attached to this Pokémon.",
 				fr: "Défaussez toutes les Énergies attachées à ce Pokémon.",
+				de: "Lege alle an dieses Pokémon angelegten Energien auf deinen Ablagestapel."
 			},
 			damage: 90,
 
@@ -78,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "When its forehead shines mysteriously, Golduck can use the full extent of its power.",
+		de: "Beginnt seine Stirn unheilvoll zu leuchten, bedeutet dies, dass es nun seine volle Macht entfesseln kann."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/36.ts
+++ b/data/Black & White/Boundaries Crossed/36.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Rollout",
 				fr: "Roulade",
+				de: "Walzer"
 			},
 
 			damage: 20,
@@ -51,6 +52,7 @@ const card: Card = {
 			name: {
 				en: "Water Gun",
 				fr: "Pistolet à O",
+				de: "Aquaknarre"
 			},
 
 			damage: 30,
@@ -69,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "The oil-filled tail functions as a buoy, so it's fine even in rivers with strong currents.",
+		de: "Sein ölgefüllter Schweif dient ihm als Rettungsboje, die es vor der Strömung reißender Flüsse schützt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/37.ts
+++ b/data/Black & White/Boundaries Crossed/37.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Marill",
 		fr: "Marill",
+		de: "Marill"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Deep Dive",
 				fr: "Plongée Profonde",
+				de: "Unterwasserausflug"
 			},
 			effect: {
 				en: "Flip 2 coins. For each heads, heal 40 damage from this Pokémon.",
 				fr: "Lancez 2 pièces. Pour chaque côté face, soignez 40 dégâts à ce Pokémon.",
+				de: "Wirf 2 Münzen. Heile pro „Kopf“ 40 Schadenspunkte bei diesem Pokémon."
 			},
 
 		},
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Aqua Sonic",
 				fr: "Aquasonique",
+				de: "Aquaschall"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by Resistance.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Résistance.",
+				de: "Der Schaden dieses Angriffs wird durch Resistenz nicht verändert."
 			},
 			damage: 70,
 
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "Its long ears are superb sensors. It can distinguish the movements of things in water and tell what they are.",
+		de: "Seine langen Ohren sind hervorragende Sensoren. Mit ihnen kann es die Quellen aller Geräusche des Flusses ausmachen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/38.ts
+++ b/data/Black & White/Boundaries Crossed/38.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Present",
 				fr: "Cadeau",
+				de: "Geschenk"
 			},
 			effect: {
 				en: "Flip a coin. If heads, search your deck for a card and put it into your hand. Shuffle your deck afterward.",
 				fr: "Lancez une pièce. Si c'est face, cherchez une carte dans votre deck puis ajoutez-la à votre main. Mélangez ensuite votre deck.",
+				de: "Wirf 1 Münze. Durchsuche bei „Kopf“ dein Deck nach 1 Karte und nimm sie auf deine Hand. Mische anschließend dein Deck."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Icy Wind",
 				fr: "Vent Glace",
+				de: "Eissturm"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 			damage: 30,
 
@@ -72,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "It carries food all day long. When someone is lost in the mountains, it shares that food.",
+		de: "Es trägt den ganzen Tag Essen mit sich herum, das es mit Menschen teilt, die in den Bergen feststecken."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/39.ts
+++ b/data/Black & White/Boundaries Crossed/39.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Rain Splash",
 				fr: "Pluie Éclaboussante",
+				de: "Regenplatscher"
 			},
 
 			damage: 10,
@@ -49,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Seashell Attack",
 				fr: "Carap'Attaque",
+				de: "Seemuschelangriff"
 			},
 
 			damage: 20,
@@ -67,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "It fights using the scalchop on its stomach. In response to an attack, it retaliates immediately by slashing.",
+		de: "Kämpft mit der Muschel auf seinem Bauch. Pariert es einen Angriff, schlägt es sofort mit einer Schnitt-Attacke zurück."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/4.ts
+++ b/data/Black & White/Boundaries Crossed/4.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gloom",
 		fr: "Ortide",
+		de: "Duflor"
 	},
 
 	stage: "Stage2",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Grass Knot",
 				fr: "Nœud Herbe",
+				de: "Strauchler"
 			},
 			effect: {
 				en: "Does 20 more damage for each Colorless in the Defending Pokémon's Retreat Cost.",
 				fr: "Inflige 20 dégâts supplémentaires pour chaque Colorless dans le coût de Retraite du Pokémon Défenseur.",
+				de: "Dieser Angriff fügt 20 weitere Schadenspunkte für jedes {C}-Symbol in den Rückzugskosten des Verteidigenden Pokémon zu."
 			},
 			damage: 10,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Petal Dance",
 				fr: "Danse-Fleur",
+				de: "Blättertanz"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 50 damage times the number of heads. This Pokémon is now Confused.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 50 dégâts multipliés par le nombre de côtés face. Ce Pokémon est maintenant Confus.",
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl „Kopf“ zu. Dieses Pokémon ist jetzt verwirrt."
 			},
 			damage: 50,
 
@@ -86,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "When the heavy rainfall season ends, it is drawn out by warm sunlight to dance in the open.",
+		de: "Sobald die Regenzeit vorbei ist, wird es von der warmen Sonne nach draußen gezogen, wo es tanzt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/40.ts
+++ b/data/Black & White/Boundaries Crossed/40.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Oshawott",
 		fr: "Moustillon",
+		de: "Ottaro"
 	},
 
 	stage: "Stage1",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Rain Splash",
 				fr: "Pluie Éclaboussante",
+				de: "Regenplatscher"
 			},
 
 			damage: 20,
@@ -55,6 +57,7 @@ const card: Card = {
 			name: {
 				en: "Waterfall",
 				fr: "Cascade",
+				de: "Kaskade"
 			},
 
 			damage: 50,
@@ -73,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "Strict training is how it learns its flowing double-scalchop technique.",
+		de: "Es eignet sich durch strenges Training elegant ineinander übergehende Attacken mit seinen zwei Muscheln an."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/41.ts
+++ b/data/Black & White/Boundaries Crossed/41.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Dewott",
 		fr: "Mateloutre",
+		de: "Zwottronin"
 	},
 
 	stage: "Stage2",
@@ -42,6 +43,7 @@ const card: Card = {
 			name: {
 				en: "Waterfall",
 				fr: "Cascade",
+				de: "Kaskade"
 			},
 
 			damage: 50,
@@ -57,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Destructive Whirlpool",
 				fr: "Siphon Destructeur",
+				de: "Schrecklicher Strudel"
 			},
 			effect: {
 				en: "Discard an Energy attached to the Defending Pokémon.",
 				fr: "Défaussez une Énergie attachée au Pokémon Défenseur.",
+				de: "Lege 1 an das Verteidigenden Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 80,
 
@@ -78,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "One swing of the sword incorporated in its armor can fell an opponent. A simple glare from one of them quiets everybody.",
+		de: "Besiegt Gegner durch einen einzigen Hieb mit der Klinge an seinem Panzer. Ein böser Blick und seine Feinde verstummen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/42.ts
+++ b/data/Black & White/Boundaries Crossed/42.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Rain Splash",
 				fr: "Pluie Éclaboussante",
+				de: "Regenplatscher"
 			},
 
 			damage: 20,
@@ -62,6 +63,7 @@ const card: Card = {
 
 	description: {
 		en: "They are better at swimming than flying, and they happily eat their favorite food, peat moss, as they dive underwater.",
+		de: "Es schwimmt besser, als es fliegen kann. Am liebsten taucht es ins kühle Nass ab, um Torfmoos, seine Leibspeise, zu essen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/43.ts
+++ b/data/Black & White/Boundaries Crossed/43.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Ducklett",
 		fr: "Couaneton",
+		de: "Piccolente"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Aerial Ace",
 				fr: "Aéropique",
+				de: "AeroAss"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Defog",
 				fr: "Anti-Brume",
+				de: "Auflockern"
 			},
 			effect: {
 				en: "You may discard any Stadium card in play. If you do, this attack does 40 more damage.",
 				fr: "Vous pouvez défausser une carte Stade en jeu. Dans ce cas, cette attaque inflige 40 dégâts supplémentaires.",
+				de: "Du kannst eine beliebige Stadionkarte aus dem Spiel auf den Ablagestapel legen. Wenn du das machst, fügt dieser Angriff 40 weitere Schadenspunkte zu."
 			},
 			damage: 60,
 
@@ -87,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "Despite their elegant appearance, they can flap their wings strongly and fly for thousands of miles.",
+		de: "Sie wirken zerbrechlich, aber ihre starken Schwingen tragen sie in einem Stück bis zu 1 000 Kilometer weit."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/44.ts
+++ b/data/Black & White/Boundaries Crossed/44.ts
@@ -38,6 +38,7 @@ const card: Card = {
 			name: {
 				en: "Wave Splash",
 				fr: "Grosse Vague",
+				de: "Wellenplatscher"
 			},
 
 			damage: 40,
@@ -56,6 +57,7 @@ const card: Card = {
 
 	description: {
 		en: "If its veil-like arms stun and wrap a foe, that foe will be dragged miles below the surface, never to return.",
+		de: "Es schlingt seine schleierartigen Arme um seine Beute und entführt sie 8 000 Meter in die Tiefe, wo es sie schließlich tötet."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/45.ts
+++ b/data/Black & White/Boundaries Crossed/45.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Frillish",
 		fr: "Viskuse",
+		de: "Quabbel"
 	},
 
 	stage: "Stage1",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "El Coste de Retirada de cada uno de los Pokémon en juego de tu rival es de Colorless más.",
 				it: "Il costo di ritirata di ciascun Pokémon in gioco del tuo avversario aumenta di Colorless.",
 				pt: "O Custo para Recuar de cada um dos Pokémon do seu oponente em jogo será de Colorless a mais.",
-				de: "Die Rückzugskosten aller Pokémon deines Gegners im Spiel erhöhen sich um Colorless."
+				de: "Die Rückzugskosten aller Pokémon deines Gegners im Spiel erhöhen sich um {C}."
 			},
 		},
 	],
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Eerie Light",
 				fr: "Lumière Étrange",
+				de: "Gespenstisches Licht"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: 40,
 
@@ -86,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "Its body is mostly seawater. It's said there's a castle of ships Jellicent have sunk on the seafloor.",
+		de: "Es heißt, am Meeresboden gebe es einen Palast aus Schiffen, die es versenkt hat. Es besteht fast nur aus Meerwasser."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/46.ts
+++ b/data/Black & White/Boundaries Crossed/46.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Ice Edge",
 				fr: "Lame de Givre",
+				de: "Eisiger Abgrund"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "They are born in snow clouds. They use chains made of ice crystals to capture prey.",
+		de: "Es fängt seine Beute mit Ketten, die sich aus Eiskristallen zusammensetzen. Entstanden ist es aus einer Schneewolke."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/47.ts
+++ b/data/Black & White/Boundaries Crossed/47.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Slicing Blade",
 				fr: "Lame Tranchante",
+				de: "Schwertschneide"
 			},
 
 			damage: 30,
@@ -51,10 +52,12 @@ const card: Card = {
 			name: {
 				en: "Hydro Pump",
 				fr: "Hydrocanon",
+				de: "Hydropumpe"
 			},
 			effect: {
 				en: "Does 10 more damage for each Water Energy attached to this Pokémon.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque Énergie Water attachée à ce Pokémon.",
+				de: "Dieser Angriff fügt 10 weitere Schadenspunkte für jede an dieses Pokémon angelegte {W}-Energie zu."
 			},
 			damage: 60,
 
@@ -72,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "It crosses the world, running over the surfaces of oceans and rivers. It appears at scenic waterfronts.",
+		de: "Es kann auf dem Wasser laufen und reist auf Flüssen und Meeren um die Welt. Zu sehen in malerischen Küstengebieten."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/48.ts
+++ b/data/Black & White/Boundaries Crossed/48.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Rising Lunge",
 				fr: "Botte Secrète",
+				de: "Aufwärtsstoß"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -54,6 +56,7 @@ const card: Card = {
 			name: {
 				en: "Hydro Kick",
 				fr: "Pied Hydro",
+				de: "Hydrokick"
 			},
 
 			damage: 70,
@@ -72,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "By blasting water from its hooves, it can glide across water. It excels at using leg moves while battling.",
+		de: "Gleitet über das Wasser, indem es seine Hufe als Wasserdüsen nutzt. Seine Beintechnik verschafft ihm im Kampf Vorteile."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/49.ts
+++ b/data/Black & White/Boundaries Crossed/49.ts
@@ -56,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Secret Sword",
 				fr: "Lame Ointe",
+				de: "Mystoschwert"
 			},
 			effect: {
 				en: "Does 20 more damage for each Water Energy attached to this Pokémon.",
 				fr: "Inflige 20 dégâts supplémentaires pour chaque Énergie Water attachée à ce Pokémon.",
+				de: "Dieser Angriff fügt 20 weitere Schadenspunkte für jede an dieses Pokémon angelegte {W}-Energie zu."
 			},
 			damage: 50,
 

--- a/data/Black & White/Boundaries Crossed/5.ts
+++ b/data/Black & White/Boundaries Crossed/5.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Nap",
 				fr: "Tit'Sieste",
+				de: "Nickerchen"
 			},
 			effect: {
 				en: "Heal 30 damage from this Pokémon.",
 				fr: "Soignez 30 dégâts à ce Pokémon.",
+				de: "Heile 30 Schadenspunkte bei diesem Pokémon."
 			},
 
 		},
@@ -52,6 +54,7 @@ const card: Card = {
 			name: {
 				en: "Vine Whip",
 				fr: "Fouet Lianes",
+				de: "Rankenhieb"
 			},
 
 			damage: 50,
@@ -77,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "Many writhing vines cover it, so its true identity remains unknown. The blue vines grow its whole life long.",
+		de: "Aufgrund der Ranken, die seinen Körper bedecken, kennt keiner seine wahre Form. Die blauen Ranken wachsen immer weiter."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/50.ts
+++ b/data/Black & White/Boundaries Crossed/50.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Pika Punch",
 				fr: "Pika-Poing",
+				de: "Pikahieb"
 			},
 
 			damage: 10,
@@ -50,10 +51,12 @@ const card: Card = {
 			name: {
 				en: "Double Voltage",
 				fr: "Double Voltage",
+				de: "Doppelspannung"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 40 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 40 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 40,
 
@@ -71,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "It occasionally uses an electric shock to recharge a fellow Pikachu that is in a weakened state.",
+		de: "Es verwendet hin und wieder Elektrizität, um ein anderes, geschwächtes Pikachu aufzuladen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/51.ts
+++ b/data/Black & White/Boundaries Crossed/51.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Static Shock",
 				fr: "Choc Statique",
+				de: "Statischer Schock"
 			},
 
 			damage: 10,
@@ -54,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "It looks just like a Poké Ball. It is dangerous because it may electrocute or explode on contact.",
+		de: "Sieht aus wie ein Pokéball. Es ist gefährlich, da es bei Berührung explodieren kann."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/52.ts
+++ b/data/Black & White/Boundaries Crossed/52.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Voltorb",
 		fr: "Voltorbe",
+		de: "Voltobal"
 	},
 
 	stage: "Stage1",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Static Shock",
 				fr: "Choc Statique",
+				de: "Statischer Schock"
 			},
 
 			damage: 20,
@@ -55,6 +57,7 @@ const card: Card = {
 			name: {
 				en: "Electro Ball",
 				fr: "Boule Élek",
+				de: "Elektroball"
 			},
 
 			damage: 60,
@@ -73,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "It is known to drift on winds if it is bloated to bursting with stored electricity.",
+		de: "Es lässt sich vom Wind treiben, wenn es so voller Elektrizität ist, dass es fast explodiert."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/53.ts
+++ b/data/Black & White/Boundaries Crossed/53.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Low Kick",
 				fr: "Balayage",
+				de: "Fußkick"
 			},
 
 			damage: 20,
@@ -51,6 +52,7 @@ const card: Card = {
 			name: {
 				en: "Magnetic Blast",
 				fr: "Explosion Magnétique",
+				de: "Magnetstoß"
 			},
 
 			damage: 50,
@@ -69,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "Research is progressing on storing lightning in Electabuzz so this energy can be used at any time.",
+		de: "Experimente, Elektek als flexiblen Speicher für frei einsetzbare Blitze zu verwenden, zeigen erste Erfolge."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/54.ts
+++ b/data/Black & White/Boundaries Crossed/54.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Electabuzz",
 		fr: "Élektek",
+		de: "Elektek"
 	},
 
 	stage: "Stage1",
@@ -43,10 +44,12 @@ const card: Card = {
 			name: {
 				en: "Electriwave",
 				fr: "Vague Électrique",
+				de: "Elektrowelle"
 			},
 			effect: {
 				en: "This attack does 30 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige 30 dégâts à chacun des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt jedem Pokémon auf der Bank deines Gegners 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -60,10 +63,12 @@ const card: Card = {
 			name: {
 				en: "Shock Wave",
 				fr: "Onde de Choc",
+				de: "Schockwelle"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by Resistance.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Résistance.",
+				de: "Der Schaden dieses Angriffs wird durch Resistenz nicht verändert."
 			},
 			damage: 80,
 
@@ -81,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "The instant it presses the tips of its tails onto an opponent, it sends over 20,000 volts of electricity into the foe.",
+		de: "Es berührt Gegner mit seinen beiden Schweifspitzen und entlädt dabei geballte 20 000 Volt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/55.ts
+++ b/data/Black & White/Boundaries Crossed/55.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Electripult",
 				fr: "Électripulte",
+				de: "Stromwurf"
 			},
 			effect: {
 				en: "This attack does 20 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige 20 dégâts à 1 des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 1 Pokémon deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "It discharges positive and negative electricity from its antenna tips to shock its foes.",
+		de: "Über seine Antennen entlädt es Elektrizität, mit der es seinen Gegnern einen Schlag versetzt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/56.ts
+++ b/data/Black & White/Boundaries Crossed/56.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Smash Kick",
 				fr: "Coud'Pattes",
+				de: "Schmetterkick"
 			},
 
 			damage: 10,
@@ -54,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "Its mane shines when it discharges electricity. They use the frequency and rhythm of these flashes to communicate.",
+		de: "Um mit Artgenossen zu kommunizieren, nutzt es das Aufblitzen seiner Mähne beim Entladen von Strom als Morsecode."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/57.ts
+++ b/data/Black & White/Boundaries Crossed/57.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Blitzle",
 		fr: "Zébibron",
+		de: "Elezeba"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Flame Charge",
 				fr: "Nitrocharge",
+				de: "Nitroladung"
 			},
 			effect: {
 				en: "Search your deck for a Fire Energy card and attach it to this Pokémon. Shuffle your deck afterward.",
 				fr: "Cherchez une carte Énergie Fire dans votre deck et attachez-la à ce Pokémon. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 1 {R}-Energiekarte und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
 			},
 
 		},
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Thunder",
 				fr: "Fatal-Foudre",
+				de: "Donner"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this Pokémon does 30 damage to itself.",
 				fr: "Lancez une pièce. Si c'est pile, ce Pokémon s'inflige 30 dégâts.",
+				de: "Wirf 1 Münze. Bei „Zahl“ fügt sich dieses Pokémon selbst 30 Schadenspunkte zu."
 			},
 			damage: 90,
 
@@ -78,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "When this ill-tempered Pokémon runs wild, it shoots lightning from its mane in all directions.",
+		de: "Ein stürmischer Geselle. Wenn es wütend ist, feuert es über seine Mähne in alle Richtungen Stromsalven ab."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/58.ts
+++ b/data/Black & White/Boundaries Crossed/58.ts
@@ -38,6 +38,7 @@ const card: Card = {
 			name: {
 				en: "Headbutt Bounce",
 				fr: "Culbute Surprise",
+				de: "Abrupter Kopfstoß"
 			},
 
 			damage: 60,
@@ -56,6 +57,7 @@ const card: Card = {
 
 	description: {
 		en: "It desperately tries to keep its black tail hidden. It is said to be proof the tail hides a secret.",
+		de: "Verzweifelt versucht es, seinen schwarzen Schweif zu verstecken. Er soll ein Geheimnis enthalten"
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/59.ts
+++ b/data/Black & White/Boundaries Crossed/59.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Flail Around",
 				fr: "Fléau Bougeant",
+				de: "Rumrudern"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 10,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "Using its tail like a spring, it keeps its heart beating by bouncing constantly. If it stops, it dies.",
+		de: "Es nutzt seinen Schweif als Sprungfeder, um sein Herz am Pumpen zu halten. Hört es auf zu springen, stirbt es."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/6.ts
+++ b/data/Black & White/Boundaries Crossed/6.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Tangela",
 		fr: "Saquedeneu",
+		de: "Tangela"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Hundred Furious Lashes",
 				fr: "Multifouets Furieux",
+				de: "Hundert heftige Hiebe"
 			},
 			effect: {
 				en: "Does 30 damage times the amount of Grass Energy attached to this Pokémon. This Pokémon can't use Hundred Furious Lashes during your next turn.",
 				fr: "Inflige 30 dégâts multipliés par le nombre d'Énergies Grass attachées à ce Pokémon. Ce Pokémon ne peut pas utiliser Multifouets Furieux pendant votre prochain tour.",
+				de: "Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl der an dieses Pokémon angelegten {G}-Energien zu. Tangoloss kann Hundert heftige Hiebe während deines nächsten Zuges nicht einsetzen."
 			},
 			damage: 30,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Mega Drain",
 				fr: "Méga-Sangsue",
+				de: "Megasauger"
 			},
 			effect: {
 				en: "Heal 30 damage from this Pokémon.",
 				fr: "Soignez 30 dégâts à ce Pokémon.",
+				de: "Heile 30 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 70,
 
@@ -87,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "Even if one of its arms is eaten, it's fine. The Pokémon regenerates quickly and will go right back to normal.",
+		de: "Seine regenerativen Kräfte sind so stark, dass ein Arm sofort nachwächst, wenn er gefressen wird."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/60.ts
+++ b/data/Black & White/Boundaries Crossed/60.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Spoink",
 		fr: "Spoink",
+		de: "Spoink"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Psybeam",
 				fr: "Rafale Psy",
+				de: "Psystrahl"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Confused.",
 				fr: "Le Pokémon Défenseur est maintenant Confus.",
+				de: "Das Verteidigende Pokémon ist jetzt verwirrt."
 			},
 			damage: 30,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Extrasensory",
 				fr: "Extrasenseur",
+				de: "Sondersensor"
 			},
 			effect: {
 				en: "If you have the same number of cards in your hand as your opponent, this attack does 60 more damage.",
 				fr: "Si vous avez le même nombre de cartes dans votre main que votre adversaire, cette attaque inflige 60 dégâts supplémentaires.",
+				de: "Wenn du die gleiche Anzahl Karten auf der Hand hast wie dein Gegner, fügt dieser Angriff 60 weitere Schadenspunkte zu."
 			},
 			damage: 60,
 
@@ -80,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "It uses black pearls to amplify its psychic power. It does a strange dance to control foes' minds.",
+		de: "Mit schwarzen Perlen verstärkt es seine Psycho-Kräfte. Mit einem Tanz kontrolliert es seine Gegner."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/61.ts
+++ b/data/Black & White/Boundaries Crossed/61.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Confuse Ray",
 				fr: "Onde Folie",
+				de: "Konfustrahl"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Confused.",
 				fr: "Le Pokémon Défenseur est maintenant Confus.",
+				de: "Das Verteidigende Pokémon ist jetzt verwirrt."
 			},
 
 		},
@@ -56,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "It loves the crying of children. It startles bad kids by passing through walls and making them cry.",
+		de: "Es mag das Weinen von Kindern. Erschreckt gemeine Kinder, indem es durch Wände geht."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/62.ts
+++ b/data/Black & White/Boundaries Crossed/62.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Duskull",
 		fr: "Skelénox",
+		de: "Zwirrlicht"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Astonish",
 				fr: "Étonnement",
+				de: "Erstauner"
 			},
 			effect: {
 				en: "Choose a random card from your opponent's hand. Your opponent reveals that card and shuffles it into his or her deck.",
 				fr: "Choisissez une carte au hasard de la main de votre adversaire. Votre adversaire montre la carte choisie et la mélange avec son deck.",
+				de: "Wähle 1 zufällige Karte aus der verdeckten Hand deines Gegners. Dein Gegner zeigt diese Karte und mischt sie zurück in sein Deck."
 			},
 
 		},
@@ -57,6 +60,7 @@ const card: Card = {
 			name: {
 				en: "Psyshot",
 				fr: "Piqûre Psy",
+				de: "Psychoschuss"
 			},
 
 			damage: 40,
@@ -75,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "It seeks drifting will-o'-the-wisps and sucks them into its empty body. What happens inside is a mystery.",
+		de: "Sucht dahintreibende Irrlichter und saugt sie in seinen leeren Körper. Alles andere ist ein Rätsel."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/63.ts
+++ b/data/Black & White/Boundaries Crossed/63.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Dusclops",
 		fr: "Téraclope",
+		de: "Zwirrklop"
 	},
 
 	stage: "Stage2",
@@ -66,10 +67,12 @@ const card: Card = {
 			name: {
 				en: "Shadow Punch",
 				fr: "Poing Ombre",
+				de: "Finsterfaust"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by Resistance.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Résistance.",
+				de: "Der Schaden dieses Angriffs wird durch Resistenz nicht verändert."
 			},
 			damage: 60,
 
@@ -87,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said to take lost spirits into its pliant body and guide them home.",
+		de: "Man sagt, dass es verlorene Seelen in seinem biegsamen Körper nach Hause geleite."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/64.ts
+++ b/data/Black & White/Boundaries Crossed/64.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Paralyzing Jab",
 				fr: "Piqûre Paralysante",
+				de: "Paralysierender Punch"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 20,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "It rarely fights fairly, but that is strictly to ensure survival. It is popular as a mascot.",
+		de: "Aufgrund seines starken Überlebensdrangs kämpft es selten fair. Beliebt als Maskottchen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/65.ts
+++ b/data/Black & White/Boundaries Crossed/65.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Poison Jab",
 				fr: "Direct Toxik",
+				de: "Gifthieb"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné.",
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet."
 			},
 			damage: 20,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "Inflating its poison sacs, it fills the area with an odd sound and hits flinching opponents with a poison jab.",
+		de: "Bläst es seine Giftbeutel auf, ertönt ein unheimliches Geräusch, das Gegner zurückschrecken lässt und vergiftet."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/66.ts
+++ b/data/Black & White/Boundaries Crossed/66.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Croagunk",
 		fr: "Cradopaud",
+		de: "Glibunkel"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Revenge",
 				fr: "Vendetta",
+				de: "Vergeltung"
 			},
 			effect: {
 				en: "If any of your Pokémon were Knocked Out by damage from an opponent's attack during his or her last turn, this attack does 70 more damage.",
 				fr: "Si l'un de vos Pokémon a été mis K.O. par les dégâts d'une attaque de votre adversaire pendant son dernier tour, cette attaque inflige 70 dégâts supplémentaires.",
+				de: "Falls eins deiner Pokémon während des letzten Zuges deines Gegners durch Schaden eines gegnerischen Angriff kampfunfähig gemacht wurde, fügt dieser Angriff 70 weitere Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Poison Jab",
 				fr: "Direct Toxik",
+				de: "Gifthieb"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné.",
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet."
 			},
 			damage: 60,
 
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "The croaking that Toxicroak produces before a battle is for churning the poison it has stored in its poison sac.",
+		de: "Vor einem Kampf gibt es einen Quaklaut von sich, um das Gift in seinem Giftbeutel umzurühren."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/67.ts
+++ b/data/Black & White/Boundaries Crossed/67.ts
@@ -57,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Psychic Protection",
 				fr: "Protection Psy",
+				de: "Psychoschützer"
 			},
 			effect: {
 				en: "During your opponent's next turn, this Pokémon has no Weakness.",
 				fr: "Pendant le prochain tour de votre adversaire, ce Pokémon n'a pas de Faiblesse.",
+				de: "Während des nächsten Zuges deines Gegners hat dieses Pokémon keine Schwäche."
 			},
 			damage: 90,
 

--- a/data/Black & White/Boundaries Crossed/68.ts
+++ b/data/Black & White/Boundaries Crossed/68.ts
@@ -59,6 +59,7 @@ const card: Card = {
 			name: {
 				en: "Psyshot",
 				fr: "Piqûre Psy",
+				de: "Psychoschuss"
 			},
 
 			damage: 20,
@@ -77,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon appears before people and Pokémon who are having nightmares and eats those dreams.",
+		de: "Es erscheint vor schlafenden Menschen und Pokémon und frisst ihre Alpträume."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/69.ts
+++ b/data/Black & White/Boundaries Crossed/69.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Munna",
 		fr: "Munna",
+		de: "Somniam"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Telekinesis",
 				fr: "Lévikinésie",
+				de: "Telekinese"
 			},
 			effect: {
 				en: "This attack does 30 damage to 1 of your opponent's Pokémon. This attack's damage isn't affected by Weakness or Resistance.",
 				fr: "Cette attaque inflige 30 dégâts à 1 des Pokémon de votre adversaire. Les dégâts de cette attaque ne sont pas affectés par la Faiblesse ou la Résistance.",
+				de: "Dieser Angriff fügt 1 Pokémon deines Gegners 30 Schadenspunkte zu. Der Schaden dieses Angriffs wird durch Schwäche und Resistenz nicht verändert."
 			},
 
 		},
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Dream Waltz",
 				fr: "Valse Rêveuse",
+				de: "Traumwalzer"
 			},
 			effect: {
 				en: "This attack can be used even if this Pokémon is Asleep. If this Pokémon is Asleep, this attack does 30 more damage.",
 				fr: "Cette attaque peut être utilisée même si ce Pokémon est Endormi. Si ce Pokémon est Endormi, cette attaque inflige 30 dégâts supplémentaires.",
+				de: "Dieser Angriff kann sogar eingesetzt werden, wenn dieses Pokémon schläft. Wenn dieses Pokémon schläft, fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: 60,
 
@@ -78,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "The dream mist coming from its forehead changes into many different colors depending on the dream that was eaten.",
+		de: "Je nach Inhalt der Träume, die es frisst, nimmt der Dunst, der aus seiner Stirn austritt, unterschiedliche Farben an."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/7.ts
+++ b/data/Black & White/Boundaries Crossed/7.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Slash",
 				fr: "Tranche",
+				de: "Schlitzer"
 			},
 
 			damage: 10,
@@ -49,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Sharp Scythe",
 				fr: "Faucille Acérée",
+				de: "Scharfe Sense"
 			},
 
 			damage: 20,
@@ -67,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "The sharp scythes on its forearms become increasingly sharp by cutting through hard objects.",
+		de: "Die scharfen Sensen an den Unterarmen werden durch das Schneiden harter Objekte noch schärfer."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/70.ts
+++ b/data/Black & White/Boundaries Crossed/70.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Scout",
 				fr: "Espionnage",
+				de: "Späher"
 			},
 			effect: {
 				en: "Your opponent reveals his or her hand.",
 				fr: "Votre adversaire montre sa main.",
+				de: "Dein Gegner deckt seine Handkarten auf."
 			},
 
 		},
@@ -51,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Heart Stamp",
 				fr: "Crèvecœur",
+				de: "Herzstempel"
 			},
 
 			damage: 20,
@@ -76,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "The heart-shaped mark left on a body after a Woobat has been attached to it is said to bring good fortune.",
+		de: "Es verheißt Glück, wenn sich ein Fleknoil an einem Menschen festsaugt und auf ihm einen herzförmigen Fleck hinterlässt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/71.ts
+++ b/data/Black & White/Boundaries Crossed/71.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Woobat",
 		fr: "Chovsourir",
+		de: "Fleknoil"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Jet Woofer",
 				fr: "Infrasons",
+				de: "Tieftonflieger"
 			},
 			effect: {
 				en: "For each Psychic Energy attached to this Pokémon, discard the top card of your opponent's deck.",
 				fr: "Pour chaque Énergie Psychic attachée à ce Pokémon, défaussez la carte du dessus du deck de votre adversaire.",
+				de: "Lege für jede an dieses Pokémon angelegte {P}-Energie die oberste Karte vom Deck deines Gegners auf seinen Ablagestapel."
 			},
 
 		},
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Acrobatics",
 				fr: "Acrobatie",
+				de: "Akrobatik"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 more damage for each heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts supplémentaires pour chaque côté face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -84,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It shakes its tail vigorously when it emits ultrasonic waves strong enough to reduce concrete to rubble.",
+		de: "Beim Abfeuern seiner Ultraschallwellen, mit denen es selbst Beton zertrümmern kann, wedelt es eifrig mit dem Schweif."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/72.ts
+++ b/data/Black & White/Boundaries Crossed/72.ts
@@ -59,6 +59,7 @@ const card: Card = {
 			name: {
 				en: "Bug Bite",
 				fr: "Piqûre",
+				de: "Käferbiss"
 			},
 
 			damage: 20,
@@ -77,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "Using the feelers on its head and tail, it picks up vibrations in the air to determine its prey's location and state.",
+		de: "Analysiert mit den Fühlern an Kopf und Schweif Luftzüge, um seine Gegner zu orten und ihren Zustand zu erkennen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/73.ts
+++ b/data/Black & White/Boundaries Crossed/73.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Venipede",
 		fr: "Venipatte",
+		de: "Toxiped"
 	},
 
 	stage: "Stage1",
@@ -65,6 +66,7 @@ const card: Card = {
 			name: {
 				en: "Spinning Attack",
 				fr: "Attaque Tournante",
+				de: "Rundumangriff"
 			},
 
 			damage: 50,
@@ -83,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "Storing energy for evolution, it sits. But, when predators approach, it moves to stab them with poison spikes.",
+		de: "Es spart sich seine Kraft für seine Entwicklung und bewegt sich nur, um sich mit seinen Giftspitzen zu verteidigen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/74.ts
+++ b/data/Black & White/Boundaries Crossed/74.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Whirlipede",
 		fr: "Scobolide",
+		de: "Rollum"
 	},
 
 	stage: "Stage2",
@@ -66,10 +67,12 @@ const card: Card = {
 			name: {
 				en: "Venoshock",
 				fr: "Choc Venin",
+				de: "Giftschock"
 			},
 			effect: {
 				en: "If the Defending Pokémon is Poisoned, this attack does 40 more damage.",
 				fr: "Si le Pokémon Défenseur est Empoisonné, cette attaque inflige 40 dégâts supplémentaires.",
+				de: "Wenn das Verteidigende Pokémon vergiftet ist, fügt dieser Angriff 40 weitere Schadenspunkte zu."
 			},
 			damage: 80,
 
@@ -87,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "It clasps its prey with the claws on its neck until it stops moving. Then it finishes it off with deadly poison.",
+		de: "Lähmt seine Beute, indem es sie mit den Zacken an seinem Hals aufspießt. Mit einer Ladung Gift gibt es ihr den Rest."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/75.ts
+++ b/data/Black & White/Boundaries Crossed/75.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Pound",
 				fr: "Écras'Face",
+				de: "Pfund"
 			},
 
 			damage: 10,
@@ -49,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Psypunch",
 				fr: "Coup de Poing Psy",
+				de: "Psyhieb"
 			},
 
 			damage: 20,
@@ -67,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "Their ribbonlike feelers increase their psychic power. They are always staring at something.",
+		de: "Die schleifenförmigen Fühler erhöhen seine Psycho-Kräfte. Es scheint stets irgendetwas anzustarren."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/76.ts
+++ b/data/Black & White/Boundaries Crossed/76.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gothita",
 		fr: "Scrutella",
+		de: "Mollimorba"
 	},
 
 	stage: "Stage1",
@@ -42,6 +43,7 @@ const card: Card = {
 			name: {
 				en: "Psypunch",
 				fr: "Coup de Poing Psy",
+				de: "Psyhieb"
 			},
 
 			damage: 30,
@@ -56,10 +58,12 @@ const card: Card = {
 			name: {
 				en: "Destructive Beam",
 				fr: "Rayon Désintégrateur",
+				de: "Zerstörungsstrahler"
 			},
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, défaussez une Énergie attachée au Pokémon Défenseur.",
+				de: "Wirf 1 Münze. Lege bei „Kopf“ 1 an das Verteidigende Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 50,
 
@@ -77,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "They use hypnosis to control people and Pokémon. Tales of Gothorita leading people astray are told in every corner.",
+		de: "Es manipuliert Pokémon und Menschen mit Hypnosetricks. In Märchen tritt es oft als Entführer auf."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/77.ts
+++ b/data/Black & White/Boundaries Crossed/77.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Psychic",
 				fr: "Psyko",
+				de: "Psychokinese"
 			},
 			effect: {
 				en: "Does 20 more damage for each Energy attached to the Defending Pokémon.",
 				fr: "Inflige 20 dégâts supplémentaires pour chaque Énergie attachée au Pokémon Défenseur.",
+				de: "Dieser Angriff fügt 20 weitere Schadenspunkte für jede an das Verteidigende Pokémon angelegte Energie zu."
 			},
 			damage: 10,
 
@@ -53,10 +55,12 @@ const card: Card = {
 			name: {
 				en: "Echoed Voice",
 				fr: "Écho",
+				de: "Widerhall"
 			},
 			effect: {
 				en: "During your next turn, this Pokémon's Echoed Voice attack does 50 more damage (before applying Weakness and Resistance).",
 				fr: "Pendant votre prochain tour, l'attaque Écho de ce Pokémon inflige 50 dégâts supplémentaires (avant application de la Faiblesse et de la Résistance).",
+				de: "Während deines nächsten Zuges fügt die Attacke Widerhall dieses Pokémon 50 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 			damage: 50,
 
@@ -74,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "The melodies sung by Meloetta have the power to make Pokémon that hear them happy or sad.",
+		de: "Es besitzt die Macht, Pokémon, die sich in deiner Nähe aufhalten, mit seinen Melodien froh oder traurig zu stimmen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/78.ts
+++ b/data/Black & White/Boundaries Crossed/78.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Rollout",
 				fr: "Roulade",
+				de: "Walzer"
 			},
 
 			damage: 10,
@@ -50,6 +51,7 @@ const card: Card = {
 			name: {
 				en: "Slash",
 				fr: "Tranche",
+				de: "Schlitzer"
 			},
 
 			damage: 40,
@@ -75,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "It digs deep burrows to live in. When in danger, it rolls up its body to withstand attacks.",
+		de: "Fristet sein Leben in selbst gegrabenen Löchern. Bei Gefahr rollt es sich zusammen und sitzt den Angriff aus."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/79.ts
+++ b/data/Black & White/Boundaries Crossed/79.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Sandshrew",
 		fr: "Sabelette",
+		de: "Sandan"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Sand-Attack",
 				fr: "Jet de Sable",
+				de: "Sandwirbel"
 			},
 			effect: {
 				en: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
 				fr: "Si le Pokémon Défenseur essaie d'attaquer pendant le prochain tour de votre adversaire, ce dernier lance une pièce. Si c’est pile, son attaque ne fait rien.",
+				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 20,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Earthquake",
 				fr: "Séisme",
+				de: "Erdbeben"
 			},
 			effect: {
 				en: "Does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à chacun de vos Pokémon de Banc. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt jedem Pokémon auf deiner Bank 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 80,
 
@@ -87,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "The spikes on its body are made up of its hardened hide. It rolls up and attacks foes with its spikes.",
+		de: "Seine Stacheln sind erhärtete Haut. Im Kampf rollt es sich zusammen und greift den Gegner mit den Stacheln an."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/8.ts
+++ b/data/Black & White/Boundaries Crossed/8.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Horn Attack",
 				fr: "Koud'Korne",
+				de: "Hornattacke"
 			},
 
 			damage: 20,
@@ -50,10 +51,12 @@ const card: Card = {
 			name: {
 				en: "Giga Horn",
 				fr: "Giga Corne",
+				de: "Gigahorn"
 			},
 			effect: {
 				en: "Flip 2 coins. If both of them are tails, this attack does nothing.",
 				fr: "Lancez 2 pièces. Si vous obtenez 2 côtés pile, cette attaque ne fait rien.",
+				de: "Wirf 2 Münzen. Wenn beide „Zahl“ zeigen, hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 80,
 
@@ -71,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "No matter how heavy its opponents, it flings them far away with its prized horn.",
+		de: "Mit seinem prämierten Horn schleudert es jeden noch so schweren Gegner bis in weite Ferne."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/80.ts
+++ b/data/Black & White/Boundaries Crossed/80.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Tail Smack",
 				fr: "Coup de Queue",
+				de: "Schweifschlag"
 			},
 
 			damage: 10,
@@ -49,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Wicked Jab",
 				fr: "Piqûre Infernale",
+				de: "Arglistiger Hieb"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 20,
 
@@ -77,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It clamps on to its chosen prey then jabs the stinger on its tail into the prey while it's stunned with surprise.",
+		de: "Es klammert sich an seiner Beute fest und nutzt den Überraschungseffekt, um seinen Giftstachel in sie zu bohren."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/81.ts
+++ b/data/Black & White/Boundaries Crossed/81.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gligar",
 		fr: "Scorplane",
+		de: "Skorgla"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Poison Ring",
 				fr: "Anneau de Poison",
+				de: "Giftring"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned. The Defending Pokémon can't retreat during your opponent's next turn.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné. Le Pokémon Défenseur ne peut pas battre en retraite pendant le prochain tour de votre adversaire.",
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet. Das Verteidigende Pokémon kann sich während des nächsten Zuges deines Gegners nicht zurückziehen."
 			},
 			damage: 20,
 
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Night Slash",
 				fr: "Tranche-Nuit",
+				de: "Nachthieb"
 			},
 			effect: {
 				en: "Switch this Pokémon with 1 of your Benched Pokémon.",
 				fr: "Échangez ce Pokémon avec 1 de vos Pokémon de Banc.",
+				de: "Tausche dieses Pokémon gegen 1 Pokémon auf deiner Bank aus."
 			},
 			damage: 40,
 
@@ -85,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "It dances silently through the sky. When it approaches prey, it can land a critical hit in an instant.",
+		de: "Es fliegt lautlos am Himmel. Sobald es sich seiner Beute genähert hat, landet es augenblicklich einen Volltreffer."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/82.ts
+++ b/data/Black & White/Boundaries Crossed/82.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Slap Push",
 				fr: "Grande Claque",
+				de: "Stoß"
 			},
 
 			damage: 30,
@@ -55,6 +56,7 @@ const card: Card = {
 
 	description: {
 		en: "It toughens its body by slamming into thick trees. Many snapped trees can be found near its nest.",
+		de: "Es stärkt seinen Körper, indem es gegen Bäume rennt. In seiner Nähe finden sich viele umgekippte Bäume."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/83.ts
+++ b/data/Black & White/Boundaries Crossed/83.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Smithereen Smash",
 				fr: "Pulvérisation",
+				de: "Splitterschlag"
 			},
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, défaussez une Énergie attachée au Pokémon Défenseur.",
+				de: "Wirf 1 Münze. Lege bei „Kopf“ 1 an das Verteidigende Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 
 		},
@@ -51,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
+				de: "Biss"
 			},
 
 			damage: 20,
@@ -76,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "It makes an inescapable conical pit and lies in wait at the bottom for prey to come tumbling down.",
+		de: "Es baut sich ein trichterförmiges Loch, aus dem es kein Entrinnen gibt, und wartet, bis Beute hineinfällt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/84.ts
+++ b/data/Black & White/Boundaries Crossed/84.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Flail",
 				fr: "Fléau",
+				de: "Dreschflegel"
 			},
 			effect: {
 				en: "Does 10 damage times the number of damage counters on this Pokémon.",
 				fr: "Inflige 10 dégâts multipliés par le nombre de marqueurs de dégâts placés sur ce Pokémon.",
+				de: "Dieser Angriff fügt 10 Schadenspunkte für jede Schadensmarke auf diesem Pokémon zu."
 			},
 			damage: 10,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "When it finds a stone of a suitable size, it secretes a liquid from its mouth to open up a hole to crawl into.",
+		de: "Sobald es einen angemessen großen Stein findet, höhlt es ihn mit einem ätzenden Sekret aus und kriecht hinein."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/85.ts
+++ b/data/Black & White/Boundaries Crossed/85.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Dwebble",
 		fr: "Crabicoque",
+		de: "Lithomith"
 	},
 
 	stage: "Stage1",
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Stone Edge",
 				fr: "Lame de Roc",
+				de: "Steinkante"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 70,
 
@@ -86,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "When its boulder is broken in battles for territory, it feels unsure and begins to weaken.",
+		de: "Wird bei Revierkämpfen der Stein auf seinem Rücken zerschlagen, fühlt es sich verwundbar und wird langsam schwächer."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/86.ts
+++ b/data/Black & White/Boundaries Crossed/86.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Steady Punch",
 				fr: "Poing Énergétique",
+				de: "Ruhiger Schlag"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 weitere Schadenspunkte zu."
 			},
 			damage: 10,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "In fights, they dominate with onslaughts of flowing, continuous attacks. With their sharp claws, they cut enemies.",
+		de: "Es deckt seine Gegner mit filigranen Attacken in Serie ein und schlitzt sie mit seinen spitzen Klauen auf."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/87.ts
+++ b/data/Black & White/Boundaries Crossed/87.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Pound",
 				fr: "Écras'Face",
+				de: "Pfund"
 			},
 
 			damage: 20,
@@ -54,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "It takes pride in the speed at which it can use moves. What it loses in power, it makes up for in quantity.",
+		de: "Schnelle Angriffe sind seine Spezialität. Es gleicht seine Schwächen mit der Vielfalt seines Attackenrepertoires aus."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/88.ts
+++ b/data/Black & White/Boundaries Crossed/88.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Mienfoo",
 		fr: "Kungfouine",
+		de: "Lin-Fu"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Knock Off",
 				fr: "Sabotage",
+				de: "Abschlag"
 			},
 			effect: {
 				en: "Discard a random card from your opponent's hand.",
 				fr: "Défaussez au hasard une carte de la main de votre adversaire.",
+				de: "Nimm 1 zufällige Karte aus der verdeckten Hand deines Gegners und lege sie auf dessen Ablagestapel."
 			},
 			damage: 20,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Double Whip",
 				fr: "Double Fouet",
+				de: "Doppelpeitsche"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 70 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 70 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 70 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 70,
 
@@ -80,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "Using the long fur on its arms like whips, it launches into combo attacks that, once started, no one can stop.",
+		de: "Niemand kann es aufhalten, wenn es eine Angriffsserie mit seinen peitschenartigen Armen startet."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/89.ts
+++ b/data/Black & White/Boundaries Crossed/89.ts
@@ -34,10 +34,12 @@ const card: Card = {
 			name: {
 				en: "Hammerhead",
 				fr: "Massue",
+				de: "Hammerkopf"
 			},
 			effect: {
 				en: "Does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 30 dégâts à 1 des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 1 Pokémon auf der Bank deines Gegners 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 30,
 
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Land's Judgment",
 				fr: "Jugement Terrestre",
+				de: "Mach dich vom Acker"
 			},
 			effect: {
 				en: "You may discard all Fighting Energy attached to this Pokémon. If you do, this attack does 70 more damage.",
 				fr: "Vous pouvez défausser toutes les Énergies Fighting attachées à ce Pokémon. Dans ce cas, cette attaque inflige 70 dégâts supplémentaires.",
+				de: "Du kannst alle an dieses Pokémon angelegten {F}-Energien auf deinen Ablagestapel legen. Wenn du das machst, fügt dieser Angriff 70 weitere Schadenspunkte zu."
 			},
 			damage: 80,
 

--- a/data/Black & White/Boundaries Crossed/9.ts
+++ b/data/Black & White/Boundaries Crossed/9.ts
@@ -56,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Wind Whisk",
 				fr: "Rafale Tranchante",
+				de: "Windbesen"
 			},
 			effect: {
 				en: "Switch this Pokémon with 1 of your Benched Pokémon.",
 				fr: "Échangez ce Pokémon avec 1 de vos Pokémon de Banc.",
+				de: "Tausche dieses Pokémon gegen 1 Pokémon auf deiner Bank aus."
 			},
 			damage: 60,
 

--- a/data/Black & White/Boundaries Crossed/90.ts
+++ b/data/Black & White/Boundaries Crossed/90.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Captivate",
 				fr: "Séduction",
+				de: "Liebreiz"
 			},
 			effect: {
 				en: "Flip a coin. If heads, switch 1 of your opponent's Benched Pokémon with the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, échangez le Pokémon Défenseur avec 1 des Pokémon de Banc de votre adversaire.",
+				de: "Wirf 1 Münze. Tausche bei „Kopf“ das Verteidigende Pokémon gegen 1 Pokémon auf der Bank deines Gegners aus."
 			},
 
 		},
@@ -63,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "Their cute act is a ruse. They trick people and steal their valuables just to see the looks on their faces.",
+		de: "Lenkt Leute mit seinem süßen Verhalten ab und stiehlt ihnen ihr Hab und Gut, nur um ihren verdutzten Blick zu sehen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/91.ts
+++ b/data/Black & White/Boundaries Crossed/91.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Purrloin",
 		fr: "Chacripan",
+		de: "Felilou"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Tail Trickery",
 				fr: "Queue Étourdissante",
+				de: "Schweiftrick"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Confused.",
 				fr: "Le Pokémon Défenseur est maintenant Confus.",
+				de: "Das Verteidigende Pokémon ist jetzt verwirrt."
 			},
 
 		},
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Assist",
 				fr: "Assistance",
+				de: "Zuschuss"
 			},
 			effect: {
 				en: "Flip a coin. If heads, choose 1 of your Benched Pokémon's attacks and use it as this attack.",
 				fr: "Lancez une pièce. Si c'est face, choisissez une attaque de l'un de vos Pokémon de Banc et utilisez-la en tant que cette attaque.",
+				de: "Wirf 1 Münze. Wähle bei „Kopf“ 1 Angriff eines Pokémon auf deiner Bank und verwende ihn als diesen Angriff."
 			},
 
 		},
@@ -84,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "Their beautiful form comes from the muscles they have developed. They run silently in the night.",
+		de: "Sein anmutiges Auftreten verdankt es den Muskeln, die es entwickelt hat. Es prescht lautlos durch die Nacht."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/92.ts
+++ b/data/Black & White/Boundaries Crossed/92.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Gust",
 				fr: "Tornade",
+				de: "Windstoß"
 			},
 
 			damage: 10,
@@ -49,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Razor Wing",
 				fr: "Aile Tranchante",
+				de: "Rasierflügel"
 			},
 
 			damage: 20,
@@ -74,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "They tend to guard their posteriors with suitable bones they have found. They pursue weak Pokémon.",
+		de: "Es schlüpft in einen passenden Schädel, um sein Hinterteil zu schützen, und scheucht schwache Pokémon umher."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/93.ts
+++ b/data/Black & White/Boundaries Crossed/93.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Vullaby",
 		fr: "Vostourno",
+		de: "Skallyk"
 	},
 
 	stage: "Stage1",
@@ -42,6 +43,7 @@ const card: Card = {
 			name: {
 				en: "Gust",
 				fr: "Tornade",
+				de: "Windstoß"
 			},
 
 			damage: 30,
@@ -57,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Dual Cut",
 				fr: "Coupe Double",
+				de: "Doppel-Zerschneider"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 80 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 80 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 80 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 80,
 
@@ -85,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It makes a nest out of the bones it finds. It grabs weakened prey in its talons and hauls it to its nest of bones.",
+		de: "Es baut sein Nest aus Knochen. Ist seine Beute geschwächt, packt es sie mit den Beinen und trägt sie zu seinem Nest."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/94.ts
+++ b/data/Black & White/Boundaries Crossed/94.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Scyther",
 		fr: "Insécateur",
+		de: "Sichlor"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Steel Slash",
 				fr: "Tranche Acier",
+				de: "Stahlschlitzer"
 			},
 			effect: {
 				en: "During your opponent's next turn, prevent all damage done to this Pokémon by attacks from Pokémon-EX.",
 				fr: "Pendant le prochain tour de votre adversaire, évitez tous les dégâts infligés à ce Pokémon par des attaques de Pokémon-EX.",
+				de: "Verhindere allen Schaden, der diesem Pokémon während des nächsten Zuges deines Gegners durch Angriffe von Pokémon-EX zugefügt würde."
 			},
 			damage: 40,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Slashing Strike",
 				fr: "Coup Déchirant",
+				de: "Schlitzender Schlag"
 			},
 			effect: {
 				en: "This Pokémon can't use Slashing Strike during your next turn.",
 				fr: "Ce Pokémon ne peut pas utiliser Coup Déchirant pendant votre prochain tour.",
+				de: "Dieses Pokémon kann Schlitzender Schlag während deines nächsten Zuges nicht einsetzen."
 			},
 			damage: 100,
 
@@ -87,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "It raises its pincers with eyelike markings for intimidation. It also swings them down dangerously.",
+		de: "Setzt seine mit Markierungen versehenen Scheren ein, um Gegner einzuschüchtern."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/95.ts
+++ b/data/Black & White/Boundaries Crossed/95.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Claw",
 				fr: "Ergots",
+				de: "Klaue"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 20,
 
@@ -53,6 +55,7 @@ const card: Card = {
 			name: {
 				en: "Drill Peck",
 				fr: "Bec Vrille",
+				de: "Bohrschnabel"
 			},
 
 			damage: 50,
@@ -78,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Despite being clad entirely in iron-hard armor, it flies at speed of over 180 mph.",
+		de: "Es wird komplett von einer eisenharten Rüstung geschützt. Wenn es fliegt, erreicht es bis zu 300 km/h."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/96.ts
+++ b/data/Black & White/Boundaries Crossed/96.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Metal Sound",
 				fr: "Strido-Son",
+				de: "Metallsound"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 
 		},
@@ -52,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Swift",
 				fr: "Météores",
+				de: "Sternschauer"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by Weakness, Resistance, or any other effects on the Defending Pokémon.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Faiblesse, la Résistance ou tout autre effet en action sur le Pokémon Défenseur.",
+				de: "Der Schaden dieses Angriffs wird durch Schwäche, Resistenz oder alle anderen Effekte auf dem Verteidigenden Pokémon nicht verändert."
 			},
 			damage: 70,
 
@@ -80,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "Its heavy-looking iron body is actually thin and light, so it can fly at speeds over 180 mph.",
+		de: "Sein stählerner Körper ist dünner und leichter, als er wirkt und erlaubt eine Fluggeschwindigkeit von bis zu 300 km/h."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/97.ts
+++ b/data/Black & White/Boundaries Crossed/97.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Reckless Charge",
 				fr: "Attaque Imprudente",
+				de: "Waghalsiger Sturmangriff"
 			},
 			effect: {
 				en: "This Pokémon does 10 damage to itself.",
 				fr: "Ce Pokémon s'inflige 10 dégâts.",
+				de: "Dieses Pokémon fügt sich selbst 10 Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -65,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "The two minigears that mesh together are predetermined. Each will rebound from other minigears without meshing.",
+		de: "Seine zwei Teile greifen ineinander wie ein Uhrwerk. Jedes andere Objekt, das man mit ihm kombinieren will, wird abgestoßen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/98.ts
+++ b/data/Black & White/Boundaries Crossed/98.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Trapinch",
 		fr: "Kraknoix",
+		de: "Knacklion"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Quick Turn",
 				fr: "Vif Retournement",
+				de: "Schnelldrehung"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Sand Pulse",
 				fr: "Vibra Sable",
+				de: "Sandimpuls"
 			},
 			effect: {
 				en: "Does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à chacun des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt jedem Pokémon auf deiner Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 50,
 
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "The ultrasonic waves it generates by rubbing its two wings together cause severe headaches.",
+		de: "Die Schallwellen, die es durch eine hohe Flügelschlagfrequenz erzeugt, verursachen heftige Kopfschmerzen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Boundaries Crossed/99.ts
+++ b/data/Black & White/Boundaries Crossed/99.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Vibrava",
 		fr: "Vibraninf",
+		de: "Vibrava"
 	},
 
 	stage: "Stage2",
@@ -66,10 +67,12 @@ const card: Card = {
 			name: {
 				en: "Flying Beatdown",
 				fr: "Dérouillée Volante",
+				de: "Fliegender Niederprügler"
 			},
 			effect: {
 				en: "You may discard a Grass Energy and a Fighting Energy attached to this Pokémon. If you do, the Defending Pokémon is now Paralyzed.",
 				fr: "Vous pouvez défausser une Énergie Grass et une Énergie Fighting attachées à ce Pokémon. Dans ce cas, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Du kannst 1 an dieses Pokémon angelegte {G}-Energie und {F}-Energie auf deinen Ablagestapel legen. Wenn du das machst, ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 80,
 
@@ -87,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "Known as \"The Desert Spirit\" this Pokémon hides in the sandstorms it causes by beating its wings.",
+		de: "Auch bekannt als „Geist der Wüste“. Es versteckt sich in Sandstürmen, die es durch seinen Flügelschlag erzeugt."
 	},
 
 	thirdParty: {


### PR DESCRIPTION
## Add missing German translations for bw7

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
