### PR TITLE
Add missing German translations for col1

### DIFF
--- a/data/Call of Legends/Call of Legends/1.ts
+++ b/data/Call of Legends/Call of Legends/1.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Clefairy",
-		fr: "Mélofée"
+		fr: "Mélofée",
+		de: "Piepi"
 	},
 
 	stage: "Stage1",
@@ -73,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "With its acute hearing, it can pick up sounds from far away. It usually hides in quiet places.",
+		de: "Mit seinem sensiblen Gehör nimmt es entfernte Geräusche wahr. Es versteckt sich an ruhigen Orten."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/10.ts
+++ b/data/Call of Legends/Call of Legends/10.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Houndour",
-		fr: "Malosse"
+		fr: "Malosse",
+		de: "Hunduster"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "If your opponent has any Fighting Pokémon in play, this attack does 20 damage plus 60 more damage.",
 				fr: "Si votre adversaire dispose de n'importe quel Pokémon  en jeu, cette attaque inflige 20 dégâts plus 60 dégâts supplémentaires.",
-				de: "Wenn dein Gegner mindestens 1 -Pokémon im Spiel hat, fügt dieser Angriff 20 Schadenspunkte plus 60 weitere Schadenspunkte zu."
+				de: "Wenn dein Gegner mindestens 1 {F}-Pokémon im Spiel hat, fügt dieser Angriff 20 Schadenspunkte plus 60 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -59,7 +60,7 @@ const card: Card = {
 			effect: {
 				en: "Your opponent discards a card from his or her hand.",
 				fr: "Votre adversaire défausse une carte de sa main.",
-				de: "Der Gegner legt eine seiner Handkarten auf seinen Ablagestapel."
+				de: "Dein Gegner legt eine seiner Handkarten auf seinen Ablagestapel."
 			},
 			damage: 50,
 
@@ -83,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "Upon hearing its eerie howls, other Pokémon get the shivers and head straight back to their nests.",
+		de: "Wenn andere Pokémon sein gräuliches Geheul hören, erschauern sie und verstecken sich schleunigst."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/11.ts
+++ b/data/Call of Legends/Call of Legends/11.ts
@@ -34,7 +34,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn, when you put Jirachi from your hand onto your Bench, you may flip 3 coins. For each heads, search your discard pile for a Psychic Energy card and attach it to Jirachi.",
 				fr: "Une seule fois lors de votre tour, lorsque vous placez Jirachi de votre main sur votre Banc, vous pouvez lancer 3 pièces. Pour chaque côté face, récupérez une carte Énergie  de votre pile de défausse et attachez-la à Jirachi.",
-				de: "Einmal während deines Zuges kannst du, wenn du Jirachi von deiner Hand auf deine Bank legst, 3 Münzen werfen. Durchsuche pro \"Kopf\" deinen Ablagestapel nach einer -Energiekarte und lege sie an Jirachi an."
+				de: "Einmal während deines Zuges kannst du, wenn du Jirachi von deiner Hand auf deine Bank legst, 3 Münzen werfen. Durchsuche pro „Kopf“ deinen Ablagestapel nach einer {P}-Energiekarte und lege sie an Jirachi an."
 			},
 		},
 	],
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Choose a number of your opponent's Stage 1 or Stage 2 Evolved Pokémon up to the amount of Energy attached to Jirachi. Remove the highest Stage Evolution card from each of those Pokémon and put those cards back into your opponent's hand.",
 				fr: "Choisissez au maximum autant de cartes Pokémon Évolution de votre adversaire (niveau 1 ou 2) qu'il y a de cartes Énergie attachées à Jirachi. Retirez les cartes Évolution de niveau le plus élevé de ces Pokémon et remettez-les dans la main de votre adversaire.",
-				de: "Wähle maximal so viele entwickelte Phase-1- oder Phase-2 Pokémon deines Gegners, wie Energien an Jirachi angelegt sind. Entferne die höchste Evolutionskarte von jedem der gewählten Pokémon. Dein Gegner nimmt diese Karten auf seine Hand zurück."
+				de: "Wähle maximal so viele entwickelte Phase-1- oder Phase-2-Pokémon deines Gegners, wie Energien an Jirachi angelegt sind. Entferne die höchste Evolutionskarte von jedem der gewählten Pokémon. Dein Gegner nimmt diese Karten auf seine Hand zurück."
 			},
 
 		},
@@ -69,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "Generations have believed that any wish written on a note on its head will come true when it awakens.",
+		de: "Wenn JIRACHI erwacht, erfüllt es die Wünsche, die man auf die Zettel an seinem Kopf geschrieben hat."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/12.ts
+++ b/data/Call of Legends/Call of Legends/12.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 40 damage to each of your opponent's Pokémon. If tails, this attack does 40 damage to each of your Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 40 dégâts à chaque Pokémon de votre adversaire. Si c’est pile, cette attaque inflige 40 dégâts à chacun de vos Pokémon. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff jedem Pokémon deines Gegners 40 Schadenspunkte zu. Bei \"Zahl\" fügt dieser Angriff jedem deiner Pokémon 40 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff jedem Pokémon deines Gegners 40 Schadenspunkte zu. Bei „Zahl“ fügt dieser Angriff jedem deiner Pokémon 40 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "A mythical Pokémon said to have swelled the seas with rain and tidal waves. It battled with Groudon.",
+		de: "Der Legende nach erschuf sein Regen das Meer. Es und GROUDON lieferten sich einen langen Kampf."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/13.ts
+++ b/data/Call of Legends/Call of Legends/13.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Eevee",
-		fr: "Évoli"
+		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -82,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "When you see Leafeon asleep in a patch of sunshine, you'll know it is using photosynthesis to produce clean air.",
+		de: "An klaren Tagen erzeugt FOLIPURBA saubere Luft, indem es Photosynthese betreibt."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/14.ts
+++ b/data/Call of Legends/Call of Legends/14.ts
@@ -24,6 +24,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Riolu",
 		fr: "Riolu",
+		de: "Riolu"
 	},
 
 	stage: "Stage1",
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "This attack's damage isn't affected by Resistance.",
 				fr: "Les dégâts infligés par cette attaque ne sont pas affectés par la Résistance.",
-				de: "Der Schaden dieses Angrffs wird durch Resistenz nicht verändert."
+				de: "Der Schaden dieses Angriffs wird durch Resistenz nicht verändert."
 			},
 			damage: 70,
 
@@ -78,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "It's said that no foe can remain invisible to Lucario, since it can detect auras. Even foes it could not otherwise see.",
+		de: "Man sagt, es sei fähig, die Aura anderer Pokémon zu sehen. So kann es unsichtbare Gegner ausmachen."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/15.ts
+++ b/data/Call of Legends/Call of Legends/15.ts
@@ -77,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said to be the guardian of the seas. It is rumored to have been seen on the night of a storm.",
+		de: "Man berichtet, es sei der Wächter der Meere und man habe es im Herzen eines tosenden Sturmes gesehen."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/16.ts
+++ b/data/Call of Legends/Call of Legends/16.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Magmar",
-		fr: "Magmar"
+		fr: "Magmar",
+		de: "Magmar"
 	},
 
 	stage: "Stage1",
@@ -63,7 +64,7 @@ const card: Card = {
 			effect: {
 				en: "Discard 2 Fire Energy attached to Magmortar.",
 				fr: "Défaussez 2 cartes Énergie  attachées à Maganon.",
-				de: "Lege 2 an Magbrant angelgte -Energien auf deinen Ablagestapel."
+				de: "Lege 2 an Magbrant angelegte {R}-Energien auf deinen Ablagestapel."
 			},
 			damage: 100,
 
@@ -81,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It blasts fireballs of over 3,600 degrees Fahrenheit out of its arms. Its breath also sears and sizzles.",
+		de: "Es schießt 2 000 Grad heiße Feuerbälle aus den Enden seiner Arme. Selbst sein Atem steht in Flammen."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/17.ts
+++ b/data/Call of Legends/Call of Legends/17.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Vulpix",
-		fr: "Goupix"
+		fr: "Goupix",
+		de: "Vulpix"
 	},
 
 	stage: "Stage1",
@@ -39,7 +40,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may discard a Fire Energy from your hand. If you do, draw 3 cards. This power can't be used if Ninetales is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez défausser une carte Énergie . Dans ce cas, piochez 3 cartes. Ce pouvoir ne peut pas être utilisé si Feunard est affecté par un État Spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 -Energiekarte aus deiner Hand auf deinen Ablagestapel legen. Wenn du das machst, ziehe 3 Karten. Diese Poké-Power kann nicht benutzt werden, wenn Vulnona von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 {R}-Energiekarte aus deiner Hand auf deinen Ablagestapel legen. Wenn du das machst, ziehe 3 Karten. Diese Poké-Power kann nicht benutzt werden, wenn Vulnona von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -73,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "Its nine beautiful tails are filled with a wondrous energy that could keep it alive for 1,000 years.",
+		de: "Seine neun schönen Schweife sind erfüllt von einer magischen Energie, um es 1000 Jahre leben zu lassen."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/18.ts
+++ b/data/Call of Legends/Call of Legends/18.ts
@@ -34,7 +34,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn, when you put Pachirisu from your hand onto your Bench, you may attach up to 2 Lightning Energy cards from your hand to Pachirisu.",
 				fr: "Une seule fois pendant votre tour, lorsque vous placez Pachirisu de votre main sur votre Banc, vous pouvez lui attacher 2 cartes Énergie Lightning.",
-				de: "Einmal während deines Zuges kannst du, wenn du Pachirisu von deiner Hand auf deine Bank legst, bis zu 2 -Energiekarten von deiner Hand an Pachirisu anlegen."
+				de: "Einmal während deines Zuges kannst du, wenn du Pachirisu von deiner Hand auf deine Bank legst, bis zu 2 {L}-Energiekarten von deiner Hand an Pachirisu anlegen."
 			},
 		},
 	],
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "It's one of the kinds of Pokémon with electric cheek pouches. It shoots charges from its tail.",
+		de: "Seine Backentaschen produzieren Elektrizität. Den so gesammelten Strom gibt es über den Schweif ab."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/19.ts
+++ b/data/Call of Legends/Call of Legends/19.ts
@@ -56,6 +56,7 @@ const card: Card = {
 
 	description: {
 		en: "Its total control over the boundaries of space enable it to transport itself to faraway places or even other dimensions.",
+		de: "Es kann frei das Gefüge des Raums manipulieren und so an entlegene Orte oder Dimensionen reisen."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/2.ts
+++ b/data/Call of Legends/Call of Legends/2.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Discard 2 Psychic Energy attached to Deoxys and remove 6 damage counters from Deoxys.",
 				fr: "Défaussez 2 Énergies Psychic attachées à Deoxys et retirez-lui 6 marqueurs de dégâts.",
-				de: "Lege 2 an Deoxys angelegte -Energien auf deinen Ablagestapel und entferne 6 Schadensmarken von Deoxys."
+				de: "Lege 2 an Deoxys angelegte {P}-Energien auf deinen Ablagestapel und entferne 6 Schadensmarken von Deoxys."
 			},
 			damage: 60,
 
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "DNA from a space virus mutated and became a Pokémon. It appears where auroras are seen.",
+		de: "DEOXYS ist ein außerirdisches Virus, das zu einem Pokémon mutierte. Es erscheint in der Nähe von Auroras."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/20.ts
+++ b/data/Call of Legends/Call of Legends/20.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			effect: {
 				en: "Discard a Fire Energy and a Lightning Energy attached to Rayquaza.",
 				fr: "Défaussez une Énergie Fire et une Énergie Lightning attachées à Rayquaza.",
-				de: "Lege 1 - und 1 -Energie, die an Rayquaza angelegt sind, auf deinen Ablagestapel."
+				de: "Lege 1 {R}- und 1 {L}-Energie, die an Rayquaza angelegt sind, auf deinen Ablagestapel."
 			},
 			damage: 100,
 
@@ -62,6 +62,7 @@ const card: Card = {
 
 	description: {
 		en: "It flies in the ozone layer, way up high in the sky. Until recently, no one had ever seen it.",
+		de: "Da es in der Ozonschicht hoch über den Wolken lebt, bekam es bis vor Kurzem noch niemand zu Gesicht."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/21.ts
+++ b/data/Call of Legends/Call of Legends/21.ts
@@ -53,7 +53,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de côtés face.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 
@@ -71,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "Once it becomes an adult, it has a tendency to let its comrades plant footprints on its back.",
+		de: "Ist es erwachsen, lässt es sich gern von seinen Kameraden Fußabdrücke auf den Rücken setzen."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/22.ts
+++ b/data/Call of Legends/Call of Legends/22.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Eevee",
-		fr: "Évoli"
+		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -59,7 +60,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 damage plus 30 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts plus 30 dégâts supplémentaires.",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff 30 Schadenspunkte plus 30 weitere Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 30 Schadenspunkte plus 30 weitere Schadenspunkte zu."
 			},
 			damage: "30+",
 
@@ -83,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "When agitated, this Pokémon protects itself by spraying poisonous sweat from its pores.",
+		de: "Fühlt es sich bedroht, sondert es tödlichen Giftschweiß aus seinen Poren ab, um sich zu schützen."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/23.ts
+++ b/data/Call of Legends/Call of Legends/23.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Flaaffy",
-		fr: "Lainergie"
+		fr: "Lainergie",
+		de: "Waaty"
 	},
 
 	stage: "Stage2",
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, Ampharos does 20 damage to itself.",
 				fr: "Lancez une pièce. Si c'est pile, Pharamp s'inflige 20 dégâts.",
-				de: "Wirf eine Münze. Bei \"Zahl\" fügt Ampharos sich selbst 20 Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Zahl“ fügt Ampharos sich selbst 20 Schadenspunkte zu."
 			},
 			damage: 80,
 
@@ -84,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "The tail's tip shines brightly and can be seen from far away. It acts as a beacon for lost people.",
+		de: "Seine Schweifspitze ist so hell, dass viele Verschollene es als Orientierungspunkt nutzen."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/24.ts
+++ b/data/Call of Legends/Call of Legends/24.ts
@@ -58,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "Because of its unusual, star-like silhouette, people believe that it came here on a meteor.",
+		de: "Aufgrund seiner ungewöhnlichen Sternform, sagt man, es sei auf einem Meteor hierhergereist."
 	},
 
 	retreat: 0,

--- a/data/Call of Legends/Call of Legends/25.ts
+++ b/data/Call of Legends/Call of Legends/25.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Croconaw",
-		fr: "Crocrodil"
+		fr: "Crocrodil",
+		de: "Tyracroc"
 	},
 
 	stage: "Stage2",
@@ -76,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "When it bites with its massive and powerful jaws, it shakes its head and savagely tears its victim up.",
+		de: "Wenn es mit seinem kräftigen Kiefer zubeißt, schüttelt es seinen Kopf und reißt seine Opfer in Stücke."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/26.ts
+++ b/data/Call of Legends/Call of Legends/26.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Snubbull",
-		fr: "Snubbull"
+		fr: "Snubbull",
+		de: "Snubbull"
 	},
 
 	stage: "Stage1",
@@ -80,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Because its fangs are too heavy, it always keeps its head tilted down. However, its bite is powerful.",
+		de: "Weil seine Reißzähne so schwer sind, ist sein Kopf gesenkt. Sein Biss ist jedoch schmerzhaft."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/27.ts
+++ b/data/Call of Legends/Call of Legends/27.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Bayleef",
-		fr: "Macronium"
+		fr: "Macronium",
+		de: "Lorblatt"
 	},
 
 	stage: "Stage2",
@@ -84,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "Meganium's breath has the power to revive dead grass and plants. It can make them healthy again.",
+		de: "MEGANIE kann mit seinem Atem abgestorbene Gräser und Planzen reanimieren. Sie sind dann gesund."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/28.ts
+++ b/data/Call of Legends/Call of Legends/28.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Misdreavus",
-		fr: "Feuforêve"
+		fr: "Feuforêve",
+		de: "Traunfugil"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Asleep.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Endormi.",
-				de: "Wirf eine Münze. Bei \"Kopf\" schläft das Verteidigende Pokémon jetzt."
+				de: "Wirf eine Münze. Bei „Kopf“ schläft das Verteidigende Pokémon jetzt."
 			},
 			damage: 30,
 
@@ -83,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "Its cries sound like incantations to torment the foe. It appears where you least expect it.",
+		de: "Sein bizarrer, bannfluchartiger Ruf quält seine Gegner. Es verschwindet so plötzlich, wie es auftaucht."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/29.ts
+++ b/data/Call of Legends/Call of Legends/29.ts
@@ -34,7 +34,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may have both you and your opponent reveal your hands. This power can't be used if Mr. Mime is affected by a Special Condition.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez choisir de révéler votre main à votre adversaire et de voir la sienne. Ce pouvoir ne peut pas être utilisé si M. Mime est affecté par un État Spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du dich dafür entscheiden, beide Spieler ihre Handkarten aufdecken zu lassen. Diese Poké-Power kann nicht verwendet werden, wenn Pantimos von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du dich dafür entscheiden, beide Spieler ihre Handkarten aufdecken zu lassen. Diese Poké-Power kann nicht benutzt werden, wenn Pantimos von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -53,7 +53,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 4 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 4 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de côtés face.",
-				de: "Wirf 4 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 4 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10×",
 
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "Its fingertips emit a peculiar force field that hardens air to create an actual wall.",
+		de: "Seine Fingerkuppen erzeugen ein spezielles Kraftfeld, das die Luft erhärtet und eine Wand generiert."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/3.ts
+++ b/data/Call of Legends/Call of Legends/3.ts
@@ -62,6 +62,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon completely controls the flow of time. It uses its power to travel at will through the past and future.",
+		de: "Es kann frei den Fluss der Zeit manipulieren und so Vergangenheit wie Zukunft bereisen."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/30.ts
+++ b/data/Call of Legends/Call of Legends/30.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pidgeotto",
-		fr: "Roucoups"
+		fr: "Roucoups",
+		de: "Tauboga"
 	},
 
 	stage: "Stage2",
@@ -42,7 +43,7 @@ const card: Card = {
 			effect: {
 				en: "During your opponent's next turn, the attack cost of each of the Defending Pokémon's attacks is ColorlessColorless more.",
 				fr: "Pendant le prochain tour de votre adversaire, le coût de chaque attaque du Pokémon Défenseur est augmentée de .",
-				de: "Während des nächsten Zuges deines Gegners kosten die Angriffe des Verteidigenden Pokémon  mehr."
+				de: "Während des nächsten Zuges deines Gegners kosten die Angriffe des Verteidigenden Pokémon {C}{C} mehr."
 			},
 			damage: 20,
 
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 40 damage plus 30 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 40 dégâts plus 30 dégâts supplémentaires.",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff 40 Schadenspunkte plus 30 weitere Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 40 Schadenspunkte plus 30 weitere Schadenspunkte zu."
 			},
 			damage: "40+",
 
@@ -83,6 +84,7 @@ const card: Card = {
 	],
 	description: {
 		en: "It spreads its beautiful wings wide to frighten its enemies. It can fly at Mach 2 speed.",
+		de: "Es spreizt seine mächtigen Flügel, um seine Feinde zu verängstigen. Es kann bis zu Mach 2 schnell fliegen."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/31.ts
+++ b/data/Call of Legends/Call of Legends/31.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Search your deck for a Metal Energy card and attach it to 1 of your Pokémon. Shuffle your deck afterward.",
 				fr: "Cherchez une carte Énergie  dans votre deck et attachez-la à l'un de vos Pokémon. Mélangez ensuite votre deck.",
-				de: "Durchsuche dein Deck nach einer -Energiekarte und lege sie an 1 deiner Pokémon an. Mische anschließend dein Deck."
+				de: "Durchsuche dein Deck nach einer {M}-Energiekarte und lege sie an 1 deiner Pokémon an. Mische anschließend dein Deck."
 			},
 
 		},
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "After nesting in bramble bushes, the wings of its chicks grow hard from scratches by thorns.",
+		de: "Die dornigen Zweige seines Nests bewirken, dass die Flügel seiner Jungen fest und hart werden."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/32.ts
+++ b/data/Call of Legends/Call of Legends/32.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Slowpoke",
-		fr: "Ramoloss"
+		fr: "Ramoloss",
+		de: "Flegmon"
 	},
 
 	stage: "Stage1",
@@ -58,7 +59,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 30,
 
@@ -76,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "It has incredible intellect and intuition. Whatever the situation, it remains calm and collected.",
+		de: "Sein feines Gespühr und Intellekt zeichnen es aus. Es bleibt in jeder Situation gelassen und besonnen."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/33.ts
+++ b/data/Call of Legends/Call of Legends/33.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Remove all damage counters from Snorlax. Snorlax can't use Layabout during your next turn.",
 				fr: "Retirez tous ses marqueurs de dégâts à Ronflex. Ronflex ne peut pas utiliser Traîne-savates pendant votre prochain tour.",
-				de: "Entferne alle Schadensmarken von Relaxo. Relaxo kann Faulenzer in deinem nächsten Zug nicht einsetzten."
+				de: "Entferne alle Schadensmarken von Relaxo. Relaxo kann Faulenzer in deinem nächsten Zug nicht einsetzen."
 			},
 
 		},
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "Its stomach's digestive juices can dissolve any kind of poison. It can even eat things off the ground.",
+		de: "Seine Magensäfte können jedes Gift zersetzen. Es kann sich sogar nur von Erdreich ernähren."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/34.ts
+++ b/data/Call of Legends/Call of Legends/34.ts
@@ -24,6 +24,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Tangela",
 		fr: "Saquedeneu",
+		de: "Tangela"
 	},
 
 	stage: "Stage1",
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed. If tails, put 1 Energy card attached to the Defending Pokémon in the Lost Zone.",
 				fr: "Lancez une pièce. Si c’est face, le Pokémon Défenseur est maintenant Paralysé. Si c’est pile, placez 1 carte Énergie attachée au Pokémon Défenseur dans la Zone Perdue.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt. Bei \"Zahl\" lege 1 an das Verteidigende Pokémon angelegte Energiekarte ins Nirgendwo."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt. Bei „Zahl“ lege 1 an das Verteidigende Pokémon angelegte Energiekarte ins Nirgendwo."
 			},
 			damage: 30,
 
@@ -83,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "Its vines grow so profusely that, in the warm season, you can't even see its eyes.",
+		de: "In warmen Jahreszeiten wuchern seine Ranken so dicht, dass man nicht einmal mehr seine Augen erkennt."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/35.ts
+++ b/data/Call of Legends/Call of Legends/35.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Quilava",
-		fr: "Feurisson"
+		fr: "Feurisson",
+		de: "Igelavar"
 	},
 
 	stage: "Stage2",
@@ -75,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "It has a secret, devastating move. It rubs its blazing fur together to cause huge explosions.",
+		de: "Es verfügt über eine verheerende Geheimattacke. Es reibt sein Fell, um Explosionen zu erzeugen."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/36.ts
+++ b/data/Call of Legends/Call of Legends/36.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "Even though it is small, it can't be ignored because it will slug any handy target without warning.",
+		de: "Es ist zwar nicht groß, aber dennoch unübersehbar, denn es schlägt jederzeit ohne Vorwarnug zu."
 	},
 
 	retreat: 0,

--- a/data/Call of Legends/Call of Legends/37.ts
+++ b/data/Call of Legends/Call of Legends/37.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Teddiursa",
-		fr: "Teddiursa"
+		fr: "Teddiursa",
+		de: "Teddiursa"
 	},
 
 	stage: "Stage1",
@@ -56,7 +57,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 50 damage plus 30 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 50 dégâts plus 30 dégâts supplémentaires.",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff 50 Schadenspunkte plus 30 weitere Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 50 Schadenspunkte plus 30 weitere Schadenspunkte zu."
 			},
 			damage: "50+",
 
@@ -74,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "With its ability to distinguish any aroma, it unfailing finds all food buried deep underground.",
+		de: "Da es alle Gerüche perfekt unterscheiden kann, findet es sogar Nahrung, die tief im Erdreich ist."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/38.ts
+++ b/data/Call of Legends/Call of Legends/38.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Koffing",
-		fr: "Smogo"
+		fr: "Smogo",
+		de: "Smogon"
 	},
 
 	stage: "Stage1",
@@ -76,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "If one of the twin Koffing inflates, the other one deflates. It constantly mixes its poisonous gases.",
+		de: "Pumpt sich eines der zwei SMOGON auf, lässt das andere Luft ab. So findet ein Giftgasaustausch statt."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/39.ts
+++ b/data/Call of Legends/Call of Legends/39.ts
@@ -71,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "Its fur would all stand on end if it smelled a Seviper nearby. Its sharp claws tear up its foes.",
+		de: "VIPITIS’ Geruch lässt ihm alle Haare zu Berge stehen. Mit seinen scharfen Klauen kratzt es seine Feinde."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/4.ts
+++ b/data/Call of Legends/Call of Legends/4.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Eevee",
-		fr: "Évoli"
+		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -58,7 +59,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt verwirrt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: 30,
 
@@ -76,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "It uses the fine hair that covers its body to sense air currents and predict its enemy's actions.",
+		de: "Mit seinen Körperhaaren nimmt es Luftströmungen wahr. Dadurch sagt es gegnerische Attacken voraus."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/40.ts
+++ b/data/Call of Legends/Call of Legends/40.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Chikorita",
-		fr: "Germignon"
+		fr: "Germignon",
+		de: "Endivie"
 	},
 
 	stage: "Stage1",
@@ -76,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "A spicy aroma emanates from around its neck. The aroma acts as a stimulant to restore health.",
+		de: "Ein würziges Aroma geht von seinen Blättern aus. Das Aroma soll gesundheitsfördernd sein."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/41.ts
+++ b/data/Call of Legends/Call of Legends/41.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Totodile",
-		fr: "Kaiminus"
+		fr: "Kaiminus",
+		de: "Karnimani"
 	},
 
 	stage: "Stage1",
@@ -75,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "If it loses a fang, a new one grows back in its place. There are always 48 fangs lining its mouth.",
+		de: "Verliert es einen seiner Zähne, wächst ein neuer nach. Es hat immer 48 Zähne in seinem Kiefer."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/42.ts
+++ b/data/Call of Legends/Call of Legends/42.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Phanpy",
-		fr: "Phanpy"
+		fr: "Phanpy",
+		de: "Phanpy"
 	},
 
 	stage: "Stage1",
@@ -63,7 +64,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 70 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 70 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 70 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 70 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "70×",
 
@@ -87,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It has sharp, hard tusks and a rugged hide. Its tackle is strong enough to knock down a house.",
+		de: "Aufgrund seiner scharfen Stoßzähne und seiner rauen Haut könnte es mit Tackle ein Haus niederreißen."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/43.ts
+++ b/data/Call of Legends/Call of Legends/43.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Mareep",
-		fr: "Wattouat"
+		fr: "Wattouat",
+		de: "Voltilamm"
 	},
 
 	stage: "Stage1",
@@ -59,7 +60,7 @@ const card: Card = {
 			effect: {
 				en: "If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 40,
 
@@ -83,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "As a result of storing too much electricity, it developed patches where even downy wool won't grow.",
+		de: "Da es zu viel Elektrizität gespeichert hat, hat es Flecken, an denen nicht einmal feine Wolle wächst."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/44.ts
+++ b/data/Call of Legends/Call of Legends/44.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Eevee",
-		fr: "Évoli"
+		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -74,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "It stores some of the air it inhales in its internal flame pouch, which heats it to over 3,000 degrees Fahrenheit.",
+		de: "Es speichert einen Teil seiner Atemluft in seinem Körper und erhitzt sie auf bis zu 1 700 Grad."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/45.ts
+++ b/data/Call of Legends/Call of Legends/45.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Eevee",
-		fr: "Évoli"
+		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of attacks, including damage, done to Jolteon during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, évitez tous les effets d'attaques (y compris les dégâts) infligés à Voltali pendant le prochain tour de votre adversaire.",
-				de: "Wirf eine Münze. Verhindere bei \"Kopf\" während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die Blitza zugefügt werden."
+				de: "Wirf eine Münze. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die Blitza zugefügt werden."
 			},
 			damage: 20,
 
@@ -78,6 +79,7 @@ const card: Card = {
 	],
 	description: {
 		en: "It concentrates the weak electric charges emitted by its cells and launches wicked lightning bolts.",
+		de: "Es sammelt die schwache Energie, die von seinen Zellen ausgeht und schleudert starke Blitze aus."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/46.ts
+++ b/data/Call of Legends/Call of Legends/46.ts
@@ -58,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "It is found in volcanic craters. Its body temperature is over 1,100 degrees Fahrenheit, so don't underestimate it.",
+		de: "Zu finden ist es in Vulkankratern. Seine Körpertemperatur erreicht über 600 Grad. Vergiss das nicht!"
 	},
 
 	retreat: 0,

--- a/data/Call of Legends/Call of Legends/47.ts
+++ b/data/Call of Legends/Call of Legends/47.ts
@@ -58,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "In an attempt to confuse its enemy, it mimics the enemy's movements. Then it wastes no time in making itself scarce!",
+		de: "Es ahmt seinen Gegner nach. Während dieser noch verblüfft dreinsieht, macht es sich aus dem Staub."
 	},
 
 	retreat: 0,

--- a/data/Call of Legends/Call of Legends/48.ts
+++ b/data/Call of Legends/Call of Legends/48.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pidgey",
-		fr: "Roucool"
+		fr: "Roucool",
+		de: "Taubsi"
 	},
 
 	stage: "Stage1",
@@ -57,7 +58,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. If both of them are tails, this attack does nothing. For each heads, discard an Energy attached to the Defending Pokémon.",
 				fr: "Lancez 2 pièces. Si vous obtenez deux fois un côté pile, cette attaque ne fait rien. Pour chaque face, défaussez une Énergie au Pokémon Défenseur.",
-				de: "Wirf 2 Münzen. Wenn beide Münzen \"Zahl\" zeigen, hat dieser Angriff keine Auswirkungen. Lege pro \"Kopf\" eine Energie, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
+				de: "Wirf 2 Münzen. Wenn beide Münzen „Zahl“ zeigen, hat dieser Angriff keine Auswirkungen. Lege pro „Kopf“ eine Energiekarte, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
 			},
 			damage: 30,
 
@@ -81,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It renders its prey immobile using well-developed claws, then carries the prey more than 60 miles to its nest.",
+		de: "Es lähmt seine Gegner mit seinen Krallen und trägt die Beute in sein bis zu 100 km entferntes Nest."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/49.ts
+++ b/data/Call of Legends/Call of Legends/49.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Cyndaquil",
-		fr: "Héricendre"
+		fr: "Héricendre",
+		de: "Feurigel"
 	},
 
 	stage: "Stage1",
@@ -75,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon is fully covered by nonflammable fur. It can withstand any kind of fire attack.",
+		de: "Das Fell dieses Pokémon ist nicht entflammbar. Es ist gegen jegliche Feuerattacken immun."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/5.ts
+++ b/data/Call of Legends/Call of Legends/5.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pineco",
-		fr: "Pomdepik"
+		fr: "Pomdepik",
+		de: "Tannza"
 	},
 
 	stage: "Stage1",
@@ -42,7 +43,7 @@ const card: Card = {
 			effect: {
 				en: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, this attack does nothing.",
 				fr: "Si le Pokémon Défenseur essaie d'attaquer pendant le prochain tour de votre adversaire, ce dernier lance une pièce. Si c'est pile, cette attaque ne fait rien.",
-				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 30,
 
@@ -85,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "Its entire body is shielded by a steel-hard shell. What lurks inside this shell is a total mystery.",
+		de: "Sein gesamter Körper steckt in einer stahlharten Schale. Sein Inneres bleibt ein Geheimnis."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/50.ts
+++ b/data/Call of Legends/Call of Legends/50.ts
@@ -53,6 +53,7 @@ const card: Card = {
 
 	description: {
 		en: "They communicate with one another using their auras. They are able to run all through the night.",
+		de: "Es nutzt seine Aura, um mit seinen Artgenossen zu kommunizieren. Es kann eine ganze Nacht lang laufen."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/51.ts
+++ b/data/Call of Legends/Call of Legends/51.ts
@@ -53,7 +53,7 @@ const card: Card = {
 			effect: {
 				en: "If Seviper is Poisoned, this attack does 20 damage plus 60 more damage and remove the Special Condition Poisoned from Seviper.",
 				fr: "Si Seviper est Empoisonné, cette attaque inflige 20 dégâts plus 60 dégâts supplémentaires. Retirez ensuite l’État Spécial Empoisonné de Seviper.",
-				de: "Wenn Vipitis vergiftet ist, fügt dieser Angriff 20 Schadenspunkte plus 60 weitere Schadenspunkte zu; entferne den Speziellen Zustand \"Vergiftet\" von Vipitis."
+				de: "Wenn Vipitis vergiftet ist, fügt dieser Angriff 20 Schadenspunkte plus 60 weitere Schadenspunkte zu; entferne den Speziellen Zustand „Vergiftet“ von Vipitis."
 			},
 			damage: "20+",
 
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "In battle, it uses its bladed tail to counter any Zangoose. It secretes a deadly venom in its tail.",
+		de: "Die flinken Angriffe von SENGO kontert es mit seinem messerscharfen Schweif, aus dem Gift austritt."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/52.ts
+++ b/data/Call of Legends/Call of Legends/52.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Eevee",
-		fr: "Évoli"
+		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -77,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "When Vaporeon's fins begin to vibrate, it is a sign that rain will come within a few hours.",
+		de: "Vibrieren die Flossen AQUANAs, bedeutet dies, dass es in den nächsten Stunden zu regnen beginnt."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/53.ts
+++ b/data/Call of Legends/Call of Legends/53.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "A sweet aroma gently wafts from the leaf on its head. It is docile and loves to soak up sunrays.",
+		de: "Ein süßer Duft geht von dem Blatt auf seinem Kopf aus. Es ist ruhig und liegt gerne in der Sonne."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/54.ts
+++ b/data/Call of Legends/Call of Legends/54.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "The moonlight that it stores in the wings on its back apparently gives it the ability to float in midair.",
+		de: "Aufgrund des gespeicherten Mondlichts in seinen Flügeln auf dem Rücken kann es in der Luft schweben."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/55.ts
+++ b/data/Call of Legends/Call of Legends/55.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, discard a Fire Energy attached to Cyndaquil.",
 				fr: "Lancez une pièce. Si c’est pile, défaussez une Énergie Fire attachée à Héricendre.",
-				de: "Wirf eine Münze. Bei \"Zahl\" lege eine an Feurigel angelegte -Energiekarte auf deinen Ablagestapel."
+				de: "Wirf eine Münze. Bei „Zahl“ lege eine an Feurigel angelegte {R}-Energie auf deinen Ablagestapel."
 			},
 			damage: 20,
 
@@ -53,6 +53,7 @@ const card: Card = {
 
 	description: {
 		en: "It is timid, and always curls itself up in a ball. If attacked, it flares up its back for protection.",
+		de: "Es ist ruhig und kugelt sich stets zusammen. Zum Schutz entflammt es seinen Rücken."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/56.ts
+++ b/data/Call of Legends/Call of Legends/56.ts
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "It has the ability to alter the composition of its body to suit its surrounding environment.",
+		de: "Es verfügt über die Fähigkeit, seinen Körper perfekt an die jeweilige Umgebung anzupassen."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/57.ts
+++ b/data/Call of Legends/Call of Legends/57.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of attacks, including damage, done to Hitmonchan during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, évitez tous les effets d'attaques (y compris les dégâts) infligés à Tygnon pendant le prochain tour de votre adversaire.",
-				de: "Wirf eine Münze. Verhindere bei \"Kopf\" während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die Nockchan zugefügt werden."
+				de: "Wirf eine Münze. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die Nockchan zugefügt werden."
 			},
 
 		},
@@ -71,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "Its punches slice the air. However, it seems to need a short break after fighting for three minutes.",
+		de: "Seine Fäuste zerschneiden die Luft. Es muss jedoch alle drei Minuten eine kurze Pause einlegen."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/58.ts
+++ b/data/Call of Legends/Call of Legends/58.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "If it starts kicking repeatedly, both legs will stretch even longer to strike a fleeing foe.",
+		de: "Wenn es anfängt pausenlos zu treten, kann es seine Beine ausfahren, um fliehende Feinde zu treffen."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/59.ts
+++ b/data/Call of Legends/Call of Legends/59.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires.",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -60,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "To corner prey, they check each other's location using barks that only they can understand.",
+		de: "Sie treiben ihre Beute in die Enge und orientieren sich dabei anhand ihres Bellens, das nur sie verstehen."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/6.ts
+++ b/data/Call of Legends/Call of Legends/6.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, discard the top 4 cards of your opponent's deck. If tails, discard the top 4 cards of your deck.",
 				fr: "Lancez une pièce. Si c’est face, défaussez les 4 premières cartes du deck de votre adversaire. Si c’est pile, défaussez les 4 premières cartes de votre deck.",
-				de: "Wirf eine Münze. Bei \"Kopf\" lege die obersten 4 Karten vom Deck deines Gegners auf seinen Ablagestapel. Bei \"Zahl\" lege die obersten 4 Karten von deinem Deck auf deinen Ablagestapel."
+				de: "Wirf eine Münze. Bei „Kopf“ lege die obersten 4 Karten vom Deck deines Gegners auf seinen Ablagestapel. Bei „Zahl“ lege die obersten 4 Karten von deinem Deck auf deinen Ablagestapel."
 			},
 			damage: 80,
 
@@ -56,6 +56,7 @@ const card: Card = {
 
 	description: {
 		en: "Said to have expanded the lands by evaporating water with raging heat. It battled titanically with Kyogre.",
+		de: "Sein Feuer erschuf einst das Land. Es und KYOGRE lieferten sich einen langen Kampf."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/60.ts
+++ b/data/Call of Legends/Call of Legends/60.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
 				fr: "Si le Pokémon Défenseur essaie d'attaquer pendant le prochain tour de votre adversaire, votre adversaire lance une pièce. Si c'est pile, cette attaque ne fait rien.",
-				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 10,
 
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "Its thin, filmy body is filled with gases that cause constant sniffles, coughs and teary eyes.",
+		de: "Sein dünner Körper ist mit Gasen angefüllt, die Husten und Schnupfen verursachen und die Augen reizen."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/61.ts
+++ b/data/Call of Legends/Call of Legends/61.ts
@@ -50,6 +50,7 @@ const card: Card = {
 
 	description: {
 		en: "For no reason, it jumps and splashes about, making it easy for predators like Pidgeotto to catch it mid-jump.",
+		de: "Es springt grundlos in die Luft. Das macht es einfach für Räuber wie TAUBOGA, es im Sprung zu fangen."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/62.ts
+++ b/data/Call of Legends/Call of Legends/62.ts
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "It dislikes cold places, so it blows scorching flames to make the environment suitable for itself.",
+		de: "Es hasst kalte Orte. Um es für sich angenehmer zu gestalten, erwärmt es seine Umgebung mit seinem Atem."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/63.ts
+++ b/data/Call of Legends/Call of Legends/63.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "Its fleece grows continually. In the summer, the fleece is fully shed, but it grows back in a week.",
+		de: "Sein Fell wächst ständig. Im Sommer wird es geschoren, aber sein Fell wächst binnen einer Woche nach."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/64.ts
+++ b/data/Call of Legends/Call of Legends/64.ts
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed and discard an Energy card attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé et vous devez défausser une Énergie qui lui est attachée.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt und lege eine Energiekarte, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt und lege eine Energiekarte, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
 			},
 			damage: 30,
 
@@ -78,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "It chomps with its gaping mouth. Its huge jaws are actually steel horns that have been transformed.",
+		de: "Sein Kiefer hat sich aus einem stählernen Horn entwickelt. Mit ihm beißt es seinen Gegner."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/65.ts
+++ b/data/Call of Legends/Call of Legends/65.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "It loves to bite and yank people's hair from behind without warning, just to see their shocked reactions.",
+		de: "Es liebt, Menschen zu beißen und sie an den Haaren zu ziehen, nur um ihre Reaktionen zu sehen."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/66.ts
+++ b/data/Call of Legends/Call of Legends/66.ts
@@ -53,7 +53,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 10 more damage.",
 				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires.",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "As a sign of affection, it bumps with its snout. However, it is so strong, it may send you flying.",
+		de: "Als Zeichen seiner Zuneigung stupst es dich mit dem Rüssel, was dich aber buchstäblich umwerfen könnte."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/67.ts
+++ b/data/Call of Legends/Call of Legends/67.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "Common in grassy areas and forests, it is very docile and will chase off enemies by flapping up sand.",
+		de: "Es ist meist in Wäldern anzutreffen. Es ist ruhig und verjagt seine Feinde, indem es Sand aufwirbelt."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/68.ts
+++ b/data/Call of Legends/Call of Legends/68.ts
@@ -53,7 +53,7 @@ const card: Card = {
 			effect: {
 				en: 'Flip a coin. If tails, this attack does nothing.',
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
-				de: "Wirf eine Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Wirf eine Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 40
 		}
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "It likes to make its shell thicker by adding layers of tree bark. The additional weight doesn't bother it.",
+		de: "Es fügt seiner Schale schichtenweise Baumrinde hinzu. Die zusätzliche Belastung ist ihm gleich."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/69.ts
+++ b/data/Call of Legends/Call of Legends/69.ts
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "During your opponent's next turn, any damage done to Relicanth by attacks is reduced by 30 (after applying Weakness and Resistance).",
 				fr: "Pendant le tour suivant de votre adversaire, les dégâts infligés par des attaques à Relicanth sont réduits de 30 (après application de la Faiblesse et de la Résistance).",
-				de: "Während des nächsten Zuges deines Gegners, wird Schaden, der Relicanth durch Angriffe zugefügt wird, um 30 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
+				de: "Während des nächsten Zuges deines Gegners wird Schaden, der Relicanth durch Angriffe zugefügt wird, um 30 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 			damage: 30,
 
@@ -71,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "Discovered by chance during deep-sea explorations, it has not changed since ancient times.",
+		de: "Es wurde zufällig bei einer Tiefsee- Expedition entdeckt. Seine Form ist seit 100 Millionen Jahren unverändert."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/7.ts
+++ b/data/Call of Legends/Call of Legends/7.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Magikarp",
-		fr: "Magicarpe"
+		fr: "Magicarpe",
+		de: "Karpador"
 	},
 
 	stage: "Stage1",
@@ -83,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "Once it appears, it goes on a rampage. It remains enraged until it demolishes everything around it.",
+		de: "Taucht es auf, randaliert es. Es beruhigt sich erst, wenn es alles um sich zerstört hat."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/70.ts
+++ b/data/Call of Legends/Call of Legends/70.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
-				de: "Wirf eine Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Wirf eine Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 20,
 
@@ -54,6 +54,7 @@ const card: Card = {
 
 	description: {
 		en: "It lazes vacantly near water. If something bites its tail, it won't even notice for a whole day.",
+		de: "Es faulenzt am Wasser. Wenn es in den Schweif gebissen wird, bemerkt es das erst am nächsten Tag."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/71.ts
+++ b/data/Call of Legends/Call of Legends/71.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon.",
 				fr: "Votre adversaire échange le Pokémon Défenseur avec l'un des Pokémon de son Banc.",
-				de: "Der Gegner tauscht das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
+				de: "Dein Gegner tauscht das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
 			},
 
 		},
@@ -67,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "It has an active, playful nature. Many women like to frolic with it because of its affectionate ways.",
+		de: "Es ist von Natur aus verspielt. Es tollt mit vielen Frauen herum, da es ihnen zugeneigt ist."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/72.ts
+++ b/data/Call of Legends/Call of Legends/72.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Search your deck for a Grass Energy card and attach it to 1 of your Pokémon. Shuffle your deck afterward.",
 				fr: "Cherchez dans votre deck 1 carte Énergie Grass et attachez-la à l’un de vos Pokémon. Mélangez ensuite votre deck.",
-				de: "Durchsuche dein Deck nach 1 -Energiekarte und lege sie an 1 deiner Pokémon an. Mische dein Deck anschließend."
+				de: "Durchsuche dein Deck nach 1 {G}-Energiekarte und lege sie an 1 deiner Pokémon an. Mische anschließend dein Deck."
 			},
 
 		},
@@ -77,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "It tangles any moving thing with its vines. Their subtle shaking is ticklish if you get ensnared.",
+		de: "Es berührt alles, was sich bewegt, mit seinen Ranken. Diese Berührungen sind sehr kitzelig."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/73.ts
+++ b/data/Call of Legends/Call of Legends/73.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, your opponent can't play any Trainer cards from his or her hand during your opponent's next turn, and any damage done to Teddiursa by attack is reduced by 30 (after applying weakness and resistance).",
 				fr: "Lancez une pièce. Si c'est face, votre adversaire ne peut pas jouer de cartes\nDresseur de sa main lors de son prochain tour, et tous les dégâts infligés à Teddiursa par des attaques sont réduits de 30 (après application de la Faiblesse et de la Résistance).",
-				de: "Wirf eine Münze. Bei \"Kopf\" kann dein Gegner in seinem nächsten Zug keine Trainerkarten von seiner Hand spielen und Schaden, der Teddiursa durch Angriffe zugefügt wird, wird um 30 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
+				de: "Wirf eine Münze. Bei „Kopf“ kann dein Gegner in seinem nächsten Zug keine Trainerkarten von seiner Hand spielen und Schaden, der Teddiursa durch Angriffe zugefügt wird, wird um 30 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 
 		},
@@ -52,6 +52,7 @@ const card: Card = {
 
 	description: {
 		en: "If it finds honey, its crescent mark glows. It always licks its paws because they are soaked with honey.",
+		de: "Findet es Honig, leuchtet die Sichel auf seinem Kopf. Es leckt oft seine mit Honig bedeckten Pfoten."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/74.ts
+++ b/data/Call of Legends/Call of Legends/74.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin for each Water Energy attached to Totodile. This attack does 30 damage plus 20 more damage for each heads.",
 				fr: "Lancez une pièce pour chaque Énergie Water attachée à Kaiminus. Cette attaque inflige 30 dégâts plus 20 dégâts supplémentaires pour chaque côté face.",
-				de: "Wirf eine Münze für jede an Karnimani angelegte -Energie. Dieser Angriff fügt 30 Schadenspunkte plus 20 weitere Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf eine Münze für jede an Karnimani angelegte {W}-Energie. Dieser Angriff fügt 30 Schadenspunkte plus 20 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "30+",
 
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "It is small but rough and tough. It won't hesitate to take a bite out of anything that moves.",
+		de: "Es ist klein, aber zäh und stark. Es zögert nicht, jeden anzugreifen, wenn dieser ihm zu nahe kommt."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/75.ts
+++ b/data/Call of Legends/Call of Legends/75.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Burned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Brûlé.",
-				de: "Wirf eine Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt verbrannt."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verbrannt."
 			},
 
 		},
@@ -53,7 +53,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, discard a Fire Energy attached to Vulpix.",
 				fr: "Lancez une pièce. Si c'est pile, défaussez une carte Énergie  attachée à Goupix.",
-				de: "Wirf eine Münze. Bei \"Zahl\" lege 1 an Vulpix angelegte -Energie auf deinen Ablagestapel."
+				de: "Wirf eine Münze. Bei „Zahl“ lege 1 an Vulpix angelegte {R}-Energie auf deinen Ablagestapel."
 			},
 			damage: 30,
 
@@ -71,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "If it is attacked by an enemy that is stronger than itself, it feigns injury to fool the enemy and escapes.",
+		de: "Greift es ein größerer Gegner an, täuscht es eine Verletzung vor, um sicher vor ihm zu flüchten."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/76.ts
+++ b/data/Call of Legends/Call of Legends/76.ts
@@ -16,7 +16,7 @@ const card: Card = {
 
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Draw 3 cards. Your opponent may draw a card.",
-		de: "Ziehe 3 Karten. Dein Gegner kann 1 Karte ziehen.",
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Ziehe 3 Karten. Dein Gegner kann 1 Karte ziehen.",
 		fr: "Piochez 3 cartes. Votre adversaire peut piocher une carte.",
 	},
 

--- a/data/Call of Legends/Call of Legends/77.ts
+++ b/data/Call of Legends/Call of Legends/77.ts
@@ -16,7 +16,7 @@ const card: Card = {
 
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Shuffle your hand into your deck. Then, draw a number of cards equal to the number of cards in your opponent's hand.",
-		de: "Mische deine Handkarten in dein Deck. Zähle danach die Anzahl der Karten auf der Hand deines Gegners. Ziehe ebenso viele Karten.",
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Mische deine Handkarten in dein Deck. Zähle danach die Anzahl der Karten auf der Hand deines Gegners. Ziehe ebenso viele Karten.",
 		fr: "Mélangez votre main avec votre deck. Ensuite, piochez un nombre de cartes égal au nombre de cartes de la main de votre adversaire.",
 	},
 

--- a/data/Call of Legends/Call of Legends/78.ts
+++ b/data/Call of Legends/Call of Legends/78.ts
@@ -16,7 +16,7 @@ const card: Card = {
 
 	effect: {
 		en: "Flip 2 coins. For each heads, search your deck for a Basic Pokémon, show it to your opponent, and put it into your hand. If you do, shuffle your deck afterward.",
-		de: "Wirf 2 Münzen. Durchsuche pro \"Kopf\" dein Deck nach einer Basis-Pokémon-Karte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck, falls du nach Karten gesucht hast.",
+		de: "Wirf 2 Münzen. Durchsuche pro „Kopf“ dein Deck nach 1 Basis-Pokémon-Karte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische anschließend dein Deck, falls du nach Karten gesucht hast.",
 		fr: "Lancez 2 pièces. Pour chaque côté face, cherchez un Pokémon de base dans votre deck, montrez-le à votre adversaire, puis ajoutez-le à votre main. Dans ce cas, mélangez ensuite votre deck.",
 	},
 

--- a/data/Call of Legends/Call of Legends/79.ts
+++ b/data/Call of Legends/Call of Legends/79.ts
@@ -16,7 +16,7 @@ const card: Card = {
 
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Look at the top 8 cards of your deck. Choose as many Energy cards as you like, show them to your opponent, and put them into your hand. Shuffle the other cards back into your deck.",
-		de: "Schau dir die obersten 8 Karten deines Decks an. Wähle beliebig viele Energiekarten, zeige sie deinem Gegner und nimm sie auf die Hand. Mische die anderen Karten anschließend in dein Deck.",
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Schau dir die obersten 8 Karten deines Decks an. Wähle beliebig viele Energiekarten, zeige sie deinem Gegner und nimm sie auf die Hand. Mische die anderen Karten anschließend in dein Deck.",
 		fr: "Regardez les 8 cartes du dessus de votre deck. Choisissez autant de cartes Énergie que vous le souhaitez, montrez-les à votre adversaire et ajoutez-les à votre main. Mélangez les autres cartes avec votre deck.",
 	},
 

--- a/data/Call of Legends/Call of Legends/8.ts
+++ b/data/Call of Legends/Call of Legends/8.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 
@@ -73,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "It launches kicks while spinning. If it spins at high speed, it may bore its way into the ground.",
+		de: "Es dreht sich um sich selbst und verteilt Tritte. Ist es schnell genug, bohrt es sich in den Boden."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/81.ts
+++ b/data/Call of Legends/Call of Legends/81.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card. Once during each player's turn, if that player's opponent has 6 or more Pokémon in the Lost Zone, the player may choose to win the game.",
 		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez-la si une autre carte Stade est jouée. Si une autre carte du même nom est en jeu, vous ne pouvez pas l'utiliser.",
-		de: "Einmal während seines Zuges darf sich jeder Spieler, wenn sich mindestens 6 Pokémon des Gegners im Nirgendwo befinden, dazu entscheiden, das Spiel zu gewinnen."
+		de: "Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadion-Karte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen. Einmal während seines Zuges darf sich jeder Spieler, wenn sich mindestens 6 Pokémon des Gegners im Nirgendwo befinden, dafür entscheiden, das Spiel zu gewinnen."
 	},
 
 	trainerType: "Stadium",

--- a/data/Call of Legends/Call of Legends/82.ts
+++ b/data/Call of Legends/Call of Legends/82.ts
@@ -16,7 +16,7 @@ const card: Card = {
 
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Search your deck for an Evolution card, show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
-		de: "Durchsuche dein Deck nach 1 Evolutionskarte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische anschließend dein Deck.",
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Durchsuche dein Deck nach 1 Evolutionskarte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische anschließend dein Deck.",
 		fr: "Cherchez une carte Évolution dans votre deck, montrez-la à votre adversaire, puis ajoutez-la à votre main. Mélangez ensuite votre deck.",
 	},
 

--- a/data/Call of Legends/Call of Legends/83.ts
+++ b/data/Call of Legends/Call of Legends/83.ts
@@ -16,7 +16,7 @@ const card: Card = {
 
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Shuffle your hand into your deck. Then, draw 6 cards.",
-		de: "Mische deine Handkarten in dein Deck. Ziehe danach 6 Karten.",
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Mische deine Handkarten in dein Deck. Ziehe danach 6 Karten.",
 		fr: "Mélangez votre main avec votre deck. Ensuite, piochez 6 cartes.",
 	},
 

--- a/data/Call of Legends/Call of Legends/85.ts
+++ b/data/Call of Legends/Call of Legends/85.ts
@@ -16,7 +16,7 @@ const card: Card = {
 
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Look at the top 5 cards of your deck. Choose any 2 cards you find there and put them into your hand. Discard the other cards.",
-		de: "Schau dir die obersten 5 Karten deines Decks an. Wähle 2 beliebige der gefundenen Karten und nimm sie auf die Hand. Lege die anderen Karten auf deinen Ablagestapel.",
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Schau dir die obersten 5 Karten deines Decks an. Wähle 2 beliebige der gefundenen Karten und nimm sie auf die Hand. Lege die anderen Karten auf deinen Ablagestapel.",
 		fr: "Regardez les 5 cartes du dessus de votre deck. Choisissez-en 2 et ajoutez-les à votre main. Défaussez les autres cartes.",
 	},
 

--- a/data/Call of Legends/Call of Legends/86.ts
+++ b/data/Call of Legends/Call of Legends/86.ts
@@ -16,7 +16,7 @@ const card: Card = {
 
 	effect: {
 		en: "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this Effect if the Pokémon that Darkness Energy is attached to isn't Darkness. Darkness Energy provides Darkness Energy. (Doesn't count as a basic Energy card.)",
-		de: "Falls das Pokémon, an das Finsternis-Energie angelegt ist, angreift, fügt der Angriff den Aktiven Pokémon 10 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden). Dieser Effekt wirkt nur, wenn die Finsternis-Energie an einem Pokémon vom Typ  angelegt ist. Finsternis-Energie liefert -Energie. (Zählt nicht als Basis-Energiekarte.)",
+		de: "Falls das Pokémon, an das Finsternis-Energie angelegt ist, angreift, fügt der Angriff den Aktiven Pokémon 10 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden). Dieser Effekt wirkt nur, wenn die Finsternis-Energie an einem Pokémon vom Typ {D} angelegt ist. Finsternis-Energie liefert {D}-Energie. (Zählt nicht als Basis-Energiekarte.)",
 		fr: "Si le Pokémon auquel est attachée Énergie Obscurité lance une attaque, cette dernière inflige 10 dégâts supplémentaires au Pokémon Actif (avant application de la Faiblesse et de la Résistance). Ignorez cet effet si le Pokémon auquel est attachée Énergie Obscurité n'est pas Obscurité. Énergie Obscurité fournit de l'Énergie Obscurité. (Elle ne compte pas comme carte Énergie de base.)",
 	},
 

--- a/data/Call of Legends/Call of Legends/87.ts
+++ b/data/Call of Legends/Call of Legends/87.ts
@@ -16,7 +16,7 @@ const card: Card = {
 
 	effect: {
 		en: "Damage done by attacks to the Pokémon that Metal Energy attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn't Metal. Metal Energy provides Metal Energy. (Doesn't count as a basic Energy card.)",
-		de: "Schaden, der dem Pokémon, an das Metall-Energie angelegt ist, durch Angriffe zugefügt wird, wird um 10 reduziert (nachdem Schwäche und Resistenz verrechnet wurden). Dieser Effekt wirkt nur, wenn die Metall-Energie an einem Pokémon vom Typ  angelegt ist. Metall-Energie spendet -Energie. (Zählt nicht als Basis-Energiekarte.)",
+		de: "Schaden, der dem Pokémon, an das Metall-Energie angelegt ist, durch Angriffe zugefügt wird, wird um 10 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden). Dieser Effekt wirkt nur, wenn die Metall-Energie an einem Pokémon vom Typ {M} angelegt ist. Metall-Energie liefert {M}-Energie. (Zählt nicht als Basis-Energiekarte.)",
 		fr: "Les dégâts d'attaque infligés au Pokémon auquel Énergie Métal est attachée sont réduits de 10 (après application de la Faiblesse et de la Résistance). Ignorez cet effet si le Pokémon auquel est attachée Énergie Métal n'est pas Métal. Énergie Métal fournit de l'Énergie Métal. (Ne compte pas comme une carte Énergie de base.)",
 	},
 

--- a/data/Call of Legends/Call of Legends/9.ts
+++ b/data/Call of Legends/Call of Legends/9.ts
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, discard all Fire Energy attached to Ho-Oh.",
 				fr: "Lancez une pièce. Si c’est pile, défaussez toutes les Énergies Fire attachées à Ho-Oh.",
-				de: "Wirf eine Münze. Bei \"Zahl\" lege alle an Ho-Oh angelegten -Energien auf deinen Ablagestapel."
+				de: "Wirf eine Münze. Bei „Zahl“ lege alle an Ho-Oh angelegten {R}-Energien auf deinen Ablagestapel."
 			},
 			damage: 100,
 
@@ -78,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "Legends claim this Pokémon flies the world's skies continuously on its magnificent seven-colored wings.",
+		de: "Man sagt, dass dieses Pokémon auf seinen siebenfarbigen Schwingen durch die Lüfte fliegt."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/SL1.ts
+++ b/data/Call of Legends/Call of Legends/SL1.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Discard 2 Psychic Energy attached to Deoxys and remove 6 damage counters from Deoxys.",
 				fr: "Défaussez 2 Énergies Psychic attachées à Deoxys et retirez-lui 6 marqueurs de dégâts.",
-				de: "Lege 2 an Deoxys angelegte -Energien auf deinen Ablagestapel und entferne 6 Schadensmarken von Deoxys."
+				de: "Lege 2 an Deoxys angelegte {P}-Energien auf deinen Ablagestapel und entferne 6 Schadensmarken von Deoxys."
 			},
 			damage: 60,
 
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "DNA from a space virus mutated and became a Pokémon. It appears where auroras are seen.",
+		de: "DEOXYS ist ein außerirdisches Virus, das zu einem Pokémon mutierte. Es erscheint in der Nähe von Auroras."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/SL10.ts
+++ b/data/Call of Legends/Call of Legends/SL10.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			effect: {
 				en: "Discard a Fire Energy and a Lightning Energy attached to Rayquaza.",
 				fr: "Défaussez une Énergie Fire et une Énergie Lightning attachées à Rayquaza.",
-				de: "Lege 1 - und 1 -Energie, die an Rayquaza angelegt sind, auf deinen Ablagestapel."
+				de: "Lege 1 {R}- und 1 {L}-Energie, die an Rayquaza angelegt sind, auf deinen Ablagestapel."
 			},
 			damage: 100,
 
@@ -62,6 +62,7 @@ const card: Card = {
 
 	description: {
 		en: "It flies in the ozone layer, way up high in the sky. Until recently, no one had ever seen it.",
+		de: "Da es in der Ozonschicht hoch über den Wolken lebt, bekam es bis vor Kurzem noch niemand zu Gesicht."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/SL11.ts
+++ b/data/Call of Legends/Call of Legends/SL11.ts
@@ -34,7 +34,7 @@ const card: Card = {
 			effect: {
 				en: "Suicune's Retreat Cost is Colorless less for each Water Energy attached to Suicune.",
 				fr: "Le Coût de retraite de Suicune est Colorless de moins pour chaque Énergie Water attachée à Suicune.",
-				de: "Die Rückzugskosten von Suicune verringern sich für jede an Suicune angelegte -Energie um ."
+				de: "Die Rückzugskosten von Suicune verringern sich für jede an Suicune angelegte {W}-Energie um {C}."
 			},
 		},
 	],
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon races across the land. It is said that north winds will somehow blow whenever it appears.",
+		de: "Dieses Pokémon jagt über das Land. Man sagt, der kalte Nordwind begleite es auf seinen Wegen."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/SL2.ts
+++ b/data/Call of Legends/Call of Legends/SL2.ts
@@ -62,6 +62,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon completely controls the flow of time. It uses its power to travel at will through the past and future.",
+		de: "Es kann frei den Fluss der Zeit manipulieren und so Vergangenheit wie Zukunft bereisen."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/SL3.ts
+++ b/data/Call of Legends/Call of Legends/SL3.ts
@@ -34,7 +34,7 @@ const card: Card = {
 			effect: {
 				en: "Entei's Retreat Cost is Colorless Energy less for each Fire Energy attached to Entei.",
 				fr: "Le Coût de retraite de Entei est Colorless de moins pour chaque Énergie Fire attachée à Entei.",
-				de: "Die Rückzugskosten von Entei verringern sich für jede an Entei angelegte -Energie um ."
+				de: "Die Rückzugskosten von Entei verringern sich für jede an Entei angelegte {R}-Energie um {C}."
 			},
 		},
 	],
@@ -71,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon that races across the land. It is said that one is born every time a new volcano appears.",
+		de: "Dieses Pokémon jagt über das Land. Man sagt, in jedem neuen Vulkan wird ein ENTEI geboren."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/SL4.ts
+++ b/data/Call of Legends/Call of Legends/SL4.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, discard the top 4 cards of your opponent's deck. If tails, discard the top 4 cards of your deck.",
 				fr: "Lancez une pièce. Si c’est face, défaussez les 4 premières cartes du deck de votre adversaire. Si c’est pile, défaussez les 4 premières cartes de votre deck.",
-				de: "Wirf eine Münze. Bei \"Kopf\" lege die obersten 4 Karten vom Deck deines Gegners auf seinen Ablagestapel. Bei \"Zahl\" lege die obersten 4 Karten von deinem Deck auf deinen Ablagestapel."
+				de: "Wirf eine Münze. Bei „Kopf“ lege die obersten 4 Karten vom Deck deines Gegners auf seinen Ablagestapel. Bei „Zahl“ lege die obersten 4 Karten von deinem Deck auf deinen Ablagestapel."
 			},
 			damage: 80,
 
@@ -56,6 +56,7 @@ const card: Card = {
 
 	description: {
 		en: "Said to have expanded the lands by evaporating water with raging heat. It battled titanically with Kyogre.",
+		de: "Sein Feuer erschuf einst das Land. Es und KYOGRE lieferten sich einen langen Kampf."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/SL5.ts
+++ b/data/Call of Legends/Call of Legends/SL5.ts
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, discard all Fire Energy attached to Ho-Oh.",
 				fr: "Lancez une pièce. Si c’est pile, défaussez toutes les Énergies Fire attachées à Ho-Oh.",
-				de: "Wirf eine Münze. Bei \"Zahl\" lege alle an Ho-Oh angelegten -Energien auf deinen Ablagestapel."
+				de: "Wirf eine Münze. Bei „Zahl“ lege alle an Ho-Oh angelegten {R}-Energien auf deinen Ablagestapel."
 			},
 			damage: 100,
 
@@ -78,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "Legends claim this Pokémon flies the world's skies continuously on its magnificent seven-colored wings.",
+		de: "Man sagt, dass dieses Pokémon auf seinen siebenfarbigen Schwingen durch die Lüfte fliegt."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/SL6.ts
+++ b/data/Call of Legends/Call of Legends/SL6.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 40 damage to each of your opponent's Pokémon. If tails, this attack does 40 damage to each of your Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 40 dégâts à chaque Pokémon de votre adversaire. Si c’est pile, cette attaque inflige 40 dégâts à chacun de vos Pokémon. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
-				de: "Wirf eine Münze. Bei \"Kopf\" fügt dieser Angriff jedem Pokémon deines Gegners 40 Schadenspunkte zu. Bei \"Zahl\" fügt dieser Angriff jedem deiner Pokémon 40 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff jedem Pokémon deines Gegners 40 Schadenspunkte zu. Bei „Zahl“ fügt dieser Angriff jedem deiner Pokémon 40 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "A mythical Pokémon said to have swelled the seas with rain and tidal waves. It battled with Groudon.",
+		de: "Der Legende nach erschuf sein Regen das Meer. Es und GROUDON lieferten sich einen langen Kampf."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/SL7.ts
+++ b/data/Call of Legends/Call of Legends/SL7.ts
@@ -77,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said to be the guardian of the seas. It is rumored to have been seen on the night of a storm.",
+		de: "Man berichtet, es sei der Wächter der Meere und man habe es im Herzen eines tosenden Sturmes gesehen."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/SL8.ts
+++ b/data/Call of Legends/Call of Legends/SL8.ts
@@ -56,6 +56,7 @@ const card: Card = {
 
 	description: {
 		en: "Its total control over the boundaries of space enable it to transport itself to faraway places or even other dimensions.",
+		de: "Es kann frei das Gefüge des Raums manipulieren und so an entlegene Orte oder Dimensionen reisen."
 	},
 
 	variants: [

--- a/data/Call of Legends/Call of Legends/SL9.ts
+++ b/data/Call of Legends/Call of Legends/SL9.ts
@@ -34,7 +34,7 @@ const card: Card = {
 			effect: {
 				en: "Raikou's Retreat Cost is Colorless less for each Lightning Energy attached to Raikou.",
 				fr: "Le Coût de retraite de Raikou est Colorless de moins pour chaque Énergie Lightning attachée à Raikou",
-				de: "Die Rückzugskosten von Raikou verringern sich für jede an Raikou angelegte -Energie um ."
+				de: "Die Rückzugskosten von Raikou verringern sich für jede an Raikou angelegte {L}-Energie um {C}."
 			},
 		},
 	],
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "Does 20 damage to 1 of your Pokémon and don't apply Weakness and Resistance to this damage.",
 				fr: "Inflige 20 dégâts à 1 de vos Pokémon. N’appliquez ni la Faiblesse ni la Résistance à ces dégâts.",
-				de: "Dieser Angriff fügt einem deiner Pokémon 20 Schadenspunkte zu; wende dabei Schwäche und Resistenz nicht an."
+				de: "Dieser Angriff fügt 1 deiner Pokémon 20 Schadenspunkte zu; wende dabei Schwäche und Resistenz nicht an."
 			},
 			damage: 70,
 
@@ -77,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon that races across the land while barking a cry that sounds like crashing thunder.",
+		de: "Dieses Pokémon jagt über das Land und stößt dabei ein Gebrüll aus, das wie krachender Donner klingt."
 	},
 
 	variants: [


### PR DESCRIPTION
## Add missing German translations for col1

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
