### PR TITLE
Add missing German translations for bw8

### DIFF
--- a/data/Black & White/Plasma Storm/1.ts
+++ b/data/Black & White/Plasma Storm/1.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Nap",
 				fr: "Tit'Sieste",
+				de: "Nickerchen"
 			},
 			effect: {
 				en: "Heal 20 damage from this Pokémon.",
 				fr: "Soignez 20 dégâts à ce Pokémon.",
+				de: "Heile 20 Schadenspunkte bei diesem Pokémon."
 			},
 
 		},
@@ -52,6 +54,7 @@ const card: Card = {
 			name: {
 				en: "Razor Leaf",
 				fr: "Tranch'Herbe",
+				de: "Rasierblatt"
 			},
 
 			damage: 30,
@@ -77,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "The shell on its back is made of soil. On a very healthy Turtwig, the shell should feel moist.",
+		de: "Der Panzer auf seinem Rücken besteht aus Erdreich. Bei gesunden Chelast ist der Panzer feucht."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/10.ts
+++ b/data/Black & White/Plasma Storm/10.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Swadloon",
 		fr: "Couverdure",
+		de: "Folikon"
 	},
 
 	stage: "Stage2",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Cleave",
 				fr: "Frappe Adhésive",
+				de: "Spalter"
 			},
 			effect: {
 				en: "Flip 2 coins. If both of them are heads, discard all Energy attached to the Defending Pokémon.",
 				fr: "Lancez 2 pièces. Si vous obtenez 2 côtés face, défaussez toutes les Énergies attachées au Pokémon Défenseur.",
+				de: "Wirf 2 Münzen. Zeigen beide „Kopf“, lege alle an das Verteidigende Pokémon angelegten Energien auf den Ablagestapel deines Gegners."
 			},
 			damage: 30,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Leaf Blade",
 				fr: "Lame-Feuille",
+				de: "Laubklinge"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 70,
 
@@ -80,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "Upon finding a small Pokémon, it weaves clothing for it from leaves by using the sticky silk secreted from its mouth.",
+		de: "Begegnet es einem jungen Pokémon, näht es ihm mit den klebrigen Fäden aus seinem Mund ein Kleid aus Blättern."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/100.ts
+++ b/data/Black & White/Plasma Storm/100.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Doduo",
 		fr: "Doduo",
+		de: "Dodu"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Raging Pecks",
 				fr: "Bec Enragé",
+				de: "Wütende Schnabelhiebe"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 30 damage times the number of heads. This Pokémon is now Confused.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face. Ce Pokémon est maintenant Confus.",
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu. Dieses Pokémon ist jetzt verwirrt."
 			},
 			damage: 30,
 
@@ -58,6 +61,7 @@ const card: Card = {
 			name: {
 				en: "Drill Peck",
 				fr: "Bec Vrille",
+				de: "Bohrschnabel"
 			},
 
 			damage: 60,
@@ -83,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "When Doduo evolves into this odd breed, one of its heads splits into two. It runs at nearly 40 mph.",
+		de: "Entwickelt sich Dodu, teilt sich einer der Köpfe in zwei. Es kann sich mit 60 km/h fortbewegen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/101.ts
+++ b/data/Black & White/Plasma Storm/101.ts
@@ -62,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Teampact",
 				fr: "Teampact",
+				de: "Teamwork"
 			},
 			effect: {
 				en: "Does 30 damage times the number of Team Plasma Pokémon you have in play.",
 				fr: "Inflige 30 dégâts multipliés par le nombre de Pokémon de la Team Plasma que vous avez en jeu.",
+				de: "Dieser Angriff fügt 30 Schadenspunkte für jedes Team Plasma-Pokémon, das du im Spiel hast, zu."
 			},
 			damage: 30,
 
@@ -83,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "When its belly is full, it becomes too lethargic to even lift a finger, so it is safe to bounce on its belly.",
+		de: "Ist sein Magen voll, wird es sehr lethargisch. Nun kann man problemlos auf seinem Bauch umherspringen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/102.ts
+++ b/data/Black & White/Plasma Storm/102.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Yawn",
 				fr: "Bâillement",
+				de: "Gähner"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 
 		},
@@ -56,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "It transforms the kindness and joy of others into happiness, which it stores in its shell.",
+		de: "Wandelt die Güte und Freude anderer in Glücksgefühle um, die es in seinem Panzer speichert."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/103.ts
+++ b/data/Black & White/Plasma Storm/103.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Togepi",
 		fr: "Togepi",
+		de: "Togepi"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Sweet Kiss",
 				fr: "Doux Baiser",
+				de: "Bitterkuss"
 			},
 			effect: {
 				en: "Your opponent draws a card.",
 				fr: "Votre adversaire pioche une carte.",
+				de: "Dein Gegner zieht 1 Karte."
 			},
 			damage: 30,
 
@@ -69,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "To share its happiness, it flies around the world seeking kind-hearted people.",
+		de: "Um sein Glück mit anderen zu teilen, fliegt es um die Welt auf der Suche nach gutherzigen Menschen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/104.ts
+++ b/data/Black & White/Plasma Storm/104.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Togetic",
 		fr: "Togetic",
+		de: "Togetic"
 	},
 
 	stage: "Stage2",
@@ -63,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Return",
 				fr: "Retour",
+				de: "Rückkehr"
 			},
 			effect: {
 				en: "Draw cards until you have 6 cards in your hand.",
 				fr: "Piochez des cartes jusqu'à ce que vous ayez 6 cartes en main.",
+				de: "Ziehe so viele Karten, bis du 6 Karten auf der Hand hast."
 			},
 			damage: 30,
 
@@ -91,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "It shares many blessings with people who respect one another's rights and avoid needless strife.",
+		de: "Menschen, die unnötigen Streit vermeiden und sich gegenseitig respektieren, ist es wohlgesonnen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/105.ts
+++ b/data/Black & White/Plasma Storm/105.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Shout",
 				fr: "Braillement",
+				de: "Krakeeler"
 			},
 			effect: {
 				en: "Flip a coin. If heads, discard a random card from your opponent's hand.",
 				fr: "Lancez une pièce. Si c'est face, défaussez au hasard une carte de la main de votre adversaire.",
+				de: "Wirf 1 Münze. Nimm bei „Kopf“ 1 zufällige Karte aus der verdeckten Hand deines Gegners und lege sie auf dessen Ablagestapel."
 			},
 
 		},
@@ -52,6 +54,7 @@ const card: Card = {
 			name: {
 				en: "Hyper Voice",
 				fr: "Mégaphone",
+				de: "Schallwelle"
 			},
 
 			damage: 30,
@@ -70,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "Usually, its cries are like quiet murmurs. If frightened, it shrieks at the same volume as a jet plane.",
+		de: "Normalerweise klingen seine Rufe wie Gemurmel. Hat es aber Angst, ist es so laut wie ein Flugzeug."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/106.ts
+++ b/data/Black & White/Plasma Storm/106.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Whismur",
 		fr: "Chuchmur",
+		de: "Flurmel"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Supersonic",
 				fr: "Ultrason",
+				de: "Superschall"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Confused.",
 				fr: "Le Pokémon Défenseur est maintenant Confus.",
+				de: "Das Verteidigende Pokémon ist jetzt verwirrt."
 			},
 
 		},
@@ -57,6 +60,7 @@ const card: Card = {
 			name: {
 				en: "Hyper Voice",
 				fr: "Mégaphone",
+				de: "Schallwelle"
 			},
 
 			damage: 50,
@@ -75,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "The shock waves from its cries can tip over trucks. It stamps its feet to power up.",
+		de: "Die Schockwellen, die durch sein Rufen entstehen, können einen LKW umkippen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/107.ts
+++ b/data/Black & White/Plasma Storm/107.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Loudred",
 		fr: "Ramboum",
+		de: "Krakeelo"
 	},
 
 	stage: "Stage2",
@@ -43,10 +44,12 @@ const card: Card = {
 			name: {
 				en: "Destructive Sound",
 				fr: "Son Destructeur",
+				de: "Trümmerton"
 			},
 			effect: {
 				en: "Your opponent reveals his or her hand. Discard all Item cards you find there.",
 				fr: "Votre adversaire montre sa main. Défaussez toutes les cartes Objet que vous y trouvez.",
+				de: "Dein Gegner deckt seine Handkarten auf. Lege alle Itemkarten, die du dort findest, auf seinen Ablagestapel."
 			},
 
 		},
@@ -60,10 +63,12 @@ const card: Card = {
 			name: {
 				en: "Round",
 				fr: "Chant Canon",
+				de: "Kanon"
 			},
 			effect: {
 				en: "Does 50 damage times the number of your Pokémon that have the Round attack.",
 				fr: "Inflige 50 dégâts multipliés par le nombre de vos Pokémon possédant l'attaque Chant Canon.",
+				de: "Dieser Angriff fügt 50 Schadenspunkte für jedes deiner Pokémon zu, das Kanon beherrscht."
 			},
 			damage: 50,
 
@@ -81,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "Its howls can be heard over six miles away. It emits all sorts of noises from the ports on its body.",
+		de: "Sein Heulen hört man in 10 km Entfernung. Es gibt alle Arten von Geräuschen von sich."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/108.ts
+++ b/data/Black & White/Plasma Storm/108.ts
@@ -57,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Plasma Gale",
 				fr: "Bourrasque Plasma",
+				de: "Plasma-Gewitter"
 			},
 			effect: {
 				en: "Discard a Plasma Energy attached to this Pokémon. If you can't discard a Plasma Energy, this attack does nothing.",
 				fr: "Défaussez une Énergie Plasma attachée à ce Pokémon. Si vous ne pouvez pas défausser une Énergie Plasma, cette attaque ne fait rien.",
+				de: "Lege 1 an dieses Pokémon angelegte Plasma-Energie auf deinen Ablagestapel. Wenn du keine Plasma-Energie auf deinen Ablagestapel legen kannst, hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 120,
 

--- a/data/Black & White/Plasma Storm/109.ts
+++ b/data/Black & White/Plasma Storm/109.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Triple Slap",
 				fr: "Triple Gifle",
+				de: "Triplexhieb"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "It shows its cute side by chasing its own tail until it gets dizzy.",
+		de: "Es zeigt gerne seine niedliche Seite, indem es seinen eigenen Schweif jagt, bis ihm schwindlig wird."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/11.ts
+++ b/data/Black & White/Plasma Storm/11.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Dazzle Dance",
 				fr: "Danse Éblouissante",
+				de: "Verwirrender Tanz"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Confused.",
 				fr: "Le Pokémon Défenseur est maintenant Confus.",
+				de: "Das Verteidigende Pokémon ist jetzt verwirrt."
 			},
 			damage: 10,
 
@@ -52,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Ambush",
 				fr: "Embuscade",
+				de: "Hinterhalt"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -80,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "When it moves rhythmically, it makes a sound similar to maracas, making the surprised Pokémon flee.",
+		de: "Erzeugt durch rhythmische Bewegungen Töne, die dem Klang von Maracas ähneln und überraschte Pokémon verjagen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/110.ts
+++ b/data/Black & White/Plasma Storm/110.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Reckless Charge",
 				fr: "Attaque Imprudente",
+				de: "Waghalsiger Sturmangriff"
 			},
 			effect: {
 				en: "This Pokémon does 10 damage to itself.",
 				fr: "Ce Pokémon s'inflige 10 dégâts.",
+				de: "Dieses Pokémon fügt sich selbst 10 Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "Extremely cautious, one of them will always be on the lookout, but it won't notice a foe coming from behind.",
+		de: "Eines dieser vorsichtigen Pokémon steht immer vor ihrem Bau Wache. Nähert sich jedoch ein Feind von hinten, ist es aus."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/111.ts
+++ b/data/Black & White/Plasma Storm/111.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Collect",
 				fr: "Collecte",
+				de: "Sammeln"
 			},
 			effect: {
 				en: "Draw a card.",
 				fr: "Piochez une carte.",
+				de: "Ziehe 1 Karte."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Slam",
 				fr: "Souplesse",
+				de: "Slam"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -72,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "Extremely cautious, there is always one keeping watch, but they don't notice enemies coming from behind.",
+		de: "Eines dieser vorsichtigen Pokémon steht immer vor ihrem Bau Wache. Nähert sich jedoch ein Feind von hinten, ist es aus."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/112.ts
+++ b/data/Black & White/Plasma Storm/112.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Patrat",
 		fr: "Ratentif",
+		de: "Nagelotz"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Fast Swipe",
 				fr: "Fauchage Éclair",
+				de: "Flinke Finger"
 			},
 			effect: {
 				en: "Discard a random card from your opponent's hand.",
 				fr: "Défaussez au hasard une carte de la main de votre adversaire.",
+				de: "Nimm 1 zufällige Karte aus der verdeckten Hand deines Gegners und lege sie auf dessen Ablagestapel."
 			},
 
 		},
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Biting Fang",
 				fr: "Croc Mordant",
+				de: "Reißfänge"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -77,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "Using luminescent matter, it makes its eyes and body glow and stuns attacking opponents.",
+		de: "Es kann mit einer körpereigenen Substanz seine Augen und seinen Torso aufleuchten lassen, um Gegner zu erschrecken."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/113.ts
+++ b/data/Black & White/Plasma Storm/113.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Patrat",
 		fr: "Ratentif",
+		de: "Nagelotz"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Second Bite",
 				fr: "Double Morsure",
+				de: "Wunde Stelle"
 			},
 			effect: {
 				en: "Does 10 more damage for each damage counter on the Defending Pokémon.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque marqueur de dégâts placé sur le Pokémon Défenseur.",
+				de: "Dieser Angriff fügt 10 weitere Schadenspunkte für jede Schadensmarke auf dem Verteidigenden Pokémon zu."
 			},
 			damage: 20,
 
@@ -59,6 +62,7 @@ const card: Card = {
 			name: {
 				en: "Low Kick",
 				fr: "Balayage",
+				de: "Fußkick"
 			},
 
 			damage: 60,
@@ -77,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Using luminescent matter, it makes its eyes and body glow and stuns attacking opponents.",
+		de: "Es kann mit einer körpereigenen Substanz seine Augen und seinen Torso aufleuchten lassen, um Gegner zu erschrecken."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/114.ts
+++ b/data/Black & White/Plasma Storm/114.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Tool Breaker",
 				fr: "Bris’Outil",
+				de: "Ausrüstungsbrecher"
 			},
 			effect: {
 				en: "Discard a Pokémon Tool card attached to the Defending Pokémon.",
 				fr: "Défaussez une carte Outil Pokémon attachée au Pokémon Défenseur.",
+				de: "Lege 1 an das Verteidigende Pokémon angelegte Pokémon-Ausrüstung auf den Ablagestapel deines Gegners."
 			},
 
 		},
@@ -53,6 +55,7 @@ const card: Card = {
 			name: {
 				en: "Hammer In",
 				fr: "Enfoncer",
+				de: "Einhämmern"
 			},
 
 			damage: 70,
@@ -71,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "They are known to charge so wildly that if a train were to enter their territory, they would send it flying.",
+		de: "Es rammt Gegner ungebändigt mit dem Kopf und schleudert selbst Züge, die sein Revier durchkreuzen, hinfort."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/115.ts
+++ b/data/Black & White/Plasma Storm/115.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Incessant Peck",
 				fr: "Rafal'Bec",
+				de: "Dauerpicker"
 			},
 			effect: {
 				en: "Flip a coin until you get tails. This attack does 20 more damage for each heads.",
 				fr: "Lancez une pièce jusqu'à ce que vous obteniez un côté pile. Cette attaque inflige 20 dégâts supplémentaires pour chaque côté face.",
+				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Dieser Angriff fügt 20 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 10,
 
@@ -65,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "It stands up to massive opponents, not out of courage, but out of recklessness. But that is how it gets stronger.",
+		de: "Dass es sich mit großen Gegnern anlegt, ist kein Zeichen von Mut, sondern von Unüberlegtheit. Doch so wird es stärker."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/116.ts
+++ b/data/Black & White/Plasma Storm/116.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Rufflet",
 		fr: "Furaiglon",
+		de: "Geronimatz"
 	},
 
 	stage: "Stage1",
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Wild Edge",
 				fr: "Tranchant Sauvage",
+				de: "Wilder Degen"
 			},
 			effect: {
 				en: "You may do 20 more damage. If you do, this Pokémon does 20 damage to itself.",
 				fr: "Vous pouvez infliger 20 dégâts supplémentaires. Dans ce cas, ce Pokémon s'inflige 20 dégâts.",
+				de: "Du kannst mit diesem Angriff 20 weitere Schadenspunkte zufügen. Wenn du das machst, fügt dieses Pokémon sich selbst 20 Schadenspunkte zu."
 			},
 			damage: 60,
 
@@ -93,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "The more scars they have, the more respect these brave soldiers of the sky get from their peers.",
+		de: "Ein tapferer Krieger der Lüfte. Je mehr Narben es vorweisen kann, desto mehr Respekt zollen ihm seine Artgenossen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/117.ts
+++ b/data/Black & White/Plasma Storm/117.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba cartas hasta que tengas 4 cartas en tu mano.",
 		it: "Pesca fino ad avere quattro carte in mano.",
 		pt: "Compre cards até ter 4 cards em sua mão.",
-		de: "Ziehe so viele Karten, bis du 4 Karten auf der Hand hast."
+		de: "Ziehe so viele Karten, bis du 4 Karten auf der Hand hast. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Plasma Storm/118.ts
+++ b/data/Black & White/Plasma Storm/118.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon las cartas de tu mano en tu baraja y barájalas todas. Después, roba un número de cartas igual al número de Pokémon en Banca (tanto tuyos como de tu rival).",
 		it: "Metti le carte che hai in mano nel tuo mazzo e rimischialo. Poi pesca un numero di carte pari al numero di Pokémon in panchina, sia tuoi che del tuo avversario.",
 		pt: "Embaralhe sua mão no seu baralho. Em seguida, compre um número de cards igual ao número de Pokémon no Banco (tanto seus quanto do seu oponente).",
-		de: "Mische deine Handkarten in dein Deck. Ziehe anschließend genauso viele Karten, wie sich Pokémon auf der Bank befinden (deiner und der deines Gegners)."
+		de: "Mische deine Handkarten in dein Deck. Ziehe anschließend genauso viele Karten, wie sich Pokémon auf der Bank befinden (deiner und der deines Gegners). Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Black & White/Plasma Storm/119.ts
+++ b/data/Black & White/Plasma Storm/119.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja una carta de Energía Plasma y únela a 1 de tus Pokémon del Equipo Plasma. Baraja las cartas de tu baraja después.",
 		it: "Cerca nel tuo mazzo una carta Energia Plasma e assegnala a uno dei tuoi Pokémon del Team Plasma. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure em seu baralho um card de Energia de Plasma e ligue-o a 1 dos seus Pokémon da Equipe Plasma. Em seguida, embaralhe seus cards.",
-		de: "Durchsuche dein Deck nach einer Plasma-Energiekarte und lege sie an 1 deiner Team-Plasma-Pokémon an. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach einer Plasma-Energiekarte und lege sie an 1 deiner Team Plasma-Pokémon an. Mische anschließend dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Plasma Storm/12.ts
+++ b/data/Black & White/Plasma Storm/12.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Astonish",
 				fr: "Étonnement",
+				de: "Erstauner"
 			},
 			effect: {
 				en: "Flip a coin. If heads, choose a random card from your opponent's hand. Your opponent reveals that card and shuffles it into his or her deck.",
 				fr: "Lancez une pièce. Si c'est face, choisissez une carte au hasard de la main de votre adversaire. Votre adversaire montre la carte choisie et la mélange avec son deck.",
+				de: "Wirf 1 Münze. Wähle bei „Kopf“ 1 zufällige Karte aus der verdeckten Hand deines Gegners. Dein Gegner zeigt diese Karte und mischt sie zurück in sein Deck."
 			},
 
 		},
@@ -63,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It lures Pokémon with its pattern that looks just like a Poké Ball then releases poison spores.",
+		de: "Es ist gemustert wie ein Pokéball. Es lockt damit andere Pokémon an, um sie dann mit Giftsporen zu besprühen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/120.ts
+++ b/data/Black & White/Plasma Storm/120.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cada jugador cambia a su Pokémon Activo por 1 de sus Pokémon en Banca. (Tu rival lo cambia primero. Si algún jugador no tiene a un Pokémon en Banca, no cambiará a su Pokémon.)",
 		it: "Ciascun giocatore scambia il suo Pokémon attivo con uno dei suoi Pokémon in panchina. Inizia il tuo avversario. Se un giocatore non ha Pokémon in panchina, non effettuerà lo scambio.",
 		pt: "Cada jogador troca seu Pokémon Ativo por 1 dos Pokémon no Banco dele ou dela. (Seu oponente troca primeiro. Se um jogador não tiver um Pokémon no Banco, ele não trocará os Pokémon.)",
-		de: "Jeder Spieler tauscht sein Aktives Pokémon gegen 1 Pokémon auf seiner Bank aus. (Dein Gegner beginnt. Hat ein Spieler kein Pokémon auf der Bank, tauscht er kein Pokémon aus.)"
+		de: "Jeder Spieler tauscht sein Aktives Pokémon gegen 1 Pokémon auf seiner Bank aus. (Dein Gegner beginnt. Hat ein Spieler kein Pokémon auf der Bank, tauscht er kein Pokémon aus.) Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Plasma Storm/121.ts
+++ b/data/Black & White/Plasma Storm/121.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Enseña la primera carta de tu baraja. Si es una carta de Energía Básica, únela a 1 de tus Pokémon. Si no es una carta de Energía Básica, ponla de nuevo en la parte superior de tu baraja.",
 		it: "Mostra la carta in cima al tuo mazzo. Se è una carta Energia base, assegnala a uno dei tuoi Pokémon. Se non lo è, rimettila in cima al tuo mazzo.",
 		pt: "Revele o card de cima do seu baralho. Se esse card for um card de Energia básica, ligue-o a 1 dos seus Pokémon. Caso contrário, coloque-o de volta em cima do seu baralho.",
-		de: "Decke die oberste Karte deines Decks auf. Handelt es sich um eine Basis-Energiekarte, lege sie an 1 deiner Pokémon an. Handelt es sich nicht um eine Basis-Energiekarte, lege sie zurück auf dein Deck."
+		de: "Decke die oberste Karte deines Decks auf. Handelt es sich um eine Basis-Energiekarte, lege sie an 1 deiner Pokémon an. Handelt es sich nicht um eine Basis-Energiekarte, lege sie zurück auf dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Plasma Storm/122.ts
+++ b/data/Black & White/Plasma Storm/122.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Si el Pokémon al que está unida esta carta es un Pokémon Básico, cualquier daño hecho a este Pokémon por ataques se reduce en 20 (después de aplicar Debilidad y Resistencia).",
 		it: "Se il Pokémon a cui è assegnata questa carta è un Pokémon Base, i danni inflitti a questo Pokémon dagli attacchi sono ridotti di 20, dopo aver applicato debolezza e resistenza.",
 		pt: "Se este card estiver ligado a um Pokémon Básico, qualquer dano causado a este Pokémon por ataques será reduzido em 20 (após a aplicação de Fraqueza e Resistência).",
-		de: "Wenn das Pokémon, an das diese Karte angelegt ist, ein Basis-Pokémon ist, wird der diesem Pokémon durch Angriffe zugefügte Schaden um 20 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn das Pokémon, an das diese Karte angelegt ist, ein Basis-Pokémon ist, wird der diesem Pokémon durch Angriffe zugefügte Schaden um 20 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden). Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Black & White/Plasma Storm/123.ts
+++ b/data/Black & White/Plasma Storm/123.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "El Pokémon Activo de tu rival pasa a estar Envenenado. Lanza una moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Dormido también.",
 		it: "Il Pokémon attivo del tuo avversario viene avvelenato. Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene anche addormentato.",
 		pt: "O Pokémon Ativo do seu oponente agora está Envenenado. Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente também ficará Adormecido.",
-		de: "Das Aktive Pokémon deines Gegners ist jetzt vergiftet. Wirf 1 Münze. Bei „Kopf“ schläft das Aktive Pokémon jetzt auch noch."
+		de: "Das Aktive Pokémon deines Gegners ist jetzt vergiftet. Wirf 1 Münze. Bei „Kopf“ schläft das Aktive Pokémon jetzt auch noch. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Plasma Storm/124.ts
+++ b/data/Black & White/Plasma Storm/124.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Los Pokémon que tengan alguna Energía Plasma unida a ellos (tanto tuyos como de tu rival) no tendrán ninguna Debilidad.",
 		it: "I Pokémon che hanno delle Energie Plasma assegnate, sia tuoi che del tuo avversario, non hanno debolezza.",
 		pt: "Qualquer Pokémon que possuir alguma Energia de Plasma ligada a ele (seu e do seu oponente) não terá Fraquezas.",
-		de: "Jedes Pokémon (deine und die deines Gegners), an dem Plasma-Energie angelegt ist, hat keine Schwäche."
+		de: "Jedes Pokémon (deine und die deines Gegners), an dem Plasma-Energie angelegt ist, hat keine Schwäche. Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 
 	trainerType: "Stadium",

--- a/data/Black & White/Plasma Storm/125.ts
+++ b/data/Black & White/Plasma Storm/125.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta una carta del Equipo Plasma de tu mano. (Si no puedes descartar una carta del Equipo Plasma, no puedes jugar esta carta.) Roba 4 cartas.",
 		it: "Scarta una carta Team Plasma presente tra le carte che hai in mano (se non puoi scartare una carta Team Plasma, non puoi giocare questa carta). Pesca quattro carte.",
 		pt: "Descarte um card de Equipe Plasma da sua mão. (Se você não puder descartar um card de Equipe Plasma, não poderá jogar esse card.) Compre 4 cards.",
-		de: "Lege 1 Team-Plasma-Karte von deiner Hand auf deinen Ablagestapel. (Wenn du keine Team-Plasma-Karte auf deinen Ablagestapel legen kannst, kannst du diese Karte nicht spielen.) Ziehe 4 Karten."
+		de: "Lege 1 Team Plasma-Karte von deiner Hand auf deinen Ablagestapel. (Wenn du keine Team Plasma-Karte auf deinen Ablagestapel legen kannst, kannst du diese Karte nicht spielen.) Ziehe 4 Karten. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Black & White/Plasma Storm/126.ts
+++ b/data/Black & White/Plasma Storm/126.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon 2 contadores de daño más sobre los Pokémon Envenenados (tanto tuyos como de tu rival) entre turnos.",
 		it: "Metti altri due segnalini danno sui Pokémon avvelenati, sia tuoi che del tuo avversario, tra un turno e l’altro.",
 		pt: "Coloque 2 marcadores de danos adicionais nos Pokémon Envenenados (tanto seus quanto do seu oponente) entre as vezes de jogar.",
-		de: "Lege zwischen den Zügen 2 weitere Schadensmarken auf vergiftete Pokémon (deine und die deines Gegners)."
+		de: "Lege zwischen den Zügen 2 weitere Schadensmarken auf vergiftete Pokémon (deine und die deines Gegners). Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 
 	trainerType: "Stadium",

--- a/data/Black & White/Plasma Storm/127.ts
+++ b/data/Black & White/Plasma Storm/127.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Esta carta proporciona Energía Colorless.",
 		it: "Cette carte fournit de l’Énergie Colorless.",
 		pt: "Este card fornece Energia Colorless.",
-		de: "Diese Karte liefert Colorless-Energie."
+		de: "Diese Karte liefert {C}-Energie."
 	},
 
 	energyType: "Special",

--- a/data/Black & White/Plasma Storm/128.ts
+++ b/data/Black & White/Plasma Storm/128.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta 2 cartas de tu mano. (Si no puedes descartar 2 cartas, no puedes jugar esta carta.) Pon una carta de Entrenador de tu pila de descartes en tu mano.",
 		it: "Scarta due delle carte che hai in mano (se non puoi scartare due carte, non potrai giocare questa carta). Prendi una carta Allenatore dalla tua pila degli scarti e aggiungila alle carte che hai in mano.",
 		pt: "Descarte 2 cards da sua mão. (Se você não puder descartar 2 cards, não poderá jogar esse card.) Coloque um card de Treinador da sua pilha de descarte em sua mão.",
-		de: "Lege 2 Karten von deiner Hand auf deinen Ablagestapel. (Wenn du keine 2 Karten auf deinen Ablagestapel legen kannst, kannst du diese Karte nicht spielen.) Nimm 1 Trainerkarte von deinem Ablagestapel auf deine Hand."
+		de: "Dein Deck darf nicht mehr als 1 ASS-KLASSE-Karte enthalten. Lege 2 Karten von deiner Hand auf deinen Ablagestapel. (Wenn du keine 2 Karten auf deinen Ablagestapel legen kannst, kannst du diese Karte nicht spielen.) Nimm 1 Trainerkarte von deinem Ablagestapel auf deine Hand. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Plasma Storm/129.ts
+++ b/data/Black & White/Plasma Storm/129.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cambia a tu Pokémon Activo por 1 de tus Pokémon en Banca. Entonces, puedes mover tantas Energías como quieras del anterior Pokémon Activo al nuevo Pokémon Activo.",
 		it: "Scambia il tuo Pokémon attivo con uno dei tuoi Pokémon in panchina. Poi, puoi spostare tutte le Energie che vuoi dal Pokémon attivo precedente a quello nuovo.",
 		pt: "Troque seu Pokémon Ativo por 1 dos Pokémon no seu Banco. Em seguida, você poderá mover tantas Energias ligadas ao antigo Pokémon Ativo para o novo Pokémon Ativo quanto desejar.",
-		de: "Tausche dein Aktives Pokémon gegen 1 Pokémon auf deiner Bank aus. Du kannst anschließend beliebig viele der an dein altes Aktives Pokémon angelegten Energien auf dein neues Aktives Pokémon verschieben."
+		de: "Dein Deck darf nicht mehr als 1 ASS-KLASSE-Karte enthalten. Tausche dein Aktives Pokémon gegen 1 Pokémon auf deiner Bank aus. Du kannst anschließend beliebig viele der an dein altes Aktives Pokémon angelegten Energien auf dein neues Aktives Pokémon verschieben. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Plasma Storm/13.ts
+++ b/data/Black & White/Plasma Storm/13.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Foongus",
 		fr: "Trompignon",
+		de: "Tarnpignon"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Astonish",
 				fr: "Étonnement",
+				de: "Erstauner"
 			},
 			effect: {
 				en: "Flip a coin. If heads, choose 3 random cards from your opponent's hand. Your opponent reveals those cards and shuffles them into his or her deck.",
 				fr: "Lancez une pièce. Si c'est face, choisissez 3 cartes au hasard de la main de votre adversaire. Votre adversaire montre les cartes choisies et les mélange avec son deck.",
+				de: "Wirf 1 Münze. Wähle bei „Kopf“ 3 zufällige Karten aus der verdeckten Hand deines Gegners. Dein Gegner zeigt diese Karten und mischt sie zurück in sein Deck."
 			},
 
 		},
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Miracle Powder",
 				fr: "Poudre Miracle",
+				de: "Wunderstaub"
 			},
 			effect: {
 				en: "Flip a coin. If heads, choose 1 Special Condition. The Defending Pokémon is now affected by that Special Condition.",
 				fr: "Lancez une pièce. Si c'est face, choisissez 1 État Spécial. Le Pokémon Défenseur est maintenant affecté par l'État Spécial choisi.",
+				de: "Wirf 1 Münze. Wähle bei „Kopf“ 1 Speziellen Zustand. Das Verteidigende Pokémon ist jetzt vom diesem Speziellen Zustand betroffen."
 			},
 			damage: 30,
 
@@ -84,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It moves the caps on both arms and does a dance to lure prey. It prefers damp places.",
+		de: "Es rüttelt die Hüte an seinen Armen und lockt Beute mit einem Tanz an. Es hält sich bevorzugt an feuchten Orten auf."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/130.ts
+++ b/data/Black & White/Plasma Storm/130.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Si esta carta está unida a Victini-EX, Victini-EX puede usar sus ataques sin importar la cantidad o el tipo de Energía unida a él.",
 		it: "Si cette carte est attachée à Victini-EX, Victini-EX peut utiliser ses attaques indépendamment de la quantité ou du type d’Énergie qui lui est attachée.",
 		pt: "Se este card estiver ligado a Victini-EX, Victini-EX poderá usar seus ataques independentemente da quantidade ou do tipo de Energia ligada a ele.",
-		de: "Wenn diese Karte an Victini-EX angelegt ist, kann Victini-EX seine Angriffe ungeachtet der Anzahl oder des Typs der angelegten Energien einsetzen."
+		de: "Dein Deck darf nicht mehr als 1 ASS-KLASSE-Karte enthalten. Wenn diese Karte an Victini-EX angelegt ist, kann Victini-EX seine Angriffe ungeachtet der Anzahl oder des Typs der angelegten Energien einsetzen. Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Black & White/Plasma Storm/131.ts
+++ b/data/Black & White/Plasma Storm/131.ts
@@ -34,10 +34,12 @@ const card: Card = {
 			name: {
 				en: "Turbo Energize",
 				fr: "Énergisant Spontané",
+				de: "Schubenergie"
 			},
 			effect: {
 				en: "Search your deck for 2 basic Energy cards and attach them to your Benched Pokémon in any way you like. Shuffle your deck afterward.",
 				fr: "Cherchez 2 cartes Énergie de base dans votre deck et attachez-les à vos Pokémon de Banc, de la manière que vous voulez. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 2 Basis-Energiekarten und lege sie beliebig an die Pokémon auf deiner Bank an. Mische anschließend dein Deck."
 			},
 
 		},
@@ -50,10 +52,12 @@ const card: Card = {
 			name: {
 				en: "Intensifying Burn",
 				fr: "Rage Brûlante",
+				de: "Brandverstärker"
 			},
 			effect: {
 				en: "If the Defending Pokémon is a Pokémon-EX, this attack does 50 more damage.",
 				fr: "Si le Pokémon Défenseur est un Pokémon-EX, cette attaque inflige 50 dégâts supplémentaires.",
+				de: "Wenn das Verteidigende Pokémon ein Pokémon-EX ist, fügt dieser Angriff 50 weitere Schadenspunkte zu."
 			},
 			damage: 50,
 

--- a/data/Black & White/Plasma Storm/132.ts
+++ b/data/Black & White/Plasma Storm/132.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Blizzard",
 				fr: "Blizzard",
+				de: "Blizzard"
 			},
 			effect: {
 				en: "Does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à chacun des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt jedem Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 60,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Frost Prison",
 				fr: "Prison de Givre",
+				de: "Kalter Knast"
 			},
 			effect: {
 				en: "If this Pokémon has any Plasma Energy attached to it, the Defending Pokémon is now Paralyzed.",
 				fr: "Si de l'Énergie Plasma est attachée à ce Pokémon, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wenn an dieses Pokémon bereits Plasma-Energie angelegt ist, ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 80,
 

--- a/data/Black & White/Plasma Storm/133.ts
+++ b/data/Black & White/Plasma Storm/133.ts
@@ -34,10 +34,12 @@ const card: Card = {
 			name: {
 				en: "Righteous Edge",
 				fr: "Lame Vertueuse",
+				de: "Edle Klinge"
 			},
 			effect: {
 				en: "Discard a Special Energy attached to the Defending Pokémon.",
 				fr: "Défaussez une Énergie spéciale attachée au Pokémon Défenseur.",
+				de: "Lege 1 an das Verteidigende Pokémon angelegte Spezial-Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 30,
 
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Steel Bullet",
 				fr: "Balle d'Acier",
+				de: "Stahlkugel"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by Weakness, Resistance, or any other effects on the Defending Pokémon.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Faiblesse, la Résistance ou tout autre effet en action sur le Pokémon Défenseur.",
+				de: "Der Schaden dieses Angriffs wird durch Schwäche, Resistenz oder alle anderen Effekte auf dem Verteidigenden Pokémon nicht verändert."
 			},
 			damage: 100,
 

--- a/data/Black & White/Plasma Storm/134.ts
+++ b/data/Black & White/Plasma Storm/134.ts
@@ -57,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Plasma Gale",
 				fr: "Bourrasque Plasma",
+				de: "Plasma-Gewitter"
 			},
 			effect: {
 				en: "Discard a Plasma Energy attached to this Pokémon. If you can't discard a Plasma Energy, this attack does nothing.",
 				fr: "Défaussez une Énergie Plasma attachée à ce Pokémon. Si vous ne pouvez pas défausser une Énergie Plasma, cette attaque ne fait rien.",
+				de: "Lege 1 an dieses Pokémon angelegte Plasma-Energie auf deinen Ablagestapel. Wenn du keine Plasma-Energie auf deinen Ablagestapel legen kannst, hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 120,
 

--- a/data/Black & White/Plasma Storm/135.ts
+++ b/data/Black & White/Plasma Storm/135.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon las cartas de tu mano en tu baraja y barájalas todas. Después, roba un número de cartas igual al número de Pokémon en Banca (tanto tuyos como de tu rival).",
 		it: "Metti le carte che hai in mano nel tuo mazzo e rimischialo. Poi pesca un numero di carte pari al numero di Pokémon in panchina, sia tuoi che del tuo avversario.",
 		pt: "Embaralhe sua mão no seu baralho. Em seguida, compre um número de cards igual ao número de Pokémon no Banco (tanto seus quanto do seu oponente).",
-		de: "Mische deine Handkarten in dein Deck. Ziehe anschließend genauso viele Karten, wie sich Pokémon auf der Bank befinden (deiner und der deines Gegners)."
+		de: "Mische deine Handkarten in dein Deck. Ziehe anschließend genauso viele Karten, wie sich Pokémon auf der Bank befinden (deiner und der deines Gegners). Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Black & White/Plasma Storm/136.ts
+++ b/data/Black & White/Plasma Storm/136.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Charmeleon",
 		fr: "Reptincel",
+		de: "Glutexo"
 	},
 
 	stage: "Stage2",
@@ -43,10 +44,12 @@ const card: Card = {
 			name: {
 				en: "Split Bomb",
 				fr: "Bombe Fendante",
+				de: "Splitterbombe"
 			},
 			effect: {
 				en: "This attack does 40 damage to 2 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige 40 dégâts à 2 des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 2 Pokémon deines Gegners 40 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -61,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Scorching Fire",
 				fr: "Feu Infernal",
+				de: "Versengendes Feuer"
 			},
 			effect: {
 				en: "Discard a Fire Energy attached to this Pokémon.",
 				fr: "Défaussez une Énergie Fire attachée à ce Pokémon.",
+				de: "Lege 1 an dieses Pokémon angelegte {R}-Energie auf deinen Ablagestapel."
 			},
 			damage: 150,
 
@@ -82,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "This extremely rare Pokémon is a different color than usual. It is very hard to find.",
+		de: "Dieses sehr seltene Pokémon hat eine andere Farbe als üblich. Es ist schwer zu finden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/137.ts
+++ b/data/Black & White/Plasma Storm/137.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Wartortle",
 		fr: "Carabaffe",
+		de: "Schillok"
 	},
 
 	stage: "Stage2",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Todas las veces que quieras durante tu turno (antes de tu ataque), puedes unir una carta de Energía Water de tu mano a 1 de tus Pokémon.",
 				it: "Durante il tuo turno, prima di attaccare, puoi assegnare a piacimento le carte Energia Water che hai in mano ai tuoi Pokémon.",
 				pt: "Tantas vezes quanto desejar em sua vez de jogar (antes de atacar), você poderá ligar um card de Energia Water da sua mão a 1 dos seus Pokémon.",
-				de: "Beliebig oft während deines Zuges (vor deinem Angriff) kannst du 1 Water-Energiekarte von deiner Hand an 1 deiner Pokémon anlegen."
+				de: "Beliebig oft während deines Zuges (vor deinem Angriff) kannst du 1 {W}-Energiekarte von deiner Hand an 1 deiner Pokémon anlegen."
 			},
 		},
 	],
@@ -66,10 +67,12 @@ const card: Card = {
 			name: {
 				en: "Hydro Pump",
 				fr: "Hydrocanon",
+				de: "Hydropumpe"
 			},
 			effect: {
 				en: "Does 10 more damage for each Water Energy attached to this Pokémon.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque Énergie Water attachée à ce Pokémon.",
+				de: "Dieser Angriff fügt 10 weitere Schadenspunkte für jede an dieses Pokémon angelegte {W}-Energie zu."
 			},
 			damage: 60,
 
@@ -87,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "This extremely rare Pokémon is a different color than usual. It is very hard to find.",
+		de: "Dieses sehr seltene Pokémon hat eine andere Farbe als üblich. Es ist schwer zu finden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/138.ts
+++ b/data/Black & White/Plasma Storm/138.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Ve enseñando cartas de la parte superior de tu baraja hasta que enseñes una carta de Partidario. Ponla en tu mano. Pon el resto de cartas de nuevo en tu baraja y barájalas todas.",
 		it: "Scopri le carte in cima al tuo mazzo fino a quando non trovi una carta Aiuto. Aggiungila a quelle che hai in mano, poi rimischia le altre carte nel tuo mazzo.",
 		pt: "Revele cards do topo do seu baralho até revelar um card de Apoiador. Coloque-o em sua mão. Embaralhe os demais cards de volta.",
-		de: "Decke solang Karten von deinem Deck auf, bis du eine Unterstützerkarte aufdeckst. Nimm sie auf deine Hand. Mische die anderen Karten zurück in dein Deck."
+		de: "Decke solang Karten von deinem Deck auf, bis du eine Unterstützerkarte aufdeckst. Nimm sie auf deine Hand. Mische die anderen Karten zurück in dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Black & White/Plasma Storm/14.ts
+++ b/data/Black & White/Plasma Storm/14.ts
@@ -35,10 +35,12 @@ const card: Card = {
 			name: {
 				en: "Destructive Flame",
 				fr: "Flamme Destructrice",
+				de: "Verzehrende Flamme"
 			},
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, défaussez une Énergie attachée au Pokémon Défenseur.",
+				de: "Wirf 1 Münze. Lege bei „Kopf“ 1 an das Verteidigende Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 30,
 
@@ -53,10 +55,12 @@ const card: Card = {
 			name: {
 				en: "Power Flame",
 				fr: "Flamme Vigoureuse",
+				de: "Mächtige Flamme"
 			},
 			effect: {
 				en: "If this Pokémon has any Plasma Energy attached to it, this attack does 40 more damage.",
 				fr: "Si de l'Énergie Plasma est attachée à ce Pokémon, cette attaque inflige 40 dégâts supplémentaires.",
+				de: "Wenn an dieses Pokémon bereits Plasma-Energie angelegt ist, fügt dieser Angriff 40 weitere Schadenspunkte zu."
 			},
 			damage: 80,
 

--- a/data/Black & White/Plasma Storm/15.ts
+++ b/data/Black & White/Plasma Storm/15.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Flare",
 				fr: "Flamboiement",
+				de: "Flackern"
 			},
 
 			damage: 20,
@@ -54,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "It is very agile. Before going to sleep, it extinguishes the flame on its tail to prevent fires.",
+		de: "Dieses flinke Pokémon löscht vor dem Schlafengehen die Flamme auf seinem Schweif, um Feuer zu verhindern."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/16.ts
+++ b/data/Black & White/Plasma Storm/16.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Chimchar",
 		fr: "Ouisticram",
+		de: "Panflam"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Loud Howl",
 				fr: "Hurlement Tonitruant",
+				de: "Lauter Jauler"
 			},
 			effect: {
 				en: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon.",
 				fr: "Votre adversaire échange le Pokémon Défenseur avec 1 de ses Pokémon de Banc.",
+				de: "Dein Gegner tauscht das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
 			},
 
 		},
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Fire Tail Slap",
 				fr: "Coup de Queue Enflammé",
+				de: "Feuerschweifschlag"
 			},
 			effect: {
 				en: "Discard an Energy attached to this Pokémon.",
 				fr: "Défaussez une Énergie attachée à ce Pokémon.",
+				de: "Lege 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel."
 			},
 			damage: 50,
 
@@ -77,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It skillfully controls the intensity of the fire on its tail to keep its foes at an ideal distance.",
+		de: "Es kontrolliert die Stärke des Feuers auf seinem Schweif geschickt, um Gegner auf Distanz zu halten."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/17.ts
+++ b/data/Black & White/Plasma Storm/17.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Monferno",
 		fr: "Chimpenfeu",
+		de: "Panpyro"
 	},
 
 	stage: "Stage2",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Torment",
 				fr: "Tourmente",
+				de: "Folterknecht"
 			},
 			effect: {
 				en: "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn.",
 				fr: "Choisissez 1 des attaques du Pokémon Défenseur. Le Pokémon ciblé ne peut pas utiliser l'attaque choisie pendant le prochain tour de votre adversaire.",
+				de: "Wähle 1 Angriff des Verteidigenden Pokémon. Das Pokémon kann den gewählten Angriff während des nächsten Zuges deines Gegners nicht einsetzen."
 			},
 			damage: 30,
 
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Malevolent Fire",
 				fr: "Feu Malveillant",
+				de: "Bösartiges Feuer"
 			},
 			effect: {
 				en: "Discard all Energy attached to this Pokémon.",
 				fr: "Défaussez toutes les Énergies attachées à ce Pokémon.",
+				de: "Lege alle an dieses Pokémon angelegten Energien auf deinen Ablagestapel."
 			},
 			damage: 120,
 
@@ -78,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "It uses unique fighting moves with fire on its hand and feet. It will take on any opponent.",
+		de: "Es verwendet einzigartige Attacken mit dem Feuer an seinen Händen und Füßen. Stellt sich jedem Gegner."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/18.ts
+++ b/data/Black & White/Plasma Storm/18.ts
@@ -34,10 +34,12 @@ const card: Card = {
 			name: {
 				en: "Turbo Energize",
 				fr: "Énergisant Spontané",
+				de: "Schubenergie"
 			},
 			effect: {
 				en: "Search your deck for 2 basic Energy cards and attach them to your Benched Pokémon in any way you like. Shuffle your deck afterward.",
 				fr: "Cherchez 2 cartes Énergie de base dans votre deck et attachez-les à vos Pokémon de Banc, de la manière que vous voulez. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 2 Basis-Energiekarten und lege sie beliebig an die Pokémon auf deiner Bank an. Mische anschließend dein Deck."
 			},
 
 		},
@@ -50,10 +52,12 @@ const card: Card = {
 			name: {
 				en: "Intensifying Burn",
 				fr: "Rage Brûlante",
+				de: "Brandverstärker"
 			},
 			effect: {
 				en: "If the Defending Pokémon is a Pokémon-EX, this attack does 50 more damage.",
 				fr: "Si le Pokémon Défenseur est un Pokémon-EX, cette attaque inflige 50 dégâts supplémentaires.",
+				de: "Wenn das Verteidigende Pokémon ein Pokémon-EX ist, fügt dieser Angriff 50 weitere Schadenspunkte zu."
 			},
 			damage: 50,
 

--- a/data/Black & White/Plasma Storm/19.ts
+++ b/data/Black & White/Plasma Storm/19.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Scratch",
 				fr: "Griffe",
+				de: "Kratzer"
 			},
 
 			damage: 20,
@@ -51,10 +52,12 @@ const card: Card = {
 			name: {
 				en: "Double Fire",
 				fr: "Double Feu",
+				de: "Duplexfeuer"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 40 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 40 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 40,
 
@@ -72,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "Very intelligent, it roasts berries before eating them. It likes to help people.",
+		de: "Ein kultiviertes Pokémon, das Beeren vor dem Verzehr stets anbrät. Es bietet den Menschen gerne seine Hilfe an."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/2.ts
+++ b/data/Black & White/Plasma Storm/2.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Turtwig",
 		fr: "Tortipouss",
+		de: "Chelast"
 	},
 
 	stage: "Stage1",
@@ -43,10 +44,12 @@ const card: Card = {
 			name: {
 				en: "Knock Away",
 				fr: "Asticotage",
+				de: "Zurückschlagen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 40,
 
@@ -71,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "It knows where pure water wells up. It carries fellow Pokémon there on its back.",
+		de: "Es weiß, wo es reinstes Quellwasser finden kann. Trägt andere Pokémon auf seinem Rücken dorthin."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/20.ts
+++ b/data/Black & White/Plasma Storm/20.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pansear",
 		fr: "Flamajou",
+		de: "Grillmak"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Searing Flame",
 				fr: "Flammes Calcinantes",
+				de: "Sengende Flammen"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Burned.",
 				fr: "Le Pokémon Défenseur est maintenant Brûlé.",
+				de: "Das Verteidigende Pokémon ist jetzt verbrannt."
 			},
 			damage: 20,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Flame Blast",
 				fr: "Explosion de Flammes",
+				de: "Flammenschuss"
 			},
 			effect: {
 				en: "Does 20 more damage for each Fire Energy attached to this Pokémon.",
 				fr: "Inflige 20 dégâts supplémentaires pour chaque Énergie Fire attachée à ce Pokémon.",
+				de: "Dieser Angriff fügt 20 weitere Schadenspunkte für jede an dieses Pokémon angelegte {R}-Energie zu."
 			},
 			damage: 40,
 
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "When it gets excited, embers rise from its head and tail and it gets hot. For some reason, it loves sweets.",
+		de: "Freut es sich, erhitzt sich sein Körper und aus seinem Kopf und Schweif sprühen Funken. Es liebt Süßigkeiten."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/21.ts
+++ b/data/Black & White/Plasma Storm/21.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Surprise Attack",
 				fr: "Attaque Surprise",
+				de: "Überraschungsangriff"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 20,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "Its flame is usually out, but it starts shining when it absorbs life force from people or Pokémon.",
+		de: "Seine Flamme entzündet sich erst, wenn es einem Menschen oder einem Pokémon die Lebensenergie absaugt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/22.ts
+++ b/data/Black & White/Plasma Storm/22.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Litwick",
 		fr: "Funécire",
+		de: "Lichtel"
 	},
 
 	stage: "Stage1",
@@ -64,6 +65,7 @@ const card: Card = {
 			name: {
 				en: "Will-O-Wisp",
 				fr: "Feu Follet",
+				de: "Irrlicht"
 			},
 
 			damage: 20,
@@ -82,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "The spirits it absorbs fuel its baleful fire. It hangs around hospitals waiting for people to pass on.",
+		de: "Es nährt seine Flamme mit den Seelen seiner Opfer. Heutzutage irrt es auf der Suche nach Seelen durch Krankenhäuser."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/23.ts
+++ b/data/Black & White/Plasma Storm/23.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Luring Flame",
 				fr: "Flamme Attrayante",
+				de: "Verlockende Flamme"
 			},
 			effect: {
 				en: "Switch 1 of your opponent's Benched Pokémon with the Defending Pokémon. The new Defending Pokémon is now Burned.",
 				fr: "Échangez 1 des Pokémon de Banc de votre adversaire avec le Pokémon Défenseur. Le nouveau Pokémon Défenseur est maintenant Brûlé.",
+				de: "Tausche 1 Pokémon auf der Bank deines Gegners gegen das Verteidigende Pokémon aus. Das neue Verteidigende Pokémon ist jetzt verbrannt."
 			},
 
 		},
@@ -52,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Fiery Licks",
 				fr: "Léchouilles Incendiaires",
+				de: "Flammenzungen"
 			},
 			effect: {
 				en: "Discard the top 4 cards of your deck. This attack does 50 damage times the number of Fire Energy cards you discarded.",
 				fr: "Défaussez les 4 cartes du dessus de votre deck. Cette attaque inflige 50 dégâts multipliés par le nombre de cartes Énergie Fire que vous avez défaussées.",
+				de: "Lege die obersten 4 Karten deines Decks auf deinen Ablagestapel. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl abgelegter {R}-Energiekarten zu."
 			},
 			damage: 50,
 
@@ -73,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "It draws in air through its tail, transforms it into fire, and uses it like a tongue. It melts Durant and eats them.",
+		de: "Über den Schweif aufgesaugte Luft wird in eine Feuerzunge verwandelt, um damit Fermicula zu schmelzen und zu fressen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/24.ts
+++ b/data/Black & White/Plasma Storm/24.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 10,
@@ -54,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "It shelters itself in its shell, then strikes back with spouts of water at every opportunity.",
+		de: "Es zieht sich in seinen Panzer zurück und greift dann mit Wasserstrahlen seine Gegner an."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/25.ts
+++ b/data/Black & White/Plasma Storm/25.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Blizzard",
 				fr: "Blizzard",
+				de: "Blizzard"
 			},
 			effect: {
 				en: "Does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à chacun des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt jedem Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 60,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Frost Prison",
 				fr: "Prison de Givre",
+				de: "Kalter Knast"
 			},
 			effect: {
 				en: "If this Pokémon has any Plasma Energy attached to it, the Defending Pokémon is now Paralyzed.",
 				fr: "Si de l'Énergie Plasma est attachée à ce Pokémon, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wenn an dieses Pokémon bereits Plasma-Energie angelegt ist, ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 80,
 

--- a/data/Black & White/Plasma Storm/26.ts
+++ b/data/Black & White/Plasma Storm/26.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Double Headbutt",
 				fr: "Double Coup d'Boule",
+				de: "Doppelte Kopfnuss"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "Rooting the tip of its snout into the ground, it searches for food. Sometimes, it even digs up a hot spring.",
+		de: "Spürt mit seiner Nase im Erdreich Futter auf und gräbt danach. Manchmal stößt es dabei auf heiße Quellen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/27.ts
+++ b/data/Black & White/Plasma Storm/27.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Swinub",
 		fr: "Marcacrin",
+		de: "Quiekel"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Ice Beam",
 				fr: "Laser Glace",
+				de: "Eisstrahl"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 20,
 
@@ -60,10 +63,12 @@ const card: Card = {
 			name: {
 				en: "Quintuple Headbutt",
 				fr: "Quintuple Coup d'Boule",
+				de: "Fünffache Kopfnuss"
 			},
 			effect: {
 				en: "Flip 5 coins. This attack does 40 damage times the number of heads.",
 				fr: "Lancez 5 pièces. Cette attaque inflige 40 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 5 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 40,
 
@@ -81,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "With its excellent sense of smell, it's even able to find mushrooms that are buried under frozen ground.",
+		de: "Sein Geruchssinn ist stark genug ausgeprägt, um damit Pilze unter vereisten Erdmassen aufzuspüren."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/28.ts
+++ b/data/Black & White/Plasma Storm/28.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Piloswine",
 		fr: "Cochignon",
+		de: "Keifel"
 	},
 
 	stage: "Stage2",
@@ -43,10 +44,12 @@ const card: Card = {
 			name: {
 				en: "Frost Stone",
 				fr: "Roc Gelé",
+				de: "Frostfelsen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage and the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires et le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu und das Verteidigende Pokémon ist jetzt paralysiert."
 			},
 			damage: 50,
 
@@ -61,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Continuous Headbutt",
 				fr: "Coup d'Boule Sans Fin",
+				de: "Anhaltender Kopfstoß"
 			},
 			effect: {
 				en: "Flip a coin until you get tails. This attack does 90 damage times the number of heads.",
 				fr: "Lancez une pièce jusqu'à ce que vous obteniez un côté pile. Cette attaque inflige 90 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Dieser Angriff fügt 90 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 90,
 
@@ -82,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "When the temperature rose at the end of the ice age, most Mamoswine disappeared.",
+		de: "Man sagt, als gegen Ende der letzten Eiszeit die Temperaturen wieder stiegen, seien viele Mamutel verschwunden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/29.ts
+++ b/data/Black & White/Plasma Storm/29.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Bubble Beam",
 				fr: "Bulles d'O",
+				de: "Blubbstrahl"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 20,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "It looks like an aquatic plant and serves as a ferry to Pokémon that can't swim.",
+		de: "Es sieht aus wie eine Wasserpflanze. Es dient den Pokémon, die nicht schwimmen können, als Fähre."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/3.ts
+++ b/data/Black & White/Plasma Storm/3.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Grotle",
 		fr: "Boskara",
+		de: "Chelcarain"
 	},
 
 	stage: "Stage2",
@@ -43,10 +44,12 @@ const card: Card = {
 			name: {
 				en: "Guard Press",
 				fr: "Pression de Garde",
+				de: "Schutzdruck"
 			},
 			effect: {
 				en: "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, tous les dégâts infligés à ce Pokémon par des attaques sont réduits de 20 (après application de la Faiblesse et de la Résistance).",
+				de: "Während des nächsten Zuges deines Gegners wird Schaden, der diesem Pokémon durch Angriffe zugefügt wird, um 20 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 			damage: 60,
 
@@ -61,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Rumble Stomp",
 				fr: "Piétinement Lourd",
+				de: "Kampfstampfer"
 			},
 			effect: {
 				en: "Flip a coin until you get tails. This attack does 20 more damage for each heads.",
 				fr: "Lancez une pièce jusqu'à ce que vous obteniez un côté pile. Cette attaque inflige 20 dégâts supplémentaires pour chaque côté face.",
+				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Dieser Angriff fügt 20 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 80,
 
@@ -89,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "Some Pokémon are born on a Torterra's back and spend their entire life there.",
+		de: "Manche Pokémon werden auf dem Rücken eines Chelterrar geboren und verbringen ihr ganzes Leben dort."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/30.ts
+++ b/data/Black & White/Plasma Storm/30.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Lotad",
 		fr: "Nénupiot",
+		de: "Loturzel"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Jump On",
 				fr: "Saut",
+				de: "Draufspringen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -59,6 +62,7 @@ const card: Card = {
 			name: {
 				en: "Wave Splash",
 				fr: "Grosse Vague",
+				de: "Wellenplatscher"
 			},
 
 			damage: 50,
@@ -77,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "It has a mischievous spirit. If it spots an angler, it will tug on the fishing line to interfere.",
+		de: "Es hat ein spitzbübisches Wesen. Sieht es einen Angler, zieht es an der Angelschnur, um ihn zu ärgern."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/31.ts
+++ b/data/Black & White/Plasma Storm/31.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Lombre",
 		fr: "Lombre",
+		de: "Lombrero"
 	},
 
 	stage: "Stage2",
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Groovy Dance",
 				fr: "Danse Enivrée",
+				de: "Fetziger Reigen"
 			},
 			effect: {
 				en: "You may discard an Energy attached to this Pokémon. If you do, the Defending Pokémon is now Confused.",
 				fr: "Vous pouvez défausser une Énergie attachée à ce Pokémon. Dans ce cas, le Pokémon Défenseur est maintenant Confus.",
+				de: "Du kannst 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel legen. Wenn du das machst, ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: 70,
 
@@ -86,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "If it hears festive music, all its muscles fill with energy. It can't help breaking out into a dance.",
+		de: "Hört es fröhliche Musik, füllen sich seine Muskeln mit Energie. Es muss dann einfach tanzen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/32.ts
+++ b/data/Black & White/Plasma Storm/32.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
+				de: "Biss"
 			},
 
 			damage: 20,
@@ -55,6 +56,7 @@ const card: Card = {
 
 	description: {
 		en: "They swarm any foe that invades their territory. Their sharp fangs can tear out boat hulls.",
+		de: "Sie begegnen jedem Gegner, der in ihr Revier eindringt, im Schwarm. Ihre Zähne durchdringen alles."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/33.ts
+++ b/data/Black & White/Plasma Storm/33.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Carvanha",
 		fr: "Carvanha",
+		de: "Kanivanha"
 	},
 
 	stage: "Stage1",
@@ -64,10 +65,12 @@ const card: Card = {
 			name: {
 				en: "Hard Bite",
 				fr: "Morsure Profonde",
+				de: "Kräftiger Biss"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 40,
 
@@ -85,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Its fangs rip through sheet iron. It swims at 75 mph and is known as",
+		de: "Seine Zähne durchdringen sogar Eisen. Es schwimmt mit 120 km/h und wird „Tyrann des Meeres“ genannt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/34.ts
+++ b/data/Black & White/Plasma Storm/34.ts
@@ -58,10 +58,12 @@ const card: Card = {
 			name: {
 				en: "Seafaring",
 				fr: "Voyage en Mer",
+				de: "Seefahrer"
 			},
 			effect: {
 				en: "Flip 3 coins. For each heads, attach a Water Energy card from your discard pile to your Benched Pokémon in any way you like.",
 				fr: "Lancez 3 pièces. Pour chaque côté face, attachez une carte Énergie Water de votre pile de défausse à vos Pokémon de Banc, de la manière que vous voulez.",
+				de: "Wirf 3 Münzen. Lege pro „Kopf“ 1 {W}-Energiekarte von deinem Ablagestapel beliebig an die Pokémon auf deiner Bank an."
 			},
 
 		},
@@ -78,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It is born with a wondrous power that lets it bond with any kind of Pokémon.",
+		de: "Es wird mit einer wundersamen Kraft geboren, die eine Bindung zu jedem anderen Pokémon möglich macht."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/35.ts
+++ b/data/Black & White/Plasma Storm/35.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Snow Squall",
 				fr: "Rafale de Neige",
+				de: "Schneeböe"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by Resistance.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Résistance.",
+				de: "Der Schaden dieses Angriffs wird durch Resistenz nicht verändert."
 			},
 			damage: 10,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "Theoretically, this Pokémon formed from icicles bathed in energy from the morning sun. Their breath is -58° F.",
+		de: "Ein Eiszapfen, der durch die Energie der aufgehenden Sonne zum Pokémon wurde. Es speit minus 50 Grad kalten Odem."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/36.ts
+++ b/data/Black & White/Plasma Storm/36.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Vanillite",
 		fr: "Sorbébé",
+		de: "Gelatini"
 	},
 
 	stage: "Stage1",
@@ -42,6 +43,7 @@ const card: Card = {
 			name: {
 				en: "Icy Snow",
 				fr: "Verglas",
+				de: "Eisiger Schnee"
 			},
 
 			damage: 30,
@@ -60,6 +62,7 @@ const card: Card = {
 
 	description: {
 		en: "They cool down the surrounding air and create ice particles, which they use to freeze their foes.",
+		de: "Es produziert Eiskörner, indem es die Luft um sich herum abkühlt, und zieht mit ihnen eine Eisschicht um seinen Gegner."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/37.ts
+++ b/data/Black & White/Plasma Storm/37.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Vanillish",
 		fr: "Sorboul",
+		de: "Gelatroppo"
 	},
 
 	stage: "Stage2",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Enefountain",
 				fr: "Fontaine d'Énergie",
+				de: "Energiebrunnen"
 			},
 			effect: {
 				en: "Attach 2 basic Energy cards from your hand to 1 of your Pokémon.",
 				fr: "Attachez 2 cartes Énergie de base de votre main à 1 de vos Pokémon.",
+				de: "Lege 2 Basis-Energiekarten von deiner Hand an 1 deiner Pokémon an."
 			},
 			damage: 30,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Blizzard",
 				fr: "Blizzard",
+				de: "Blizzard"
 			},
 			effect: {
 				en: "Does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à chacun des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt jedem Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 70,
 
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "Swallowing large amounts of water, they make snow clouds inside their bodies and, when angry, cause violent blizzards.",
+		de: "Es verschluckt Unmengen an Wasser und wandelt es intern in Schneewolken um. Ist es wütend, erzeugt es Schneestürme."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/38.ts
+++ b/data/Black & White/Plasma Storm/38.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Absorb",
 				fr: "Vol-Vie",
+				de: "Absorber"
 			},
 			effect: {
 				en: "Heal 10 damage from this Pokémon.",
 				fr: "Soignez 10 dégâts à ce Pokémon.",
+				de: "Heile 10 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 10,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "If its veil-like arms stun and wrap a foe, that foe will be dragged miles below the surface, never to return.",
+		de: "Es schlingt seine schleierartigen Arme um seine Beute und entführt sie 8 000 Meter in die Tiefe, wo es sie schließlich tötet."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/39.ts
+++ b/data/Black & White/Plasma Storm/39.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Frillish",
 		fr: "Viskuse",
+		de: "Quabbel"
 	},
 
 	stage: "Stage1",
@@ -64,10 +65,12 @@ const card: Card = {
 			name: {
 				en: "Aqua Bullet",
 				fr: "Aquaballe",
+				de: "Aquageschoss"
 			},
 			effect: {
 				en: "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à 1 des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt 1 Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 40,
 
@@ -85,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Its body is mostly seawater. It's said there's a castle of ships Jellicent have sunk on the seafloor.",
+		de: "Es heißt, am Meeresboden gebe es einen Palast aus Schiffen, die es versenkt hat. Es besteht fast nur aus Meerwasser."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/4.ts
+++ b/data/Black & White/Plasma Storm/4.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Sting Missile",
 				fr: "Dard-Missile",
+				de: "Stachelrakete"
 			},
 			effect: {
 				en: "Shuffle this Pokémon and all cards attached to it into your deck.",
 				fr: "Mélangez ce Pokémon et toutes les cartes qui lui sont attachées avec votre deck.",
+				de: "Mische dieses Pokémon und alle daran angelegten Karten zurück in dein Deck."
 			},
 			damage: 30,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon is a set of three. When they sleep, they gather up and form a giant hive of 100 Combee.",
+		de: "Ein Pokémon-Trio. Zur Schlafenszeit scharen sie sich zu Hunderten und bilden einen riesigen Bienenstock."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/40.ts
+++ b/data/Black & White/Plasma Storm/40.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Hail",
 				fr: "Grêle",
+				de: "Hagelsturm"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts à chacun des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff jedem Pokémon deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -52,6 +54,7 @@ const card: Card = {
 			name: {
 				en: "Icy Snow",
 				fr: "Verglas",
+				de: "Eisiger Schnee"
 			},
 
 			damage: 30,
@@ -70,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "Their snot is a barometer of health. When healthy, their snot is sticky and the power of their ice moves increases.",
+		de: "Fühlt es sich wohl, wird der Schleim, der aus seiner Nase trieft, klebrig, und die Stärke seiner Eis-Attacken nimmt zu."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/41.ts
+++ b/data/Black & White/Plasma Storm/41.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cubchoo",
 		fr: "Polarhume",
+		de: "Petznief"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Powerful Rage",
 				fr: "Rage Massive",
+				de: "Mächtige Wut"
 			},
 			effect: {
 				en: "Does 20 damage times the number of damage counters on this Pokémon.",
 				fr: "Inflige 20 dégâts multipliés par le nombre de marqueurs de dégâts placés sur ce Pokémon.",
+				de: "Dieser Angriff fügt 20 Schadenspunkte für jede Schadensmarke auf diesem Pokémon zu."
 			},
 			damage: 20,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Glacier Drop",
 				fr: "Chute de Glacier",
+				de: "Gletschersturz"
 			},
 			effect: {
 				en: "Discard the top card of your opponent's deck.",
 				fr: "Défaussez la carte du dessus du deck de votre adversaire.",
+				de: "Lege die oberste Karte vom Deck deines Gegners auf seinen Ablagestapel."
 			},
 			damage: 90,
 
@@ -80,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "They love the cold seas of the north. They create pathways around the ocean waters by freezing their own breath.",
+		de: "Es liebt die kalten Meere im Norden und überquert ihre Flächen auf Stegen, die es mit seinem gefrorenen Atem baut."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/42.ts
+++ b/data/Black & White/Plasma Storm/42.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Metal Sound",
 				fr: "Strido-Son",
+				de: "Metallsound"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 
 		},
@@ -51,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Electro Ball",
 				fr: "Boule Élek",
+				de: "Elektroball"
 			},
 
 			damage: 20,
@@ -69,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "The electromagnetic waves emitted by the units at the sides of its head expel antigravity, which allows it to float.",
+		de: "Die seitlichen Module halten es in der Luft, indem sie mit elektromagnetischen Wellen die Schwerkraft überlisten."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/43.ts
+++ b/data/Black & White/Plasma Storm/43.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Electro Ball",
 				fr: "Boule Élek",
+				de: "Elektroball"
 			},
 
 			damage: 10,
@@ -54,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "The electromagnetic waves emitted by the units at the sides of its head expel antigravity, which allows it to float.",
+		de: "Die seitlichen Module halten es in der Luft, indem sie mit elektromagnetischen Wellen die Schwerkraft überlisten."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/44.ts
+++ b/data/Black & White/Plasma Storm/44.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Magnemite",
 		fr: "Magnéti",
+		de: "Magnetilo"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Metal Sound",
 				fr: "Strido-Son",
+				de: "Metallsound"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Confused.",
 				fr: "Le Pokémon Défenseur est maintenant Confus.",
+				de: "Das Verteidigende Pokémon ist jetzt verwirrt."
 			},
 
 		},
@@ -56,6 +59,7 @@ const card: Card = {
 			name: {
 				en: "Electro Ball",
 				fr: "Boule Élek",
+				de: "Elektroball"
 			},
 
 			damage: 30,
@@ -74,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "The stronger electromagnetic waves from the three linked Magnemite are enough to dry out surrounding moisture.",
+		de: "Die vereinten elektromagnetischen Wellen von 3 Magnetilo bringen alles Wasser in der Umgebung zum Verdampfen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/45.ts
+++ b/data/Black & White/Plasma Storm/45.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Magnemite",
 		fr: "Magnéti",
+		de: "Magnetilo"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Knock Away",
 				fr: "Asticotage",
+				de: "Zurückschlagen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -63,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "The stronger electromagnetic waves from the three linked Magnemite are enough to dry out surrounding moisture.",
+		de: "Die vereinten elektromagnetischen Wellen von 3 Magnetilo bringen alles Wasser in der Umgebung zum Verdampfen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/46.ts
+++ b/data/Black & White/Plasma Storm/46.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Magneton",
 		fr: "Magnéton",
+		de: "Magneton"
 	},
 
 	stage: "Stage2",
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Gyro Ball",
 				fr: "Gyroballe",
+				de: "Gyroball"
 			},
 			effect: {
 				en: "Switch this Pokémon with 1 of your Benched Pokémon. Then, your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon.",
 				fr: "Échangez ce Pokémon avec 1 de vos Pokémon de Banc. Ensuite, votre adversaire échange le Pokémon Défenseur avec 1 de ses Pokémon de Banc.",
+				de: "Tausche dieses Pokémon gegen 1 Pokémon auf deiner Bank aus. Danach tauscht dein Gegner das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
 			},
 			damage: 80,
 
@@ -86,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "Sometimes the magnetism emitted by Magnezone is too strong, making them attract each other so they cannot move.",
+		de: "Gelegentlich erzeugen sie so starke Magnetfelder, dass sie sich gegenseitig anziehen und einander immobilisieren."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/47.ts
+++ b/data/Black & White/Plasma Storm/47.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Magneton",
 		fr: "Magnéton",
+		de: "Magneton"
 	},
 
 	stage: "Stage2",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Double Assist",
 				fr: "Double Assistance",
+				de: "Doppelstütze"
 			},
 			effect: {
 				en: "Attach 2 basic Energy cards from your discard pile to 1 of your Pokémon.",
 				fr: "Attachez 2 cartes Énergie de base de votre pile de défausse à 1 de vos Pokémon.",
+				de: "Lege 2 Basis-Energiekarten von deinem Ablagestapel an 1 deiner Pokémon an."
 			},
 			damage: 30,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Tumbling Attack",
 				fr: "Attaque Trébuchante",
+				de: "Taumler"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: 70,
 
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "Sometimes the magnetism emitted by Magnezone is too strong, making them attract each other so they cannot move.",
+		de: "Gelegentlich erzeugen sie so starke Magnetfelder, dass sie sich gegenseitig anziehen und einander immobilisieren."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/48.ts
+++ b/data/Black & White/Plasma Storm/48.ts
@@ -35,10 +35,12 @@ const card: Card = {
 			name: {
 				en: "Agility",
 				fr: "Hâte",
+				de: "Agilität"
 			},
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, évitez tous les effets d'attaques (y compris les dégâts) infligés à ce Pokémon pendant le prochain tour de votre adversaire.",
+				de: "Wirf 1 Münze. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die diesem Pokémon zugefügt werden."
 			},
 			damage: 30,
 
@@ -53,10 +55,12 @@ const card: Card = {
 			name: {
 				en: "Powervolt",
 				fr: "Méga Voltage",
+				de: "Megavolt"
 			},
 			effect: {
 				en: "If this Pokémon has any Plasma Energy attached to it, this attack does 40 more damage.",
 				fr: "Si de l'Énergie Plasma est attachée à ce Pokémon, cette attaque inflige 40 dégâts supplémentaires.",
+				de: "Wenn an dieses Pokémon bereits Plasma-Energie angelegt ist, fügt dieser Angriff 40 weitere Schadenspunkte zu."
 			},
 			damage: 80,
 

--- a/data/Black & White/Plasma Storm/49.ts
+++ b/data/Black & White/Plasma Storm/49.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Electribonus",
 				fr: "Électribonus",
+				de: "Elektrobonus"
 			},
 			effect: {
 				en: "Discard a Lightning Energy card from your hand. If you do, draw 3 cards.",
 				fr: "Défaussez une carte Énergie Lightning de votre main. Dans ce cas, piochez 3 cartes.",
+				de: "Lege 1 {L}-Energie aus deiner Hand auf deinen Ablagestapel. Wenn du das machst, ziehe 3 Karten."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Poltergeist",
 				fr: "Poltergeist",
+				de: "Poltergeist"
 			},
 			effect: {
 				en: "Your opponent reveals his or her hand. This attack does 20 damage times the number of Trainer cards in your opponent's hand.",
 				fr: "Votre adversaire montre sa main. Cette attaque inflige 20 dégâts multipliés par le nombre de cartes Dresseur dans la main de votre adversaire.",
+				de: "Dein Gegner deckt seine Handkarten auf. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl der Trainerkarten auf der Hand deines Gegners zu."
 			},
 			damage: 20,
 
@@ -72,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "Its electric-like body can enter some kinds of machines and take control in order to make mischief.",
+		de: "Es kann mit seinem Körper in elektrische Geräte eindringen und dann für Chaos sorgen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/5.ts
+++ b/data/Black & White/Plasma Storm/5.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Combee",
 		fr: "Apitrini",
+		de: "Wadribie"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Gather Order",
 				fr: "Ralliement",
+				de: "Antrittsappell"
 			},
 			effect: {
 				en: "Search your deck for as many Combee as you like and put them onto your Bench. Shuffle your deck afterward.",
 				fr: "Cherchez dans votre deck autant d'Apitrini que vous voulez et placez-les sur votre Banc. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach beliebig vielen Wadribie und lege sie auf deine Bank. Mische anschließend dein Deck."
 			},
 
 		},
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Damage Beat",
 				fr: "Rouste Ravageuse",
+				de: "Heftige Prügel"
 			},
 			effect: {
 				en: "Does 20 damage times the number of damage counters on the Defending Pokémon.",
 				fr: "Inflige 20 dégâts multipliés par le nombre de marqueurs de dégâts placés sur le Pokémon Défenseur.",
+				de: "Dieser Angriff fügt 20 Schadenspunkte für jede Schadensmarke auf dem Verteidigenden Pokémon zu."
 			},
 			damage: 20,
 
@@ -77,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It houses its colony in cells in its body and releases various pheromones to make those grubs do its bidding.",
+		de: "Es beherbergt Jung-Pokémon in seinem Rumpf, die es mithilfe von verschiedenen Pheromonen frei herumkommandieren kann."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/50.ts
+++ b/data/Black & White/Plasma Storm/50.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Jump On",
 				fr: "Saut",
+				de: "Draufspringen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 weitere Schadenspunkte zu."
 			},
 			damage: 10,
 
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "Since it can't generate its own electricity, it sticks onto large-bodied Pokémon and absorbs static electricity.",
+		de: "Da es selbst keinen Strom erzeugen kann, klettert es auf andere Pokémon, um ihnen elektrostatische Energie abzusaugen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/51.ts
+++ b/data/Black & White/Plasma Storm/51.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Joltik",
 		fr: "Statitik",
+		de: "Wattzapf"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Discharge",
 				fr: "Coup d'Jus",
+				de: "Ladungsstoß"
 			},
 			effect: {
 				en: "Discard all Lightning Energy attached to this Pokémon. This attack does 30 damage times the number of Energy cards you discarded.",
 				fr: "Défaussez toutes les Énergies Lightning attachées à ce Pokémon. Cette attaque inflige 30 dégâts multipliés par le nombre de cartes Énergie que vous avez défaussées.",
+				de: "Lege alle an dieses Pokémon angelegten {L}-Energien auf deinen Ablagestapel. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl abgelegter Energiekarten zu."
 			},
 			damage: 30,
 
@@ -57,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Signal Beam",
 				fr: "Rayon Signal",
+				de: "Ampelleuchte"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: 30,
 
@@ -78,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "It creates barriers from electrified silk that stun foes. This works as a weapon as well as a defense.",
+		de: "Errichtet mit elektrisch geladenen Fäden Barrieren, die lähmend wirken und ihm zur Verteidigung und zum Angriff dienen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/52.ts
+++ b/data/Black & White/Plasma Storm/52.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Spiral Drain",
 				fr: "Spirale Épuisante",
+				de: "Spiralsauger"
 			},
 			effect: {
 				en: "Heal 10 damage from this Pokémon.",
 				fr: "Soignez 10 dégâts à ce Pokémon.",
+				de: "Heile 10 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 10,
 
@@ -64,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "It does not need eyes, because it emits ultrasonic waves to check its surrounding while it flies.",
+		de: "Es benötigt keine Augen, da es seine Umgebung im Flug durch das Aussenden von Schallwellen erschließt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/53.ts
+++ b/data/Black & White/Plasma Storm/53.ts
@@ -59,6 +59,7 @@ const card: Card = {
 			name: {
 				en: "Wing Attack",
 				fr: "Cru-Aile",
+				de: "Flügelschlag"
 			},
 
 			damage: 20,
@@ -84,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "It does not need eyes, because it emits ultrasonic waves to check its surrounding while it flies.",
+		de: "Es benötigt keine Augen, da es seine Umgebung im Flug durch das Aussenden von Schallwellen erschließt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/54.ts
+++ b/data/Black & White/Plasma Storm/54.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Zubat",
 		fr: "Nosferapti",
+		de: "Zubat"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Spiral Drain",
 				fr: "Spirale Épuisante",
+				de: "Spiralsauger"
 			},
 			effect: {
 				en: "Heal 20 damage from this Pokémon.",
 				fr: "Soignez 20 dégâts à ce Pokémon.",
+				de: "Heile 20 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 20,
 
@@ -70,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "Flitting around in the dead of night, it sinks its fangs into its prey and drains a nearly fatal amount of blood.",
+		de: "Bei Nacht sucht es unermüdlich nach Beute, der es mit seinen scharfen Zähnen große Blutmengen absaugt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/55.ts
+++ b/data/Black & White/Plasma Storm/55.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Golbat",
 		fr: "Nosferalto",
+		de: "Golbat"
 	},
 
 	stage: "Stage2",
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Ultra-Toxic Fang",
 				fr: "Croc Ultratoxik",
+				de: "Hochgiftiger Zahn"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned. Put 4 damage counters instead of 1 on that Pokémon between turns.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné. Placez 4 marqueurs de dégâts au lieu d'un sur le Pokémon ciblé entre chaque tour.",
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet. Lege zwischen den Zügen 4 Schadensmarken anstelle von 1 Schadensmarke auf das Pokémon."
 			},
 			damage: 40,
 
@@ -93,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "Having four wings allows it to fly more quickly and quietly so it can sneak up on prey without its noticing.",
+		de: "Dank seiner 4 Flügel kann es sich seiner Beute noch schneller und leiser nähern, ohne dabei bemerkt zu werden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/56.ts
+++ b/data/Black & White/Plasma Storm/56.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 10,
@@ -49,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Double Spin",
 				fr: "Double Tour",
+				de: "Doppeldreher"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -70,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "Toxic gas is held within its thin, balloon-shaped body, so it can cause massive explosions.",
+		de: "Sein dünner, ballonartiger Körper ist mit schrecklichem Giftgas gefüllt, das riesige Explosionen verursachen kann."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/57.ts
+++ b/data/Black & White/Plasma Storm/57.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Smokescreen",
 				fr: "Brouillard",
+				de: "Rauchwolke"
 			},
 			effect: {
 				en: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
 				fr: "Si le Pokémon Défenseur essaie d'attaquer pendant le prochain tour de votre adversaire, ce dernier lance une pièce. Si c’est pile, son attaque ne fait rien.",
+				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 20,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "Toxic gas is held within its thin, balloon-shaped body, so it can cause massive explosions.",
+		de: "Sein dünner, ballonartiger Körper ist mit schrecklichem Giftgas gefüllt, das riesige Explosionen verursachen kann."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/58.ts
+++ b/data/Black & White/Plasma Storm/58.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Koffing",
 		fr: "Smogo",
+		de: "Smogon"
 	},
 
 	stage: "Stage1",
@@ -64,10 +65,12 @@ const card: Card = {
 			name: {
 				en: "Smogbank",
 				fr: "Smog Envahissant",
+				de: "Smogbank"
 			},
 			effect: {
 				en: "This attack does 20 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige 20 dégâts à chacun des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Dieser Angriff fügt jedem Pokémon deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -84,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "Inhaling toxic fumes from trash and mixing them inside its body lets it spread an even fouler stench.",
+		de: "Es saugt giftige Abgase aus dem Müll auf, die sich in seinem Körper zu einem noch übleren Gestank vermischen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/59.ts
+++ b/data/Black & White/Plasma Storm/59.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Psy Bolt",
 				fr: "Choc Mental",
+				de: "Konfusion"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 
 		},
@@ -56,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "If its horns capture the warm feelings of people or Pokémon, its body warms up slightly.",
+		de: "Es erfasst warme Gefühle von Menschen und Pokémon mit seinen Hörnern und wärmt sich daran auf."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/6.ts
+++ b/data/Black & White/Plasma Storm/6.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Leech Seed",
 				fr: "Vampigraine",
+				de: "Egelsamen"
 			},
 			effect: {
 				en: "Heal 10 damage from this Pokémon.",
 				fr: "Soignez 10 dégâts à ce Pokémon.",
+				de: "Heile 10 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 10,
 
@@ -64,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "The small ball is not only filled with nutrients, it is also tasty. Starly try to peck it off.",
+		de: "Der kleine Ball ist nicht nur voller Nährstoffe, sondern auch schmackhaft. Staralili pickt oft danach."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/60.ts
+++ b/data/Black & White/Plasma Storm/60.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Ralts",
 		fr: "Tarsal",
+		de: "Trasla"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Psy Bolt",
 				fr: "Choc Mental",
+				de: "Konfusion"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 20,
 
@@ -62,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "If its Trainer becomes happy, it overflows with energy, dancing joyously while spinning about.",
+		de: "Ist sein Trainer glücklich, tanzt es in einem Schwall von Energie fröhlich umher."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/61.ts
+++ b/data/Black & White/Plasma Storm/61.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Kirlia",
 		fr: "Kirlia",
+		de: "Kirlia"
 	},
 
 	stage: "Stage2",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Powerful Storm",
 				fr: "Tempête Puissante",
+				de: "Mächtiger Sturm"
 			},
 			effect: {
 				en: "Does 20 damage times the amount of Energy attached to all of your Pokémon.",
 				fr: "Inflige 20 dégâts multipliés par le nombre d'Énergies attachées à tous vos Pokémon.",
+				de: "Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl der an all deinen Pokémon angelegten Energien zu."
 			},
 			damage: 20,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Swift Lunge",
 				fr: "Estocade",
+				de: "Flinker Ausfall"
 			},
 			effect: {
 				en: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon.",
 				fr: "Votre adversaire échange le Pokémon Défenseur avec 1 de ses Pokémon de Banc.",
+				de: "Dein Gegner tauscht das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
 			},
 			damage: 80,
 
@@ -80,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "When trying to protect someone, it extends its elbows as if they were swords and fights savagely.",
+		de: "Will es beschützen, streckt es seine Ellbogen zu etwas Schwertähnlichem und kämpft auf wilde Art."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/62.ts
+++ b/data/Black & White/Plasma Storm/62.ts
@@ -38,10 +38,12 @@ const card: Card = {
 			name: {
 				en: "Hex",
 				fr: "Châtiment",
+				de: "Bürde"
 			},
 			effect: {
 				en: "If the Defending Pokémon is affected by a Special Condition, this attack does 50 more damage.",
 				fr: "Si le Pokémon Défenseur est affecté par un État Spécial, cette attaque inflige 50 dégâts supplémentaires.",
+				de: "Wenn das Verteidigende Pokémon von einem Speziellen Zustand betroffen ist, fügt dieser Angriff 50 weitere Schadenspunkte zu."
 			},
 			damage: 50,
 
@@ -56,10 +58,12 @@ const card: Card = {
 			name: {
 				en: "Shadow Claw",
 				fr: "Griffe Ombre",
+				de: "Dunkelklaue"
 			},
 			effect: {
 				en: "Discard a random card from your opponent's hand.",
 				fr: "Défaussez au hasard une carte de la main de votre adversaire.",
+				de: "Nimm 1 zufällige Karte aus der verdeckten Hand deines Gegners und lege sie auf dessen Ablagestapel."
 			},
 			damage: 90,
 
@@ -77,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "It was banished for its violence. It silently gazed upon the old world from the Distortion World.",
+		de: "Es wurde aufgrund seines Verhaltens verbannt. Aus der Zerrwelt schaut es auf die alte Welt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/63.ts
+++ b/data/Black & White/Plasma Storm/63.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Pile Up",
 				fr: "Amoncellement",
+				de: "Eindecken"
 			},
 			effect: {
 				en: "Flip a coin. If heads, search your deck for a Pokémon Tool card, reveal it, and put it into your hand. Shuffle your deck afterward.",
 				fr: "Lancez une pièce. Si c'est face, cherchez une carte Outil Pokémon dans votre deck, montrez-la, puis ajoutez-la à votre main. Mélangez ensuite votre deck.",
+				de: "Wirf 1 Münze. Durchsuche bei „Kopf“ dein Deck nach 1 Pokémon-Ausrüstung, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
 			},
 
 		},
@@ -51,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Sludge Toss",
 				fr: "Giclée Vaseuse",
+				de: "Schleimwurf"
 			},
 
 			damage: 20,
@@ -69,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "The combination of garbage bags and industrial waste caused the chemical reaction that created this Pokémon.",
+		de: "Eine Mülltüte, der Industrieabfälle und chemische Reaktionen neues Leben eingehaucht haben."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/64.ts
+++ b/data/Black & White/Plasma Storm/64.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Pound",
 				fr: "Écras'Face",
+				de: "Pfund"
 			},
 
 			damage: 10,
@@ -50,6 +51,7 @@ const card: Card = {
 			name: {
 				en: "Sludge Bomb",
 				fr: "Bomb-Beurk",
+				de: "Matschbombe"
 			},
 
 			damage: 40,
@@ -68,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "Wanting more garbage, they follow people who litter. They always belch poison gas.",
+		de: "Um an frischen Müll zu kommen, heftet es sich Umweltsündern an die Fersen. Es speit unaufhörlich giftige Gase."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/65.ts
+++ b/data/Black & White/Plasma Storm/65.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Tool Drop",
 				fr: "Chute d’Outils",
+				de: "Ausrüstungssturz"
 			},
 			effect: {
 				en: "Does 20 damage for each Pokémon Tool card attached to Pokémon in play (both yours and your opponent's).",
 				fr: "Inflige 20 dégâts pour chaque carte Outil Pokémon attachée aux Pokémon en jeu (les vôtres et ceux de votre adversaire).",
+				de: "Dieser Angriff fügt für jede an Pokémon im Spiel (an deine und die deines Gegners) angelegte Pokémon-Ausrüstung 20 Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -58,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "Wanting more garbage, they follow people who litter. They always belch poison gas.",
+		de: "Um an frischen Müll zu kommen, heftet es sich Umweltsündern an die Fersen. Es speit unaufhörlich giftige Gase."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/66.ts
+++ b/data/Black & White/Plasma Storm/66.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Trubbish",
 		fr: "Miamiasme",
+		de: "Unratütox"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Biosmog",
 				fr: "Brouillard Toxique",
+				de: "Biosmog"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned. Flip a coin. If heads, discard an Energy attached to that Pokémon.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné. Lancez une pièce. Si c'est face, défaussez une Énergie attachée au Pokémon Défenseur.",
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet. Wirf 1 Münze. Lege bei „Kopf“ 1 an dieses Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 20,
 
@@ -58,6 +61,7 @@ const card: Card = {
 			name: {
 				en: "Sludge Bomb",
 				fr: "Bomb-Beurk",
+				de: "Matschbombe"
 			},
 
 			damage: 70,
@@ -76,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "Consuming garbage makes new kinds of poison gases and liquids inside their bodies.",
+		de: "Jedes Mal, wenn es frischen Müll in sich aufsaugt, erzeugt es völlig neue Formen von Giftgasen und Toxinen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/67.ts
+++ b/data/Black & White/Plasma Storm/67.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Trubbish",
 		fr: "Miamiasme",
+		de: "Unratütox"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Ensnarl",
 				fr: "Empêtrement",
+				de: "Verstricker"
 			},
 			effect: {
 				en: "Does 20 damage times the number of Colorless in the Defending Pokémon's Retreat Cost.",
 				fr: "Inflige 20 dégâts multipliés par le nombre de Colorless dans le coût de Retraite du Pokémon Défenseur.",
+				de: "Dieser Angriff fügt 20 Schadenspunkte für jedes {C}-Symbol in den Rückzugskosten des Verteidigenden Pokémon zu."
 			},
 			damage: 20,
 
@@ -60,10 +63,12 @@ const card: Card = {
 			name: {
 				en: "Double Ducts",
 				fr: "Double Boyau",
+				de: "Doppelrinne"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 80 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 80 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 80 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 80,
 
@@ -81,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "Consuming garbage makes new kinds of poison gases and liquids inside their bodies.",
+		de: "Jedes Mal, wenn es frischen Müll in sich aufsaugt, erzeugt es völlig neue Formen von Giftgasen und Toxinen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/68.ts
+++ b/data/Black & White/Plasma Storm/68.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Psyshot",
 				fr: "Piqûre Psy",
+				de: "Psychoschuss"
 			},
 
 			damage: 30,
@@ -55,6 +56,7 @@ const card: Card = {
 
 	description: {
 		en: "Rumors of its origin are linked to a UFO crash site in the desert 50 years ago.",
+		de: "Man sagt, es sei vor 50 Jahren aus den Tiefen einer Wüste erschienen, in der zuvor angeblich ein UFO abgestürzt war."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/69.ts
+++ b/data/Black & White/Plasma Storm/69.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Reflect",
 				fr: "Protection",
+				de: "Reflektor"
 			},
 			effect: {
 				en: "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, tous les dégâts infligés à ce Pokémon par des attaques sont réduits de 20 (après application de la Faiblesse et de la Résistance).",
+				de: "Während des nächsten Zuges deines Gegners wird Schaden, der diesem Pokémon durch Angriffe zugefügt wird, um 20 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Smash Punch",
 				fr: "Poing Écrasant",
+				de: "Schmetterschlag"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 30,
 
@@ -72,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "Rumors of its origin are linked to a UFO crash site in the desert 50 years ago.",
+		de: "Man sagt, es sei vor 50 Jahren aus den Tiefen einer Wüste erschienen, in der zuvor angeblich ein UFO abgestürzt war."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/7.ts
+++ b/data/Black & White/Plasma Storm/7.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cherubi",
 		fr: "Ceribou",
+		de: "Kikugi"
 	},
 
 	stage: "Stage1",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Una vez durante tu turno (antes de tu ataque), puedes curar 20 puntos de daño a 1 de tus Pokémon que tenga alguna Energía Grass unida a él.",
 				it: "Una sola volta durante il tuo turno, prima di attaccare, puoi curare da 20 danni uno dei tuoi Pokémon che ha Energie Grass assegnate.",
 				pt: "Uma vez na sua vez de jogar (antes de atacar), você poderá curar 20 de danos de 1 dos seus Pokémon com qualquer Energia Grass ligada a ele.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 20 Schadenspunkte bei 1 deiner Pokémon heilen, an das Grass-Energie angelegt ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 20 Schadenspunkte bei 1 deiner Pokémon heilen, an das {G}-Energie angelegt ist."
 			},
 		},
 	],
@@ -64,10 +65,12 @@ const card: Card = {
 			name: {
 				en: "Random Peck",
 				fr: "Coup d'Bec au Pif",
+				de: "Zufälliger Schnabelhieb"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 more damage for each heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts supplémentaires pour chaque côté face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -92,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "If it senses strong sunlight, it opens its folded petals to absorb the sun's rays with its whole body.",
+		de: "Spürt es Sonnenlicht, öffnet es seine Blütenblätter und nimmt die Energie der Sonnenstrahlen auf."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/70.ts
+++ b/data/Black & White/Plasma Storm/70.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Elgyem",
 		fr: "Lewsor",
+		de: "Pygraulon"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Lock Up",
 				fr: "Cage",
+				de: "Einsperren"
 			},
 			effect: {
 				en: "The Defending Pokémon can't retreat during your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas battre en retraite pendant le prochain tour de votre adversaire.",
+				de: "Das Verteidigende Pokémon kann sich während des nächsten Zuges deines Gegners nicht zurückziehen."
 			},
 			damage: 20,
 
@@ -58,10 +61,12 @@ const card: Card = {
 			name: {
 				en: "Damakinesis",
 				fr: "Dégâkinésie",
+				de: "Schadenstransfer"
 			},
 			effect: {
 				en: "Move 6 damage counters from any of your Pokémon to the Defending Pokémon.",
 				fr: "Déplacez 6 marqueurs de dégâts de vos Pokémon vers le Pokémon Défenseur.",
+				de: "Verschiebe 6 Schadensmarken von beliebigen deiner Pokémon auf das Verteidigende Pokémon."
 			},
 
 		},
@@ -78,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "Apparently, it communicates by flashing its three fingers, but those patterns haven't been decoded.",
+		de: "Es spricht, indem es seine Fingerspitzen leuchten lässt, doch noch konnte der Code dahinter nicht entziffert werden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/71.ts
+++ b/data/Black & White/Plasma Storm/71.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 10,
@@ -50,6 +51,7 @@ const card: Card = {
 			name: {
 				en: "Rollout",
 				fr: "Roulade",
+				de: "Walzer"
 			},
 
 			damage: 50,
@@ -75,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "It is strong despite its compact size. It can easily pick up and carry an adult human on its back.",
+		de: "Trotz seiner geringen Größe ist es stark. Es kann einen Erwachsenen mühelos auf dem Rücken tragen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/72.ts
+++ b/data/Black & White/Plasma Storm/72.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Phanpy",
 		fr: "Phanpy",
+		de: "Phanpy"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Spinning Turn",
 				fr: "Volte-Face",
+				de: "Fliegender Wechsel"
 			},
 			effect: {
 				en: "Switch this Pokémon with 1 of your Benched Pokémon.",
 				fr: "Échangez ce Pokémon avec 1 de vos Pokémon de Banc.",
+				de: "Tausche dieses Pokémon gegen 1 Pokémon auf deiner Bank aus."
 			},
 			damage: 40,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Wreck",
 				fr: "Anéantissement",
+				de: "Abreißen"
 			},
 			effect: {
 				en: "If there is any Stadium card in play, this attack does 60 more damage. Discard that Stadium card.",
 				fr: "S'il y a une carte Stade en jeu, cette attaque inflige 60 dégâts supplémentaires. Défaussez la carte Stade.",
+				de: "Wenn eine Stadionkarte im Spiel ist, fügt dieser Angriff 60 weitere Schadenspunkte zu. Lege diese Stadionkarte auf den Ablagestapel."
 			},
 			damage: 80,
 
@@ -87,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "It attacks by curling up, then rolling into its foe. It can blow apart a house in one hit.",
+		de: "Wenn es angreift, rollt es sich zusammen und auf den Gegner zu. Es kann Häuser zum Einsturz bringen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/73.ts
+++ b/data/Black & White/Plasma Storm/73.ts
@@ -59,6 +59,7 @@ const card: Card = {
 			name: {
 				en: "Rock Throw",
 				fr: "Jet-Pierres",
+				de: "Steinwurf"
 			},
 
 			damage: 30,
@@ -77,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "The phase of the moon apparently has some effect on its power. It's active on the night of a full moon.",
+		de: "Anscheinend steht die Zunahme seiner Kraft mit den Mondphasen in Verbindung, da es bei Vollmond aktiv wird."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/74.ts
+++ b/data/Black & White/Plasma Storm/74.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Heat Burn",
 				fr: "Chaleur Brûlante",
+				de: "Brandwunde"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Burned.",
 				fr: "Le Pokémon Défenseur est maintenant Brûlé.",
+				de: "Das Verteidigende Pokémon ist jetzt verbrannt."
 			},
 			damage: 20,
 
@@ -54,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Explosion",
 				fr: "Explosion",
+				de: "Explosion"
 			},
 			effect: {
 				en: "This Pokémon does 90 damage to itself.",
 				fr: "Ce Pokémon s'inflige 90 dégâts.",
+				de: "Dieses Pokémon fügt sich selbst 90 Schadenspunkte zu."
 			},
 			damage: 90,
 
@@ -75,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "Solar energy is the source of its power, so it is strong during the daytime. When it spins, its body shines.",
+		de: "Da es seine Energie aus Sonnenlicht gewinnt, ist es tagsüber am stärksten. Wenn es sich dreht, leuchtet es."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/75.ts
+++ b/data/Black & White/Plasma Storm/75.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Punch",
 				fr: "Koud'Poing",
+				de: "Boxhieb"
 			},
 
 			damage: 10,
@@ -49,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Kick",
 				fr: "Koud'Pied",
+				de: "Tritt"
 			},
 
 			damage: 20,
@@ -67,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "It has the peculiar power of being able to see emotions such as joy and rage in the form of waves.",
+		de: "Es hat die eigenartige Fähigkeit, Gefühle wie Freude oder Wut in Wellenform zu sehen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/76.ts
+++ b/data/Black & White/Plasma Storm/76.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Kick",
 				fr: "Koud'Pied",
+				de: "Tritt"
 			},
 
 			damage: 20,
@@ -51,10 +52,12 @@ const card: Card = {
 			name: {
 				en: "Feint",
 				fr: "Ruse",
+				de: "Offenlegung"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by Resistance.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Résistance.",
+				de: "Der Schaden dieses Angriffs wird durch Resistenz nicht verändert."
 			},
 			damage: 40,
 
@@ -72,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "They communicate with one another using their auras made tangible by their emotions.",
+		de: "Es kommuniziert mit seinen Artgenossen über Wellen, die je nach Gefühlslage eine andere Form annehmen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/77.ts
+++ b/data/Black & White/Plasma Storm/77.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Riolu",
 		fr: "Riolu",
+		de: "Riolu"
 	},
 
 	stage: "Stage1",
@@ -42,6 +43,7 @@ const card: Card = {
 			name: {
 				en: "Kick",
 				fr: "Koud'Pied",
+				de: "Tritt"
 			},
 
 			damage: 30,
@@ -56,6 +58,7 @@ const card: Card = {
 			name: {
 				en: "Mach Cross",
 				fr: "Passage Éclair",
+				de: "Tempo-Cross"
 			},
 
 			damage: 70,
@@ -74,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "A well-trained one can sense auras to identify and take in the feelings of creatures over half a mile away.",
+		de: "Ist es trainiert, spürt es Auren, um Gefühle entfernter Kreaturen zu erkennen und aufzunehmen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/78.ts
+++ b/data/Black & White/Plasma Storm/78.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Riolu",
 		fr: "Riolu",
+		de: "Riolu"
 	},
 
 	stage: "Stage1",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Si este Pokémon tiene alguna Energía Metal unida a él, el tipo de este Pokémon es Fighting y Metal.",
 				it: "Se questo Pokémon ha delle Energie Metal assegnate, il tipo di questo Pokémon è sia Fighting che Metal.",
 				pt: "Se este Pokémon possui alguma Energia Metal ligada a ele, o tipo desse Pokémon é Fighting e Metal.",
-				de: "Wenn an dieses Pokémon bereits Metal-Energie angelegt ist, ist dieses Pokémon sowohl vom Typ Fighting als auch Metal."
+				de: "Wenn an dieses Pokémon bereits {M}-Energie angelegt ist, ist dieses Pokémon sowohl vom Typ {F} als auch {M}."
 			},
 		},
 	],
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Hurricane Kick",
 				fr: "Pied Ouragan",
+				de: "Orkantritt"
 			},
 			effect: {
 				en: "Does 30 more damage for each Prize card your opponent has taken.",
 				fr: "Inflige 30 dégâts supplémentaires pour chaque carte Récompense que votre adversaire a récupérée.",
+				de: "Dieser Angriff fügt 30 weitere Schadenspunkte für jede Preiskarte zu, die dein Gegner bereits genommen hat."
 			},
 			damage: 60,
 
@@ -86,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "By reading the auras of all things, it can tell how others are feeling from over half a mile away.",
+		de: "Kann aus einem Kilometer Entfernung die Gefühle anderer Wesen erfassen, indem es die Wellen liest, die sie aussenden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/79.ts
+++ b/data/Black & White/Plasma Storm/79.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Knock Back",
 				fr: "Dégagement",
+				de: "Schlag versetzen"
 			},
 			effect: {
 				en: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon.",
 				fr: "Votre adversaire échange le Pokémon Défenseur avec 1 de ses Pokémon de Banc.",
+				de: "Dein Gegner tauscht das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
 			},
 			damage: 20,
 
@@ -54,6 +56,7 @@ const card: Card = {
 			name: {
 				en: "Low Kick",
 				fr: "Balayage",
+				de: "Fußkick"
 			},
 
 			damage: 40,
@@ -72,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "Always carrying squared logs, they help out with construction. As they grow, they carry bigger logs.",
+		de: "Trägt stets einen Holzbalken bei sich und hilft auf Baustellen aus. Nach einer Weile sucht es sich einen größeren Balken."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/8.ts
+++ b/data/Black & White/Plasma Storm/8.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Bug Bite",
 				fr: "Piqûre",
+				de: "Käferbiss"
 			},
 
 			damage: 20,
@@ -54,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "Since this Pokémon makes its own clothes out of leaves, it is a popular mascot for fashion designers.",
+		de: "Unter Modeschöpfern gilt es als beliebtes Maskottchen, da es sich aus Blättern Kleidchen schneidert."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/80.ts
+++ b/data/Black & White/Plasma Storm/80.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Timburr",
 		fr: "Charpenti",
+		de: "Praktibalk"
 	},
 
 	stage: "Stage1",
@@ -43,10 +44,12 @@ const card: Card = {
 			name: {
 				en: "Dynamic Punch",
 				fr: "Dynamopoing",
+				de: "Wuchtschlag"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage and the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts supplémentaires et le Pokémon Défenseur est maintenant Confus.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu und das Verteidigende Pokémon ist jetzt verwirrt."
 			},
 			damage: 40,
 
@@ -61,6 +64,7 @@ const card: Card = {
 			name: {
 				en: "Hammer In",
 				fr: "Enfoncer",
+				de: "Einhämmern"
 			},
 
 			damage: 80,
@@ -79,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "With strengthened bodies, they skillfully wield steel beams to take down buildings.",
+		de: "Diese durchtrainierten Muskelprotze sind im Umgang mit Stahlträgern versiert und können damit ganze Häuser abreißen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/81.ts
+++ b/data/Black & White/Plasma Storm/81.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gurdurr",
 		fr: "Ouvrifier",
+		de: "Strepoli"
 	},
 
 	stage: "Stage2",
@@ -43,10 +44,12 @@ const card: Card = {
 			name: {
 				en: "Facade",
 				fr: "Façade",
+				de: "Fassade"
 			},
 			effect: {
 				en: "If this Pokémon is Burned or Poisoned, this attack does 60 more damage.",
 				fr: "Si ce Pokémon est Brûlé ou Empoisonné, cette attaque inflige 60 dégâts supplémentaires.",
+				de: "Wenn dieses Pokémon verbrannt oder vergiftet ist, fügt dieser Angriff 60 weitere Schadenspunkte zu."
 			},
 			damage: 60,
 
@@ -61,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Drain Punch",
 				fr: "Vampipoing",
+				de: "Ableithieb"
 			},
 			effect: {
 				en: "Heal 20 damage from this Pokémon.",
 				fr: "Soignez 20 dégâts à ce Pokémon.",
+				de: "Heile 20 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 80,
 
@@ -82,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "Rather than rely on force, they master moves that utilize the centrifugal force of spinning concrete.",
+		de: "Es setzt Attacken ein, die sich die Zentrifugalkraft zunutze machen, indem es seine Betonpfeiler umherschwingt."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/82.ts
+++ b/data/Black & White/Plasma Storm/82.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Tail Trickery",
 				fr: "Queue Étourdissante",
+				de: "Schweiftrick"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Fury Swipes",
 				fr: "Combo-Griffe",
+				de: "Kratzfurie"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 10,
 
@@ -79,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "Its cute act is a ruse. When victims let down their guard, they find their items taken. It attacks with sharp claws.",
+		de: "Es lenkt die Menschen durch sein süßes Verhalten ab, um sie zu bestehlen. Ist es wütend, kratzt es gern mal."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/83.ts
+++ b/data/Black & White/Plasma Storm/83.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Scout",
 				fr: "Espionnage",
+				de: "Späher"
 			},
 			effect: {
 				en: "Your opponent reveals his or her hand.",
 				fr: "Votre adversaire montre sa main.",
+				de: "Dein Gegner deckt seine Handkarten auf."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Fasten Claws",
 				fr: "Griffes Accrochantes",
+				de: "Klauen anlegen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 weitere Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -79,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "Their cute act is a ruse. They trick people and steal their valuables just to see the looks on their faces.",
+		de: "Lenkt Leute mit seinem süßen Verhalten ab und stiehlt ihnen ihr Hab und Gut, nur um ihren verdutzten Blick zu sehen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/84.ts
+++ b/data/Black & White/Plasma Storm/84.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Purrloin",
 		fr: "Chacripan",
+		de: "Felilou"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Silent Claw",
 				fr: "Griffe Silencieuse",
+				de: "Flüsterklaue"
 			},
 			effect: {
 				en: "Your opponent reveals his or her hand. Discard a Supporter card you find there. Use the effect of that card as the effect of this attack.",
 				fr: "Votre adversaire montre sa main. Défaussez une carte Supporter que vous y trouvez. Utilisez l'effet de la carte Supporter défaussée en tant qu'effet de cette attaque.",
+				de: "Dein Gegner deckt seine Handkarten auf. Befindet sich darunter 1 Unterstützerkarte, lege sie auf seinen Ablagestapel. Verwende den Effekt dieser Karte als Effekt dieses Angriffs."
 			},
 
 		},
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Fake Out",
 				fr: "Bluff",
+				de: "Mogelhieb"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt paralysiert."
 			},
 			damage: 30,
 
@@ -84,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "Their beautiful form comes from the muscles they have developed. They run silently in the night.",
+		de: "Sein anmutiges Auftreten verdankt es den Muskeln, die es entwickelt hat. Es prescht lautlos durch die Nacht."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/85.ts
+++ b/data/Black & White/Plasma Storm/85.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Headbutt",
 				fr: "Coup d'Boule",
+				de: "Kopfnuss"
 			},
 
 			damage: 10,
@@ -49,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Low Kick",
 				fr: "Balayage",
+				de: "Fußkick"
 			},
 
 			damage: 20,
@@ -74,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "Proud of its sturdy skull, it suddenly headbutts everything, but its weight makes it unstable, too.",
+		de: "Verteilt gerne unvermittelt Kopfnüsse, deren Wucht auch seine Sinne vernebelt. Es ist stolz auf seinen robusten Schädel."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/86.ts
+++ b/data/Black & White/Plasma Storm/86.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Scraggy",
 		fr: "Baggiguane",
+		de: "Zurrokex"
 	},
 
 	stage: "Stage1",
@@ -42,10 +43,12 @@ const card: Card = {
 			name: {
 				en: "Kick Away",
 				fr: "Coud'Pied Éjecteur",
+				de: "Wegkicken"
 			},
 			effect: {
 				en: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon.",
 				fr: "Votre adversaire échange le Pokémon Défenseur avec 1 de ses Pokémon de Banc.",
+				de: "Dein Gegner tauscht das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
 			},
 			damage: 30,
 
@@ -59,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Reinforced Headbutt",
 				fr: "Coup d’Boule Renforcé",
+				de: "Kräftige Kopfnuss"
 			},
 			effect: {
 				en: "If this Pokémon has a Pokémon Tool card attached to it, this attack does 50 more damage.",
 				fr: "Si une carte Outil Pokémon est attachée à ce Pokémon, cette attaque inflige 50 dégâts supplémentaires.",
+				de: "Wenn an dieses Pokémon eine Pokémon-Ausrüstung angelegt ist, fügt dieser Angriff 50 weitere Schadenspunkte zu."
 			},
 			damage: 50,
 
@@ -87,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "It pulls up its shed skin to protect itself while it kicks. The bigger the crest, the more respected it is.",
+		de: "Es wehrt Angriffe mit seiner alten Haut ab und kontert mit Tritten. Sein Ego entspricht der Größe seines Kamms."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/87.ts
+++ b/data/Black & White/Plasma Storm/87.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Cargo Jet",
 				fr: "Aérocargo",
+				de: "Frachtflugzeug"
 			},
 			effect: {
 				en: "Discard a Team Plasma card from your hand. If you do, draw 3 cards.",
 				fr: "Défaussez une carte de la Team Plasma de votre main. Dans ce cas, piochez 3 cartes.",
+				de: "Lege 1 Team Plasma-Karte von deiner Hand auf deinen Ablagestapel. Wenn du das machst, ziehe 3 Karten."
 			},
 
 		},
@@ -52,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Steel Wing",
 				fr: "Aile d'Acier",
+				de: "Stahlflügel"
 			},
 			effect: {
 				en: "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, tous les dégâts infligés à ce Pokémon par des attaques sont réduits de 20 (après application de la Faiblesse et de la Résistance).",
+				de: "Während des nächsten Zuges deines Gegners wird Schaden, der diesem Pokémon durch Angriffe zugefügt wird, um 20 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 			damage: 40,
 
@@ -80,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "Its heavy-looking iron body is actually thin and light, so it can fly at speeds over 180 mph.",
+		de: "Sein stählerner Körper ist dünner und leichter, als er wirkt und erlaubt eine Fluggeschwindigkeit von bis zu 300 km/h."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/88.ts
+++ b/data/Black & White/Plasma Storm/88.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Rigidify",
 				fr: "Solidification",
+				de: "Verfestiger"
 			},
 			effect: {
 				en: "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, tous les dégâts infligés à ce Pokémon par des attaques sont réduits de 20 (après application de la Faiblesse et de la Résistance).",
+				de: "Während des nächsten Zuges deines Gegners wird Schaden, der diesem Pokémon durch Angriffe zugefügt wird, um 20 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 
 		},
@@ -51,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Vice Grip",
 				fr: "Force Poigne",
+				de: "Klammer"
 			},
 
 			damage: 20,
@@ -76,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "Two bodies comprise a fixed pair. They spin around each other to generate energy.",
+		de: "Sein Körper ist eine stets identische Anordnung von Einzelteilen, die Energie erzeugen, wenn sie gedreht werden."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/89.ts
+++ b/data/Black & White/Plasma Storm/89.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Klink",
 		fr: "Tic",
+		de: "Klikk"
 	},
 
 	stage: "Stage1",
@@ -41,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Vice Grip",
 				fr: "Force Poigne",
+				de: "Klammer"
 			},
 
 			damage: 20,
@@ -55,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Gear Smash",
 				fr: "Méca-Fracas",
+				de: "Getriebesalat"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 more damage for each heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts supplémentaires pour chaque côté face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 30,
 
@@ -83,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "A minigear and big gear comprises its body. If the minigear it launches at its foe doesn't return, it will die.",
+		de: "Besteht aus kleinen und großen Rädern. Kehrt ein kleines Rad, das es abgefeuert hat, nicht zurück, wird es brenzlig."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/9.ts
+++ b/data/Black & White/Plasma Storm/9.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Sewaddle",
 		fr: "Larveyette",
+		de: "Strawickl"
 	},
 
 	stage: "Stage1",
@@ -41,10 +42,12 @@ const card: Card = {
 			name: {
 				en: "Swaddle Guard",
 				fr: "Layette Protectrice",
+				de: "Schutzwickel"
 			},
 			effect: {
 				en: "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 40 (after applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, tous les dégâts infligés à ce Pokémon par des attaques sont réduits de 40 (après application de la Faiblesse et de la Résistance).",
+				de: "Während des nächsten Zuges deines Gegners wird Schaden, der diesem Pokémon durch Angriffe zugefügt wird, um 40 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 
 		},
@@ -56,10 +59,12 @@ const card: Card = {
 			name: {
 				en: "Surprise Attack",
 				fr: "Attaque Surprise",
+				de: "Überraschungsangriff"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 40,
 
@@ -77,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "Preferring dark, damp places, it spends the entire day eating fallen leaves that lie around it.",
+		de: "Es hält sich bevorzugt an finsteren, feuchten Orten auf und knabbert den ganzen Tag an zu Boden gefallenem Laub."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/90.ts
+++ b/data/Black & White/Plasma Storm/90.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Klang",
 		fr: "Clic",
+		de: "Kliklak"
 	},
 
 	stage: "Stage2",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Evita todo el daño infligido a tus Pokémon Metal por ataques de los Pokémon-EX de tu rival.",
 				it: "Previeni tutti i danni da attacchi inflitti ai tuoi Pokémon Metal dai Pokémon-EX del tuo avversario.",
 				pt: "Previne todos os danos causados a seus Pokémon Metal causados pelos ataques dos Pokémon-EX do seu oponente.",
-				de: "Verhindere allen Schaden, der deinen Metal-Pokémon durch Angriffe von Pokémon-EX deines Gegners zugefügt würde."
+				de: "Verhindere allen Schaden, der deinen {M}-Pokémon durch Angriffe von Pokémon-EX deines Gegners zugefügt würde."
 			},
 		},
 	],
@@ -65,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Heavy Bullet",
 				fr: "Projectile Lourd",
+				de: "Schweres Geschoss"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts à 1 des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 1 Pokémon auf der Bank deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 70,
 
@@ -93,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "The minigear spins at high speed. Then the energy from the red core charges the minigear to make it ready to fire.",
+		de: "Lässt das kleine Rad schnell rotieren und feuert es ab, indem darauf Energie aus seinem roten Kern übertragen wird."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/91.ts
+++ b/data/Black & White/Plasma Storm/91.ts
@@ -37,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Gnaw",
 				fr: "Ronge",
+				de: "Nagen"
 			},
 
 			damage: 20,
@@ -51,10 +52,12 @@ const card: Card = {
 			name: {
 				en: "Hard Crunch",
 				fr: "Mâchouil'Dur",
+				de: "Kräftiger Knirscher"
 			},
 			effect: {
 				en: "If the Defending Pokémon already has any damage counters on it, this attack does 30 more damage.",
 				fr: "Si le Pokémon Défenseur a déjà des marqueurs de dégâts, cette attaque inflige 30 dégâts supplémentaires.",
+				de: "Wenn auf dem Verteidigenden Pokémon bereits mindestens 1 Schadensmarke liegt, fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: 40,
 
@@ -79,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "Individuals each play different roles in driving Heatmor, their natural predator, away from their colony.",
+		de: "Eine ausgeklügelte Rollenverteilung hilft ihnen dabei, ihren natürlichen Feind Furnifraß aus dem Nest zu verjagen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/92.ts
+++ b/data/Black & White/Plasma Storm/92.ts
@@ -36,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Call for Backup",
 				fr: "Renforts",
+				de: "Back-up"
 			},
 			effect: {
 				en: "Search your deck for a Pokémon, reveal it, and put it into your hand. Shuffle your deck afterward.",
 				fr: "Cherchez un Pokémon dans votre deck, montrez-le, puis ajoutez-le à votre main. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck."
 			},
 
 		},
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Metal Jail",
 				fr: "Prison Métallique",
+				de: "Metallgefängnis"
 			},
 			effect: {
 				en: "The Defending Pokémon can't retreat during your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas battre en retraite pendant le prochain tour de votre adversaire.",
+				de: "Das Verteidigende Pokémon kann sich während des nächsten Zuges deines Gegners nicht zurückziehen."
 			},
 			damage: 30,
 
@@ -79,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "Individuals each play different roles in driving Heatmor, their natural predator, away from their colony.",
+		de: "Eine ausgeklügelte Rollenverteilung hilft ihnen dabei, ihren natürlichen Feind Furnifraß aus dem Nest zu verjagen."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/93.ts
+++ b/data/Black & White/Plasma Storm/93.ts
@@ -34,10 +34,12 @@ const card: Card = {
 			name: {
 				en: "Righteous Edge",
 				fr: "Lame Vertueuse",
+				de: "Edle Klinge"
 			},
 			effect: {
 				en: "Discard a Special Energy attached to the Defending Pokémon.",
 				fr: "Défaussez une Énergie spéciale attachée au Pokémon Défenseur.",
+				de: "Lege 1 an das Verteidigende Pokémon angelegte Spezial-Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 30,
 
@@ -51,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Steel Bullet",
 				fr: "Balle d'Acier",
+				de: "Stahlkugel"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by Weakness, Resistance, or any other effects on the Defending Pokémon.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Faiblesse, la Résistance ou tout autre effet en action sur le Pokémon Défenseur.",
+				de: "Der Schaden dieses Angriffs wird durch Schwäche, Resistenz oder alle anderen Effekte auf dem Verteidigenden Pokémon nicht verändert."
 			},
 			damage: 100,
 

--- a/data/Black & White/Plasma Storm/94.ts
+++ b/data/Black & White/Plasma Storm/94.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Guard Press",
 				fr: "Pression de Garde",
+				de: "Schutzdruck"
 			},
 			effect: {
 				en: "During your opponent's next turn, any damage done to this Pokémon by attacks is reduced by 20 (after applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, tous les dégâts infligés à ce Pokémon par des attaques sont réduits de 20 (après application de la Faiblesse et de la Résistance).",
+				de: "Während des nächsten Zuges deines Gegners wird Schaden, der diesem Pokémon durch Angriffe zugefügt wird, um 20 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 			damage: 20,
 
@@ -55,6 +57,7 @@ const card: Card = {
 			name: {
 				en: "Dragon Claw",
 				fr: "Dracogriffe",
+				de: "Drachenklaue"
 			},
 
 			damage: 90,
@@ -73,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "It runs through the narrow tunnels formed by Excadrill and Onix. It uses its sharp claws to catch prey.",
+		de: "Es jagt in schmalen, von Stalobor und Onix gegrabenen Schächten nach Beute und spießt sie mit spitzen Klauen auf."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/95.ts
+++ b/data/Black & White/Plasma Storm/95.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Slash",
 				fr: "Tranche",
+				de: "Schlitzer"
 			},
 
 			damage: 60,
@@ -51,10 +52,12 @@ const card: Card = {
 			name: {
 				en: "Black Ballista",
 				fr: "Baliste Noire",
+				de: "Schwarze Schleuder"
 			},
 			effect: {
 				en: "Discard 3 Energy attached to this Pokémon.",
 				fr: "Défaussez 3 Énergies attachées à ce Pokémon.",
+				de: "Lege 3 an dieses Pokémon angelegte Energien auf deinen Ablagestapel."
 			},
 			damage: 200,
 

--- a/data/Black & White/Plasma Storm/96.ts
+++ b/data/Black & White/Plasma Storm/96.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Slash",
 				fr: "Tranche",
+				de: "Schlitzer"
 			},
 
 			damage: 60,
@@ -51,10 +52,12 @@ const card: Card = {
 			name: {
 				en: "White Inferno",
 				fr: "Fureur Blanche",
+				de: "Weiße Wut"
 			},
 			effect: {
 				en: "Does 10 more damage for each damage counter on this Pokémon.",
 				fr: "Inflige 10 dégâts supplémentaires pour chaque marqueur de dégâts placé sur ce Pokémon.",
+				de: "Dieser Angriff fügt 10 weitere Schadenspunkte für jede Schadensmarke auf diesem Pokémon zu."
 			},
 			damage: 100,
 

--- a/data/Black & White/Plasma Storm/97.ts
+++ b/data/Black & White/Plasma Storm/97.ts
@@ -36,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Pound",
 				fr: "Écras'Face",
+				de: "Pfund"
 			},
 
 			damage: 10,
@@ -49,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Double Slap",
 				fr: "Torgnoles",
+				de: "Duplexhieb"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
 
@@ -70,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "On nights with a full moon, Clefairy gather from all over and dance. Bathing in moonlight makes them float.",
+		de: "Bei Vollmond kommen die Piepi von überall zusammen, um zu tanzen. Das Mondlicht lässt sie in der Luft schweben."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/98.ts
+++ b/data/Black & White/Plasma Storm/98.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Clefairy",
 		fr: "Mélofée",
+		de: "Piepi"
 	},
 
 	stage: "Stage1",
@@ -65,6 +66,7 @@ const card: Card = {
 			name: {
 				en: "Moon Impact",
 				fr: "Impact Lunaire",
+				de: "Mondeinschlag"
 			},
 
 			damage: 50,
@@ -83,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "Their ears are sensitive enough to hear a pin drop from over a mile away, so they're usually found in quiet places.",
+		de: "Ihr Gehör erfasst das Geräusch einer fallenden Nadel noch aus einem Kilometer Entfernung. Sie bevorzugen ruhige Orte."
 	},
 
 	thirdParty: {

--- a/data/Black & White/Plasma Storm/99.ts
+++ b/data/Black & White/Plasma Storm/99.ts
@@ -37,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Gatling Peck",
 				fr: "Mitra-Bec",
+				de: "Schnabelgeschütz"
 			},
 			effect: {
 				en: "Flip 5 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 5 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
+				de: "Wirf 5 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 10,
 
@@ -65,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "The brains in its two heads appear to communicate emotions to each other with telepathic power.",
+		de: "Die Gehirne der beiden Köpfe kommunizieren ihre Gefühle über Telepathie."
 	},
 
 	thirdParty: {


### PR DESCRIPTION
## Add missing German translations for bw8

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
