### PR TITLE
Add missing German translations for xy2

### DIFF
--- a/data/XY/Flashfire/1.ts
+++ b/data/XY/Flashfire/1.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "For protection, it releases a horrible stench from the antennae on its head to drive away enemies.",
+		de: "Als Schutz vor Feinden sondert es einen übel riechenden Gestank mit seinen Antennen ab."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/10.ts
+++ b/data/XY/Flashfire/10.ts
@@ -70,7 +70,7 @@ const card: Card = {
 				es: "Lanza 2 monedas. Este ataque hace 20 puntos de daño por cada cara.",
 				it: "Lancia due volte una moneta. Questo attacco infligge 20 danni ogni volta che esce testa.",
 				pt: "Jogue 2 moedas. Esse ataque causa 20 de danos vezes o número de caras.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It uses an up-tempo song and dance to drive away the bird Pokémon that prey on its flower seeds.",
+		de: "Verjagt Vogel-Pokémon, die auf seine Blüten aus sind, mit einem flotten Tänzchen und lauter Untermalung."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/100.ts
+++ b/data/XY/Flashfire/100.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, busca en tu baraja hasta 3 cartas de Energía Básica y únelas a este Pokémon. Baraja las cartas de tu baraja después.",
 				it: "Lancia una moneta. Se esce testa, cerca nel tuo mazzo fino a tre carte Energia base e assegnale a questo Pokémon. Poi rimischia le carte del tuo mazzo.",
 				pt: "Jogue uma moeda. Se sair cara, procure em seu baralho até 3 cards de Energia básica e ligue-os a esse Pokémon. Em seguida, embaralhe seus cards.",
-				de: "Wirf 1 Münze. Durchsuche bei \"Kopf\" dein Deck nach bis zu 3 Basis-Energiekarten und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
+				de: "Wirf 1 Münze. Durchsuche bei „Kopf“ dein Deck nach bis zu 3 Basis-Energiekarten und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
 			},
 
 		},

--- a/data/XY/Flashfire/103.ts
+++ b/data/XY/Flashfire/103.ts
@@ -71,7 +71,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, este ataque hace 30 puntos de daño más.",
 				it: "Lancia una moneta. Se esce testa, questo attacco infligge 30 danni in più.",
 				pt: "Jogue uma moeda. Se sair cara, esse ataque causará 30 de danos adicionais.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 30 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: "70+",
 

--- a/data/XY/Flashfire/104.ts
+++ b/data/XY/Flashfire/104.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cambia 1 de los Pokémon en Banca de tu rival por su Pokémon Activo.",
 		it: "Scambia uno dei Pokémon nella panchina del tuo avversario con il suo Pokémon attivo.",
 		pt: "Troque 1 dos Pokémon no Banco do seu oponente pelo Pokémon Ativo desse oponente.",
-		de: "Tausche 1 Pokémon auf der Bank deines Gegners gegen das Aktive Pokémon deines Gegners aus."
+		de: "Tausche 1 Pokémon auf der Bank deines Gegners gegen das Aktive Pokémon deines Gegners aus. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/XY/Flashfire/105.ts
+++ b/data/XY/Flashfire/105.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cura 60 puntos de daño y elimina todas las Condiciones Especiales de 1 de tus Pokémon.",
 		it: "Cura uno dei tuoi Pokémon da 60 danni e rimuovi tutte le condizioni speciali che lo influenzano.",
 		pt: "Cure 60 de danos e remova todas as Condições Especiais de 1 dos seus Pokémon.",
-		de: "Heile 60 Schadenspunkte bei 1 deiner Pokémon. Alle Speziellen Zustände auf diesem Pokémon verlieren ihre Wirkung."
+		de: "Heile 60 Schadenspunkte bei 1 deiner Pokémon. Alle Speziellen Zustände auf diesem Pokémon verlieren ihre Wirkung. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/XY/Flashfire/106.ts
+++ b/data/XY/Flashfire/106.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 2 Pokémon Básicos, enséñalos y ponlos en tu mano. Baraja las cartas de tu baraja después.",
 		it: "Cerca nel tuo mazzo fino a due Pokémon Base, mostrali e aggiungili alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure no seu baralho até 2 Pokémon Básicos, revele-os e coloque-os na mão. Em seguida, embaralhe seus cards.",
-		de: "Durchsuche dein Deck nach bis zu 2 Basis-Pokémon, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach bis zu 2 Basis-Pokémon, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/XY/Flashfire/109.ts
+++ b/data/XY/Flashfire/109.ts
@@ -58,7 +58,7 @@ const card: Card = {
 				es: "Lanza 1 moneda hasta que salga cruz. Este ataque hace 30 puntos de daño más por cada cara.",
 				it: "Lancia una moneta finché non esce croce. Ogni volta che esce testa, questo attacco infligge 30 danni in più.",
 				pt: "Jogue uma moeda até sair coroa. Este ataque causa 30 de danos adicionais para cada cara.",
-				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis \"Zahl\" kommt. Dieser Angriff fügt 30 weitere Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Dieser Angriff fügt 30 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "100+",
 

--- a/data/XY/Flashfire/11.ts
+++ b/data/XY/Flashfire/11.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, busca en tu baraja hasta 3 cartas de Energía Básica y únelas a este Pokémon. Baraja las cartas de tu baraja después.",
 				it: "Lancia una moneta. Se esce testa, cerca nel tuo mazzo fino a tre carte Energia base e assegnale a questo Pokémon. Poi rimischia le carte del tuo mazzo.",
 				pt: "Jogue uma moeda. Se sair cara, procure em seu baralho até 3 cards de Energia básica e ligue-os a esse Pokémon. Em seguida, embaralhe seus cards.",
-				de: "Wirf 1 Münze. Durchsuche bei \"Kopf\" dein Deck nach bis zu 3 Basis-Energiekarten und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
+				de: "Wirf 1 Münze. Durchsuche bei „Kopf“ dein Deck nach bis zu 3 Basis-Energiekarten und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
 			},
 
 		},

--- a/data/XY/Flashfire/14.ts
+++ b/data/XY/Flashfire/14.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, evita todos los efectos de los ataques, incluido el daño, infligidos a este Pokémon durante el próximo turno de tu rival.",
 				it: "Lancia una moneta. Se esce testa, previeni tutti gli effetti degli attacchi, inclusi i danni, inflitti a questo Pokémon durante il prossimo turno del tuo avversario.",
 				pt: "Jogue uma moeda. Se sair cara, impedirá todos os efeitos dos ataques a este Pokémon, inclusive danos, durante a próxima vez de jogar do seu oponente.",
-				de: "Wirf 1 Münze. Verhindere bei \"Kopf\" während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die diesem Pokémon zugefügt werden."
+				de: "Wirf 1 Münze. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die diesem Pokémon zugefügt werden."
 			},
 			damage: 10,
 
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "As a newborn, it can barely stand. However, through galloping, its legs are made tougher and faster.",
+		de: "Neugeboren kann es kaum stehen. Durch das Galoppieren werden seine Beine aber schneller und kräftiger."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/15.ts
+++ b/data/XY/Flashfire/15.ts
@@ -56,7 +56,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, evita todos los efectos de los ataques, incluido el daño, infligidos a este Pokémon durante el próximo turno de tu rival.",
 				it: "Lancia una moneta. Se esce testa, previeni tutti gli effetti degli attacchi, inclusi i danni, inflitti a questo Pokémon durante il prossimo turno del tuo avversario.",
 				pt: "Jogue uma moeda. Se sair cara, impedirá todos os efeitos dos ataques a este Pokémon, inclusive danos, durante a próxima vez de jogar do seu oponente.",
-				de: "Wirf 1 Münze. Verhindere bei \"Kopf\" während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die diesem Pokémon zugefügt werden."
+				de: "Wirf 1 Münze. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die diesem Pokémon zugefügt werden."
 			},
 			damage: 20,
 
@@ -98,6 +98,7 @@ const card: Card = {
 
 	description: {
 		en: "Very competitive, this Pokémon will chase anything that moves fast in the hopes of racing it.",
+		de: "Dieses Pokémon verfolgt schnelle Objekte in der Hoffnung, ein Wettrennen gegen sie zu gewinnen."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/16.ts
+++ b/data/XY/Flashfire/16.ts
@@ -65,7 +65,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cruz, descarta 1 Energía unida a este Pokémon.",
 				it: "Lancia una moneta. Se esce croce, scarta un'Energia assegnata a questo Pokémon.",
 				pt: "Jogue uma moeda. Se sair coroa, descarte uma Energia ligada a este Pokémon.",
-				de: "Wirf 1 Münze. Lege bei \"Zahl\" 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel."
+				de: "Wirf 1 Münze. Lege bei „Zahl“ 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel."
 			},
 			damage: 80,
 
@@ -83,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "You find abandoned coal mines full of them. They dig tirelessly in search of coal.",
+		de: "Große Gruppen Qurtel siedeln sich in stillgelegten Bergwerken an und graben dort emsig nach Kohle."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/17.ts
+++ b/data/XY/Flashfire/17.ts
@@ -56,7 +56,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, este ataque hace 20 puntos de daño más.",
 				it: "Lancia una moneta. Se esce testa, questo attacco infligge 20 danni in più.",
 				pt: "Jogue uma moeda. Se sair cara, esse ataque causará 20 de danos adicionais.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 20 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "From its beak, it expels embers that set the tall grass on fire. Then it pounces on the bewildered prey that pop out of the grass.",
+		de: "Es speit Funken aus seinem Schnabel und fängt die Beute, die überrascht aus dem angesengten Gras hervorspringt."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/18.ts
+++ b/data/XY/Flashfire/18.ts
@@ -60,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "The stronger the opponent it faces, the more heat surges from its mane and the more power flows through its body.",
+		de: "Je stärker sein Gegner ist, desto heißer wird seine Mähne und umso kraftvoller wird es."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/19.ts
+++ b/data/XY/Flashfire/19.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "The stronger the opponent it faces, the more heat surges from its mane and the more power flows through its body.",
+		de: "Je stärker sein Gegner ist, desto heißer wird seine Mähne und umso kraftvoller wird es."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/2.ts
+++ b/data/XY/Flashfire/2.ts
@@ -96,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "A steel-hard shell protects its tender body. It quietly endures hardships while awaiting evolution.",
+		de: "Der stahlharte Panzer schützt seinen zarten Körper. Es wartet geduldig auf seine Entwicklung."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/20.ts
+++ b/data/XY/Flashfire/20.ts
@@ -80,7 +80,7 @@ const card: Card = {
 				es: "Puedes descartar 1 Energía Fire unida a este Pokémon. Si lo haces, este ataque hace 30 puntos de daño más.",
 				it: "Puoi scartare un'Energia Fire assegnata a questo Pokémon. Se lo fai, questo attacco infligge 30 danni in più.",
 				pt: "Você pode descartar uma Energia Fire ligada a este Pokémon. Se fizer isso, esse ataque causará 30 de danos adicionais.",
-				de: "Du kannst 1 an dieses Pokémon angelegte Fire-Energie auf deinen Ablagestapel legen. Wenn du das machst, fügt dieser Angriff 30 weitere Schadenspunkte zu."
+				de: "Du kannst 1 an dieses Pokémon angelegte {R}-Energie auf deinen Ablagestapel legen. Wenn du das machst, fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: "60+",
 
@@ -98,6 +98,7 @@ const card: Card = {
 
 	description: {
 		en: "The male with the largest mane of fire is the leader of the pride.",
+		de: "Das Männchen mit der prächtigsten Feuermähne führt das Rudel an."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/21.ts
+++ b/data/XY/Flashfire/21.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "To fire its poison spikes, it must inflate its body by drinking over 2.6 gallons of water all at once.",
+		de: "Um seine Giftstacheln abzufeuern, muss es seinen Körper aufpumpen, indem es 10 l trinkt."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/22.ts
+++ b/data/XY/Flashfire/22.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cruz, este ataque no hace nada.",
 				it: "Lancia una moneta. Se esce croce, questo attacco non ha effetto.",
 				pt: "Jogue uma moeda. Se sair coroa, esse ataque não fará nada.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 10,
 
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It eats anything, so it can even live in polluted streams and lakes. No one pays any attention to it.",
+		de: "Es frisst einfach alles und kann daher auch in verschmutzter Umgebung leben. Niemand beachtet es."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/23.ts
+++ b/data/XY/Flashfire/23.ts
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "Milotic is breathtakingly beautiful. Those that see it are said to forget their combative spirits.",
+		de: "Milotic ist atemberaubend schön. Man sagt, dass diejenigen, die es sehen, vergessen zu kämpfen."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/24.ts
+++ b/data/XY/Flashfire/24.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "They can't swim well yet, and they move much faster by rolling. When they're happy they clap fins.",
+		de: "Es ist noch kein guter Schwimmer und bewegt sich rollend schneller fort. Ist es froh, klatscht es mit seinen Flossen."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/25.ts
+++ b/data/XY/Flashfire/25.ts
@@ -92,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "It has a very sensitive nose. It touches new things with its nose to examine them.",
+		de: "Die Nerven in seiner Nase sind sehr empfindlich. Sieht es etwas Neues, berührt es es zuerst mit der Nase."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/26.ts
+++ b/data/XY/Flashfire/26.ts
@@ -102,6 +102,7 @@ const card: Card = {
 
 	description: {
 		en: "It shatters ice with its big tusks. Its thick blubber repels not only the cold, but also enemy attacks.",
+		de: "Mit seinen Stoßzähnen bricht es durch Eis. Eine Speckschicht schützt es vor Kälte und Angriffen."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/27.ts
+++ b/data/XY/Flashfire/27.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, tu rival no puede robar 1 carta al principio de su próximo turno.",
 				it: "Lancia una moneta. Se esce testa, il tuo avversario non può pescare una carta all'inizio del suo prossimo turno.",
 				pt: "Jogue uma moeda. Se sair cara, seu oponente não poderá comprar um card no começo da próxima vez de jogar dele ou dela.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" kann dein Gegner zu Beginn seines nächsten Zuges keine Karte ziehen."
+				de: "Wirf 1 Münze. Bei „Kopf“ kann dein Gegner zu Beginn seines nächsten Zuges keine Karte ziehen."
 			},
 
 		},
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives in warm seas. It is said that a couple finding this Pokémon will be blessed with eternal love.",
+		de: "Es lebt in warmen Meeren. Man sagt, dass Verliebte, die es sehen, mit ewiger Liebe gesegnet sind."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/28.ts
+++ b/data/XY/Flashfire/28.ts
@@ -64,7 +64,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, este ataque hace 20 puntos de daño más.",
 				it: "Lancia una moneta. Se esce testa, questo attacco infligge 20 danni in più.",
 				pt: "Jogue uma moeda. Se sair cara, esse ataque causará 20 de danos adicionais.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 20 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It swims by rotating its two tails like a screw. When it dives, its flotation sac collapses.",
+		de: "Es schwimmt, indem es seine beiden Schweife wie eine Schiffsschraube rotieren lässt."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/29.ts
+++ b/data/XY/Flashfire/29.ts
@@ -79,7 +79,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, descarta 1 Energía unida al Pokémon Activo de tu rival.",
 				it: "Lancia una moneta. Se esce testa, scarta un'Energia assegnata al Pokémon attivo del tuo avversario.",
 				pt: "Jogue uma moeda. Se sair cara, descarte uma Energia ligada ao Pokémon Ativo do seu oponente.",
-				de: "Wirf 1 Münze. Lege bei \"Kopf\" 1 an das Aktive Pokémon deines Gegners angelegte Energie auf den Ablagestapel deines Gegners."
+				de: "Wirf 1 Münze. Lege bei „Kopf“ 1 an das Aktive Pokémon deines Gegners angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 30,
 
@@ -97,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "It floats using its well-developed flotation sac. It assists in the rescues of drowning people.",
+		de: "Es treibt mithilfe einer Art Rettungsring auf dem Wasser und hilft dem, der zu ertrinken droht."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/3.ts
+++ b/data/XY/Flashfire/3.ts
@@ -98,6 +98,7 @@ const card: Card = {
 
 	description: {
 		en: "It loves the honey of flowers and can locate flower patches that have even tiny amounts of pollen.",
+		de: "Es liebt Blütenhonig. Es findet selbst Blumen, die sehr wenig Pollen haben."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/30.ts
+++ b/data/XY/Flashfire/30.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It blocks opponents' attacks with the ice that shields its body. It uses cold air to repair any cracks with new ice.",
+		de: "Es wehrt gegnerische Angriffe mit seinem in Eis gehüllten Körper ab. Bruchstellen bessert es mit aus kalter Luft gewonnenem neuen Eis aus."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/31.ts
+++ b/data/XY/Flashfire/31.ts
@@ -102,6 +102,7 @@ const card: Card = {
 
 	description: {
 		en: "Its ice-covered body is as hard as steel. Its cumbersome frame crushes anything that stands in its way.",
+		de: "Sein eisbedeckter Körper ist so hart wie Stahl. Es nutzt diese stahlharte Hülle, um Hindernisse zu zerschmettern und sich so seinen Weg zu bahnen."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/32.ts
+++ b/data/XY/Flashfire/32.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Paralizado.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene paralizzato.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente será Paralisado.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Aktive Pokémon deines Gegners jetzt paralysiert."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 			},
 
 		},
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "The extension and contraction of its muscles generates electricity. It glows when in trouble.",
+		de: "Es erzeugt Elektrizität durch das Strecken und Zusammenziehen seiner Muskeln. Bei Bedrohung glüht es."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/33.ts
+++ b/data/XY/Flashfire/33.ts
@@ -99,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "Its claws loose electricity with enough amperage to cause fainting. They live in small groups.",
+		de: "Seine Krallen geben Elektrizität ab, die stark genug ist, jemanden bewusstlos zu machen."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/34.ts
+++ b/data/XY/Flashfire/34.ts
@@ -107,6 +107,7 @@ const card: Card = {
 
 	description: {
 		en: "When its eyes gleam gold, it can spot hiding prey–even those taking shelter behind a wall.",
+		de: "Leuchten seine Augen golden auf, kann es Beute, die sich versteckt, sehen. Es kann durch Wände sehen."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/36.ts
+++ b/data/XY/Flashfire/36.ts
@@ -64,7 +64,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, descarta 1 Energía unida al Pokémon Activo de tu rival.",
 				it: "Lancia una moneta. Se esce testa, scarta un'Energia assegnata al Pokémon attivo del tuo avversario.",
 				pt: "Jogue uma moeda. Se sair cara, descarte uma Energia ligada ao Pokémon Ativo do seu oponente.",
-				de: "Wirf 1 Münze. Lege bei \"Kopf\" 1 an das Aktive Pokémon deines Gegners angelegte Energie auf den Ablagestapel deines Gegners."
+				de: "Wirf 1 Münze. Lege bei „Kopf“ 1 an das Aktive Pokémon deines Gegners angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 
 		},
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "They make their home in deserts. They can generate their energy from basking in the sun, so eating food is not a requirement.",
+		de: "Es ist in der Wüste zu Hause und wandelt die Energie der Sonne in Körperkraft um, wodurch es auch ohne Nahrung auskommt."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/37.ts
+++ b/data/XY/Flashfire/37.ts
@@ -80,7 +80,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, este ataque hace 30 puntos de daño más.",
 				it: "Lancia una moneta. Se esce testa, questo attacco infligge 30 danni in più.",
 				pt: "Jogue uma moeda. Se sair cara, esse ataque causará 30 de danos adicionais.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 30 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: "60+",
 
@@ -105,6 +105,7 @@ const card: Card = {
 
 	description: {
 		en: "They flare their frills and generate energy. A single Heliolisk can generate sufficient electricity to power a skyscraper.",
+		de: "Die Strommenge, die ein Elezard mit ausgebreiteten Hautlappen durch Umwandlung von Sonnenstrahlen erzeugt, genügt zur Versorgung eines Wolkenkratzers."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/38.ts
+++ b/data/XY/Flashfire/38.ts
@@ -93,6 +93,7 @@ const card: Card = {
 
 	description: {
 		en: "It doggedly pursues its prey wherever it goes. However, the chase is abandoned at sunrise.",
+		de: "Verbissen verfolgt es seine Beute überallhin. Doch sobald die Sonne aufgeht, ist die Jagd vorbei."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/39.ts
+++ b/data/XY/Flashfire/39.ts
@@ -104,6 +104,7 @@ const card: Card = {
 
 	description: {
 		en: "Anyone who dares peer into its body to see its spectral ball of fire will have their spirit stolen away.",
+		de: "Blickt man direkt in den Feuerball in seinem Inneren, wird einem die Seele ausgesaugt."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/4.ts
+++ b/data/XY/Flashfire/4.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "It likes to make its shell thicker by adding layers of tree bark. The additional weight doesn't bother it.",
+		de: "Es fügt seiner Schale schichtenweise Baumrinde hinzu. Die zusätzliche Belastung ist ihm gleich."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/40.ts
+++ b/data/XY/Flashfire/40.ts
@@ -54,7 +54,7 @@ const card: Card = {
 				es: "Todas las veces que quieras durante tu turno (antes de tu ataque), puedes mover 1 contador de daño de 1 de tus Pokémon a este Pokémon.",
 				it: "Durante il tuo turno, prima di attaccare, puoi spostare un segnalino danno da uno dei tuoi Pokémon a questo Pokémon tutte le volte che vuoi.",
 				pt: "Tantas vezes quanto desejar em sua vez de jogar (antes de atacar), você pode mover 1 contador de danos de 1 dos seus Pokémon para este Pokémon.",
-				de: "Beliebig oft während deines Zuges (vor deinem Angriff ) kannst du 1 Schadensmarke von 1 deiner Pokémon auf dieses Pokémon verschieben."
+				de: "Beliebig oft während deines Zuges (vor deinem Angriff) kannst du 1 Schadensmarke von 1 deiner Pokémon auf dieses Pokémon verschieben."
 			},
 		},
 	],
@@ -104,6 +104,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said to take lost spirits into its pliant body and guide them home.",
+		de: "Man sagt, dass es verlorene Seelen in seinem biegsamen Körper nach Hause geleite."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/42.ts
+++ b/data/XY/Flashfire/42.ts
@@ -64,7 +64,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Paralizado.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene paralizzato.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente será Paralisado.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Aktive Pokémon deines Gegners jetzt paralysiert."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 			},
 			damage: 10,
 
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "The organ that emits its intense psychic power is sheltered by its ears to keep power from leaking out.",
+		de: "Damit die starken Psycho-Kräfte dieses Pokémon nicht unkontrolliert nach außen dringen, ist das Organ, das diese freisetzt, von seinen Ohren bedeckt."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/43.ts
+++ b/data/XY/Flashfire/43.ts
@@ -98,6 +98,7 @@ const card: Card = {
 
 	description: {
 		en: "When in danger, it raises its ears and releases enough psychic power to grind a 10-ton truck into dust.",
+		de: "In Gefahrensituationen hebt es seine Ohren an und setzt Psycho-Kräfte frei, die einen 10 t schweren LKW zu Schrott verarbeiten können."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/44.ts
+++ b/data/XY/Flashfire/44.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Envenenado.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene avvelenato.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente será Envenenado.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Aktive Pokémon deines Gegners jetzt vergiftet."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Aktive Pokémon deines Gegners jetzt vergiftet."
 			},
 
 		},
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "Camouflaged as rotten kelp, they spray liquid poison on prey that approaches unawares and then finish it off.",
+		de: "Als verfaulter Seetang getarnt, lauert es auf Beute und bespritzt alles und jeden, der sich ahnungslos nähert, mit flüssigem Gift, bevor es ihm den Rest gibt."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/45.ts
+++ b/data/XY/Flashfire/45.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "Found in fields and mountains. Mistaking them for boulders, people often step or trip on them.",
+		de: "Wanderer stolpern in den Bergen häufig über dieses Pokémon, da es wie ein Stein aussieht."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/46.ts
+++ b/data/XY/Flashfire/46.ts
@@ -95,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "With a free and uncaring nature, it doesn't mind if pieces break off while it rolls down mountains.",
+		de: "Es ist ihm völlig gleichgültig, wenn Stücke aus ihm herausbrechen, während es Berge hinabrollt."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/47.ts
+++ b/data/XY/Flashfire/47.ts
@@ -58,7 +58,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, este ataque hace 30 puntos de daño más.",
 				it: "Lancia una moneta. Se esce testa, questo attacco infligge 30 danni in più.",
 				pt: "Jogue uma moeda. Se sair cara, esse ataque causará 30 de danos adicionais.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 30 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: "60+",
 
@@ -102,6 +102,7 @@ const card: Card = {
 
 	description: {
 		en: "It tumbles down mountains, leaving grooves from peak to base. Stay clear of these grooves.",
+		de: "Sie rollen Berge hinunter und hinterlassen Spurrillen. Halte dich von diesen Rillen fern."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/48.ts
+++ b/data/XY/Flashfire/48.ts
@@ -48,7 +48,7 @@ const card: Card = {
 				es: "Lanza 2 monedas. Este ataque hace 30 puntos de daño por cada cara.",
 				it: "Lancia due volte una moneta. Questo attacco infligge 30 danni ogni volta che esce testa.",
 				pt: "Jogue 2 moedas. Esse ataque causa 30 de danos vezes o número de caras.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "30×",
 
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "Two Binacle live together on one rock. When they fight, one of them will move to a different rock.",
+		de: "Bithora bewohnen jeweils zu zweit einen Felsen. Entzweien sie sich im Streit, sucht sich eines der beiden einen neuen Felsen als Unterkunft."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/49.ts
+++ b/data/XY/Flashfire/49.ts
@@ -57,7 +57,7 @@ const card: Card = {
 				es: "Descarta tantas cartas de Energía Fighting como quieras de tu mano. Este ataque hace 30 puntos de daño por cada carta de Energía que hayas descartado.",
 				it: "Scarta tutte le carte Energia Fighting che vuoi dalla tua mano. Questo attacco infligge 30 danni per ogni carta Energia che hai scartato.",
 				pt: "Descarte tantos cards de Energia Fighting quanto desejar da sua mão. Esse ataque causa 30 de danos vezes o número de cards de Energia descartados.",
-				de: "Lege beliebig viele Fighting-Energiekarten von deiner Hand auf deinen Ablagestapel. Dieser Angriff fügt 30 Schadenspunkte für jede der von dir abgelegten Energiekarten zu."
+				de: "Lege beliebig viele {F}-Energiekarten von deiner Hand auf deinen Ablagestapel. Dieser Angriff fügt 30 Schadenspunkte für jede der von dir abgelegten Energiekarten zu."
 			},
 			damage: "30×",
 
@@ -93,6 +93,7 @@ const card: Card = {
 
 	description: {
 		en: "When they evolve, two Binacle multiply into seven. They fight with the power of seven Binacle.",
+		de: "Es entsteht bei der entwicklungsbedingten Aufspaltung der beiden Bithora in sieben Vertreter ihrer Art. Gemeinsam verfügen sie über die siebenfache Stärke."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/5.ts
+++ b/data/XY/Flashfire/5.ts
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "It attaches itself to a tree branch using the top of its head. Strong winds can sometimes make it fall.",
+		de: "Mit dem Stiel auf seinem Kopf hängt es sich an Äste. Bei starkem Wind fällt es durchaus einmal herunter."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/50.ts
+++ b/data/XY/Flashfire/50.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It feeds on eggs stolen from nests. Its sharply hooked claws rip vulnerable spots on prey.",
+		de: "Es ernährt sich von Eiern, die es aus Nestern stiehlt. Beute greift es mit seinen scharfen Krallen an."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/51.ts
+++ b/data/XY/Flashfire/51.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It feeds on eggs stolen from nests. Its sharply hooked claws rip vulnerable spots on prey.",
+		de: "Es ernährt sich von Eiern, die es aus Nestern stiehlt. Beute greift es mit seinen scharfen Krallen an."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/52.ts
+++ b/data/XY/Flashfire/52.ts
@@ -105,6 +105,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives in snowy regions. It carves patterns in trees with its claws as a signal to others.",
+		de: "Es lebt in schneereichen Gebieten. Snibunna senden einander Signale, indem sie Zeichen in Rinde ritzen."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/53.ts
+++ b/data/XY/Flashfire/53.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Si el Pokémon Defensor intenta atacar durante el próximo turno de tu rival, este lanza 1 moneda. Si sale cruz, ese ataque no hace nada.",
 				it: "Se durante il prossimo turno del tuo avversario il Pokémon difensore prova ad attaccare, il tuo avversario lancia una moneta. Se esce croce, quell'attacco non ha effetto.",
 				pt: "Se o Pokémon Defensor tentar atacar durante a próxima vez de jogar do seu oponente, seu oponente jogará uma moeda. Se sair coroa, o ataque não fará nada.",
-				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 
 		},
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It sprays a foul fluid from its rear. Its stench spreads over a mile radius, driving Pokémon away.",
+		de: "Versprüht eine Substanz aus seinem Hinterleib, die in einem großen Radius andere Pokémon fernhält."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/54.ts
+++ b/data/XY/Flashfire/54.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It sprays a foul fluid from its rear. Its stench spreads over a mile radius, driving Pokémon away.",
+		de: "Versprüht eine Substanz aus seinem Hinterleib, die in einem großen Radius andere Pokémon fernhält."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/55.ts
+++ b/data/XY/Flashfire/55.ts
@@ -82,7 +82,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, descarta 1 Energía unida al Pokémon Activo de tu rival.",
 				it: "Lancia una moneta. Se esce testa, scarta un'Energia assegnata al Pokémon attivo del tuo avversario.",
 				pt: "Jogue uma moeda. Se sair cara, descarte uma Energia ligada ao Pokémon Ativo do seu oponente.",
-				de: "Wirf 1 Münze. Lege bei \"Kopf\" 1 an das Aktive Pokémon deines Gegners angelegte Energie auf den Ablagestapel deines Gegners."
+				de: "Wirf 1 Münze. Lege bei „Kopf“ 1 an das Aktive Pokémon deines Gegners angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 70,
 
@@ -107,6 +107,7 @@ const card: Card = {
 
 	description: {
 		en: "It sprays a vile-smelling fluid from the tip of its tail to attack. Its range is over 160 feet.",
+		de: "Über seine Schweifspitze versprüht es eine übelriechende Substanz. Die Reichweite liegt bei über 50 m."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/56.ts
+++ b/data/XY/Flashfire/56.ts
@@ -48,7 +48,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cruz, este ataque no hace nada.",
 				it: "Lancia una moneta. Se esce croce, questo attacco non ha effetto.",
 				pt: "Jogue uma moeda. Se sair coroa, esse ataque não fará nada.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 40,
 
@@ -73,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "It moves along below the sand's surface, except for its nose and eyes. A dark membrane shields its eyes from the sun.",
+		de: "Wenn es sich durch den Sand gräbt, ragen nur noch Nase und Augen hervor. Die schwarze Haut dient als Augenschutz."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/57.ts
+++ b/data/XY/Flashfire/57.ts
@@ -81,7 +81,7 @@ const card: Card = {
 				es: "Lanza 2 monedas. Este ataque hace 60 puntos de daño por cada cara.",
 				it: "Lancia due volte una moneta. Questo attacco infligge 60 danni ogni volta che esce testa.",
 				pt: "Jogue 2 moedas. Esse ataque causa 60 de danos vezes o número de caras.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 60 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 60 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "60×",
 
@@ -106,6 +106,7 @@ const card: Card = {
 
 	description: {
 		en: "They live in groups of a few individuals. Protective membranes shield their eyes from sandstorms.",
+		de: "Bildet mit mehreren Artgenossen ein Rudel. Eine Membran schützt seine Augen vor Sandstürmen."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/58.ts
+++ b/data/XY/Flashfire/58.ts
@@ -48,7 +48,7 @@ const card: Card = {
 				es: "Lanza 2 monedas. Este ataque hace 20 puntos de daño por cada cara.",
 				it: "Lancia due volte una moneta. Questo attacco infligge 20 danni ogni volta che esce testa.",
 				pt: "Jogue 2 moedas. Esse ataque causa 20 de danos vezes o número de caras.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 
@@ -73,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "Its skin has a rubbery elasticity, so it can reduce damage by defensively pulling it skin up to its neck.",
+		de: "Es zieht seine gummiartige Haut bis zum Hals hinauf und nimmt eine Abwehrhaltung ein, um sich vor Schaden zu schützen."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/59.ts
+++ b/data/XY/Flashfire/59.ts
@@ -100,6 +100,7 @@ const card: Card = {
 
 	description: {
 		en: "It pulls up its shed skin to protect itself while it kicks. The bigger the crest, the more respected it is.",
+		de: "Es wehrt Angriffe mit seiner alten Haut ab und kontert mit Tritten. Sein Ego entspricht der Größe seines Kamms."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/6.ts
+++ b/data/XY/Flashfire/6.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "The sound of its grass flute makes its listeners uneasy. It lives deep in forests.",
+		de: "Der Ton seiner Grasflöte beunruhigt die, die ihn hören. Es lebt tief in den Wäldern."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/60.ts
+++ b/data/XY/Flashfire/60.ts
@@ -46,7 +46,7 @@ const card: Card = {
 				es: "Tempestad de Espinas",
 				it: "Spintempesta",
 				pt: "Tempestade de Espinhos",
-				de: "Stachelsturm"
+				de: "Dornengewitter"
 			},
 			effect: {
 				en: "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may put 1 damage counter on each of your opponent's Pokémon.",
@@ -79,7 +79,7 @@ const card: Card = {
 				es: "Este ataque hace 20 puntos de daño más por cada Colorless en el Coste de Retirada del Pokémon Activo de tu rival.",
 				it: "Questo attacco infligge 20 danni in più per ogni Energia Colorless nel costo di ritirata del Pokémon attivo del tuo avversario.",
 				pt: "Esse ataque causa 20 de danos adicionais para cada Colorless no Custo para Recuar do Pokémon Ativo do seu oponente.",
-				de: "Dieser Angriff fügt 20 weitere Schadenspunkte für jedes Colorless-Symbol in den Rückzugskosten des Aktiven Pokémon deines Gegners zu."
+				de: "Dieser Angriff fügt 20 weitere Schadenspunkte für jedes {C}-Symbol in den Rückzugskosten des Aktiven Pokémon deines Gegners zu."
 			},
 			damage: "20+",
 
@@ -104,6 +104,7 @@ const card: Card = {
 
 	description: {
 		en: "It is encased in a steel shell. Its peering eyes are all that can be seen of its mysterious innards.",
+		de: "Dieses Pokémon ist von einer Stahlhülle umgeben. Seine stechenden Augen sind alles, was man von ihm sieht."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/61.ts
+++ b/data/XY/Flashfire/61.ts
@@ -70,7 +70,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, este ataque hace 20 puntos de daño más.",
 				it: "Lancia una moneta. Se esce testa, questo attacco infligge 20 danni in più.",
 				pt: "Jogue uma moeda. Se sair cara, esse ataque causará 20 de danos adicionais.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 20 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -95,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "Individuals each play different roles in driving Heatmor, their natural predator, away from their colony.",
+		de: "Eine ausgeklügelte Rollenverteilung hilft ihnen dabei, ihren natürlichen Feind Furnifraß aus dem Nest zu verjagen."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/62.ts
+++ b/data/XY/Flashfire/62.ts
@@ -71,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "It draws out and controls the hidden power of flowers. The flower Flabébé holds is most likely part of its body.",
+		de: "Es entlockt Blumen ihre geheimen Kräfte und kontrolliert diese nach Belieben. Die Blume, die es trägt, ist wie ein Teil seines Körpers."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/63.ts
+++ b/data/XY/Flashfire/63.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It draws out and controls the hidden power of flowers. The flower Flabébé holds is most likely part of its body.",
+		de: "Es entlockt Blumen ihre geheimen Kräfte und kontrolliert diese nach Belieben. Die Blume, die es trägt, ist wie ein Teil seines Körpers."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/64.ts
+++ b/data/XY/Flashfire/64.ts
@@ -54,7 +54,7 @@ const card: Card = {
 				es: "Cada uno de tus Pokémon Grass en juego obtiene 20 PS más.",
 				it: "Tutti i tuoi Pokémon Grass in gioco hanno 20 PS in più.",
 				pt: "Cada um dos seus Pokémon Grass em jogo recebe +20 PS.",
-				de: "Jedes deiner Grass-Pokémon im Spiel erhält +20 KP."
+				de: "Jedes deiner {G}-Pokémon im Spiel erhält +20 KP."
 			},
 		},
 	],
@@ -96,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "It flutters around fields of flowers and cares for flowers that are starting to wilt. It draws out the hidden power of flowers to battle.",
+		de: "Es fliegt auf Wiesen umher und kümmert sich um welkende Blumen. Es setzt deren geheime Kräfte frei und nutzt diese zum Kämpfen."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/65.ts
+++ b/data/XY/Flashfire/65.ts
@@ -97,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "It flutters around fields of flowers and cares for flowers that are starting to wilt. It draws out the hidden power of flowers to battle.",
+		de: "Es fliegt auf Wiesen umher und kümmert sich um welkende Blumen. Es setzt deren geheime Kräfte frei und nutzt diese zum Kämpfen."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/66.ts
+++ b/data/XY/Flashfire/66.ts
@@ -102,6 +102,7 @@ const card: Card = {
 
 	description: {
 		en: "It claims exquisite flower gardens as its territory, and it obtains power from basking in the energy emitted by flowering plants.",
+		de: "Wunderschöne Blumengärten sind sein Revier. Es badet in der von blühenden Blumen freigesetzten Energie und zieht daraus seine Kraft."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/67.ts
+++ b/data/XY/Flashfire/67.ts
@@ -64,7 +64,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cruz, este ataque no hace nada.",
 				it: "Lancia una moneta. Se esce croce, questo attacco non ha effetto.",
 				pt: "Jogue uma moeda. Se sair coroa, esse ataque não fará nada.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 30,
 
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It emits a scent that enraptures those who smell it. This fragrance changes depending on what it has eaten.",
+		de: "Der von ihm verströmte Duft verzückt jeden, der ihn riecht. Je nachdem, was es frisst, ändert sich sein Duft."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/68.ts
+++ b/data/XY/Flashfire/68.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, evita todos los efectos de los ataques, incluido el daño, infligidos a este Pokémon durante el próximo turno de tu rival.",
 				it: "Lancia una moneta. Se esce testa, previeni tutti gli effetti degli attacchi, inclusi i danni, inflitti a questo Pokémon durante il prossimo turno del tuo avversario.",
 				pt: "Jogue uma moeda. Se sair cara, impedirá todos os efeitos dos ataques a este Pokémon, inclusive danos, durante a próxima vez de jogar do seu oponente.",
-				de: "Wirf 1 Münze. Verhindere bei \"Kopf\" während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die diesem Pokémon zugefügt werden."
+				de: "Wirf 1 Münze. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die diesem Pokémon zugefügt werden."
 			},
 
 		},
@@ -71,7 +71,7 @@ const card: Card = {
 				es: "Este ataque hace 20 puntos de daño más por cada Energía Fairy unida a este Pokémon.",
 				it: "Questo attacco infligge 20 danni in più per ogni Energia Fairy assegnata a questo Pokémon.",
 				pt: "Esse ataque causa 20 de danos adicionais para cada Energia Fairy ligada a este Pokémon.",
-				de: "Dieser Angriff fügt 20 weitere Schadenspunkte für jede an dieses Pokémon angelegte Fairy-Energie zu."
+				de: "Dieser Angriff fügt 20 weitere Schadenspunkte für jede an dieses Pokémon angelegte {FAIRY}-Energie zu."
 			},
 			damage: "40+",
 
@@ -96,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "Born from temperatures and pressures deep underground, it fires beams from the stone in its head.",
+		de: "Dieses Pokémon entstand aus Druck und Hitze in den tiefsten Erdschichten. Mithilfe des Steines in seinem Kopf feuert es Energiestrahlen ab."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/7.ts
+++ b/data/XY/Flashfire/7.ts
@@ -54,7 +54,7 @@ const card: Card = {
 				es: "Una vez durante tu turno (antes de tu ataque), puedes descartar 1 carta de Energía Grass de tu mano. Si lo haces, roba 3 cartas.",
 				it: "Una sola volta durante il tuo turno, prima di attaccare, puoi scartare una carta Energia Grass che hai in mano. Se lo fai, pesca tre carte.",
 				pt: "Uma vez durante sua vez de jogar (antes de atacar), você pode descartar um card de Energia Grass da sua mão. Se fizer isso, compre 3 cards.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 Grass-Energiekarte von deiner Hand auf deinen Ablagestapel legen. Wenn du das machst, ziehe 3 Karten."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 {G}-Energiekarte von deiner Hand auf deinen Ablagestapel legen. Wenn du das machst, ziehe 3 Karten."
 			},
 		},
 	],
@@ -98,6 +98,7 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon that was feared as a forest guardian. It can read the foe's mind and take preemptive action.",
+		de: "Dieses Pokémon wurde als Wächter des Waldes gefürchtet. Es kann die Gedanken des Gegners lesen und präventiv handeln."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/70.ts
+++ b/data/XY/Flashfire/70.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "It races through narrow caves, using its sharp claws to catch prey. The skin on its face is harder than a rock.",
+		de: "Es jagt durch enge Höhlengänge und spießt seine Gegner mit spitzen Klauen auf. Seine Kopfhaut ist fester als Stein."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/71.ts
+++ b/data/XY/Flashfire/71.ts
@@ -80,7 +80,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Envenenado.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene avvelenato.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente será Envenenado.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Aktive Pokémon deines Gegners jetzt vergiftet."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Aktive Pokémon deines Gegners jetzt vergiftet."
 			},
 			damage: 60,
 
@@ -98,6 +98,7 @@ const card: Card = {
 
 	description: {
 		en: "Their poison is strong enough to eat through the hull of a tanker, and they spit it indiscriminately at anything that enters their territory.",
+		de: "Das Gift, mit dem es Eindringlinge in seinem Revier bespritzt, ist ätzend genug, um sich durch den Stahl eines Tankschiffes zu fressen."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/72.ts
+++ b/data/XY/Flashfire/72.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "The weakest Dragon-type Pokémon, it lives in damp, shady places, so its body doesn't dry out.",
+		de: "Dieses schwächste aller Drachen-Pokémon lebt an feuchten und schattigen Plätzen, um seinen glitschigen Körper vor dem Austrocknen zu bewahren."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/73.ts
+++ b/data/XY/Flashfire/73.ts
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "It drives away opponents by excreting a sticky liquid that can dissolve anything. Its eyes devolved, so it can't see anything.",
+		de: "Es verjagt Gegner durch Absonderung eines alles zersetzenden Schleims. Die zurückgebildeten Augäpfel des Pokémon gewähren ihm keine Sicht."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/74.ts
+++ b/data/XY/Flashfire/74.ts
@@ -80,7 +80,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, este ataque hace 40 puntos de daño más.",
 				it: "Lancia una moneta. Se esce testa, questo attacco infligge 40 danni in più.",
 				pt: "Jogue uma moeda. Se sair cara, este ataque causará 40 de danos adicionais.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 40 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 40 weitere Schadenspunkte zu."
 			},
 			damage: "80+",
 
@@ -98,6 +98,7 @@ const card: Card = {
 
 	description: {
 		en: "This very friendly Dragon-type Pokémon will hug its beloved Trainer, leaving that Trainer covered in sticky slime.",
+		de: "Dieses äußerst freundliche Drachen-Pokémon neigt dazu, seinen geliebten Trainer zu umarmen und so mit einer dicken Schleimschicht zu umhüllen."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/75.ts
+++ b/data/XY/Flashfire/75.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "A common sight in forests and woods. It flaps its wings at ground level to kick up blinding sand.",
+		de: "Ein vorwiegend in Wäldern lebendes Pokémon, das zur Verteidigung mit den Flügeln Sand aufwirbelt."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/76.ts
+++ b/data/XY/Flashfire/76.ts
@@ -56,7 +56,7 @@ const card: Card = {
 				es: "Si el Pokémon Defensor intenta atacar durante el próximo turno de tu rival, este lanza 1 moneda. Si sale cruz, ese ataque no hace nada.",
 				it: "Se durante il prossimo turno del tuo avversario il Pokémon difensore prova ad attaccare, il tuo avversario lancia una moneta. Se esce croce, quell'attacco non ha effetto.",
 				pt: "Se o Pokémon Defensor tentar atacar durante a próxima vez de jogar do seu oponente, seu oponente jogará uma moeda. Se sair coroa, o ataque não fará nada.",
-				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 
 		},
@@ -79,7 +79,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, este ataque hace 20 puntos de daño más.",
 				it: "Lancia una moneta. Se esce testa, questo attacco infligge 20 danni in più.",
 				pt: "Jogue uma moeda. Se sair cara, esse ataque causará 20 de danos adicionais.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 20 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -104,6 +104,7 @@ const card: Card = {
 
 	description: {
 		en: "The claws on its feet are well developed. It can carry prey such as an Exeggcute to its nest over 60 miles away.",
+		de: "Die Krallen an seinen Füßen sind sehr ausgeprägt. Es kann sogar ein Owei zu seinem Nest in 100 km Entfernung tragen."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/77.ts
+++ b/data/XY/Flashfire/77.ts
@@ -107,6 +107,7 @@ const card: Card = {
 
 	description: {
 		en: "When hunting, it skims the surface of water at high speed to pick off unwary prey such as Magikarp.",
+		de: "Dieses Pokémon schnellt bei der Jagd blitzschnell unter Wasser, um seine ahnungslose Beute zu fangen."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/78.ts
+++ b/data/XY/Flashfire/78.ts
@@ -71,7 +71,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, este ataque hace 30 puntos de daño más.",
 				it: "Lancia una moneta. Se esce testa, questo attacco infligge 30 danni in più.",
 				pt: "Jogue uma moeda. Se sair cara, esse ataque causará 30 de danos adicionais.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 30 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: "70+",
 

--- a/data/XY/Flashfire/79.ts
+++ b/data/XY/Flashfire/79.ts
@@ -58,7 +58,7 @@ const card: Card = {
 				es: "Lanza 1 moneda hasta que salga cruz. Este ataque hace 30 puntos de daño más por cada cara.",
 				it: "Lancia una moneta finché non esce croce. Ogni volta che esce testa, questo attacco infligge 30 danni in più.",
 				pt: "Jogue uma moeda até sair coroa. Este ataque causa 30 de danos adicionais para cada cara.",
-				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis \"Zahl\" kommt. Dieser Angriff fügt 30 weitere Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Dieser Angriff fügt 30 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "100+",
 

--- a/data/XY/Flashfire/8.ts
+++ b/data/XY/Flashfire/8.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Dormido.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene addormentato.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente ficará Adormecido.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" schläft das Aktive Pokémon deines Gegners jetzt."
+				de: "Wirf 1 Münze. Bei „Kopf“ schläft das Aktive Pokémon deines Gegners jetzt."
 			},
 			damage: 10,
 
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It uses the different poisons in each hand separately when it attacks. The stronger its aroma, the healthier it is.",
+		de: "Aus seinen Händen verströmt es jeweils ein anderes Gift. Je stärker Roselia duftet, desto gesünder ist es."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/80.ts
+++ b/data/XY/Flashfire/80.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Si este Pokémon está Dormido, lanza 2 monedas en vez de 1 entre turnos. Si sale cruz en alguna de ellas, este Pokémon está todavía Dormido.",
 				it: "Se questo Pokémon è addormentato, tra un turno e l'altro, lancia due volte una moneta invece di una. Se esce almeno una volta croce, questo Pokémon resta addormentato.",
 				pt: "Se este Pokémon estiver Adormecido, jogue 2 moedas em vez de 1 entre as vezes de jogar. Se alguma delas for coroa, esse Pokémon permanecerá Adormecido.",
-				de: "Wenn dieses Pokémon schläft, wirf zwischen den Zügen 2 Münzen anstelle von 1 Münze. Wenn eine oder beide Münzen \"Zahl\" zeigen, schläft dieses Pokémon weiter."
+				de: "Wenn dieses Pokémon schläft, wirf zwischen den Zügen 2 Münzen anstelle von 1 Münze. Wenn eine oder beide Münzen „Zahl“ zeigen, schläft dieses Pokémon weiter."
 			},
 		},
 	],
@@ -90,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "It is not satisfied unless it eats over 880 pounds of food every day. When it is done eating, it goes promptly to sleep.",
+		de: "Es ist erst satt, wenn es über 400 kg Nahrung am Tag gefressen hat. Ist es mit dem Essen fertig, schläft es sofort ein."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/81.ts
+++ b/data/XY/Flashfire/81.ts
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "When acting as a lookout, it warns others of danger by screeching and hitting the ground with its tail.",
+		de: "Wenn es Wache hat, warnt es seine Artgenossen, indem es schreit und mit dem Schwanz auf den Boden schlägt."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/82.ts
+++ b/data/XY/Flashfire/82.ts
@@ -79,7 +79,7 @@ const card: Card = {
 				es: "Lanza 2 monedas. Este ataque hace 30 puntos de daño por cada cara.",
 				it: "Lancia due volte una moneta. Questo attacco infligge 30 danni ogni volta che esce testa.",
 				pt: "Jogue 2 moedas. Esse ataque causa 30 de danos vezes o número de caras.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "30×",
 
@@ -97,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "The mother puts its offspring to sleep by curling up around them. It corners foes with speed.",
+		de: "Es rollt sich um seine Jungen, wenn diese schlafen sollen. Gegnern begegnet es mit Schnelligkeit."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/83.ts
+++ b/data/XY/Flashfire/83.ts
@@ -83,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "If it is around babies, the milk it produces contains much more nutrition than usual.",
+		de: "Wenn es gerade ein Junges hat, dann enthält seine Milch mehr Nährstoffe als gewöhnlich."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/84.ts
+++ b/data/XY/Flashfire/84.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "Its ears are always rolled up. They can be forcefully extended to shatter even a large boulder.",
+		de: "Seine Ohren sind immer aufgerollt. Mit ihnen kann es selbst große Felsbrocken zertrümmern."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/85.ts
+++ b/data/XY/Flashfire/85.ts
@@ -80,7 +80,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cruz, este Pokémon no puede atacar durante tu próximo turno.",
 				it: "Lancia una moneta. Se esce croce, durante il tuo prossimo turno, questo Pokémon non può attaccare.",
 				pt: "Jogue uma moeda. Se sair coroa, este Pokémon não poderá atacar durante sua próxima vez de jogar.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" kann dieses Pokémon während deines nächsten Zuges nicht angreifen."
+				de: "Wirf 1 Münze. Bei „Zahl“ kann dieses Pokémon während deines nächsten Zuges nicht angreifen."
 			},
 			damage: 80,
 
@@ -98,6 +98,7 @@ const card: Card = {
 
 	description: {
 		en: "Extremely cautious, it quickly bounds off when it senses danger.",
+		de: "Es ist extrem vorsichtig. Wenn es Gefahr wittert, macht es sich mit flinken Sprüngen aus dem Staub."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/86.ts
+++ b/data/XY/Flashfire/86.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, este ataque hace 10 puntos de daño más.",
 				it: "Lancia una moneta. Se esce testa, questo attacco infligge 10 danni in più.",
 				pt: "Jogue uma moeda. Se sair cara, este ataque causará 10 de danos adicionais.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 10 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "These friendly Pokémon send signals to one another with beautiful chirps and tail-feather movements.",
+		de: "Ein sehr zutrauliches Pokémon. Durch Zwitschern und Bewegen der Schwanzfedern sendet es Signale an seine Gefährten."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/87.ts
+++ b/data/XY/Flashfire/87.ts
@@ -48,7 +48,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Paralizado.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene paralizzato.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente será Paralisado.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Aktive Pokémon deines Gegners jetzt paralysiert."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 			},
 			damage: 20,
 
@@ -84,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "Trimming its fluffy fur not only makes it more elegant but also increases the swiftness of its movements.",
+		de: "Schneidet man sein Fell zurecht, wird es nicht nur schöner, sondern auch beweglicher."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/88.ts
+++ b/data/XY/Flashfire/88.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Une 2 cartas de Energía Fire de tu pila de descartes a 1 de tus Pokémon Fire.",
 		it: "Assegna a uno dei tuoi Pokémon Fire due carte Energia Fire dalla tua pila degli scarti.",
 		pt: "Ligue 2 cards de Energia Fire da sua pilha de descarte a 1 dos seus Pokémon Fire.",
-		de: "Lege 2 Fire-Energiekarten von deinem Ablagestapel an 1 deiner Fire-Pokémon an."
+		de: "Lege 2 {R}-Energiekarten von deinem Ablagestapel an 1 deiner {R}-Pokémon an. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/XY/Flashfire/88a.ts
+++ b/data/XY/Flashfire/88a.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Une 2 cartas de Energía Fire de tu pila de descartes a 1 de tus Pokémon Fire.",
 		it: "Assegna a uno dei tuoi Pokémon Fire due carte Energia Fire dalla tua pila degli scarti.",
 		pt: "Ligue 2 cards de Energia Fire da sua pilha de descarte a 1 dos seus Pokémon Fire.",
-		de: "Lege 2 Fire-Energiekarten von deinem Ablagestapel an 1 deiner Fire-Pokémon an."
+		de: "Lege 2 {R}-Energiekarten von deinem Ablagestapel an 1 deiner {R}-Pokémon an. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/89.ts
+++ b/data/XY/Flashfire/89.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta 1 carta de Energía Fire de tu mano. (Si no puedes descartar 1 carta de Energía Fire, no puedes jugar esta carta). Roba 2 cartas.",
 		it: "Scarta una carta Energia Fire presente tra le carte che hai in mano (se non puoi scartare una carta Energia Fire, non puoi giocare questa carta). Pesca due carte.",
 		pt: "Descarte um card de Energia Fire de sua mão. (Se você não puder descartar um card de Energia Fire, não poderá jogar esse card.) Compre 2 cards.",
-		de: "Lege 1 Fire-Energiekarte von deiner Hand auf deinen Ablagestapel. (Wenn du keine Fire-Energiekarte auf deinen Ablagestapel legen kannst, kannst du diese Karte nicht spielen.) Ziehe 2 Karten."
+		de: "Lege 1 {R}-Energiekarte von deiner Hand auf deinen Ablagestapel. (Wenn du keine {R}-Energiekarte auf deinen Ablagestapel legen kannst, kannst du diese Karte nicht spielen.) Ziehe 2 Karten. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/XY/Flashfire/9.ts
+++ b/data/XY/Flashfire/9.ts
@@ -56,7 +56,7 @@ const card: Card = {
 				es: "Lanza 1 moneda hasta que salga cruz. Por cada cara, descarta 1 Energía unida al Pokémon Activo de tu rival.",
 				it: "Lancia una moneta finché non esce croce. Ogni volta che esce testa, scarta un'Energia assegnata al Pokémon attivo del tuo avversario.",
 				pt: "Jogue uma moeda até sair coroa. Para cada cara, descarte uma Energia ligada ao Pokémon Ativo do seu oponente.",
-				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis \"Zahl\" kommt. Lege pro \"Kopf\" 1 an das Aktive Pokémon deines Gegners angelegte Energie auf den Ablagestapel deines Gegners."
+				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Lege pro „Kopf“ 1 an das Aktive Pokémon deines Gegners angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 
 		},
@@ -98,6 +98,7 @@ const card: Card = {
 
 	description: {
 		en: "Luring prey with a sweet scent, it uses poison whips on its arms to poison, bind, and finish off the prey.",
+		de: "Es lockt seine Beute mit süßem Duft an, um sie danach mit seinen dornigen Ranken zu peitschen oder zu würgen."
 	},
 
 	thirdParty: {

--- a/data/XY/Flashfire/90.ts
+++ b/data/XY/Flashfire/90.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cambia 1 de los Pokémon en Banca de tu rival por su Pokémon Activo.",
 		it: "Scambia uno dei Pokémon nella panchina del tuo avversario con il suo Pokémon attivo.",
 		pt: "Troque 1 dos Pokémon no Banco do seu oponente pelo Pokémon Ativo desse oponente.",
-		de: "Tausche 1 Pokémon auf der Bank deines Gegners gegen das Aktive Pokémon deines Gegners aus."
+		de: "Tausche 1 Pokémon auf der Bank deines Gegners gegen das Aktive Pokémon deines Gegners aus. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/XY/Flashfire/91.ts
+++ b/data/XY/Flashfire/91.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Los Pokémon en juego no tienen ninguna Resistencia.",
 		it: "Nessun Pokémon in gioco ha resistenza.",
 		pt: "Cada um dos Pokémon em jogo não possui Resistência.",
-		de: "Jedes Pokémon im Spiel hat keine Resistenz."
+		de: "Jedes Pokémon im Spiel hat keine Resistenz. Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 
 	trainerType: "Stadium",

--- a/data/XY/Flashfire/92.ts
+++ b/data/XY/Flashfire/92.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon 2 cartas de Partidario de tu pila de descartes en tu baraja y barájalas todas.",
 		it: "Rimischia due carte Aiuto dalla tua pila degli scarti nel tuo mazzo.",
 		pt: "Embaralhe 2 cards de Apoiador da sua pilha de descarte no seu baralho.",
-		de: "Mische 2 Unterstützerkarten aus deinem Ablagestapel in dein Deck."
+		de: "Mische 2 Unterstützerkarten aus deinem Ablagestapel in dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/XY/Flashfire/93.ts
+++ b/data/XY/Flashfire/93.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cura 60 puntos de daño y elimina todas las Condiciones Especiales de 1 de tus Pokémon.",
 		it: "Cura uno dei tuoi Pokémon da 60 danni e rimuovi tutte le condizioni speciali che lo influenzano.",
 		pt: "Cure 60 de danos e remova todas as Condições Especiais de 1 dos seus Pokémon.",
-		de: "Heile 60 Schadenspunkte bei 1 deiner Pokémon. Alle Speziellen Zustände auf diesem Pokémon verlieren ihre Wirkung."
+		de: "Heile 60 Schadenspunkte bei 1 deiner Pokémon. Alle Speziellen Zustände auf diesem Pokémon verlieren ihre Wirkung. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/XY/Flashfire/94.ts
+++ b/data/XY/Flashfire/94.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 2 Pokémon Básicos, enséñalos y ponlos en tu mano. Baraja las cartas de tu baraja después.",
 		it: "Cerca nel tuo mazzo fino a due Pokémon Base, mostrali e aggiungili alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure no seu baralho até 2 Pokémon Básicos, revele-os e coloque-os na mão. Em seguida, embaralhe seus cards.",
-		de: "Durchsuche dein Deck nach bis zu 2 Basis-Pokémon, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach bis zu 2 Basis-Pokémon, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/XY/Flashfire/95.ts
+++ b/data/XY/Flashfire/95.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Evita todo el daño al Pokémon al que esté unida esta carta por ataques que este use.",
 		it: "Previeni tutti i danni inflitti al Pokémon a cui è assegnata questa carta da attacchi che usa.",
 		pt: "Impede todos os danos causados ao Pokémon ao qual este card está ligado pelos ataques que ele usa.",
-		de: "Verhindere allen Schaden, der dem Pokémon, an das diese Karte angelegt ist, durch Angriffe, die es einsetzt, zugefügt würde."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Verhindere allen Schaden, der dem Pokémon, an das diese Karte angelegt ist, durch Angriffe, die es einsetzt, zugefügt würde. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/XY/Flashfire/96.ts
+++ b/data/XY/Flashfire/96.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon 5 Pokémon de tu pila de descartes en tu baraja y baraja todas las cartas.",
 		it: "Rimischia cinque Pokémon dalla tua pila degli scarti nel tuo mazzo.",
 		pt: "Embaralhe 5 Pokémon da sua pilha de descarte no seu baralho.",
-		de: "Mische 5 Pokémon aus deinem Ablagestapel in dein Deck."
+		de: "Mische 5 Pokémon aus deinem Ablagestapel in dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/XY/Flashfire/97.ts
+++ b/data/XY/Flashfire/97.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta todas las cartas de Herramienta Pokémon unidas a cada uno de los Pokémon de tu rival.",
 		it: "Scarta tutte le carte Oggetto Pokémon assegnate ai Pokémon del tuo avversario.",
 		pt: "Descarte todos os cards de Ferramenta Pokémon ligados aos Pokémon do oponente.",
-		de: "Lege alle an gegnerische Pokémon angelegte Pokémon-Ausrüstungen auf den Ablagestapel deines Gegners."
+		de: "Lege alle an gegnerische Pokémon angelegte Pokémon-Ausrüstungen auf den Ablagestapel deines Gegners. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/XY/Flashfire/98.ts
+++ b/data/XY/Flashfire/98.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mira la primera carta de la baraja de cualquiera de los jugadores. Puedes descartar esa carta o devolverla a la parte superior de la baraja.",
 		it: "Guarda la carta in cima al mazzo di uno dei giocatori. Puoi scartare quella carta o rimetterla in cima al mazzo.",
 		pt: "Olhe o card de cima do baralho de cada jogador. Você pode descartá-lo ou devolvê-lo para cima do baralho.",
-		de: "Schau dir die oberste Karte des Decks eines Spielers an. Du kannst diese Karte auf den Ablagestapel oder zurück auf das Deck legen."
+		de: "Schau dir die oberste Karte des Decks eines Spielers an. Du kannst diese Karte auf den Ablagestapel oder zurück auf das Deck legen. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/XY/Flashfire/99.ts
+++ b/data/XY/Flashfire/99.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta 2 cartas de tu mano. (Si no puedes descartar 2 cartas, no puedes jugar esta carta). Busca en tu baraja un Pokémon, enséñalo y ponlo en tu mano. Baraja las cartas de tu baraja después.",
 		it: "Scarta due delle carte che hai in mano (se non puoi scartare due carte, non potrai giocare questa carta). Cerca nel tuo mazzo un Pokémon, mostralo e aggiungilo alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Descarte 2 cards da sua mão. (Se você não puder descartar 2 cards, não poderá jogar esse card.) Procure um Pokémon em seu baralho, revele-o e coloque-o em sua mão. Em seguida, embaralhe seus cards.",
-		de: "Lege 2 Karten von deiner Hand auf deinen Ablagestapel. (Wenn du keine 2 Karten auf deinen Ablagestapel legen kannst, kannst du diese Karte nicht spielen.) Durchsuche dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck."
+		de: "Lege 2 Karten von deiner Hand auf deinen Ablagestapel. (Wenn du keine 2 Karten auf deinen Ablagestapel legen kannst, kannst du diese Karte nicht spielen.) Durchsuche dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",


### PR DESCRIPTION
## Add missing German translations for xy2

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
