### PR TITLE
(fix) Remove rule-box text imported as attacks

### DIFF
--- a/data/Black & White/BW Black Star Promos/BW96.ts
+++ b/data/Black & White/BW Black Star Promos/BW96.ts
@@ -56,18 +56,6 @@ const card: Card = {
 			damage: 100,
 
 		},
-		{
-
-			name: {
-				en: "Pokémon EX Rule",
-				fr: "Règle pour les Pokémon ex",
-			},
-			effect: {
-				en: "When a Pokémon-EX has been Knocked Out, your opponent takes 2 Prize cards.",
-				fr: "Lorsqu'un Pokémon-EX est mis K.O., l'adversaire récupère 2 cartes Récompense.",
-			},
-
-		},
 	],
 	weaknesses: [
 		{

--- a/data/Sun & Moon/Hidden Fates/29.ts
+++ b/data/Sun & Moon/Hidden Fates/29.ts
@@ -50,19 +50,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Tackle",
-				fr: "Rendez-Vous Tous",
-			},
-			damage: 40,
-
-		},
-		{
-			cost: [
-				"Colorless",
-			],
-			name: {
 				fr: "Charge",
 			},
-
 			damage: 40,
 
 		},

--- a/data/Sun & Moon/Hidden Fates/44.ts
+++ b/data/Sun & Moon/Hidden Fates/44.ts
@@ -31,7 +31,7 @@ const card: Card = {
 			],
 			name: {
 				en: "Trinity Burn",
-				fr: "Règle des ESCOUADES",
+				fr: "Triple Brûlure",
 			},
 
 			damage: 210,
@@ -43,23 +43,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Sky Legends GX",
-				fr: "Triple Brûlure",
+				fr: "Légendes Célestes GX",
 			},
 			effect: {
 				en: "Shuffle this Pokémon and all cards attached to it into your deck. If this Pokémon has at least 1 extra Fire, Water, and Lightning Energy attached to it (in addition to this attack’s cost), this attack does 110 damage to 3 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)",
-				fr: "Mélangez ce Pokémon et toutes les cartes qui lui sont attachées avec votre deck. Si au moins une Énergie ,  et  supplémentaire sont attachées à ce Pokémon (en plus du coût de cette attaque), cette attaque inflige 110 dégâts à 3 des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.) (Vous ne pouvez utiliser qu'une attaque GX par partie.)"
-			},
-
-		},
-		{
-			cost: [
-				"Colorless",
-			],
-			name: {
-				fr: "Légendes Célestes-GX",
-			},
-			effect: {
-				fr: "Mélangez ce Pokémon et toutes les cartes qui lui sont attachées avec votre deck. Si au moins une Énergie Fire, Water et Lightning supplémentaire sont attachées à ce Pokémon (en plus du coût de cette attaque), cette attaque inflige 110 dégâts à 3 des Pokémon de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.) (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				fr: "Mélangez ce Pokémon et toutes les cartes qui lui sont attachées avec votre deck. Si au moins une Énergie Fire, Water et Lightning supplémentaire sont attachées à ce Pokémon (en plus du coût de cette attaque), cette attaque inflige 110 dégâts à 3 des Pokémon de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.) (Vous ne pouvez utiliser qu’une attaque GX par partie.)"
 			},
 
 		},

--- a/data/Sun & Moon/Hidden Fates/66.ts
+++ b/data/Sun & Moon/Hidden Fates/66.ts
@@ -31,7 +31,7 @@ const card: Card = {
 			],
 			name: {
 				en: "Trinity Burn",
-				fr: "Règle des ESCOUADES",
+				fr: "Triple Brûlure",
 			},
 
 			damage: 210,
@@ -43,11 +43,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Sky Legends GX",
-				fr: "Triple Brûlure",
+				fr: "Légendes Célestes GX",
 			},
 			effect: {
 				en: "Shuffle this Pokémon and all cards attached to it into your deck. If this Pokémon has at least 1 extra Fire, Water, and Lightning Energy attached to it (in addition to this attack’s cost), this attack does 110 damage to 3 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)",
-				fr: "Mélangez ce Pokémon et toutes les cartes qui lui sont attachées avec votre deck. Si au moins une Énergie ,  et  supplémentaire sont attachées à ce Pokémon (en plus du coût de cette attaque), cette attaque inflige 110 dégâts à 3 des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.) (Vous ne pouvez utiliser qu'une attaque GX par partie.)"
+				fr: "Mélangez ce Pokémon et toutes les cartes qui lui sont attachées avec votre deck. Si au moins une Énergie Fire, Water et Lightning supplémentaire sont attachées à ce Pokémon (en plus du coût de cette attaque), cette attaque inflige 110 dégâts à 3 des Pokémon de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.) (Vous ne pouvez utiliser qu’une attaque GX par partie.)"
 			},
 
 		},

--- a/data/Sun & Moon/Hidden Fates/69.ts
+++ b/data/Sun & Moon/Hidden Fates/69.ts
@@ -31,7 +31,7 @@ const card: Card = {
 			],
 			name: {
 				en: "Trinity Burn",
-				fr: "Règle des ESCOUADES",
+				fr: "Triple Brûlure",
 			},
 
 			damage: 210,
@@ -43,11 +43,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Sky Legends GX",
-				fr: "Triple Brûlure",
+				fr: "Légendes Célestes GX",
 			},
 			effect: {
 				en: "Shuffle this Pokémon and all cards attached to it into your deck. If this Pokémon has at least 1 extra Fire, Water, and Lightning Energy attached to it (in addition to this attack’s cost), this attack does 110 damage to 3 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)",
-				fr: "Mélangez ce Pokémon et toutes les cartes qui lui sont attachées avec votre deck. Si au moins une Énergie ,  et  supplémentaire sont attachées à ce Pokémon (en plus du coût de cette attaque), cette attaque inflige 110 dégâts à 3 des Pokémon de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.) (Vous ne pouvez utiliser qu'une attaque GX par partie.)"
+				fr: "Mélangez ce Pokémon et toutes les cartes qui lui sont attachées avec votre deck. Si au moins une Énergie Fire, Water et Lightning supplémentaire sont attachées à ce Pokémon (en plus du coût de cette attaque), cette attaque inflige 110 dégâts à 3 des Pokémon de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.) (Vous ne pouvez utiliser qu’une attaque GX par partie.)"
 			},
 
 		}

--- a/data/Sun & Moon/Unbroken Bonds/107.ts
+++ b/data/Sun & Moon/Unbroken Bonds/107.ts
@@ -71,20 +71,6 @@ const card: Card = {
 				pt: "Coloque 2 Pokémon GX Darkness e Pokémon EX Darkness da sua pilha de descarte no seu Banco em qualquer combinação. Se este Pokémon tiver pelo menos 1 Energia adicional ligada a ele (além do custo deste ataque), ligue 2 cartas de Energia da sua pilha de descarte a cada Pokémon que colocou no seu Banco desta forma (você não pode usar mais de 1 ataque GX por partida).",
 				de: "Lege eine beliebige Kombination aus 2 Darkness-Pokémon-GX und Darkness-Pokémon-EX aus deinem Ablagestapel auf deine Bank. Wenn an dieses Pokémon mindestens 1 extra Energie angelegt ist (zusätzlich zu den Kosten dieser Attacke), lege 2 Energiekarten aus deinem Ablagestapel an jedes auf diese Weise auf deine Bank gelegte Pokémon an. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
-			damage: "30+",
-
-		},
-		{
-			cost: [
-				"Darkness",
-				"Colorless",
-			],
-			name: {
-				fr: "Union Ténébreuse-GX",
-			},
-			effect: {
-				fr: "Ajoutez de votre pile de défausse à votre Banc une combinaison de 2 cartes choisies parmi des Pokémon-GX Darkness et des Pokémon-EX Darkness. Si au moins une Énergie supplémentaire est attachée à ce Pokémon (en plus du coût de cette attaque), attachez 2 cartes Énergie de votre pile de défausse à chacun des Pokémon que vous avez placés sur votre Banc de cette façon. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
-			},
 
 		},
 	],


### PR DESCRIPTION
## Changes

Six cards carry an extra entry in `attacks` that is not an attack: it is the
card's rule box (Pokémon-EX rule, TAG TEAM rule) or, on Weezing, its Ability
name. On four of them the phantom entry also shifted every French attack name
down one slot.

The clearest symptom is Hidden Fates 44, where `attacks[0].name.fr` reads
`Règle des ESCOUADES` on **Trinity Burn**, `attacks[1].name.fr` reads
`Triple Brûlure` on **Sky Legends GX**, and a French-only third attack holds
the name that belongs on the second.

Same bug class as #2136 (Lost Thunder 154 Ditto ◇, the Prism Star rule box),
which stays in its own PR — this one does not touch that file.

## Details

| Card | Problem | Fix |
| --- | --- | --- |
| BW Black Star Promos BW96 — Tornadus-EX | third attack is the `Pokémon EX Rule` rule box | drop it |
| Hidden Fates 29 — Weezing | `Tackle` is labelled `Rendez-Vous Tous` (the Ability name); `Charge` sits in an orphan second attack | `Tackle` → `Charge`, drop the orphan |
| Hidden Fates 44 — Moltres & Zapdos & Articuno GX | both French names shifted; French effect text has its energy symbols stripped to empty (`une Énergie ,  et  supplémentaire`); orphan third attack | restore both names and the effect text, drop the orphan |
| Hidden Fates 66, 69 | same shift and same stripped effect text (no orphan) | same |
| Unbroken Bonds 107 — Greninja & Zoroark GX | orphan third attack duplicating **Dark Union GX**, plus a `damage: "30+"` on Dark Union GX that its other printings do not have | drop both |

Corrected values are taken from the same cards' other printings, which are
intact — no external source was needed:
