### PR TITLE
(fix) Remove video-game Pokédex descriptions (not on card and currently en only) from Pocket ex cards

### DIFF
--- a/data/Pokémon TCG Pocket/Crimson Blaze/004.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/004.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Ivysaur"
 	},
 
-	description: {
-		en: "In order to support its flower, which has grown\nlarger due to Mega Evolution, its back and legs\nhave become stronger."
-	},
-
 	stage: "Stage2",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Crimson Blaze/014.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/014.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Charmeleon"
 	},
 
-	description: {
-		en: "Its bond with its Trainer is the source of\nits power. It boasts speed and maneuverability\ngreater than that of a jet."
-	},
-
 	stage: "Stage2",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Crimson Blaze/020.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/020.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Wartortle"
 	},
 
-	description: {
-		en: "The cannon on its back is as powerful as a\ntank gun. Its tough legs and back enable it to\nwithstand the recoil from firing the cannon."
-	},
-
 	stage: "Stage2",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Crimson Blaze/042.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/042.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Buneary"
 	},
 
-	description: {
-		en: "It swings its ears like whips and strikes its\nenemies with them. It has an intensely\ncombative disposition."
-	},
-
 	stage: "Stage1",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Crimson Blaze/052.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/052.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Onix"
 	},
 
-	description: {
-		en: "To protect itself from opponents' attacks, it uses\nmagnetism to control pieces of its hard outer\nshell that have flaked off."
-	},
-
 	stage: "Stage1",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Crimson Blaze/076.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/076.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Ivysaur"
 	},
 
-	description: {
-		en: "In order to support its flower, which has grown\nlarger due to Mega Evolution, its back and legs\nhave become stronger."
-	},
-
 	stage: "Stage2",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Crimson Blaze/077.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/077.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Charmeleon"
 	},
 
-	description: {
-		en: "Its bond with its Trainer is the source of\nits power. It boasts speed and maneuverability\ngreater than that of a jet."
-	},
-
 	stage: "Stage2",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Crimson Blaze/078.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/078.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Wartortle"
 	},
 
-	description: {
-		en: "The cannon on its back is as powerful as a\ntank gun. Its tough legs and back enable it to\nwithstand the recoil from firing the cannon."
-	},
-
 	stage: "Stage2",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Crimson Blaze/079.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/079.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Buneary"
 	},
 
-	description: {
-		en: "It swings its ears like whips and strikes its\nenemies with them. It has an intensely\ncombative disposition."
-	},
-
 	stage: "Stage1",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Crimson Blaze/080.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/080.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Onix"
 	},
 
-	description: {
-		en: "To protect itself from opponents' attacks, it uses\nmagnetism to control pieces of its hard outer\nshell that have flaked off."
-	},
-
 	stage: "Stage1",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Crimson Blaze/083.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/083.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Ivysaur"
 	},
 
-	description: {
-		en: "In order to support its flower, which has grown\nlarger due to Mega Evolution, its back and legs\nhave become stronger."
-	},
-
 	stage: "Stage2",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Crimson Blaze/084.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/084.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Wartortle"
 	},
 
-	description: {
-		en: "The cannon on its back is as powerful as a\ntank gun. Its tough legs and back enable it to\nwithstand the recoil from firing the cannon."
-	},
-
 	stage: "Stage2",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Crimson Blaze/085.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/085.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Buneary"
 	},
 
-	description: {
-		en: "It swings its ears like whips and strikes its\nenemies with them. It has an intensely\ncombative disposition."
-	},
-
 	stage: "Stage1",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Crimson Blaze/086.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/086.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Onix"
 	},
 
-	description: {
-		en: "To protect itself from opponents' attacks, it uses\nmagnetism to control pieces of its hard outer\nshell that have flaked off."
-	},
-
 	stage: "Stage1",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Crimson Blaze/087.ts
+++ b/data/Pokémon TCG Pocket/Crimson Blaze/087.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Charmeleon"
 	},
 
-	description: {
-		en: "Its bond with its Trainer is the source of\nits power. It boasts speed and maneuverability\ngreater than that of a jet."
-	},
-
 	stage: "Stage2",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Fantastical Parade/036.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/036.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Marshtomp"
 	},
 
-	description: {
-		en: "Its arms are hard as rock. With one swing, it can\nbreak an enormous boulder into pieces."
-	},
-
 	stage: "Stage2",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Fantastical Parade/066.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/066.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Kirlia"
 	},
 
-	description: {
-		en: "When it opens the red plate on its chest and\nunleashes its heart, its strongest psychic power\nis released."
-	},
-
 	stage: "Stage2",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Fantastical Parade/113.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/113.ts
@@ -16,10 +16,6 @@ const card: Card = {
 	hp: 170,
 	types: ["Metal"],
 
-	description: {
-		en: "Its two sets of jaws thrash about violently as if\nthey each had a will of their own. One gnash from\nthem can turn a boulder to dust."
-	},
-
 	stage: "Basic",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Fantastical Parade/127.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/127.ts
@@ -16,10 +16,6 @@ const card: Card = {
 	hp: 180,
 	types: ["Colorless"],
 
-	description: {
-		en: "Mega Kangaskhan's strength derives from the\nmother's happiness about her child's growth.\nWatching it grow up keeps her spirits high."
-	},
-
 	stage: "Basic",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Fantastical Parade/183.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/183.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Marshtomp"
 	},
 
-	description: {
-		en: "Its arms are hard as rock. With one swing, it can\nbreak an enormous boulder into pieces."
-	},
-
 	stage: "Stage2",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Fantastical Parade/185.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/185.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Kirlia"
 	},
 
-	description: {
-		en: "When it opens the red plate on its chest and\nunleashes its heart, its strongest psychic power\nis released."
-	},
-
 	stage: "Stage2",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Fantastical Parade/188.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/188.ts
@@ -16,10 +16,6 @@ const card: Card = {
 	hp: 170,
 	types: ["Metal"],
 
-	description: {
-		en: "Its two sets of jaws thrash about violently as if\nthey each had a will of their own. One gnash from\nthem can turn a boulder to dust."
-	},
-
 	stage: "Basic",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Fantastical Parade/189.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/189.ts
@@ -16,10 +16,6 @@ const card: Card = {
 	hp: 180,
 	types: ["Colorless"],
 
-	description: {
-		en: "Mega Kangaskhan's strength derives from the\nmother's happiness about her child's growth.\nWatching it grow up keeps her spirits high."
-	},
-
 	stage: "Basic",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Fantastical Parade/197.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/197.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Marshtomp"
 	},
 
-	description: {
-		en: "Its arms are hard as rock. With one swing, it can\nbreak an enormous boulder into pieces."
-	},
-
 	stage: "Stage2",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Fantastical Parade/201.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/201.ts
@@ -16,10 +16,6 @@ const card: Card = {
 	hp: 170,
 	types: ["Metal"],
 
-	description: {
-		en: "Its two sets of jaws thrash about violently as if\nthey each had a will of their own. One gnash from\nthem can turn a boulder to dust."
-	},
-
 	stage: "Basic",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Fantastical Parade/202.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/202.ts
@@ -16,10 +16,6 @@ const card: Card = {
 	hp: 180,
 	types: ["Colorless"],
 
-	description: {
-		en: "Mega Kangaskhan's strength derives from the\nmother's happiness about her child's growth.\nWatching it grow up keeps her spirits high."
-	},
-
 	stage: "Basic",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Fantastical Parade/203.ts
+++ b/data/Pokémon TCG Pocket/Fantastical Parade/203.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Kirlia"
 	},
 
-	description: {
-		en: "When it opens the red plate on its chest and\nunleashes its heart, its strongest psychic power\nis released."
-	},
-
 	stage: "Stage2",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Mega Rising/002.ts
+++ b/data/Pokémon TCG Pocket/Mega Rising/002.ts
@@ -16,10 +16,6 @@ const card: Card = {
 	hp: 170,
 	types: ["Grass"],
 
-	description: {
-		en: "The influence of Mega Evolution leaves it in a\nstate of constant excitement. It pierces enemies\nwith its two large horns before shredding them."
-	},
-
 	stage: "Basic",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Mega Rising/036.ts
+++ b/data/Pokémon TCG Pocket/Mega Rising/036.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Combusken"
 	},
 
-	description: {
-		en: "When facing a tough foe, it looses flames from\nits wrists. Its powerful legs let it jump clear over\nbuildings."
-	},
-
 	stage: "Stage2",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Mega Rising/052.ts
+++ b/data/Pokémon TCG Pocket/Mega Rising/052.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Magikarp"
 	},
 
-	description: {
-		en: "Mega Evolution also affects its brain, leaving\nno other function except its destructive instinct\nto burn everything to cinders."
-	},
-
 	stage: "Stage1",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Mega Rising/085.ts
+++ b/data/Pokémon TCG Pocket/Mega Rising/085.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Flaaffy"
 	},
 
-	description: {
-		en: "The tail's tip shines brightly and can be seen from\nfar away. It acts as a beacon for lost people."
-	},
-
 	stage: "Stage2",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Mega Rising/102.ts
+++ b/data/Pokémon TCG Pocket/Mega Rising/102.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Swablu"
 	},
 
-	description: {
-		en: "On sunny days, it flies freely through the sky and\nblends into the clouds. It sings in a beautiful\nsoprano."
-	},
-
 	stage: "Stage1",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Mega Rising/151.ts
+++ b/data/Pokémon TCG Pocket/Mega Rising/151.ts
@@ -16,10 +16,6 @@ const card: Card = {
 	hp: 170,
 	types: ["Darkness"],
 
-	description: {
-		en: "As the energy of Mega Evolution fills it, its fur\nbristles. What you see on its back are not true\nwings, and this Pokémon isn't able to fly."
-	},
-
 	stage: "Basic",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Mega Rising/251.ts
+++ b/data/Pokémon TCG Pocket/Mega Rising/251.ts
@@ -16,10 +16,6 @@ const card: Card = {
 	hp: 170,
 	types: ["Grass"],
 
-	description: {
-		en: "The influence of Mega Evolution leaves it in a\nstate of constant excitement. It pierces enemies\nwith its two large horns before shredding them."
-	},
-
 	stage: "Basic",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Mega Rising/254.ts
+++ b/data/Pokémon TCG Pocket/Mega Rising/254.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Combusken"
 	},
 
-	description: {
-		en: "When facing a tough foe, it looses flames from\nits wrists. Its powerful legs let it jump clear over\nbuildings."
-	},
-
 	stage: "Stage2",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Mega Rising/255.ts
+++ b/data/Pokémon TCG Pocket/Mega Rising/255.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Magikarp"
 	},
 
-	description: {
-		en: "Mega Evolution also affects its brain, leaving\nno other function except its destructive instinct\nto burn everything to cinders."
-	},
-
 	stage: "Stage1",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Mega Rising/258.ts
+++ b/data/Pokémon TCG Pocket/Mega Rising/258.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Flaaffy"
 	},
 
-	description: {
-		en: "The tail's tip shines brightly and can be seen from\nfar away. It acts as a beacon for lost people."
-	},
-
 	stage: "Stage2",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Mega Rising/259.ts
+++ b/data/Pokémon TCG Pocket/Mega Rising/259.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Swablu"
 	},
 
-	description: {
-		en: "On sunny days, it flies freely through the sky and\nblends into the clouds. It sings in a beautiful\nsoprano."
-	},
-
 	stage: "Stage1",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Mega Rising/262.ts
+++ b/data/Pokémon TCG Pocket/Mega Rising/262.ts
@@ -16,10 +16,6 @@ const card: Card = {
 	hp: 170,
 	types: ["Darkness"],
 
-	description: {
-		en: "As the energy of Mega Evolution fills it, its fur\nbristles. What you see on its back are not true\nwings, and this Pokémon isn't able to fly."
-	},
-
 	stage: "Basic",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Mega Rising/272.ts
+++ b/data/Pokémon TCG Pocket/Mega Rising/272.ts
@@ -16,10 +16,6 @@ const card: Card = {
 	hp: 170,
 	types: ["Grass"],
 
-	description: {
-		en: "The influence of Mega Evolution leaves it in a\nstate of constant excitement. It pierces enemies\nwith its two large horns before shredding them."
-	},
-
 	stage: "Basic",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Mega Rising/277.ts
+++ b/data/Pokémon TCG Pocket/Mega Rising/277.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Flaaffy"
 	},
 
-	description: {
-		en: "The tail's tip shines brightly and can be seen from\nfar away. It acts as a beacon for lost people."
-	},
-
 	stage: "Stage2",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Mega Rising/280.ts
+++ b/data/Pokémon TCG Pocket/Mega Rising/280.ts
@@ -16,10 +16,6 @@ const card: Card = {
 	hp: 170,
 	types: ["Darkness"],
 
-	description: {
-		en: "As the energy of Mega Evolution fills it, its fur\nbristles. What you see on its back are not true\nwings, and this Pokémon isn't able to fly."
-	},
-
 	stage: "Basic",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Mega Rising/284.ts
+++ b/data/Pokémon TCG Pocket/Mega Rising/284.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Combusken"
 	},
 
-	description: {
-		en: "When facing a tough foe, it looses flames from\nits wrists. Its powerful legs let it jump clear over\nbuildings."
-	},
-
 	stage: "Stage2",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Mega Rising/285.ts
+++ b/data/Pokémon TCG Pocket/Mega Rising/285.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Magikarp"
 	},
 
-	description: {
-		en: "Mega Evolution also affects its brain, leaving\nno other function except its destructive instinct\nto burn everything to cinders."
-	},
-
 	stage: "Stage1",
 	suffix: "EX",
 

--- a/data/Pokémon TCG Pocket/Mega Rising/286.ts
+++ b/data/Pokémon TCG Pocket/Mega Rising/286.ts
@@ -20,10 +20,6 @@ const card: Card = {
 		en: "Swablu"
 	},
 
-	description: {
-		en: "On sunny days, it flies freely through the sky and\nblends into the clouds. It sings in a beautiful\nsoprano."
-	},
-
 	stage: "Stage1",
 	suffix: "EX",
 


### PR DESCRIPTION
Mega Rising (B1, 18 cards), Crimson Blaze (B1a, 15) and Fantastical Parade (B2, 12) store an English-only `description` on 45 of their ex cards. These aren't card text:

- Printed TCG Pocket ex cards carry no flavour text — verified against card images.
- Every other Pocket set in the repository stores no description on any of its ex cards (Genetic Apex 0/42, Wisdom of Sea and Sky 0/40, Celestial Guardians 0/40, …); only these three newest sets deviate.
- The texts are the species' **video-game Pokédex entries** (e.g. Mega Pinsir's game dex entry on B1 002), complete with mid-sentence line breaks from the source they were scraped from.
- They exist in English only, on otherwise multi-language cards — no localisation ever wrote them, because the card doesn't print them.

This PR removes exactly those 45 `description` blocks and nothing else (180 deleted lines, 0 insertions). `npm run validate` passes.

Side benefit: localisation tooling stops flagging these as missing translations.