### PR TITLE
(data) Add Japanese M set M6 Storm Emeralda

### DIFF
--- a/data-asia/M/M6.ts
+++ b/data-asia/M/M6.ts
@@ -1,0 +1,20 @@
+import { Set } from "../../interfaces";
+import serie from "../M";
+
+const set: Set = {
+	id: "M6",
+	name: {
+		ja: "ストームエメラルダ",
+	},
+
+	serie: serie,
+
+	cardCount: {
+		official: 76,
+	},
+	releaseDate: {
+		ja: "2026-07-31",
+	},
+};
+
+export default set;

--- a/data-asia/M/M6/001.ts
+++ b/data-asia/M/M6/001.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヘラクロス",
+	},
+
+	illustrator: "Satoshi Ito",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Grass"],
+
+	description: {
+		ja: "自慢のツノを 相手の お腹の 下に ねじこみ 一気に 持ち上げ ぶん投げてしまう 力持ち。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "スパイクドロー" },
+			damage: 20,
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の山札を2枚引く。",
+			},
+		},
+		{
+			name: { ja: "10まんばりき" },
+			damage: 130,
+			cost: ["Grass", "Grass", "Colorless"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899786,
+				tcgplayer: 709157,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [214],
+};
+
+export default card;

--- a/data-asia/M/M6/002.ts
+++ b/data-asia/M/M6/002.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アメタマ",
+	},
+
+	illustrator: "Gemi",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Grass"],
+
+	description: {
+		ja: "頭の 先から 水飴に 似た 甘い 匂いの 液体を 出す。 水草の 多い 池に 棲む。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふえる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から「アメタマ」を2枚まで選び、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "むしくい" },
+			damage: 10,
+			cost: ["Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899791,
+				tcgplayer: 709158,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [283],
+};
+
+export default card;

--- a/data-asia/M/M6/003.ts
+++ b/data-asia/M/M6/003.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アメモース",
+	},
+
+	illustrator: "Kazumasa Yasukuni",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Grass"],
+
+	description: {
+		ja: "雨に 濡れると 特徴的な 目玉模様の 触角が 重くなり 飛べなくなって しまう。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "こわいもよう" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、ワザが使えない。",
+			},
+		},
+		{
+			name: { ja: "バグパニック" },
+			damage: "50×",
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の山札を下から7枚オモテにして、その中にある、ワザ「バグパニック」を持つポケモンの枚数×50ダメージ。オモテにしたポケモンは山札にもどして切る。残りのカードはトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899793,
+				tcgplayer: 709159,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アメタマ",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [284],
+};
+
+export default card;

--- a/data-asia/M/M6/004.ts
+++ b/data-asia/M/M6/004.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サボネア",
+	},
+
+	illustrator: "Minato",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "雨が 少ない 乾燥した 地域に 生息。 １年に １回 黄色の 花を 咲かせる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はねとばす" },
+			damage: "10+",
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、10ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899794,
+				tcgplayer: 709160,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [331],
+};
+
+export default card;

--- a/data-asia/M/M6/005.ts
+++ b/data-asia/M/M6/005.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ノクタス",
+	},
+
+	illustrator: "okayamatakatoshi",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Grass"],
+
+	description: {
+		ja: "砂漠に 生息。 夜になると 動きだし 砂漠の 暑さで 疲れ果てた 獲物を 捕らえる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ちょくげきだん" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+		{
+			name: { ja: "パニッシュニードル" },
+			damage: "10+",
+			cost: ["Grass"],
+			effect: {
+				ja: "相手の場の特性を持つポケモンの数×50ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 899795,
+				tcgplayer: 709161,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "サボネア",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Rare",
+	dexId: [332],
+};
+
+export default card;

--- a/data-asia/M/M6/006.ts
+++ b/data-asia/M/M6/006.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ミツハニー",
+	},
+
+	illustrator: "nisimono",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Grass"],
+
+	description: {
+		ja: "生まれたときから ３匹 一緒。 ビークインに 喜んでもらうため いつも 花の蜜を 集めている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぱっときえる" },
+			damage: 10,
+			cost: ["Grass"],
+			effect: {
+				ja: "このポケモンと、ついているすべてのカードを、手札にもどす。",
+			},
+		},
+		{
+			name: { ja: "バグパニック" },
+			damage: "50×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札を下から7枚オモテにして、その中にある、ワザ「バグパニック」を持つポケモンの枚数×50ダメージ。オモテにしたポケモンは山札にもどして切る。残りのカードはトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899796,
+				tcgplayer: 709162,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [415],
+};
+
+export default card;

--- a/data-asia/M/M6/007.ts
+++ b/data-asia/M/M6/007.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ビークイン",
+	},
+
+	illustrator: "Masako Tomii",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Grass"],
+
+	description: {
+		ja: "体の 穴の 中で 子どもを 育てる。 ミツハニーを 操る フェロモンを 分泌する。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "つきさす" },
+			damage: 40,
+			cost: ["Grass"],
+		},
+		{
+			name: { ja: "クリーンヒット" },
+			damage: "80+",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが進化ポケモンなら、80ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899797,
+				tcgplayer: 709163,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ミツハニー",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [416],
+};
+
+export default card;

--- a/data-asia/M/M6/008.ts
+++ b/data-asia/M/M6/008.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コソクムシ",
+	},
+
+	illustrator: "Jerky",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Grass"],
+
+	description: {
+		ja: "ビーチから 海底まで 色んな 場所に 棲む。 腐った餌でも 喜び 食べる 自然の掃除屋。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "よわごし" },
+			effect: {
+				ja: "相手の場に「ポケモンex」がいるなら、このポケモンはにげるためのエネルギーが、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ぶつかる" },
+			damage: 10,
+			cost: ["Grass"],
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899798,
+				tcgplayer: 709164,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [767],
+};
+
+export default card;

--- a/data-asia/M/M6/009.ts
+++ b/data-asia/M/M6/009.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガグソクムシャex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 340,
+	types: ["Grass"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "とどめをさす" },
+			damage: "60+",
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンにダメカンがのっているなら、160ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "クワトロホールド" },
+			damage: 160,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 899818,
+				tcgplayer: 709165,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コソクムシ",
+	},
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Double rare",
+	dexId: [768],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M6/010.ts
+++ b/data-asia/M/M6/010.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガーディ",
+	},
+
+	illustrator: "Teeziro",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	description: {
+		ja: "人懐こく 誠実な 性格。 敵には ほえて かみつき 追い払おうとする。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ほえる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+		{
+			name: { ja: "うしろげり" },
+			damage: 50,
+			cost: ["Fire", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899839,
+				tcgplayer: 709166,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [58],
+};
+
+export default card;

--- a/data-asia/M/M6/011.ts
+++ b/data-asia/M/M6/011.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ウインディ",
+	},
+
+	illustrator: "Felicia Chen",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Fire"],
+
+	description: {
+		ja: "堂々とした 鳴き声は 威厳に あふれ 聞いたものは 思わず ひれ伏してしまう。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "はりきりファング" },
+			damage: "90+",
+			cost: ["Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のサイドの残り枚数が4枚以下なら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "ヒートタックル" },
+			damage: 200,
+			cost: ["Fire", "Fire", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンにも50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 899854,
+				tcgplayer: 709167,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ガーディ",
+	},
+
+	retreat: 4,
+	regulationMark: "J",
+	rarity: "Rare",
+	dexId: [59],
+};
+
+export default card;

--- a/data-asia/M/M6/012.ts
+++ b/data-asia/M/M6/012.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブーバー",
+	},
+
+	illustrator: "GOSSAN",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Fire"],
+
+	description: {
+		ja: "体の 表面には 太陽と 同じような 炎の ゆらめきが 発生している。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ちからをあつめる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札から基本エネルギーを2枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "かえん" },
+			damage: 30,
+			cost: ["Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899857,
+				tcgplayer: 709168,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [126],
+};
+
+export default card;

--- a/data-asia/M/M6/013.ts
+++ b/data-asia/M/M6/013.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブーバーン",
+	},
+
+	illustrator: "Ryuta Fuse",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fire"],
+
+	description: {
+		ja: "火山の 火口に 棲む。 １つの 火山には ひとつがいの ブーバーンしかいないと いわれる。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "バディブースト" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札から「基本[R]エネルギー」と「基本[L]エネルギー」をそれぞれ1枚まで選び、自分の「エレキブル」または「ブーバーン」に好きなようにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ヒートスタンプ" },
+			damage: 80,
+			cost: ["Fire", "Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899861,
+				tcgplayer: 709169,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ブーバー",
+	},
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [467],
+};
+
+export default card;

--- a/data-asia/M/M6/014.ts
+++ b/data-asia/M/M6/014.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "コータス",
+	},
+
+	illustrator: "Tonji Matsuno",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fire"],
+
+	description: {
+		ja: "石炭が エネルギーの 源。 コータスの 棲んでいる 山には 多くの 石炭が 眠っている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "やきこがす" },
+			damage: 30,
+			cost: ["Fire", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをやけどにする。",
+			},
+		},
+		{
+			name: { ja: "かえんばく" },
+			damage: 120,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンは「かえんばく」が使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899867,
+				tcgplayer: 709170,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [324],
+};
+
+export default card;

--- a/data-asia/M/M6/015.ts
+++ b/data-asia/M/M6/015.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒートロトムex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "さいかねつ" },
+			damage: "30×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある「基本[R]エネルギー」をすべて相手に見せて、その枚数×30ダメージ。その後、見せたエネルギーを山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "ストロングフレア" },
+			damage: 170,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 899868,
+				tcgplayer: 709171,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Double rare",
+	dexId: [479],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M6/016.ts
+++ b/data-asia/M/M6/016.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クイタラン",
+	},
+
+	illustrator: "Takeshi Nakamura",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fire"],
+
+	description: {
+		ja: "しっぽの 穴から 空気を 取りこみ 炎を 燃やす。 穴を 塞がれると 具合が 悪くなる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はかいび" },
+			damage: 30,
+			cost: ["Fire"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンについているエネルギーを1個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899881,
+				tcgplayer: 709172,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [631],
+};
+
+export default card;

--- a/data-asia/M/M6/017.ts
+++ b/data-asia/M/M6/017.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マンタイン",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Water"],
+
+	description: {
+		ja: "泳いで スピードが のってくると 波の上に 飛びだし そのまま １００メートルも 滑空 する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なみをおこす" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "おたがいのプレイヤーは、それぞれ手札をすべて山札にもどして切る。その後、それぞれ山札を4枚引く。",
+			},
+		},
+		{
+			name: { ja: "バブルドレイン" },
+			damage: 30,
+			cost: ["Water", "Colorless"],
+			effect: {
+				ja: "このポケモンのHPを「30」回復する。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899890,
+				tcgplayer: 709173,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [226],
+};
+
+export default card;

--- a/data-asia/M/M6/018.ts
+++ b/data-asia/M/M6/018.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カイオーガ",
+	},
+
+	illustrator: "Anderson",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Water"],
+
+	description: {
+		ja: "大雨と 大津波で 海を 広げた 神話の ポケモン。 グラードンと 激しく 戦った。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たきのぼり" },
+			damage: 40,
+			cost: ["Water", "Colorless"],
+		},
+		{
+			name: { ja: "あらぶるうず" },
+			damage: 100,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "名前に「伝説」とつくスタジアムが場に出ているなら、相手のベンチポケモン全員にも、それぞれ50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 899895,
+				tcgplayer: 709174,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Rare",
+	dexId: [382],
+};
+
+export default card;

--- a/data-asia/M/M6/019.ts
+++ b/data-asia/M/M6/019.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "プルリル",
+	},
+
+	illustrator: "Mousho",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Water"],
+
+	description: {
+		ja: "ベールの ような 手足で 獲物を 抱きかかえ ８０００メートルの 深海へと 引きずり込む。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひっかける" },
+			damage: 10,
+			cost: ["Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899896,
+				tcgplayer: 709175,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [592],
+};
+
+export default card;

--- a/data-asia/M/M6/020.ts
+++ b/data-asia/M/M6/020.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブルンゲル",
+	},
+
+	illustrator: "Nurikabe",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Water"],
+
+	description: {
+		ja: "体の ほとんどが 海水と 同じ 成分で できている。 沈没船を 根城にする。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "しんかいドロー" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を1枚引く。その後、のぞむなら、自分の手札を1枚選び、山札の下にもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ひっぱたく" },
+			damage: 100,
+			cost: ["Water", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899897,
+				tcgplayer: 709176,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "プルリル",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [593],
+};
+
+export default card;

--- a/data-asia/M/M6/021.ts
+++ b/data-asia/M/M6/021.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨワシex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "オーシャンゲイン" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。このポケモンのHPを「50」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ハイドロスプラッシュ" },
+			damage: 220,
+			cost: ["Water", "Water", "Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 899898,
+				tcgplayer: 709177,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Double rare",
+	dexId: [746],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M6/022.ts
+++ b/data-asia/M/M6/022.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エレブー",
+	},
+
+	illustrator: "kurumitsu",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Lightning"],
+
+	description: {
+		ja: "エレブーに 雷を 溜めこませ いつでも 使えるようにする 研究が 進められている。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なかまをよぶ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からたねポケモンを2枚まで選び、ベンチに出す。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "ずつき" },
+			damage: 60,
+			cost: ["Lightning", "Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899902,
+				tcgplayer: 709178,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [125],
+};
+
+export default card;

--- a/data-asia/M/M6/023.ts
+++ b/data-asia/M/M6/023.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エレキブル",
+	},
+
+	illustrator: "hncl",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Lightning"],
+
+	description: {
+		ja: "相手に 尻尾の先を 押しつけ 瞬時に ２万ボルト 以上の 高圧 電流を 送りこむ。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "のしかかり" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "ボルテージハンマー" },
+			damage: "60×",
+			cost: ["Lightning", "Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている基本エネルギーを好きなだけトラッシュし、その枚数×60ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899905,
+				tcgplayer: 709179,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "エレブー",
+	},
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [466],
+};
+
+export default card;

--- a/data-asia/M/M6/024.ts
+++ b/data-asia/M/M6/024.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ライコウex",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "いかずちをまとう" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "このワザは、先攻プレイヤーの最初の番でも使える。自分の山札からエネルギーを1枚選び、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "パワーラッシュ" },
+			damage: 200,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 899908,
+				tcgplayer: 709286,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "J",
+	rarity: "Double rare",
+	dexId: [243],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M6/025.ts
+++ b/data-asia/M/M6/025.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ボルトロス",
+	},
+
+	illustrator: "Takumi Wada",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Lightning"],
+
+	description: {
+		ja: "大空を 飛び回りながら あちこちに 雷を 落として 山火事を 起こすので 嫌われる。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "けしんだんけつ" },
+			effect: {
+				ja: "自分の場に「トルネロス」「ボルトロス」「ランドロス」「ラブトロス」がいるなら、このポケモンはワザを使うための[C]エネルギーが、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "サンダーエッジ" },
+			damage: 90,
+			cost: ["Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは、相手のバトルポケモンにかかっている効果を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899926,
+				tcgplayer: 709289,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [642],
+};
+
+export default card;

--- a/data-asia/M/M6/026.ts
+++ b/data-asia/M/M6/026.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バチンウニ",
+	},
+
+	illustrator: "OKUBO",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Lightning"],
+
+	description: {
+		ja: "藻屑が 触っただけで 驚き 放電してしまうほど 臆病。 唇は 電気を 通さない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "エナジークラッシュ" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン全員についているエネルギーの数×20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899929,
+				tcgplayer: 709180,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [871],
+};
+
+export default card;

--- a/data-asia/M/M6/027.ts
+++ b/data-asia/M/M6/027.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カイデン",
+	},
+
+	illustrator: "Yukihiro Tada",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Lightning"],
+
+	description: {
+		ja: "海岸の 崖に 巣を 作る。 巣は パチパチ 弾ける 不思議な 食感で 人気の 珍味。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "こうそくいどう" },
+			damage: 10,
+			cost: ["Lightning"],
+			effect: {
+				ja: "コインを1回投げオモテなら、次の相手の番、このポケモンはワザのダメージや効果を受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899930,
+				tcgplayer: 709181,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [940],
+};
+
+export default card;

--- a/data-asia/M/M6/028.ts
+++ b/data-asia/M/M6/028.ts
@@ -1,0 +1,60 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "タイカイデン",
+	},
+
+	illustrator: "OKACHEKE",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Lightning"],
+
+	description: {
+		ja: "のど袋に 翼で 作った 電気を 溜める。 羽の 油分が とても 少なく 泳ぎは 苦手。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "しゅうげき" },
+			damage: "30+",
+			cost: ["Lightning"],
+			effect: {
+				ja: "この番に、このポケモンが「カイデン」から進化していたなら、90ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "スピードひこう" },
+			damage: 70,
+			cost: ["Lightning", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899931,
+				tcgplayer: 709182,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "カイデン",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [941],
+};
+
+export default card;

--- a/data-asia/M/M6/029.ts
+++ b/data-asia/M/M6/029.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スリープ",
+	},
+
+	illustrator: "Hachinana",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Psychic"],
+
+	description: {
+		ja: "突き出た 鼻を ひくひくさせると どこの だれが どんな 夢を 見ているのか 全部 わかるという。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はたく" },
+			damage: 20,
+			cost: ["Psychic"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899932,
+				tcgplayer: 709183,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [96],
+};
+
+export default card;

--- a/data-asia/M/M6/030.ts
+++ b/data-asia/M/M6/030.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "スリーパー",
+	},
+
+	illustrator: "Yuta Kawazu",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "どんなときでも 持っている 振り子を 決まったリズムで 揺らしている。 近寄ると なぜか 眠くなる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "マインドルーラー" },
+			damage: "20×",
+			cost: ["Psychic"],
+			effect: {
+				ja: "相手の手札の枚数×20ダメージ。",
+			},
+		},
+		{
+			name: { ja: "さいみんはどう" },
+			damage: 50,
+			cost: ["Psychic", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをねむりにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899933,
+				tcgplayer: 709184,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "スリープ",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [97],
+};
+
+export default card;

--- a/data-asia/M/M6/031.ts
+++ b/data-asia/M/M6/031.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ギラティナ",
+	},
+
+	illustrator: "toriyufu",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Psychic"],
+
+	description: {
+		ja: "常識の 通用しない この世の 裏側にあると 言われる 破れた世界に 生息する。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "カオスクローラー" },
+			damage: 120,
+			cost: ["Psychic", "Psychic", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンはワザのダメージを受けない。前の自分の番に、自分のポケモンが「カオスクローラー」を使っていたなら、このワザは使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 899934,
+				tcgplayer: 709185,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Rare",
+	dexId: [487],
+};
+
+export default card;

--- a/data-asia/M/M6/032.ts
+++ b/data-asia/M/M6/032.ts
@@ -1,0 +1,48 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ゴビット",
+	},
+
+	illustrator: "Hideki Ishikawa",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Psychic"],
+
+	description: {
+		ja: "古代人が しもべに するため 粘土を こねて こしらえたらしいが エネルギー源は 不明だ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "なぐる" },
+			damage: 50,
+			cost: ["Psychic", "Psychic"],
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899935,
+				tcgplayer: 709186,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [622],
+};
+
+export default card;

--- a/data-asia/M/M6/033.ts
+++ b/data-asia/M/M6/033.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガゴルーグex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 350,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "きどうせいげん" },
+			effect: {
+				ja: "自分の手札が10枚以上のときにしか、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ゴライアスパンチ" },
+			damage: 300,
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 899936,
+				tcgplayer: 709187,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴビット",
+	},
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Double rare",
+	dexId: [623],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M6/034.ts
+++ b/data-asia/M/M6/034.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラブトロス",
+	},
+
+	illustrator: "Anesaki Dynamic",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	description: {
+		ja: "海を越えて 飛来したらば 厳しき冬の 終わりを知る。 慈愛が ヒスイの地に 新しき命 芽吹かせるとの 伝承あり。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "けしんだんけつ" },
+			effect: {
+				ja: "自分の場に「トルネロス」「ボルトロス」「ランドロス」「ラブトロス」がいるなら、このポケモンはワザを使うための[C]エネルギーが、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ライジングハート" },
+			damage: "100+",
+			cost: ["Psychic", "Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが「ポケモンex」なら、100ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899937,
+				tcgplayer: 709188,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [905],
+};
+
+export default card;

--- a/data-asia/M/M6/035.ts
+++ b/data-asia/M/M6/035.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サンド",
+	},
+
+	illustrator: "Izucch",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Fighting"],
+
+	description: {
+		ja: "どんなに 高い ところから 落ちても 体を 丸めれば バウンドできて 助かるのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かくせい" },
+			cost: ["Fighting"],
+			effect: {
+				ja: "このポケモンから進化するカードを、自分の山札から1枚選び、このポケモンにのせて進化させる。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899938,
+				tcgplayer: 709288,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [27],
+};
+
+export default card;

--- a/data-asia/M/M6/036.ts
+++ b/data-asia/M/M6/036.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "サンドパン",
+	},
+
+	illustrator: "aoki",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Fighting"],
+
+	description: {
+		ja: "トゲは 皮膚が 硬くなったもの。 体を 丸めて トゲトゲを 刺すように 相手を 攻撃する。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はんげきばり" },
+			effect: {
+				ja: "このポケモンが、バトル場で相手のポケモンからワザのダメージを受けたとき、ワザを使ったポケモンにダメカンを3個のせる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "あなほりクロー" },
+			damage: 60,
+			cost: ["Fighting"],
+			effect: {
+				ja: "相手の山札を上から1枚トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899939,
+				tcgplayer: 709189,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "サンド",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [28],
+};
+
+export default card;

--- a/data-asia/M/M6/037.ts
+++ b/data-asia/M/M6/037.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イワーク",
+	},
+
+	illustrator: "Kedamahadaitai Yawarakai",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Fighting"],
+
+	description: {
+		ja: "普段は 土の中に 棲んでいる。 地中を 時速８０キロで 掘りながら エサを 探す。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ガードプレス" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899940,
+				tcgplayer: 709190,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [95],
+};
+
+export default card;

--- a/data-asia/M/M6/038.ts
+++ b/data-asia/M/M6/038.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ハガネール",
+	},
+
+	illustrator: "Shin Nagasawa",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Fighting"],
+
+	description: {
+		ja: "丈夫な あごで 岩石を かみくだき 進む。 真っ暗な 地中でも 見える 目を 持つ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "こうみつどアーマー" },
+			effect: {
+				ja: "このポケモンのHPがまんたんの状態なら、このポケモンが相手のポケモンから受けるワザのダメージは「-60」される。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ハードスイング" },
+			damage: 150,
+			cost: ["Fighting", "Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "このワザのダメージは抵抗力を計算しない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899941,
+				tcgplayer: 709191,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イワーク",
+	},
+
+	retreat: 4,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [208],
+};
+
+export default card;

--- a/data-asia/M/M6/039.ts
+++ b/data-asia/M/M6/039.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グラードン",
+	},
+
+	illustrator: "Nisota Niso",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Fighting"],
+
+	description: {
+		ja: "高熱で 水を 蒸発させて 大地を 広げたと 言われている。 カイオーガと 激しく 戦った。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かいりき" },
+			damage: 40,
+			cost: ["Fighting", "Colorless"],
+		},
+		{
+			name: { ja: "あらぶるだいち" },
+			damage: "100+",
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "名前に「伝説」とつくスタジアムが場に出ているなら、170ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 899942,
+				tcgplayer: 709192,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "J",
+	rarity: "Rare",
+	dexId: [383],
+};
+
+export default card;

--- a/data-asia/M/M6/040.ts
+++ b/data-asia/M/M6/040.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ランドロス",
+	},
+
+	illustrator: "Oku",
+	category: "Pokemon",
+	hp: 130,
+	types: ["Fighting"],
+
+	description: {
+		ja: "ランドロスが 訪れる 土地は 作物が たくさん 実るため 畑の神様 と 言われている。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "けしんだんけつ" },
+			effect: {
+				ja: "自分の場に「トルネロス」「ボルトロス」「ランドロス」「ラブトロス」がいるなら、このポケモンはワザを使うための[C]エネルギーが、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ガイアクラッシュ" },
+			damage: 110,
+			cost: ["Fighting", "Colorless", "Colorless"],
+			effect: {
+				ja: "場に出ているスタジアムをトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899943,
+				tcgplayer: 709193,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [645],
+};
+
+export default card;

--- a/data-asia/M/M6/041.ts
+++ b/data-asia/M/M6/041.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニドラン♀",
+	},
+
+	illustrator: "tayu",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "オスよりも 匂いに 敏感。 ヒゲで 風向きを 確認しながら 風下で エサを 探すのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ともだちをさがす" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "自分の山札からポケモンを1枚選び、相手に見せて、手札に加える。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "かじる" },
+			damage: 10,
+			cost: ["Darkness"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899944,
+				tcgplayer: 709194,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [29],
+};
+
+export default card;

--- a/data-asia/M/M6/042.ts
+++ b/data-asia/M/M6/042.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニドリーナ",
+	},
+
+	illustrator: "Jiro Sasumo",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Darkness"],
+
+	description: {
+		ja: "額の ツノは 子どもに エサを 与えるときに 刺さらないよう 退化したと 考えられている。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "たいあたり" },
+			damage: 60,
+			cost: ["Darkness", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899945,
+				tcgplayer: 709195,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニドラン♀",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [30],
+};
+
+export default card;

--- a/data-asia/M/M6/043.ts
+++ b/data-asia/M/M6/043.ts
@@ -1,0 +1,65 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニドクイン",
+	},
+
+	illustrator: "Aliya Chen",
+	category: "Pokemon",
+	hp: 170,
+	types: ["Darkness"],
+
+	description: {
+		ja: "攻めるよりも 守るほうが 得意。 鎧のような ウロコで いかなる 攻撃からも 子どもを 守る。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "ははのいざない" },
+			effect: {
+				ja: "自分の番に1回使える。コインを1回投げオモテなら、相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ギガインパクト" },
+			damage: 150,
+			cost: ["Darkness", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 899946,
+				tcgplayer: 709196,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ニドリーナ",
+	},
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Rare",
+	dexId: [31],
+};
+
+export default card;

--- a/data-asia/M/M6/044.ts
+++ b/data-asia/M/M6/044.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "イトマル",
+	},
+
+	illustrator: "Apios",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "細くて 丈夫な 糸を 張り巡らして 罠を 仕掛けると 獲物が かかるのを ひたすら待つ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "どくばり" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。",
+			},
+		},
+		{
+			name: { ja: "バグパニック" },
+			damage: "50×",
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "自分の山札を下から7枚オモテにして、その中にある、ワザ「バグパニック」を持つポケモンの枚数×50ダメージ。オモテにしたポケモンは山札にもどして切る。残りのカードはトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899947,
+				tcgplayer: 709197,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [167],
+};
+
+export default card;

--- a/data-asia/M/M6/045.ts
+++ b/data-asia/M/M6/045.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アリアドス",
+	},
+
+	illustrator: "UKUMO uiti",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Darkness"],
+
+	description: {
+		ja: "お尻からだけでなく 口からも 糸を 出すので 見ただけでは どっちが 頭か わからない。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "げきつうどく" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをどくにする。このどくでのせるダメカンの数は4個になる。",
+			},
+		},
+		{
+			name: { ja: "おんみつばり" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このポケモンはたねポケモンからワザのダメージを受けない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899948,
+				tcgplayer: 709198,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "イトマル",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [168],
+};
+
+export default card;

--- a/data-asia/M/M6/046.ts
+++ b/data-asia/M/M6/046.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤミラミ",
+	},
+
+	illustrator: "Shinji Kanda",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Darkness"],
+
+	description: {
+		ja: "洞窟の 暗闇に 潜む。 宝石を 食べているうちに 目が 宝石に なってしまった。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "おびきだす" },
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手の山札を上から5枚オモテにして、その中からたねポケモンを好きなだけ選び、相手のベンチに出す。残りのカードは山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "ふきつなめ" },
+			cost: ["Darkness", "Colorless"],
+			effect: {
+				ja: "相手のポケモン1匹に、ダメカンを5個のせる。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899949,
+				tcgplayer: 709199,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [302],
+};
+
+export default card;

--- a/data-asia/M/M6/047.ts
+++ b/data-asia/M/M6/047.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーイーカ",
+	},
+
+	illustrator: "kawayoo",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	description: {
+		ja: "光の 点滅で 襲ってきた 敵の 戦意を なくしてしまう。 その 隙に 姿を くらますのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はたきおとす" },
+			damage: 10,
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899950,
+				tcgplayer: 709200,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [686],
+};
+
+export default card;

--- a/data-asia/M/M6/048.ts
+++ b/data-asia/M/M6/048.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガカラマネロex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 320,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "サイコマリオネット" },
+			damage: "70×",
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "相手のベンチポケモンの数×70ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ぶきみなねんぱ" },
+			damage: 200,
+			cost: ["Darkness", "Darkness", "Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 899951,
+				tcgplayer: 709201,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マーイーカ",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Double rare",
+	dexId: [687],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M6/049.ts
+++ b/data-asia/M/M6/049.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "クリムガン",
+	},
+
+	illustrator: "AKIRA EGAWA",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Dragon"],
+
+	description: {
+		ja: "あなぐらに 棲む。 体が 冷えると 動けなくなるので 日光浴は 欠かさない。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ひきずりだす" },
+			cost: ["Fire", "Water"],
+			effect: {
+				ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。その後、新しく出てきたポケモンに40ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ツメできりさく" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899952,
+				tcgplayer: 709202,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [621],
+};
+
+export default card;

--- a/data-asia/M/M6/050.ts
+++ b/data-asia/M/M6/050.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャラコ",
+	},
+
+	illustrator: "June",
+	category: "Pokemon",
+	hp: 70,
+	types: ["Dragon"],
+
+	description: {
+		ja: "ウロコを 叩く 音で 仲間と コミュニケーションを とる。 群れで いると とても うるさい。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かたいあたま" },
+			damage: 30,
+			cost: ["Lightning", "Fighting"],
+			effect: {
+				ja: "次の相手の番、このポケモンが受けるワザのダメージは「-30」される。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899953,
+				tcgplayer: 709203,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [782],
+};
+
+export default card;

--- a/data-asia/M/M6/051.ts
+++ b/data-asia/M/M6/051.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャランゴ",
+	},
+
+	illustrator: "Scav",
+	category: "Pokemon",
+	hp: 100,
+	types: ["Dragon"],
+
+	description: {
+		ja: "ウロコを 力強く 叩きながら 踊り 自らを ふるい立たせる。 雄叫びは 戦いの 合図。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "ダブルスマッシュ" },
+			damage: "70×",
+			cost: ["Lightning", "Fighting"],
+			effect: {
+				ja: "コインを2回投げ、オモテの数×70ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899954,
+				tcgplayer: 709204,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジャラコ",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [783],
+};
+
+export default card;

--- a/data-asia/M/M6/052.ts
+++ b/data-asia/M/M6/052.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ジャラランガ",
+	},
+
+	illustrator: "Mitsuhiro Arita",
+	category: "Pokemon",
+	hp: 160,
+	types: ["Dragon"],
+
+	description: {
+		ja: "ウロコを 打ち鳴らして 相手の 度胸を 試す。 弱い者は その 音に 恐れ 逃げ出すのだ。",
+	},
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "スケイルビート" },
+			effect: {
+				ja: "自分の番に1回使える。自分の山札を上から6枚見て、その中から基本エネルギーを好きなだけ選び、自分の[N]ポケモンに好きなようにつける。残りのカードは山札にもどして切る。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ぶちかます" },
+			damage: 170,
+			cost: ["Lightning", "Fighting", "Colorless"],
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 899955,
+				tcgplayer: 709205,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ジャランゴ",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Rare",
+	dexId: [784],
+};
+
+export default card;

--- a/data-asia/M/M6/053.ts
+++ b/data-asia/M/M6/053.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "モトトカゲ",
+	},
+
+	illustrator: "Saboteri",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Dragon"],
+
+	description: {
+		ja: "喉の ひだの中に エネルギーを 蓄えているので 人を 乗せて 長距離を 走り続けられる。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かみつく" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+		},
+		{
+			name: { ja: "ブレイクスルー" },
+			damage: 110,
+			cost: ["Grass", "Darkness", "Colorless"],
+			effect: {
+				ja: "相手のベンチポケモン1匹にも、30ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899956,
+				tcgplayer: 709206,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [967],
+};
+
+export default card;

--- a/data-asia/M/M6/054.ts
+++ b/data-asia/M/M6/054.ts
@@ -1,0 +1,50 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルリリ",
+	},
+
+	illustrator: "TOMATO MARKET",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Colorless"],
+
+	description: {
+		ja: "まるくて 大きな 尻尾には 成長に 必要な 栄養が たっぷりと 詰まっているのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぴょんぴょんチャージ" },
+			cost: [],
+			effect: {
+				ja: "自分の山札からエネルギーを1枚選び、ベンチポケモンにつける。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899957,
+				tcgplayer: 709207,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [298],
+};
+
+export default card;

--- a/data-asia/M/M6/055.ts
+++ b/data-asia/M/M6/055.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チルット",
+	},
+
+	illustrator: "Shiburingaru",
+	category: "Pokemon",
+	hp: 50,
+	types: ["Colorless"],
+
+	description: {
+		ja: "人の 頭の 上に ちょこんと 乗って 帽子のように ふるまうのが なぜか 大好き。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はしゃぐ" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "このポケモンをベンチポケモンと入れ替える。",
+			},
+		},
+		{
+			name: { ja: "つつく" },
+			damage: 20,
+			cost: ["Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899962,
+				tcgplayer: 709208,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [333],
+};
+
+export default card;

--- a/data-asia/M/M6/056.ts
+++ b/data-asia/M/M6/056.ts
@@ -1,0 +1,62 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チルタリス",
+	},
+
+	illustrator: "Atsushi Furusawa",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Colorless"],
+
+	description: {
+		ja: "大空を ゆったりと 飛ぶ。 チルタリスの 美しい ハミングを 聴くと うっとり 夢心地だ。",
+	},
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "コットンキャリー" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分のたねポケモン全員は、にげるためのエネルギーが、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "はばたく" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 899968,
+				tcgplayer: 709209,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チルット",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Rare",
+	dexId: [334],
+};
+
+export default card;

--- a/data-asia/M/M6/057.ts
+++ b/data-asia/M/M6/057.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カクレオン",
+	},
+
+	illustrator: "Akira Komayama",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Colorless"],
+
+	description: {
+		ja: "体の 色を 変えて 景色に 溶けこみ 獲物に 忍び寄る。 お腹の 模様は 消せないのだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "カラフルウィップ" },
+			damage: "30×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の手札からポケモンを好きなだけ相手に見せて、見せたポケモンのタイプの数×30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899972,
+				tcgplayer: 709210,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [352],
+};
+
+export default card;

--- a/data-asia/M/M6/058.ts
+++ b/data-asia/M/M6/058.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガレックウザex",
+	},
+
+	illustrator: "takuyoa",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はしゃのほうこう" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の山札を上から4枚見て、その中から基本エネルギーを1枚選び、このポケモンにつける。残りのカードはウラにして切り、山札の下にもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ストームエメラルダ" },
+			damage: "50×",
+			cost: ["Fire", "Lightning", "Colorless"],
+			effect: {
+				ja: "自分のポケモン全員についている[R]と[L]エネルギーの数×50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 899977,
+				tcgplayer: 709211,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Double rare",
+	dexId: [384],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M6/059.ts
+++ b/data-asia/M/M6/059.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "トルネロス",
+	},
+
+	illustrator: "Uta",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Colorless"],
+
+	description: {
+		ja: "雲のような エネルギー体に 下半身が 包まれている。 時速３００キロで 空を 飛ぶ。",
+	},
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "けしんだんけつ" },
+			effect: {
+				ja: "自分の場に「トルネロス」「ボルトロス」「ランドロス」「ラブトロス」がいるなら、このポケモンはワザを使うための[C]エネルギーが、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "スクリューダイブ" },
+			damage: 70,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、自分の手札が6枚になるように、山札を引く。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899980,
+				tcgplayer: 709212,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Uncommon",
+	dexId: [641],
+};
+
+export default card;

--- a/data-asia/M/M6/060.ts
+++ b/data-asia/M/M6/060.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヤヤコマ",
+	},
+
+	illustrator: "takashi shiraishi",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Colorless"],
+
+	description: {
+		ja: "さえずる 声は 美しいが 縄張りに 入った 相手は 容赦しない 荒々しさだ。",
+	},
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ふいをつく" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、このワザは失敗。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899985,
+				tcgplayer: 709213,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [661],
+};
+
+export default card;

--- a/data-asia/M/M6/061.ts
+++ b/data-asia/M/M6/061.ts
@@ -1,0 +1,55 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒノヤコマ",
+	},
+
+	illustrator: "Souichirou Gunjima",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Colorless"],
+
+	description: {
+		ja: "お腹の 炎袋の 火力が 強まるほど 速く 飛べるが 点火するまで 時間が かかる。",
+	},
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "わしづかみ" },
+			damage: 40,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 899986,
+				tcgplayer: 709214,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヤヤコマ",
+	},
+
+	retreat: 0,
+	regulationMark: "J",
+	rarity: "Common",
+	dexId: [662],
+};
+
+export default card;

--- a/data-asia/M/M6/062.ts
+++ b/data-asia/M/M6/062.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ファイアローex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Colorless"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エキサイトダイブ" },
+			effect: {
+				ja: "自分の番に、このカードが手札にあり、自分の場に[C]タイプの「メガシンカex」がいるなら、1回使える。このカードをベンチに出す。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かぎづめハント" },
+			damage: 150,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、自分の山札から好きなカードを2枚まで選び、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 899993,
+				tcgplayer: 709215,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒノヤコマ",
+	},
+
+	retreat: 0,
+	regulationMark: "J",
+	rarity: "Double rare",
+	dexId: [663],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M6/063.ts
+++ b/data-asia/M/M6/063.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "おいしいおむすび",
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンのHPを「30」回復する。自分のトラッシュにある「おいしいおむすび」（このカードをのぞく）1枚につき、回復するHPは「30」多くなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 900000,
+				tcgplayer: 709216,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "J",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/M/M6/064.ts
+++ b/data-asia/M/M6/064.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ぼうけんのランタン",
+	},
+
+	illustrator: "inose yukie",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から「基本[R]エネルギー」と「基本[L]エネルギー」を1枚ずつ選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 900001,
+				tcgplayer: 709217,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "J",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M6/065.ts
+++ b/data-asia/M/M6/065.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "とくちゅうチョッキ",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモン（「メガシンカex」をのぞく）が、相手の「メガシンカex」から受けるワザのダメージは「-60」される。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 900002,
+				tcgplayer: 709218,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "J",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M6/066.ts
+++ b/data-asia/M/M6/066.ts
@@ -1,0 +1,42 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガレックウザキャップ",
+	},
+
+	illustrator: "AYUMI ODASHIMA",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモンは、このカードに書かれているワザを使える。［ワザを使うためのエネルギーは必要。］",
+	},
+
+	attacks: [
+		{
+			name: { ja: "デルタギフト" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "「メガレックウザキャップ」がついている自分のポケモン全員に、山札から基本エネルギーを1枚ずつつける。そして山札を切る。",
+			},
+		},
+	],
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 900003,
+				tcgplayer: 709219,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "J",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M6/067.ts
+++ b/data-asia/M/M6/067.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "MCの盛り上げ",
+	},
+
+	illustrator: "DOM",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を2枚引く。相手のサイドの残り枚数が3枚以下なら、さらに2枚引く。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 900004,
+				tcgplayer: 709220,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Common",
+};
+
+export default card;

--- a/data-asia/M/M6/068.ts
+++ b/data-asia/M/M6/068.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ギリー",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札からサポートとスタジアムを合計3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 900005,
+				tcgplayer: 709221,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M6/069.ts
+++ b/data-asia/M/M6/069.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒガナの信頼",
+	},
+
+	illustrator: "GIDORA",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。その後、ベンチに入れ替えたポケモンについているエネルギーを1個選び、新しいバトルポケモンにつけ替える。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 900006,
+				tcgplayer: 709222,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M6/070.ts
+++ b/data-asia/M/M6/070.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フウとランの修行",
+	},
+
+	illustrator: "Yuu Nishida",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を2枚引く。その後、名前に「伝説」とつくスタジアムが場に出ているなら、この「フウとランの修行」はトラッシュせず、手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 900007,
+				tcgplayer: 709223,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M6/071.ts
+++ b/data-asia/M/M6/071.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "伝説の海溝",
+	},
+
+	illustrator: "danciao",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのポケモン全員は、HPを回復するとき、回復するHPが2倍になる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 900076,
+				tcgplayer: 709224,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "J",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M6/072.ts
+++ b/data-asia/M/M6/072.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "伝説の海溝",
+	},
+
+	illustrator: "danciao",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいのポケモン全員は、HPを回復するとき、回復するHPが2倍になる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 900083,
+				tcgplayer: 709225,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "J",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M6/073.ts
+++ b/data-asia/M/M6/073.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "伝説の山頂",
+	},
+
+	illustrator: "nagimiso",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの[C]ポケモンが、相手のポケモンからワザのダメージを受けてきぜつしたとき、とられるサイドは1枚少なくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 900084,
+				tcgplayer: 709226,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "J",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M6/074.ts
+++ b/data-asia/M/M6/074.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "伝説の山頂",
+	},
+
+	illustrator: "nagimiso",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの[C]ポケモンが、相手のポケモンからワザのダメージを受けてきぜつしたとき、とられるサイドは1枚少なくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 900085,
+				tcgplayer: 709227,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "J",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M6/075.ts
+++ b/data-asia/M/M6/075.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "伝説の溶岩洞",
+	},
+
+	illustrator: "akagi",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの場の進化ポケモン全員は、特性がすべてなくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 900086,
+				tcgplayer: 709228,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "J",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M6/076.ts
+++ b/data-asia/M/M6/076.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "伝説の溶岩洞",
+	},
+
+	illustrator: "akagi",
+	category: "Trainer",
+
+	effect: {
+		ja: "おたがいの場の進化ポケモン全員は、特性がすべてなくなる。",
+	},
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 900089,
+				tcgplayer: 709229,
+			},
+		},
+	],
+
+	trainerType: "Stadium",
+	regulationMark: "J",
+	rarity: "Uncommon",
+};
+
+export default card;

--- a/data-asia/M/M6/077.ts
+++ b/data-asia/M/M6/077.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "アメモース",
+	},
+
+	illustrator: "REND",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Grass"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "こわいもよう" },
+			damage: 30,
+			cost: ["Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、ワザが使えない。",
+			},
+		},
+		{
+			name: { ja: "バグパニック" },
+			damage: "50×",
+			cost: ["Grass"],
+			effect: {
+				ja: "自分の山札を下から7枚オモテにして、その中にある、ワザ「バグパニック」を持つポケモンの枚数×50ダメージ。オモテにしたポケモンは山札にもどして切る。残りのカードはトラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900099,
+				tcgplayer: 709230,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "アメタマ",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+	dexId: [284],
+};
+
+export default card;

--- a/data-asia/M/M6/078.ts
+++ b/data-asia/M/M6/078.ts
@@ -1,0 +1,51 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ガーディ",
+	},
+
+	illustrator: "Yoshimoto Yoshimon",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ほえる" },
+			cost: ["Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンをベンチポケモンと入れ替える。［バトル場に出すポケモンは相手が選ぶ。］",
+			},
+		},
+		{
+			name: { ja: "うしろげり" },
+			damage: 50,
+			cost: ["Fire", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900101,
+				tcgplayer: 709231,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+	dexId: [58],
+};
+
+export default card;

--- a/data-asia/M/M6/079.ts
+++ b/data-asia/M/M6/079.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ブーバーン",
+	},
+
+	illustrator: "Taiga Kasai",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Fire"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "バディブースト" },
+			effect: {
+				ja: "自分の番に1回使える。自分の手札から「基本[R]エネルギー」と「基本[L]エネルギー」をそれぞれ1枚まで選び、自分の「エレキブル」または「ブーバーン」に好きなようにつける。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ヒートスタンプ" },
+			damage: 80,
+			cost: ["Fire", "Fire", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900104,
+				tcgplayer: 709232,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ブーバー",
+	},
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+	dexId: [467],
+};
+
+export default card;

--- a/data-asia/M/M6/080.ts
+++ b/data-asia/M/M6/080.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カイオーガ",
+	},
+
+	illustrator: "Nurikabe",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "たきのぼり" },
+			damage: 40,
+			cost: ["Water", "Colorless"],
+		},
+		{
+			name: { ja: "あらぶるうず" },
+			damage: 100,
+			cost: ["Water", "Water", "Colorless"],
+			effect: {
+				ja: "名前に「伝説」とつくスタジアムが場に出ているなら、相手のベンチポケモン全員にも、それぞれ50ダメージ。［ベンチは弱点・抵抗力を計算しない。］",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900105,
+				tcgplayer: 709233,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+	dexId: [382],
+};
+
+export default card;

--- a/data-asia/M/M6/081.ts
+++ b/data-asia/M/M6/081.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "エレキブル",
+	},
+
+	illustrator: "Rianti Hidayat",
+	category: "Pokemon",
+	hp: 140,
+	types: ["Lightning"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "のしかかり" },
+			damage: 30,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "コインを1回投げオモテなら、相手のバトルポケモンをマヒにする。",
+			},
+		},
+		{
+			name: { ja: "ボルテージハンマー" },
+			damage: "60×",
+			cost: ["Lightning", "Lightning", "Colorless", "Colorless"],
+			effect: {
+				ja: "このポケモンについている基本エネルギーを好きなだけトラッシュし、その枚数×60ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900107,
+				tcgplayer: 709234,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "エレブー",
+	},
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+	dexId: [466],
+};
+
+export default card;

--- a/data-asia/M/M6/082.ts
+++ b/data-asia/M/M6/082.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バチンウニ",
+	},
+
+	illustrator: "Tetsu Kayama",
+	category: "Pokemon",
+	hp: 80,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "エナジークラッシュ" },
+			damage: "20×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "相手のポケモン全員についているエネルギーの数×20ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900108,
+				tcgplayer: 709235,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+	dexId: [871],
+};
+
+export default card;

--- a/data-asia/M/M6/083.ts
+++ b/data-asia/M/M6/083.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ラブトロス",
+	},
+
+	illustrator: "Taira Akitsu",
+	category: "Pokemon",
+	hp: 120,
+	types: ["Psychic"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "けしんだんけつ" },
+			effect: {
+				ja: "自分の場に「トルネロス」「ボルトロス」「ランドロス」「ラブトロス」がいるなら、このポケモンはワザを使うための[C]エネルギーが、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ライジングハート" },
+			damage: "100+",
+			cost: ["Psychic", "Psychic", "Colorless", "Colorless"],
+			effect: {
+				ja: "相手のバトルポケモンが「ポケモンex」なら、100ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Metal", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900109,
+				tcgplayer: 709236,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+	dexId: [905],
+};
+
+export default card;

--- a/data-asia/M/M6/084.ts
+++ b/data-asia/M/M6/084.ts
@@ -1,0 +1,52 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グラードン",
+	},
+
+	illustrator: "Ryota Murayama",
+	category: "Pokemon",
+	hp: 150,
+	types: ["Fighting"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "かいりき" },
+			damage: 40,
+			cost: ["Fighting", "Colorless"],
+		},
+		{
+			name: { ja: "あらぶるだいち" },
+			damage: "100+",
+			cost: ["Fighting", "Fighting", "Colorless"],
+			effect: {
+				ja: "名前に「伝説」とつくスタジアムが場に出ているなら、170ダメージ追加。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900110,
+				tcgplayer: 709237,
+			},
+		},
+	],
+
+	retreat: 4,
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+	dexId: [383],
+};
+
+export default card;

--- a/data-asia/M/M6/085.ts
+++ b/data-asia/M/M6/085.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "マーイーカ",
+	},
+
+	illustrator: "Rond",
+	category: "Pokemon",
+	hp: 60,
+	types: ["Darkness"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "はたきおとす" },
+			damage: 10,
+			cost: ["Darkness"],
+			effect: {
+				ja: "相手の手札からオモテを見ないで1枚選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900111,
+				tcgplayer: 709238,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+	dexId: [686],
+};
+
+export default card;

--- a/data-asia/M/M6/086.ts
+++ b/data-asia/M/M6/086.ts
@@ -1,0 +1,46 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ルリリ",
+	},
+
+	illustrator: "Narumi Sato",
+	category: "Pokemon",
+	hp: 30,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "ぴょんぴょんチャージ" },
+			cost: [],
+			effect: {
+				ja: "自分の山札からエネルギーを1枚選び、ベンチポケモンにつける。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900112,
+				tcgplayer: 709239,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+	dexId: [298],
+};
+
+export default card;

--- a/data-asia/M/M6/087.ts
+++ b/data-asia/M/M6/087.ts
@@ -1,0 +1,58 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "チルタリス",
+	},
+
+	illustrator: "kodama",
+	category: "Pokemon",
+	hp: 110,
+	types: ["Colorless"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "コットンキャリー" },
+			effect: {
+				ja: "このポケモンがいるかぎり、自分のたねポケモン全員は、にげるためのエネルギーが、すべてなくなる。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "はばたく" },
+			damage: 80,
+			cost: ["Colorless", "Colorless", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900113,
+				tcgplayer: 709240,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "チルット",
+	},
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+	dexId: [334],
+};
+
+export default card;

--- a/data-asia/M/M6/088.ts
+++ b/data-asia/M/M6/088.ts
@@ -1,0 +1,47 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "カクレオン",
+	},
+
+	illustrator: "Tomokazu Komiya",
+	category: "Pokemon",
+	hp: 90,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "カラフルウィップ" },
+			damage: "30×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分の手札からポケモンを好きなだけ相手に見せて、見せたポケモンのタイプの数×30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900114,
+				tcgplayer: 709241,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+	dexId: [352],
+};
+
+export default card;

--- a/data-asia/M/M6/089.ts
+++ b/data-asia/M/M6/089.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガグソクムシャex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 340,
+	types: ["Grass"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "とどめをさす" },
+			damage: "60+",
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンにダメカンがのっているなら、160ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "クワトロホールド" },
+			damage: 160,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900115,
+				tcgplayer: 709242,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コソクムシ",
+	},
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+	dexId: [768],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M6/090.ts
+++ b/data-asia/M/M6/090.ts
@@ -1,0 +1,57 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒートロトムex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 190,
+	types: ["Fire"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "さいかねつ" },
+			damage: "30×",
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "自分のトラッシュにある「基本[R]エネルギー」をすべて相手に見せて、その枚数×30ダメージ。その後、見せたエネルギーを山札にもどして切る。",
+			},
+		},
+		{
+			name: { ja: "ストロングフレア" },
+			damage: 170,
+			cost: ["Fire", "Fire", "Colorless"],
+			effect: {
+				ja: "このポケモンについているエネルギーを2個選び、トラッシュする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Water", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900116,
+				tcgplayer: 709243,
+			},
+		},
+	],
+
+	retreat: 1,
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+	dexId: [479],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M6/091.ts
+++ b/data-asia/M/M6/091.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヨワシex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 260,
+	types: ["Water"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "オーシャンゲイン" },
+			effect: {
+				ja: "このポケモンがバトル場にいるなら、自分の番に1回使える。このポケモンのHPを「50」回復する。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ハイドロスプラッシュ" },
+			damage: 220,
+			cost: ["Water", "Water", "Water", "Colorless"],
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900117,
+				tcgplayer: 709244,
+			},
+		},
+	],
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+	dexId: [746],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M6/092.ts
+++ b/data-asia/M/M6/092.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ライコウex",
+	},
+
+	illustrator: "aky CG Works",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "いかずちをまとう" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "このワザは、先攻プレイヤーの最初の番でも使える。自分の山札からエネルギーを1枚選び、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "パワーラッシュ" },
+			damage: 200,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900123,
+				tcgplayer: 709245,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+	dexId: [243],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M6/093.ts
+++ b/data-asia/M/M6/093.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガゴルーグex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 350,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "きどうせいげん" },
+			effect: {
+				ja: "自分の手札が10枚以上のときにしか、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ゴライアスパンチ" },
+			damage: 300,
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900126,
+				tcgplayer: 709246,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴビット",
+	},
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+	dexId: [623],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M6/094.ts
+++ b/data-asia/M/M6/094.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガカラマネロex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 320,
+	types: ["Darkness"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "サイコマリオネット" },
+			damage: "70×",
+			cost: ["Darkness", "Darkness"],
+			effect: {
+				ja: "相手のベンチポケモンの数×70ダメージ。",
+			},
+		},
+		{
+			name: { ja: "ぶきみなねんぱ" },
+			damage: 200,
+			cost: ["Darkness", "Darkness", "Darkness"],
+			effect: {
+				ja: "相手のバトルポケモンをこんらんにする。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Grass", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900127,
+				tcgplayer: 709247,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "マーイーカ",
+	},
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+	dexId: [687],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M6/095.ts
+++ b/data-asia/M/M6/095.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガレックウザex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はしゃのほうこう" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の山札を上から4枚見て、その中から基本エネルギーを1枚選び、このポケモンにつける。残りのカードはウラにして切り、山札の下にもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ストームエメラルダ" },
+			damage: "50×",
+			cost: ["Fire", "Lightning", "Colorless"],
+			effect: {
+				ja: "自分のポケモン全員についている[R]と[L]エネルギーの数×50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900128,
+				tcgplayer: 709248,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+	dexId: [384],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M6/096.ts
+++ b/data-asia/M/M6/096.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ファイアローex",
+	},
+
+	illustrator: "5ban Graphics",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Colorless"],
+
+	stage: "Stage2",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "エキサイトダイブ" },
+			effect: {
+				ja: "自分の番に、このカードが手札にあり、自分の場に[C]タイプの「メガシンカex」がいるなら、1回使える。このカードをベンチに出す。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "かぎづめハント" },
+			damage: 150,
+			cost: ["Colorless", "Colorless"],
+			effect: {
+				ja: "のぞむなら、自分の山札から好きなカードを2枚まで選び、手札に加える。そして山札を切る。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900129,
+				tcgplayer: 709249,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ヒノヤコマ",
+	},
+
+	retreat: 0,
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+	dexId: [663],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M6/097.ts
+++ b/data-asia/M/M6/097.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ぼうけんのランタン",
+	},
+
+	illustrator: "inose yukie",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札から「基本[R]エネルギー」と「基本[L]エネルギー」を1枚ずつ選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900130,
+				tcgplayer: 709250,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+};
+
+export default card;

--- a/data-asia/M/M6/098.ts
+++ b/data-asia/M/M6/098.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "とくちゅうチョッキ",
+	},
+
+	illustrator: "Studio Bora Inc.",
+	category: "Trainer",
+
+	effect: {
+		ja: "このカードをつけているポケモン（「メガシンカex」をのぞく）が、相手の「メガシンカex」から受けるワザのダメージは「-60」される。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900131,
+				tcgplayer: 709251,
+			},
+		},
+	],
+
+	trainerType: "Tool",
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+};
+
+export default card;

--- a/data-asia/M/M6/099.ts
+++ b/data-asia/M/M6/099.ts
@@ -1,0 +1,31 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ポケモンキャッチャー",
+	},
+
+	illustrator: "Toyste Beach",
+	category: "Trainer",
+
+	effect: {
+		ja: "相手のベンチポケモンを1匹選び、バトルポケモンと入れ替える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900132,
+				tcgplayer: 709252,
+			},
+		},
+	],
+
+	trainerType: "Item",
+	rarity: "Mega Hyper Rare",
+};
+
+export default card;

--- a/data-asia/M/M6/100.ts
+++ b/data-asia/M/M6/100.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "MCの盛り上げ",
+	},
+
+	illustrator: "DOM",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を2枚引く。相手のサイドの残り枚数が3枚以下なら、さらに2枚引く。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900133,
+				tcgplayer: 709253,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+};
+
+export default card;

--- a/data-asia/M/M6/101.ts
+++ b/data-asia/M/M6/101.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ギリー",
+	},
+
+	illustrator: "Sanosuke Sakuma",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札からサポートとスタジアムを合計3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900134,
+				tcgplayer: 709254,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+};
+
+export default card;

--- a/data-asia/M/M6/102.ts
+++ b/data-asia/M/M6/102.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒガナの信頼",
+	},
+
+	illustrator: "GIDORA",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。その後、ベンチに入れ替えたポケモンについているエネルギーを1個選び、新しいバトルポケモンにつけ替える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900135,
+				tcgplayer: 709255,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+};
+
+export default card;

--- a/data-asia/M/M6/103.ts
+++ b/data-asia/M/M6/103.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "フウとランの修行",
+	},
+
+	illustrator: "Yuu Nishida",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札を2枚引く。その後、名前に「伝説」とつくスタジアムが場に出ているなら、この「フウとランの修行」はトラッシュせず、手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900136,
+				tcgplayer: 709256,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+};
+
+export default card;

--- a/data-asia/M/M6/104.ts
+++ b/data-asia/M/M6/104.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "グロウ草エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、ポケモンについているかぎり、[G]エネルギー1個ぶんとしてはたらく。このカードをつけている[G]ポケモンは、最大HPが「＋20」される。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900137,
+				tcgplayer: 709257,
+			},
+		},
+	],
+
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+};
+
+export default card;

--- a/data-asia/M/M6/105.ts
+++ b/data-asia/M/M6/105.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ニトロ炎エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、ポケモンについているかぎり、[R]エネルギー1個ぶんとしてはたらく。このカードをつけている[R]ポケモンが使うワザの効果で、このカードがトラッシュされたなら、ワザのダメージや効果のあとに、手札にもどす。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900138,
+				tcgplayer: 709258,
+			},
+		},
+	],
+
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+};
+
+export default card;

--- a/data-asia/M/M6/106.ts
+++ b/data-asia/M/M6/106.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "バブル水エネルギー",
+	},
+
+	illustrator: "",
+	category: "Energy",
+	energyType: "Special",
+
+	effect: {
+		ja: "このカードは、ポケモンについているかぎり、[W]エネルギー1個ぶんとしてはたらく。このカードをつけている[W]ポケモンは、特殊状態にならず、受けている特殊状態は、すべて回復する。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900139,
+				tcgplayer: 709259,
+			},
+		},
+	],
+
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+};
+
+export default card;

--- a/data-asia/M/M6/107.ts
+++ b/data-asia/M/M6/107.ts
@@ -1,0 +1,61 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガグソクムシャex",
+	},
+
+	illustrator: "nagimiso",
+	category: "Pokemon",
+	hp: 340,
+	types: ["Grass"],
+
+	stage: "Stage1",
+
+	attacks: [
+		{
+			name: { ja: "とどめをさす" },
+			damage: "60+",
+			cost: ["Grass"],
+			effect: {
+				ja: "相手のバトルポケモンにダメカンがのっているなら、160ダメージ追加。",
+			},
+		},
+		{
+			name: { ja: "クワトロホールド" },
+			damage: 160,
+			cost: ["Colorless", "Colorless", "Colorless"],
+			effect: {
+				ja: "次の相手の番、このワザを受けたポケモンは、にげられない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fire", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900140,
+				tcgplayer: 709260,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "コソクムシ",
+	},
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+	dexId: [768],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M6/108.ts
+++ b/data-asia/M/M6/108.ts
@@ -1,0 +1,56 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ライコウex",
+	},
+
+	illustrator: "Oku",
+	category: "Pokemon",
+	hp: 200,
+	types: ["Lightning"],
+
+	stage: "Basic",
+
+	attacks: [
+		{
+			name: { ja: "いかずちをまとう" },
+			cost: ["Lightning"],
+			effect: {
+				ja: "このワザは、先攻プレイヤーの最初の番でも使える。自分の山札からエネルギーを1枚選び、このポケモンにつける。そして山札を切る。",
+			},
+		},
+		{
+			name: { ja: "パワーラッシュ" },
+			damage: 200,
+			cost: ["Lightning", "Lightning", "Colorless"],
+			effect: {
+				ja: "コインを1回投げウラなら、次の自分の番、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Fighting", value: "x2" }],
+	resistances: [],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900141,
+				tcgplayer: 709261,
+			},
+		},
+	],
+
+	retreat: 0,
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+	dexId: [243],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M6/109.ts
+++ b/data-asia/M/M6/109.ts
@@ -1,0 +1,63 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガゴルーグex",
+	},
+
+	illustrator: "Takeshi Nakamura",
+	category: "Pokemon",
+	hp: 350,
+	types: ["Psychic"],
+
+	stage: "Stage1",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "きどうせいげん" },
+			effect: {
+				ja: "自分の手札が10枚以上のときにしか、このポケモンはワザが使えない。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ゴライアスパンチ" },
+			damage: 300,
+			cost: ["Psychic", "Psychic"],
+			effect: {
+				ja: "このポケモンにも30ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Darkness", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900142,
+				tcgplayer: 709262,
+			},
+		},
+	],
+
+	evolveFrom: {
+		ja: "ゴビット",
+	},
+
+	retreat: 3,
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+	dexId: [623],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M6/110.ts
+++ b/data-asia/M/M6/110.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガレックウザex",
+	},
+
+	illustrator: "Kozuki Minami",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はしゃのほうこう" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の山札を上から4枚見て、その中から基本エネルギーを1枚選び、このポケモンにつける。残りのカードはウラにして切り、山札の下にもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ストームエメラルダ" },
+			damage: "50×",
+			cost: ["Fire", "Lightning", "Colorless"],
+			effect: {
+				ja: "自分のポケモン全員についている[R]と[L]エネルギーの数×50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900143,
+				tcgplayer: 709264,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+	dexId: [384],
+
+	suffix: "EX",
+};
+
+export default card;

--- a/data-asia/M/M6/111.ts
+++ b/data-asia/M/M6/111.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ギリー",
+	},
+
+	illustrator: "Shimaris Yukichi",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分の山札からサポートとスタジアムを合計3枚まで選び、相手に見せて、手札に加える。そして山札を切る。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900144,
+				tcgplayer: 709265,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+};
+
+export default card;

--- a/data-asia/M/M6/112.ts
+++ b/data-asia/M/M6/112.ts
@@ -1,0 +1,32 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "ヒガナの信頼",
+	},
+
+	illustrator: "Teeziro",
+	category: "Trainer",
+
+	effect: {
+		ja: "自分のバトルポケモンをベンチポケモンと入れ替える。その後、ベンチに入れ替えたポケモンについているエネルギーを1個選び、新しいバトルポケモンにつけ替える。",
+	},
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900145,
+				tcgplayer: 709266,
+			},
+		},
+	],
+
+	trainerType: "Supporter",
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+};
+
+export default card;

--- a/data-asia/M/M6/113.ts
+++ b/data-asia/M/M6/113.ts
@@ -1,0 +1,59 @@
+import { Card } from "../../../interfaces";
+import Set from "../M6";
+
+const card: Card = {
+	set: Set,
+	name: {
+		ja: "メガレックウザex",
+	},
+
+	illustrator: "takuyoa",
+	category: "Pokemon",
+	hp: 280,
+	types: ["Colorless"],
+
+	stage: "Basic",
+
+	abilities: [
+		{
+			type: "Ability",
+			name: { ja: "はしゃのほうこう" },
+			effect: {
+				ja: "自分の番に、このカードを手札からベンチに出したとき、1回使える。自分の山札を上から4枚見て、その中から基本エネルギーを1枚選び、このポケモンにつける。残りのカードはウラにして切り、山札の下にもどす。",
+			},
+		},
+	],
+
+	attacks: [
+		{
+			name: { ja: "ストームエメラルダ" },
+			damage: "50×",
+			cost: ["Fire", "Lightning", "Colorless"],
+			effect: {
+				ja: "自分のポケモン全員についている[R]と[L]エネルギーの数×50ダメージ。",
+			},
+		},
+	],
+
+	weaknesses: [{ type: "Lightning", value: "x2" }],
+	resistances: [{ type: "Fighting", value: "-30" }],
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 900146,
+				tcgplayer: 709267,
+			},
+		},
+	],
+
+	retreat: 2,
+	regulationMark: "J",
+	rarity: "Mega Hyper Rare",
+	dexId: [384],
+
+	suffix: "EX",
+};
+
+export default card;


### PR DESCRIPTION
## What

Adds the complete Japanese set **M6 ストームエメラルダ (Storm Emeralda)**, released 2026-07-31:

- `data-asia/M/M6.ts` — set definition (76 official cards)
- `data-asia/M/M6/001.ts` … `113.ts` — all 113 cards (76 regular + 37 secret rares: 37 Mega Hyper Rare)

## Data sources

- **pokemon-card.com** (official database): Japanese names, flavor texts, National Dex numbers, official card count
- **limitlesstcg.com**: full Japanese card text, stages, weaknesses/resistances/retreat, rarities, illustrators, attack costs
- **Cardmarket**: product IDs as `thirdParty.cardmarket` on the variant objects (899786–900146)
- **TCGplayer** via [tcgcsv.com](https://tcgcsv.com) (category 85, "Pokemon Japan"): product IDs as `thirdParty.tcgplayer` (709157–709289), keyed by the collection number each product carries in `extendedData`

## Notes

- Follows the file format and conventions of the M-era sets (#1728)
- 066 is a Pokémon Tool that grant an attack — modeled as `effect` + `attacks`, like their English prints
- All 113 files type-check against `interfaces.d.ts` (`tsc --noEmit`)
