### PR TITLE
Add missing German translations for xy0

### DIFF
--- a/data/XY/Kalos Starter Set/1.ts
+++ b/data/XY/Kalos Starter Set/1.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Paralizado.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene paralizzato.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente será Paralisado.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Aktive Pokémon deines Gegners jetzt paralysiert."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 			},
 			damage: 10,
 
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "Often found in forests and grasslands. It has a sharp, toxic barb of around two inches on top of its head.",
+		de: "Es lebt bevorzugt in Wäldern und in hohem Gras. Auf dem Kopf trägt es einen circa 5 cm langen, spitzen, giftigen Stachel."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/10.ts
+++ b/data/XY/Kalos Starter Set/10.ts
@@ -94,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "It gazes into the flame at the tip of its branch to achieve a focused state, which allows it to see into the future.",
+		de: "Es kann die Zukunft vorhersehen, indem es konzentriert in die Flamme an der Spitze seines Zweiges blickt."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/11.ts
+++ b/data/XY/Kalos Starter Set/11.ts
@@ -70,7 +70,7 @@ const card: Card = {
 				es: "Lanza 3 monedas. Este ataque hace 10 puntos de daño por cada cara.",
 				it: "Lancia tre volte una moneta. Questo attacco infligge 10 danni ogni volta che esce testa.",
 				pt: "Jogue 3 moedas. Este ataque causa 30 de danos vezes o número de caras.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10×",
 
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "The water stored inside the tuft on its head is full of nutrients. It waters plants with it using its tail.",
+		de: "Das Büschel auf seinem Kopf enthält eine sehr nahrhafte Flüssigkeit, mit der es über seinen Schweif Pflanzen wässert."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/12.ts
+++ b/data/XY/Kalos Starter Set/12.ts
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "It secretes flexible bubbles from its chest and back. The bubbles reduce the damage it would otherwise take when attacked.",
+		de: "Es stößt aus Brust und Rücken elastische Blasen aus, mit denen es gegnerische Angriffe abfängt und so den erlittenen Schaden verringert."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/13.ts
+++ b/data/XY/Kalos Starter Set/13.ts
@@ -74,7 +74,7 @@ const card: Card = {
 				es: "Lanza 2 monedas. Este ataque hace 20 puntos de daño más por cada cara.",
 				it: "Lancia due volte una moneta. Questo attacco infligge 20 danni in più ogni volta che esce testa.",
 				pt: "Jogue 2 moedas. Este ataque causa 20 de danos adicionais para cada cara.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 weitere Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: '40+',
 
@@ -92,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "It can throw bubble-covered pebbles with precise control, hitting empty cans up to a hundred feet away.",
+		de: "Es kann kleine in Blasen gehüllte Steine mit solcher Präzision werfen, dass es selbst 30 m entfernte Dosen problemlos trifft."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/14.ts
+++ b/data/XY/Kalos Starter Set/14.ts
@@ -56,7 +56,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, descarta 1 Energía unida al Pokémon Activo de tu rival.",
 				it: "Lancia una moneta. Se esce testa, scarta un'Energia assegnata al Pokémon attivo del tuo avversario.",
 				pt: "Jogue uma moeda. Se sair cara, descarte uma Energia ligada ao Pokémon Ativo do seu oponente.",
-				de: "Wirf 1 Münze. Lege bei \"Kopf\" 1 an das Aktive Pokémon deines Gegners angelegte Energie auf den Ablagestapel deines Gegners."
+				de: "Wirf 1 Münze. Lege bei „Kopf“ 1 an das Aktive Pokémon deines Gegners angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 40,
 
@@ -92,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "It creates throwing stars out of compressed water. When it spins them and throws them at high speed, these stars can split metal in two.",
+		de: "Es stellt Wurfsterne aus komprimiertem Wasser her, die durch ihre hohe Drehgeschwindigkeit beim Werfen sogar Metall durchtrennen."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/15.ts
+++ b/data/XY/Kalos Starter Set/15.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "They knock down flying prey by firing compressed water from their massive claws like shooting a pistol.",
+		de: "Mit Salven komprimierten Wassers, die es wie Pistolenkugeln aus seinen Scheren abfeuert, schießt es fliegende Beute ab."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/16.ts
+++ b/data/XY/Kalos Starter Set/16.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon with a persistent nature, it chases its chosen prey until the prey becomes exhausted.",
+		de: "Ein beharrliches Pokémon, das seine Beute jagt, bis diese erschöpft ist."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/17.ts
+++ b/data/XY/Kalos Starter Set/17.ts
@@ -57,7 +57,7 @@ const card: Card = {
 				es: "Lanza una moneda. Si sale cara, este ataque hace 20 puntos de daño más.",
 				it: "Lancia una moneta. Se esce testa, questo attacco infligge 20 danni in più.",
 				pt: "Jogue uma moeda. Se sair cara, este ataque causará 20 de danos adicionais.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 20 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: "40+",
 
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It will always obey the commands of a skilled Trainer. Its behavior arises from its living in packs in ancient times.",
+		de: "Es wird stets die Befehle eines begabten Trainers befolgen. Dieses Verhalten geht darauf zurück, dass es früher im Rudel lebte."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/18.ts
+++ b/data/XY/Kalos Starter Set/18.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "Opponents who stare at the flashing of the light-emitting spots on its body become dazed and lose their will to fight.",
+		de: "Gegner, die auf die blinkenden Punkte an seinem Körper blicken, werden geblendet und verlieren den Willen zu kämpfen."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/19.ts
+++ b/data/XY/Kalos Starter Set/19.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "Blades comprise this Pokémon's entire body. If battling dulls the blades, it sharpens them on stones by the river.",
+		de: "Sein Körper ist mit Klingen übersät, die es an Felsen eines Flussbettes schärft, wenn sie im Kampf schartig werden."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/2.ts
+++ b/data/XY/Kalos Starter Set/2.ts
@@ -70,7 +70,7 @@ const card: Card = {
 				es: "Lanza 3 monedas. Este ataque hace 10 puntos de daño por cada cara.",
 				it: "Lancia tre volte una moneta. Questo attacco infligge 10 danni ogni volta che esce testa.",
 				pt: "Jogue 3 moedas. Este ataque causa 30 de danos vezes o número de caras.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10×",
 
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It shares the leaf on its head with weary-looking Pokémon. These leaves are known to relieve stress.",
+		de: "Schwächelnden Pokémon gibt es ein paar der Kräuter auf seinem Kopf ab und hilft ihnen so wieder auf die Beine."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/20.ts
+++ b/data/XY/Kalos Starter Set/20.ts
@@ -56,7 +56,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Paralizado.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene paralizzato.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente será Paralisado.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Aktive Pokémon deines Gegners jetzt paralysiert."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 			},
 			damage: 20,
 
@@ -99,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "This pitiless Pokémon commands a group of Pawniard to hound prey into immobility. It then moves in to finish the prey off.",
+		de: "Ein kaltblütiges Pokémon, das Gegner zunächst mit einer Schar von Gladiantri lähmt und dann zweiteilt."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/21.ts
+++ b/data/XY/Kalos Starter Set/21.ts
@@ -48,7 +48,7 @@ const card: Card = {
 				es: "Lanza 1 moneda hasta que salga cruz. Este ataque hace 30 puntos de daño por cada cara.",
 				it: "Lancia una moneta finché non esce croce. Questo attacco infligge 30 danni ogni volta che esce testa.",
 				pt: "Jogue uma moeda até sair coroa. Esse ataque causa 30 de danos vezes o número de caras.",
-				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis \"Zahl\" kommt. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: '30x',
 
@@ -73,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "Apparently this Pokémon is born when a departed spirit inhabits a sword. It attaches itself to people and drinks their life force.",
+		de: "Dieses Pokémon wird geboren, wenn die Seele eines Verstorbenen sich in einem Schwert festsetzt. Es heftet sich an Menschen und saugt deren Lebenskraft aus."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/22.ts
+++ b/data/XY/Kalos Starter Set/22.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "It has an active, playful nature. Many women like to frolic with it because of its affectionate ways.",
+		de: "Es ist von Natur aus verspielt. Es tollt mit vielen Frauen herum, da es ihnen zugeneigt ist."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/23.ts
+++ b/data/XY/Kalos Starter Set/23.ts
@@ -75,7 +75,7 @@ const card: Card = {
 				es: "Lanza 2 monedas. Este ataque hace 20 puntos de daño más por cada cara.",
 				it: "Lancia due volte una moneta. Ogni volta che esce testa, questo attacco infligge 20 danni in più.",
 				pt: "Jogue 2 moedas. Este ataque causa 20 de danos adicionais para cada cara.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 weitere Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "50+",
 
@@ -100,6 +100,7 @@ const card: Card = {
 
 	description: {
 		en: "It is timid in spite of its looks. If it becomes enraged, however, it will strike with its huge fangs.",
+		de: "Es ist trotz seines Äußeren schüchtern. Wird es wütend, schnappt es mit seinen Fängen zu."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/24.ts
+++ b/data/XY/Kalos Starter Set/24.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "To entangle its opponents in battle, it extrudes white threads as sweet and sticky as cotton candy.",
+		de: "Es stößt weiße Fäden aus, die so süß und klebrig wie Zuckerwatte sind. Mit ihnen umwickelt es den Gegner und hindert ihn daran, sich zu bewegen."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/25.ts
+++ b/data/XY/Kalos Starter Set/25.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "The plant stalk it holds is its weapon. The stalk is used like a sword to cut all sorts of things.",
+		de: "Dieses Pokémon nutzt eine Lauchstange als Waffe. Es setzt sie wie ein Schwert ein."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/26.ts
+++ b/data/XY/Kalos Starter Set/26.ts
@@ -49,7 +49,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, este ataque hace 30 puntos de daño más.",
 				it: "Lancia una moneta. Se esce testa, questo attacco infligge 30 danni in più.",
 				pt: "Jogue uma moeda. Se sair cara, este ataque causará 30 de danos adicionais.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 30 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: '10+',
 
@@ -86,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "It is not satisfied unless it eats over 880 pounds of food every day. When it is done eating, it goes promptly to sleep.",
+		de: "Es ist erst satt, wenn es über 400 kg Nahrung am Tag gefressen hat. Ist es mit dem Essen fertig, schläft es sofort ein."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/27.ts
+++ b/data/XY/Kalos Starter Set/27.ts
@@ -49,7 +49,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, este ataque hace 20 puntos de daño más.",
 				it: "Lancia una moneta. Se esce testa, questo attacco infligge 20 danni in più.",
 				pt: "Jogue uma moeda. Se sair cara, este ataque causará 20 de danos adicionais.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 20 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: "50+",
 
@@ -67,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "If it is around babies, it milk it produces contains much more nutrition than usual.",
+		de: "Wenn es gerade ein Junges hat, dann enthält seine Milch mehr Nährstoffe als gewöhnlich."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/28.ts
+++ b/data/XY/Kalos Starter Set/28.ts
@@ -48,7 +48,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, este ataque hace 20 puntos de daño más.",
 				it: "Lancia una moneta. Se esce testa, questo attacco infligge 20 danni in più.",
 				pt: "Jogue uma moeda. Se sair cara, este ataque causará 20 de danos adicionais.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 20 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "It can't stop itself from chasing moving things, and it runs in a circle, chasing its own tail.",
+		de: "Es muss Dinge, die sich bewegen, einfach jagen. Es rennt oft im Kreis und jagt seinen eigenen Schweif."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/29.ts
+++ b/data/XY/Kalos Starter Set/29.ts
@@ -60,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "With nerves of steel, nothing can perturb it. It is more agile and active than it appears.",
+		de: "Es hat Nerven wie Drahtseile, nichts kann es erschüttern. Es ist agiler und aktiver, als es scheint."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/3.ts
+++ b/data/XY/Kalos Starter Set/3.ts
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "The quills on its head are usually soft. When it flexes them, the points become so hard and sharp that they can pierce rock.",
+		de: "Wenn es seine Kraft auf die sonst eher weichen Stacheln auf seinem Kopf konzentriert, werden diese robust genug, um damit Steine zu zertrümmern."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/30.ts
+++ b/data/XY/Kalos Starter Set/30.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "They use their large ears to dig burrows. They will dig the whole night through.",
+		de: "Mit seinen großen Ohren schaufelt es sich einen Bau. Es kann die ganze Nacht ohne Pause durchschaufeln."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/31.ts
+++ b/data/XY/Kalos Starter Set/31.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Lanza una moneda. Si sale cruz, este ataque no hace nada.",
 				it: "Lancia una moneta. Se esce croce, questo attacco non ha effetto.",
 				pt: "Jogue uma moeda. Se sair coroa, esse ataque não fará nada.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 20,
 
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "These friendly Pokémon send signals to one another with beautiful chirps and tail-feather movements.",
+		de: "Ein sehr zutrauliches Pokémon. Durch Zwitschern und Bewegen der Schwanzfedern sendet es Signale an seine Gefährten."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/32.ts
+++ b/data/XY/Kalos Starter Set/32.ts
@@ -48,7 +48,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Paralizado.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene paralizzato.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente será Paralisado.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Aktive Pokémon deines Gegners jetzt paralysiert."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 			},
 			damage: 20,
 
@@ -84,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "Trimming its fluffy fur not only makes it more elegant but also increases the swiftness of its movements.",
+		de: "Schneidet man sein Fell zurecht, wird es nicht nur schöner, sondern auch beweglicher."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/33.ts
+++ b/data/XY/Kalos Starter Set/33.ts
@@ -48,7 +48,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Paralizado.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene paralizzato.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente será Paralisado.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Aktive Pokémon deines Gegners jetzt paralysiert."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 			},
 			damage: 20,
 
@@ -84,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "Trimming its fluffy fur not only makes it more elegant but also increases the swiftness of its movements.",
+		de: "Schneidet man sein Fell zurecht, wird es nicht nur schöner, sondern auch beweglicher."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/34.ts
+++ b/data/XY/Kalos Starter Set/34.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Lanza una moneda. Si sale cara, descarta una Energía unida a 1 de los Pokémon de tu rival.",
 		it: "Lancia una moneta. Se esce testa, scarta un'Energia assegnata a uno dei Pokémon del tuo avversario.",
 		pt: "Jogue uma moeda. Se sair cara, descarte uma Energia ligada a 1 dos Pokémon do seu oponente.",
-		de: "Wirf 1 Münze. Lege bei \"Kopf\" 1 an das gegnerische Pokémon angelegte Energie auf den Ablagestapel deines Gegners."
+		de: "Wirf 1 Münze. Lege bei „Kopf“ 1 an ein gegnerisches Pokémon angelegte Energie auf den Ablagestapel deines Gegners. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/XY/Kalos Starter Set/35.ts
+++ b/data/XY/Kalos Starter Set/35.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Lanza 1 moneda. Si sale cara, busca en tu baraja 1 Pokémon, enséñalo y ponlo en tu mano. Baraja las cartas de tu baraja después.",
 		it: "Lancia una moneta. Se esce testa, cerca nel tuo mazzo un Pokémon, mostralo e aggiungilo alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Jogue uma moeda. Se sair cara, procure um Pokémon no seu baralho, mostre-o e coloque-o em sua mão. Em seguida, embaralhe seus cards.",
-		de: "Wirf 1 Münze. Durchsuche bei \"Kopf\" dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck."
+		de: "Wirf 1 Münze. Durchsuche bei „Kopf“ dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/XY/Kalos Starter Set/36.ts
+++ b/data/XY/Kalos Starter Set/36.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Lanza 1 moneda. Si sale cara, cambia 1 de los Pokémon en Banca de tu rival por su Pokémon Activo.",
 		it: "Lancia una moneta. Se esce testa, scambia uno dei Pokémon nella panchina del tuo avversario con il suo Pokémon attivo.",
 		pt: "Jogue uma moeda. Se sair cara, troque 1 dos Pokémon no Banco do seu oponente pelo Pokémon Ativo desse oponente.",
-		de: "Wirf 1 Münze. Tausche bei \"Kopf\" 1 Pokémon auf der Bank deines Gegners gegen das Aktive Pokémon deines Gegners aus."
+		de: "Wirf 1 Münze. Tausche bei „Kopf“ 1 Pokémon auf der Bank deines Gegners gegen das Aktive Pokémon deines Gegners aus. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/XY/Kalos Starter Set/37.ts
+++ b/data/XY/Kalos Starter Set/37.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cura 30 puntos de daño a 1 de tus Pokémon.",
 		it: "Cura uno dei tuoi Pokémon da 30 danni.",
 		pt: "Cure 30 de danos de 1 dos seus Pokémon.",
-		de: "Heile 30 Schadenspunkte bei 1 deiner Pokémon."
+		de: "Heile 30 Schadenspunkte bei 1 deiner Pokémon. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/XY/Kalos Starter Set/38.ts
+++ b/data/XY/Kalos Starter Set/38.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cambia tu Pokémon Activo por 1 de tus Pokémon en Banca.",
 		it: "Scambia il tuo Pokémon attivo con uno dei tuoi Pokémon in panchina.",
 		pt: "Substitua seu Pokémon Ativo por 1 dos Pokémon do seu Banco.",
-		de: "Tausche dein Aktives Pokémon gegen 1 Pokémon auf deiner Bank aus."
+		de: "Tausche dein Aktives Pokémon gegen 1 Pokémon auf deiner Bank aus. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/XY/Kalos Starter Set/39.ts
+++ b/data/XY/Kalos Starter Set/39.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba 3 cartas.",
 		it: "Pesca tre carte.",
 		pt: "Compre 3 cards.",
-		de: "Ziehe 3 Karten."
+		de: "Ziehe 3 Karten. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/XY/Kalos Starter Set/4.ts
+++ b/data/XY/Kalos Starter Set/4.ts
@@ -93,6 +93,7 @@ const card: Card = {
 
 	description: {
 		en: "It relies on its sturdy shell to deflect predators' attacks. It counterattacks with its sharp quills.",
+		de: "Der Panzer, der seinen Körper umgibt, bietet ihm Schutz vor Angreifern und straft direkte Angriffe postwendend mit spitzen Stacheln ab."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/5.ts
+++ b/data/XY/Kalos Starter Set/5.ts
@@ -77,7 +77,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, este ataque hace 40 puntos de daño más.",
 				it: "Lancia una moneta. Se esce testa, questo attacco infligge 40 danni in più.",
 				pt: "Jogue uma moeda. Se sair cara, este ataque causará 40 de danos adicionais.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 40 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 40 weitere Schadenspunkte zu."
 			},
 			damage: "80+",
 
@@ -95,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "Its Tackle is forceful enough to flip a 50-ton tank. It shields its allies from danger with its own body.",
+		de: "Es ist so stark, dass es selbst 50 t schwere Panzer umkippen kann. Es schützt seine Artgenossen, indem es sich ihnen als Schild anbietet."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/6.ts
+++ b/data/XY/Kalos Starter Set/6.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "A common sight in volcanic areas, it slowly slithers around in a constant search for warm places.",
+		de: "Es hält sich ständig bei Vulkanen auf und ist stets kriechend auf der Suche nach warmen Aufenthaltsorten."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/7.ts
+++ b/data/XY/Kalos Starter Set/7.ts
@@ -70,7 +70,7 @@ const card: Card = {
 				es: "Lanza 3 monedas. Este ataque hace 10 puntos de daño por cada cara.",
 				it: "Lancia tre volte una moneta. Questo attacco infligge 10 danni ogni volta che esce testa.",
 				pt: "Jogue 3 moedas. Este ataque causa 30 de danos vezes o número de caras.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10×",
 
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Very intelligent, it roasts berries before eating them. It likes to help people.",
+		de: "Ein kultiviertes Pokémon, das Beeren vor dem Verzehr stets anbrät. Es bietet den Menschen gerne seine Hilfe an."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/8.ts
+++ b/data/XY/Kalos Starter Set/8.ts
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "Eating a twig fills it with energy, and its roomy ears give vent to air hotter than 390 degrees Fahrenheit.",
+		de: "Wenn es Zweige frisst, fasst es neue Kraft und stößt über seine Ohren über 200 °C heiße Luft aus."
 	},
 
 	thirdParty: {

--- a/data/XY/Kalos Starter Set/9.ts
+++ b/data/XY/Kalos Starter Set/9.ts
@@ -57,7 +57,7 @@ const card: Card = {
 				es: "Lanza una moneda. Si sale cara, este ataque hace 20 puntos de daño más.",
 				it: "Lancia una moneta. Se esce testa, questo attacco infligge 20 danni in più.",
 				pt: "Jogue uma moeda. Se sair cara, este ataque causará 20 de danos adicionais.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 20 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: '20+',
 
@@ -93,6 +93,7 @@ const card: Card = {
 
 	description: {
 		en: "It has a twig stuck in its tail. With friction from its tail fur, it sets the twig on fire and launches into battle.",
+		de: "In seinem Schweif steckt ein Zweig, den es bei Bedarf mit der Reibungswärme seiner Schweifhaare anzündet und im Kampf einsetzt."
 	},
 
 	thirdParty: {


### PR DESCRIPTION
## Add missing German translations for xy0

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
