### PR TITLE
Add missing German translations for hgss4

### DIFF
--- a/data/HeartGold & SoulSilver/Triumphant/1.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/1.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Lairon",
-		fr: "Galegon"
+		fr: "Galegon",
+		de: "Stollrak"
 	},
 
 	stage: "Stage2",
@@ -87,7 +88,8 @@ const card: Card = {
 	retreat: 4,
 
 	description: {
-		en: "You can tell its age by the length of its iron horns. It claims an entire mountain as its territory."
+		en: "You can tell its age by the length of its iron horns. It claims an entire mountain as its territory.",
+		de: "An der Länge seines Stahlhorns erkennt man sein Alter. Als Revier beansprucht es einen ganzen Berg."
 	},
 
 	variants: [		{

--- a/data/HeartGold & SoulSilver/Triumphant/10.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/10.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Choose Grass Fire Water Lightning Psychic Fighting Darkness Metal or Colorless type. Put 1 damage counter on each Pokémon your opponent has in play of the type you chose.",
 				fr: "Choisissez le type GrassFireWaterLightningPsychicFightingDarknessMetal ou Colorless. Placez un marqueur de dégât sur chacun des Pokémon que votre adversaire a en jeu et qui correspond au type choisi.",
-				de: "Wähle einen Typ: ,  oder . Lege auf jedes Pokémon des gewählten Typs, das dein Gegner im Spiel hat, 1 Schadensmarke."
+				de: "Wähle einen Typ: {G}{R}{W}{L}{P}{F}{D}{M} oder {C}. Lege auf jedes Pokémon des gewählten Typs, das dein Gegner im Spiel hat, 1 Schadensmarke."
 			},
 
 		},
@@ -68,7 +68,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It was formed by uniting 108 spirits. It has been bound to the Odd Keystone to keep it from doing any mischief."
+		en: "It was formed by uniting 108 spirits. It has been bound to the Odd Keystone to keep it from doing any mischief.",
+		de: "Es besteht aus 108 Geistern, die an einen Spiritkern gebunden sind, damit sie nichts mehr anstellen."
 	},
 
 	variants: [		{

--- a/data/HeartGold & SoulSilver/Triumphant/101.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/101.ts
@@ -45,7 +45,7 @@ const card: Card = {
 
 		effect: {
 			en: "Discard all Metal Energy attached to Palkia & Dialga LEGEND. Add the top 2 cards of your opponent's deck to his or her Prize cards.",
-			de: "Lege alle -Energien, die an Palkia- und Dialga-LEGENDE angelegt sind, auf deinen Ablagestapel. Füge die obersten 2 Karten vom Deck deines Gegner seinen Preiskarten hinzu."
+			de: "Lege alle {M}-Energien, die an Palkia- und Dialga-LEGENDE angelegt sind, auf deinen Ablagestapel. Füge die obersten 2 Karten vom Deck deines Gegner seinen Preiskarten hinzu."
 		},
 
 		cost: ["Metal", "Metal", "Colorless"]

--- a/data/HeartGold & SoulSilver/Triumphant/102.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/102.ts
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "Discard all Metal Energy attached to Palkia & Dialga LEGEND. Add the top 2 cards of your opponent’s deck to his or her Prize cards.",
 				fr: "Défaussez toutes les cartes Énergie Metal attachées à Palkia & Dialga LÉGENDE. Ajoutez les 2 cartes du dessus du deck de votre adversaire à ses cartes Récompense.",
-				de: 'Lege alle -Energien, die an Palkia- und Dialga-LEGENDE angelegt sind, auf deinen Ablagestapel. Füge die obersten 2 Karten vom Deck deines Gegner seinen Preiskarten hinzu.  '
+				de: "Lege alle {M}-Energien, die an Palkia- und Dialga-LEGENDE angelegt sind, auf deinen Ablagestapel. Füge die obersten 2 Karten vom Deck deines Gegner seinen Preiskarten hinzu."
 			},
 
 		}

--- a/data/HeartGold & SoulSilver/Triumphant/11.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/11.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Venonat",
-		fr: "Mimitoss"
+		fr: "Mimitoss",
+		de: "Bluzuk"
 	},
 
 	stage: "Stage1",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may flip a coin. If heads, your opponent's Active Pokémon is now Poisoned. If tails, your Active Pokémon is now Poisoned. This power can't be used if Venomoth is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez lancer une pièce. Si c’est face, le Pokémon Actif de votre adversaire est maintenant Empoisonné. Si c’est pile, votre Pokémon Actif est maintenant Empoisonné. Ce Poké-Power ne peut pas être utilisé si Aéromite est affecté par un État Spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du eine Münze werfen. Bei \"Kopf\" ist das Aktive Pokémon deines Gegners jetzt vergiftet. Bei \"Zahl\" ist dein Aktives Pokémon jetzt vergiftet. Diese Poké-Power kann nicht benutzt werden, wenn Omot von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du eine Münze werfen. Bei „Kopf“ ist das Aktive Pokémon deines Gegners jetzt vergiftet. Bei „Zahl“ ist dein Aktives Pokémon jetzt vergiftet. Diese Poké-Power kann nicht benutzt werden, wenn Omot von einem Speziellen Zustand betroffen ist."
 			}
 		},
 	],
@@ -58,7 +59,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c’est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 30,
 
@@ -75,7 +76,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "The powder on its wings is poisonous if it is dark in hue. If it is light in hue, it causes paralysis."
+		en: "The powder on its wings is poisonous if it is dark in hue. If it is light in hue, it causes paralysis.",
+		de: "Ist es schwarz, enthält sein Puder Gift. Ist es weiß, paralysiert sein Puder alle Gegner bei Berührung."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/12.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/12.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Weepinbell",
-		fr: "Boustiflor"
+		fr: "Boustiflor",
+		de: "Ultrigaria"
 	},
 
 	stage: "Stage2",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "As long as Victreebel is your Active Pokémon, your opponent's Active Pokémon's Retreat Cost is ColorlessColorless more.",
 				fr: "Tant qu’Empiflor est votre Pokémon Actif, le Coût de retraite du Pokémon Actif de votre adversaire est augmenté de ColorlessColorless.",
-				de: "Solange Sarzenia dein Aktives Pokémon ist, betragen die Rückzugskosten für das Aktive Pokémon deines Gegners 2  mehr."
+				de: "Solange Sarzenia dein Aktives Pokémon ist, betragen die Rückzugskosten für das Aktive Pokémon deines Gegners {C}{C} mehr."
 			}
 		},
 	],
@@ -75,7 +76,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "Acid that has dissolved many prey becomes sweeter, making it even more effective at attracting prey."
+		en: "Acid that has dissolved many prey becomes sweeter, making it even more effective at attracting prey.",
+		de: "Säure, in der bereits viele Insekten aufgelöst wurden, ist süßer und effektiver beim Beutefang."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/13.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/13.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Aipom",
-		fr: "Capumain"
+		fr: "Capumain",
+		de: "Griffel"
 	},
 
 	stage: "Stage1",
@@ -77,7 +78,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "They live on large trees. They are said to communicate by connecting their tails to those of others."
+		en: "They live on large trees. They are said to communicate by connecting their tails to those of others.",
+		de: "Es bewohnt hohe Bäume. Man sagt, sie kommunizieren miteinander, indem sie einander beim Schweif fassen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/14.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/14.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Shuppet",
-		fr: "Polichombr"
+		fr: "Polichombr",
+		de: "Shuppet"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, choose 1 Energy card attached to 1 of your opponent's Pokémon and put it in the Lost Zone.",
 				fr: "Lancez une pièce. Si c’est face, choisissez une carte Énergie attachée à l’un des Pokémon de votre adversaire et placez-la dans la Zone Perdue.",
-				de: "Wirf eine Münze. Wähle bei \"Kopf\" 1 an 1 Pokémon deines Gegners angelegte Energiekarte und lege sie ins Nirgendwo."
+				de: "Wirf eine Münze. Wähle bei „Kopf“ 1 an 1 Pokémon deines Gegners angelegte Energiekarte und lege sie ins Nirgendwo."
 			},
 
 		},
@@ -82,7 +83,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "This Pokémon developed from an abandoned doll that amassed a grudge. It is seen in dark alleys."
+		en: "This Pokémon developed from an abandoned doll that amassed a grudge. It is seen in dark alleys.",
+		de: "Eine weggeworfene Puppe, die nun ganz von Hass durchdrungen ist. Man findet es in dunklen Gassen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/15.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/15.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Bronzor",
-		fr: "Archeomire"
+		fr: "Archeomire",
+		de: "Bronzel"
 	},
 
 	stage: "Stage1",
@@ -82,7 +83,8 @@ const card: Card = {
 	retreat: 3,
 
 	description: {
-		en: "Ancient people believed that petitioning Bronzong for rain was the way to make crops grow."
+		en: "Ancient people believed that petitioning Bronzong for rain was the way to make crops grow.",
+		de: "Früher verehrten die Menschen die BRONZONG, weil sie sich davon Regen oder gute Ernten erhofften."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/16.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/16.ts
@@ -78,7 +78,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It walks around on its tentacles in search of a tree branch where it can dangle down and ambush prey."
+		en: "It walks around on its tentacles in search of a tree branch where it can dangle down and ambush prey.",
+		de: "Es sucht sich einen Ast, von dem aus es seiner Beute mit seinen gelenkigen Tentakeln auflauert."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/17.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/17.ts
@@ -34,7 +34,7 @@ const card: Card = {
 			effect: {
 				en: "The number of Benched Pokémon your opponent can have is now 4. If your opponent has 5 Benched Pokémon, your opponent must discard 1 of them and all cards attached to it.",
 				fr: "Le nombre de Pokémon de Banc de votre adversaire est maintenant limité à 4. Si votre adversaire a 5 Pokémon de Banc, il doit défausser l’un d’entre eux et toutes les cartes qui lui sont attachées.",
-				de: "Die Anzahl der Pokémon, die dein Gegner auf seiner Bank haben kann, beträgt nun 4. Falls dein Gegner 5 Pokémon auf der Bank hat, muss er 1 davon und alle daran angelegten Karten auf seinen Ablagestapel legen."
+				de: "Die Anzahl der Pokémon, die dein Gegner auf seiner Bank haben kann, beträgt nun 4. Falls dein Gegner 5 Pokémon auf seiner Bank hat, muss er 1 davon und alle daran angelegten Karten auf seinen Ablagestapel legen."
 			}
 		},
 	],
@@ -66,7 +66,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Its transformation ability is perfect. However, if made to laugh, it can’t maintain its disguise."
+		en: "Its transformation ability is perfect. However, if made to laugh, it can’t maintain its disguise.",
+		de: "Seine Verwandlungskunst ist perfekt. Bringt man es jedoch zum Lachen, fällt seine Tarnung."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/18.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/18.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Dragonair",
-		fr: "Draco"
+		fr: "Draco",
+		de: "Dragonir"
 	},
 
 	stage: "Stage2",
@@ -63,7 +64,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. If both of them are tails, this attack does nothing. If both of them are heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez 2 pièces. Si vous obtenez deux fois un côté pile, cette attaque ne fait rien. Si vous obtenez deux fois face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 2 Münzen. Wenn beide Münzen \"Zahl\" zeigen, hat dieser Angriff keine Auswirkungen. Wenn beide Münzen \"Kopf\" zeigen, ist das Verteidigende Pokémon jezt gelähmt."
+				de: "Wirf 2 Münzen. Wenn beide Münzen „Zahl“ zeigen, hat dieser Angriff keine Auswirkungen. Wenn beide Münzen „Kopf“ zeigen, ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 80,
 
@@ -87,7 +88,8 @@ const card: Card = {
 	retreat: 4,
 
 	description: {
-		en: "This marine Pokémon has an impressive build that lets it freely fly over raging seas without trouble."
+		en: "This marine Pokémon has an impressive build that lets it freely fly over raging seas without trouble.",
+		de: "Dieses Pokémon ist so gebaut, dass es bedenkenlos selbst über tosende Gewässer fliegen kann."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/19.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/19.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Diglett",
-		fr: "Taupiqueur"
+		fr: "Taupiqueur",
+		de: "Digda"
 	},
 
 	stage: "Stage1",
@@ -56,7 +57,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin for each Fighting Energy attached to Dugtrio. This attack does 50 damage plus 20 more damage for each heads.",
 				fr: "Lancez une pièce pour chaque Énergie Fighting attachée à Triopikeur. Cette attaque inflige 50 dégâts plus 20 dégâts supplémentaires pour chaque côté face.",
-				de: "Wirf für jede an Digdri angelegte -Energie 1 Münze. Dieser Angriff fügt 50 Schadenspunkte plus 20 weitere Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf für jede an Digdri angelegte {F}-Energie 1 Münze. Dieser Angriff fügt 50 Schadenspunkte plus 20 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "50+",
 
@@ -80,7 +81,8 @@ const card: Card = {
 	retreat: 0,
 
 	description: {
-		en: "Extremely powerful, they can dig through even the hardest ground to a depth of over 60 miles."
+		en: "Extremely powerful, they can dig through even the hardest ground to a depth of over 60 miles.",
+		de: "Es ist so stark, dass es sich mit Schaufler sogar durch steinharten Boden bis in 100 km Tiefe gräbt."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/2.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/2.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Swablu",
-		fr: "Tylton"
+		fr: "Tylton",
+		de: "Wablu"
 	},
 
 	stage: "Stage1",
@@ -84,7 +85,8 @@ const card: Card = {
 	retreat: 0,
 
 	description: {
-		en: "It flies gracefully through the sky. Its melodic humming makes you feel like you’re in a dream."
+		en: "It flies gracefully through the sky. Its melodic humming makes you feel like you’re in a dream.",
+		de: "Es schwebt gemächlich durch den Himmel. Sein wunderschönes Summen löst verträumte Dösezustände aus."
 	},
 
 	variants: [		{

--- a/data/HeartGold & SoulSilver/Triumphant/20.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/20.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Electabuzz",
-		fr: "Elektek"
+		fr: "Elektek",
+		de: "Elektek"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Search your discard pile for a Lightning Energy card and attach it to Electivire.",
 				fr: "Cherchez une carte Énergie Lightning dans votre pile de défausse et attachez-la à Elekable.",
-				de: "Durchsuche deinen Ablagestapel nach einer -Energiekarte und lege sie an Elevoltek an."
+				de: "Durchsuche deinen Ablagestapel nach einer {L}-Energiekarte und lege sie an Elevoltek an."
 			},
 			damage: 30,
 
@@ -83,7 +84,8 @@ const card: Card = {
 	retreat: 3,
 
 	description: {
-		en: "As its electric charge amplifies, blue sparks begin to crackle between its horns."
+		en: "As its electric charge amplifies, blue sparks begin to crackle between its horns.",
+		de: "Bei voller Ladung zucken feurige, blass-weiße Funken zwischen seinen zwei Hörnern hin und her."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/21.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/21.ts
@@ -59,7 +59,8 @@ const card: Card = {
 	retreat: 0,
 
 	description: {
-		en: "Even in the most vicious storm, this Pokémon plays happily if thunder rumbles in the sky."
+		en: "Even in the most vicious storm, this Pokémon plays happily if thunder rumbles in the sky.",
+		de: "Im schlimmsten Sturm, mit Blitzen und Donnergetöse, fühlt sich dieses Pokémon am wohlsten."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/22.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/22.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Psyduck",
-		fr: "Psykokwak"
+		fr: "Psykokwak",
+		de: "Enton"
 	},
 
 	stage: "Stage1",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Whenever you attach a Water Energy card from your hand to Golduck, remove 2 damage counters from Golduck.",
 				fr: "Lorsque vous attachez une carte Énergie Water de votre main à Akwakwak, retirez-lui 2 marqueurs de dégât.",
-				de: "Entferne jedes Mal, wenn du eine -Energiekarte von deiner Hand an Entoron anlegst, 2 Schadensmarken von Entoron."
+				de: "Entferne jedes Mal, wenn du eine {W}-Energiekarte von deiner Hand an Entoron anlegst, 2 Schadensmarken von Entoron."
 			}
 		},
 	],
@@ -58,7 +59,7 @@ const card: Card = {
 			effect: {
 				en: "Does 30 damage plus 10 more damage for each Water Energy attached to all of your Pokémon.",
 				fr: "Inflige 30 dégâts plus 10 dégâts supplémentaires pour chaque carte Énergie Water attachée à tous vos Pokémon.",
-				de: "Dieser Angriff fügt 30 Schadenspunkte plus 10 weitere Schadenspunkte für jede -Energie, die an deinen Pokémon angelegt ist, zu."
+				de: "Dieser Angriff fügt 30 Schadenspunkte plus 10 weitere Schadenspunkte für jede {W}-Energie, die an deinen Pokémon angelegt ist, zu."
 			},
 			damage: "30+",
 
@@ -75,7 +76,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "When it swims at full speed using its long, webbed limbs, its forehead somehow begins to glow."
+		en: "When it swims at full speed using its long, webbed limbs, its forehead somehow begins to glow.",
+		de: "Wenn es mit seinen Flossen schnell durch das Wasser schwimmt, beginnt seine Stirn zu glühen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/23.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/23.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Spoink",
-		fr: "Spoink"
+		fr: "Spoink",
+		de: "Spoink"
 	},
 
 	stage: "Stage1",
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Your opponent flips a coin for each of his or her Benched Pokémon. This attack does 40 damage times the number of tails. This attack's damage isn't affected by Weakness or Resistance.",
 				fr: "Votre adversaire lance une pièce pour chacun de ses Pokémon de Banc. Cette attaque inflige 40 dégâts multipliés par le nombre de côtés pile. Les dégâts infligés par cette attaque ne sont pas affectés par la Faiblesse ou la Résistance.",
-				de: "Dein Gegner wirft eine Münze für jedes Pokémon auf seiner Bank. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl \"Zahl\" zu. Der Schaden dieses Angriffs wird durch Schwäche und Resistenz nicht verändert."
+				de: "Dein Gegner wirft eine Münze für jedes Pokémon auf seiner Bank. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl „Zahl“ zu. Der Schaden dieses Angriffs wird durch Schwäche und Resistenz nicht verändert."
 			},
 			damage: "40×",
 
@@ -78,7 +79,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It can perform odd dance steps to influence foes. Its style of dancing became hugely popular overseas."
+		en: "It can perform odd dance steps to influence foes. Its style of dancing became hugely popular overseas.",
+		de: "Die seltsamen Tanzschritte, mit denen es seine Gegner kontrolliert, sind eine alte, ausländische Mode."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/24.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/24.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Kricketot",
-		fr: "Crikzik"
+		fr: "Crikzik",
+		de: "Zirpurze"
 	},
 
 	stage: "Stage1",
@@ -42,7 +43,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c’est face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt verwirrt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: 30,
 
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. If 1 of them is heads, this attack does 20 damage plus 20 more damage. If 2 of them are heads, this attack does 20 damage plus 40 more damage. If all of them are heads, this attack does 20 damage plus 100 more damage.",
 				fr: "Lancez 3 pièces. Si vous obtenez une fois un côté face, cette attaque inflige 20 dégâts plus 20 dégâts supplémentaires. Si vous obtenez deux fois un côté face, cette attaque inflige 20 dégâts plus 40 dégâts supplémentaires. Si vous obtenez chaque fois un côté face, cette attaque inflige 20 dégâts plus 100 dégâts supplémentaires.",
-				de: "Wirf 3 Münzen. Bei 1 Mal \"Kopf\" fügt dieser Angriff 20 Schadenspunkte plus 20 weitere Schadenspunkte zu. Bei 2 Mal \"Kopf\" fügt dieser Angriff 20 Schadenspunkte plus 40 weitere Schadenspunkte zu. Bei 3 Mal \"Kopf\" fügt dieser Angriff 20 Schadenspunkte plus 100 weitere Schadenspunkte zu."
+				de: "Wirf 3 Münzen. Bei 1 Mal „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 20 weitere Schadenspunkte zu. Bei 2 Mal „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 40 weitere Schadenspunkte zu. Bei 3 Mal „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 100 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -78,7 +79,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "By allowing its cry to resonate in the hollow of its belly, it produces a captivating sound."
+		en: "By allowing its cry to resonate in the hollow of its belly, it produces a captivating sound.",
+		de: "Seinen wunderschönen Ruf erzeugt es durch einen Hohlraum im Körper, der als Verstärker fungiert."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/25.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/25.ts
@@ -67,7 +67,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It was discovered at the site of a meteor strike 40 years ago. Its stare can lull its foes to sleep."
+		en: "It was discovered at the site of a meteor strike 40 years ago. Its stare can lull its foes to sleep.",
+		de: "Wurde erstmals vor 40 Jahren bei einem Meteoritenkrater entdeckt. Sein Blick wirkt einschläfernd."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/26.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/26.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Machoke",
-		fr: "Machopeur"
+		fr: "Machopeur",
+		de: "Maschock"
 	},
 
 	stage: "Stage2",
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Does 60 damage plus 10 more damage for each Fighting Energy attached to Machamp.",
 				fr: "Inflige 60 dégâts plus 10 dégâts supplémentaires pour chaque carte Énergie Fighting attachée à Mackogneur.",
-				de: "Dieser Angriff fügt 60 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Machomei angelegte -Energie zu."
+				de: "Dieser Angriff fügt 60 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Machomei angelegte {F}-Energie zu."
 			},
 			damage: "60+",
 
@@ -77,7 +78,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It quickly swings its four arms to rock its opponents with ceaseless punches and chops from all angles."
+		en: "It quickly swings its four arms to rock its opponents with ceaseless punches and chops from all angles.",
+		de: "Es verwendet seine vier Arme, um seine Gegner mit Schlägen aus allen Winkeln einzudecken."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/27.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/27.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Magmar",
-		fr: "Magmar"
+		fr: "Magmar",
+		de: "Magmar"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "For each Fire Energy attached to Magmortar, discard the top card from your opponent's deck. Then, flip a coin. If tail, discard all Fire Energy attached to Magmortar.",
 				fr: "Pour chaque carte Énergie Fire attachée à Maganon, défaussez la carte du dessus du deck de votre adversaire. Lancez ensuite une pièce. Si c’est pile, défaussez toutes les cartes Énergie Fire attachées à Maganon.",
-				de: "Lege für jede an Magbrant angelegte -Energie die oberste Karte vom Deck deines Gegners auf seinen Ablagestapel. Wirf anschließend eine Münze. Bei \"Zahl\" lege alle an Magbrant angelegten -Energien auf deinen Ablagestapel."
+				de: "Lege für jede an Magbrant angelegte {R}-Energie die oberste Karte vom Deck deines Gegners auf seinen Ablagestapel. Wirf anschließend eine Münze. Bei „Zahl“ lege alle an Magbrant angelegten {R}-Energien auf deinen Ablagestapel."
 			},
 
 		},
@@ -76,7 +77,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It blasts fireballs of over 3,600 degrees Fahrenheit out of its arms. Its breath also sears and sizzles."
+		en: "It blasts fireballs of over 3,600 degrees Fahrenheit out of its arms. Its breath also sears and sizzles.",
+		de: "Es schießt 2 000 Grad heiße Feuerbälle aus den Enden seiner Arme. Selbst sein Atem steht in Flammen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/28.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/28.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Nidorina",
-		fr: "Nidorina"
+		fr: "Nidorina",
+		de: "Nidorina"
 	},
 
 	stage: "Stage2",
@@ -77,7 +78,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It uses its scaly, rugged body to seal the entrance of its nest and protect its young from predators."
+		en: "It uses its scaly, rugged body to seal the entrance of its nest and protect its young from predators.",
+		de: "Es benutzt seinen schuppigen Körper, um den Höhleneingang als Schutz für seine Jungen zu sperren."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/29.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/29.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pidgeotto",
-		fr: "Roucoups"
+		fr: "Roucoups",
+		de: "Tauboga"
 	},
 
 	stage: "Stage2",
@@ -42,7 +43,7 @@ const card: Card = {
 			effect: {
 				en: "During your opponent's next turn, the attack cost of each of the Defending Pokémon's attacks is ColorlessColorless more.",
 				fr: "Pendant le prochain tour de votre adversaire, le coût de chaque attaque du Pokémon Défenseur est augmenté de ColorlessColorless.",
-				de: "Während des nächsten Zuges deines Gegners kosten die Angriffe des Verteidigenden Pokémon  mehr."
+				de: "Während des nächsten Zuges deines Gegners kosten die Angriffe des Verteidigenden Pokémon {C}{C} mehr."
 			},
 			damage: 20,
 
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 40 damage plus 30 more damage.",
 				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 40 dégâts plus 30 dégâts supplémentaires.",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff 40 Schadenspunkte plus 30 weitere Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 40 Schadenspunkte plus 30 weitere Schadenspunkte zu."
 			},
 			damage: "40+",
 
@@ -85,7 +86,8 @@ const card: Card = {
 	retreat: 0,
 
 	description: {
-		en: "It spreads its beautiful wings wide to frighten its enemies. It can fly at Mach 2 speed."
+		en: "It spreads its beautiful wings wide to frighten its enemies. It can fly at Mach 2 speed.",
+		de: "Es spreizt seine mächtigen Flügel, um seine Feinde zu verängstigen. Es kann bis zu Mach 2 schnell fliegen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/3.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/3.ts
@@ -53,7 +53,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c’est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 30,
 
@@ -70,7 +70,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "This Pokémon wanders across time. Grass and trees flourish in the forests in which it has appeared."
+		en: "This Pokémon wanders across time. Grass and trees flourish in the forests in which it has appeared.",
+		de: "Dieses Pokémon reist durch Zeit und Raum. Bäume und Wiesen wuchern, wenn es in der Nähe ist."
 	},
 
 	variants: [		{

--- a/data/HeartGold & SoulSilver/Triumphant/30.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/30.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Carvanha",
-		fr: "Carvanha"
+		fr: "Carvanha",
+		de: "Kanivanha"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. If both of them are heads, your opponent discards all card from his or her hand.",
 				fr: "Lancez 2 pièces. Si vous obtenez deux fois un côté face, votre adversaire défausse toutes les cartes de sa main.",
-				de: "Wirf 2 Münzen. Wenn beide \"Kopf\" zeigen, legt dein Gegner alle Handkarten auf seinen Ablagestapel."
+				de: "Wirf 2 Münzen. Wenn beide „Kopf“ zeigen, legt dein Gegner alle Handkarten auf seinen Ablagestapel."
 			},
 			damage: 20,
 
@@ -77,7 +78,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It can swim at speeds of 75 mph by jetting seawater through its body. It is the bandit of the sea."
+		en: "It can swim at speeds of 75 mph by jetting seawater through its body. It is the bandit of the sea.",
+		de: "TOHAIDO mag Radau und schwimmt bis zu 120 km/h schnell, indem es Wasser aus seinem Hinterteil ausstößt."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/31.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/31.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Wailmer",
-		fr: "Wailmer"
+		fr: "Wailmer",
+		de: "Wailmer"
 	},
 
 	stage: "Stage1",
@@ -42,7 +43,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. For each heads, remove 3 damage counters from Wailord.",
 				fr: "Lancez 2 pièces. Pour chaque côté face, retirez 3 marqueurs de dégât à Wailord.",
-				de: "Wirf 2 Münzen. Entferne pro \"Kopf\" 3 Schadensmarken von Wailord."
+				de: "Wirf 2 Münzen. Entferne pro „Kopf“ 3 Schadensmarken von Wailord."
 			},
 
 		},
@@ -78,7 +79,8 @@ const card: Card = {
 	retreat: 4,
 
 	description: {
-		en: "It is the largest of all identified Pokémon. They jump as a pack to herd their prey."
+		en: "It is the largest of all identified Pokémon. They jump as a pack to herd their prey.",
+		de: "Das größte Pokémon. Es treibt seine Beute in der Gruppe zusammen, indem es aus dem Wasser springt."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/32.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/32.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Dratini",
-		fr: "Minidraco"
+		fr: "Minidraco",
+		de: "Dratini"
 	},
 
 	stage: "Stage1",
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 40 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 40 dégâts multipliés par le nombre de côtés face.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "40×",
 
@@ -77,7 +78,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Its crystalline orbs appear to give this Pokémon the power to freely control the weather."
+		en: "Its crystalline orbs appear to give this Pokémon the power to freely control the weather.",
+		de: "Die kristallenen Bälle an seinem Schweif ermöglichen es ihm, das Wetter zu beeinflussen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/33.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/33.ts
@@ -51,7 +51,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, discard all Lightning Energy attached to Electabuzz.",
 				fr: "Lancez une pièce. Si c’est pile, défaussez toutes les cartes Énergie Lightning attachées à Elektek.",
-				de: "Wirf eine Münze. Bei \"Zahl\" lege alle an Elektek angelegten -Energien auf deinen Ablagestapel."
+				de: "Wirf eine Münze. Bei „Zahl“ lege alle an Elektek angelegten {L}-Energien auf deinen Ablagestapel."
 			},
 			damage: 60,
 
@@ -75,7 +75,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "Its body constantly discharges electricity. Getting close to it will make your hair stand on end."
+		en: "Its body constantly discharges electricity. Getting close to it will make your hair stand on end.",
+		de: "Sein Körper entlädt sich ständig. Kommt man ihm zu nahe, stehen einem die Haare senkrecht vom Kopf ab."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/34.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/34.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Voltorb",
-		fr: "Voltorbe"
+		fr: "Voltorbe",
+		de: "Voltobal"
 	},
 
 	stage: "Stage1",
@@ -56,7 +57,7 @@ const card: Card = {
 			effect: {
 				en: "You may do 40 damage plus 60 more damage. If you do, discard all Lightning Energy attached to Electrode.",
 				fr: "Vous pouvez infliger 40 dégâts plus 60 dégâts supplémentaires. Dans ce cas, défaussez toutes les cartes Énergie Lightning attachées à Electrode.",
-				de: "Du kannst mit diesem Angriff kann 40 Schadenspunkte plus 60 weitere Schadenspunkte zufügen. Wenn du das machst, lege alle an Lektrobal angelegten -Energien auf deinen Ablagestapel."
+				de: "Du kannst mit diesem Angriff kann 40 Schadenspunkte plus 60 weitere Schadenspunkte zufügen. Wenn du das machst, lege alle an Lektrobal angelegten {L}-Energien auf deinen Ablagestapel."
 			},
 			damage: "40+",
 
@@ -80,7 +81,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It is dangerous. If it has too much electricity and has nothing to do, it amuses itself by exploding."
+		en: "It is dangerous. If it has too much electricity and has nothing to do, it amuses itself by exploding.",
+		de: "Es ist gefährlich. Besitzt es zu viel Elektrizität und Freizeit, amüsiert es sich, indem es explodiert."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/35.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/35.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Gastly",
-		fr: "Fantominus"
+		fr: "Fantominus",
+		de: "Nebulak"
 	},
 
 	stage: "Stage1",
@@ -81,7 +82,8 @@ const card: Card = {
 	retreat: 0,
 
 	description: {
-		en: "Its tongue is made of gas. If licked, its victim starts shaking constantly until death eventually comes."
+		en: "Its tongue is made of gas. If licked, its victim starts shaking constantly until death eventually comes.",
+		de: "Seine Zunge ist aus Gas. Leckt es an einem Gegner, zittert er und verliert eventuell das Bewusstsein."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/36.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/36.ts
@@ -56,7 +56,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 50 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 50 dégâts multipliés par le nombre de côtés face.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "50×",
 
@@ -73,7 +73,8 @@ const card: Card = {
 	retreat: 3,
 
 	description: {
-		en: "If it is safe, the young gets out of the belly pouch to play. The adult keeps a close eye on the youngster."
+		en: "If it is safe, the young gets out of the belly pouch to play. The adult keeps a close eye on the youngster.",
+		de: "Fühlt es sich sicher, dann verlässt das Junge den Beutel. Die Mutter behält es ständig im Auge."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/37.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/37.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Aron",
-		fr: "Galekid"
+		fr: "Galekid",
+		de: "Stollunior"
 	},
 
 	stage: "Stage1",
@@ -67,7 +68,8 @@ const card: Card = {
 	retreat: 3,
 
 	description: {
-		en: "It loves iron ore. Groups of them fight for territory by bashing one another with their steel bodies."
+		en: "It loves iron ore. Groups of them fight for territory by bashing one another with their steel bodies.",
+		de: "Ist verrückt nach Eisenerz. Bei Revierkämpfen stoßen STOLLRAK einander mit ihren Stahlkörpern."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/38.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/38.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Lickitung",
-		fr: "Excelangue"
+		fr: "Excelangue",
+		de: "Schlurp"
 	},
 
 	stage: "Stage1",
@@ -76,7 +77,8 @@ const card: Card = {
 	retreat: 3,
 
 	description: {
-		en: "It has space in its throat to store saliva. It can also roll up its tongue and store it in the same spot."
+		en: "It has space in its throat to store saliva. It can also roll up its tongue and store it in the same spot.",
+		de: "Tief in seinem Rachen sammelt sich Speichel. Es umklammert Gegner mit seiner Zunge und zieht sie dorthin hinab."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/39.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/39.ts
@@ -69,7 +69,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Its heart-shaped body makes it popular. In some places, you would give a Luvdisc to someone you love."
+		en: "Its heart-shaped body makes it popular. In some places, you would give a Luvdisc to someone you love.",
+		de: "Seine Herzform macht es beliebt. In einigen Gegenden schenken sich Liebende noch heute LIEBISKUS."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/4.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/4.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Skorupi",
-		fr: "Rapion"
+		fr: "Rapion",
+		de: "Pionskora"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned. Put 2 damage counters instead of 1 on that Pokémon between turns.",
 				fr: "Lancez une pièce. Si c’est face, le Pokémon Défenseur est maintenant Empoisonné. Placez 2 marqueurs de dégât au lieu d’un seul sur ce Pokémon entre deux tours.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt vergiftet. Lege zwischen den Zügen 2 Schadensmarken anstelle von 1 Schadensmarke auf dieses Pokémon."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet. Lege zwischen den Zügen 2 Schadensmarken anstelle von 1 Schadensmarke auf dieses Pokémon."
 			},
 			damage: 40,
 
@@ -83,7 +84,8 @@ const card: Card = {
 	retreat: 3,
 
 	description: {
-		en: "It attacks people and Pokémon that cross the desert. This has only furthered its bad reputation."
+		en: "It attacks people and Pokémon that cross the desert. This has only furthered its bad reputation.",
+		de: "Menschen wie Pokémon fürchten PIONDRAGI, das alle angreift, die wagen, die Wüste zu durchqueren."
 	},
 
 	variants: [		{

--- a/data/HeartGold & SoulSilver/Triumphant/40.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/40.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Machop",
-		fr: "Machoc"
+		fr: "Machoc",
+		de: "Machollo"
 	},
 
 	stage: "Stage1",
@@ -73,7 +74,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It always goes at its full power, but this very tough and durable Pokémon never gets tired."
+		en: "It always goes at its full power, but this very tough and durable Pokémon never gets tired.",
+		de: "Es kämpft immer mit all seiner Kraft. Dieses Pokémon hat eine enorme Kondition und wird nie müde."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/41.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/41.ts
@@ -59,7 +59,8 @@ const card: Card = {
 	retreat: 0,
 
 	description: {
-		en: "It is found in volcanic craters. Its body temperature is over 1,100 degrees Fahrenheit, so don’t underestimate it."
+		en: "It is found in volcanic craters. Its body temperature is over 1,100 degrees Fahrenheit, so don’t underestimate it.",
+		de: "Zu finden ist es in Vulkankratern. Seine Körpertemperatur erreicht über 600 Grad. Vergiss das nicht!"
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/42.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/42.ts
@@ -68,7 +68,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "The fiery surface of its body gives off a wavering, rippling glare that is similar to the sun."
+		en: "The fiery surface of its body gives off a wavering, rippling glare that is similar to the sun.",
+		de: "Die feurige Haut seines Körpers besitzt einen flackernden Glanz, der an die Sonne erinnert."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/43.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/43.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Magnemite",
-		fr: "Magneti"
+		fr: "Magneti",
+		de: "Magnetilo"
 	},
 
 	stage: "Stage1",
@@ -55,7 +56,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 
@@ -79,7 +80,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "The Magnemite are united by a magnetism so powerful, it dries all moisture in its vicinity."
+		en: "The Magnemite are united by a magnetism so powerful, it dries all moisture in its vicinity.",
+		de: "Die MAGNETILO werden von einem starken Magnetfeld zusammengehalten, das Feuchtigkeit aufsaugt."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/44.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/44.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Cubone",
-		fr: "Osselait"
+		fr: "Osselait",
+		de: "Tragosso"
 	},
 
 	stage: "Stage1",
@@ -42,7 +43,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 60 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 60 dégâts multipliés par le nombre de côtés face.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 60 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 60 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "60×",
 
@@ -84,7 +85,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It has been seen pounding boulders with the bone it carries in order to tap out messages to others."
+		en: "It has been seen pounding boulders with the bone it carries in order to tap out messages to others.",
+		de: "Es schlägt mit dem Knochen in seiner Hand gegen Felsen, um anderen Botschaften zu übermitteln."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/45.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/45.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Nidoran♀",
-		fr: "Nidoran♀"
+		fr: "Nidoran♀",
+		de: "Nidoran♀"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 10 more damage.",
 				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires.",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -73,7 +74,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It has a calm and caring nature. Because its horn grows slowly, it prefers not to fight."
+		en: "It has a calm and caring nature. Because its horn grows slowly, it prefers not to fight.",
+		de: "Es ist von Natur aus sehr ruhig und umsorgend. Da sein Horn langsam wächst, vermeidet es den Kampf."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/46.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/46.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Nidoran♂",
-		fr: "Nidoran♂"
+		fr: "Nidoran♂",
+		de: "Nidoran♂"
 	},
 
 	stage: "Stage1",
@@ -57,7 +58,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c’est pile, cette attaque ne fait rien.",
-				de: "Wirf eine Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Wirf eine Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 80,
 
@@ -74,7 +75,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Quick to anger, it stabs enemies with its horn to inject a powerful poison when it becomes agitated."
+		en: "Quick to anger, it stabs enemies with its horn to inject a powerful poison when it becomes agitated.",
+		de: "Es ist aufbrausend und setzt sein Horn, dessen Gift im Kampf noch potenter ist, ohne zu zögern ein."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/47.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/47.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pidgey",
-		fr: "Roucool"
+		fr: "Roucool",
+		de: "Taubsi"
 	},
 
 	stage: "Stage1",
@@ -57,7 +58,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. If both of them are tails, this attack does nothing. For each heads, discard an Energy attached to the Defending Pokémon.",
 				fr: "Lancez 2 pièces. Si vous obtenez deux fois un côté pile, cette attaque ne fait rien. Pour chaque face, défaussez une Énergie attachée au Pokémon Défenseur.",
-				de: "Wirf 2 Münzen. Wenn beide Münzen \"Zahl\" zeigen, hat dieser Angriff keine Auswirkungen. Lege pro \"Kopf\" eine Energiekarte, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
+				de: "Wirf 2 Münzen. Wenn beide Münzen „Zahl“ zeigen, hat dieser Angriff keine Auswirkungen. Lege pro „Kopf“ eine Energiekarte, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
 			},
 			damage: 30,
 
@@ -81,7 +82,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It renders its prey immobile using well-developed claws, then carries the prey more than 60 miles to its nest."
+		en: "It renders its prey immobile using well-developed claws, then carries the prey more than 60 miles to its nest.",
+		de: "Es lähmt seine Gegner mit seinen Krallen und trägt die Beute in sein bis zu 100 km entferntes Nest."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/48.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/48.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Swinub",
-		fr: "Marcacrin"
+		fr: "Marcacrin",
+		de: "Quiekel"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage to each of your opponent's Benched Pokémon. If tails, this attack does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 10 dégâts à chaque Pokémon de Banc de votre adversaire. Si c’est pile, cette attaque inflige 10 dégâts à chacun de vos Pokémon de Banc. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff jedem Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. Bei \"Zahl\" fügt dieser Angriff jedem Pokémon auf deiner Bank 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff jedem Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. Bei „Zahl“ fügt dieser Angriff jedem Pokémon auf deiner Bank 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 40,
 
@@ -76,7 +77,8 @@ const card: Card = {
 	retreat: 3,
 
 	description: {
-		en: "Because the long hair all over its body obscures its sight, it just keeps charging repeatedly."
+		en: "Because the long hair all over its body obscures its sight, it just keeps charging repeatedly.",
+		de: "Da sein haariges Fell seine Sicht enorm beeinträchtigt, greift es ständig an, um den Gegner zu treffen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/49.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/49.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Porygon",
-		fr: "Porygon"
+		fr: "Porygon",
+		de: "Porygon"
 	},
 
 	stage: "Stage1",
@@ -58,7 +59,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 
@@ -75,7 +76,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "Further research enhanced its abilities. Sometimes, it may exhibit motions that were not programmed."
+		en: "Further research enhanced its abilities. Sometimes, it may exhibit motions that were not programmed.",
+		de: "Seine Fähigkeiten wurden verbessert. Es zeigt manchmal sogar Handlungen, die nicht einprogrammiert sind."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/5.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/5.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Piloswine",
-		fr: "Cochignon"
+		fr: "Cochignon",
+		de: "Keifel"
 	},
 
 	stage: "Stage2",
@@ -80,7 +81,8 @@ const card: Card = {
 	retreat: 4,
 
 	description: {
-		en: "A frozen Mamoswine was dug from ice dating back 10,000 years. This Pokémon has been around a long, long, long time."
+		en: "A frozen Mamoswine was dug from ice dating back 10,000 years. This Pokémon has been around a long, long, long time.",
+		de: "Es existiert schon seit Urzeiten. MAMUTEL wurde sogar schon in 10 000 Jahre altem Eis gefunden."
 	},
 
 	variants: [		{

--- a/data/HeartGold & SoulSilver/Triumphant/50.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/50.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Tentacool",
-		fr: "Tentacool"
+		fr: "Tentacool",
+		de: "Tentacha"
 	},
 
 	stage: "Stage1",
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy card attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c’est face, défaussez une carte Énergie attachée au Pokémon Défenseur.",
-				de: "Wirf eine Münze. Lege bei \"Kopf\" eine Energiekarte, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
+				de: "Wirf eine Münze. Lege bei „Kopf“ eine Energiekarte, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
 			},
 			damage: 50,
 
@@ -77,7 +78,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "In battle, it extends all 80 of its tentacles to entrap its opponent inside a poisonous net."
+		en: "In battle, it extends all 80 of its tentacles to entrap its opponent inside a poisonous net.",
+		de: "Im Kampf bilden seine 80 Tentakel ein Giftnetz, in dem es seine Gegner fängt und sie vergiftet."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/51.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/51.ts
@@ -65,7 +65,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Its flat, thin body is always stuck on walls. Its shape appears to have some meaning."
+		en: "Its flat, thin body is always stuck on walls. Its shape appears to have some meaning.",
+		de: "Sein flacher, dünner Körper hängt immer an Wänden. Seine Form scheint eine Bedeutung zu haben."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/52.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/52.ts
@@ -70,7 +70,8 @@ const card: Card = {
 	retreat: 3,
 
 	description: {
-		en: "It bounces playfully like a ball. The more seawater it swallows, the higher it bounces."
+		en: "It bounces playfully like a ball. The more seawater it swallows, the higher it bounces.",
+		de: "Es hüpft gerne wie ein Ball herum. Je mehr Meerwasser es trinkt, desto höher kann es springen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/53.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/53.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Bellsprout",
-		fr: "Chetiflor"
+		fr: "Chetiflor",
+		de: "Knofensa"
 	},
 
 	stage: "Stage1",
@@ -58,7 +59,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, look at your opponent's hand, choose 1 card, and discard it.",
 				fr: "Lancez une pièce. Si c’est face, regardez la main de votre adversaire, choisissez une carte et défaussez-la.",
-				de: "Wirf eine Münze. Schau dir bei \"Kopf\" die Handkarten deines Gegners an, wähle 1 davon und lege sie auf seinen Ablagestapel."
+				de: "Wirf eine Münze. Schau dir bei „Kopf“ die Handkarten deines Gegners an, wähle 1 davon und lege sie auf seinen Ablagestapel."
 			},
 			damage: 10,
 
@@ -75,7 +76,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Even though it is filled with acid, it does not melt because it also oozes a protective fluid."
+		en: "Even though it is filled with acid, it does not melt because it also oozes a protective fluid.",
+		de: "Obwohl es mit Säure angefüllt ist, verätzt es sich nicht, da es gegen Säure resistent ist."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/54.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/54.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Yanma",
-		fr: "Yanma"
+		fr: "Yanma",
+		de: "Yanma"
 	},
 
 	stage: "Stage1",
@@ -84,7 +85,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "The beat of its wings is so powerful that it accidentally dislodges full-grown trees when it takes off in flight."
+		en: "The beat of its wings is so powerful that it accidentally dislodges full-grown trees when it takes off in flight.",
+		de: "Sein Flügelschlag ist ungemein mächtig. Fliegt es mit Kraft in die Höhe, mäht der Wind selbst große Bäume nieder."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/55.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/55.ts
@@ -65,7 +65,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Its tail is so powerful that it can use it to grab a tree branch and hold itself up in the air."
+		en: "Its tail is so powerful that it can use it to grab a tree branch and hold itself up in the air.",
+		de: "Sein Schweif ist so kräftig, dass es sich stundenlang damit an einem Ast in der Luft halten kann."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/56.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/56.ts
@@ -74,7 +74,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "When it evolves, it sheds the steel carapace that covered its whole body and develops a new one."
+		en: "When it evolves, it sheds the steel carapace that covered its whole body and develops a new one.",
+		de: "Entwickelt es sich, wirft es seinen alten Stahlpanzer ab und bildet einen neuen aus."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/57.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/57.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Switch the Defending Pokémon with 1 of your opponent's Benched Pokémon.",
 				fr: "Échangez le Pokémon Défenseur avec l’un des Pokémon de Banc de votre adversaire.",
-				de: "Tausche das Verteidigende Pokémon gegen 1 Pokémon auf der Bank deines Gegeners aus."
+				de: "Tausche das Verteidigende Pokémon gegen 1 Pokémon auf der Bank deines Gegners aus."
 			},
 
 		},
@@ -69,7 +69,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Even though its body is extremely skinny, it is blindingly fast when catching its prey."
+		en: "Even though its body is extremely skinny, it is blindingly fast when catching its prey.",
+		de: "Obwohl sein Körper sehr schmal ist, schnappt es blitzschnell nach Beute."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/58.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/58.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of attacks, including damage, done to Bronzor during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c’est face, prévenez tous les effets d’attaques (y compris les dégâts) infligés à Archéomire durant le prochain tour de votre adversaire.",
-				de: "Wirf eine Münze. Verhindere bei \"Kopf\" während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die Bronzel zugefügt werden."
+				de: "Wirf eine Münze. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die Bronzel zugefügt werden."
 			},
 
 		},
@@ -73,7 +73,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Ancient people believed that the pattern on Bronzor’s back contained a mysterious power."
+		en: "Ancient people believed that the pattern on Bronzor’s back contained a mysterious power.",
+		de: "Früher glaubten die Menschen, dem Muster auf seinem Rücken wohne eine mysteriöse Kraft inne."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/59.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/59.ts
@@ -65,7 +65,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "They form packs to attack boats and rip out their hulls to sink them. They live in rivers in the jungle."
+		en: "They form packs to attack boats and rip out their hulls to sink them. They live in rivers in the jungle.",
+		de: "Schwärme von KANIVANHA haben in Dschungelflüssen schon so manches Boot zerbissen und versenkt."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/6.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/6.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Nidorino",
-		fr: "Nidorino"
+		fr: "Nidorino",
+		de: "Nidorino"
 	},
 
 	stage: "Stage2",
@@ -84,7 +85,8 @@ const card: Card = {
 	retreat: 3,
 
 	description: {
-		en: "Its tail is thick and powerful. If it binds an enemy, it can render the victim helpless quite easily."
+		en: "Its tail is thick and powerful. If it binds an enemy, it can render the victim helpless quite easily.",
+		de: "Sein Schweif ist sehr stark. Wickelt es einen Gegner ein, kann es mühelos sein Rückgrat brechen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/60.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/60.ts
@@ -53,7 +53,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin until you get tails. This attack does 20 damage times the number of heads.",
 				fr: "Lancez une pièce jusqu’à ce qu’elle tombe sur pile. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
-				de: "Wirf so lange 1 Münze, bis zum ersten Mal das Ergebnis \"Zahl\" kommt. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf so lange 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 
@@ -77,7 +77,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "If it is sad or lonely, the skull it wears shakes and emits a plaintive and mournful sound."
+		en: "If it is sad or lonely, the skull it wears shakes and emits a plaintive and mournful sound.",
+		de: "Ist es einsam oder traurig, wackelt der Schädel den es trägt und man hört es jammern und wimmern."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/61.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/61.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Sand Veil",
 				fr: "Voile Sable",
-				de: "Sandschleicher"
+				de: "Sandschleier"
 			},
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of attacks, including damage, done to Diglett during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c’est face, prévenez tous les effets d’attaques (y compris les dégâts) infligés à Taupiqueur pendant le prochain tour de votre adversaire.",
-				de: "Wirf eine Münze. Verhindere bei \"Kopf\" während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die Digda zugefügt werden."
+				de: "Wirf eine Münze. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die Digda zugefügt werden."
 			},
 
 		},
@@ -77,7 +77,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "If a Diglett digs through a field, it leaves the soil perfectly tilled and ideal for planting crops."
+		en: "If a Diglett digs through a field, it leaves the soil perfectly tilled and ideal for planting crops.",
+		de: "Setzt ein DIGDA Schaufler auf einem Acker ein, ist die Erde ideal gepflügt, um etwas anzupflanzen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/62.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/62.ts
@@ -67,7 +67,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "This Pokémon is full of life energy. It continually sheds its skin and grows steadily larger."
+		en: "This Pokémon is full of life energy. It continually sheds its skin and grows steadily larger.",
+		de: "Dieses Pokémon strotzt vor Lebensenergie. Es häutet sich ständig und wird dadurch größer."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/63.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/63.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Put 1 damage counter on 1 of your opponent's Pokémon.",
 				fr: "Placez un marqueur de dégât sur l’un des Pokémon de votre adversaire.",
-				de: "Lege 1 Schadensmarken auf 1 Pokémon deines Gegners."
+				de: "Lege 1 Schadensmarke auf 1 Pokémon deines Gegners."
 			},
 
 		},
@@ -59,7 +59,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Its body is made of gas. Despite lacking substance, it can envelop an opponent of any size and cause suffocation."
+		en: "Its body is made of gas. Despite lacking substance, it can envelop an opponent of any size and cause suffocation.",
+		de: "Es hat einen gasförmigen Körper. Es kann jeden Gegner mit Giftgas einnebeln und dadurch ersticken."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/64.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/64.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin for each Volbeat you have in play. This attack does 30 damage times the number of heads.",
 				fr: "Lancez une pièce pour chacun de vos Muciole en jeu. Cette attaque inflige 30 dégâts multipliés par le nombre de côtés face.",
-				de: "Wirf für jedes Volbeat, das du im Spiel hast, eine Münze. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf für jedes Volbeat, das du im Spiel hast, eine Münze. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "30×",
 
@@ -69,7 +69,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Its fragrance attracts a swarm of Volbeat, so they draw over 200 patterns in the night sky."
+		en: "Its fragrance attracts a swarm of Volbeat, so they draw over 200 patterns in the night sky.",
+		de: "Sein süßer Duft leitet VOLBEAT an, über 200 verschiedene Lichtmuster an den Nachthimmel zu malen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/65.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/65.ts
@@ -50,7 +50,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "When its antennae hit each other, it sounds like the music of a xylophone."
+		en: "When its antennae hit each other, it sounds like the music of a xylophone.",
+		de: "Wenn seine zwei Antennen sich berühren, erklingt ein Ruf wie das Spiel eines Xylophons."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/66.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/66.ts
@@ -67,7 +67,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "Its long tongue, slathered with a gooey saliva, sticks to anything, so it is very useful."
+		en: "Its long tongue, slathered with a gooey saliva, sticks to anything, so it is very useful.",
+		de: "Seine Zunge ist mit klebrigem Speichel bedeckt, der überall haftet. Dies ist sehr nützlich."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/67.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/67.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 10 more damage.",
 				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires.",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -68,7 +68,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "Always brimming with power, it passes time by lifting boulders. Doing so makes it even stronger."
+		en: "Always brimming with power, it passes time by lifting boulders. Doing so makes it even stronger.",
+		de: "Da es vor Kraft strotzt, hebt es zum Zeitvertreib Felsen. Dadurch gewinnt es an zusätzlicher Stärke."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/68.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/68.ts
@@ -53,7 +53,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c’est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -77,7 +77,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "The units at the sides of its body generate antigravity energy to keep it aloft in the air."
+		en: "The units at the sides of its body generate antigravity energy to keep it aloft in the air.",
+		de: "Die Magneten an seinem Körper erzeugen ein AntiGrav.-Feld, um es ständig in der Schwebe zu halten."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/69.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/69.ts
@@ -53,7 +53,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 
@@ -70,7 +70,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Although not very combative, it will torment its foes with poison spikes if it is threatened in any way."
+		en: "Although not very combative, it will torment its foes with poison spikes if it is threatened in any way.",
+		de: "Obwohl es nicht aggressiv ist, malträtiert es seine Feinde bei Bedrohung mit seinen Giftstacheln."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/7.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/7.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Porygon2",
-		fr: "Porygon2"
+		fr: "Porygon2",
+		de: "Porygon2"
 	},
 
 	stage: "Stage2",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may flip a coin. If heads, search your discard pile for a Trainer card, show it to your opponent, and put it on top of your deck. This power can't be used if Porygon-Z is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez lancer une pièce. Si c’est face, cherchez une carte Dresseur dans votre pile de défausse, montrez-la à votre adversaire, puis placez-la sur le dessus de votre deck. Ce Poké-Power ne peut pas être utilisé si Porygon-Z est affecté par un État Spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du eine Münze werfen. Bei \"Kopf\" durchsuche deinen Ablagestapel nach 1 Trainer-Karte, zeige sie deinem Gegner und lege sie oben auf dein Deck. Diese Poké-Power kann nicht benutzt werden, wenn Porygon-Z von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du eine Münze werfen. Bei „Kopf“ durchsuche deinen Ablagestapel nach 1 Trainer-Karte, zeige sie deinem Gegner und lege sie oben auf dein Deck. Diese Poké-Power kann nicht benutzt werden, wenn Porygon-Z von einem Speziellen Zustand betroffen ist."
 			}
 		},
 	],
@@ -76,7 +77,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "Its programming was modified to enable it to travel through alien dimensions. Seems there might have been an error…"
+		en: "Its programming was modified to enable it to travel through alien dimensions. Seems there might have been an error…",
+		de: "Eine neue Software sollte es zu interdimensionalen Reisen befähigen, doch anscheinend ging etwas schief."
 	},
 
 	variants: [		{

--- a/data/HeartGold & SoulSilver/Triumphant/70.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/70.ts
@@ -67,7 +67,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It raises its big ears to check its surroundings. It will strike first if it senses any danger."
+		en: "It raises its big ears to check its surroundings. It will strike first if it senses any danger.",
+		de: "Es stellt seine Ohren auf, um die Umgebung zu prüfen. Spürt es Gefahr, greift es stets zuerst an."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/71.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/71.ts
@@ -72,7 +72,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Common in grassy areas and forests, it is very docile and will chase off enemies by flapping up sand."
+		en: "Common in grassy areas and forests, it is very docile and will chase off enemies by flapping up sand.",
+		de: "Es ist meist in Wäldern anzutreffen. Es ist ruhig und verjagt seine Feinde, indem es Sand aufwirbelt."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/72.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/72.ts
@@ -63,7 +63,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It is a weak runner immediately after birth. It gradually becomes faster by chasing after its parents."
+		en: "It is a weak runner immediately after birth. It gradually becomes faster by chasing after its parents.",
+		de: "Nach der Geburt ist es noch langsam, aber es wird bald schneller, da es seinen Eltern nachrennt."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/73.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/73.ts
@@ -50,7 +50,7 @@ const card: Card = {
 			effect: {
 				en: "Discard an Energy attached to Porygon and remove 4 damage counters from Porygon.",
 				fr: "Défaussez une carte Énergie attachée à Porygon et retirez-lui 4 marqueurs de dégât.",
-				de: "Lege 1 an Porygon angelegten Energie auf deinen Ablagestapel und entferne 4 Schadensmarken von Porygon."
+				de: "Lege 1 an Porygon angelegte Energie auf deinen Ablagestapel und entferne 4 Schadensmarken von Porygon."
 			},
 
 		},
@@ -66,7 +66,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "A manmade Pokémon that came about as a result of research. It is programmed with only basic motions."
+		en: "A manmade Pokémon that came about as a result of research. It is programmed with only basic motions.",
+		de: "Ein künstlich produziertes Pokémon, welches das Ergebnis von Forschungen ist. Es ist simpel aufgebaut."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/74.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/74.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 damage to 1 of your opponent's Pokémon. If tails, this attack does 30 damage to 1 of your Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 30 dégâts à l’un des Pokémon de Banc de votre adversaire. Si c’est pile, cette attaque inflige 30 dégâts à l’un de vos Pokémon. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff 1 Pokémon deines Gegners 30 Schadenspunkte zu. Bei \"Zahl\" fügt dieser Angriff 1 deiner Pokémon 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 1 Pokémon deines Gegners 30 Schadenspunkte zu. Bei „Zahl“ fügt dieser Angriff 1 deiner Pokémon 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -52,7 +52,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It has mystical powers but doesn’t recall that it has used them. That is why it always looks puzzled."
+		en: "It has mystical powers but doesn’t recall that it has used them. That is why it always looks puzzled.",
+		de: "Es besitzt mystische Kräfte, die es unbewusst einsetzt. Daher ist sein Blick immer verwirrt."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/75.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/75.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c’est face, choisissez l’une des attaques du Pokémon Défenseur. Ce Pokémon ne peut pas utiliser cette attaque pendant le prochain tour de votre adversaire.",
-				de: "Wirf eine Münze. Wähle bei \"Kopf\" 1 Angriff des Verteidigenden Pokémon. Das Pokémon kann den gewählten Angriff im nächsten Zug deines Gegners nicht einsetzen."
+				de: "Wirf eine Münze. Wähle bei „Kopf“ 1 Angriff des Verteidigenden Pokémon. Das Pokémon kann den gewählten Angriff im nächsten Zug deines Gegners nicht einsetzen."
 			},
 
 		},
@@ -75,7 +75,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It uses its horn to feed on envy and malice, or so it’s said. It’s very active at night."
+		en: "It uses its horn to feed on envy and malice, or so it’s said. It’s very active at night.",
+		de: "Man sagt, durch sein Horn ernähre es sich von Rachsucht und Neid. Erst nachts wird es richtig aktiv."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/76.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/76.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c’est pile, cette attaque ne fait rien. Si c’est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen. Bei \"Kopf\" ist das Verteidigenede Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 30,
 
@@ -54,7 +54,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It burrows under the sand to lie in wait for prey. Its tail claws can inject its prey with a savage poison."
+		en: "It burrows under the sand to lie in wait for prey. Its tail claws can inject its prey with a savage poison.",
+		de: "Es wartet im Sand versteckt auf Beute, die es sich mit seinem giftigen Schweif krallt."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/77.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/77.ts
@@ -52,7 +52,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It bounces around on its tail to keep its heart pumping. It carries a pearl from Clamperl on its head."
+		en: "It bounces around on its tail to keep its heart pumping. It carries a pearl from Clamperl on its head.",
+		de: "Seine Hüpfbewegungen bringen sein Herz zum schlagen. Es trägt eine Perle von PERLU auf dem Kopf."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/78.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/78.ts
@@ -60,7 +60,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Its wings bring cottony clouds to mind. It grooms with springwater and loves to sit on heads."
+		en: "Its wings bring cottony clouds to mind. It grooms with springwater and loves to sit on heads.",
+		de: "Seine Schäfchenwolkenflügel pflegt es mit Quellwasser. Es liebt es, auf den Köpfen von Menschen zu sitzen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/79.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/79.ts
@@ -63,7 +63,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It rubs its snout on the ground to find and dig up food. It sometimes discovers hot springs."
+		en: "It rubs its snout on the ground to find and dig up food. It sometimes discovers hot springs.",
+		de: "Auf Nahrungssuche schnüffelt es am Boden entlang. Es entdeckt dabei manchmal auch heiße Quellen."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/8.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/8.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Ponyta",
-		fr: "Ponyta"
+		fr: "Ponyta",
+		de: "Ponita"
 	},
 
 	stage: "Stage1",
@@ -76,7 +77,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "At full gallop, its four hooves barely touch the ground because it moves so incredibly fast."
+		en: "At full gallop, its four hooves barely touch the ground because it moves so incredibly fast.",
+		de: "Bei vollem Galopp berühren seine Hufe kaum den Boden, da es so unglaublich schnell ist."
 	},
 
 	variants: [		{

--- a/data/HeartGold & SoulSilver/Triumphant/80.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/80.ts
@@ -53,7 +53,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It drifts aimlessly in waves. Very difficult to see in water, it may not be noticed until it stings."
+		en: "It drifts aimlessly in waves. Very difficult to see in water, it may not be noticed until it stings.",
+		de: "Es treibt ziellos im Wasser. Es ist schwer zu erkennen und wird erst bemerkt, wenn es zusticht."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/81.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/81.ts
@@ -68,7 +68,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Poison oozes from all over its body. It catches and eats small bugs at night that are attracted by light."
+		en: "Poison oozes from all over its body. It catches and eats small bugs at night that are attracted by light.",
+		de: "Gift bedeckt seinen Körper. Es fängt und frisst nachts kleine Käfer, die von Licht angelockt wurden."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/82.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/82.ts
@@ -71,7 +71,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It emits light from its tail to communicate. It loves the sweet aroma given off by Illumise."
+		en: "It emits light from its tail to communicate. It loves the sweet aroma given off by Illumise.",
+		de: "Es kommuniziert mit seinen Artgenossen, indem es mit dem Hinterteil blinkt. Es liebt ILLUMISEs Duft."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/83.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/83.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 10 more damage. If tails, Voltorb does 10 damage to itself.",
 				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires. Si c’est pile, Voltorbe s’inflige 10 dégâts.",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff 20 Schadenspunkte plus 10 weiteren Schadenspunkte zu. Bei \"Zahl\" fügt Voltobal sich selbst 10 Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu. Bei „Zahl“ fügt Voltobal sich selbst 10 Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -60,7 +60,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It rolls to move. If the ground is uneven, a sudden jolt from hitting a bump can cause it to explode."
+		en: "It rolls to move. If the ground is uneven, a sudden jolt from hitting a bump can cause it to explode.",
+		de: "Es bewegt sich rollend fort. Rollt es gegen ein Hindernis, kann es plötzlich explodieren."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/84.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/84.ts
@@ -73,7 +73,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Its large eyes can scan 360 degrees. It looks in all directions to seek out insects as its prey."
+		en: "Its large eyes can scan 360 degrees. It looks in all directions to seek out insects as its prey.",
+		de: "Seine riesigen Augen verfügen über einen Blickwinkel von 360 Grad. Es erspäht mit ihnen Beutetiere."
 	},
 
 	variants: [

--- a/data/HeartGold & SoulSilver/Triumphant/85.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/85.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		fr: "Vous pouvez utiliser cette carte uniquement s’il vous reste plus de cartes Récompense que votre adversaire. Pendant ce tour, chaque attaque de votre Pokémon Actif inflige 40 dégâts supplémentaires au Pokémon Actif de votre adversaire (avant application de la Faiblesse et de la Résistance).",
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. You may use this card only if you have more Prize cards left than your opponent. During this turn, each of your Active Pokémon's attacks does 40 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
-		de: "Du darfst diese Karte nur spielen, wenn du mehr Preise übrig hast als dein Gegner. Während dieses Zuges fügt jeder Angriff deines Aktiven Pokémon den Aktiven Pokémon des Gegners 40 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Du darfst diese Karte nur spielen, wenn du mehr Preise übrig hast als dein Gegner. Während dieses Zuges fügt jeder Angriff deines Aktiven Pokémon den Aktiven Pokémon des Gegners 40 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 	},
 
 	trainerType: "Supporter",

--- a/data/HeartGold & SoulSilver/Triumphant/86.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/86.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez-la si une autre carte Stade est jouée. Si une autre carte du même nom est en jeu, vous ne pouvez pas l’utiliser.",
 		en: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card. Each Pokémon LEGEND in play (both yours and your opponent's) gets +30 HP.",
-		de: "Jede Pokémon-LEGENDE im Spiel (deine und die deines Gegners) erhält +30 KP."
+		de: "Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadion-Karte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen. Jede Pokémon-LEGENDE im Spiel (deine und die deines Gegners) erhält +30 KP."
 	},
 
 	trainerType: "Stadium",

--- a/data/HeartGold & SoulSilver/Triumphant/88.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/88.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		fr: "Chaque joueur récupère l’un de ses Pokémon de Banc dans sa main, ainsi que toutes les cartes qui lui sont attachées. (Vous récupérez votre Pokémon en premier.)",
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Each player returns 1 of his or her Benched Pokémon and all cards attached to it to his or her hand. (You return your Pokémon first.)",
-		de: "Jeder Spieler nimmt 1 Pokémon von seiner Bank und alle daran angelegten Karten zurück auf seine Hand. (Du nimmst dein Pokémon zuerst.)"
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Jeder Spieler nimmt 1 Pokémon von seiner Bank und alle daran angelegten Karten zurück auf seine Hand. (Du nimmst dein Pokémon zuerst.)"
 	},
 
 	trainerType: "Supporter",

--- a/data/HeartGold & SoulSilver/Triumphant/89.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/89.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		fr: "Vous pouvez utiliser cette carte uniquement s’il vous reste plus de cartes Récompense que votre adversaire. Cherchez 2 cartes dans votre deck et ajoutez-les à votre main. Mélangez ensuite votre deck.",
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. You may use this card only if you have more Prize cards left than your opponent. Search your deck for any 2 cards and put them into your hand. Shuffle your deck afterward.",
-		de: "Du darfst diese Karte nur spielen, wenn du mehr Preise übrig hast als dein Gegner. Durchsuche dein Deck nach 2 Karten und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Du darfst diese Karte nur spielen, wenn du mehr Preise übrig hast als dein Gegner. Durchsuche dein Deck nach 2 Karten und nimm sie auf deine Hand. Mische anschließend dein Deck."
 	},
 
 	trainerType: "Supporter",

--- a/data/HeartGold & SoulSilver/Triumphant/9.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/9.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
 				fr: "Si le Pokémon Défenseur essaie d’attaquer pendant le prochain tour de votre adversaire, ce dernier lance une pièce. Si c’est pile, cette attaque ne fait rien.",
-				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 20,
 
@@ -69,7 +69,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "When it rotates itself, it gives off light similar to the sun, thus blinding its foes."
+		en: "When it rotates itself, it gives off light similar to the sun, thus blinding its foes.",
+		de: "Es rotiert um die eigene Achse und strahlt dabei sonnengleiches Licht aus, mit dem es den Gegner blendet."
 	},
 
 	variants: [		{

--- a/data/HeartGold & SoulSilver/Triumphant/90.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/90.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		fr: "Énergie Rescousse fournit de l’Énergie Colorless. Si le Pokémon auquel est attachée cette carte est mis K.O. par une attaque, récupérez ce Pokémon dans votre main. (Défaussez toutes les cartes attachées à ce Pokémon.)",
 		en: "Rescue Energy provides Colorless Energy. If the Pokémon this card is attached to is Knocked Out by damage from an attack, put that Pokémon back into your hand. (Discard all cards attached to that Pokémon.)",
-		de: "Berge-Energie liefert -Energie. Wenn das Pokémon, an das diese Karte angelegt ist, durch einen Angriff deines Gegners kampfunfähig gemacht wurde, nimm dieses Pokémon zurück auf deine Hand. (Lege alle an dieses Pokémon angelegten Karten auf deinen Ablagestapel.)"
+		de: "Berge-Energie liefert {C}-Energie. Wenn das Pokémon, an das diese Karte angelegt ist, durch einen Angriff deines Gegners kampfunfähig gemacht wurde, nimm dieses Pokémon zurück auf deine Hand. (Lege alle an dieses Pokémon angelegten Karten auf deinen Ablagestapel.)"
 	},
 
 	energyType: "Special",

--- a/data/HeartGold & SoulSilver/Triumphant/92.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/92.ts
@@ -34,7 +34,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), if Celebi is your Active Pokémon, you may attach a Grass Energy card from your hand to 1 of your Pokémon. This power can't be used if Celebi is affected by a Special Condition.",
 				fr: "Une fois pendant votre tour (avant votre attaque), si Celebi est votre Pokémon Actif, vous pouvez attacher une carte Énergie Grass de votre main à l’un de vos Pokémon. Ce Poké-Power ne peut pas être utilisé si Celebi est affecté par un État Spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn Celebi dein Aktives Pokémon ist, 1 -Energiekarte von deiner Hand an 1 deiner Pokémon anlegen. Diese Poké-Power kann nicht benutzt werden, wenn Celebi von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn Celebi dein Aktives Pokémon ist, 1 {G}-Energiekarte von deiner Hand an 1 deiner Pokémon anlegen. Diese Poké-Power kann nicht benutzt werden, wenn Celebi von einem Speziellen Zustand betroffen ist."
 			}
 		},
 	],

--- a/data/HeartGold & SoulSilver/Triumphant/93.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/93.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Voltorb",
-		fr: "Voltorbe"
+		fr: "Voltorbe",
+		de: "Voltobal"
 	},
 
 	stage: "Stage1",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may use this power. If you do, Electrode is Knocked Out. Look at the top 7 cards of your deck. Choose as many Energy cards as you like and attach them to your Pokémon in any way you like. Discard the other cards. This power can't be used if Electrode is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez utiliser ce Poké-Power. Dans ce cas, Electrode est mis K.O. Regardez les 7 cartes du dessus de votre deck. Choisissez autant de cartes Énergie que vous le souhaitez et attachez-les à vos Pokémon comme bon vous semble. Défaussez les autres cartes. Ce Poké-Power ne peut pas être utilisé si Electrode est affecté par un État Spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du diese Poké-Power benutzen. Wenn du das machst, wird Lektrobal kampfunfähig. Schau dir die obersten 7 Karten deines Decks an. Wähle beliebig viele Energiekarten, die du dort gefunden hast, und lege sie in beliebiger Verteilung an deine Pokémon an. Lege die anderen Karten auf deinen Ablagestapel. Diese Poké-Power kann nicht verwendet werden, wenn Lektrobal von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du diese Poké-Power benutzen. Wenn du das machst, wird Lektrobal kampfunfähig. Schau dir die obersten 7 Karten deines Decks an. Wähle beliebig viele Energiekarten, die du dort gefunden hast, und lege sie in beliebiger Verteilung an deine Pokémon an. Lege die anderen Karten auf deinen Ablagestapel. Diese Poké-Power kann nicht benutzt werden, wenn Lektrobal von einem Speziellen Zustand betroffen ist."
 			}
 		},
 	],

--- a/data/HeartGold & SoulSilver/Triumphant/94.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/94.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Haunter",
-		fr: "Spectrum"
+		fr: "Spectrum",
+		de: "Alpollo"
 	},
 
 	stage: "Stage2",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "As long as Gengar is your Active Pokémon, if any of your opponent's Pokémon would be Knocked Out, put that Pokémon in the Lost Zone instead of discarding. (Discard all cards attached to that Pokémon.)",
 				fr: "Tant qu’Ectoplasma est votre Pokémon Actif, si l’un des Pokémon de votre adversaire est mis K.O., placez ce Pokémon dans la Zone Perdue au lieu de le défausser. (Défaussez toutes les cartes attachées à ce Pokémon.)",
-				de: "Solange Gengar dein Aktives Pokémon ist, lege alle Pokémon deines Gegners, die kampfunfähig gemacht würden, nicht auf den Ablagestapel, sondern ins Nirgendwo. (Lege alle an dieses Pokémon angelegten Karten auf den jeweiligen Ablagestapel)."
+				de: "Solange Gengar dein Aktives Pokémon ist, lege alle Pokémon deines Gegners, die kampfunfähig gemacht würden, nicht auf den Ablagestapel, sondern ins Nirgendwo. (Lege alle an dieses Pokémon angelegten Karten auf den jeweiligen Ablagestapel.)"
 			}
 		},
 	],
@@ -57,7 +58,7 @@ const card: Card = {
 			effect: {
 				en: "Look at your opponent's hand and choose a number of Pokémon you find there up to the number of Psychic Energy attached to Gengar. Put the Pokémon you chose in the Lost Zone.",
 				fr: "Regardez la main de votre adversaire et choisissez-y autant de Pokémon qu’il existe de cartes Énergie Psychic attachées à Ectoplasma. Placez les Pokémon que vous avez choisis dans la Zone Perdue.",
-				de: "Schau dir die Handkarten deines Gegners an und wähle eine Anzahl Pokémon-Karten, die du dort findest, die höchstens der Anzahl der an Gengar angeleten -Energien entspricht. Lege die gewählten Pokémon-Karten ins Nirgendwo."
+				de: "Schau dir die Handkarten deines Gegners an und wähle eine Anzahl Pokémon-Karten, die du dort findest, die höchstens der Anzahl der an Gengar angeleten {P}-Energien entspricht. Lege die gewählten Pokémon-Karten ins Nirgendwo."
 			},
 
 		},

--- a/data/HeartGold & SoulSilver/Triumphant/95.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/95.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Machoke",
-		fr: "Machopeur"
+		fr: "Machopeur",
+		de: "Maschock"
 	},
 
 	stage: "Stage2",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), if Machamp is on your Bench, you may move all Fighting Energy attached to your Active Pokémon to Machamp. If you do, switch Machamp with your Active Pokémon.",
 				fr: "Une fois pendant votre tour (avant votre attaque), si Mackogneur est sur votre Banc, vous pouvez lui attribuer toutes les cartes Énergie Fighting attachées à votre Pokémon Actif. Dans ce cas, échangez Mackogneur avec votre Pokémon Actif.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn sich Machomei auf deiner Bank befindet, alle an dein Aktives Pokémon angelegten -Energien an Machomei anlegen. Wenn du das machst, tausche Machomei mit deinem Aktiven Pokémon aus."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn sich Machomei auf deiner Bank befindet, alle an dein Aktives Pokémon angelegten {F}-Energien an Machomei anlegen. Wenn du das machst, tausche Machomei gegen dein Aktives Pokémon aus."
 			}
 		},
 	],

--- a/data/HeartGold & SoulSilver/Triumphant/96.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/96.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Magneton",
-		fr: "Magneton"
+		fr: "Magneton",
+		de: "Magneton"
 	},
 
 	stage: "Stage2",

--- a/data/HeartGold & SoulSilver/Triumphant/98.ts
+++ b/data/HeartGold & SoulSilver/Triumphant/98.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Yanma",
-		fr: "Yanma"
+		fr: "Yanma",
+		de: "Yanma"
 	},
 
 	stage: "Stage1",
@@ -58,7 +59,7 @@ const card: Card = {
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Choisissez l’un des Pokémon de votre adversaire. Cette attaque inflige 40 dégâts à ce Pokémon. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
-				de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 40 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an)."
+				de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 40 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},


### PR DESCRIPTION
## Add missing German translations for hgss4

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
