### PR TITLE
Add missing German translations for xy11

### DIFF
--- a/data/XY/Steam Siege/1.ts
+++ b/data/XY/Steam Siege/1.ts
@@ -48,7 +48,7 @@ const card: Card = {
 				es: "Lanza 2 monedas. Este ataque hace 30 puntos de daño por cada cara.",
 				it: "Lancia due volte una moneta. Questo attacco infligge 30 danni ogni volta che esce testa.",
 				pt: "Jogue 2 moedas. Este ataque causa 30 de danos vezes o número de caras.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "30×",
 
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "It tangles any moving thing with its vines. Their subtle shaking is ticklish if you get ensnared.",
+		de: "Es berührt alles, was sich bewegt, mit seinen Ranken. Diese Berührungen kitzeln sehr."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/10.ts
+++ b/data/XY/Steam Siege/10.ts
@@ -90,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives deep in forests. With the leaf on its head, it makes a flute whose song makes listeners uneasy.",
+		de: "Lebt tief im Wald. Es baut sich eine Flöte aus den Blättern seines Kopfes. Ihr Ton verbreitet Schrecken."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/100.ts
+++ b/data/XY/Steam Siege/100.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mira las 7 últimas cartas de tu baraja. Puedes enseñar 1 Anorith que encuentres entre ellas y ponerlo en tu Banca. Pon el resto de cartas de nuevo en tu baraja y barájalas todas.",
 		it: "Guarda le ultime sette carte del tuo mazzo. Puoi mostrare un Anorith presente tra quelle carte e metterlo nella tua panchina. Poi rimischia le altre carte nel tuo mazzo.",
 		pt: "Olhe os 7 cards debaixo do seu baralho. Você poderá revelar um Anorith que encontrar lá e colocá-lo no seu Banco. Embaralhe os demais cards de volta no seu baralho.",
-		de: "Schau dir die untersten 7 Karten deines Decks an. Falls du dort ein Anorith findest, kannst du es deinem Gegner zeigen und auf deine Bank legen. Mische die anderen Karten zurück in dein Deck."
+		de: "Schau dir die untersten 7 Karten deines Decks an. Falls du dort ein Anorith findest, kannst du es deinem Gegner zeigen und auf deine Bank legen. Mische die anderen Karten zurück in dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/XY/Steam Siege/101.ts
+++ b/data/XY/Steam Siege/101.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Tu turno no termina si el Pokémon al que está unida esta carta se convierte en M-Gardevoir-EX.",
 		it: "Il tuo turno non finisce se il Pokémon a cui è assegnata questa carta diventa M Gardevoir-EX.",
 		pt: "Sua vez de jogar não terminará se o Pokémon ao qual este card está ligado tornar-se M-Gardevoir-EX.",
-		de: "Dein Zug endet nicht, wenn das Pokémon, an das diese Karte angelegt ist, zu M-Guardevoir-EX wird."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Dein Zug endet nicht, wenn das Pokémon, an das diese Karte angelegt ist, zu M-Guardevoir-EX wird. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/XY/Steam Siege/102.ts
+++ b/data/XY/Steam Siege/102.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Puedes jugar esta carta solo si la has cogido de entre las cartas de Premio que están boca abajo, antes de ponerla en tu mano.Lanza 1 moneda. Si sale cara, coge 1 carta de Premio más.",
 		it: "Puoi giocare questa carta solo se l'hai presa come carta Premio ed era a faccia in giù prima di aggiungerla alla tua mano.Lancia una moneta. Se esce testa, prendi un'altra carta Premio.",
 		pt: "Você pode jogar este card somente se o pegou dos seus cards de Prêmio virados para baixo, antes de colocá-lo na sua mão.Jogue uma moeda. Se sair cara, pegue mais 1 card de Prêmio.",
-		de: "Du kannst diese Karte nur spielen, wenn du sie als verdeckte Preiskarte auf deine Hand genommen hast.Wirf 1 Münze. Nimm bei \"Kopf\" 1 zusätzliche Preiskarte."
+		de: "Du kannst diese Karte nur spielen, wenn du sie als verdeckte Preiskarte auf deine Hand genommen hast. Wirf 1 Münze. Nimm bei „Kopf“ 1 zusätzliche Preiskarte. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/XY/Steam Siege/103.ts
+++ b/data/XY/Steam Siege/103.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Elige 1 de tus Pokémon Básicos en juego. Busca en tu baraja 1 Pokémon Básico y cámbialo por ese Pokémon. (Todas las cartas unidas a este Pokémon, los contadores de daño, las Condiciones Especiales, los turnos de juego y todos los demás efectos permanecen en el nuevo Pokémon). Pon el primer Pokémon de nuevo en tu baraja y baraja todas las cartas.",
 		it: "Scegli uno dei tuoi Pokémon Base in gioco. Cerca nel tuo mazzo un Pokémon Base e scambialo con quel Pokémon (le carte assegnate, i segnalini danno, le condizioni speciali, il numero di turni da cui è in gioco e qualsiasi altro effetto restano sul nuovo Pokémon). Poi rimischia il primo Pokémon nel tuo mazzo.",
 		pt: "Escolha 1 dos seus Pokémon Básicos em jogo. Procure em seu baralho 1 Pokémon Básico e troque-o com aquele Pokémon. (Quaisquer cards ligados, contadores de danos, Condições Especiais, vezes em jogo e quaisquer outros efeitos permanecem no novo Pokémon.) Embaralhe o primeiro Pokémon de volta no seu baralho.",
-		de: "Wähle 1 deiner Basis-Pokémon im Spiel. Durchsuche dein Deck nach 1 Basis-Pokémon und tausche es gegen jenes Pokémon aus. (Alle angelegten Karten sowie alle Schadensmarken, Speziellen Zustände, Spielzüge und alle anderen Effekte verbleiben auf dem neuen Pokémon.) Mische das erste Pokémon in dein Deck."
+		de: "Wähle 1 deiner Basis-Pokémon im Spiel. Durchsuche dein Deck nach 1 Basis-Pokémon und tausche es gegen jenes Pokémon aus. (Alle angelegten Karten sowie alle Schadensmarken, Speziellen Zustände, Spielzüge und alle anderen Effekte verbleiben auf dem neuen Pokémon.) Mische das erste Pokémon in dein Deck. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/XY/Steam Siege/104.ts
+++ b/data/XY/Steam Siege/104.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Elimina todos los efectos de los ataques en cada jugador y sus Pokémon.",
 		it: "Rimuovi tutti gli effetti degli attacchi da ciascun giocatore e dai suoi Pokémon.",
 		pt: "Remove todos os efeitos de ataques em cada jogador e seus Pokémon.",
-		de: "Alle Effekte von Angriffen verlieren bei beiden Spielern und ihren Pokémon ihre Wirkung."
+		de: "Alle Effekte von Angriffen verlieren bei beiden Spielern und ihren Pokémon ihreWirkung. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/XY/Steam Siege/105.ts
+++ b/data/XY/Steam Siege/105.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon 2 cartas de Energía Especial de tu pila de descartes en tu baraja y barájalas todas.",
 		it: "Rimischia due carte Energia speciale dalla tua pila degli scarti nel tuo mazzo.",
 		pt: "Embaralhe 2 cards de Energia Especial da sua pilha de descarte em seu baralho.",
-		de: "Mische 2 Basis-Energiekarten aus deinem Ablagestapel in dein Deck."
+		de: "Mische 2 Basis-Energiekarten aus deinem Ablagestapel in dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/XY/Steam Siege/106.ts
+++ b/data/XY/Steam Siege/106.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Tu turno no termina si el Pokémon al que está unida esta carta se convierte en M-Steelix-EX.",
 		it: "Il tuo turno non finisce se il Pokémon a cui è assegnata questa carta diventa M Steelix-EX.",
 		pt: "Sua vez de jogar não terminará se o Pokémon ao qual este card está ligado tornar-se M-Steelix-EX.",
-		de: "Dein Zug endet nicht, wenn das Pokémon, an das diese Karte angelegt ist, zu M-Stahlos -EX wird."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Dein Zug endet nicht, wenn das Pokémon, an das diese Karte angelegt ist, zu M-Stahlos-EX wird. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/XY/Steam Siege/107.ts
+++ b/data/XY/Steam Siege/107.ts
@@ -46,7 +46,7 @@ const card: Card = {
 				es: "Una vez durante tu turno (antes de tu ataque), puedes descartar 1 carta de Energía Fire de tu mano. Si lo haces, durante este turno, los ataques de tus Pokémon Fire Básicos hacen 30 puntos de daños más al Pokémon Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
 				it: "Una sola volta durante il tuo turno, prima di attaccare, puoi scartare una carta Energia Fire dalla tua mano. Se lo fai, durante questo turno gli attacchi dei tuoi Pokémon Base Fire infliggono 30 danni in più al Pokémon attivo del tuo avversario, prima di aver applicato debolezza e resistenza.",
 				pt: "Uma vez durante sua vez de jogar (antes de atacar), você pode descartar um card de Energia Fire da sua mão. Se fizer isso, durante esta vez de jogar, os ataques dos seus Pokémon Fire Básicos causarão 30 de danos adicionais ao Pokémon Ativo do seu oponente (antes da aplicação de Fraqueza e Resistência).",
-				de: "Einmal während deines Zuges (vor deinem Angriff), kannst du 1 Fire-Energiekarte von deiner Hand auf deinen Ablagestapel legen. Wenn du das machst, fügen die Angriffe deiner Basis-Fire-Pokémon dem Aktiven Pokémon deines Gegners während dieses Zuges 30 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
+				de: "Einmal während deines Zuges (vor deinem Angriff), kannst du 1 {R}-Energiekarte von deiner Hand auf deinen Ablagestapel legen. Wenn du das machst, fügen die Angriffe deiner Basis-{R}-Pokémon dem Aktiven Pokémon deines Gegners während dieses Zuges 30 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 		},
 	],

--- a/data/XY/Steam Siege/108.ts
+++ b/data/XY/Steam Siege/108.ts
@@ -77,7 +77,7 @@ const card: Card = {
 				es: "Lanza 1 moneda hasta que salga cruz. Este ataque hace 100 puntos de daño por cada cara.",
 				it: "Lancia una moneta finché non esce croce. Questo attacco infligge 100 danni ogni volta che esce testa.",
 				pt: "Jogue uma moeda até sair coroa. Este ataque causa 100 de danos vezes o número de caras.",
-				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis \"Zahl\" kommt. Dieser Angriff fügt 100 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Dieser Angriff fügt 100 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "100×",
 

--- a/data/XY/Steam Siege/11.ts
+++ b/data/XY/Steam Siege/11.ts
@@ -99,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "By flapping its leafy fan, it can whip up gusts of 100 ft/second that can level houses.",
+		de: "Seine großen Fächer erzeugen Böen, die eine Geschwindigkeit von 30 m/sek erreichen können."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/110.ts
+++ b/data/XY/Steam Siege/110.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Evita todos los efectos de los ataques de tu rival, excepto el daño, infligidos a cada uno de tus Pokémon que tenga alguna Energía Metal unida a él. (No se eliminan los efectos ya existentes).",
 				it: "Previeni tutti gli effetti degli attacchi del tuo avversario, esclusi i danni, inflitti ai tuoi Pokémon che abbiano delle Energie Metal assegnate. Gli effetti esistenti non vengono rimossi.",
 				pt: "Previne todos os efeitos dos ataques do seu oponente, exceto danos, causados a cada um dos seus Pokémon que possui alguma Energia Metal ligada a ele. (Efeitos existentes não são removidos.)",
-				de: "Verhindere alle Effekte von gegnerischen Angriffen, außer Schaden, bei jedem deiner Pokémon, an das Metal-Energie angelegt ist. (Bestehende Effekte behalten ihre Wirkung.)"
+				de: "Verhindere alle Effekte von gegnerischen Angriffen, außer Schaden, bei jedem deiner Pokémon, an das {M}-Energie angelegt ist. (Bestehende Effekte behalten ihre Wirkung.)"
 			},
 		},
 	],

--- a/data/XY/Steam Siege/113.ts
+++ b/data/XY/Steam Siege/113.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Elimina todos los efectos de los ataques en cada jugador y sus Pokémon.",
 		it: "Rimuovi tutti gli effetti degli attacchi da ciascun giocatore e dai suoi Pokémon.",
 		pt: "Remove todos os efeitos de ataques em cada jogador e seus Pokémon.",
-		de: "Alle Effekte von Angriffen verlieren bei beiden Spielern und ihren Pokémon ihre Wirkung."
+		de: "Alle Effekte von Angriffen verlieren bei beiden Spielern und ihren Pokémon ihreWirkung. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/XY/Steam Siege/114.ts
+++ b/data/XY/Steam Siege/114.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta las cartas de tu mano y roba 7 cartas.",
 		it: "Scarta la tua mano e pesca sette carte.",
 		pt: "Descarte sua mão e compre 7 cards.",
-		de: "Lege deine Handkarten auf deinen Ablagestapel und ziehe 7 Karten."
+		de: "Lege deine Handkarten auf deinen Ablagestapel und ziehe 7 Karten. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/XY/Steam Siege/115.ts
+++ b/data/XY/Steam Siege/115.ts
@@ -46,7 +46,7 @@ const card: Card = {
 				es: "Una vez durante tu turno (antes de tu ataque), puedes descartar 1 carta de Energía Fire de tu mano. Si lo haces, durante este turno, los ataques de tus Pokémon Fire Básicos hacen 30 puntos de daños más al Pokémon Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
 				it: "Una sola volta durante il tuo turno, prima di attaccare, puoi scartare una carta Energia Fire dalla tua mano. Se lo fai, durante questo turno gli attacchi dei tuoi Pokémon Base Fire infliggono 30 danni in più al Pokémon attivo del tuo avversario, prima di aver applicato debolezza e resistenza.",
 				pt: "Uma vez durante sua vez de jogar (antes de atacar), você pode descartar um card de Energia Fire da sua mão. Se fizer isso, durante esta vez de jogar, os ataques dos seus Pokémon Fire Básicos causarão 30 de danos adicionais ao Pokémon Ativo do seu oponente (antes da aplicação de Fraqueza e Resistência).",
-				de: "Einmal während deines Zuges (vor deinem Angriff), kannst du 1 Fire-Energiekarte von deiner Hand auf deinen Ablagestapel legen. Wenn du das machst, fügen die Angriffe deiner Basis-Fire-Pokémon dem Aktiven Pokémon deines Gegners während dieses Zuges 30 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
+				de: "Einmal während deines Zuges (vor deinem Angriff), kannst du 1 {R}-Energiekarte von deiner Hand auf deinen Ablagestapel legen. Wenn du das machst, fügen die Angriffe deiner Basis-{R}-Pokémon dem Aktiven Pokémon deines Gegners während dieses Zuges 30 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 		},
 	],

--- a/data/XY/Steam Siege/12.ts
+++ b/data/XY/Steam Siege/12.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It lures Pokémon with its pattern that looks just like a Poké Ball then releases poison spores.",
+		de: "Es ist gemustert wie ein Pokéball. Es lockt damit andere Pokémon an, um sie dann mit Giftsporen zu besprühen."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/13.ts
+++ b/data/XY/Steam Siege/13.ts
@@ -97,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "It lures prey close by dancing and waving its arm caps, which resemble Poké Balls, in a swaying motion.",
+		de: "Es lockt seine Beute an, indem es die Hüte in Form von Pokébällen an seinen Armen rüttelt und einen Tanz aufführt."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/14.ts
+++ b/data/XY/Steam Siege/14.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "The base of volcanoes is where they make their homes. They shoot fire from their five horns to repel attacking enemies.",
+		de: "Es lebt am Fuß von Vulkanen. Mit Gegnern räumt es auf, indem es aus seinen fünf Hörnern Flammen auf sie abfeuert."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/15.ts
+++ b/data/XY/Steam Siege/15.ts
@@ -57,7 +57,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Confundido. Si sale cruz, el Pokémon Activo de tu rival pasa a estar Paralizado.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene confuso. Se esce croce, il Pokémon attivo del tuo avversario viene paralizzato.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente ficará Confuso. Se sair coroa, o Pokémon Ativo do seu oponente será Paralisado.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Aktive Pokémon deines Gegners jetzt verwirrt. Bei \"Zahl\" ist das Aktive Pokémon deines Gegners jetzt paralysiert."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Aktive Pokémon deines Gegners jetzt verwirrt. Bei „Zahl“ ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 			},
 			damage: 20,
 
@@ -100,6 +100,7 @@ const card: Card = {
 
 	description: {
 		en: "When volcanic ash darkened the atmosphere, it is said that Volcarona's fire provided a replacement for the sun.",
+		de: "Es heißt, als das Land einst unter einer düsteren Wolke aus Vulkanasche lag, übernahm es die Rolle der Sonne."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/16.ts
+++ b/data/XY/Steam Siege/16.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Pon 2 cartas de Energía Fire de tu pila de descartes en tu mano.",
 				it: "Prendi due carte Energia Fire dalla tua pila degli scarti e aggiungile alle carte che hai in mano.",
 				pt: "Coloque 2 cards de Energia Fire da sua pilha de descarte em sua mão.",
-				de: "Nimm 2 Fire-Energiekarten von deinem Ablagestapel auf deine Hand."
+				de: "Nimm 2 {R}-Energiekarten von deinem Ablagestapel auf deine Hand."
 			},
 
 		},
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "Its legs grow strong while it chases after its parent. It runs in fields and mountains all day.",
+		de: "Seine Beine werden kräftig, da es seinen Eltern hinterherläuft. Es rennt den ganzen Tag umher."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/17.ts
+++ b/data/XY/Steam Siege/17.ts
@@ -73,7 +73,7 @@ const card: Card = {
 				es: "Descarta 1 Energía Fire unida a este Pokémon.",
 				it: "Scarta un'Energia Fire assegnata a questo Pokémon.",
 				pt: "Descarte uma Energia Fire ligada a este Pokémon.",
-				de: "Lege 1 an dieses Pokémon angelegte Fire-Energie auf deinen Ablagestapel."
+				de: "Lege 1 an dieses Pokémon angelegte {R}-Energie auf deinen Ablagestapel."
 			},
 			damage: 70,
 
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "It gallops at nearly 150 mph. With its mane blazing ferociously, it races as if it were an arrow.",
+		de: "Seine Mähne lodert auf, wenn es mit 240 km/h pfeilschnell galoppiert."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/18.ts
+++ b/data/XY/Steam Siege/18.ts
@@ -64,7 +64,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cruz, descarta 1 Energía Fire unida a este Pokémon.",
 				it: "Lancia una moneta. Se esce croce, scarta un'Energia Fire assegnata a questo Pokémon.",
 				pt: "Jogue uma moeda. Se sair coroa, descarte uma Energia Fire ligada a este Pokémon.",
-				de: "Wirf 1 Münze. Lege bei \"Zahl\" 1 an dieses Pokémon angelegte Fire-Energie auf deinen Ablagestapel."
+				de: "Wirf 1 Münze. Lege bei „Zahl“ 1 an dieses Pokémon angelegte {R}-Energie auf deinen Ablagestapel."
 			},
 			damage: 30,
 
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "The gas made in its belly burns from its rear end. The fire burns weakly when it feels sick.",
+		de: "An seinem Rücken verbrennt es die Gase aus seinem Bauch. Geht es ihm schlecht, leuchtet es weniger hell."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/19.ts
+++ b/data/XY/Steam Siege/19.ts
@@ -84,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "It uses ceilings and walls to launch aerial attacks. Its fiery tail is but one weapon.",
+		de: "Es stürzt sich von Decken und Wänden auf Beute. Sein feuriger Schweif ist nur eine seiner Waffen."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/2.ts
+++ b/data/XY/Steam Siege/2.ts
@@ -58,7 +58,7 @@ const card: Card = {
 				es: "Cura 40 puntos de daño a cada uno de tus Pokémon Grass.",
 				it: "Cura ciascuno dei tuoi Pokémon Grass da 40 danni.",
 				pt: "Cure 40 de danos de cada um dos seus Pokémon Grass.",
-				de: "Heile 40 Schadenspunkte bei jedem deiner Grass-Pokémon."
+				de: "Heile 40 Schadenspunkte bei jedem deiner {G}-Pokémon."
 			},
 			damage: 80,
 
@@ -84,7 +84,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, este ataque hace 30 puntos de daño más.",
 				it: "Lancia una moneta. Se esce testa, questo attacco infligge 30 danni in più.",
 				pt: "Jogue uma moeda. Se sair cara, este ataque causará 30 de danos adicionais.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 30 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: "110+",
 
@@ -102,6 +102,7 @@ const card: Card = {
 
 	description: {
 		en: "Its vines grow so profusely that, in the warm season, you can't even see its eyes.",
+		de: "In warmen Jahreszeiten wuchern seine Ranken so dicht, dass man nicht einmal mehr seine Augen erkennt."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/20.ts
+++ b/data/XY/Steam Siege/20.ts
@@ -57,7 +57,7 @@ const card: Card = {
 				es: "Descarta todas las Energías Fire unidas a este Pokémon.",
 				it: "Scarta tutte le Energie Fire assegnate a questo Pokémon.",
 				pt: "Descarte toda a Energia Fire ligada a este Pokémon.",
-				de: "Lege alle an dieses Pokémon angelegten Fire-Energien auf deinen Ablagestapel."
+				de: "Lege alle an dieses Pokémon angelegten {R}-Energien auf deinen Ablagestapel."
 			},
 			damage: 120,
 
@@ -81,7 +81,7 @@ const card: Card = {
 				es: "Si tienes menos de 10 cartas de Energía Fire en tu pila de descartes, este ataque no hace nada. Pon 10 cartas de Energía Fire de tu pila de descartes en tu baraja y barájalas todas.",
 				it: "Se hai meno di dieci carte Energia Fire nella tua pila degli scarti, questo attacco non ha effetto. Rimischia dieci carte Energia Fire dalla tua pila degli scarti nel tuo mazzo.",
 				pt: "Se você possuir menos de 10 cards de Energia Fire na sua pilha de descarte, este ataque não fará nada. Embaralhe 10 cards de Energia Fire da sua pilha de descarte em seu baralho.",
-				de: "Wenn du weniger als 10 Fire-Energiekarten in deinem Ablagestapel hast, hat dieser Angriff keine Auswirkungen. Mische 10 Fire-Energiekarten aus deinem Ablagestapel in dein Deck."
+				de: "Wenn du weniger als 10 {R}-Energiekarten in deinem Ablagestapel hast, hat dieser Angriff keine Auswirkungen. Mische 10 {R}-Energiekarten aus deinem Ablagestapel in dein Deck."
 			},
 			damage: 200,
 
@@ -99,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "It tosses its enemies around with agility. It uses all its limbs to fight in its own unique style.",
+		de: "Es hält den Gegner mit flinken Bewegungen zum Narren. Im Kampf setzt es alle Gliedmaßen ein."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/21.ts
+++ b/data/XY/Steam Siege/21.ts
@@ -57,7 +57,7 @@ const card: Card = {
 				es: "Descarta todas las Energías Fire unidas a este Pokémon.",
 				it: "Scarta tutte le Energie Fire assegnate a questo Pokémon.",
 				pt: "Descarte toda a Energia Fire ligada a este Pokémon.",
-				de: "Lege alle an dieses Pokémon angelegten Fire-Energien auf deinen Ablagestapel."
+				de: "Lege alle an dieses Pokémon angelegten {R}-Energien auf deinen Ablagestapel."
 			},
 			damage: 150,
 

--- a/data/XY/Steam Siege/22.ts
+++ b/data/XY/Steam Siege/22.ts
@@ -48,7 +48,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cruz, este ataque no hace nada.",
 				it: "Lancia una moneta. Se esce croce, questo attacco non ha effetto.",
 				pt: "Jogue uma moeda. Se sair coroa, este ataque não fará nada.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 30,
 
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "They set off on their own from their pride and live by themselves to become stronger. These hot-blooded Pokémon are quick to fight.",
+		de: "Sie verlassen ihr Rudel schon sehr früh, um stärker zu werden und auf eigenen Pfoten zu stehen. Sie sind sehr hitzköpfig und streitlustig."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/23.ts
+++ b/data/XY/Steam Siege/23.ts
@@ -57,7 +57,7 @@ const card: Card = {
 				es: "Busca en tu baraja 1 carta de Energía Fire y únela a este Pokémon. Baraja las cartas de tu baraja después.",
 				it: "Cerca nel tuo mazzo una carta Energia Fire e assegnala a questo Pokémon. Poi rimischia le carte del tuo mazzo.",
 				pt: "Procure em seu baralho um card de Energia Fire e ligue-o a este Pokémon. Em seguida, embaralhe seus cards.",
-				de: "Durchsuche dein Deck nach 1 Fire-Energiekarte und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
+				de: "Durchsuche dein Deck nach 1 {R}-Energiekarte und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
 			},
 			damage: 60,
 
@@ -100,6 +100,7 @@ const card: Card = {
 
 	description: {
 		en: "With fiery breath of more than 10,000 degrees Fahrenheit, they viciously threaten any challenger. The females protect the pride's cubs.",
+		de: "Sie bedrohen ihre Gegner, indem sie 6 000 °C heiße Atemluft ausstoßen. Die Weibchen beschützen die Jungen des Rudels."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/25.ts
+++ b/data/XY/Steam Siege/25.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Elige 2 de tus Pokémon en Banca. Une 1 carta de Energía Fire de tu pila de descartes a cada uno de esos Pokémon.",
 				it: "Scegli due dei tuoi Pokémon in panchina. Assegna a ciascuno di quei Pokémon una carta Energia Fire dalla tua pila degli scarti.",
 				pt: "Escolha 2 dos seus Pokémon no Banco. Ligue um card de Energia Fire da sua pilha de descarte a cada um daqueles Pokémon.",
-				de: "Wähle 2 Pokémon auf deiner Bank. Lege 1 Fire-Energiekarte aus deinem Ablagestapel an jedes dieser Pokémon an."
+				de: "Wähle 2 Pokémon auf deiner Bank. Lege 1 {R}-Energiekarte aus deinem Ablagestapel an jedes dieser Pokémon an."
 			},
 			damage: 20,
 
@@ -83,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "It expels its internal steam from the arms on its back. It has enough power to blow away a mountain.",
+		de: "Über die Arme auf seinem Rücken stößt es Wasserdampf aus. Seine Kraft reicht aus, um Berge zu versetzen."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/26.ts
+++ b/data/XY/Steam Siege/26.ts
@@ -46,7 +46,7 @@ const card: Card = {
 				es: "Una vez durante tu turno (antes de tu ataque), puedes descartar 1 carta de Energía Fire de tu mano. Si lo haces, durante este turno, los ataques de tus Pokémon Fire Básicos hacen 30 puntos de daños más al Pokémon Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
 				it: "Una sola volta durante il tuo turno, prima di attaccare, puoi scartare una carta Energia Fire dalla tua mano. Se lo fai, durante questo turno gli attacchi dei tuoi Pokémon Base Fire infliggono 30 danni in più al Pokémon attivo del tuo avversario, prima di aver applicato debolezza e resistenza.",
 				pt: "Uma vez durante sua vez de jogar (antes de atacar), você pode descartar um card de Energia Fire da sua mão. Se fizer isso, durante esta vez de jogar, os ataques dos seus Pokémon Fire Básicos causarão 30 de danos adicionais ao Pokémon Ativo do seu oponente (antes da aplicação de Fraqueza e Resistência).",
-				de: "Einmal während deines Zuges (vor deinem Angriff), kannst du 1 Fire-Energiekarte von deiner Hand auf deinen Ablagestapel legen. Wenn du das machst, fügen die Angriffe deiner Basis-Fire-Pokémon dem Aktiven Pokémon deines Gegners während dieses Zuges 30 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
+				de: "Einmal während deines Zuges (vor deinem Angriff), kannst du 1 {R}-Energiekarte von deiner Hand auf deinen Ablagestapel legen. Wenn du das machst, fügen die Angriffe deiner Basis-{R}-Pokémon dem Aktiven Pokémon deines Gegners während dieses Zuges 30 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 		},
 	],

--- a/data/XY/Steam Siege/27.ts
+++ b/data/XY/Steam Siege/27.ts
@@ -96,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "While elegantly swimming in the sea, it ignores Remoraid that cling to its fins seeking food scraps.",
+		de: "Zieht elegant durch die Meere und ignoriert dabei Remoraid, die an seinen Flossen haften."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/28.ts
+++ b/data/XY/Steam Siege/28.ts
@@ -58,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "Its shape and coloration vary, depending on its habitat.",
+		de: "Form und Farbe dieses Pokémon ändern sich je nach der Umgebung, in der es lebt."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/29.ts
+++ b/data/XY/Steam Siege/29.ts
@@ -56,7 +56,7 @@ const card: Card = {
 				es: "Durante el próximo turno de tu rival, los ataques del Pokémon Defensor cuestan Colorless más, y su Coste de Retirada es de Colorless más.",
 				it: "Durante il prossimo turno del tuo avversario, gli attacchi del Pokémon difensore costano Colorless in più e il suo costo di ritirata aumenta di Colorless.",
 				pt: "Durante a próxima vez de jogar do seu oponente, o custo dos ataques do Pokémon Defensor será Colorless maior e o seu Custo para Recuar será Colorless maior.",
-				de: "Während des nächsten Zuges deines Gegners erhöhen sich die Angriffskosten und die Rückzugskosten des Verteidigenden Pokémon um Colorless."
+				de: "Während des nächsten Zuges deines Gegners erhöhen sich die Angriffskosten und die Rückzugskosten des Verteidigenden Pokémon um {C}."
 			},
 			damage: 20,
 
@@ -99,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "It apparently had a huge shell for protection in ancient times. It lives in shallow tidal pools.",
+		de: "In Urzeiten muss es einen großen Schutzpanzer besessen haben. Es lebt in kleinen Wasserstellen."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/3.ts
+++ b/data/XY/Steam Siege/3.ts
@@ -58,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "It drifts on winds. It is said that when Hoppip gather in fields and mountains, spring is on the way.",
+		de: "Es reitet auf dem Wind. Man sagt, wenn sich Hoppspross versammeln, kommt der Frühling bald."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/30.ts
+++ b/data/XY/Steam Siege/30.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "It fights using the scalchop on its stomach. In response to an attack, it retaliates immediately by slashing.",
+		de: "Kämpft mit der Muschel auf seinem Bauch. Pariert es einen Angriff, schlägt es sofort mit einer Schnitt-Attacke zurück."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/31.ts
+++ b/data/XY/Steam Siege/31.ts
@@ -57,7 +57,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, este ataque hace 20 puntos de daño más.",
 				it: "Lancia una moneta. Se esce testa, questo attacco infligge 20 danni in più.",
 				pt: "Jogue uma moeda. Se sair cara, este ataque causará 20 de danos adicionais.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 20 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: "30+",
 
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "As a result of strict training, each Dewott learns different forms for using the scalchops.",
+		de: "Jedes Zwottronin eignet sich über strenges Training einen völlig eigenen Muschelkampfstil an."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/32.ts
+++ b/data/XY/Steam Siege/32.ts
@@ -100,6 +100,7 @@ const card: Card = {
 
 	description: {
 		en: "One swing of the sword incorporated in its armor can fell an opponent. A simple glare from one of them quiets everybody.",
+		de: "Besiegt Gegner durch einen einzigen Hieb mit der Klinge an seinem Panzer. Ein böser Blick und seine Feinde verstummen."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/33.ts
+++ b/data/XY/Steam Siege/33.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Lanza 2 monedas. Este ataque hace 10 puntos de daño por cada cara.",
 				it: "Lancia due volte una moneta. Questo attacco infligge 10 danni ogni volta che esce testa.",
 				pt: "Jogue 2 moedas. Este ataque causa 10 de danos vezes o número de caras.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10×",
 
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "Through controlled expulsions of internal gas, it can expel water like a pistol shot. At close distances, it can shatter rock.",
+		de: "Durch die Explosion körpereigener Gase feuert es wie eine Pistole Wassersalven ab, die aus kurzer Distanz selbst Felsen zerschmettern."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/34.ts
+++ b/data/XY/Steam Siege/34.ts
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "By expelling water from the nozzle in the back of its claw, it can move at a speed of 60 knots.",
+		de: "Indem es über die Düsen am hinteren Ende seiner Scheren Wasser absondert, kann es sich mit einer Geschwindigkeit von 60 Knoten fortbewegen."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/36.ts
+++ b/data/XY/Steam Siege/36.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Using air of -150 degrees Fahrenheit, they freeze opponents solid. They live in herds above the snow line on mountains.",
+		de: "Es friert seine Gegner mittels eines -100 °C kalten Luftstromes ein. Mit seinen Artgenossen lebt es herdenweise auf Bergen inmitten des ewigen Eises."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/37.ts
+++ b/data/XY/Steam Siege/37.ts
@@ -57,7 +57,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sala cara, descarta 1 Energía unida al Pokémon Activo de tu rival.",
 				it: "Lancia una moneta. Se esce testa, scarta un'Energia assegnata al Pokémon attivo del tuo avversario.",
 				pt: "Jogue uma moeda. Se sair cara, descarte uma Energia ligada ao Pokémon Ativo do seu oponente.",
-				de: "Wirf 1 Münze. Lege bei \"Kopf\" 1 an das Aktive Pokémon deines Gegners angelegte Energie auf den Ablagestapel deines Gegners."
+				de: "Wirf 1 Münze. Lege bei „Kopf“ 1 an das Aktive Pokémon deines Gegners angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 30,
 
@@ -82,7 +82,7 @@ const card: Card = {
 				es: "Descarta las 3 primeras cartas de tu baraja. Por cada carta de Energía Water descartada de esta manera, descarta las 3 primeras cartas de la baraja de tu rival.",
 				it: "Scarta le prime tre carte del tuo mazzo. Per ogni carta Energia Water scartata in questo modo, scarta le prime tre carte del mazzo del tuo avversario.",
 				pt: "Descarte 3 cards de cima do seu baralho. Para cada card de Energia Water descartado desta forma, descarte os 3 cards de cima do baralho do seu oponente.",
-				de: "Lege die obersten 3 Karten deines Decks auf deinen Ablagestapel. Lege für jede Water-Energie, die du auf diese Weise auf deinen Ablagestapel gelegt hast, die obersten 3 Karten vom Deck deines Gegners auf seinen Ablagestapel."
+				de: "Lege die obersten 3 Karten deines Decks auf deinen Ablagestapel. Lege für jede {W}-Energie, die du auf diese Weise auf deinen Ablagestapel gelegt hast, die obersten 3 Karten vom Deck deines Gegners auf seinen Ablagestapel."
 			},
 
 		},
@@ -99,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "The way several Bergmite huddle on its back make it look like an aircraft carrier made of ice.",
+		de: "Mit den zahlreichen Arktip auf seinem Rücken sieht es aus wie ein Flugzeugträger aus Eis."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/38.ts
+++ b/data/XY/Steam Siege/38.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Paralizado.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene paralizzato.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente será Paralisado.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Aktive Pokémon deines Gegners jetzt paralysiert."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 			},
 
 		},
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It stores lots of air in its soft fur, allowing it to stay cool in summer and warm in winter.",
+		de: "Es speichert viel Luft in seinem weichen Pelz. Dadurch ist es im Sommer kalt und im Winter warm."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/39.ts
+++ b/data/XY/Steam Siege/39.ts
@@ -74,7 +74,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Paralizado.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene paralizzato.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente será Paralisado.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Aktive Pokémon deines Gegners jetzt paralysiert."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 			},
 			damage: 50,
 
@@ -99,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "If its coat becomes fully charged with electricity, its tail lights up. It fires hair that zaps on impact.",
+		de: "Hat es sich mit Elektrizität aufgeladen, leuchtet sein Schweif und es feuert Haare ab, die sich entladen."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/4.ts
+++ b/data/XY/Steam Siege/4.ts
@@ -67,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "It spreads its petals to absorb sunlight. It also floats in the air to get closer to the sun.",
+		de: "Es öffnet seine Blüte, um Sonnenlicht aufzunehmen. Es schwebt in der Luft, um der Sonne näher zu sein."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/40.ts
+++ b/data/XY/Steam Siege/40.ts
@@ -80,7 +80,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, este ataque hace 40 puntos de daño más. Si sale cruz, el Pokémon Activo de tu rival pasa a estar Paralizado.",
 				it: "Lancia una moneta. Se esce testa, questo attacco infligge 40 danni in più. Se esce croce, il Pokémon attivo del tuo avversario viene paralizzato.",
 				pt: "Jogue uma moeda. Se sair cara, este ataque causará 40 de danos adicionais. Se sair coroa, o Pokémon Ativo do seu oponente será Paralisado.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 40 weitere Schadenspunkte zu. Bei \"Zahl\" ist das Aktive Pokémon deines Gegners jetzt paralysiert."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 40 weitere Schadenspunkte zu. Bei „Zahl“ ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 			},
 			damage: "80+",
 
@@ -105,6 +105,7 @@ const card: Card = {
 
 	description: {
 		en: "The tail's tip shines brightly and can be seen from far away. It acts as a beacon for lost people.",
+		de: "Seine Schweifspitze ist so hell, dass viele Verschollene es als Orientierungspunkt nutzen."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/41.ts
+++ b/data/XY/Steam Siege/41.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "They attach themselves to large-bodied Pokémon and absorb static electricity, which they store in an electric pouch.",
+		de: "Es pflanzt sich an großen Pokémon fest und zapft ihnen elektrische Energie ab. Diese hortet es in seinen Ladetaschen."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/42.ts
+++ b/data/XY/Steam Siege/42.ts
@@ -104,6 +104,7 @@ const card: Card = {
 
 	description: {
 		en: "When attacked, they create an electric barrier by spitting out many electrically charged threads.",
+		de: "Wird es angegriffen, spuckt es mit vielen elektrisch geladenen Fäden um sich und baut sich eine Elektrobarriere."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/43.ts
+++ b/data/XY/Steam Siege/43.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Its large ears are flapped like wings when it is listening to distant sounds. It extends toxic barbs when angered.",
+		de: "Seine großen Ohren schlagen wie Flügel, wenn es Geräusche in weiter Entfernung hört. Es fährt giftige Stacheln aus, wenn es verärgert ist."
 	},
 }
 

--- a/data/XY/Steam Siege/44.ts
+++ b/data/XY/Steam Siege/44.ts
@@ -93,6 +93,7 @@ const card: Card = {
 
 	description: {
 		en: "An aggressive Pokémon that is quick to attack. The horn on its head secretes a powerful venom.",
+		de: "Ein aggressives Pokémon, das sehr flink angreift. Das Horn auf dem Kopf sondert starkes Gift ab."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/45.ts
+++ b/data/XY/Steam Siege/45.ts
@@ -98,6 +98,7 @@ const card: Card = {
 
 	description: {
 		en: "One swing of its mighty tail can snap a telephone pole as if it were a matchstick.",
+		de: "Ein Schlag mit seinem gewaltigen Schweif kann einen Telegrafenmast knicken wie ein Streichholz."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/46.ts
+++ b/data/XY/Steam Siege/46.ts
@@ -71,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "These Pokémon are called the \"Signpost for Wandering Spirits.\" Children holding them sometimes vanish.",
+		de: "Auch bekannt als „Wegweiser für umherstreifende Geister“. Kinder, die sie halten, verschwinden manchmal."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/47.ts
+++ b/data/XY/Steam Siege/47.ts
@@ -105,6 +105,7 @@ const card: Card = {
 
 	description: {
 		en: "It's drowsy in daytime, but flies off in the evening in big groups. No one knows where they go.",
+		de: "Tagsüber treibt es faul vor sich hin, nachts fliegt es mit anderen umher. Niemand weiß wohin."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/48.ts
+++ b/data/XY/Steam Siege/48.ts
@@ -71,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "Litwick shines a light that absorbs the life energy of people and Pokémon, which becomes the fuel that it burns.",
+		de: "Es entfacht eine Flamme, die von der Lebensenergie eines Menschen oder eines Pokémon zehrt."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/49.ts
+++ b/data/XY/Steam Siege/49.ts
@@ -104,6 +104,7 @@ const card: Card = {
 
 	description: {
 		en: "It arrives near the moment of death and steals spirit from the body.",
+		de: "Es erscheint im Augenblick des Todes und verschlingt die Seele des Verblichenen, sofort nachdem sie den Körper verlassen hat."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/5.ts
+++ b/data/XY/Steam Siege/5.ts
@@ -96,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "Even in the fiercest wind, it can control its fluff to make its way to any place in the world it wants.",
+		de: "Auch im stärksten Wind kann es kontrollieren, wo seine Saat auf dem Erdball niedergehen soll."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/50.ts
+++ b/data/XY/Steam Siege/50.ts
@@ -104,6 +104,7 @@ const card: Card = {
 
 	description: {
 		en: "The spirits burned up in its ominous flame lose their way and wander this world forever.",
+		de: "Seelen, die das Feuer seiner schaurigen Flammen gekostet haben, irren bis ans Ende der Tage ziellos durch diese Welt."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/51.ts
+++ b/data/XY/Steam Siege/51.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said to be able to seize anything it desires with its six rings and six huge arms. With its power sealed, it is transformed into a much smaller form.",
+		de: "Mit seinen sechs Ringen und seinen sechs riesigen Armen kann es alles an sich reißen, was es möchte. Wenn seine Kraft versiegelt wird, nimmt es jedoch eine kleinere Gestalt an."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/52.ts
+++ b/data/XY/Steam Siege/52.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives in treetop colonies. If one becomes enraged, the whole colony rampages for no reason.",
+		de: "Es lebt mit anderen in Baumkronen. Wird eines von ihnen wütend, werden alle anderen auch wütend."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/53.ts
+++ b/data/XY/Steam Siege/53.ts
@@ -56,7 +56,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sala cara, descarta 1 Energía unida al Pokémon Activo de tu rival.",
 				it: "Lancia una moneta. Se esce testa, scarta un'Energia assegnata al Pokémon attivo del tuo avversario.",
 				pt: "Jogue uma moeda. Se sair cara, descarte uma Energia ligada ao Pokémon Ativo do seu oponente.",
-				de: "Wirf 1 Münze. Lege bei \"Kopf\" 1 an das Aktive Pokémon deines Gegners angelegte Energie auf den Ablagestapel deines Gegners."
+				de: "Wirf 1 Münze. Lege bei „Kopf“ 1 an das Aktive Pokémon deines Gegners angelegte Energie auf den Ablagestapel deines Gegners."
 			},
 			damage: 20,
 
@@ -98,6 +98,7 @@ const card: Card = {
 
 	description: {
 		en: "It is always outrageously furious. If it gives chase, it will tenaciously track the target no matter how far.",
+		de: "Es ist immer außerordentlich wütend. Nimmt es die Verfolgung auf, bleibt es dem Opfer hartnäckig auf den Fersen, egal wie weit oder wie lange."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/54.ts
+++ b/data/XY/Steam Siege/54.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Paralizado.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene paralizzato.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente será Paralisado.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Aktive Pokémon deines Gegners jetzt paralysiert."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 			},
 
 		},
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "Its magnetic nose consistently faces north. Travelers check Nosepass to get their bearings.",
+		de: "Seine magnetische Nase zeigt stets gen Norden. Reisende überprüfen Nasgnet, um sich zu orientieren."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/55.ts
+++ b/data/XY/Steam Siege/55.ts
@@ -99,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "It freely controls three small units called Mini-Noses using magnetic force.",
+		de: "Es steuert drei kleine Einheiten mithilfe von starkem Magnetismus. Man nennt sie Mininasen."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/56.ts
+++ b/data/XY/Steam Siege/56.ts
@@ -69,7 +69,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, este ataque hace 20 puntos de daño más.",
 				it: "Lancia una moneta. Se esce testa, questo attacco infligge 20 danni in più.",
 				pt: "Jogue uma moeda. Se sair cara, este ataque causará 20 de danos adicionais.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 20 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -96,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon ancestor that was reanimated from a fossil. It lived in the sea and hunted with claws.",
+		de: "Ein Vorfahre der Pokémon, der aus einem Fossil neu belebt wurde. Es lebte im Meer und jagte mit Klauen."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/57.ts
+++ b/data/XY/Steam Siege/57.ts
@@ -99,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "Protected by a hard shell, its body is very sturdy. It skewers prey with its claws to feed.",
+		de: "Sein robuster Körper wird von einem harten Panzer geschützt. Es spießt die Beute mit seinen Scheren auf, ehe es sie verspeist."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/58.ts
+++ b/data/XY/Steam Siege/58.ts
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "Inflating its poison sacs, it fills the area with an odd sound and hits flinching opponents with a poison jab.",
+		de: "Bläst es seine Giftbeutel auf, ertönt ein unheimliches Geräusch, das Gegner zurückschrecken lässt und vergiftet."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/59.ts
+++ b/data/XY/Steam Siege/59.ts
@@ -79,7 +79,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Envenenado.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene avvelenato.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente será Envenenado.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Aktive Pokémon deines Gegners jetzt vergiftet."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Aktive Pokémon deines Gegners jetzt vergiftet."
 			},
 			damage: 50,
 
@@ -97,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "Its knuckle claws secrete a toxin so vile that even a scratch could prove fatal.",
+		de: "Die Gelenke an seinen Klauen geben ein so starkes Gift ab, dass selbst ein kleiner Kratzer fatal ist."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/6.ts
+++ b/data/XY/Steam Siege/6.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "If it flaps its wings really fast, it can generate shock waves that will shatter windows in the area.",
+		de: "Schlägt es schnell mit den Flügeln, erzeugt es Schockwellen, durch die sogar Fenster zerbersten."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/60.ts
+++ b/data/XY/Steam Siege/60.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, evita todos los efectos de los ataques, incluido el daño, infligidos a este Pokémon durante el próximo turno de tu rival.",
 				it: "Lancia una moneta. Se esce testa, previeni tutti gli effetti degli attacchi, inclusi i danni, inflitti a questo Pokémon durante il prossimo turno del tuo avversario.",
 				pt: "Jogue uma moeda. Se sair cara, todos os efeitos dos ataques causados a este Pokémon serão prevenidos, inclusive danos, durante a próxima vez de jogar do seu oponente.",
-				de: "Wirf 1 Münze. Verhindere bei \"Kopf\" während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die diesem Pokémon zugefügt werden."
+				de: "Wirf 1 Münze. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die diesem Pokémon zugefügt werden."
 			},
 			damage: 10,
 
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "Its paws conceal sharp claws. If attacked, it suddenly extends the claws and startles its enemy.",
+		de: "In seinen Pfoten stecken scharfe Krallen. Es fährt sie blitzschnell aus, um die Gegner zu überraschen."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/61.ts
+++ b/data/XY/Steam Siege/61.ts
@@ -97,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "They live in cold regions, forming groups of four or five that hunt prey with impressive coordination.",
+		de: "Es lebt in kalten Gebieten in Gruppen von vier oder fünf Pokémon, die bei der Jagd großes Geschick zeigen."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/62.ts
+++ b/data/XY/Steam Siege/62.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "It was bound to a fissure in an Odd Keystone as punishment for misdeeds 500 years ago.",
+		de: "Es wurde in einen Spalt eines Steins gebannt, als Sühne für Untaten, die es vor 500 Jahren begangen hatte."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/63.ts
+++ b/data/XY/Steam Siege/63.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "Ignoring their injuries, groups attack by sinking the blades that cover their bodies into their prey.",
+		de: "Selbst wenn sie verletzt sind, greifen sie ihren Gegner unbeirrt in der Gruppe an, indem sie ihre Klingen in ihn hineinrammen."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/64.ts
+++ b/data/XY/Steam Siege/64.ts
@@ -106,6 +106,7 @@ const card: Card = {
 
 	description: {
 		en: "Bisharp pursues prey in the company of a large group of Pawniard. Then Bisharp finishes off the prey.",
+		de: "Es rückt seinen Opfern mit einer Schar von Gladiantri im Gefolge auf den Pelz. Den letzten Hieb übernimmt es selbst."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/65.ts
+++ b/data/XY/Steam Siege/65.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Une 1 carta de Energía Darkness de tu pila de descartes a 1 de tus Pokémon en Banca.",
 				it: "Assegna a uno dei tuoi Pokémon in panchina una carta Energia Darkness dalla tua pila degli scarti.",
 				pt: "Ligue um card de Energia Darkness da sua pilha de descarte a 1 dos seus Pokémon no Banco.",
-				de: "Lege 1 Darkness-Energiekarte von deinem Ablagestapel an 1 Pokémon auf deiner Bank an."
+				de: "Lege 1 {D}-Energiekarte von deinem Ablagestapel an 1 Pokémon auf deiner Bank an."
 			},
 			damage: 30,
 
@@ -72,7 +72,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cruz, este Pokémon no puede atacar durante tu próximo turno.",
 				it: "Lancia una moneta. Se esce croce, durante il tuo prossimo turno, questo Pokémon non può attaccare.",
 				pt: "Jogue uma moeda. Se sair coroa, este Pokémon não poderá atacar durante sua próxima vez de jogar.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" kann dieses Pokémon während deines nächsten Zuges nicht angreifen."
+				de: "Wirf 1 Münze. Bei „Zahl“ kann dieses Pokémon während deines nächsten Zuges nicht angreifen."
 			},
 			damage: 100,
 
@@ -97,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "When its life comes to an end, it absorbs the life energy of every living thing and turns into a cocoon once more.",
+		de: "Neigt sich seine Lebensspanne dem Ende zu, entzieht es anderen Lebewesen deren Energie und verwandelt sich zurück in einen Kokon."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/67.ts
+++ b/data/XY/Steam Siege/67.ts
@@ -77,7 +77,7 @@ const card: Card = {
 				es: "Lanza 1 moneda hasta que salga cruz. Este ataque hace 100 puntos de daño por cada cara.",
 				it: "Lancia una moneta finché non esce croce. Questo attacco infligge 100 danni ogni volta che esce testa.",
 				pt: "Jogue uma moeda até sair coroa. Este ataque causa 100 de danos vezes o número de caras.",
-				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis \"Zahl\" kommt. Dieser Angriff fügt 100 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Dieser Angriff fügt 100 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "100×",
 

--- a/data/XY/Steam Siege/69.ts
+++ b/data/XY/Steam Siege/69.ts
@@ -100,6 +100,7 @@ const card: Card = {
 
 	description: {
 		en: "It was generated from a fossil dug out of a layer of clay that was older than anyone knows. It has a sturdy face.",
+		de: "Das Fossil, aus dem es entstand, wurde aus einer 100 Millionen Jahre alten Gesteinsschicht geborgen."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/7.ts
+++ b/data/XY/Steam Siege/7.ts
@@ -105,6 +105,7 @@ const card: Card = {
 
 	description: {
 		en: "This six-legged Pokémon is easily capable of transporting an adult in flight. The wings on its tail help it stay balanced.",
+		de: "Es kann mühelos einen Erwachsenen umhertragen. Die Federn an seinem Hinterteil stabilisieren seinen Flug."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/70.ts
+++ b/data/XY/Steam Siege/70.ts
@@ -107,6 +107,7 @@ const card: Card = {
 
 	description: {
 		en: "Any frontal attack is repulsed. It is a docile Pokémon that feeds on grass and berries.",
+		de: "Jeder Frontalangriff wird abgeschmettert. Dieses friedliche Pokémon ernährt sich von Gras und Beeren."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/71.ts
+++ b/data/XY/Steam Siege/71.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Lanza 4 monedas. Este ataque hace 10 puntos de daño por cada cara.",
 				it: "Lancia quattro volte una moneta. Questo attacco infligge 10 danni ogni volta che esce testa.",
 				pt: "Jogue 4 moedas. Este ataque causa 10 de danos vezes o número de caras.",
-				de: "Wirf 4 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 4 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10×",
 
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "The two minigears that mesh together are predetermined. Each will rebound from other minigears without meshing.",
+		de: "Seine zwei Teile greifen ineinander wie ein Uhrwerk. Jedes andere Objekt, das man mit ihm kombinieren will, wird abgestoßen."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/72.ts
+++ b/data/XY/Steam Siege/72.ts
@@ -75,7 +75,7 @@ const card: Card = {
 				es: "Lanza 4 monedas. Este ataque hace 30 puntos de daño por cada cara.",
 				it: "Lancia quattro volte una moneta. Questo attacco infligge 30 danni ogni volta che esce testa.",
 				pt: "Jogue 4 moedas. Este ataque causa 30 de danos vezes o número de caras.",
-				de: "Wirf 4 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 4 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "30×",
 
@@ -100,6 +100,7 @@ const card: Card = {
 
 	description: {
 		en: "A minigear and big gear comprise its body. If the minigear it launches at a foe doesn't return, it will die.",
+		de: "Besteht aus kleinen und großen Rädern. Kehrt ein kleines Rad, das es abgefeuert hat, nicht zurück, wird es brenzlig."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/73.ts
+++ b/data/XY/Steam Siege/73.ts
@@ -54,7 +54,7 @@ const card: Card = {
 				es: "Cualquier daño infligido a este Pokémon por un ataque de tu rival se reduce en 10 por cada Colorless en el Coste de Retirada del Pokémon Activo de tu rival (después de aplicar Debilidad y Resistencia).",
 				it: "I danni inflitti a questo Pokémon da un attacco del tuo avversario sono ridotti di 10 per ogni Colorless nel costo di ritirata del Pokémon attivo del tuo avversario, dopo aver applicato debolezza e resistenza.",
 				pt: "Qualquer dano causado a este Pokémon por ataques de um oponente será reduzido em 10 para cada Colorless no Custo para Recuar do Pokémon Ativo do seu oponente (após a aplicação de Fraqueza e Resistência).",
-				de: "Schaden, der diesem Pokémon durch einen gegnerischen Angriff zugefügt wird, wird um 10 Schadenspunkte für jedes Colorless-Symbol in den Rückzugskosten des Aktiven Pokémon deines Gegners reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
+				de: "Schaden, der diesem Pokémon durch einen gegnerischen Angriff zugefügt wird, wird um 10 Schadenspunkte für jedes {C}-Symbol in den Rückzugskosten des Aktiven Pokémon deines Gegners reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 		},
 	],
@@ -105,6 +105,7 @@ const card: Card = {
 
 	description: {
 		en: "Its red core functions as an energy tank. It fires the charged energy through its spikes into an area.",
+		de: "Der rote Zentralbestandteil dient als Energiespeicher. Darin geladene Energie feuert es über seine Stacheln ab."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/74.ts
+++ b/data/XY/Steam Siege/74.ts
@@ -95,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "It has a body and heart of steel. It worked with its allies to punish people when they hurt Pokémon.",
+		de: "Sein Körper und Herz sind aus Stahl. Gemeinsam mit seinen Gefährten bestrafte es alle Menschen, die Pokémon verletzen."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/75.ts
+++ b/data/XY/Steam Siege/75.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Evita todos los efectos de los ataques de tu rival, excepto el daño, infligidos a cada uno de tus Pokémon que tenga alguna Energía Metal unida a él. (No se eliminan los efectos ya existentes).",
 				it: "Previeni tutti gli effetti degli attacchi del tuo avversario, esclusi i danni, inflitti ai tuoi Pokémon che abbiano delle Energie Metal assegnate. Gli effetti esistenti non vengono rimossi.",
 				pt: "Previne todos os efeitos dos ataques do seu oponente, exceto danos, causados a cada um dos seus Pokémon que possui alguma Energia Metal ligada a ele. (Efeitos existentes não são removidos.)",
-				de: "Verhindere alle Effekte von gegnerischen Angriffen, außer Schaden, bei jedem deiner Pokémon, an das Metal-Energie angelegt ist. (Bestehende Effekte behalten ihre Wirkung.)"
+				de: "Verhindere alle Effekte von gegnerischen Angriffen, außer Schaden, bei jedem deiner Pokémon, an das {M}-Energie angelegt ist. (Bestehende Effekte behalten ihre Wirkung.)"
 			},
 		},
 	],

--- a/data/XY/Steam Siege/76.ts
+++ b/data/XY/Steam Siege/76.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "The tip of its tail is filled with oil that is lighter than water, so it acts as a float.",
+		de: "Seine Schweifspitze ist mit Öl gefüllt, das leichter als Wasser ist, sodass es nicht untergeht."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/77.ts
+++ b/data/XY/Steam Siege/77.ts
@@ -58,7 +58,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, este ataque hace 30 puntos de daño más.",
 				it: "Lancia una moneta. Se esce testa, questo attacco infligge 30 danni in più.",
 				pt: "Jogue uma moeda. Se sair cara, este ataque causará 30 de danos adicionais.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 30 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 weitere Schadenspunkte zu."
 			},
 			damage: "30+",
 
@@ -108,6 +108,7 @@ const card: Card = {
 
 	description: {
 		en: "The bubble-like pattern on its stomach helps it camouflage itself when it's in the water.",
+		de: "Das blasenähnliche Muster auf seinem Bauch hilft ihm, sich perfekt zu tarnen, wenn es im Wasser ist."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/80.ts
+++ b/data/XY/Steam Siege/80.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It never lets go of a key that it likes, so people give it the keys to vaults and safes as a way to prevent crime.",
+		de: "Da es Schlüssel, die ihm gefallen, wie seinen Augapfel hütet, vertrauen Menschen ihm die Schlüssel ihrer Tresore an, um Diebstahl vorzubeugen."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/81.ts
+++ b/data/XY/Steam Siege/81.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Elige 2 de tus Pokémon en Banca. Para cada uno de esos Pokémon, busca en tu baraja 1 carta de Energía Fairy y únela a ese Pokémon. Baraja las cartas de tu baraja después.",
 				it: "Scegli due dei tuoi Pokémon in panchina. Per ognuno di essi, cerca nel tuo mazzo una carta Energia Fairy e assegnagliela. Poi rimischia le carte del tuo mazzo.",
 				pt: "Escolha 2 dos seus Pokémon no Banco. Para cada um desses Pokémon, procure em seu baralho um card de Energia Fairy e ligue-o a esse Pokémon. Em seguida, embaralhe seus cards.",
-				de: "Wähle 2 Pokémon auf deiner Bank aus. Durchsuche dein Deck nach jeweils 1 Fairy-Energiekarte für jedes dieser Pokémon und lege sie an das jeweilige Pokémon an. Mische anschließend dein Deck."
+				de: "Wähle 2 Pokémon auf deiner Bank aus. Durchsuche dein Deck nach jeweils 1 {FAIRY}-Energiekarte für jedes dieser Pokémon und lege sie an das jeweilige Pokémon an. Mische anschließend dein Deck."
 			},
 
 		},
@@ -96,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "Legends say it can share eternal life. It slept for a thousand years in the form of a tree before its revival.",
+		de: "Es heißt, dieses Pokémon spende ewiges Leben, sobald das Geweih auf seinem Haupt in sieben verschiedenen Farben leuchtet."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/83.ts
+++ b/data/XY/Steam Siege/83.ts
@@ -73,7 +73,7 @@ const card: Card = {
 				es: "Lanza 2 monedas. Si ambas son cruz, este ataque no hace nada.",
 				it: "Lancia due volte una moneta. Se esce entrambe le volte croce, questo attacco non ha effetto.",
 				pt: "Jogue 2 moedas. Se ambas saírem coroa, este ataque não fará nada.",
-				de: "Wirf 2 Münzen. Wenn beide \"Zahl\" zeigen, hat dieser Angriff keine Auswirkungen."
+				de: "Wirf 2 Münzen. Wenn beide „Zahl“ zeigen, hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 100,
 
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "It warms its body by absorbing sunlight with its wings. When its body temperature falls, it can no longer move.",
+		de: "Es erwärmt seinen Körper, indem es mit den Flügeln das Sonnenlicht einfängt. Kühlt sein Körper ab, erstarrt es."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/84.ts
+++ b/data/XY/Steam Siege/84.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Lacking sight, it's unaware of its surroundings, so it bumps into things and eats anything that moves.",
+		de: "Da es nichts sehen kann, rammt und frisst es alles, was ihm auf dem Weg in die Quere kommt."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/85.ts
+++ b/data/XY/Steam Siege/85.ts
@@ -56,7 +56,7 @@ const card: Card = {
 				es: "Lanza 2 monedas. Este ataque hace 20 puntos de daño por cada cara.",
 				it: "Lancia due volte una moneta. Questo attacco infligge 20 danni ogni volta che esce testa.",
 				pt: "Jogue 2 moedas. Este ataque causa 20 de danos vezes o número de caras.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 
@@ -99,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "After it has eaten up all the food in its territory, it moves to another area. Its two heads do not get along.",
+		de: "Wenn es sein Revier leergejagt hat, sucht es sich ein neues. Seine beiden Köpfe liegen ständig im Streit."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/86.ts
+++ b/data/XY/Steam Siege/86.ts
@@ -82,7 +82,7 @@ const card: Card = {
 				es: "Descarta tantas Energías Darkness unidas a tus Pokémon como quieras. Este ataque hace 50 puntos de daño por cada Energía Darkness que hayas descartado de esta manera.",
 				it: "Scarta a piacimento le Energie Darkness assegnate ai tuoi Pokémon. Questo attacco infligge 50 danni per ogni carta Energia Darkness che hai scartato in questo modo.",
 				pt: "Descarte tantas Energias Darkness ligadas aos seus Pokémon quanto desejar. Este ataque causa 50 de danos vezes a quantidade de cards de Energia Darkness descartados desta forma.",
-				de: "Lege beliebig viele an deine Pokémon angelegte Darkness-Energien auf deinen Ablagestapel. Dieser Angriff fügt 50 Schadenspunkte für jede der auf diese Weise abgelegte Darkness-Energie zu."
+				de: "Lege beliebig viele an deine Pokémon angelegte {D}-Energien auf deinen Ablagestapel. Dieser Angriff fügt 50 Schadenspunkte für jede der auf diese Weise abgelegte {D}-Energie zu."
 			},
 			damage: "50×",
 
@@ -100,6 +100,7 @@ const card: Card = {
 
 	description: {
 		en: "It responds to movement by attacking. This scary, three-headed Pokémon devours everything in its path!",
+		de: "Ein kaltblütiges Pokémon, das auf alles reagiert, was sich bewegt, indem es mit seinen drei Köpfen danach schnappt."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/88.ts
+++ b/data/XY/Steam Siege/88.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Adores round objects. It wanders the streets on a nightly basis to look for dropped loose change.",
+		de: "Dieses Pokémon bewundert runde Objekte. Es sucht nachts auf den Straßen nach verlorenen Münzen."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/89.ts
+++ b/data/XY/Steam Siege/89.ts
@@ -80,7 +80,7 @@ const card: Card = {
 				es: "Lanza 3 monedas. Este ataque hace 30 puntos de daño por cada cara.",
 				it: "Lancia tre volte una moneta. Questo attacco infligge 30 danni ogni volta che esce testa.",
 				pt: "Jogue 3 moedas. Este ataque causa 30 de danos vezes o número de caras.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "30×",
 
@@ -98,6 +98,7 @@ const card: Card = {
 
 	description: {
 		en: "Its lithe muscles allow it to walk without making a sound. It attacks in an instant.",
+		de: "Aufgrund seiner geschmeidigen Muskeln kann es sich lautlos bewegen. Es greift ohne Vorwarnung an."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/9.ts
+++ b/data/XY/Steam Siege/9.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, si este Pokémon fuese a quedar Fuera de Combate por el daño de un ataque durante el próximo turno de tu rival, este Pokémon no queda Fuera de Combate, y sus PS restantes pasan a ser 10.",
 				it: "Lancia una moneta. Se esce testa, se questo Pokémon sta per essere messo KO dai danni di un attacco durante il prossimo turno del tuo avversario, non viene messo KO e i suoi PS rimanenti diventano 10.",
 				pt: "Jogue uma moeda. Se sair cara, se este Pokémon estiver prestes a ser Nocauteado por danos causados por um ataque durante a próxima vez de jogar do seu oponente, ele não será Nocauteado e o seu PS restante se tornará 10.",
-				de: "Wirf 1 Münze. Würde dieses Pokémon während des nächsten Zuges deines Gegners durch Schaden eines Angriffs kampfunfähig, wird es dies bei \"Kopf\" nicht und behält stattdessen 10 KP."
+				de: "Wirf 1 Münze. Würde dieses Pokémon während des nächsten Zuges deines Gegners durch Schaden eines Angriffs kampfunfähig, wird es dies bei „Kopf“ nicht und behält stattdessen 10 KP."
 			},
 
 		},
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "When it dangles from a tree branch, it looks just like an acorn. It enjoys scaring other Pokémon.",
+		de: "Es sieht aus wie eine Eichel, die am Baum hängt. Es liebt es, andere Pokémon zu erschrecken."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/90.ts
+++ b/data/XY/Steam Siege/90.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Its tail is so powerful that it can use it to grab a tree branch and hold itself up in the air.",
+		de: "Sein Schweif ist so kräftig, dass es sich stundenlang damit an einem Ast in der Luft halten kann."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/91.ts
+++ b/data/XY/Steam Siege/91.ts
@@ -81,7 +81,7 @@ const card: Card = {
 				es: "Lanza 2 monedas. Este ataque hace 50 puntos de daño por cada cara.",
 				it: "Lancia due volte una moneta. Questo attacco infligge 50 danni ogni volta che esce testa.",
 				pt: "Jogue 2 moedas. Este ataque causa 50 de danos vezes o número de caras.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "50×",
 
@@ -99,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "To eat, it deftly shucks nuts with its two tails. It rarely uses its arms now.",
+		de: "Wenn es hungrig ist, knackt es Nüsse mit seinen beiden Schweifen. Nur selten verwendet es die Arme."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/92.ts
+++ b/data/XY/Steam Siege/92.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "They will challenge anything, even strong opponents, without fear. Their frequent fights help them become stronger.",
+		de: "Es zettelt willkürlich Kämpfe an, egal wie stark der Gegner auch ist. Es gewinnt an Stärke, indem es seine Fehler analysiert."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/93.ts
+++ b/data/XY/Steam Siege/93.ts
@@ -57,7 +57,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, este ataque hace 50 puntos de daño más.",
 				it: "Lancia una moneta. Se esce testa, questo attacco infligge 50 danni in più.",
 				pt: "Jogue uma moeda. Se sair cara, este ataque causará 50 de danos adicionais.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 50 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 50 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -82,7 +82,7 @@ const card: Card = {
 				es: "Este ataque hace 120 puntos de daño menos 20 puntos de daño por cada Colorless en el Coste de Retirada del Pokémon Activo de tu rival.",
 				it: "Questo attacco infligge 120 danni meno 20 per ogni Colorless nel costo di ritirata del Pokémon attivo del tuo avversario.",
 				pt: "Este ataque causa 120 de danos menos 20 de danos para cada Colorless no Custo para Recuar do Pokémon Ativo do seu oponente.",
-				de: "Dieser Angriff fügt 120 Schadenspunkte minus 20 Schadenspunkte für jedes Colorless-Symbol in den Rückzugskosten des Aktiven Pokémon deines Gegners zu."
+				de: "Dieser Angriff fügt 120 Schadenspunkte minus 20 Schadenspunkte für jedes {C}-Symbol in den Rückzugskosten des Aktiven Pokémon deines Gegners zu."
 			},
 			damage: "120−",
 
@@ -107,6 +107,7 @@ const card: Card = {
 
 	description: {
 		en: "They fight for their friends without any thought about danger to themselves. One can carry a car while flying.",
+		de: "Für Freunde stürzt es sich selbstlos in den Kampf. Es kann mit seinen Krallen Autos durch die Lüfte tragen."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/94.ts
+++ b/data/XY/Steam Siege/94.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "Despite the beauty of its lilting voice, it's merciless to intruders that enter its territory.",
+		de: "Sein Zwitschern ist wunderschön, aber wenn Gegner sein Revier betreten, kennt es keine Gnade."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/95.ts
+++ b/data/XY/Steam Siege/95.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "The hotter the flame sac on its belly, the faster it can fly, but it takes some time to get the fire going.",
+		de: "Je heißer die Flammen im Feuersack seines Bauches lodern, desto schneller kann es fliegen. Es dauert jedoch eine Weile, bis es zur Zündung kommt."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/96.ts
+++ b/data/XY/Steam Siege/96.ts
@@ -103,6 +103,7 @@ const card: Card = {
 
 	description: {
 		en: "When attacking prey, it can reach speeds of up to 310 mph. It finishes its prey off with a colossal kick.",
+		de: "Bei der Jagd erreicht es Geschwindigkeiten von bis zu 500 km/h. Es erledigt seine Beute mit einem kräftigen Tritt."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/97.ts
+++ b/data/XY/Steam Siege/97.ts
@@ -70,7 +70,7 @@ const card: Card = {
 				es: "Lanza 2 monedas. Este ataque hace 20 puntos de daño más por cada cara.",
 				it: "Lancia due volte una moneta. Ogni volta che esce testa, questo attacco infligge 20 danni in più.",
 				pt: "Jogue 2 moedas. Este ataque causa 20 de danos adicionais para cada cara.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 weitere Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20+",
 
@@ -95,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "With its wings, it controls its position in the air. It likes to attack from above, a maneuver that is difficult to defend against.",
+		de: "Es nutzt seine Flügel, um sich am Himmel in Position zu halten. Gegen seine Angriffe aus der Luft kann man sich nur schwer zur Wehr setzen."
 	},
 
 	thirdParty: {

--- a/data/XY/Steam Siege/98.ts
+++ b/data/XY/Steam Siege/98.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mira las 7 últimas cartas de tu baraja. Puedes enseñar 1 Shieldon que encuentres entre ellas y ponerlo en tu Banca. Pon el resto de cartas de nuevo en tu baraja y barájalas todas.",
 		it: "Guarda le ultime sette carte del tuo mazzo. Puoi mostrare uno Shieldon presente tra quelle carte e metterlo nella tua panchina. Poi rimischia le altre carte nel tuo mazzo.",
 		pt: "Olhe os 7 cards debaixo do seu baralho. Você poderá revelar um Shieldon que encontrar lá e colocá-lo em seu Banco. Embaralhe os demais cards de volta no seu baralho.",
-		de: "Schau dir die untersten 7 Karten deines Decks an. Falls du dort ein Schilterus findest, kannst du es deinem Gegner zeigen und auf deine Bank legen. Mische die anderen Karten anschließend in dein Deck."
+		de: "Schau dir die untersten 7 Karten deines Decks an. Falls du dort ein Schilterus findest, kannst du es deinem Gegner zeigen und auf deine Bank legen. Mische die anderen Karten anschließend in dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/XY/Steam Siege/99.ts
+++ b/data/XY/Steam Siege/99.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Tu rival enseña las cartas de su mano. Pon tantos Pokémon Básicos que encuentres entre ellas como quieras en la Banca de tu rival.",
 		it: "Il tuo avversario mostra le carte che ha in mano. Prendi un numero qualsiasi di Pokémon Base presenti tra quelle carte e mettili nella sua panchina.",
 		pt: "Seu oponente revela a própria mão. Coloque qualquer número de Pokémon Básico que encontrar lá no Banco do seu oponente.",
-		de: "Dein Gegner deckt seine Handkarten auf. Lege beliebig viele Basis-Pokémon, die du dort findest, auf die Bank deines Gegners."
+		de: "Dein Gegner deckt seine Handkarten auf. Lege beliebig viele Basis-Pokémon, die du dort findest, auf die Bank deines Gegners. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",


### PR DESCRIPTION
## Add missing German translations for xy11

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
