### PR TITLE
Add missing German translations for sm3

### DIFF
--- a/data/Sun & Moon/Burning Shadows/1.ts
+++ b/data/Sun & Moon/Burning Shadows/1.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "When attacked by bird Pokémon, it resists by releasing a terrifically strong odor from its antennae, but it often becomes their prey.",
+		de: "Es versucht, angreifende Vogel-Pokémon mit dem Gestank aus seinen Antennen in die Flucht zu schlagen. Das gelingt ihm aber nicht immer."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/10.ts
+++ b/data/Sun & Moon/Burning Shadows/10.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Ledyba",
 		fr: "Coxy",
+		de: "Ledyba"
 	},
 
 	stage: "Stage1",
@@ -95,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "While it's believed that starlight provides it with energy, this Pokémon also loves to eat berries. In the daytime, it curls up in the grass to sleep.",
+		de: "Es heißt, es ziehe seine Energie aus dem Licht der Sterne, aber es frisst trotzdem mit Wonne Beeren. Tagsüber schläft es im Gras."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/100.ts
+++ b/data/Sun & Moon/Burning Shadows/100.ts
@@ -68,7 +68,7 @@ const card: Card = {
 				es: "Descarta 1 Energía Darkness y 1 Energía Fairy de este Pokémon.",
 				it: "Scarta un’Energia Darkness e un’Energia Fairy assegnate a questo Pokémon.",
 				pt: "Descarte 1 Energia Darkness e 1 Energia Fairy deste Pokémon.",
-				de: "Lege 1 Darkness-Energie sowie 1 Fairy-Energie von diesem Pokémon auf deinen Ablagestapel."
+				de: "Lege 1 {D}-Energie sowie 1 {FAIRY}-Energie von diesem Pokémon auf deinen Ablagestapel."
 			},
 			damage: 150,
 
@@ -86,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "This is Zygarde's form at times when it uses its overwhelming power to suppress those who endanger the ecosystem.",
+		de: "Diese Form nimmt es an, um Lebewesen, die eine Bedrohung für das Ökosystem darstellen, mit überwältigender Kraft zu bezwingen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/101.ts
+++ b/data/Sun & Moon/Burning Shadows/101.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It lies around all day, becoming active near dusk. At night, it wanders the city in search of loose change.",
+		de: "Tagsüber ist es faul und schläft ständig. Erst nach Sonnenuntergang wird es aktiv und durchstöbert die Stadt nach Münzen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/102.ts
+++ b/data/Sun & Moon/Burning Shadows/102.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Meowth",
 		fr: "Miaouss",
+		de: "Mauzi"
 	},
 
 	stage: "Stage1",
@@ -85,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "It has a violent temperament. It will attack anything that looks it in the eye. Its sharp claws inflict deep wounds.",
+		de: "Sieht man diesem ungestümen Pokémon nur in die Augen, fällt es einen bereits an. Seine scharfen Klauen hinterlassen tiefe Wunden."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/103.ts
+++ b/data/Sun & Moon/Burning Shadows/103.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "Roughly 20 years ago, it was artificially created, utilizing the latest technology of the time.",
+		de: "Dieses Pokémon wurde vor 20 Jahren künstlich erschaffen. Damals stellte es das Nonplusultra der technischen Möglichkeiten dar."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/104.ts
+++ b/data/Sun & Moon/Burning Shadows/104.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Porygon",
 		fr: "Porygon",
+		de: "Porygon"
 	},
 
 	stage: "Stage1",
@@ -87,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "For the purposes of planetary development, Porygon was updated with the most cutting-edge technology available.",
+		de: "In der Absicht, andere Planeten zu erforschen, verpasste man Porygon ein Upgrade auf dem höchsten Stand der damaligen Technologie."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/105.ts
+++ b/data/Sun & Moon/Burning Shadows/105.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Porygon2",
 		fr: "Porygon2",
+		de: "Porygon2"
 	},
 
 	stage: "Stage2",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "In order to create a more advanced Pokémon, an additional program was installed, but apparently it contained a defect that makes it move oddly.",
+		de: "Zusätzliche Software wurde installiert, um das Pokémon zu verbessern. Etwas ging jedoch schief und seitdem benimmt es sich seltsam."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/106.ts
+++ b/data/Sun & Moon/Burning Shadows/106.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It has a perfect sense of time. Whatever happens, it keeps rhythm by precisely tilting its head in time.",
+		de: "Sein Zeitgefühl ist perfekt. Was auch immer passiert, es behält den Rhythmus, da sein Kopf wackelt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/107.ts
+++ b/data/Sun & Moon/Burning Shadows/107.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Hoothoot",
 		fr: "Hoothoot",
+		de: "Hoothoot"
 	},
 
 	stage: "Stage1",
@@ -102,6 +103,7 @@ const card: Card = {
 
 	description: {
 		en: "Its eyes are specially adapted. They concentrate even faint light and enable it to see in the dark.",
+		de: "Sein Sehvermögen ist hervorragend. Selbst bei schwachem Licht kann es jedes Detail erkennen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/108.ts
+++ b/data/Sun & Moon/Burning Shadows/108.ts
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "They charge wildly and headbutt everything. Their headbutts have enough destructive force to derail a train.",
+		de: "Rammt seine Gegner ohne Rücksicht auf Verluste mit dem Kopf und vermag damit sogar Züge zum Entgleisen zu bringen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/109.ts
+++ b/data/Sun & Moon/Burning Shadows/109.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "They live in pitch black caves. Their enormous ears can emit ultrasonic waves of 200,000 hertz.",
+		de: "Es lebt im Inneren pechschwarzer Höhlen. Seine riesigen Ohren setzen Ultraschallwellen von 200 000 Hz frei."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/11.ts
+++ b/data/Sun & Moon/Burning Shadows/11.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "This powerful Pokémon thrusts its prized horn under its enemies' bellies, then lifts and throws them.",
+		de: "Dieses kräftige Pokémon rammt sein stolzes Horn unter den Rumpf des Gegners und wirft ihn um."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/110.ts
+++ b/data/Sun & Moon/Burning Shadows/110.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Despite its adorable appearance, when it gets angry and flails about, its arms and legs could knock a pro wrestler sprawling.",
+		de: "Es sieht sehr süß aus, aber wehe, es wird wütend. Mit seinen Armen wirbelnd haut es selbst den stärksten Wrestler um."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/111.ts
+++ b/data/Sun & Moon/Burning Shadows/111.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Stufful",
 		fr: "Nounourson",
+		de: "Velursi"
 	},
 
 	stage: "Stage1",
@@ -95,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "This immensely dangerous Pokémon possesses overwhelming physical strength. Its habitat is generally off-limits.",
+		de: "Dieses Pokémon verfügt über immense Muskelkraft und ist äußerst gefährlich. Sein Habitat ist generell Sperrgebiet."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/112.ts
+++ b/data/Sun & Moon/Burning Shadows/112.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon 1 de tus Pokémon que tenga algún contador de daño sobre él y todas las cartas unidas a él en tu mano.",
 		it: "Riprendi in mano uno dei tuoi Pokémon che abbia dei segnalini danno e tutte le carte a esso assegnate.",
 		pt: "Coloque 1 dos seus Pokémon que tiver algum contador de dano nele e todas as cartas ligadas a ele na sua mão.",
-		de: "Nimm 1 deiner Pokémon, auf dem mindestens 1 Schadensmarke liegt, und alle an es angelegten Karten auf deine Hand."
+		de: "Nimm 1 deiner Pokémon, auf dem mindestens 1 Schadensmarke liegt, und alle an es angelegten Karten auf deine Hand. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Burning Shadows/113.ts
+++ b/data/Sun & Moon/Burning Shadows/113.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "El Pokémon de Fase 1 al que esté unida esta carta obtiene 40 PS más.",
 		it: "Il Pokémon di Fase 1 a cui è assegnata questa carta ha 40 PS in più.",
 		pt: "O Pokémon Estágio 1 ao qual esta carta está ligada recebe 40 PS a mais.",
-		de: "Das Phase-1-Pokémon, an das diese Karte angelegt ist, erhält 40 KP mehr."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Das Phase-1-Pokémon, an das diese Karte angelegt ist, erhält 40 KP mehr. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sun & Moon/Burning Shadows/114.ts
+++ b/data/Sun & Moon/Burning Shadows/114.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cada jugador cambia su Pokémon Activo por 1 de sus Pokémon en Banca. Tu rival lo cambia primero. (Si algún jugador no tiene ningún Pokémon en Banca, no cambiará su Pokémon).",
 		it: "Ciascun giocatore scambia il suo Pokémon attivo con uno dei suoi Pokémon in panchina. Inizia il tuo avversario. Se un giocatore non ha Pokémon in panchina, non effettuerà lo scambio.",
 		pt: "Cada jogador troca o seu Pokémon Ativo por 1 dos próprios Pokémon no Banco. O seu oponente troca primeiro (se um jogador não possuir Pokémon no Banco, aquele jogador não troca o Pokémon).",
-		de: "Jeder Spieler tauscht sein Aktives Pokémon gegen 1 Pokémon auf seiner Bank aus. Dein Gegener tauscht als Erster. (Hat ein Spieler kein Pokémon auf der Bank, tauscht jener Spieler kein Pokémon aus.)"
+		de: "Jeder Spieler tauscht sein Aktives Pokémon gegen 1 Pokémon auf seiner Bank aus. Dein Gegner tauscht als Erster. (Hat ein Spieler kein Pokémon auf der Bank, tauscht jener Spieler kein Pokémon aus.) Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Burning Shadows/115.ts
+++ b/data/Sun & Moon/Burning Shadows/115.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cambia 1 de los Pokémon en Banca de tu rival por su Pokémon Activo. Si lo haces, cambia tu Pokémon Activo por 1 de tus Pokémon en Banca.",
 		it: "Scambia uno dei Pokémon nella panchina del tuo avversario con il suo Pokémon attivo. Se lo fai, scambia il tuo Pokémon attivo con uno dei tuoi Pokémon in panchina.",
 		pt: "Troque 1 dos Pokémon no Banco do seu oponente pelo Pokémon Ativo dele(a). Se fizer isto, troque o seu Pokémon Ativo por 1 dos seus Pokémon no Banco.",
-		de: "Tausche 1 Pokémon auf der Bank deines Gegners gegen sein Aktives Pokémon aus. Wenn du das machst, tausche dein Aktives Pokémon gegen 1 Pokémon auf deiner Bank aus."
+		de: "Tausche 1 Pokémon auf der Bank deines Gegners gegen sein Aktives Pokémon aus. Wenn du das machst, tausche dein Aktives Pokémon gegen 1 Pokémon auf deiner Bank aus. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Burning Shadows/116.ts
+++ b/data/Sun & Moon/Burning Shadows/116.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 4 cartas de Energía Fire y únelas a 1 de tus Pokémon. Después, baraja las cartas de tu baraja. Tu turno termina.",
 		it: "Cerca nel tuo mazzo fino a quattro carte Energia Fire e assegnale a uno dei tuoi Pokémon. Poi rimischia le carte del tuo mazzo. Il tuo turno finisce.",
 		pt: "Procure por até 4 cartas de Energia Fire no seu baralho e ligue-as a 1 dos seus Pokémon. Em seguida, embaralhe o seu baralho. A sua vez de jogar acaba.",
-		de: "Durchsuche dein Deck nach bis zu 4 Fire-Energiekarten und lege sie an 1 deiner Pokémon an. Mische anschließend dein Deck. Dein Zug endet."
+		de: "Durchsuche dein Deck nach bis zu 4 {R}-Energiekarten und lege sie an 1 deiner Pokémon an. Mische anschließend dein Deck. Dein Zug endet. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Burning Shadows/117.ts
+++ b/data/Sun & Moon/Burning Shadows/117.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cura 50 puntos de daño a cada uno de tus Pokémon que tenga alguna Energía Water unida a él.",
 		it: "Cura ciascuno dei tuoi Pokémon che abbia delle Energie Water assegnate da 50 danni.",
 		pt: "Cure 50 pontos de dano de cada um dos seus Pokémon que tiver alguma Energia Water ligada a ele.",
-		de: "Heile 50 Schadenspunkte bei jedem deiner Pokémon, an das mindestens 1 Water-Energie angelegt ist."
+		de: "Heile 50 Schadenspunkte bei jedem deiner Pokémon, an das mindestens 1 {W}-Energie angelegt ist. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Burning Shadows/118.ts
+++ b/data/Sun & Moon/Burning Shadows/118.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "El Coste de Retirada de cada Pokémon Básico en juego (tanto tuyos como de tu rival) es de Colorless más.",
 		it: "Il costo di ritirata di ciascun Pokémon Base in gioco, sia tuoi che del tuo avversario, aumenta di Colorless.",
 		pt: "O custo de Recuo de cada Pokémon Básico em jogo (seus e do seu oponente) será Colorless a mais.",
-		de: "Die Rückzugskosten jedes Basis-Pokémon im Spiel (deiner und der deines Gegners) erhöhen sich um Colorless."
+		de: "Die Rückzugskosten jedes Basis-Pokémon im Spiel (deiner und der deines Gegners) erhöhen sich um {C}. Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 
 	trainerType: "Stadium",

--- a/data/Sun & Moon/Burning Shadows/119.ts
+++ b/data/Sun & Moon/Burning Shadows/119.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 2 Pokémon-GX, enséñalos y ponlos en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo fino a due Pokémon-GX, mostrali e aggiungili alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por até 2 Pokémon-GX no seu baralho, revele-os e coloque-os na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach bis zu 2 Pokémon-GX, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach bis zu 2 Pokémon-GX, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Burning Shadows/12.ts
+++ b/data/Sun & Moon/Burning Shadows/12.ts
@@ -58,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "It shares the leaf on its head with weary-looking Pokémon. These leaves are known to relieve stress.",
+		de: "Schwächelnden Pokémon gibt es ein paar der Kräuter auf seinem Kopf ab und hilft ihnen so wieder auf die Beine."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/120.ts
+++ b/data/Sun & Moon/Burning Shadows/120.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta 2 cartas de tu mano. Si lo haces, descarta 1 Energía de 1 de los Pokémon de tu rival.",
 		it: "Scarta due delle carte che hai in mano. Se lo fai, scarta un’Energia assegnata a uno dei Pokémon del tuo avversario.",
 		pt: "Descarte 2 cartas da sua mão. Se fizer isto, descarte 1 Energia de 1 dos Pokémon do seu oponente.",
-		de: "Lege 2 Karten aus deiner Hand auf deinen Ablagestapel. Wenn du das machst, lege 1 Energie von 1 Pokémon deines Gegners auf seinen Ablagestapel."
+		de: "Lege 2 Karten aus deiner Hand auf deinen Ablagestapel. Wenn du das machst, lege 1 Energie von 1 Pokémon deines Gegners auf seinen Ablagestapel. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Burning Shadows/121.ts
+++ b/data/Sun & Moon/Burning Shadows/121.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cada vez que algún jugador juegue 1 Pokémon de su mano para hacer evolucionar a 1 de sus Pokémon, pon 3 contadores de daño en ese Pokémon.",
 		it: "Ogni volta che un giocatore gioca un Pokémon dalla sua mano per far evolvere uno dei suoi Pokémon, metti tre segnalini danno su quel Pokémon.",
 		pt: "Sempre que algum jogador jogar 1 Pokémon da própria mão para evoluir 1 dos próprios Pokémon, coloque 3 contadores de dano naquele Pokémon.",
-		de: "Lege jedes Mal, wenn ein Spieler 1 Pokémon aus seiner Hand spielt, um 1 seiner Pokémon zu entwickeln, 3 Schadensmarken auf jenes Pokémon."
+		de: "Lege jedes Mal, wenn ein Spieler 1 Pokémon aus seiner Hand spielt, um 1 seiner Pokémon zu entwickeln, 3 Schadensmarken auf jenes Pokémon. Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 
 	trainerType: "Stadium",

--- a/data/Sun & Moon/Burning Shadows/122.ts
+++ b/data/Sun & Moon/Burning Shadows/122.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mira las 4 primeras cartas de tu baraja y vuelve a ponerlas en la parte superior de tu baraja en el orden que quieras o ponlas en tu baraja y barájalas todas.",
 		it: "Guarda le prime quattro carte del tuo mazzo e rimettile a posto nell’ordine che preferisci oppure rimischiale nel tuo mazzo.",
 		pt: "Olhe as 4 primeiras cartas do seu baralho e coloque-as de volta em qualquer ordem ou embaralhe-as no seu baralho.",
-		de: "Schau dir die obersten 4 Karten deines Decks an und lege sie in beliebiger Reihenfolge zurück auf dein Deck oder mische sie in dein Deck."
+		de: "Schau dir die obersten 4 Karten deines Decks an und lege sie in beliebiger Reihenfolge zurück auf dein Deck oder mische sie in dein Deck. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Burning Shadows/123.ts
+++ b/data/Sun & Moon/Burning Shadows/123.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta 2 cartas de tu mano. Si lo haces, roba 4 cartas.",
 		it: "Scarta due delle carte che hai in mano. Se lo fai, pesca quattro carte.",
 		pt: "Descarte 2 cartas da sua mão. Se fizer isto, compre 4 cartas.",
-		de: "Lege 2 Karten aus deiner Hand auf deinen Ablagestapel. Wenn du das machst, ziehe 4 Karten."
+		de: "Lege 2 Karten aus deiner Hand auf deinen Ablagestapel. Wenn du das machst, ziehe 4 Karten. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Burning Shadows/124.ts
+++ b/data/Sun & Moon/Burning Shadows/124.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Lanza 1 moneda. Si sale cara, pon 1 de tus Pokémon y todas las cartas unidas a él en tu mano.",
 		it: "Lancia una moneta. Se esce testa, riprendi in mano uno dei tuoi Pokémon e tutte le carte a esso assegnate.",
 		pt: "Jogue 1 moeda. Se sair cara, coloque 1 dos seus Pokémon e todas as cartas ligadas a ele na sua mão.",
-		de: "Wirf 1 Münze. Nimm bei Kopf 1 deiner Pokémon und alle an es angelegten Karten auf deine Hand."
+		de: "Wirf 1 Münze. Nimm bei Kopf 1 deiner Pokémon und alle an es angelegten Karten auf deine Hand. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Burning Shadows/125.ts
+++ b/data/Sun & Moon/Burning Shadows/125.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Elige 1 carta aleatoria de la mano de tu rival. Tu rival enseña esa carta. Si es una carta de Partidario, descártala.",
 		it: "Scegli una carta a caso dalla mano del tuo avversario. Il tuo avversario mostra quella carta. Se si tratta di una carta Aiuto, scartala.",
 		pt: "Escolha 1 carta aleatória da mão do seu oponente. Seu oponente revela aquela carta. Se for uma carta de Apoiador, descarte-a.",
-		de: "Wähle 1 zufällige Karte aus der Hand deines Gegners. Dein Gegner zeigt dir jene Karte. Wenn es eine Unterstützerkarte ist, lege sie auf seinen Ablagestapel."
+		de: "Wähle 1 zufällige Karte aus der Hand deines Gegners. Dein Gegner zeigt dir jene Karte. Wenn es eine Unterstützerkarte ist, lege sie auf seinen Ablagestapel. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Burning Shadows/126.ts
+++ b/data/Sun & Moon/Burning Shadows/126.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "El Pokémon al que esté unida esta carta no tiene ninguna Debilidad.",
 		it: "Il Pokémon a cui è assegnata questa carta non ha debolezza.",
 		pt: "O Pokémon ao qual esta carta está ligada não possui Fraqueza.",
-		de: "Das Pokémon, an das diese Karte angelegt ist, hat keine Schwäche."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Das Pokémon, an das diese Karte angelegt ist, hat keine Schwäche. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sun & Moon/Burning Shadows/127.ts
+++ b/data/Sun & Moon/Burning Shadows/127.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cada jugador cuenta las cartas de su mano, pone esas cartas en su baraja y las baraja todas, y después roba ese mismo número de cartas.",
 		it: "Ciascun giocatore conta le carte che ha in mano, le rimischia nel proprio mazzo, quindi pesca lo stesso numero di carte.",
 		pt: "Cada jogador conta as cartas nas próprias mãos, embaralha-as no próprio baralho e em seguida compra aquele mesmo número de cartas.",
-		de: "Jeder Spieler zählt die Karten auf seiner Hand, mischt jene Karten in sein Deck und zieht anschließend dieselbe Anzahl Karten."
+		de: "Jeder Spieler zählt die Karten auf seiner Hand, mischt jene Karten in sein Deck und zieht anschließend dieselbe Anzahl Karten. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Burning Shadows/128.ts
+++ b/data/Sun & Moon/Burning Shadows/128.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Si el Pokémon al que está unida esta carta es tu Pokémon Activo y queda Fuera de Combate por el daño de un ataque de tu rival, mueve hasta 3 cartas de Energía Básica de ese Pokémon a 1 de tus Pokémon en Banca.",
 		it: "Se il Pokémon a cui è assegnata questa carta è il tuo Pokémon attivo e viene messo KO dai danni inflitti da un attacco del tuo avversario, sposta fino a tre carte Energia base da quel Pokémon a uno di quelli nella tua panchina.",
 		pt: "Se o Pokémon ao qual esta carta está ligada for o seu Pokémon Ativo e ele for Nocauteado pelo dano de um ataque do seu oponente, mova até 3 cartas de Energia básica daquele Pokémon para 1 dos seus Pokémon no Banco.",
-		de: "Wenn das Pokémon, an das diese Karte angelegt ist, dein Aktives Pokémon ist und durch Schaden einer Attacke deines Gegners kampfunfähig wird, verschiebe bis zu 3 Basis-Energiekarten von jenem Pokémon auf 1 Pokémon auf deiner Bank."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn das Pokémon, an das diese Karte angelegt ist, dein Aktives Pokémon ist und durch Schaden einer Attacke deines Gegners kampfunfähig wird, verschiebe bis zu 3 Basis-Energiekarten von jenem Pokémon auf 1 Pokémon auf deiner Bank. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sun & Moon/Burning Shadows/129.ts
+++ b/data/Sun & Moon/Burning Shadows/129.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Wimpod",
 		fr: "Sovkipou",
+		de: "Reißlaus"
 	},
 
 	suffix: "GX",
@@ -94,7 +95,7 @@ const card: Card = {
 				es: "Corte Transversal GX",
 				it: "Sferzata Incrociata-GX",
 				pt: "Corte Transversal GX",
-				de: "Quertreiber GX"
+				de: "Quertreiber-GX"
 			},
 			effect: {
 				en: "Switch this Pokémon with 1 of your Benched Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Burning Shadows/13.ts
+++ b/data/Sun & Moon/Burning Shadows/13.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pansage",
 		fr: "Feuillajou",
+		de: "Vegimak"
 	},
 
 	stage: "Stage1",
@@ -69,7 +70,7 @@ const card: Card = {
 				es: "Puedes unir 1 carta de Energía Grass de tu mano a 1 de tus Pokémon.",
 				it: "Puoi assegnare una carta Energia Grass dalla tua mano a uno dei tuoi Pokémon.",
 				pt: "Você pode ligar 1 carta de Energia Grass da sua mão a 1 dos seus Pokémon.",
-				de: "Du kannst 1 Grass-Energiekarte aus deiner Hand an 1 deiner Pokémon anlegen."
+				de: "Du kannst 1 {G}-Energiekarte aus deiner Hand an 1 deiner Pokémon anlegen."
 			},
 			damage: 50,
 
@@ -87,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It attacks enemies with strikes of its thorn-covered tail. This Pokémon is wild tempered.",
+		de: "Wer sich mit diesem temperamentvollen Pokémon anlegt, bekommt seinen mit Dornen bestückten Schweif zu spüren."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/131.ts
+++ b/data/Sun & Moon/Burning Shadows/131.ts
@@ -91,7 +91,7 @@ const card: Card = {
 				es: "Llama Eterna GX",
 				it: "Fiamma Eterna-GX",
 				pt: "Flama Perene GX",
-				de: "Ewige Flamme GX"
+				de: "Ewige Flamme-GX"
 			},
 			effect: {
 				en: "Put 3 in any combination of Fire Pokémon-GX or Fire Pokémon-EX from your discard pile onto your Bench. (You can’t use more than 1 GX attack in a game.)",
@@ -99,7 +99,7 @@ const card: Card = {
 				es: "Pon 3 Pokémon-GX Fire o Pokémon-EX Fire, en cualquier combinación, de tu pila de descartes en tu Banca. (No puedes usar más de 1 ataque GX en una partida).",
 				it: "Prendi tre Pokémon-GX Fire o Pokémon-EX Fire in qualsiasi combinazione dalla tua pila degli scarti e mettili nella tua panchina. Non puoi usare più di un attacco GX a partita.",
 				pt: "Coloque 3 Pokémon-GX Fire ou Pokémon-EX Fire da sua pilha de descarte no seu Banco em qualquer combinação (você não pode usar mais de 1 ataque GX por partida).",
-				de: "Lege eine beliebige Kombination aus 3 Fire-Pokémon-GX oder Fire-Pokémon-EX aus deinem Ablagestapel auf deine Bank. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
+				de: "Lege eine beliebige Kombination aus 3 {R}-Pokémon-GX oder {R}-Pokémon-EX aus deinem Ablagestapel auf deine Bank. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Burning Shadows/132.ts
+++ b/data/Sun & Moon/Burning Shadows/132.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Salandit",
 		fr: "Tritox",
+		de: "Molunk"
 	},
 
 	suffix: "GX",
@@ -86,7 +87,7 @@ const card: Card = {
 				es: "Niebla Regia GX",
 				it: "Foschia della Regina-GX",
 				pt: "Névoa da Rainha GX",
-				de: "Dunst der Königin GX"
+				de: "Dunst der Königin-GX"
 			},
 			effect: {
 				en: "Discard all Energy from your opponent’s Active Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Burning Shadows/133.ts
+++ b/data/Sun & Moon/Burning Shadows/133.ts
@@ -72,7 +72,7 @@ const card: Card = {
 				es: "Descarta 2 Energías Water de este Pokémon. Este ataque hace 120 puntos de daño a 1 de los Pokémon de tu rival. (No apliques Debilidad y Resistencia a los Pokémon en Banca).",
 				it: "Scarta due Energie Water assegnate a questo Pokémon. Questo attacco infligge 120 danni a uno dei Pokémon del tuo avversario. Ricorda che non puoi applicare debolezza e resistenza ai Pokémon in panchina.",
 				pt: "Descarte 2 Energias Water deste Pokémon. Este ataque causa 120 pontos de dano a 1 dos Pokémon do seu oponente (não aplique Fraqueza e Resistência aos Pokémon no Banco).",
-				de: "Lege 2 Water-Energien von diesem Pokémon auf deinen Ablagestapel. Diese Attacke fügt 1 Pokémon deines Gegners 120 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Lege 2 {W}-Energien von diesem Pokémon auf deinen Ablagestapel. Diese Attacke fügt 1 Pokémon deines Gegners 120 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -86,7 +86,7 @@ const card: Card = {
 				es: "Tormenta Tapu GX",
 				it: "Taputempesta-GX",
 				pt: "Tempestade Tapu GX",
-				de: "Kapu-Sturm GX"
+				de: "Kapu-Sturm-GX"
 			},
 			effect: {
 				en: "Shuffle your opponent’s Active Pokémon and all cards attached to it into their deck. If your opponent has no Benched Pokémon, this attack does nothing. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Burning Shadows/134.ts
+++ b/data/Sun & Moon/Burning Shadows/134.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Evita todo el daño infligido a este Pokémon por ataques de Pokémon Colorless.",
 				it: "Previeni tutti i danni da attacchi inflitti a questo Pokémon dai Pokémon Colorless.",
 				pt: "Previne todo o dano causado a este Pokémon por ataques de Pokémon Colorless.",
-				de: "Verhindere allen Schaden, der diesem Pokémon durch Attacken von Colorless-Pokémon zugefügt wird."
+				de: "Verhindere allen Schaden, der diesem Pokémon durch Attacken von {C}-Pokémon zugefügt wird."
 			},
 		},
 	],
@@ -71,7 +71,7 @@ const card: Card = {
 				es: "Descarta todas las Energías Psychic de este Pokémon. Este ataque hace 60 puntos de daño más por cada carta que hayas descartado de esta manera.",
 				it: "Scarta tutte le Energie Psychic assegnate a questo Pokémon. Questo attacco infligge 60 danni in più per ogni carta che hai scartato in questo modo.",
 				pt: "Descarte todas as Energias Psychic deste Pokémon. Este ataque causa 60 pontos de dano a mais para cada carta descartada desta forma.",
-				de: "Lege alle Psychic-Energien von diesem Pokémon auf deinen Ablagestapel. Diese Attacke fügt 60 Schadenspunkte mehr mal der Anzahl der auf diese Weise auf deinen Ablagestapel gelegten Karten zu."
+				de: "Lege alle {P}-Energien von diesem Pokémon auf deinen Ablagestapel. Diese Attacke fügt 60 Schadenspunkte mehr mal der Anzahl der auf diese Weise auf deinen Ablagestapel gelegten Karten zu."
 			},
 			damage: "10+",
 
@@ -88,7 +88,7 @@ const card: Card = {
 				es: "Rayo Negro GX",
 				it: "Raggio Nero-GX",
 				pt: "Raio Preto GX",
-				de: "Schwarzer Strahl GX"
+				de: "Schwarzer Strahl-GX"
 			},
 			effect: {
 				en: "This attack does 100 damage to each of your opponent’s Pokémon-GX and Pokémon-EX. This damage isn’t affected by Weakness or Resistance. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Burning Shadows/135.ts
+++ b/data/Sun & Moon/Burning Shadows/135.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Machoke",
 		fr: "Machopeur",
+		de: "Maschock"
 	},
 
 	suffix: "GX",
@@ -95,7 +96,7 @@ const card: Card = {
 				es: "Puro Músculo GX",
 				it: "Pugno Nerboruto-GX",
 				pt: "Soco Musculoso GX",
-				de: "Muskel-Punch GX"
+				de: "Muskel-Punch-GX"
 			},
 			effect: {
 				en: "This attack’s damage isn’t affected by Resistance. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Burning Shadows/136.ts
+++ b/data/Sun & Moon/Burning Shadows/136.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Rockruff",
 		fr: "Rocabot",
+		de: "Wuffels"
 	},
 
 	suffix: "GX",

--- a/data/Sun & Moon/Burning Shadows/138.ts
+++ b/data/Sun & Moon/Burning Shadows/138.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Alolan Grimer",
 		fr: "Tadmorv d’Alola",
+		de: "Alola-Sleima"
 	},
 
 	suffix: "GX",
@@ -93,7 +94,7 @@ const card: Card = {
 				es: "Triple Riesgo GX",
 				it: "Triplo Rischio-GX",
 				pt: "Perigo Triplo GX",
-				de: "Dreifachgefahr GX"
+				de: "Dreifachgefahr-GX"
 			},
 			effect: {
 				en: "Switch 1 of your opponent’s Benched Pokémon with their Active Pokémon. The new Active Pokémon is now Burned, Paralyzed, and Poisoned. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Burning Shadows/139.ts
+++ b/data/Sun & Moon/Burning Shadows/139.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Una vez durante tu turno (antes de tu ataque), si este Pokémon está en tu pila de descartes, puedes ponerlo en tu Banca. Después, une 1 carta de Energía Darkness de tu pila de descartes a este Pokémon.",
 				it: "Una sola volta durante il tuo turno, prima di attaccare, se questo Pokémon è nella tua pila degli scarti, puoi metterlo in panchina. Poi, assegnagli una carta Energia Darkness dalla tua pila degli scarti.",
 				pt: "Uma vez durante a sua vez de jogar (antes de atacar), se este Pokémon estiver na sua pilha de descarte, você poderá colocá-lo no seu Banco. Em seguida, ligue 1 carta de Energia Darkness da sua pilha de descarte a este Pokémon.",
-				de: "Einmal während deines Zuges (bevor du angreifst), wenn sich dieses Pokémon in deinem Ablagestapel befindet, kannst du es auf deine Bank legen. Lege anschließend 1 Darkness-Energiekarte aus deinem Ablagestapel an dieses Pokémon an."
+				de: "Einmal während deines Zuges (bevor du angreifst), wenn sich dieses Pokémon in deinem Ablagestapel befindet, kannst du es auf deine Bank legen. Lege anschließend 1 {D}-Energiekarte aus deinem Ablagestapel an dieses Pokémon an."
 			},
 		},
 	],
@@ -88,7 +88,7 @@ const card: Card = {
 				es: "Sin Retorno GX",
 				it: "Vicolo Cieco-GX",
 				pt: "Sem Saída GX",
-				de: "Sackgasse GX"
+				de: "Sackgasse-GX"
 			},
 			effect: {
 				en: "If your opponent’s Active Pokémon is affected by a Special Condition, that Pokémon is Knocked Out. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Burning Shadows/14.ts
+++ b/data/Sun & Moon/Burning Shadows/14.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, este ataque hace 10 puntos de daño más.",
 				it: "Lancia una moneta. Se esce testa, questo attacco infligge 10 danni in più.",
 				pt: "Jogue uma moeda. Se sair cara, esse ataque causará 10 de danos adicionais.",
-				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei Kopf fügt diese Attacke 10 Schadenspunkte mehr zu."
 			},
 			damage: "10+",
 
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It crawls onto the land in search of food. Its water bubble allows it to breathe and protects its soft head.",
+		de: "Die Futtersuche treibt es an Land. Eine Wasserblase versorgt es mit Atemluft und schützt zugleich seinen weichen Kopf."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/140.ts
+++ b/data/Sun & Moon/Burning Shadows/140.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Kirlia",
 		fr: "Kirlia",
+		de: "Kirlia"
 	},
 
 	suffix: "GX",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Una vez durante tu turno (antes de tu ataque), puedes unir 1 carta de Energía Fairy de tu mano a 1 de tus Pokémon.",
 				it: "Una sola volta durante il tuo turno, prima di attaccare, puoi assegnare a uno dei tuoi Pokémon una carta Energia Fairy dalla tua mano.",
 				pt: "Uma vez durante a sua vez de jogar (antes de atacar), você pode ligar 1 carta de Energia Fairy da sua mão a 1 dos seus Pokémon.",
-				de: "Einmal während deines Zuges (bevor du angreifst) kannst du 1 Fairy-Energiekarte aus deiner Hand an 1 deiner Pokémon anlegen."
+				de: "Einmal während deines Zuges (bevor du angreifst) kannst du 1 {FAIRY}-Energiekarte aus deiner Hand an 1 deiner Pokémon anlegen."
 			},
 		},
 	],
@@ -89,7 +90,7 @@ const card: Card = {
 				es: "Crepúsculo GX",
 				it: "Crepuscolo-GX",
 				pt: "Crepúsculo GX",
-				de: "Zwielicht GX"
+				de: "Zwielicht-GX"
 			},
 			effect: {
 				en: "Shuffle 10 cards from your discard pile into your deck. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Burning Shadows/141.ts
+++ b/data/Sun & Moon/Burning Shadows/141.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Noibat",
 		fr: "Sonistrelle",
+		de: "eF-eM"
 	},
 
 	suffix: "GX",
@@ -95,7 +96,7 @@ const card: Card = {
 				es: "Estruendo GX",
 				it: "Ondaboato-GX",
 				pt: "Rajada Explosiva GX",
-				de: "Überschallknall GX"
+				de: "Überschallknall-GX"
 			},
 			effect: {
 				en: "This attack does 50 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Burning Shadows/142.ts
+++ b/data/Sun & Moon/Burning Shadows/142.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon 1 de tus Pokémon que tenga algún contador de daño sobre él y todas las cartas unidas a él en tu mano.",
 		it: "Riprendi in mano uno dei tuoi Pokémon che abbia dei segnalini danno e tutte le carte a esso assegnate.",
 		pt: "Coloque 1 dos seus Pokémon que tiver algum contador de dano nele e todas as cartas ligadas a ele na sua mão.",
-		de: "Nimm 1 deiner Pokémon, auf dem mindestens 1 Schadensmarke liegt, und alle an es angelegten Karten auf deine Hand."
+		de: "Nimm 1 deiner Pokémon, auf dem mindestens 1 Schadensmarke liegt, und alle an es angelegten Karten auf deine Hand. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Burning Shadows/143.ts
+++ b/data/Sun & Moon/Burning Shadows/143.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cambia 1 de los Pokémon en Banca de tu rival por su Pokémon Activo. Si lo haces, cambia tu Pokémon Activo por 1 de tus Pokémon en Banca.",
 		it: "Scambia uno dei Pokémon nella panchina del tuo avversario con il suo Pokémon attivo. Se lo fai, scambia il tuo Pokémon attivo con uno dei tuoi Pokémon in panchina.",
 		pt: "Troque 1 dos Pokémon no Banco do seu oponente pelo Pokémon Ativo dele(a). Se fizer isto, troque o seu Pokémon Ativo por 1 dos seus Pokémon no Banco.",
-		de: "Tausche 1 Pokémon auf der Bank deines Gegners gegen sein Aktives Pokémon aus. Wenn du das machst, tausche dein Aktives Pokémon gegen 1 Pokémon auf deiner Bank aus."
+		de: "Tausche 1 Pokémon auf der Bank deines Gegners gegen sein Aktives Pokémon aus. Wenn du das machst, tausche dein Aktives Pokémon gegen 1 Pokémon auf deiner Bank aus. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Burning Shadows/144.ts
+++ b/data/Sun & Moon/Burning Shadows/144.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 4 cartas de Energía Fire y únelas a 1 de tus Pokémon. Después, baraja las cartas de tu baraja. Tu turno termina.",
 		it: "Cerca nel tuo mazzo fino a quattro carte Energia Fire e assegnale a uno dei tuoi Pokémon. Poi rimischia le carte del tuo mazzo. Il tuo turno finisce.",
 		pt: "Procure por até 4 cartas de Energia Fire no seu baralho e ligue-as a 1 dos seus Pokémon. Em seguida, embaralhe o seu baralho. A sua vez de jogar acaba.",
-		de: "Durchsuche dein Deck nach bis zu 4 Fire-Energiekarten und lege sie an 1 deiner Pokémon an. Mische anschließend dein Deck. Dein Zug endet."
+		de: "Durchsuche dein Deck nach bis zu 4 {R}-Energiekarten und lege sie an 1 deiner Pokémon an. Mische anschließend dein Deck. Dein Zug endet. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Burning Shadows/145.ts
+++ b/data/Sun & Moon/Burning Shadows/145.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta 2 cartas de tu mano. Si lo haces, descarta 1 Energía de 1 de los Pokémon de tu rival.",
 		it: "Scarta due delle carte che hai in mano. Se lo fai, scarta un’Energia assegnata a uno dei Pokémon del tuo avversario.",
 		pt: "Descarte 2 cartas da sua mão. Se fizer isto, descarte 1 Energia de 1 dos Pokémon do seu oponente.",
-		de: "Lege 2 Karten aus deiner Hand auf deinen Ablagestapel. Wenn du das machst, lege 1 Energie von 1 Pokémon deines Gegners auf seinen Ablagestapel."
+		de: "Lege 2 Karten aus deiner Hand auf deinen Ablagestapel. Wenn du das machst, lege 1 Energie von 1 Pokémon deines Gegners auf seinen Ablagestapel. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Burning Shadows/146.ts
+++ b/data/Sun & Moon/Burning Shadows/146.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta 2 cartas de tu mano. Si lo haces, roba 4 cartas.",
 		it: "Scarta due delle carte che hai in mano. Se lo fai, pesca quattro carte.",
 		pt: "Descarte 2 cartas da sua mão. Se fizer isto, compre 4 cartas.",
-		de: "Lege 2 Karten aus deiner Hand auf deinen Ablagestapel. Wenn du das machst, ziehe 4 Karten."
+		de: "Lege 2 Karten aus deiner Hand auf deinen Ablagestapel. Wenn du das machst, ziehe 4 Karten. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Burning Shadows/147.ts
+++ b/data/Sun & Moon/Burning Shadows/147.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cada jugador cuenta las cartas de su mano, pone esas cartas en su baraja y las baraja todas, y después roba ese mismo número de cartas.",
 		it: "Ciascun giocatore conta le carte che ha in mano, le rimischia nel proprio mazzo, quindi pesca lo stesso numero di carte.",
 		pt: "Cada jogador conta as cartas nas próprias mãos, embaralha-as no próprio baralho e em seguida compra aquele mesmo número de cartas.",
-		de: "Jeder Spieler zählt die Karten auf seiner Hand, mischt jene Karten in sein Deck und zieht anschließend dieselbe Anzahl Karten."
+		de: "Jeder Spieler zählt die Karten auf seiner Hand, mischt jene Karten in sein Deck und zieht anschließend dieselbe Anzahl Karten. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Burning Shadows/148.ts
+++ b/data/Sun & Moon/Burning Shadows/148.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Wimpod",
 		fr: "Sovkipou",
+		de: "Reißlaus"
 	},
 
 	suffix: "GX",
@@ -94,7 +95,7 @@ const card: Card = {
 				es: "Corte Transversal GX",
 				it: "Sferzata Incrociata-GX",
 				pt: "Corte Transversal GX",
-				de: "Quertreiber GX"
+				de: "Quertreiber-GX"
 			},
 			effect: {
 				en: "Switch this Pokémon with 1 of your Benched Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Burning Shadows/15.ts
+++ b/data/Sun & Moon/Burning Shadows/15.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Dewpider",
 		fr: "Araqua",
+		de: "Araqua"
 	},
 
 	stage: "Stage1",
@@ -53,7 +54,7 @@ const card: Card = {
 				es: "No se puede unir Energía al Pokémon Defensor de la mano de tu rival durante su próximo turno.",
 				it: "Nessuna Energia può essere assegnata al Pokémon difensore dalla mano del tuo avversario durante il suo prossimo turno.",
 				pt: "Energias não poderão ser ligadas ao Pokémon Defensor da mão do seu oponente durante a próxima vez dele(a) jogar.",
-				de: "Energie aus der Hand deines Gegners kann während seines nächsten Zuges nicht an das Verteidigende Pokémon angelegt werden."
+				de: "Energie aus der Hand deines Gegners kann während seines nächsten Zuges nicht an das verteidigende Pokémon angelegt werden."
 			},
 			damage: 30,
 
@@ -89,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "It delivers headbutts with the water bubble on its head. Small Pokémon get sucked into the bubble, where they drown.",
+		de: "Es verteilt mit seiner Wasserblase Kopfstöße. Kleine Pokémon werden dabei hineingezogen und ertrinken."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/150.ts
+++ b/data/Sun & Moon/Burning Shadows/150.ts
@@ -73,7 +73,7 @@ const card: Card = {
 				es: "Descarta 3 Energías Fire unidas a este Pokémon.",
 				it: "Scarta tre Energie Fire assegnate a questo Pokémon.",
 				pt: "Descarte 3 Energias Fire deste Pokémon.",
-				de: "Lege 3 Fire-Energien von diesem Pokémon auf deinen Ablagestapel."
+				de: "Lege 3 {R}-Energien von diesem Pokémon auf deinen Ablagestapel."
 			},
 			damage: 300,
 
@@ -90,7 +90,7 @@ const card: Card = {
 				es: "Enojo GX",
 				it: "Sfogo Rabbioso-GX",
 				pt: "Cólera GX",
-				de: "Tobsuchtsanfall GX"
+				de: "Tobsuchtsanfall-GX"
 			},
 			effect: {
 				en: "Discard the top 10 cards of your opponent’s deck. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Burning Shadows/151.ts
+++ b/data/Sun & Moon/Burning Shadows/151.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Salandit",
 		fr: "Tritox",
+		de: "Molunk"
 	},
 
 	suffix: "GX",
@@ -86,7 +87,7 @@ const card: Card = {
 				es: "Niebla Regia GX",
 				it: "Foschia della Regina-GX",
 				pt: "Névoa da Rainha GX",
-				de: "Dunst der Königin GX"
+				de: "Dunst der Königin-GX"
 			},
 			effect: {
 				en: "Discard all Energy from your opponent’s Active Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Burning Shadows/152.ts
+++ b/data/Sun & Moon/Burning Shadows/152.ts
@@ -72,7 +72,7 @@ const card: Card = {
 				es: "Descarta 2 Energías Water de este Pokémon. Este ataque hace 120 puntos de daño a 1 de los Pokémon de tu rival. (No apliques Debilidad y Resistencia a los Pokémon en Banca).",
 				it: "Scarta due Energie Water assegnate a questo Pokémon. Questo attacco infligge 120 danni a uno dei Pokémon del tuo avversario. Ricorda che non puoi applicare debolezza e resistenza ai Pokémon in panchina.",
 				pt: "Descarte 2 Energias Water deste Pokémon. Este ataque causa 120 pontos de dano a 1 dos Pokémon do seu oponente (não aplique Fraqueza e Resistência aos Pokémon no Banco).",
-				de: "Lege 2 Water-Energien von diesem Pokémon auf deinen Ablagestapel. Diese Attacke fügt 1 Pokémon deines Gegners 120 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Lege 2 {W}-Energien von diesem Pokémon auf deinen Ablagestapel. Diese Attacke fügt 1 Pokémon deines Gegners 120 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -86,7 +86,7 @@ const card: Card = {
 				es: "Tormenta Tapu GX",
 				it: "Taputempesta-GX",
 				pt: "Tempestade Tapu GX",
-				de: "Kapu-Sturm GX"
+				de: "Kapu-Sturm-GX"
 			},
 			effect: {
 				en: "Shuffle your opponent’s Active Pokémon and all cards attached to it into their deck. If your opponent has no Benched Pokémon, this attack does nothing. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Burning Shadows/153.ts
+++ b/data/Sun & Moon/Burning Shadows/153.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Evita todo el daño infligido a este Pokémon por ataques de Pokémon Colorless.",
 				it: "Previeni tutti i danni da attacchi inflitti a questo Pokémon dai Pokémon Colorless.",
 				pt: "Previne todo o dano causado a este Pokémon por ataques de Pokémon Colorless.",
-				de: "Verhindere allen Schaden, der diesem Pokémon durch Attacken von Colorless-Pokémon zugefügt wird."
+				de: "Verhindere allen Schaden, der diesem Pokémon durch Attacken von {C}-Pokémon zugefügt wird."
 			},
 		},
 	],
@@ -71,7 +71,7 @@ const card: Card = {
 				es: "Descarta todas las Energías Psychic de este Pokémon. Este ataque hace 60 puntos de daño más por cada carta que hayas descartado de esta manera.",
 				it: "Scarta tutte le Energie Psychic assegnate a questo Pokémon. Questo attacco infligge 60 danni in più per ogni carta che hai scartato in questo modo.",
 				pt: "Descarte todas as Energias Psychic deste Pokémon. Este ataque causa 60 pontos de dano a mais para cada carta descartada desta forma.",
-				de: "Lege alle Psychic-Energien von diesem Pokémon auf deinen Ablagestapel. Diese Attacke fügt 60 Schadenspunkte mehr mal der Anzahl der auf diese Weise auf deinen Ablagestapel gelegten Karten zu."
+				de: "Lege alle {P}-Energien von diesem Pokémon auf deinen Ablagestapel. Diese Attacke fügt 60 Schadenspunkte mehr mal der Anzahl der auf diese Weise auf deinen Ablagestapel gelegten Karten zu."
 			},
 			damage: "10+",
 
@@ -88,7 +88,7 @@ const card: Card = {
 				es: "Rayo Negro GX",
 				it: "Raggio Nero-GX",
 				pt: "Raio Preto GX",
-				de: "Schwarzer Strahl GX"
+				de: "Schwarzer Strahl-GX"
 			},
 			effect: {
 				en: "This attack does 100 damage to each of your opponent’s Pokémon-GX and Pokémon-EX. This damage isn’t affected by Weakness or Resistance. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Burning Shadows/154.ts
+++ b/data/Sun & Moon/Burning Shadows/154.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Machoke",
 		fr: "Machopeur",
+		de: "Maschock"
 	},
 
 	suffix: "GX",
@@ -95,7 +96,7 @@ const card: Card = {
 				es: "Puro Músculo GX",
 				it: "Pugno Nerboruto-GX",
 				pt: "Soco Musculoso GX",
-				de: "Muskel-Punch GX"
+				de: "Muskel-Punch-GX"
 			},
 			effect: {
 				en: "This attack’s damage isn’t affected by Resistance. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Burning Shadows/155.ts
+++ b/data/Sun & Moon/Burning Shadows/155.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Rockruff",
 		fr: "Rocabot",
+		de: "Wuffels"
 	},
 
 	suffix: "GX",

--- a/data/Sun & Moon/Burning Shadows/157.ts
+++ b/data/Sun & Moon/Burning Shadows/157.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Alolan Grimer",
 		fr: "Tadmorv d’Alola",
+		de: "Alola-Sleima"
 	},
 
 	suffix: "GX",
@@ -93,7 +94,7 @@ const card: Card = {
 				es: "Triple Riesgo GX",
 				it: "Triplo Rischio-GX",
 				pt: "Perigo Triplo GX",
-				de: "Dreifachgefahr GX"
+				de: "Dreifachgefahr-GX"
 			},
 			effect: {
 				en: "Switch 1 of your opponent’s Benched Pokémon with their Active Pokémon. The new Active Pokémon is now Burned, Paralyzed, and Poisoned. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Burning Shadows/158.ts
+++ b/data/Sun & Moon/Burning Shadows/158.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Una vez durante tu turno (antes de tu ataque), si este Pokémon está en tu pila de descartes, puedes ponerlo en tu Banca. Después, une 1 carta de Energía Darkness de tu pila de descartes a este Pokémon.",
 				it: "Una sola volta durante il tuo turno, prima di attaccare, se questo Pokémon è nella tua pila degli scarti, puoi metterlo in panchina. Poi, assegnagli una carta Energia Darkness dalla tua pila degli scarti.",
 				pt: "Uma vez durante a sua vez de jogar (antes de atacar), se este Pokémon estiver na sua pilha de descarte, você poderá colocá-lo no seu Banco. Em seguida, ligue 1 carta de Energia Darkness da sua pilha de descarte a este Pokémon.",
-				de: "Einmal während deines Zuges (bevor du angreifst), wenn sich dieses Pokémon in deinem Ablagestapel befindet, kannst du es auf deine Bank legen. Lege anschließend 1 Darkness-Energiekarte aus deinem Ablagestapel an dieses Pokémon an."
+				de: "Einmal während deines Zuges (bevor du angreifst), wenn sich dieses Pokémon in deinem Ablagestapel befindet, kannst du es auf deine Bank legen. Lege anschließend 1 {D}-Energiekarte aus deinem Ablagestapel an dieses Pokémon an."
 			},
 		},
 	],
@@ -88,7 +88,7 @@ const card: Card = {
 				es: "Sin Retorno GX",
 				it: "Vicolo Cieco-GX",
 				pt: "Sem Saída GX",
-				de: "Sackgasse GX"
+				de: "Sackgasse-GX"
 			},
 			effect: {
 				en: "If your opponent’s Active Pokémon is affected by a Special Condition, that Pokémon is Knocked Out. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Burning Shadows/159.ts
+++ b/data/Sun & Moon/Burning Shadows/159.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Kirlia",
 		fr: "Kirlia",
+		de: "Kirlia"
 	},
 
 	suffix: "GX",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Una vez durante tu turno (antes de tu ataque), puedes unir 1 carta de Energía Fairy de tu mano a 1 de tus Pokémon.",
 				it: "Una sola volta durante il tuo turno, prima di attaccare, puoi assegnare a uno dei tuoi Pokémon una carta Energia Fairy dalla tua mano.",
 				pt: "Uma vez durante a sua vez de jogar (antes de atacar), você pode ligar 1 carta de Energia Fairy da sua mão a 1 dos seus Pokémon.",
-				de: "Einmal während deines Zuges (bevor du angreifst) kannst du 1 Fairy-Energiekarte aus deiner Hand an 1 deiner Pokémon anlegen."
+				de: "Einmal während deines Zuges (bevor du angreifst) kannst du 1 {FAIRY}-Energiekarte aus deiner Hand an 1 deiner Pokémon anlegen."
 			},
 		},
 	],
@@ -89,7 +90,7 @@ const card: Card = {
 				es: "Crepúsculo GX",
 				it: "Crepuscolo-GX",
 				pt: "Crepúsculo GX",
-				de: "Zwielicht GX"
+				de: "Zwielicht-GX"
 			},
 			effect: {
 				en: "Shuffle 10 cards from your discard pile into your deck. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Burning Shadows/16.ts
+++ b/data/Sun & Moon/Burning Shadows/16.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon is a coward. As it desperately dashes off, the flailing of its many legs leaves a sparkling clean path in its wake.",
+		de: "Es ist so feige, dass es wild mit seinen vielen Füßen herumschlägt und verzweifelt davonläuft. Nach seiner Flucht glänzt der Boden herrlich."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/160.ts
+++ b/data/Sun & Moon/Burning Shadows/160.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Noibat",
 		fr: "Sonistrelle",
+		de: "eF-eM"
 	},
 
 	suffix: "GX",
@@ -95,7 +96,7 @@ const card: Card = {
 				es: "Estruendo GX",
 				it: "Ondaboato-GX",
 				pt: "Rajada Explosiva GX",
-				de: "Überschallknall GX"
+				de: "Überschallknall-GX"
 			},
 			effect: {
 				en: "This attack does 50 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Burning Shadows/161.ts
+++ b/data/Sun & Moon/Burning Shadows/161.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "El Pokémon de Fase 1 al que esté unida esta carta obtiene 40 PS más.",
 		it: "Il Pokémon di Fase 1 a cui è assegnata questa carta ha 40 PS in più.",
 		pt: "O Pokémon Estágio 1 que esta carta estiver ligada receberá +40 PS.",
-		de: "Das Phase-1-Pokémon, an das diese Karte angelegt ist, erhält 40 KP mehr."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Das Phase-1-Pokémon, an das diese Karte angelegt ist, erhält 40 KP mehr. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sun & Moon/Burning Shadows/162.ts
+++ b/data/Sun & Moon/Burning Shadows/162.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Los ataques del Pokémon al que esté unida esta carta hacen 30 puntos de daño más al Pokémon-GX Activo o Pokémon-EX Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
 		it: "Gli attacchi del Pokémon a cui è assegnata questa carta infliggono 30 danni in più al Pokémon-GX attivo o al Pokémon-EX attivo del tuo avversario, prima di aver applicato debolezza e resistenza.",
 		pt: "Os ataques do Pokémon ao qual esta carta está ligada causam 30 pontos de dano a mais ao Pokémon-GX Ativo ou ao Pokémon-EX Ativo do seu oponente (antes de aplicar Fraqueza e Resistência).",
-		de: "Die Attacken des Pokémon, an das diese Karte angelegt ist, fügen dem Aktiven Pokémon-GX oder Aktiven Pokémon-EX deines Gegners 30 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Die Attacken des Pokémon, an das diese Karte angelegt ist, fügen dem Aktiven Pokémon-GX oder Aktiven Pokémon-EX deines Gegners 30 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden). Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sun & Moon/Burning Shadows/163.ts
+++ b/data/Sun & Moon/Burning Shadows/163.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cada jugador cambia su Pokémon Activo por 1 de sus Pokémon en Banca. Tu rival lo cambia primero. (Si algún jugador no tiene ningún Pokémon en Banca, no cambiará su Pokémon).",
 		it: "Ciascun giocatore scambia il suo Pokémon attivo con uno dei suoi Pokémon in panchina. Inizia il tuo avversario. Se un giocatore non ha Pokémon in panchina, non effettuerà lo scambio.",
 		pt: "Cada jogador troca o seu Pokémon Ativo por 1 dos próprios Pokémon no Banco. O seu oponente troca primeiro (se um jogador não possuir Pokémon no Banco, aquele jogador não troca o Pokémon).",
-		de: "Jeder Spieler tauscht sein Aktives Pokémon gegen 1 Pokémon auf seiner Bank aus. Dein Gegener tauscht als Erster. (Hat ein Spieler kein Pokémon auf der Bank, tauscht jener Spieler kein Pokémon aus.)"
+		de: "Jeder Spieler tauscht sein Aktives Pokémon gegen 1 Pokémon auf seiner Bank aus. Dein Gegner tauscht als Erster. (Hat ein Spieler kein Pokémon auf der Bank, tauscht jener Spieler kein Pokémon aus.) Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Burning Shadows/164.ts
+++ b/data/Sun & Moon/Burning Shadows/164.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mueve 1 Energía de 1 de tus Pokémon en Banca a tu Pokémon Activo.",
 		it: "Sposta un’Energia da uno dei tuoi Pokémon in panchina al tuo Pokémon attivo.",
 		pt: "Mova 1 Energia de 1 dos seus Pokémon no Banco para o seu Pokémon Ativo.",
-		de: "Verschiebe 1 Energie von 1 Pokémon auf deiner Bank auf dein Aktives Pokémon."
+		de: "Verschiebe 1 Energie von 1 Pokémon auf deiner Bank auf dein Aktives Pokémon. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Burning Shadows/165.ts
+++ b/data/Sun & Moon/Burning Shadows/165.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Elige 1 opción:\n\n• Pon 1 Pokémon de tu pila de descartes en tu mano.\n• Pon 3 Pokémon de tu pila de descartes en tu baraja y baraja todas las cartas.",
 		it: "Scegli:\n\n• Prendi un Pokémon dalla tua pila degli scarti e aggiungilo alle carte che hai in mano.\n• Rimischia tre Pokémon dalla tua pila degli scarti nel tuo mazzo.",
 		pt: "Escolha 1:\n\n• Coloque 1 Pokémon da sua pilha de descarte na sua mão.\n• Embaralhe 3 Pokémon da sua pilha de descarte no seu baralho.",
-		de: "Wähle 1 aus:\n\n• Nimm 1 Pokémon aus deinem Ablagestapel auf deine Hand.\n• Mische 3 Pokémon aus deinem Ablagestapel in dein Deck."
+		de: "Wähle 1 aus: Nimm 1 Pokémon aus deinem Ablagestapel auf deine Hand. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen. Mische 3 Pokémon aus deinem Ablagestapel in dein Deck."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Burning Shadows/166.ts
+++ b/data/Sun & Moon/Burning Shadows/166.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Lanza 1 moneda. Si sale cara, pon 1 de tus Pokémon y todas las cartas unidas a él en tu mano.",
 		it: "Lancia una moneta. Se esce testa, riprendi in mano uno dei tuoi Pokémon e tutte le carte a esso assegnate.",
 		pt: "Jogue 1 moeda. Se sair cara, coloque 1 dos seus Pokémon e todas as cartas ligadas a ele na sua mão.",
-		de: "Wirf 1 Münze. Nimm bei Kopf 1 deiner Pokémon und alle an es angelegten Karten auf deine Hand."
+		de: "Wirf 1 Münze. Nimm bei Kopf 1 deiner Pokémon und alle an es angelegten Karten auf deine Hand. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Burning Shadows/17.ts
+++ b/data/Sun & Moon/Burning Shadows/17.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Wimpod",
 		fr: "Sovkipou",
+		de: "Reißlaus"
 	},
 
 	suffix: "GX",
@@ -94,7 +95,7 @@ const card: Card = {
 				es: "Corte Transversal GX",
 				it: "Sferzata Incrociata-GX",
 				pt: "Corte Transversal GX",
-				de: "Quertreiber GX"
+				de: "Quertreiber-GX"
 			},
 			effect: {
 				en: "Switch this Pokémon with 1 of your Benched Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Burning Shadows/18.ts
+++ b/data/Sun & Moon/Burning Shadows/18.ts
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "The flame on its tail indicates Charmander's life force. If it is healthy, the flame burns brightly.",
+		de: "Die Flamme auf seiner Schweifspitze zeigt die Lebensenergie an. Ist es gesund, leuchtet sie hell."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/19.ts
+++ b/data/Sun & Moon/Burning Shadows/19.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Charmander",
 		fr: "Salamèche",
+		de: "Glumanda"
 	},
 
 	stage: "Stage1",
@@ -82,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "It lashes about with its tail to knock down its foe. It then tears up the fallen opponent with sharp claws.",
+		de: "Es schlägt im Kampf mit seinem Schwanz nach seinen Gegnern. Anschließend zerfetzt es die Gegner mit seinen scharfen Klauen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/2.ts
+++ b/data/Sun & Moon/Burning Shadows/2.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Caterpie",
 		fr: "Chenipan",
+		de: "Raupy"
 	},
 
 	stage: "Stage1",
@@ -86,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "Its shell is filled with its soft innards. It doesn't move much because of the risk it might carelessly spill its innards out.",
+		de: "Sein harter Panzer birgt ein weiches Inneres. Um zu vermeiden, dass dieses versehentlich ausläuft, bewegt es sich kaum."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/20.ts
+++ b/data/Sun & Moon/Burning Shadows/20.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Charmeleon",
 		fr: "Reptincel",
+		de: "Glutexo"
 	},
 
 	suffix: "GX",
@@ -74,7 +75,7 @@ const card: Card = {
 				es: "Descarta 3 Energías Fire unidas a este Pokémon.",
 				it: "Scarta tre Energie Fire assegnate a questo Pokémon.",
 				pt: "Descarte 3 Energias Fire deste Pokémon.",
-				de: "Lege 3 Fire-Energien von diesem Pokémon auf deinen Ablagestapel."
+				de: "Lege 3 {R}-Energien von diesem Pokémon auf deinen Ablagestapel."
 			},
 			damage: 300,
 
@@ -91,7 +92,7 @@ const card: Card = {
 				es: "Enojo GX",
 				it: "Sfogo Rabbioso-GX",
 				pt: "Cólera GX",
-				de: "Tobsuchtsanfall GX"
+				de: "Tobsuchtsanfall-GX"
 			},
 			effect: {
 				en: "Discard the top 10 cards of your opponent’s deck. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Burning Shadows/21.ts
+++ b/data/Sun & Moon/Burning Shadows/21.ts
@@ -91,7 +91,7 @@ const card: Card = {
 				es: "Llama Eterna GX",
 				it: "Fiamma Eterna-GX",
 				pt: "Flama Perene GX",
-				de: "Ewige Flamme GX"
+				de: "Ewige Flamme-GX"
 			},
 			effect: {
 				en: "Put 3 in any combination of Fire Pokémon-GX or Fire Pokémon-EX from your discard pile onto your Bench. (You can’t use more than 1 GX attack in a game.)",
@@ -99,7 +99,7 @@ const card: Card = {
 				es: "Pon 3 Pokémon-GX Fire o Pokémon-EX Fire, en cualquier combinación, de tu pila de descartes en tu Banca. (No puedes usar más de 1 ataque GX en una partida).",
 				it: "Prendi tre Pokémon-GX Fire o Pokémon-EX Fire in qualsiasi combinazione dalla tua pila degli scarti e mettili nella tua panchina. Non puoi usare più di un attacco GX a partita.",
 				pt: "Coloque 3 Pokémon-GX Fire ou Pokémon-EX Fire da sua pilha de descarte no seu Banco em qualquer combinação (você não pode usar mais de 1 ataque GX por partida).",
-				de: "Lege eine beliebige Kombination aus 3 Fire-Pokémon-GX oder Fire-Pokémon-EX aus deinem Ablagestapel auf deine Bank. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
+				de: "Lege eine beliebige Kombination aus 3 {R}-Pokémon-GX oder {R}-Pokémon-EX aus deinem Ablagestapel auf deine Bank. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Burning Shadows/22.ts
+++ b/data/Sun & Moon/Burning Shadows/22.ts
@@ -58,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "Very intelligent, it roasts berries before eating them. It likes to help people.",
+		de: "Ein kultiviertes Pokémon, das Beeren vor dem Verzehr stets anbrät. Es bietet den Menschen gerne seine Hilfe an."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/23.ts
+++ b/data/Sun & Moon/Burning Shadows/23.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pansear",
 		fr: "Flamajou",
+		de: "Grillmak"
 	},
 
 	stage: "Stage1",
@@ -69,7 +70,7 @@ const card: Card = {
 				es: "Une 1 carta de Energía Fire de tu pila de descartes a 1 de tus Pokémon en Banca.",
 				it: "Assegna a uno dei tuoi Pokémon in panchina una carta Energia Fire dalla tua pila degli scarti.",
 				pt: "Ligue 1 carta de Energia Fire da sua pilha de descarte a 1 dos seus Pokémon no Banco.",
-				de: "Lege 1 Fire-Energiekarte aus deinem Ablagestapel an 1 Pokémon auf deiner Bank an."
+				de: "Lege 1 {R}-Energiekarte aus deinem Ablagestapel an 1 Pokémon auf deiner Bank an."
 			},
 			damage: 50,
 
@@ -87,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "A flame burns inside its body. It scatters embers from its head and tail to sear its opponents.",
+		de: "Es entfacht in seinem Körper ein Feuer und verkohlt Gegner mit Funken aus seinem Kopf und Schweif."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/24.ts
+++ b/data/Sun & Moon/Burning Shadows/24.ts
@@ -90,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "Using their very hot, flame-covered tongues, they burn through Durant's steel bodies and consume their insides.",
+		de: "Mit seiner brandheißen Zunge bringt es Fermicula zum Schmelzen, um so an sein weiches Inneres zu gelangen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/25.ts
+++ b/data/Sun & Moon/Burning Shadows/25.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Salandit",
 		fr: "Tritox",
+		de: "Molunk"
 	},
 
 	suffix: "GX",
@@ -86,7 +87,7 @@ const card: Card = {
 				es: "Niebla Regia GX",
 				it: "Foschia della Regina-GX",
 				pt: "Névoa da Rainha GX",
-				de: "Dunst der Königin GX"
+				de: "Dunst der Königin-GX"
 			},
 			effect: {
 				en: "Discard all Energy from your opponent’s Active Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Burning Shadows/26.ts
+++ b/data/Sun & Moon/Burning Shadows/26.ts
@@ -48,7 +48,7 @@ const card: Card = {
 				es: "Une 1 carta de Energía Fire de tu pila de descartes a este Pokémon.",
 				it: "Assegna a questo Pokémon una carta Energia Fire dalla tua pila degli scarti.",
 				pt: "Ligue 1 carta de Energia Fire da sua pilha de descarte a este Pokémon.",
-				de: "Lege 1 Fire-Energiekarte aus deinem Ablagestapel an dieses Pokémon an."
+				de: "Lege 1 {R}-Energiekarte aus deinem Ablagestapel an dieses Pokémon an."
 			},
 			damage: 30,
 
@@ -84,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "The shell on its back is chemically unstable and explodes violently if struck. The hole in its stomach is its weak point.",
+		de: "Sein Rückenpanzer ist explosiv, man sollte ihm also niemals auf den Rücken klopfen. Das Loch in seinem Bauch ist seine Schwachstelle."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/27.ts
+++ b/data/Sun & Moon/Burning Shadows/27.ts
@@ -79,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "It exhales air colder than -58 degrees Fahrenheit. Elderly people in Alola call this Pokémon by an older name—Keokeo.",
+		de: "Sein eisiger Atem beträgt -50 °C. Einige der älteren Einwohner von Alola nennen es bei seinem früheren Namen „Ke’oke’o“."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/28.ts
+++ b/data/Sun & Moon/Burning Shadows/28.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Alolan Vulpix",
 		fr: "Goupix d’Alola",
+		de: "Alola-Vulpix"
 	},
 
 	stage: "Stage1",
@@ -87,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It creates drops of ice in its coat and showers them over its enemies. Anyone who angers it will be frozen stiff in an instant.",
+		de: "Es greift seine Feinde mittels Eiskristallen an, die es mit seinem Fell erzeugt. Wer es wütend macht, wird in Sekundenschnelle tiefgefroren."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/29.ts
+++ b/data/Sun & Moon/Burning Shadows/29.ts
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "Known to shoot down flying bugs with precision blasts of ink from the surface of the water.",
+		de: "Dieses Pokémon schießt mit Tinte auf über der Wasseroberfläche fliegende Insekten."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/3.ts
+++ b/data/Sun & Moon/Burning Shadows/3.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Metapod",
 		fr: "Chrysacier",
+		de: "Safcon"
 	},
 
 	stage: "Stage2",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "Close examination of its large eyes reveals that each eye is composed of a myriad of tiny eyes.",
+		de: "Bei genauerer Betrachtung zeigt sich, dass seine zwei großen Augen jeweils aus einer Vielzahl an kleineren Augen bestehen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/30.ts
+++ b/data/Sun & Moon/Burning Shadows/30.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Horsea",
 		fr: "Hypotrempe",
+		de: "Seeper"
 	},
 
 	stage: "Stage1",
@@ -69,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "Its body bristles with sharp spikes. Carelessly trying to touch it could cause fainting from the spikes.",
+		de: "Sein Körper ist mit scharfen Stacheln gespickt. Wenn man sorglos ist und es berührt, kann man durch die Stacheln bewusstlos werden."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/31.ts
+++ b/data/Sun & Moon/Burning Shadows/31.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Seadra",
 		fr: "Hypocéan",
+		de: "Seemon"
 	},
 
 	stage: "Stage2",
@@ -74,7 +75,7 @@ const card: Card = {
 				es: "Descarta 1 Energía Water de este Pokémon. Este ataque hace 30 puntos de daño a 1 de los Pokémon en Banca de tu rival. (No apliques Debilidad y Resistencia a los Pokémon en Banca).",
 				it: "Scarta un’Energia Water assegnata a questo Pokémon. Questo attacco infligge 30 danni a uno dei Pokémon in panchina del tuo avversario. Ricorda che non puoi applicare debolezza e resistenza ai Pokémon in panchina.",
 				pt: "Descarte 1 Energia Water deste Pokémon. Este ataque causa 30 pontos de dano a 1 dos Pokémon no Banco do seu oponente (não aplique Fraqueza e Resistência aos Pokémon no Banco).",
-				de: "Lege 1 Water-Energie von diesem Pokémon auf deinen Ablagestapel. Diese Attacke fügt 1 Pokémon auf der Bank deines Gegners 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Lege 1 {W}-Energie von diesem Pokémon auf deinen Ablagestapel. Diese Attacke fügt 1 Pokémon auf der Bank deines Gegners 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 90,
 
@@ -92,6 +93,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said that it usually hides in underwater caves. It can create whirlpools by yawning.",
+		de: "Man sagt, es hause in Unterwasserhöhlen. Es kann mächtige Strudel generieren, wenn es gähnt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/32.ts
+++ b/data/Sun & Moon/Burning Shadows/32.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "Although weak and helpless, this Pokémon is incredibly fertile. They exist in such multitudes, you'll soon grow tired of seeing them.",
+		de: "Es ist schwach und unzuverlässig, aber es vermehrt sich unglaublich schnell. Deshalb trifft man es auch öfter an, als einem lieb ist."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/33.ts
+++ b/data/Sun & Moon/Burning Shadows/33.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Magikarp",
 		fr: "Magicarpe",
+		de: "Karpador"
 	},
 
 	stage: "Stage1",
@@ -97,6 +98,7 @@ const card: Card = {
 
 	description: {
 		en: "A tale is told of a town that angered Gyarados. Before the sun rose the next day, flames utterly consumed the town, leaving not a trace behind.",
+		de: "Es heißt, es habe eine ganze Stadt, deren Bewohner es verärgert hatten, über Nacht vollständig in Schutt und Asche gelegt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/34.ts
+++ b/data/Sun & Moon/Burning Shadows/34.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "The fur on its body naturally repels water. It can stay dry, even when it plays in the water.",
+		de: "Sein Fell ist von Natur aus wasserabweisend. Es bleibt trocken, auch wenn es im Wasser spielt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/35.ts
+++ b/data/Sun & Moon/Burning Shadows/35.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Marill",
 		fr: "Marill",
+		de: "Marill"
 	},
 
 	stage: "Stage1",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Cualquier daño infligido a este Pokémon por ataques de los Pokémon Fire o Water de tu rival se reduce en 30 (después de aplicar Debilidad y Resistencia).",
 				it: "I danni inflitti a questo Pokémon dagli attacchi dei Pokémon Fire o Water del tuo avversario sono ridotti di 30, dopo aver applicato debolezza e resistenza.",
 				pt: "Qualquer dano feito a este Pokémon por ataques de Pokémon Fire ou Water do seu oponente será reduzido em 30 (após a aplicação de Fraqueza e Resistência).",
-				de: "Schaden, der diesem Pokémon durch Angriffe der Fire- oder Water- Pokémon deines Gegners zugefügt wird, wird um 30 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
+				de: "Diesem Pokémon werden durch Attacken der {R}- oder {W}-Pokémon deines Gegners 30 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 		},
 	],
@@ -87,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Its long ears are superb sensors. It can distinguish the movements of living things on riverbeds.",
+		de: "Seine langen Ohren sind hervorragende Sensoren. Mit ihnen kann es Bewegungen im Fluss wahrnehmen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/36.ts
+++ b/data/Sun & Moon/Burning Shadows/36.ts
@@ -58,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "The water stored inside the tuft on its head is full of nutrients. It waters plants with it using its tail.",
+		de: "Das Büschel auf seinem Kopf enthält eine sehr nahrhafte Flüssigkeit, mit der es über seinen Schweif Pflanzen wässert."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/37.ts
+++ b/data/Sun & Moon/Burning Shadows/37.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Panpour",
 		fr: "Flotajou",
+		de: "Sodamak"
 	},
 
 	stage: "Stage1",
@@ -69,7 +70,7 @@ const card: Card = {
 				es: "Mueve 1 Energía Water de este Pokémon a 1 de tus Pokémon en Banca.",
 				it: "Sposta un’Energia Water da questo Pokémon a uno di quelli nella tua panchina.",
 				pt: "Mova 1 Energia Water deste Pokémon para 1 dos seus Pokémon no Banco.",
-				de: "Verschiebe 1 Water-Energie von diesem Pokémon auf 1 Pokémon auf deiner Bank."
+				de: "Verschiebe 1 {W}-Energie von diesem Pokémon auf 1 Pokémon auf deiner Bank."
 			},
 			damage: 50,
 
@@ -87,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "The high-pressure water expelled from its tail is so powerful, it can destroy a concrete wall.",
+		de: "Es schießt mit so hohem Druck Wasser aus seinem Schweif, dass selbst Betonwände den Kürzeren ziehen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/38.ts
+++ b/data/Sun & Moon/Burning Shadows/38.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "When it unleashes its psychic power from the protuberance on its head, the grating sound of grinding teeth echoes through the area.",
+		de: "Wenn es über den Fortsatz an seinem Kopf Psycho-Kräfte freisetzt, ertönt in seiner Umgebung ein unangenehmes Zähneknirschen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/39.ts
+++ b/data/Sun & Moon/Burning Shadows/39.ts
@@ -72,7 +72,7 @@ const card: Card = {
 				es: "Descarta 2 Energías Water de este Pokémon. Este ataque hace 120 puntos de daño a 1 de los Pokémon de tu rival. (No apliques Debilidad y Resistencia a los Pokémon en Banca).",
 				it: "Scarta due Energie Water assegnate a questo Pokémon. Questo attacco infligge 120 danni a uno dei Pokémon del tuo avversario. Ricorda che non puoi applicare debolezza e resistenza ai Pokémon in panchina.",
 				pt: "Descarte 2 Energias Water deste Pokémon. Este ataque causa 120 pontos de dano a 1 dos Pokémon do seu oponente (não aplique Fraqueza e Resistência aos Pokémon no Banco).",
-				de: "Lege 2 Water-Energien von diesem Pokémon auf deinen Ablagestapel. Diese Attacke fügt 1 Pokémon deines Gegners 120 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Lege 2 {W}-Energien von diesem Pokémon auf deinen Ablagestapel. Diese Attacke fügt 1 Pokémon deines Gegners 120 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -86,7 +86,7 @@ const card: Card = {
 				es: "Tormenta Tapu GX",
 				it: "Taputempesta-GX",
 				pt: "Tempestade Tapu GX",
-				de: "Kapu-Sturm GX"
+				de: "Kapu-Sturm-GX"
 			},
 			effect: {
 				en: "Shuffle your opponent’s Active Pokémon and all cards attached to it into their deck. If your opponent has no Benched Pokémon, this attack does nothing. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Burning Shadows/4.ts
+++ b/data/Sun & Moon/Burning Shadows/4.ts
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "During the day, it stays in the cold underground to avoid the sun. It grows by bathing in moonlight.",
+		de: "Tagsüber versteckt es sich in der kalten Erde, um die Sonne zu meiden. Es wächst im Mondschein."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/40.ts
+++ b/data/Sun & Moon/Burning Shadows/40.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "A plan was recently announced to gather many Pikachu and make an electric power plant.",
+		de: "Vor Kurzem wurden Pläne verkündet, mithilfe einer großen Anzahl an Pikachu ein ganzes Kraftwerk zu betreiben."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/41.ts
+++ b/data/Sun & Moon/Burning Shadows/41.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pikachu",
 		fr: "Pikachu",
+		de: "Pikachu"
 	},
 
 	stage: "Stage1",
@@ -101,6 +102,7 @@ const card: Card = {
 
 	description: {
 		en: "It unleashes electric shocks that can reach 100,000 volts. When agitated, it can knock out even an Indian elephant.",
+		de: "Seine elektrischen Ladungen erreichen bis zu 100 000 V. Bei unvorsichtigem Kontakt wird sogar ein indischer Elefant bewusstlos."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/42.ts
+++ b/data/Sun & Moon/Burning Shadows/42.ts
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "Half of all sudden blackouts are caused by Electabuzz gathering at electric power plants and gobbling up electricity.",
+		de: "Für die Hälfte aller plötzlichen Stromausfälle sind Elektek verantwortlich. Sie belagern gerne Kraftwerke und zapfen ihnen Strom ab."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/43.ts
+++ b/data/Sun & Moon/Burning Shadows/43.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Electabuzz",
 		fr: "Élektek",
+		de: "Elektek"
 	},
 
 	stage: "Stage1",
@@ -105,6 +106,7 @@ const card: Card = {
 
 	description: {
 		en: "It pushes the tips of its tails against its foes and then lets loose a high-voltage current. Its foes are burned to a crisp in an instant.",
+		de: "Es berührt Gegner mit seinen Schweifspitzen und entlädt dann starke Elektrizität. So kann es sie im Nullkommanichts verkohlen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/44.ts
+++ b/data/Sun & Moon/Burning Shadows/44.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Si el Pokémon Activo de tu rival tiene alguna Energía Water unida a él, este ataque hace 30 puntos de daño más.",
 				it: "Se il Pokémon attivo del tuo avversario ha delle Energie Water assegnate, questo attacco infligge 30 danni in più.",
 				pt: "Se o Pokémon Ativo do seu oponente possuir alguma Energia Water ligada a ele, este ataque causará 30 pontos de dano a mais.",
-				de: "Wenn an das Aktive Pokémon deines Gegners mindestens 1 Water-Energie angelegt ist, fügt diese Attacke 30 Schadenspunkte mehr zu."
+				de: "Wenn an das Aktive Pokémon deines Gegners mindestens 1 {W}-Energie angelegt ist, fügt diese Attacke 30 Schadenspunkte mehr zu."
 			},
 			damage: "10+",
 
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "While one alone doesn't have much power, a chain of many Tynamo can be as powerful as lightning.",
+		de: "Allein erzeugt es nur wenig Strom, doch tritt es geschlossen im Schwarm auf, gleicht seine Kraft der eines Blitzes."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/45.ts
+++ b/data/Sun & Moon/Burning Shadows/45.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Tynamo",
 		fr: "Anchwatt",
+		de: "Zapplardin"
 	},
 
 	stage: "Stage1",
@@ -78,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "It wraps itself around its prey and paralyzes it with electricity from the round spots on its sides. Then it chomps.",
+		de: "Schlingt sich um Gegner, lähmt sie über die rund gemaserten Flächen an seinem Körper mit Strom und beißt beherzt zu."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/46.ts
+++ b/data/Sun & Moon/Burning Shadows/46.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eelektrik",
 		fr: "Lampéroie",
+		de: "Zapplalek"
 	},
 
 	stage: "Stage2",
@@ -103,6 +104,7 @@ const card: Card = {
 
 	description: {
 		en: "With their sucker mouths, they suck in prey. Then they use their fangs to shock the prey with electricity.",
+		de: "Mit dem Saugnapf an seinem Maul hakt es sich an seiner Beute fest und versetzt ihr über seine Fangzähne Stromschläge."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/47.ts
+++ b/data/Sun & Moon/Burning Shadows/47.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "The spiny fur on its back is normally at rest. When this Pokémon becomes agitated, its fur stands on end and stabs into its attackers.",
+		de: "Normalerweise liegen seine Stacheln am Rücken an, aber wenn es sich aufregt, stellen sie sich auf und stechen angreifende Gegner."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/48.ts
+++ b/data/Sun & Moon/Burning Shadows/48.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Slowpoke",
 		fr: "Ramoloss",
+		de: "Flegmon"
 	},
 
 	stage: "Stage1",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "A poisonous bite reacted with its system, blessing it with the enhanced intellect of a genius. It has full control of its psychic powers.",
+		de: "Durch einen giftigen Biss wurde es zu einer wahren Intelligenzbestie. Es verfügt über Psycho-Kräfte."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/49.ts
+++ b/data/Sun & Moon/Burning Shadows/49.ts
@@ -49,7 +49,7 @@ const card: Card = {
 				es: "Este ataque hace 50 puntos de daño por cada Colorless en el Coste de Retirada del Pokémon Activo de tu rival.",
 				it: "Questo attacco infligge 50 danni per ogni Colorless nel costo di ritirata del Pokémon attivo del tuo avversario.",
 				pt: "Este ataque causa 50 pontos de dano para cada Colorless no custo de Recuo do Pokémon Ativo do seu oponente.",
-				de: "Diese Attacke fügt 50 Schadenspunkte mal der Anzahl der Colorless-Symbole in den Rückzugskosten des Aktiven Pokémon deines Gegners zu."
+				de: "Diese Attacke fügt 50 Schadenspunkte mal der Anzahl der {C}-Symbole in den Rückzugskosten des Aktiven Pokémon deines Gegners zu."
 			},
 			damage: "50×",
 
@@ -67,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "It hates light and shock. If attacked, it inflates its body to build up its counterstrike.",
+		de: "Es hasst Licht und Schläge. Wird es angegriffen, pumpt es sich auf, um einen Gegenschlag vorzubereiten."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/5.ts
+++ b/data/Sun & Moon/Burning Shadows/5.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Oddish",
 		fr: "Mystherbe",
+		de: "Myrapla"
 	},
 
 	stage: "Stage1",
@@ -86,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "Smells incredibly foul! However, around one out of a thousand people enjoy sniffing its nose-bending stink.",
+		de: "Dieses Pokémon sondert einen übelriechenden Geruch ab. Trotzdem halten einige Leute es im Haus."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/50.ts
+++ b/data/Sun & Moon/Burning Shadows/50.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "In battle, it uses its bladed tail to counter any Zangoose. It secretes a deadly venom in its tail.",
+		de: "Die flinken Angriffe von Sengo kontert es mit seinem messerscharfen Schweif, aus dem Gift austritt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/51.ts
+++ b/data/Sun & Moon/Burning Shadows/51.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It doggedly pursues its prey wherever it goes. However, the chase is abandoned at sunrise.",
+		de: "Verbissen verfolgt es seine Beute überallhin. Doch sobald die Sonne aufgeht, ist die Jagd vorbei."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/52.ts
+++ b/data/Sun & Moon/Burning Shadows/52.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Duskull",
 		fr: "Skelénox",
+		de: "Zwirrlicht"
 	},
 
 	stage: "Stage1",
@@ -101,6 +102,7 @@ const card: Card = {
 
 	description: {
 		en: "Anyone who dares peer into its body to see its spectral ball of fire will have their spirit stolen away.",
+		de: "Blickt man direkt in den Feuerball in seinem Inneren, wird einem die Seele ausgesaugt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/53.ts
+++ b/data/Sun & Moon/Burning Shadows/53.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Dusclops",
 		fr: "Téraclope",
+		de: "Zwirrklop"
 	},
 
 	stage: "Stage2",
@@ -101,6 +102,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said to take lost spirits into its pliant body and guide them home.",
+		de: "Man sagt, dass es verlorene Seelen in seinem biegsamen Körper nach Hause geleite."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/54.ts
+++ b/data/Sun & Moon/Burning Shadows/54.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "Its cheeks hold poison sacs. It tries to catch foes off guard to jab them with toxic fingers.",
+		de: "In seinen Backen sammelt sich Gift. Es versucht, Beute zu überraschen und mit Giftfingern zu schnappen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/55.ts
+++ b/data/Sun & Moon/Burning Shadows/55.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Croagunk",
 		fr: "Cradopaud",
+		de: "Glibunkel"
 	},
 
 	stage: "Stage1",
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "It has a poison sac at its throat. When it croaks, the stored poison is churned for greater potency.",
+		de: "Verfügt über einen Giftsack an seiner Kehle. Quakt es, schäumt das Gift und wird so noch stärker."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/56.ts
+++ b/data/Sun & Moon/Burning Shadows/56.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It discovers what is going on around it by using the feelers on its head and tail. It is brutally aggressive.",
+		de: "Mit seinen Ruten und den Fühlern an seinem Kopf tastet es die Umgebung ab. Ein überaus aggressiver Geselle."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/57.ts
+++ b/data/Sun & Moon/Burning Shadows/57.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Venipede",
 		fr: "Venipatte",
+		de: "Toxiped"
 	},
 
 	stage: "Stage1",
@@ -89,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "Protected by a hard shell, it spins its body like a wheel and crashes furiously into its enemies.",
+		de: "Von einem harten Schutzpanzer umgeben. Es greift seine Gegner an, indem es mit Karacho wie ein Rad in sie hineinrollt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/58.ts
+++ b/data/Sun & Moon/Burning Shadows/58.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Whirlipede",
 		fr: "Scobolide",
+		de: "Rollum"
 	},
 
 	stage: "Stage2",
@@ -98,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "It clasps its prey with the claws on its neck until it stops moving. Then it finishes it off with deadly poison.",
+		de: "Lähmt seine Beute, indem es sie mit den Zacken an seinem Hals aufspießt. Mit einer Ladung Gift gibt es ihr den Rest."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/59.ts
+++ b/data/Sun & Moon/Burning Shadows/59.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "La Debilidad del Pokémon Defensor pasa a ser Psychic hasta el final de tu próximo turno. (La cantidad de Debilidad no cambia).",
 				it: "La debolezza del Pokémon difensore diventa Psychic fino alla fine del tuo prossimo turno. Quanto è debole non cambia.",
 				pt: "A Fraqueza do Pokémon Defensor será Psychic até o final da sua próxima vez de jogar (a quantidade de Fraqueza não muda).",
-				de: "Bis zum Ende deines nächsten Zuges ist die Schwäche des Verteidigenden Pokémon jetzt Psychic. (Die Höhe der Schwäche ändert sich nicht.)"
+				de: "Bis zum Ende deines nächsten Zuges ist die Schwäche des Verteidigenden Pokémon jetzt {P}. (Die Höhe der Schwäche ändert sich nicht.)"
 			},
 
 		},
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "The organ that emits its intense psychic power is sheltered by its ears to keep power from leaking out.",
+		de: "Damit die starken Psycho-Kräfte dieses Pokémon nicht unkontrolliert nach außen dringen, ist das Organ, das diese freisetzt, von seinen Ohren bedeckt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/6.ts
+++ b/data/Sun & Moon/Burning Shadows/6.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gloom",
 		fr: "Ortide",
+		de: "Duflor"
 	},
 
 	stage: "Stage2",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "The larger its petals, the more toxic pollen it contains. Its big head is heavy and hard to hold up.",
+		de: "Je größer die Blütenblätter, desto mehr giftige Pollen sind in der Blüte enthalten."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/60.ts
+++ b/data/Sun & Moon/Burning Shadows/60.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Espurr",
 		fr: "Psystigri",
+		de: "Psiau"
 	},
 
 	stage: "Stage1",
@@ -93,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "When in danger, it raises its ears and releases enough psychic power to grind a 10-ton truck to dust.",
+		de: "In Gefahrensituationen hebt es seine Ohren an und setzt Psycho-Kräfte frei, die einen 10 t schweren LKW zu Schrott verarbeiten können."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/61.ts
+++ b/data/Sun & Moon/Burning Shadows/61.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "Born from a sand mound playfully built by a child, this Pokémon embodies the grudges of the departed.",
+		de: "Der Groll eines verstorbenen Reisenden fuhr in einen Sandhügel, den ein Kind gebaut hatte, und brachte dieses Pokémon in die Welt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/62.ts
+++ b/data/Sun & Moon/Burning Shadows/62.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Sandygast",
 		fr: "Bacabouh",
+		de: "Sankabuh"
 	},
 
 	stage: "Stage1",
@@ -105,6 +106,7 @@ const card: Card = {
 
 	description: {
 		en: "Possessed people controlled by this Pokémon transformed its sand mound into a castle. As it evolved, its power to curse grew ever stronger.",
+		de: "Brachte Menschen dazu, den Sandhügel zu einer stattlichen Sandburg auszubauen. Auch seine Flüche haben an Stärke gewonnen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/63.ts
+++ b/data/Sun & Moon/Burning Shadows/63.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Evita todo el daño infligido a este Pokémon por ataques de Pokémon Colorless.",
 				it: "Previeni tutti i danni da attacchi inflitti a questo Pokémon dai Pokémon Colorless.",
 				pt: "Previne todo o dano causado a este Pokémon por ataques de Pokémon Colorless.",
-				de: "Verhindere allen Schaden, der diesem Pokémon durch Attacken von Colorless-Pokémon zugefügt wird."
+				de: "Verhindere allen Schaden, der diesem Pokémon durch Attacken von {C}-Pokémon zugefügt wird."
 			},
 		},
 	],
@@ -71,7 +71,7 @@ const card: Card = {
 				es: "Descarta todas las Energías Psychic de este Pokémon. Este ataque hace 60 puntos de daño más por cada carta que hayas descartado de esta manera.",
 				it: "Scarta tutte le Energie Psychic assegnate a questo Pokémon. Questo attacco infligge 60 danni in più per ogni carta che hai scartato in questo modo.",
 				pt: "Descarte todas as Energias Psychic deste Pokémon. Este ataque causa 60 pontos de dano a mais para cada carta descartada desta forma.",
-				de: "Lege alle Psychic-Energien von diesem Pokémon auf deinen Ablagestapel. Diese Attacke fügt 60 Schadenspunkte mehr mal der Anzahl der auf diese Weise auf deinen Ablagestapel gelegten Karten zu."
+				de: "Lege alle {P}-Energien von diesem Pokémon auf deinen Ablagestapel. Diese Attacke fügt 60 Schadenspunkte mehr mal der Anzahl der auf diese Weise auf deinen Ablagestapel gelegten Karten zu."
 			},
 			damage: "10+",
 
@@ -88,7 +88,7 @@ const card: Card = {
 				es: "Rayo Negro GX",
 				it: "Raggio Nero-GX",
 				pt: "Raio Preto GX",
-				de: "Schwarzer Strahl GX"
+				de: "Schwarzer Strahl-GX"
 			},
 			effect: {
 				en: "This attack does 100 damage to each of your opponent’s Pokémon-GX and Pokémon-EX. This damage isn’t affected by Weakness or Resistance. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Burning Shadows/64.ts
+++ b/data/Sun & Moon/Burning Shadows/64.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Machoke",
 		fr: "Machopeur",
+		de: "Maschock"
 	},
 
 	suffix: "GX",
@@ -95,7 +96,7 @@ const card: Card = {
 				es: "Puro Músculo GX",
 				it: "Pugno Nerboruto-GX",
 				pt: "Soco Musculoso GX",
-				de: "Muskel-Punch GX"
+				de: "Muskel-Punch-GX"
 			},
 			effect: {
 				en: "This attack’s damage isn’t affected by Resistance. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Burning Shadows/65.ts
+++ b/data/Sun & Moon/Burning Shadows/65.ts
@@ -77,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "Strong, but not too bright, this Pokémon can shatter even a skyscraper with its charging Tackles.",
+		de: "Stark, aber nicht allzu klug, kann dieses Pokémon sogar Hochhäuser mit seinem Tackle-Angriff zum Einsturz bringen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/66.ts
+++ b/data/Sun & Moon/Burning Shadows/66.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Rhyhorn",
 		fr: "Rhinocorne",
+		de: "Rihorn"
 	},
 
 	stage: "Stage1",
@@ -98,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "Protected by an armor-like hide, it is capable of living in molten lava of 3,600 degrees Fahrenheit.",
+		de: "Durch seine panzerähnliche Körperhülle kann es in bis zu 2 000 °C heißer Lava leben."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/67.ts
+++ b/data/Sun & Moon/Burning Shadows/67.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Rhydon",
 		fr: "Rhinoféros",
+		de: "Rizeros"
 	},
 
 	stage: "Stage2",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Cuando juegues este Pokémon de tu mano para hacer evolucionar a 1 de tus Pokémon, puedes descartar las 3 primeras cartas de la baraja de tu rival.",
 				it: "Quando giochi questo Pokémon dalla tua mano per far evolvere uno dei tuoi Pokémon, puoi scartare le tre carte in cima al mazzo del tuo avversario.",
 				pt: "Ao jogar este Pokémon da sua mão para evoluir 1 dos seus Pokémon, você pode descartar os 3 cards de cima do baralho do seu oponente.",
-				de: "Wenn du dieses Pokémon von deiner Hand spielst, um 1 deiner Pokémon zu entwickeln, kannst du die obersten 3 Karten vom Deck deines Gegners auf seinen Ablagestapel legen."
+				de: "Wenn du dieses Pokémon aus deiner Hand spielst, um 1 deiner Pokémon während deines Zuges zu entwickeln, kannst du die obersten 3 Karten vom Deck deines Gegners auf seinen Ablagestapel legen."
 			},
 		},
 	],
@@ -95,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "From holes in its palms, it fires out Geodude. Its carapace can withstand volcanic eruptions.",
+		de: "Es feuert Kleinstein aus seinen Handflächen. Durch seinen Schützer erträgt es sogar Vulkanausbrüche."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/68.ts
+++ b/data/Sun & Moon/Burning Shadows/68.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Because it turns active on nights of the full moon, it is said to have some link to the lunar phases.",
+		de: "Da es in Vollmondnächten aktiv wird, sagt man ihm nach, mit den Mondphasen in Verbindung zu stehen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/69.ts
+++ b/data/Sun & Moon/Burning Shadows/69.ts
@@ -87,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "Solar energy is the source of its power, so it is strong during the daytime. When it spins, its body shines.",
+		de: "Da es seine Energie aus Sonnenlicht gewinnt, ist es tagsüber am stärksten. Wenn es sich dreht, leuchtet es."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/7.ts
+++ b/data/Sun & Moon/Burning Shadows/7.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "Many writhing vines cover it, so its true identity remains unknown. The blue vines grow its whole life long.",
+		de: "Aufgrund der Ranken, die seinen Körper bedecken, kennt keiner seine wahre Form. Die blauen Ranken wachsen immer weiter."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/70.ts
+++ b/data/Sun & Moon/Burning Shadows/70.ts
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "It can discern the physical and emotional states of people, Pokémon, and other natural things from the shape of their aura waves.",
+		de: "Es sieht sowohl die Gefühle von Menschen und Pokémon als auch die ihn umgebende Natur in Form von Wellen, die Aura genannt werden."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/71.ts
+++ b/data/Sun & Moon/Burning Shadows/71.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Riolu",
 		fr: "Riolu",
+		de: "Riolu"
 	},
 
 	stage: "Stage1",
@@ -87,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Not only does it perceive auras, but it has also gained the power to control them. It employs them in battle.",
+		de: "Es kann Auren nicht nur wahrnehmen, sondern auch manipulieren. Diese Fähigkeit nutzt es beim Kämpfen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/72.ts
+++ b/data/Sun & Moon/Burning Shadows/72.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Desiring the strongest karate chop, they seclude themselves in mountains and train without sleeping.",
+		de: "Es lebt zurückgezogen in den Bergen und trainiert Tag und Nacht, um seinen Karateschlag zu perfektionieren."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/73.ts
+++ b/data/Sun & Moon/Burning Shadows/73.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "While guarding its weak points with its pincers, it looks for an opening and unleashes punches. When it loses, it foams at the mouth and faints.",
+		de: "Schützt mit den Scheren seine Schwachstellen und bereitet einen Gegenschlag vor. Verliert es, bläst es Trübsal."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/74.ts
+++ b/data/Sun & Moon/Burning Shadows/74.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Crabrawler",
 		fr: "Crabagarre",
+		de: "Krabbox"
 	},
 
 	stage: "Stage1",
@@ -95,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "It aimed for the top but got lost and ended up on a snowy mountain. Being forced to endure the cold, this Pokémon evolved and grew fur.",
+		de: "Es wollte auf eine verschneite Bergspitze, hat sich aber verlaufen. In der Kälte wuchs ihm dann ein Fell und es entwickelte sich weiter."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/75.ts
+++ b/data/Sun & Moon/Burning Shadows/75.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Rockruff",
 		fr: "Rocabot",
+		de: "Wuffels"
 	},
 
 	stage: "Stage1",
@@ -95,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "The more intimidating the opponent it faces, the more this Pokémon's blood boils. It will attack with no regard for its own safety.",
+		de: "Je gefährlicher sein Gegner, desto mehr kommt es in Fahrt. Im Kampf ist es bereit, alles aufs Spiel zu setzen, um den Sieg zu erringen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/76.ts
+++ b/data/Sun & Moon/Burning Shadows/76.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Rockruff",
 		fr: "Rocabot",
+		de: "Wuffels"
 	},
 
 	stage: "Stage1",
@@ -82,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "Its quick movements confuse its enemies. Well equipped with claws and fangs, it also uses the sharp rocks in its mane as weapons.",
+		de: "Irritiert seine Feinde mit schnellen Bewegungen. Als Waffen hat es nicht nur Krallen und Hauer, sondern auch die spitzen Felsen seiner Mähne."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/77.ts
+++ b/data/Sun & Moon/Burning Shadows/77.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "The mud stuck to Mudbray's hooves enhances its grip and its powerful running gait.",
+		de: "Der ganze Schlamm an seinen Füßen sorgt für die nötige Bodenhaftung, die es für seinen kraftvollen Lauf braucht."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/78.ts
+++ b/data/Sun & Moon/Burning Shadows/78.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Mudbray",
 		fr: "Tiboudet",
+		de: "Pampuli"
 	},
 
 	stage: "Stage1",
@@ -98,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "It spits a mud that provides resistance to both wind and rain, so the walls of old houses were often coated with it.",
+		de: "Der Schlamm, den es ausspuckt, schützt gegen Wind und Wetter, wenn er hart wird. Deshalb hat man früher auch Hauswände damit verstärkt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/79.ts
+++ b/data/Sun & Moon/Burning Shadows/79.ts
@@ -83,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "They form groups of roughly 20 individuals. Their mutual bond is remarkable—they will never let down a comrade.",
+		de: "Es gründet Gruppen von etwa 20 Exemplaren. Der Zusammenhalt der Gruppe ist extrem stark, kein Kamerad wird jemals im Stich gelassen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/8.ts
+++ b/data/Sun & Moon/Burning Shadows/8.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Tangela",
 		fr: "Saquedeneu",
+		de: "Tangela"
 	},
 
 	stage: "Stage1",
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "It ensnares prey by extending arms made of vines. Losing arms to predators does not trouble it.",
+		de: "Es umwickelt Beute, indem es seine Arme, die aus Ranken bestehen, verlängert."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/81.ts
+++ b/data/Sun & Moon/Burning Shadows/81.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "With its incisors, it gnaws through doors and infiltrates people's homes. Then, with a twitch of its whiskers, it steals whatever food it finds.",
+		de: "Mithilfe seiner Vorderzähne knabbert es sich durch Wohnungstüren. Vibrierende Schnurrhaare helfen ihm, Futter zu finden und es zu stehlen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/82.ts
+++ b/data/Sun & Moon/Burning Shadows/82.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Alolan Rattata",
 		fr: "Rattata d’Alola",
+		de: "Alola-Rattfratz"
 	},
 
 	stage: "Stage1",
@@ -98,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "It forms a group of Rattata, which it assumes command of. Each group has its own territory, and disputes over food happen often.",
+		de: "Schart eine Gruppe Rattfratz um sich. Zwischen den Gruppen, die jeweils ihr eigenes Territorium besitzen, entbrennen oft Kämpfe um Futter."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/83.ts
+++ b/data/Sun & Moon/Burning Shadows/83.ts
@@ -92,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "A Grimer, which had been brought in to solve a problem with garbage, developed over time into this form.",
+		de: "Sleima, die zur Lösung der Abfallproblematik aus anderen Regionen nach Alola gebracht wurden, entwickelten sich eines Tages zu dieser Form."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/84.ts
+++ b/data/Sun & Moon/Burning Shadows/84.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Alolan Grimer",
 		fr: "Tadmorv d’Alola",
+		de: "Alola-Sleima"
 	},
 
 	suffix: "GX",
@@ -93,7 +94,7 @@ const card: Card = {
 				es: "Triple Riesgo GX",
 				it: "Triplo Rischio-GX",
 				pt: "Perigo Triplo GX",
-				de: "Dreifachgefahr GX"
+				de: "Dreifachgefahr-GX"
 			},
 			effect: {
 				en: "Switch 1 of your opponent’s Benched Pokémon with their Active Pokémon. The new Active Pokémon is now Burned, Paralyzed, and Poisoned. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Burning Shadows/85.ts
+++ b/data/Sun & Moon/Burning Shadows/85.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It has a cunning yet savage disposition. It waits for parents to leave their nests, and then it sneaks in to steal their eggs.",
+		de: "Dieses Pokémon hat ein durchtriebenes, grausames Wesen. Es sucht nach unbewachten Nestern und stiehlt die Eier."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/86.ts
+++ b/data/Sun & Moon/Burning Shadows/86.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Sneasel",
 		fr: "Farfuret",
+		de: "Sniebel"
 	},
 
 	stage: "Stage1",
@@ -93,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "They travel in groups of four or five, leaving signs for one another on trees and rocks. They bring down their prey with coordinated attacks.",
+		de: "Sie sind immer zu viert oder fünft unterwegs. Bei der Jagd arbeiten sie zusammen, indem sie Zeichen in Felsen und Bäume ritzen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/87.ts
+++ b/data/Sun & Moon/Burning Shadows/87.ts
@@ -98,6 +98,7 @@ const card: Card = {
 
 	description: {
 		en: "It chases people and Pokémon from its territory by causing them to experience deep, nightmarish slumbers.",
+		de: "Es vertreibt Eindringlinge aus seinem Revier, indem es sie in Schlaf versetzt und mit Alpträumen quält."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/88.ts
+++ b/data/Sun & Moon/Burning Shadows/88.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Una vez durante tu turno (antes de tu ataque), si este Pokémon está en tu pila de descartes, puedes ponerlo en tu Banca. Después, une 1 carta de Energía Darkness de tu pila de descartes a este Pokémon.",
 				it: "Una sola volta durante il tuo turno, prima di attaccare, se questo Pokémon è nella tua pila degli scarti, puoi metterlo in panchina. Poi, assegnagli una carta Energia Darkness dalla tua pila degli scarti.",
 				pt: "Uma vez durante a sua vez de jogar (antes de atacar), se este Pokémon estiver na sua pilha de descarte, você poderá colocá-lo no seu Banco. Em seguida, ligue 1 carta de Energia Darkness da sua pilha de descarte a este Pokémon.",
-				de: "Einmal während deines Zuges (bevor du angreifst), wenn sich dieses Pokémon in deinem Ablagestapel befindet, kannst du es auf deine Bank legen. Lege anschließend 1 Darkness-Energiekarte aus deinem Ablagestapel an dieses Pokémon an."
+				de: "Einmal während deines Zuges (bevor du angreifst), wenn sich dieses Pokémon in deinem Ablagestapel befindet, kannst du es auf deine Bank legen. Lege anschließend 1 {D}-Energiekarte aus deinem Ablagestapel an dieses Pokémon an."
 			},
 		},
 	],
@@ -88,7 +88,7 @@ const card: Card = {
 				es: "Sin Retorno GX",
 				it: "Vicolo Cieco-GX",
 				pt: "Sem Saída GX",
-				de: "Sackgasse GX"
+				de: "Sackgasse-GX"
 			},
 			effect: {
 				en: "If your opponent’s Active Pokémon is affected by a Special Condition, that Pokémon is Knocked Out. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Burning Shadows/89.ts
+++ b/data/Sun & Moon/Burning Shadows/89.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Opponents who stare at the flashing of the light-emitting spots on its body become dazed and lose their will to fight.",
+		de: "Gegner, die auf die blinkenden Punkte an seinem Körper blicken, werden geblendet und verlieren den Willen zu kämpfen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/9.ts
+++ b/data/Sun & Moon/Burning Shadows/9.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "They are timid and grow uneasy when not in a swarm with others of their kind. The pattern on their backs differs slightly from one to another.",
+		de: "Es ist scheu und fürchtet sich, wenn es nicht Teil des Schwarms ist. Das Muster auf seinem Rücken ist bei jedem Exemplar minimal anders."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/90.ts
+++ b/data/Sun & Moon/Burning Shadows/90.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Inkay",
 		fr: "Sepiatop",
+		de: "Iscalar"
 	},
 
 	stage: "Stage1",
@@ -102,6 +103,7 @@ const card: Card = {
 
 	description: {
 		en: "It wields the most compelling hypnotic powers of any Pokémon, and it forces others to do whatever it wants.",
+		de: "Unter allen Pokémon verfügt es über die stärksten hypnotischen Kräfte, mit denen es Gegner nach Belieben kontrollieren kann."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/91.ts
+++ b/data/Sun & Moon/Burning Shadows/91.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "If its horns capture the warm feelings of people or Pokémon, its body warms up slightly.",
+		de: "Es erfasst warme Gefühle von Menschen und Pokémon mit seinen Hörnern und wärmt sich daran auf."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/92.ts
+++ b/data/Sun & Moon/Burning Shadows/92.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Ralts",
 		fr: "Tarsal",
+		de: "Trasla"
 	},
 
 	stage: "Stage1",
@@ -87,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "The cheerful spirit of its Trainer gives it energy for its psychokinetic power. It spins and dances when happy.",
+		de: "Die fröhliche Stimmung seines Trainers verleiht ihm Energie für psychokinetische Kraft. Wenn es glücklich ist, tanzt und dreht es sich."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/93.ts
+++ b/data/Sun & Moon/Burning Shadows/93.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Kirlia",
 		fr: "Kirlia",
+		de: "Kirlia"
 	},
 
 	suffix: "GX",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Una vez durante tu turno (antes de tu ataque), puedes unir 1 carta de Energía Fairy de tu mano a 1 de tus Pokémon.",
 				it: "Una sola volta durante il tuo turno, prima di attaccare, puoi assegnare a uno dei tuoi Pokémon una carta Energia Fairy dalla tua mano.",
 				pt: "Uma vez durante a sua vez de jogar (antes de atacar), você pode ligar 1 carta de Energia Fairy da sua mão a 1 dos seus Pokémon.",
-				de: "Einmal während deines Zuges (bevor du angreifst) kannst du 1 Fairy-Energiekarte aus deiner Hand an 1 deiner Pokémon anlegen."
+				de: "Einmal während deines Zuges (bevor du angreifst) kannst du 1 {FAIRY}-Energiekarte aus deiner Hand an 1 deiner Pokémon anlegen."
 			},
 		},
 	],
@@ -89,7 +90,7 @@ const card: Card = {
 				es: "Crepúsculo GX",
 				it: "Crepuscolo-GX",
 				pt: "Crepúsculo GX",
-				de: "Zwielicht GX"
+				de: "Zwielicht-GX"
 			},
 			effect: {
 				en: "Shuffle 10 cards from your discard pile into your deck. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Burning Shadows/94.ts
+++ b/data/Sun & Moon/Burning Shadows/94.ts
@@ -70,7 +70,7 @@ const card: Card = {
 				es: "Cura 30 puntos de daño a cada uno de tus Pokémon Fairy.",
 				it: "Cura ciascuno dei tuoi Pokémon Fairy da 30 danni.",
 				pt: "Cure 30 pontos de dano de cada um dos seus Pokémon Fairy.",
-				de: "Heile 30 Schadenspunkte bei jedem deiner Fairy-Pokémon."
+				de: "Heile 30 Schadenspunkte bei jedem deiner {FAIRY}-Pokémon."
 			},
 			damage: 30,
 
@@ -95,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "A sudden transformation of Carbink, its pink, glimmering body is said to be the loveliest sight in the whole world.",
+		de: "Dieses Pokémon ist eine Mutation von Rocara. Sein rosafarben schimmernder Körper gilt als schönster Anblick überhaupt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/95.ts
+++ b/data/Sun & Moon/Burning Shadows/95.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It feeds on the nectar and pollen of flowers. Because it's able to sense auras, it can identify which flowers are about to bloom.",
+		de: "Es ernährt sich von Blütenstaub und Honig. Da es die Aura von Lebewesen wahrnehmen kann, spürt es, wenn eine Blume bald blühen wird."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/96.ts
+++ b/data/Sun & Moon/Burning Shadows/96.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cutiefly",
 		fr: "Bombydou",
+		de: "Wommel"
 	},
 
 	stage: "Stage1",
@@ -92,6 +93,7 @@ const card: Card = {
 
 	description: {
 		en: "It rolls up pollen into puffs. It makes many different varieties, some used as food and others used in battle.",
+		de: "Dieses Pokémon rollt Blütenstaub zu Kugeln. Manche dieser Pollenknödel dienen als Nahrung, andere setzt es aber auch im Kampf ein."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/97.ts
+++ b/data/Sun & Moon/Burning Shadows/97.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It scatters spores that flicker and glow. Anyone seeing these lights falls into a deep slumber.",
+		de: "Es streut blinkende Sporen aus. Jeder, der dieses Licht sieht, schläft fest ein."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/98.ts
+++ b/data/Sun & Moon/Burning Shadows/98.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Morelull",
 		fr: "Spododo",
+		de: "Bubungus"
 	},
 
 	stage: "Stage1",
@@ -103,6 +104,7 @@ const card: Card = {
 
 	description: {
 		en: "Forests where Shiinotic live are treacherous to enter at night. People confused by its strange lights can never find their way home again.",
+		de: "Nachts sollte man Wälder meiden, in denen Lamellux leben. Ihr unheimliches Licht raubt jedem die Orientierung."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Burning Shadows/99.ts
+++ b/data/Sun & Moon/Burning Shadows/99.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Noibat",
 		fr: "Sonistrelle",
+		de: "eF-eM"
 	},
 
 	suffix: "GX",
@@ -95,7 +96,7 @@ const card: Card = {
 				es: "Estruendo GX",
 				it: "Ondaboato-GX",
 				pt: "Rajada Explosiva GX",
-				de: "Überschallknall GX"
+				de: "Überschallknall-GX"
 			},
 			effect: {
 				en: "This attack does 50 damage to each of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)",


### PR DESCRIPTION
## Add missing German translations for sm3

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
