### PR TITLE
Add missing German translations for tk-xy-su

### DIFF
--- a/data/Trainer kits/XY trainer Kit (Suicune)/14.ts
+++ b/data/Trainer kits/XY trainer Kit (Suicune)/14.ts
@@ -23,25 +23,29 @@ const card: Card = {
 	illustrator: "Yoshinobu Saito",
 
 	description: {
-		en: "Said to be the embodiment of north winds, it can instantly purify filthy, murky water."
+		en: "Said to be the embodiment of north winds, it can instantly purify filthy, murky water.",
+		de: "Man sagt, es sei die Wiedergeburt des Nordwindes. Es kann verschmutztes Wasser im Nu reinigen."
 	},
 
 	attacks: [{
 		name: {
 			en: "Spiral Drain",
-			fr: "Spirale Épuisante"
+			fr: "Spirale Épuisante",
+			de: "Spiralsauger"
 		},
 
 		damage: 20,
 
 		effect: {
 			en: "Heal 20 damage from this Pokémon.",
-			fr: "Soignez 20 dégâts à ce Pokémon."
+			fr: "Soignez 20 dégâts à ce Pokémon.",
+			de: "Heile 20 Schadenspunkte bei diesem Pokémon."
 		}
 	}, {
 		name: {
 			en: "Aurora Beam",
-			fr: "Onde Boréale"
+			fr: "Onde Boréale",
+			de: "Aurorastrahl"
 		},
 
 		damage: 80

--- a/data/Trainer kits/XY trainer Kit (Suicune)/20.ts
+++ b/data/Trainer kits/XY trainer Kit (Suicune)/20.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba 3 cartas.",
 		it: "Pesca tre carte.",
 		pt: "Compre 3 cards.",
-		de: "Ziehe 3 Karten."
+		de: "Ziehe 3 Karten. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Trainer kits/XY trainer Kit (Suicune)/29.ts
+++ b/data/Trainer kits/XY trainer Kit (Suicune)/29.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba 3 cartas.",
 		it: "Pesca tre carte.",
 		pt: "Compre 3 cards.",
-		de: "Ziehe 3 Karten."
+		de: "Ziehe 3 Karten. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Trainer kits/XY trainer Kit (Suicune)/30.ts
+++ b/data/Trainer kits/XY trainer Kit (Suicune)/30.ts
@@ -23,25 +23,29 @@ const card: Card = {
 	illustrator: "Yoshinobu Saito",
 
 	description: {
-		en: "Said to be the embodiment of north winds, it can instantly purify filthy, murky water."
+		en: "Said to be the embodiment of north winds, it can instantly purify filthy, murky water.",
+		de: "Man sagt, es sei die Wiedergeburt des Nordwindes. Es kann verschmutztes Wasser im Nu reinigen."
 	},
 
 	attacks: [{
 		name: {
 			en: "Spiral Drain",
-			fr: "Spirale Épuisante"
+			fr: "Spirale Épuisante",
+			de: "Spiralsauger"
 		},
 
 		damage: 20,
 
 		effect: {
 			en: "Heal 20 damage from this Pokémon.",
-			fr: "Soignez 20 dégâts à ce Pokémon."
+			fr: "Soignez 20 dégâts à ce Pokémon.",
+			de: "Heile 20 Schadenspunkte bei diesem Pokémon."
 		}
 	}, {
 		name: {
 			en: "Aurora Beam",
-			fr: "Onde Boréale"
+			fr: "Onde Boréale",
+			de: "Aurorastrahl"
 		},
 
 		damage: 80

--- a/data/Trainer kits/XY trainer Kit (Suicune)/4.ts
+++ b/data/Trainer kits/XY trainer Kit (Suicune)/4.ts
@@ -23,27 +23,31 @@ const card: Card = {
 	illustrator: "Kouki Saitou",
 
 	description: {
-		en: "Thanks to its unstable genetic makeup, this special Pokémon conceals many different possible evolutions."
+		en: "Thanks to its unstable genetic makeup, this special Pokémon conceals many different possible evolutions.",
+		de: "Aufgrund einer genetischen Anomalie kann seine Entwicklung viele verschiedene Formen annehmen."
 	},
 
 	attacks: [{
 		name: {
 			en: "Tackle",
-			fr: "Charge"
+			fr: "Charge",
+			de: "Tackle"
 		},
 
 		damage: 10
 	}, {
 		name: {
 			en: "Lunge",
-			fr: "Coup Rapide"
+			fr: "Coup Rapide",
+			de: "Ausfall"
 		},
 
 		damage: 30,
 
 		effect: {
 			en: "Flip a coin. If tails, this attack does nothing.",
-			fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien."
+			fr: "Lancez une pièce. Si c'est pile, cette attaque ne fait rien.",
+			de: "Wird 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkung."
 		}
 	}],
 


### PR DESCRIPTION
## Add missing German translations for tk-xy-su

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
