### PR TITLE
Add missing German translations for hgss1

### DIFF
--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/1.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/1.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Growlithe",
-		fr: "Caninos"
+		fr: "Caninos",
+		de: "Fukano"
 	},
 
 	stage: "Stage1",
@@ -71,7 +72,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "This legendary Chinese Pokémon is considered magnificent. Many people are enchanted by its grand mane."
+		en: "This legendary Chinese Pokémon is considered magnificent. Many people are enchanted by its grand mane.",
+		de: "Dieses legendäre chinesische Pokémon wird wegen seiner Schönheit verehrt. Vor allem wegen der Mähne."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/10.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/10.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pikachu",
-		fr: "Pikachu"
+		fr: "Pikachu",
+		de: "Pikachu"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin until you get tails. This attack does 30 damage times the number of heads.",
 				fr: "Lancez une pièce jusqu’à ce qu’elle tombe sur pile. Cette attaque inflige 30 dégâts multipliés par le nombre de faces.",
-				de: "Wirf so lange 1 Münze, bis zum ersten Mal das Ergebnis \"Zahl\" kommt. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf so lange 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "30×",
 
@@ -83,7 +84,8 @@ const card: Card = {
 	retreat: 0,
 
 	description: {
-		en: "If the electric pouches in its cheeks become fully charged, both ears will stand straight up."
+		en: "If the electric pouches in its cheeks become fully charged, both ears will stand straight up.",
+		de: "Wenn seine Backentaschen voll aufgeladen sind, stehen seine beiden Ohren senkrecht nach oben."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/101.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/101.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		fr: "Vous ne pouvez jouer qu’une carte Supporter à chaque tour. Lorsque vous jouez cette carte, placez-la près de votre Pokémon actif. Une fois votre tour terminé, défaussez-vous de cette carte.",
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Shuffle your hand into your deck. Then, draw 6 cards.",
-		de: "Mische deine Handkarten in dein Deck. Ziehe danach 6 Karten."
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Mische deine Handkarten in dein Deck. Ziehe danach 6 Karten."
 	},
 
 	trainerType: "Supporter",

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/105.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/105.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Flaaffy",
-		fr: "Lainergie"
+		fr: "Lainergie",
+		de: "Waaty"
 	},
 
 	stage: "Stage2",
@@ -59,7 +60,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 40 damage plus 40 more damage. If tails, discard an Energy attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 40 dégâts plus 40 dégâts supplémentaires. Si c’est pile, défaussez-vous d’une carte Énergie attachée au Pokémon Défenseur.",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff 40 Schadenspunkte plus 40 weitere Schadenspunkte zu. Bei \"Zahl\" lege eine Energiekarte, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 40 Schadenspunkte plus 40 weitere Schadenspunkte zu. Bei „Zahl“ lege eine Energiekarte, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
 			},
 			damage: "40+",
 

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/106.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/106.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Chansey",
-		fr: "Leveinard"
+		fr: "Leveinard",
+		de: "Chaneira"
 	},
 
 	stage: "Stage1",

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/107.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/107.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Phanpy",
-		fr: "Phanpy"
+		fr: "Phanpy",
+		de: "Phanpy"
 	},
 
 	stage: "Stage1",

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/108.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/108.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Croconaw",
-		fr: "Crocodil"
+		fr: "Crocodil",
+		de: "Tyracroc"
 	},
 
 	stage: "Stage2",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "As often as you like during your turn (before your attack), you may attach a Water Energy card from your hand to 1 of your Water Pokémon. This power can't be used if Feraligatr is affected by a Special Condition.",
 				fr: "Autant de fois que vous le souhaitez pendant votre tour (avant votre attaque), vous pouvez attacher une carte Énergie Water de votre main à l’un de vos Pokémon Water. Ce pouvoir ne peut pas être utilisé si Aligatueur est affecté par un État spécial.",
-				de: "Beliebig oft während deines Zuges (vor deinem Angriff) kannst du 1 -Energiekarte von deiner Hand an 1 deiner -Pokémon anlegen. Diese Poké-Power kann nicht benutzt werden, wenn Impergator von einem Speziellen Zustand betroffen ist."
+				de: "Beliebig oft während deines Zuges (vor deinem Angriff) kannst du 1 {W}-Energiekarte von deiner Hand an 1 deiner {W}-Pokémon anlegen. Diese Poké-Power kann nicht benutzt werden, wenn Impergator von einem Speziellen Zustand betroffen ist."
 			}
 		},
 	],

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/109.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/109.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Bayleef",
-		fr: "Macronium"
+		fr: "Macronium",
+		de: "Lorblatt"
 	},
 
 	stage: "Stage2",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "As often as you like during your turn (before your attack), you may move a Grass Energy attached to 1 of your Pokémon to another of your Pokémon. This power can't be used if Meganium is affected by a Special Condition.",
 				fr: "Autant de fois que vous le souhaitez pendant votre tour (avant votre attaque), vous pouvez déplacer une carte Énergie Grass attachée à l’un de vos Pokémon sur un autre Pokémon. Ce pouvoir ne peut pas être utilisé si Meganium est affecté par un État spécial.",
-				de: "Beliebig oft während deines Zuges (vor deinem Angriff) kannst du 1 -Energie, die an 1 deiner Pokémon angelegt ist, an 1 anderes deiner Pokémon anlegen. Diese Poké-Power kann nicht benutzt werden, wenn Meganie von einem Speziellen Zustand betroffen ist."
+				de: "Beliebig oft während deines Zuges (vor deinem Angriff) kannst du 1 {G}-Energie, die an 1 deiner Pokémon angelegt ist, an 1 anderes deiner Pokémon anlegen. Diese Poké-Power kann nicht benutzt werden, wenn Meganie von einem Speziellen Zustand betroffen ist."
 			}
 		},
 	],

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/11.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/11.ts
@@ -53,7 +53,7 @@ const card: Card = {
 			effect: {
 				en: "The Defending Pokémon is now Poisoned.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné.",
-				de: "Das Verteidigende Pokémon ist jetzt vergifet."
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet."
 			},
 			damage: 30,
 
@@ -70,7 +70,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "The berries it stores in its vase-like shell decompose and become a gooey liquid."
+		en: "The berries it stores in its vase-like shell decompose and become a gooey liquid.",
+		de: "Die Beeren, die es in seinem Inneren lagert, gären und daraus entsteht ein dickflüssiger Saft."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/110.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/110.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Quilava",
-		fr: "Fleurisson"
+		fr: "Fleurisson",
+		de: "Igelavar"
 	},
 
 	stage: "Stage2",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may search your discard pile for a Fire Energy card and attach it to 1 of your Pokémon. If you do, put 1 damage counter on that Pokémon. This power can't be used if Typhlosion is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez chercher dans votre pile de défausse une carte Énergie Fire et l’attacher à l’un de vos Pokémon. Dans ce cas, ajoutez un marqueur de dégâts sur ce Pokémon. Ce pouvoir ne peut pas être utilisé si Typhlosion est affecté par un État spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du deinen Ablagestapel nach 1 -Energiekarte durchsuchen und sie an 1 deiner Pokémon anlegen. Wenn du das machst, lege 1 Schadensmarke auf dieses Pokémon. Diese Poké-Power kann nicht benutzt werden, wenn Tornupto von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du deinen Ablagestapel nach 1 {R}-Energiekarte durchsuchen und sie an 1 deiner Pokémon anlegen. Wenn du das machst, lege 1 Schadensmarke auf dieses Pokémon. Diese Poké-Power kann nicht benutzt werden, wenn Tornupto von einem Speziellen Zustand betroffen ist."
 			}
 		},
 	],

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/111.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/111.ts
@@ -38,7 +38,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "Legends claim this Pokémon flies the world’s skies continuously on its magnificent, seven-colored wings."
+		en: "Legends claim this Pokémon flies the world’s skies continuously on its magnificent, seven-colored wings.",
+		de: "Man sagt, dass dieses Pokémon auf seinen siebenfarbigen Schwingen durch die Lüfte fliegt."
 	},
 
 	variants: [
@@ -55,11 +56,13 @@ const card: Card = {
 			type: "Poke-BODY",
 			name: {
 				en: "Sacred Rainbow",
-				fr: "Arc-en-ciel sacré"
+				fr: "Arc-en-ciel sacré",
+				de: "Heiliger Regenbogen"
 			},
 			effect: {
 				en: "All Energy attached to Ho-Oh LEGEND are Fire Energy instead of their usual type.",
-				fr: "Toutes les Énergies attachées à Ho-Oh LÉGENDE sont de type Feu et non de leur type habituel."
+				fr: "Toutes les Énergies attachées à Ho-Oh LÉGENDE sont de type Feu et non de leur type habituel.",
+				de: "Alle Energien, die an Ho-Oh-LEGENDE angelegt sind, liefern {R}-Energie anstelle ihres normalen Typs."
 			}
 		},
 	],

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/112.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/112.ts
@@ -32,7 +32,7 @@ const card: Card = {
 			effect: {
 				en: "All Energy attached to Ho-Oh LEGEND are Fire Energy instead of their usual type.",
 				fr: "Toute les énergies attachées au Ho-Oh LÉGENDAIRE sont de type Fire et non de leur type habituel.",
-				de: "Alle Energien, die an Ho-Oh-LEGENDE angelegt sind, liefern -Energie anstelle ihres normalen Typs."
+				de: "Alle Energien, die an Ho-Oh-LEGENDE angelegt sind, liefern {R}-Energie anstelle ihres normalen Typs."
 			}
 		},
 	],
@@ -78,7 +78,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Legends claim this Pokémon flies the world’s skies continuously on its magnificent, seven-colored wings."
+		en: "Legends claim this Pokémon flies the world’s skies continuously on its magnificent, seven-colored wings.",
+		de: "Man sagt, dass dieses Pokémon auf seinen siebenfarbigen Schwingen durch die Lüfte fliegt."
 	},
 
 	hp: 140,

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/113.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/113.ts
@@ -38,7 +38,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It is said to be the guardian of the seas. It is rumored to have been seen on the night of a storm."
+		en: "It is said to be the guardian of the seas. It is rumored to have been seen on the night of a storm.",
+		de: "Man berichtet, es sei der Wächter der Meere und man habe es im Herzen eines tosenden Sturmes gesehen."
 	},
 
 	variants: [
@@ -56,11 +57,13 @@ const card: Card = {
 			type: "Poke-POWER",
 			name: {
 				en: "Ocean Grow",
-				fr: "Vaste océan"
+				fr: "Vaste océan",
+				de: "Meereswachstum"
 			},
 			effect: {
 				en: "Once during your turn, when you put Lugia LEGEND into play, you may look at the top 5 cards of your deck and attach all Energy cards you find there to Lugia LEGEND. Discard the other cards.",
-				fr: "Une seule fois pendant votre tour, lorsque vous mettez Lugia LÉGENDE en jeu, vous pouvez regarder les cinq cartes du dessus de votre deck et attacher les cartes Énergie figurant parmi ces cartes à Lugia LÉGENDE. Défaussez les autres cartes."
+				fr: "Une seule fois pendant votre tour, lorsque vous mettez Lugia LÉGENDE en jeu, vous pouvez regarder les cinq cartes du dessus de votre deck et attacher les cartes Énergie figurant parmi ces cartes à Lugia LÉGENDE. Défaussez les autres cartes.",
+				de: "Einmal während deines Zuges, wenn du Lugia-LEGENDE von deiner Hand ins Spiel bringst, kannst du dir die obersten 5 Karten deines Decks anschauen und alle dabei gefundenen Energiekarten an Lugia-LEGENDE anlegen. Lege die anderen Karten auf deinen Ablagestapel."
 			}
 		},
 	],
@@ -75,7 +78,7 @@ const card: Card = {
 			damage: 200,
 			effect: {
 				en: "Discard a Fire Energy, Water Energy, and Lightning Energy attached to Lugia LEGEND.",
-				de: "Lege 1 -Energie, 1 -Energie und 1 -Energie, die an Lugia-LEGENDE angelegt sind, auf deinen Ablagestapel.",
+				de: "Lege 1 {R}-Energie, 1 {W}-Energie und 1 {L}-Energie, die an Lugia-LEGENDE angelegt sind, auf deinen Ablagestapel.",
 				fr: "Défaussez une Énergie Feu, une Énergie Eau et une Énergie Électrique attachées à Lugia LÉGENDE."
 			},
 			cost: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/114.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/114.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Discard a Fire Energy, Water Energy, and Lightning Energy attached to Lugia LEGEND.",
 				fr: "Défaussez-vous d’une Énergie Fire, d’une Énergie Water et d’une Énergie Lightning attachées à Lugia LÉGENDAIRE.",
-				de: "Lege 1 -Energie, 1 -Energie und 1 -Energie, die an Lugia-LEGENDE angelegt sind, auf deinen Ablagestapel."
+				de: "Lege 1 {R}-Energie, 1 {W}-Energie und 1 {L}-Energie, die an Lugia-LEGENDE angelegt sind, auf deinen Ablagestapel."
 			},
 			damage: 200,
 
@@ -77,7 +77,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It is said to be the guardian of the seas. It is rumored to have been seen on the night of a storm."
+		en: "It is said to be the guardian of the seas. It is rumored to have been seen on the night of a storm.",
+		de: "Man berichtet, es sei der Wächter der Meere und man habe es im Herzen eines tosenden Sturmes gesehen."
 	},
 
 	hp: 130,

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/12.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/12.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Slowpoke",
-		fr: "Ramoloss"
+		fr: "Ramoloss",
+		de: "Flegmon"
 	},
 
 	stage: "Stage1",
@@ -58,7 +59,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c’est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 30,
 
@@ -75,7 +76,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It has incredible intellect and intuition. Whatever the situation, it remains calm and collected."
+		en: "It has incredible intellect and intuition. Whatever the situation, it remains calm and collected.",
+		de: "Sein feines Gespühr und Intellekt zeichnen es aus. Es bleibt in jeder Situation gelassen und besonnen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/123.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/123.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Magikarp",
-		fr: "Magicarpe"
+		fr: "Magicarpe",
+		de: "Karpador"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "If heads, this attack does 30 damage plus 20 more damage. If tails, Gyarados does 20 damage to itself.",
 				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 30 dégâts plus 20 dégâts supplémentaires. Si c’est pile, Léviator s’inflige 20 dégâts.",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff 30 Schadenspunkte plus 20 weitere Schadenspunkte zu. Bei \"Zahl\" fügt Garados sich selbst 20 Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 30 Schadenspunkte plus 20 weitere Schadenspunkte zu. Bei „Zahl“ fügt Garados sich selbst 20 Schadenspunkte zu."
 			},
 			damage: "30+",
 
@@ -81,7 +82,8 @@ const card: Card = {
 	retreat: 3,
 
 	description: {
-		en: "They say that during past strife, Gyarados would appear and leave blazing ruins in its wake."
+		en: "They say that during past strife, Gyarados would appear and leave blazing ruins in its wake.",
+		de: "Man sagt, dass GARADOS in den alten Kriegen aufgetaucht sei und nichts als Ruinen hinterlassen hat."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/13.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/13.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage times the number of damage counters on Wobbuffet.",
 				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 20 dégâts multipliés par le nombre de marqueurs de dégâts sur Qulbutoke.",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff 20 Schadenspunkte mal der Anzahl an Schadensmarken auf Woingenau zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte mal der Anzahl an Schadensmarken auf Woingenau zu."
 			},
 			damage: "20×",
 
@@ -54,7 +54,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It hates light and shock. If attacked, it inflates its body to build up its counterstrike."
+		en: "It hates light and shock. If attacked, it inflates its body to build up its counterstrike.",
+		de: "Es hasst Licht und Schläge. Wird es angegriffen, pumpt es sich auf, um einen Gegenschlag vorzubereiten."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/14.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/14.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Flaaffy",
-		fr: "Lainergie"
+		fr: "Lainergie",
+		de: "Waaty"
 	},
 
 	stage: "Stage2",
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, Ampharos does 20 damage to itself.",
 				fr: "Lancez une pièce. Si c’est pile, Pharamp s’inflige 20 dégâts.",
-				de: "Wirf eine Münze. Bei \"Zahl\" fügt Ampharos sich selbst 20 Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Zahl“ fügt Ampharos sich selbst 20 Schadenspunkte zu."
 			},
 			damage: 80,
 
@@ -84,7 +85,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "The tail’s tip shines brightly and can be seen from far away. It acts as a beacon for lost people."
+		en: "The tail’s tip shines brightly and can be seen from far away. It acts as a beacon for lost people.",
+		de: "Seine Schweifspitze ist so hell, dass viele Verschollene es als Orientierungspunkt nutzen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/15.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/15.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Spinarak",
-		fr: "Mimigal"
+		fr: "Mimigal",
+		de: "Webarak"
 	},
 
 	stage: "Stage1",
@@ -78,7 +79,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It spins string not only from its rear but also from its mouth. It’s hard to tell which end is which."
+		en: "It spins string not only from its rear but also from its mouth. It’s hard to tell which end is which.",
+		de: "Da es Fäden sowohl mit dem Hinterleib, als auch mit dem Mund spinnt, verwechselt man die beiden leicht."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/16.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/16.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Metapod",
-		fr: "Chrysacier"
+		fr: "Chrysacier",
+		de: "Safcon"
 	},
 
 	stage: "Stage2",
@@ -83,7 +84,8 @@ const card: Card = {
 	retreat: 0,
 
 	description: {
-		en: "Water-repellent powder on its wings enables it to collect honey, even in the heaviest of rains."
+		en: "Water-repellent powder on its wings enables it to collect honey, even in the heaviest of rains.",
+		de: "Da seine Flügel mit einem wasserabweisenden Puder überzogen sind, kann es im Regen Honig sammeln."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/17.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/17.ts
@@ -59,7 +59,8 @@ const card: Card = {
 	retreat: 0,
 
 	description: {
-		en: "Because of its unusual, star-like silhouette, people believe that it came here on a meteor."
+		en: "Because of its unusual, star-like silhouette, people believe that it came here on a meteor.",
+		de: "Aufgrund seiner ungewöhnlichen Sternform, sagt man, es sei auf einem Meteor hierhergereist."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/18.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/18.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Exeggcute",
-		fr: "Noeunoeuf"
+		fr: "Noeunoeuf",
+		de: "Owei"
 	},
 
 	stage: "Stage1",
@@ -57,7 +58,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin for each Energy attached to Exeggutor. This attack does 40 damage times the number of heads.",
 				fr: "Lancez une pièce pour chaque carte Énergie attachée à Noadkoko. Cette attaque inflige 40 dégâts multipliés par le nombre de faces.",
-				de: "Wirf für jede an Kokowei angelegte Energie 1 Münze. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf für jede an Kokowei angelegte Energie 1 Münze. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "40×",
 
@@ -74,7 +75,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "If a head drops off, it emits a telepathic call in search of others to form an Exeggcute cluster."
+		en: "If a head drops off, it emits a telepathic call in search of others to form an Exeggcute cluster.",
+		de: "Fällt einer der Köpfe ab, sendet er Telepathiewellen aus, um mit OWEI eine Gruppe zu bilden."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/19.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/19.ts
@@ -76,7 +76,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "If it eats the plant stalk it carries as emergency rations, it runs off in search of a new stalk."
+		en: "If it eats the plant stalk it carries as emergency rations, it runs off in search of a new stalk.",
+		de: "Wenn es seine Stange im Notfall auffrisst, begibt es sich sofort auf die Suche nach einer neuen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/2.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/2.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Marill",
-		fr: "Marill"
+		fr: "Marill",
+		de: "Marill"
 	},
 
 	stage: "Stage1",
@@ -57,7 +58,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c’est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 60,
 
@@ -74,7 +75,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "When it plays in water, it rolls up its elongated ears to prevent their insides from getting wet."
+		en: "When it plays in water, it rolls up its elongated ears to prevent their insides from getting wet.",
+		de: "Spielt es im Wasser, rollt es seine langen Ohren zusammen, um zu verhindern, dass Wasser eindringt."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/20.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/20.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Croconaw",
-		fr: "Crocodil"
+		fr: "Crocodil",
+		de: "Tyracroc"
 	},
 
 	stage: "Stage2",
@@ -75,7 +76,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "When it bites with its massive and powerful jaws, it shakes its head and savagely tears its victim up."
+		en: "When it bites with its massive and powerful jaws, it shakes its head and savagely tears its victim up.",
+		de: "Wenn es mit seinem kräftigen Kiefer zubeißt, schüttelt es seinen Kopf und reißt seine Opfer in Stücke."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/21.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/21.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Sentret",
-		fr: "Fouinette"
+		fr: "Fouinette",
+		de: "Wiesor"
 	},
 
 	stage: "Stage1",
@@ -58,7 +59,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 20 more damage.",
 				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 20 dégâts plus 20 dégâts supplémentaires.",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff 20 Schadenspunkte plus 20 weitere Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -75,7 +76,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It makes a nest to suit its long and skinny body. The nest is impossible for other Pokémon to enter."
+		en: "It makes a nest to suit its long and skinny body. The nest is impossible for other Pokémon to enter.",
+		de: "Sein Nest ist seinem schmalen und dünnen Körper angepasst. Kein anderes Pokémon kommt hinein."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/22.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/22.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Snubbull",
-		fr: "Snubbull"
+		fr: "Snubbull",
+		de: "Snubbull"
 	},
 
 	stage: "Stage1",
@@ -79,7 +80,8 @@ const card: Card = {
 	retreat: 3,
 
 	description: {
-		en: "Because its fangs are too heavy, it always keeps its head tilted down. However, its bite is powerful."
+		en: "Because its fangs are too heavy, it always keeps its head tilted down. However, its bite is powerful.",
+		de: "Weil seine Reißzähne so schwer sind, ist sein Kopf gesenkt. Sein Biss ist jedoch schmerzhaft."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/23.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/23.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Drowzee",
-		fr: "Soporifik"
+		fr: "Soporifik",
+		de: "Traumato"
 	},
 
 	stage: "Stage1",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may flip a coin. If heads, the Defending Pokémon is now Asleep. This power can't be used if Hypno is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez lancer une pièce. Si c’est face, le Pokémon Défenseur est maintenant Endormi. Ce pouvoir ne peut pas être utilisé si Hypnomade est affecté par un État spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du eine Münze werfen. Bei \"Kopf\" schläft das Verteidigende Pokémon jetzt. Diese Poké-Power kann nicht benutzt werden, wenn Hypno von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du eine Münze werfen. Bei „Kopf“ schläft das Verteidigende Pokémon jetzt. Diese Poké-Power kann nicht benutzt werden, wenn Hypno von einem Speziellen Zustand betroffen ist."
 			}
 		},
 	],
@@ -76,7 +77,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "Always holding a pendulum that it swings at a steady rhythm, it causes drowsiness in anyone nearby."
+		en: "Always holding a pendulum that it swings at a steady rhythm, it causes drowsiness in anyone nearby.",
+		de: "Es hält immer ein Pendel, das es ständig bewegt. Das verursacht bei jedem in seiner Nähe Müdigkeit."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/24.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/24.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c’est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -71,7 +71,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "They have gentle hearts. Because they rarely fight, many have been caught. Their number has dwindled."
+		en: "They have gentle hearts. Because they rarely fight, many have been caught. Their number has dwindled.",
+		de: "Sie sind gutmütig. Da sie selten kämpfen, wurden sie oft gefangen. Ihre Anzahl ist stark reduziert."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/25.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/25.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Ledyba",
-		fr: "Coxy"
+		fr: "Coxy",
+		de: "Ledyba"
 	},
 
 	stage: "Stage1",
@@ -83,7 +84,8 @@ const card: Card = {
 	retreat: 0,
 
 	description: {
-		en: "The spot patterns on its back grow larger or smaller depending on the number of stars in the night sky."
+		en: "The spot patterns on its back grow larger or smaller depending on the number of stars in the night sky.",
+		de: "Die Größe des Sternenmusters hängt direkt mit der Anzahl der Sterne am Firmament zusammen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/26.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/26.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Bayleef",
-		fr: "Macronium"
+		fr: "Macronium",
+		de: "Lorblatt"
 	},
 
 	stage: "Stage2",
@@ -84,7 +85,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "Meganium’s breath has the power to revive dead grass and plants. It can make them healthy again."
+		en: "Meganium’s breath has the power to revive dead grass and plants. It can make them healthy again.",
+		de: "MEGANIE kann mit seinem Atem abgestorbene Gräser und Planzen reanimieren. Sie sind dann gesund."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/27.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/27.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Meowth",
-		fr: "Miaouss"
+		fr: "Miaouss",
+		de: "Mauzi"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. For each heads, discard a card from your opponent's hand without looking.",
 				fr: "Lancez 3 pièces. Pour chaque face, défaussez une carte de la main de votre adversaire sans la regarder.",
-				de: "Wirf 3 Münzen. Wähle pro \"Kopf\" 1 Karte von der Hand deines Gegners (ohne sie vorher anzusehen) und lege sie auf seinen Ablagestapel."
+				de: "Wirf 3 Münzen. Wähle pro „Kopf“ 1 Karte von der Hand deines Gegners (ohne sie vorher anzusehen) und lege sie auf seinen Ablagestapel."
 			},
 
 		},
@@ -58,7 +59,7 @@ const card: Card = {
 			effect: {
 				en: "If Persian has any Darkness Energy attached to it, this attack does 30 damage plus 30 more damage.",
 				fr: "Si des cartes Énergie Darkness sont attachées à Persian, cette attaque inflige 30 dégâts plus 30 dégâts supplémentaires.",
-				de: "Wenn an Snobilikat mindestens 1 -Energie angelegt ist, fügt dieser Angriff 30 Schadenspunkte plus 30 weitere Schadenspunkte zu."
+				de: "Wenn an Snobilikat mindestens 1 {D}-Energie angelegt ist, fügt dieser Angriff 30 Schadenspunkte plus 30 weitere Schadenspunkte zu."
 			},
 			damage: "30+",
 
@@ -75,7 +76,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Its lithe muscles allow it to walk without making a sound. It attacks in an instant."
+		en: "Its lithe muscles allow it to walk without making a sound. It attacks in an instant.",
+		de: "Aufgrund seiner geschmeidigen Muskeln kann es sich lautlos bewegen. Es greift ohne Vorwarnung an."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/28.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/28.ts
@@ -50,7 +50,7 @@ const card: Card = {
 			effect: {
 				en: "Each player may search his or her deck for as many Basic Pokémon as he or she likes, put them onto his or her Bench, and shuffle his or her deck afterward. (You put your Pokémon on the Bench first.) Pichu is now Asleep.",
 				fr: "Chaque joueur peut chercher dans son deck autant de Pokémon de base qu’il le souhaite, les mettre sur son Banc, puis mélanger son deck. (Vous devez être le premier à mettre vos Pokémon sur le Banc.) Pichu est maintenant Endormi.",
-				de: "Jeder Spieler kann sein Deck nach beliebig vielen Basis-Pokémon-Karten durchsuchen, sie auf die Bank legen und anschließend sein Deck mischen. (Du legst deine Pokémon zuerst auf die Bank.) Pichu schläft jetzt."
+				de: "Jeder Spieler kann sein Deck nach beliebig vielen Basis-Pokémon-Karten durchsuchen, sie auf seine Bank legen und anschließend sein Deck mischen. (Du legst deine Pokémon zuerst auf die Bank.) Pichu schläft jetzt."
 			},
 
 		},
@@ -59,7 +59,8 @@ const card: Card = {
 	retreat: 0,
 
 	description: {
-		en: "Despite its small size, it can zap even adult humans. However, if it does so, it also surprises itself."
+		en: "Despite its small size, it can zap even adult humans. However, if it does so, it also surprises itself.",
+		de: "Obwohl es so klein ist, kann es sogar Erwachsene überwältigen. Tritt dies ein, ist es selbst erstaunt."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/29.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/29.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Sandshrew",
-		fr: "Sabelette"
+		fr: "Sabelette",
+		de: "Sandan"
 	},
 
 	stage: "Stage1",
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 30 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 30 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "30×",
 
@@ -85,7 +86,8 @@ const card: Card = {
 	retreat: 0,
 
 	description: {
-		en: "If it digs at an incredible pace, it may snap off its spike and claws. They grow back in a day."
+		en: "If it digs at an incredible pace, it may snap off its spike and claws. They grow back in a day.",
+		de: "Wenn es schnell gräbt, können seine Stacheln und Krallen abbrechen. Sie wachsen binnen eines Tages nach."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/3.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/3.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Clefairy",
-		fr: "Mélofée"
+		fr: "Mélofée",
+		de: "Piepi"
 	},
 
 	stage: "Stage1",
@@ -72,7 +73,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "With its acute hearing, it can pick up sounds from far away. It usually hides in quiet places."
+		en: "With its acute hearing, it can pick up sounds from far away. It usually hides in quiet places.",
+		de: "Mit seinem sensiblen Gehör nimmt es entfernte Geräusche wahr. Es versteckt sich an ruhigen Orten."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/30.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/30.ts
@@ -59,7 +59,8 @@ const card: Card = {
 	retreat: 0,
 
 	description: {
-		en: "Its lips are the most sensitive part of its body. It always uses its lips first to examine things."
+		en: "Its lips are the most sensitive part of its body. It always uses its lips first to examine things.",
+		de: "Die Lippen sind sein empfindlichster Körperteil. Neue Dinge untersucht es zuerst damit."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/31.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/31.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Sunkern",
-		fr: "Tournegrin"
+		fr: "Tournegrin",
+		de: "Sonnkern"
 	},
 
 	stage: "Stage1",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may search your deck for a Grass Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward. This power can't be used if Sunflora is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez chercher un Pokémon Grass dans votre deck, le montrer à votre adversaire et l’ajouter à votre main. Mélangez ensuite votre deck. Ce pouvoir ne peut pas être utilisé si Heliatronc est affecté par un État spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du dein Deck nach 1 -Pokémon durchsuchen, es deinem Gegner zeigen und auf die Hand nehmen. Mische anschließend dein Deck. Diese Poké-Power kann nicht benutzt werden, wenn Sonnflora von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du dein Deck nach 1 {G}-Pokémon durchsuchen, es deinem Gegner zeigen und auf die Hand nehmen. Mische anschließend dein Deck. Diese Poké-Power kann nicht benutzt werden, wenn Sonnflora von einem Speziellen Zustand betroffen ist."
 			}
 		},
 	],
@@ -79,7 +80,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It converts sunlight into energy. In the darkness after sunset, it closes its petals and becomes still."
+		en: "It converts sunlight into energy. In the darkness after sunset, it closes its petals and becomes still.",
+		de: "Es wandelt Sonnenlicht in Energie. Nach Sonnenuntergang schließt es seine Blüten und wird still."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/32.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/32.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Quilava",
-		fr: "Fleurisson"
+		fr: "Fleurisson",
+		de: "Igelavar"
 	},
 
 	stage: "Stage2",
@@ -74,7 +75,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It has a secret, devastating move. It rubs its blazing fur together to cause huge explosions."
+		en: "It has a secret, devastating move. It rubs its blazing fur together to cause huge explosions.",
+		de: "Es verfügt über eine verheerende Geheimattacke. Es reibt sein Fell, um Explosionen zu erzeugen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/33.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/33.ts
@@ -60,7 +60,8 @@ const card: Card = {
 	retreat: 0,
 
 	description: {
-		en: "Even though it is small, it can’t be ignored because it will slug any handy target without warning."
+		en: "Even though it is small, it can’t be ignored because it will slug any handy target without warning.",
+		de: "Es ist zwar nicht groß, aber dennoch unübersehbar, denn es schlägt jederzeit ohne Vorwarnug zu."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/34.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/34.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Koffing",
-		fr: "Smogo"
+		fr: "Smogo",
+		de: "Smogon"
 	},
 
 	stage: "Stage1",
@@ -75,7 +76,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "If one of the twin Koffing inflates, the other one deflates. It constantly mixes its poisonous gases."
+		en: "If one of the twin Koffing inflates, the other one deflates. It constantly mixes its poisonous gases.",
+		de: "Pumpt sich eines der zwei SMOGON auf, lässt das andere Luft ab. So findet ein Giftgasaustausch statt."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/35.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/35.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Chikorita",
-		fr: "Germignon"
+		fr: "Germignon",
+		de: "Endivie"
 	},
 
 	stage: "Stage1",
@@ -76,7 +77,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "A spicy aroma emanates from around its neck. The aroma acts as a stimulant to restore health."
+		en: "A spicy aroma emanates from around its neck. The aroma acts as a stimulant to restore health.",
+		de: "Ein würziges Aroma geht von seinen Blättern aus. Das Aroma soll gesundheitsfördernd sein."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/36.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/36.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Chansey",
-		fr: "Leveinard"
+		fr: "Leveinard",
+		de: "Chaneira"
 	},
 
 	stage: "Stage1",
@@ -77,7 +78,8 @@ const card: Card = {
 	retreat: 3,
 
 	description: {
-		en: "Anyone who takes even one taste of Blissey’s egg becomes unfailingly caring and pleasant to everyone."
+		en: "Anyone who takes even one taste of Blissey’s egg becomes unfailingly caring and pleasant to everyone.",
+		de: "Jeder, der einen Bissen von dem Ei, das HEITEIRA hält, nimmt, wird gegenüber anderen sorgsam und höflich."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/37.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/37.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Discard a Water Energy attached to Corsola and remove all damage counters from Corsola.",
 				fr: "Défaussez une carte Énergie Water attachée à Corayon et retirez tous les marqueurs de dégâts sur Corayon.",
-				de: "Lege 1 an Corasonn angelegte -Energie auf deinen Ablagestapel und entferne alle Schadensmarken von Corasonn."
+				de: "Lege 1 an Corasonn angelegte {W}-Energie auf deinen Ablagestapel und entferne alle Schadensmarken von Corasonn."
 			},
 
 		},
@@ -53,7 +53,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. If both of them are heads, this attack does 20 damage plus 50 more damage.",
 				fr: "Lancez 2 pièces. Si les deux pièces tombent sur face, cette attaque inflige 20 dégâts plus 50 dégâts supplémentaires.",
-				de: "Wirf 2 Münzen. Wenn beide \"Kopf\" zeigen, fügt dieser Angriff 20 Schadenspunkte plus 50 weitere Schadenspunkte zu."
+				de: "Wirf 2 Münzen. Wenn beide „Kopf“ zeigen, fügt dieser Angriff 20 Schadenspunkte plus 50 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -70,7 +70,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It continuously sheds and grows. The tip of its head is prized as a treasure because of its beauty."
+		en: "It continuously sheds and grows. The tip of its head is prized as a treasure because of its beauty.",
+		de: "Es häutet sich ständig und wächst. Seine Kopfspitze wurde als Schatz der Schönheit ausgezeichnet."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/38.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/38.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Totodile",
-		fr: "Kaiminus"
+		fr: "Kaiminus",
+		de: "Karnimani"
 	},
 
 	stage: "Stage1",
@@ -74,7 +75,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "If it loses a fang, a new one grows back in its place. There are always 48 fangs lining its mouth."
+		en: "If it loses a fang, a new one grows back in its place. There are always 48 fangs lining its mouth.",
+		de: "Verliert es einen seiner Zähne, wächst ein neuer nach. Es hat immer 48 Zähne in seinem Kiefer."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/39.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/39.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Draw a card for each Water Energy attached to all of your Pokémon.",
 				fr: "Piochez une carte pour chaque carte Énergie Water attachée à l’ensemble de vos Pokémon.",
-				de: "Ziehe eine Karte für jede -Energie, die an allen deinen Pokémon angelegt ist."
+				de: "Ziehe eine Karte für jede {W}-Energie, die an allen deinen Pokémon angelegt ist."
 			},
 
 		},
@@ -76,7 +76,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It nests at the edge of sharp cliffs. It spends all day carrying food to its awaiting chicks."
+		en: "It nests at the edge of sharp cliffs. It spends all day carrying food to its awaiting chicks.",
+		de: "Sein Nest baut es an scharfkantigen Felsklippen. Es ist den ganzen Tag auf Futtersuche für seine Jungen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/4.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/4.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Magikarp",
-		fr: "Magicarpe"
+		fr: "Magicarpe",
+		de: "Karpador"
 	},
 
 	stage: "Stage1",
@@ -83,7 +84,8 @@ const card: Card = {
 	retreat: 3,
 
 	description: {
-		en: "Once it appears, it goes on a rampage. It remains enraged until it demolishes everything around it."
+		en: "Once it appears, it goes on a rampage. It remains enraged until it demolishes everything around it.",
+		de: "Taucht es auf, randaliert es. Es beruhigt sich erst, wenn es alles um sich zerstört hat."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/40.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/40.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Phanpy",
-		fr: "Phanpy"
+		fr: "Phanpy",
+		de: "Phanpy"
 	},
 
 	stage: "Stage1",
@@ -63,7 +64,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 70 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 70 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 70 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 70 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "70×",
 
@@ -87,7 +88,8 @@ const card: Card = {
 	retreat: 3,
 
 	description: {
-		en: "It has sharp, hard tusks and a rugged hide. Its tackle is strong enough to knock down a house."
+		en: "It has sharp, hard tusks and a rugged hide. Its tackle is strong enough to knock down a house.",
+		de: "Aufgrund seiner scharfen Stoßzähne und seiner rauen Haut könnte es mit Tackle ein Haus niederreißen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/41.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/41.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c’est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 
 		},
@@ -69,7 +69,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "When spotted, this Pokémon escapes backward by furiously boring into the ground with its tail."
+		en: "When spotted, this Pokémon escapes backward by furiously boring into the ground with its tail.",
+		de: "Wird es entdeckt, flüchtet dieses Pokémon, indem es sich mit seinem Schweif in den Boden gräbt."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/42.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/42.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Mareep",
-		fr: "Wattouat"
+		fr: "Wattouat",
+		de: "Voltilamm"
 	},
 
 	stage: "Stage1",
@@ -59,7 +60,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c’est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 40,
 
@@ -83,7 +84,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "As a result of storing too much electricity, it developed patches where even downy wool won’t grow."
+		en: "As a result of storing too much electricity, it developed patches where even downy wool won’t grow.",
+		de: "Da es zu viel Elektrizität gespeichert hat, hat es Flecken, an denen nicht einmal feine Wolle wächst."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/43.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/43.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			effect: {
 				en: "Draw a card for each of your Grass Pokémon in play.",
 				fr: "Piochez une carte pour chacun de vos Pokémon Grass en jeu.",
-				de: "Ziehe eine Karte für jedes deiner -Pokémon im Spiel."
+				de: "Ziehe eine Karte für jedes deiner {G}-Pokémon im Spiel."
 			},
 
 		},
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 30 damage plus 20 more damage for each heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts plus 20 dégâts supplémentaires pour chaque face.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte plus 20 weitere Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte plus 20 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "30+",
 
@@ -72,7 +72,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "This powerful Pokémon thrusts its prized horn under its enemies’ bellies, then lifts and throws them."
+		en: "This powerful Pokémon thrusts its prized horn under its enemies’ bellies, then lifts and throws them.",
+		de: "Dieses kräftige Pokémon rammt sein stolzes Horn unter den Rumpf des Gegners und wirft ihn um."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/44.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/44.ts
@@ -50,7 +50,7 @@ const card: Card = {
 			effect: {
 				en: "Igglybuff is now Asleep. During your opponent's next turn, the attack cost of each of the Defending Pokémon's attacks is Colorless more.",
 				fr: "Toudoudou est maintenant Endormi. Au prochain tour de votre adversaire, le coût de l’attaque de chaque Pokémon Défenseur est plus élevé de Colorless.",
-				de: "Fluffeluff schläft jetzt. Während des nächsten Zuges deines Gegners kosten die Angriffe jedes Verteidigenden Pokémons  mehr."
+				de: "Fluffeluff schläft jetzt. Während des nächsten Zuges deines Gegners kosten die Angriffe jedes Verteidigenden Pokémons {C} mehr."
 			},
 
 		},
@@ -59,7 +59,8 @@ const card: Card = {
 	retreat: 0,
 
 	description: {
-		en: "Its extremely flexible and elastic body makes it bounce continuously—anytime, anywhere."
+		en: "Its extremely flexible and elastic body makes it bounce continuously—anytime, anywhere.",
+		de: "Aufgrund seines extrem flexiblen und elastischen Körpers springt es ständig überall umher."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/45.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/45.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Search your deck for a Water Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
 				fr: "Cherchez un Pokémon Water dans votre deck, montrez-le à votre adversaire, puis ajoutez-le à votre main. Mélangez ensuite votre deck.",
-				de: "Durchsuche dein Deck nach 1 -Pokémon-Karte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische anschließend dein Deck."
+				de: "Durchsuche dein Deck nach 1 {W}-Pokémon-Karte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische anschließend dein Deck."
 			},
 
 		},
@@ -77,7 +77,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "As it majestically swims, it doesn’t care if Remoraid attach to it for scavenging its leftovers."
+		en: "As it majestically swims, it doesn’t care if Remoraid attach to it for scavenging its leftovers.",
+		de: "Da es so majestätisch schwimmt, schert es sich nicht um REMORAID, das seine Essensreste vertilgt."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/46.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/46.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Caterpie",
-		fr: "Chenipan"
+		fr: "Chenipan",
+		de: "Raupy"
 	},
 
 	stage: "Stage1",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Each of your Grass Pokémon has no Weakness.",
 				fr: "Vos Pokémon Grass ne subissent plus la Faiblesse.",
-				de: "Jedes deiner -Pokémon hat keine Schwäche mehr."
+				de: "Jedes deiner {G}-Pokémon hat keine Schwäche mehr."
 			}
 		},
 	],
@@ -71,7 +72,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It prepares for evolution by hardening its shell as much as possible to protect its soft body."
+		en: "It prepares for evolution by hardening its shell as much as possible to protect its soft body.",
+		de: "Steht seine Entwicklung bevor, härtet es seine Schale, um seinen empfindlichen Körper zu schützen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/47.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/47.ts
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c’est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 30,
 
@@ -71,7 +71,8 @@ const card: Card = {
 	retreat: 3,
 
 	description: {
-		en: "If it is around babies, the milk it produces contains much more nutrition than usual."
+		en: "If it is around babies, the milk it produces contains much more nutrition than usual.",
+		de: "Wenn es gerade ein Junges hat, dann enthält seine Milch mehr Nährstoffe als gewöhnlich."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/48.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/48.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Paras",
-		fr: "Paras"
+		fr: "Paras",
+		de: "Paras"
 	},
 
 	stage: "Stage1",
@@ -72,7 +73,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "The larger the mushroom on its back grows, the stronger the mushroom spores it scatters."
+		en: "The larger the mushroom on its back grows, the stronger the mushroom spores it scatters.",
+		de: "Je größer der Pilz auf seinem Rücken wird, desto stärker werden auch die Sporen, die es verteilt."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/49.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/49.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Cyndaquil",
-		fr: "Héricendre"
+		fr: "Héricendre",
+		de: "Feurigel"
 	},
 
 	stage: "Stage1",
@@ -74,7 +75,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "This Pokémon is fully covered by nonflammable fur. It can withstand any kind of fire attack."
+		en: "This Pokémon is fully covered by nonflammable fur. It can withstand any kind of fire attack.",
+		de: "Das Fell dieses Pokémon ist nicht entflammbar. Es ist gegen jegliche Feuerattacken immun."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/5.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/5.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 
@@ -72,7 +72,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It launches kicks while spinning. If it spins at high speed, it may bore its way into the ground."
+		en: "It launches kicks while spinning. If it spins at high speed, it may bore its way into the ground.",
+		de: "Es dreht sich um sich selbst und verteilt Tritte. Ist es schnell genug, bohrt es sich in den Boden."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/50.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/50.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned. If tails, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c’est face, le Pokémon Défenseur est maintenant Empoisonné. Si c’est pile, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt vergiftet. Bei \"Zahl\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet. Bei „Zahl“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 30,
 
@@ -54,7 +54,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "To fire its poison spikes, it must inflate its body by drinking over 2.6 gallons of water all at once."
+		en: "To fire its poison spikes, it must inflate its body by drinking over 2.6 gallons of water all at once.",
+		de: "Um seine Giftstacheln abzufeuern, muss es seinen Körper aufpumpen, indem es 10 Liter trinkt."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/51.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/51.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Hoppip",
-		fr: "Granivol"
+		fr: "Granivol",
+		de: "Hoppspross"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 10 more damage.",
 				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires.",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -65,7 +66,8 @@ const card: Card = {
 	retreat: 0,
 
 	description: {
-		en: "The bloom on top of its head opens and closes as the temperature fluctuates up and down."
+		en: "The bloom on top of its head opens and closes as the temperature fluctuates up and down.",
+		de: "Temperaturschwankungen veranlassen es, die Blüte auf seinem Kopf immer zu öffnen oder zu schließen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/52.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/52.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Slowpoke",
-		fr: "Ramoloss"
+		fr: "Ramoloss",
+		de: "Flegmon"
 	},
 
 	stage: "Stage1",
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Does 30 damage plus 20 more damage for each Psychic Energy attached to Slowbro.",
 				fr: "Inflige 30 dégâts plus 20 dégâts supplémentaires pour chaque carte Énergie Psychic attachée à Flagadoss.",
-				de: "Dieser Angriff fügt 30 Schadenspunkte plus 20 weitere Schadenspunkte für jede an Lahmus angelegte -Energie zu."
+				de: "Dieser Angriff fügt 30 Schadenspunkte plus 20 weitere Schadenspunkte für jede an Lahmus angelegte {P}-Energie zu."
 			},
 			damage: "30+",
 
@@ -77,7 +78,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "If the tail-biting Shellder is thrown off in a harsh battle, it reverts to being an ordinary Slowpoke."
+		en: "If the tail-biting Shellder is thrown off in a harsh battle, it reverts to being an ordinary Slowpoke.",
+		de: "Wenn das MUSCHAS an seinem Schweif in einem Kampf abgeschüttelt wird, entwickelt es sich zu FLEGMON zurück."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/53.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/53.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Staryu",
-		fr: "Stari"
+		fr: "Stari",
+		de: "Sterndu"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Choose as many Water Energy attached to your Pokémon as you like. This attack does 20 damage times the number of Energy you chose. Shuffle those cards back into your deck.",
 				fr: "Choisissez autant de cartes Énergie Water attachées à votre Pokémon que vous le souhaitez. Cette attaque inflige 20 dégâts multipliés par le nombre de cartes Énergie que vous avez choisies. Mélangez ces cartes dans votre deck.",
-				de: "Wähle eine beliebige Anzahl -Energien, die an 1 deiner Pokémon angelegt sind. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl der gewählten Energie zu. Mische die gewählten Karten anschließend in dein Deck."
+				de: "Wähle eine beliebige Anzahl {W}-Energien, die an 1 deiner Pokémon angelegt sind. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl der gewählten Energien zu. Mische die gewählten Karten anschließend in dein Deck."
 			},
 			damage: "20×",
 
@@ -58,7 +59,8 @@ const card: Card = {
 	retreat: 0,
 
 	description: {
-		en: "The middle section of its body is called the core. It glows in a different color each time it is seen."
+		en: "The middle section of its body is called the core. It glows in a different color each time it is seen.",
+		de: "Der Mittelteil seines Körpers wird Kern genannt. Bei jedem Hinsehen leuchtet er in einer anderen Farbe."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/54.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/54.ts
@@ -65,7 +65,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Their shapes look like hieroglyphs on ancient tablets. It is said that the two are somehow related."
+		en: "Their shapes look like hieroglyphs on ancient tablets. It is said that the two are somehow related.",
+		de: "Ihr Äußeres erinnert an Hieroglyphen auf antiken Steinplatten. Man sagt, es gäbe einen Zusammenhang."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/55.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/55.ts
@@ -65,7 +65,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Its flat, thin body is always stuck on walls. Its shape appears to have some meaning."
+		en: "Its flat, thin body is always stuck on walls. Its shape appears to have some meaning.",
+		de: "Sein flacher, dünner Körper hängt immer an Wänden. Seine Form scheint eine Bedeutung zu haben."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/56.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/56.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Jigglypuff",
-		fr: "Rondoudou"
+		fr: "Rondoudou",
+		de: "Pummeluff"
 	},
 
 	stage: "Stage1",
@@ -42,7 +43,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 40 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 40 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "40×",
 
@@ -78,7 +79,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It has a very fine fur. Take care not to make it angry, or it may inflate steadily and hit with a Body Slam."
+		en: "It has a very fine fur. Take care not to make it angry, or it may inflate steadily and hit with a Body Slam.",
+		de: "Es hat ein weiches Fell. Verärgere es nicht, denn andernfalls setzt es ständig Bodyslam ein."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/57.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/57.ts
@@ -49,7 +49,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Its feet have suction cups designed to stick to any surface. It tenaciously climbs trees to forage."
+		en: "Its feet have suction cups designed to stick to any surface. It tenaciously climbs trees to forage.",
+		de: "Die Saugnäpfe an seinen Beinen haften auf jedem Untergrund. Es sucht hartnäckig in Bäumen nach Futter."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/58.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/58.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, remove 3 damage counters from Chansey.",
 				fr: "Lancez une pièce. Si c’est face, retirez 3 marqueurs de dégâts de Leveinard.",
-				de: "Wirf eine Münze. Entferne bei \"Kopf\" 3 Schadensmarken von Chaneira."
+				de: "Wirf eine Münze. Entferne bei „Kopf“ 3 Schadensmarken von Chaneira."
 			},
 			damage: 30,
 
@@ -69,7 +69,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It walks carefully to prevent its egg from breaking. However, it is extremely fast at running away."
+		en: "It walks carefully to prevent its egg from breaking. However, it is extremely fast at running away.",
+		de: "Es läuft extrem langsam, damit sein Ei nicht zerbricht. Es kann jedoch schnell davonlaufen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/59.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/59.ts
@@ -70,7 +70,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Its pleasantly aromatic leaf has the ability to check the humidity and temperature."
+		en: "Its pleasantly aromatic leaf has the ability to check the humidity and temperature.",
+		de: "Mit seinem aromatischem Blatt ist es in der Lage, die Temperatur und die Luftfeuchtigkeit zu messen"
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/6.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/6.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Skiploom",
-		fr: "Floravol"
+		fr: "Floravol",
+		de: "Hubelupf"
 	},
 
 	stage: "Stage2",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Does 10 damage times the number of Pokémon in play (both yours and your opponent's).",
 				fr: "Inflige 10 dégâts multiplié par le nombre de Pokémon en jeu (les vôtres et ceux de votre adversaire).",
-				de: "Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl der Pokémon im Spiel (deiner und deines Gegners) zu."
+				de: "Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl der Pokémon im Spiel (deiner und der deines Gegners) zu."
 			},
 			damage: "10×",
 
@@ -82,7 +83,8 @@ const card: Card = {
 	retreat: 0,
 
 	description: {
-		en: "Once it catches the wind, it deftly controls its cotton-puff spores—it can even float around the world."
+		en: "Once it catches the wind, it deftly controls its cotton-puff spores—it can even float around the world.",
+		de: "Wenn es einmal vom Wind erfasst wurde, wird es mit seinen Fallschirmchen um den ganzen Erdball getragen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/60.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/60.ts
@@ -65,7 +65,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "The moonlight that it stores in the wings on its back apparently gives it the ability to float in midair."
+		en: "The moonlight that it stores in the wings on its back apparently gives it the ability to float in midair.",
+		de: "Aufgrund des gespeicherten Mondlichts in seinen Flügeln auf dem Rücken kann es in der Luft schweben."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/61.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/61.ts
@@ -63,7 +63,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It usually stays hunched over. If it is angry or surprised, it shoots flames out of its back."
+		en: "It usually stays hunched over. If it is angry or surprised, it shoots flames out of its back.",
+		de: "Es ist immer gebeugt. Wird es angegriffen oder überrascht, schießen Flammen aus seinem Rücken."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/62.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/62.ts
@@ -66,7 +66,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It remembers every dream it eats. It rarely eats the dreams of adults because children’s are much tastier."
+		en: "It remembers every dream it eats. It rarely eats the dreams of adults because children’s are much tastier.",
+		de: "Es kann sich an jeden gefressenen Traum erinnern. Die Träume von Kindern bekommen ihm besser."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/63.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/63.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin until you get tails. This attack does 10 damage times the number of heads.",
 				fr: "Lancez une pièce jusqu’à ce qu’elle tombe sur pile. Cette attaque inflige 10 dégâts multipliés par le nombre de faces.",
-				de: "Wirf solange eine Münze, bis zum ersten Mal das Ergebnis \"Zahl\" kommt. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf so lange 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10×",
 
@@ -53,7 +53,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Using telepathy only they can employ, they always form a cluster of six Exeggcute."
+		en: "Using telepathy only they can employ, they always form a cluster of six Exeggcute.",
+		de: "Mit Telepathie, die nur sie verstehen, bilden sie stets eine Gruppe von sechs OWEI."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/64.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/64.ts
@@ -66,7 +66,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Its tail has a small brain of its own. Beware! If you get close, it may react to your scent and bite."
+		en: "Its tail has a small brain of its own. Beware! If you get close, it may react to your scent and bite.",
+		de: "Sein Schweif hat ein eigenes Gehirn. Achtung! Kommst du ihm zu nahe, kann es dich riechen und beißt."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/65.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/65.ts
@@ -64,7 +64,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It has a brave and trustworthy nature. It fearlessly stands up to bigger and stronger foes."
+		en: "It has a brave and trustworthy nature. It fearlessly stands up to bigger and stronger foes.",
+		de: "Es ist von Natur aus tapfer und vertrauenswürdig. Es scheut nicht vor starken Gegnern zurück."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/66.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/66.ts
@@ -73,7 +73,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It always stands on one foot. It changes feet so fast, the movement can rarely be seen."
+		en: "It always stands on one foot. It changes feet so fast, the movement can rarely be seen.",
+		de: "Es steht immer auf einem Bein. Es wechselt sein Standbein so schnell, dass man es kaum sieht."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/67.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/67.ts
@@ -60,7 +60,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "To keep from being blown away by the wind, they gather in clusters. But they do enjoy gentle breezes."
+		en: "To keep from being blown away by the wind, they gather in clusters. But they do enjoy gentle breezes.",
+		de: "Um nicht vom Wind davongeweht zu werden, treten sie stets in Gruppen auf. Eine Brise gefällt ihnen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/68.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/68.ts
@@ -54,7 +54,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Looking into its cute, round eyes causes it to sing a relaxing melody, inducing its enemies to sleep."
+		en: "Looking into its cute, round eyes causes it to sing a relaxing melody, inducing its enemies to sleep.",
+		de: "Schaut man ihm in seine niedlichen Kulleraugen, beginnt es zu singen und seine Gegner schlafen ein."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/69.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/69.ts
@@ -53,7 +53,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c’est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -70,7 +70,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It rocks its body rhythmically. It appears to alter the rhythm depending on how it is feeling."
+		en: "It rocks its body rhythmically. It appears to alter the rhythm depending on how it is feeling.",
+		de: "Es bewegt seinen Körper rhythmisch hin und her. Seine Gemütslage bestimmt den Rhythmus."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/7.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/7.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Vulpix",
-		fr: "Goupix"
+		fr: "Goupix",
+		de: "Vulpix"
 	},
 
 	stage: "Stage1",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may discard a Fire Energy card from your hand. If you do, draw 3 cards. This power can't be used if Ninetales is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez vous défausser d’une carte Énergie Fire. Dans ce cas, piochez 3 cartes. Ce pouvoir ne peut pas être utilisé si Feunard est affecté par un État spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 -Energiekarte aus deiner Hand auf deinen Ablagestapel legen. Wenn du das machst, ziehe 3 Karten. Diese Poké-Power kann nicht benutzt werden, wenn Vulnona von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 {R}-Energiekarte aus deiner Hand auf deinen Ablagestapel legen. Wenn du das machst, ziehe 3 Karten. Diese Poké-Power kann nicht benutzt werden, wenn Vulnona von einem Speziellen Zustand betroffen ist."
 			}
 		},
 	],
@@ -72,7 +73,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Its nine beautiful tails are filled with a wondrous energy that could keep it alive for 1,000 years."
+		en: "Its nine beautiful tails are filled with a wondrous energy that could keep it alive for 1,000 years.",
+		de: "Seine neun schönen Schweife sind erfüllt von einer magischen Energie, um es 1000 Jahre leben zu lassen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/70.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/70.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
 				fr: "Si le Pokémon Défenseur essaie d’attaquer pendant le prochain tour de votre adversaire, votre adversaire lance une pièce. Si c’est pile, cette attaque ne fait rien.",
-				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 10,
 
@@ -67,7 +67,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Its thin, filmy body is filled with gases that cause constant sniffles, coughs and teary eyes."
+		en: "Its thin, filmy body is filled with gases that cause constant sniffles, coughs and teary eyes.",
+		de: "Sein dünner Körper ist mit Gasen angefüllt, die Husten und Schnupfen verursachen und die Augen reizen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/71.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/71.ts
@@ -50,7 +50,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 4 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 4 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 4 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 4 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10×",
 
@@ -74,7 +74,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "When the weather turns cold, lots of Ledyba gather from everywhere to cluster and keep each other warm."
+		en: "When the weather turns cold, lots of Ledyba gather from everywhere to cluster and keep each other warm.",
+		de: "Wird es kalt, versammeln sich viele LEDYBA von nah und fern, um sich gegenseitig Wärme zu schenken."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/72.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/72.ts
@@ -49,7 +49,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "For no reason, it jumps and splashes about, making it easy for predators like Pidgeotto to catch it mid-jump."
+		en: "For no reason, it jumps and splashes about, making it easy for predators like Pidgeotto to catch it mid-jump.",
+		de: "Es springt grundlos in die Luft. Das macht es einfach für Räuber wie TAUBOGA, es im Sprung zu fangen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/73.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/73.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Search your deck for a number of Lightning Energy cards up to the number of Mareep in play (both yours and your opponent's) and attach them to Mareep. Shuffle your deck afterward.",
 				fr: "Cherchez dans votre deck un nombre de cartes Énergie Lightning allant jusqu’au nombre de Wattouat en jeu (les vôtres et ceux de votre adversaire) et attachez-les à Wattouat. Mélangez ensuite votre deck.",
-				de: "Durchsuche dein Deck nach einer Anzahl Elektro-Energiekarten, die höchstens der Anzahl an Voltilamm-Karten im Spiel (deinen und denen deines Gegners) entspricht und lege sie an Voltilamm an. Mische anschließend dein Deck."
+				de: "Durchsuche dein Deck nach einer Anzahl {L}-Energiekarten, die höchstens der Anzahl an Voltilamm-Karten im Spiel (deinen und denen deines Gegners) entspricht und lege sie an Voltilamm an. Mische anschließend dein Deck."
 			},
 
 		},
@@ -73,7 +73,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "If static electricity builds in its body, its fleece doubles in volume. Touching it will shock you."
+		en: "If static electricity builds in its body, its fleece doubles in volume. Touching it will shock you.",
+		de: "Lädt es sich statisch auf, verdoppelt sich sein Umfang. Wer es berührt, erhält einen Elektroschock."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/74.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/74.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 10 more damage.",
 				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires.",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -68,7 +68,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "The end of its tail serves as a buoy that keeps it from drowning, even in a vicious current."
+		en: "The end of its tail serves as a buoy that keeps it from drowning, even in a vicious current.",
+		de: "Da es am Schweifende eine Art Boje trägt, kann es selbst bei der stärksten Strömung nicht ertrinken."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/75.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/75.ts
@@ -67,7 +67,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It loves anything that shines. It especially adores coins that it picks up and secretly hoards."
+		en: "It loves anything that shines. It especially adores coins that it picks up and secretly hoards.",
+		de: "Es liebt alles Glänzende. Es hat eine Vorliebe für Münzen, die es aufliest und unbemerkt hortet."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/76.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/76.ts
@@ -67,7 +67,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "As its body grows large, large mushrooms named tochukaso start sprouting out of its back."
+		en: "As its body grows large, large mushrooms named tochukaso start sprouting out of its back.",
+		de: "Während es langsam heranwächst, sprießen große, exotische Pilze aus seinem Rücken."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/77.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/77.ts
@@ -60,7 +60,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It swings its long snout around playfully, but because it is so strong, that can be dangerous."
+		en: "It swings its long snout around playfully, but because it is so strong, that can be dangerous.",
+		de: "Es wirft seinen langen Rüssel im Spiel wild hin und her. Da es so stark ist, könnte dies gefährlich werden."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/78.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/78.ts
@@ -50,7 +50,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 10 more damage.",
 				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires.",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -74,7 +74,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It raises its tail to check its surroundings. The tail is sometimes struck by lightning in this pose."
+		en: "It raises its tail to check its surroundings. The tail is sometimes struck by lightning in this pose.",
+		de: "Es streckt seinen Schweif nach oben, um seine Umgebung zu prüfen. Häufig fährt ein Blitz hinein."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/79.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/79.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, prevent all damage done to Sandshrew by attacks during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c’est face, évitez tous les dégâts infligés à Sabelette par des attaques pendant le prochain tour de votre adversaire.",
-				de: "Wirf eine Münze. Bei \"Kopf\" verhindere alle Schadenspunkte, die Sandan während des nächsten Zuges deines Gegners durch Angriff zugefügt werden."
+				de: "Wirf eine Münze. Bei „Kopf“ verhindere alle Schadenspunkte, die Sandan während des nächsten Zuges deines Gegners durch Angriffe zugefügt werden."
 			},
 
 		},
@@ -72,7 +72,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Disliking water, it lives in deep burrows in arid areas. It can roll itself instantly into a ball."
+		en: "Disliking water, it lives in deep burrows in arid areas. It can roll itself instantly into a ball.",
+		de: "Da es Wasser verabscheut, gräbt es sich in trockenes Erdreich ein. Es kann sich rasch zu einem Ball einrollen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/8.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/8.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Hoothoot",
-		fr: "Hoothoot"
+		fr: "Hoothoot",
+		de: "Hoothoot"
 	},
 
 	stage: "Stage1",
@@ -83,7 +84,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Its eyes are specially adapted. They concentrate even faint light and enable it to see in the dark."
+		en: "Its eyes are specially adapted. They concentrate even faint light and enable it to see in the dark.",
+		de: "Sein Sehvermögen ist hervorragend. Selbst bei schwachem Licht kann es jedes Detail erkennen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/80.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/80.ts
@@ -65,7 +65,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "A very cautious Pokémon, it raises itself up using its tail to get a better view of its surroundings."
+		en: "A very cautious Pokémon, it raises itself up using its tail to get a better view of its surroundings.",
+		de: "Ein sehr vorsichtiges Pokémon. Es stellt sich auf seinen Schweif, um die Umgebung zu überblicken."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/81.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/81.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c’est pile, cette attaque ne fait rien.",
-				de: "Wirf eine Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Wirf eine Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 20,
 
@@ -53,7 +53,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It lazes vacantly near water. If something bites its tail, it won’t even notice for a whole day."
+		en: "It lazes vacantly near water. If something bites its tail, it won’t even notice for a whole day.",
+		de: "Es faulenzt am Wasser. Wenn es in den Schweif gebissen wird, bemerkt es das erst am nächsten Tag."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/82.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/82.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon.",
 				fr: "Votre adversaire échange le Pokémon Défenseur avec l’un des Pokémon de son Banc.",
-				de: "Der Gegner tauscht das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
+				de: "Dein Gegner tauscht das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
 			},
 
 		},
@@ -66,7 +66,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It has an active, playful nature. Many women like to frolic with it because of its affectionate ways."
+		en: "It has an active, playful nature. Many women like to frolic with it because of its affectionate ways.",
+		de: "Es ist von Natur aus verspielt. Es tollt mit vielen Frauen herum, da es ihnen zugeneigt ist."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/83.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/83.ts
@@ -65,7 +65,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It lies still in the same pose for days in its web, waiting for its unsuspecting prey to wander close."
+		en: "It lies still in the same pose for days in its web, waiting for its unsuspecting prey to wander close.",
+		de: "Es sitzt tagelang regungslos in seinem Netz und lauert unvorsichtiger Beute auf, die ihm zu nahe kommt."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/84.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/84.ts
@@ -49,7 +49,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "At night, the center of its body slowly flickers with the same rhythm as a human heartbeat."
+		en: "At night, the center of its body slowly flickers with the same rhythm as a human heartbeat.",
+		de: "Nachts blinkt die Mitte seines Körpers im selben Rhythmus wie das menschliche Herz."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/85.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/85.ts
@@ -73,7 +73,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It may plummet from the sky. If attacked by a Spearow, it will violently shake its leaves."
+		en: "It may plummet from the sky. If attacked by a Spearow, it will violently shake its leaves.",
+		de: "Manchmal fällt es plötzlich vom Himmel. Wird es von HABITAK angegriffen, schüttelt es seine Blätter."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/86.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/86.ts
@@ -63,7 +63,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Its powerful, well-developed jaws are capable of crushing anything. Even its trainer must be careful."
+		en: "Its powerful, well-developed jaws are capable of crushing anything. Even its trainer must be careful.",
+		de: "Seine starken Kiefer können alles zermalmen. Selbst sein Trainer muss sich vor ihm in Acht nehmen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/87.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/87.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Burned.",
 				fr: "Lancez une pièce. Si c’est face, le Pokémon Défenseur est maintenant Brûlé.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt verbrannt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verbrannt."
 			},
 
 		},
@@ -53,7 +53,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, discard a Fire Energy attached to Vulpix.",
 				fr: "Lancez une pièce. Si c’est pile, défaussez-vous d’une carte Énergie Fire attachée à Goupix.",
-				de: "Wirf eine Münze. Bei \"Zahl\" lege 1 an Vulpix angelegte -Energie auf deinen Ablagestapel."
+				de: "Wirf eine Münze. Bei „Zahl“ lege 1 an Vulpix angelegte {R}-Energie auf deinen Ablagestapel."
 			},
 			damage: 30,
 
@@ -70,7 +70,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "If it is attacked by an enemy that is stronger than itself, it feigns injury to fool the enemy and escapes."
+		en: "If it is attacked by an enemy that is stronger than itself, it feigns injury to fool the enemy and escapes.",
+		de: "Greift es ein größerer Gegner an, täuscht es eine Verletzung vor, um sicher vor ihm zu flüchten."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/88.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/88.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon can't attack during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c’est face, le Pokémon Défenseur ne peut pas attaquer durant le prochain tour de votre adversaire.",
-				de: "Wirf eine Münze. Bei \"Kopf\" kann das Verteidigende Pokémon im nächsten Zug deines Gegners nicht angreifen."
+				de: "Wirf eine Münze. Bei „Kopf“ kann das Verteidigende Pokémon im nächsten Zug deines Gegners nicht angreifen."
 			},
 
 		},
@@ -72,7 +72,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "When it walks around on the ground, it coats its body with a slimy, poisonous film."
+		en: "When it walks around on the ground, it coats its body with a slimy, poisonous film.",
+		de: "Bewegt es sich an Land, bedeckt es seinen gesamten Körper mit einem schleimigen Giftfilm."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/9.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/9.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Wooper",
-		fr: "Axoloto"
+		fr: "Axoloto",
+		de: "Felino"
 	},
 
 	stage: "Stage1",
@@ -83,7 +84,8 @@ const card: Card = {
 	retreat: 3,
 
 	description: {
-		en: "Due to its relaxed and carefree attitude, it often bumps its head on boulders and boat hulls as it swims."
+		en: "Due to its relaxed and carefree attitude, it often bumps its head on boulders and boat hulls as it swims.",
+		de: "Aufgrund seiner sorglosen Einstellung rammt es seinen Kopf oft gegen Felsen oder Schiffsrümpfe."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/91.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/91.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		fr: "Prenez une carte Énergie de base attachée à l’un de vos Pokémon et attachez-la à un autre de vos Pokémon.",
 		en: "Move a basic Energy card attached 1 of your Pokémon to another of your Pokémon.",
-		de: "Lege 1 Basis-Energiekarte, die an 1 deiner Pokémon angelegt ist, an ein anderes deiner Pokémon an."
+		de: "Lege eine Basis-Energiekarte, die an 1 deiner Pokémon angelegt ist, an ein anderes deiner Pokémon an."
 	},
 
 	trainerType: "Item",

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/96.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/96.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		fr: "Regardez les 7 cartes du dessus de votre deck. Choisissez l’une des cartes Supporter qui s’y trouve, montrez-la à votre adversaire et placez-la dans votre main. Mélangez les autres cartes dans votre deck.",
 		en: "Look at the top 7 cards of your deck. Choose a Supporter card you find there, show it to your opponent, and put it into your hand. Shuffle the other cards back into your deck.",
-		de: "Schau dir die obersten 7 Karten deines Decks an. Falls Unterstützungskarten darunter sind, wähle eine davon, zeige sie deinem Gegner und nimm sie auf die Hand. Mische die anderen Karten anschließend in dein Deck."
+		de: "Schau dir die obersten 7 Karten deines Decks an. Falls Unterstützerkarten darunter sind, wähle eine davon, zeige sie deinem Gegner und nimm sie auf die Hand. Mische die anderen Karten anschließend in dein Deck."
 	},
 
 	trainerType: "Item",

--- a/data/HeartGold & SoulSilver/HeartGold SoulSilver/97.ts
+++ b/data/HeartGold & SoulSilver/HeartGold SoulSilver/97.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		fr: "Vous ne pouvez jouer qu’une carte Supporter à chaque tour. Lorsque vous jouez cette carte, placez-la près de votre Pokémon actif. Une fois votre tour terminé, défaussez-vous de cette carte.",
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Search your deck for up to 3 Basic Pokémon, show them to your opponent, and put them into your hand. Shuffle your deck afterward.",
-		de: "Durchsuche dein Deck nach bis zu 3 Basis-Pokémon-Karten, zeige sie deinem Gegner und nimm sie auf die Hand. Mische anschließend dein Deck."
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Durchsuche dein Deck nach bis zu 3 Basis-Pokémon-Karten, zeige sie deinem Gegner und nimm sie auf die Hand. Mische anschließend dein Deck."
 	},
 
 	trainerType: "Supporter",


### PR DESCRIPTION
## Add missing German translations for hgss1

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
