### PR TITLE
Add missing German translations for xy12

### DIFF
--- a/data/XY/Evolutions/10.ts
+++ b/data/XY/Evolutions/10.ts
@@ -76,7 +76,7 @@ const card: Card = {
 				es: "Descarta 1 Energía Fire unida a este Pokémon.",
 				it: "Scarta un'Energia Fire assegnata a questo Pokémon.",
 				pt: "Descarte uma Energia Fire ligada a este Pokémon.",
-				de: "Lege 1 an dieses Pokémon angelegte Fire-Energie auf deinen Ablagestapel."
+				de: "Lege 1 an dieses Pokémon angelegte {R}-Energie auf deinen Ablagestapel."
 			},
 			damage: 90,
 
@@ -94,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "It lashes about with its tail to knock down its foe. It then tears up the fallen opponent with sharp claws.",
+		de: "Es schlägt im Kampf mit seinem Schwanz nach seinen Gegnern. Anschließend zerfetzt es die Gegner mit seinen scharfen Klauen."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/107.ts
+++ b/data/XY/Evolutions/107.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon, en cualquier combinación, 6 cartas de Pokémon y de Energía Básica de tu pila de descartes en tu baraja y barájalas todas.",
 		it: "Rimischia sei carte Pokémon e Energia base, in qualsiasi combinazione, dalla tua pila degli scarti nel tuo mazzo.",
 		pt: "Embaralhe qualquer combinação de 6 cards entre Pokémon e Energia básica da sua pilha de descarte para o seu baralho.",
-		de: "Mische eine beliebige Kombination aus 6 Pokémon- und Basis-Energiekarten von deinem Ablagestapel zurück in dein Deck."
+		de: "Mische eine beliebige Kombination aus 6 Pokémon- und Basis-Energiekarten von deinem Ablagestapel zurück in dein Deck. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/XY/Evolutions/108.ts
+++ b/data/XY/Evolutions/108.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta 1 carta de tu mano. Si lo haces, mira las 8 primeras cartas de tu baraja y pon 1 de ellas en tu mano. Pon el resto de cartas de nuevo en tu baraja y barájalas todas.",
 		it: "Scarta una delle carte che hai in mano. Se lo fai, guarda le prime otto carte del tuo mazzo e aggiungi una di esse alle carte che hai in mano. Poi rimischia le altre carte nel tuo mazzo.",
 		pt: "Descarte um card da sua mão. Se fizer isso, olhe os 8 cards de cima do seu baralho e coloque 1 deles na sua mão. Embaralhe os demais cards de volta no seu baralho.",
-		de: "Lege 1 Karte von deiner Hand auf deinen Ablagestapel. Wenn du das machst, schau dir die obersten 8 Karten deines Decks an und nimm 1 davon auf deine Hand. Mische die anderen Karten anschließend in dein Deck."
+		de: "Lege 1 Karte von deiner Hand auf deinen Ablagestapel. Wenn du das machst, schau dir die obersten 8 Karten deines Decks an und nimm 1 davon auf deine Hand. Mische die anderen Karten anschließend in dein Deck. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/XY/Evolutions/109.ts
+++ b/data/XY/Evolutions/109.ts
@@ -53,7 +53,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, este ataque hace 10 puntos de daño más.",
 				it: "Lancia una moneta. Se esce testa, questo attacco infligge 10 danni in più.",
 				pt: "Jogue uma moeda. Se sair cara, este ataque causará 10 de danos adicionais.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 10 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 

--- a/data/XY/Evolutions/11.ts
+++ b/data/XY/Evolutions/11.ts
@@ -54,7 +54,7 @@ const card: Card = {
 				es: "Todas las Energías unidas a este Pokémon son Energías Fire en vez de su tipo habitual.",
 				it: "Tutte le Energie assegnate a questo Pokémon sono Energie Fire anziché del loro solito tipo.",
 				pt: "Toda Energia ligada a este Pokémon é Energia Fire em vez do tipo usual.",
-				de: "Alle Energien, die an dieses Pokémon angelegt sind, liefern Fire-Energie anstelle ihres normalen Typs."
+				de: "Alle Energien, die an dieses Pokémon angelegt sind, liefern {R}-Energie anstelle ihres normalen Typs."
 			},
 		},
 	],
@@ -106,6 +106,7 @@ const card: Card = {
 
 	description: {
 		en: "Its wings can carry this Pokémon close to an altitude of 4,600 feet. It blows out fire at very high temperatures.",
+		de: "Dieses Pokémon kann mit seinen Flügeln eine Höhe von bis zu 1 400 m erreichen. Es spuckt sehr heißes Feuer."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/110.ts
+++ b/data/XY/Evolutions/110.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Paralizado.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene paralizzato.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente será Paralisado.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Aktive Pokémon deines Gegners jetzt paralysiert."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 			},
 			damage: 10,
 
@@ -72,7 +72,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cruz, este ataque no hace nada. Si sale cara, evita todos los efectos de los ataques, incluido el daño, infligidos a este Pokémon durante el próximo turno de tu rival.",
 				it: "Lancia una moneta. Se esce croce, questo attacco non ha effetto. Se esce testa, previeni tutti gli effetti degli attacchi, inclusi i danni, inflitti a questo Pokémon durante il prossimo turno del tuo avversario.",
 				pt: "Jogue uma moeda. Se sair coroa, esse ataque não fará nada. Se sair cara, todos os efeitos dos ataques causados a este Pokémon serão prevenidos, inclusive danos, durante a próxima vez de jogar do seu oponente.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen. Verhindere bei \"Kopf\" während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die diesem Pokémon zugefügt werden."
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen. Verhindere bei „Kopf“ während des nächsten Zuges deines Gegners alle Effekte von Angriffen, einschließlich Schaden, die diesem Pokémon zugefügt werden."
 			},
 			damage: 30,
 
@@ -90,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "By learning how to fly, Pikachu overcame its weakness to Fighting Pokémon.",
+		de: "Indem es das Fliegen erlernte, bezwang Pikachu seine Schwäche gegenüber Kampf-Pokémon."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/111.ts
+++ b/data/XY/Evolutions/111.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "One summer, a group of Pikachu was found riding the waves at the local beach.",
+		de: "Eines Sommers fand man eine Gruppe Pikachu am örtlichen Strand Wellen reiten."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/113.ts
+++ b/data/XY/Evolutions/113.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cada jugador pone todas sus cartas de Premio boca arriba. (Esas cartas de Premio permanecerán boca arriba durante el resto de la partida).",
 		it: "Entrambi i giocatori girano tutte le loro carte Premio a faccia in su (rimarranno così per il resto della partita).",
 		pt: "Cada jogador vira seus cards de Prêmio com a face voltada para cima. (Os cards de Prêmio permanecerão virados para cima pelo resto do jogo.)",
-		de: "Beide Spieler decken alle ihre Preiskarten auf. (Diese Preiskarten bleiben für den Rest des Spiels aufgedeckt.)"
+		de: "Beide Spieler decken alle ihre Preiskarten auf. (Diese Preiskarten bleiben für den Rest des Spiels aufgedeckt.) Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/XY/Evolutions/14.ts
+++ b/data/XY/Evolutions/14.ts
@@ -48,7 +48,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Confundido.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene confuso.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente ficará Confuso.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Aktive Pokémon deines Gegners jetzt verwirrt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Aktive Pokémon deines Gegners jetzt verwirrt."
 			},
 			damage: 20,
 
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "While young, it has six gorgeous tails. When it grows, several new tails are sprouted.",
+		de: "In seiner Jugend hat es sechs hinreißende Schweife. Während es wächst, kommen noch weitere neue Schweife hinzu."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/15.ts
+++ b/data/XY/Evolutions/15.ts
@@ -80,7 +80,7 @@ const card: Card = {
 				es: "Descarta 1 Energía Fire unida a este Pokémon.",
 				it: "Scarta un'Energia Fire assegnata a questo Pokémon.",
 				pt: "Descarte uma Energia Fire ligada a este Pokémon.",
-				de: "Lege 1 an dieses Pokémon angelegte Fire-Energie auf deinen Ablagestapel."
+				de: "Lege 1 an dieses Pokémon angelegte {R}-Energie auf deinen Ablagestapel."
 			},
 			damage: 120,
 
@@ -98,6 +98,7 @@ const card: Card = {
 
 	description: {
 		en: "It has nine long tails and fur that gleams gold. It is said to live for 1,000 years.",
+		de: "Es hat neun lange Schweife und sein Fell glänzt gülden. Man sagt, es soll 1 000 Jahre alt werden."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/16.ts
+++ b/data/XY/Evolutions/16.ts
@@ -57,7 +57,7 @@ const card: Card = {
 				es: "Descarta todas las Energías Fire unidas a este Pokémon. Este ataque hace 60 puntos de daño más por cada carta de Energía descartada de esta manera.",
 				it: "Scarta tutte le Energie Fire assegnate a questo Pokémon. Questo attacco infligge 60 danni in più per ogni carta Energia scartata in questo modo.",
 				pt: "Descarte toda a Energia Fire ligada a este Pokémon. Este ataque causa 60 de danos adicionais para cada card de Energia descartado desta forma.",
-				de: "Lege alle an dieses Pokémon angelegten Fire-Energien auf deinen Ablagestapel. Dieser Angriff fügt 60 weitere Schadenspunkte für jede Energiekarte zu, die auf diese Weise auf den Ablagestapel gelegt wurde."
+				de: "Lege alle an dieses Pokémon angelegten {R}-Energien auf deinen Ablagestapel. Dieser Angriff fügt 60 weitere Schadenspunkte für jede Energiekarte zu, die auf diese Weise auf den Ablagestapel gelegt wurde."
 			},
 			damage: "10+",
 

--- a/data/XY/Evolutions/17.ts
+++ b/data/XY/Evolutions/17.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "Very friendly and faithful to people. It will try to repel enemies by barking and biting.",
+		de: "Es ist sehr freundlich und bleibt den Menschen treu. Durch Bellen und Beißen versucht es, Gegner zu verscheuchen."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/18.ts
+++ b/data/XY/Evolutions/18.ts
@@ -54,7 +54,7 @@ const card: Card = {
 				es: "Una vez durante tu turno (antes de tu ataque), si este Pokémon estaba en la Banca y se ha convertido en tu Pokémon Activo en este turno, puedes mover cualquier cantidad de Energía Fire unida a tus Pokémon a este Pokémon.",
 				it: "Una sola volta durante il tuo turno, prima di attaccare, se questo Pokémon era in panchina ed è diventato il tuo Pokémon attivo in questo turno, puoi spostare un numero qualsiasi di Energie Fire assegnate ai tuoi Pokémon su questo Pokémon.",
 				pt: "Uma vez durante sua vez de jogar (antes de atacar), se este Pokémon estava no Banco e tornou-se o seu Pokémon Ativo nesta vez de jogar, você poderá ligar qualquer número de Energia Fire ligada a seus Pokémon a este Pokémon.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn dieses Pokémon auf der Bank war und während dieses Zuges zu deinem Aktiven Pokémon wurde, beliebig viele Fire-Energien, die an deine Pokémon angelegt sind, auf dieses Pokémon verschieben."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn dieses Pokémon auf der Bank war und während dieses Zuges zu deinem Aktiven Pokémon wurde, beliebig viele {R}-Energien, die an deine Pokémon angelegt sind, auf dieses Pokémon verschieben."
 			},
 		},
 	],
@@ -99,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon that is described in Chinese legends. It is said to race at an unbelievable speed.",
+		de: "Ein Pokémon, das in chinesischen Legenden beschrieben wird. Man sagt, es bewegt sich mit schier unglaublicher Geschwindigkeit."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/19.ts
+++ b/data/XY/Evolutions/19.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "Its body is light, and its legs are incredibly powerful. It can clear Ayers Rock in one leap.",
+		de: "Sein Körper ist leicht und seine Beine extrem kräftig. Es kommt mit einem Sprung über den Ayers Rock."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/20.ts
+++ b/data/XY/Evolutions/20.ts
@@ -66,7 +66,7 @@ const card: Card = {
 				es: "Descarta 1 Energía Fire unida a este Pokémon.",
 				it: "Scarta un'Energia Fire assegnata a questo Pokémon.",
 				pt: "Descarte uma Energia Fire ligada a este Pokémon.",
-				de: "Lege 1 an dieses Pokémon angelegte Fire-Energie auf deinen Ablagestapel."
+				de: "Lege 1 an dieses Pokémon angelegte {R}-Energie auf deinen Ablagestapel."
 			},
 			damage: 60,
 
@@ -84,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "Found near the mouth of a volcano. This fire-breather's body temperature is nearly 2,200 degrees Fahrenheit.",
+		de: "Es wurde in der Nähe eines Vulkans gefunden. Die Körpertemperatur dieses Feuerspuckers liegt bei fast 1200 Grad Celsius."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/21.ts
+++ b/data/XY/Evolutions/21.ts
@@ -73,7 +73,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cruz, este Pokémon se hace 30 puntos de daño a sí mismo.",
 				it: "Lancia una moneta. Se esce croce, questo Pokémon infligge 30 danni a se stesso.",
 				pt: "Jogue uma moeda. Se sair coroa, este Pokémon causará 30 de danos a ele mesmo.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" fügt sich dieses Pokémon selbst 30 Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Zahl“ fügt sich dieses Pokémon selbst 30 Schadenspunkte zu."
 			},
 			damage: 120,
 

--- a/data/XY/Evolutions/23.ts
+++ b/data/XY/Evolutions/23.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "Its slick black skin is thin and damp. A part of its internal organs can be seen through the skin as a spiral pattern.",
+		de: "Seine glatte, schwarze Haut ist dünn und feucht. Teilweise sind seine Innereien als spiralförmige Muster sichtbar."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/24.ts
+++ b/data/XY/Evolutions/24.ts
@@ -82,7 +82,7 @@ const card: Card = {
 				es: "Lanza 2 monedas. Este ataque hace 50 puntos de daño por cada cara.",
 				it: "Lancia due volte una moneta. Questo attacco infligge 50 danni ogni volta che esce testa.",
 				pt: "Jogue 2 moedas. Este ataque causa 50 de danos vezes o número de caras.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "50×",
 
@@ -100,6 +100,7 @@ const card: Card = {
 
 	description: {
 		en: "Its two legs are well developed. Even though it can live on the ground, it prefers living in water.",
+		de: "Seine beiden Beine sind gut entwickelt. Auch wenn es an Land leben kann, bevorzugt es das Leben im Wasser."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/25.ts
+++ b/data/XY/Evolutions/25.ts
@@ -99,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "An adept swimmer, it knows the front crawl, butterfly, and more. It is faster than the best human swimmers.",
+		de: "Ein formidabler Schwimmer. Es kann Brustschwimmen, Freistil und Schmetterling. Kein Mensch kann schneller schwimmen."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/28.ts
+++ b/data/XY/Evolutions/28.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Covered with light blue fur, its hide is thick and tough. It is active in bitter cold of -40 degrees Fahrenheit.",
+		de: "Unter seinem hellblauen Pelz liegt eine dicke und feste Haut. Es ist bei frostigen -40 °C noch aktiv."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/29.ts
+++ b/data/XY/Evolutions/29.ts
@@ -98,6 +98,7 @@ const card: Card = {
 
 	description: {
 		en: "Its body is covered with a pure white fur. The colder the weather, the more active it becomes.",
+		de: "Sein Körper ist mit reinem, weißem Fell überzogen. Je kälter es wird, desto aktiver wird dieses Pokémon."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/3.ts
+++ b/data/XY/Evolutions/3.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It is covered with a green skin. When it grows, it sheds the skin, covers itself with silk, and becomes a cocoon.",
+		de: "Seine Haut ist grün. Beim Wachsen streift es sie ab und verpuppt sich in einen Seidenkokon."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/30.ts
+++ b/data/XY/Evolutions/30.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, este ataque hace 10 puntos de daño más.",
 				it: "Lancia una moneta. Se esce testa, questo attacco infligge 10 danni in più.",
 				pt: "Jogue uma moeda. Se sair cara, este ataque causará 10 de danos adicionais.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 10 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It appears in large numbers by seashores. At night, its central core flashes with a red light.",
+		de: "Es taucht in großer Anzahl an Ufern auf. Nachts leuchtet der Kern in seiner Mitte rot auf."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/31.ts
+++ b/data/XY/Evolutions/31.ts
@@ -79,7 +79,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Paralizado.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene paralizzato.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente será Paralisado.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Aktive Pokémon deines Gegners jetzt paralysiert."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 			},
 			damage: 30,
 
@@ -97,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon has a geometric body. Because of its body, the locals suspect that it is an alien creature.",
+		de: "Dieses Pokémon hat einen geometrischen Körper. Aufgrund seines Körpers vermuten die Einheimischen, es sei außerirdischen Ursprungs."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/33.ts
+++ b/data/XY/Evolutions/33.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It is virtually worthless in terms of both power and speed. It is the most weak and pathetic Pokémon in the world.",
+		de: "Es ist nutzlos, was Kraft und Geschwindigkeit angeht. Dieses ist das schwächste und erbärmlichste Pokémon der Welt."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/34.ts
+++ b/data/XY/Evolutions/34.ts
@@ -58,7 +58,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Paralizado.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene paralizzato.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente será Paralisado.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Aktive Pokémon deines Gegners jetzt paralysiert."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 			},
 			damage: 50,
 
@@ -84,7 +84,7 @@ const card: Card = {
 				es: "Lanza 2 monedas. Si sale cruz en alguna de ellas, este ataque no hace nada.",
 				it: "Lancia due volte una moneta. Se esce almeno una volta croce, questo attacco non ha effetto.",
 				pt: "Jogue 2 moedas. Se uma delas for coroa, este ataque não fará nada.",
-				de: "Wirf 2 Münzen. Wenn eine oder beide Münzen \"Zahl\" zeigen, hat dieser Angriff keine Auswirkungen."
+				de: "Wirf 2 Münzen. Wenn eine oder beide Münzen „Zahl“ zeigen, hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 180,
 
@@ -102,6 +102,7 @@ const card: Card = {
 
 	description: {
 		en: "It has an extremely aggressive nature. The Hyper Beam it shoots from its mouth totally incinerates all targets.",
+		de: "Es ist von Natur aus sehr aggressiv. Der Hyperstrahl, den es aus seinem Maul verschießt, äschert seine Gegner ein."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/35.ts
+++ b/data/XY/Evolutions/35.ts
@@ -64,7 +64,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cruz, este Pokémon se hace 10 puntos de daño a sí mismo.",
 				it: "Lancia una moneta. Se esce croce, questo Pokémon infligge 10 danni a se stesso.",
 				pt: "Jogue uma moeda. Se sair coroa, este Pokémon causará 10 de danos a ele mesmo.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" fügt sich dieses Pokémon selbst 10 Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Zahl“ fügt sich dieses Pokémon selbst 10 Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It has small electric sacs on both its cheeks. If threatened, it looses electric charges from the sacs.",
+		de: "Es hat kleine Backentaschen, die mit Elektrizität gefüllt sind. Bei Gefahr entlädt es sie."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/36.ts
+++ b/data/XY/Evolutions/36.ts
@@ -56,7 +56,7 @@ const card: Card = {
 				es: "Une 1 carta de Energía Lightning de tu pila de descartes a este Pokémon.",
 				it: "Assegna a questo Pokémon una carta Energia Lightning dalla tua pila degli scarti.",
 				pt: "Ligue um card de Energia Lightning da sua pilha de descarte a este Pokémon.",
-				de: "Nimm 1 Lightning-Energiekarte von deinem Ablagestapel und lege sie an dieses Pokémon an."
+				de: "Nimm 1 {L}-Energiekarte von deinem Ablagestapel und lege sie an dieses Pokémon an."
 			},
 
 		},
@@ -105,6 +105,7 @@ const card: Card = {
 
 	description: {
 		en: "Its electric charges can reach even 100,000 volts. Careless contact can cause even an Indian elephant to faint.",
+		de: "Seine elektrischen Ladungen können bis zu 100 000 Volt erreichen. Unvorsichtiger Kontakt kann sogar einem indischen Elefanten das Bewusstsein nehmen."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/37.ts
+++ b/data/XY/Evolutions/37.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Paralizado.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene paralizzato.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente será Paralisado.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Aktive Pokémon deines Gegners jetzt paralysiert."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 			},
 
 		},
@@ -95,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "It moves while constantly hovering. It discharges Thunder Wave and so on from the units at its sides.",
+		de: "Es bewegt sich schwebend. Seine Magnete an den Seiten entladen eine Donnerwelle nach der nächsten."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/38.ts
+++ b/data/XY/Evolutions/38.ts
@@ -57,7 +57,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Paralizado.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene paralizzato.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente será Paralisado.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Aktive Pokémon deines Gegners jetzt paralysiert."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 			},
 			damage: 30,
 
@@ -107,6 +107,7 @@ const card: Card = {
 
 	description: {
 		en: "A linked cluster formed of several Magnemite. It discharges powerful magnetic waves at high voltage.",
+		de: "Schließen sich mehrere Magnetilo zusammen, entsteht dieses Pokémon. Es entlädt kräftige Hochspannungsmagnetwellen."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/39.ts
+++ b/data/XY/Evolutions/39.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Lanza 1 moneda hasta que salga cruz. Este ataque hace 10 puntos de daño por cada cara.",
 				it: "Lancia una moneta finché non esce croce. Questo attacco infligge 10 danni ogni volta che esce testa.",
 				pt: "Jogue uma moeda até sair coroa. Este ataque causa 10 de danos vezes o número de caras.",
-				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis \"Zahl\" kommt. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10×",
 
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "A life-form whose identity is unknown. It is said to Screech or suddenly Self-Destruct.",
+		de: "Eine Lebensform, deren Ursprung ungeklärt ist. Man sagt, es setzt Kreideschrei oder plötzlich Finale ein."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/4.ts
+++ b/data/XY/Evolutions/4.ts
@@ -80,7 +80,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Paralizado.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene paralizzato.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente será Paralisado.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Aktive Pokémon deines Gegners jetzt paralysiert."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 			},
 			damage: 20,
 
@@ -98,6 +98,7 @@ const card: Card = {
 
 	description: {
 		en: "Even though it is encased in a sturdy shell, the body inside is tender. It can't withstand a harsh attack.",
+		de: "In seiner harten Schale ist ein weicher Körper. Einem brutalen Angriff hat es nichts entgegenzusetzen."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/40.ts
+++ b/data/XY/Evolutions/40.ts
@@ -54,7 +54,7 @@ const card: Card = {
 				es: "Una vez durante tu turno (antes de tu ataque), puedes dejar Fuera de Combate a este Pokémon y unirlo a 1 de tus Pokémon Lightning como carta de Energía Especial. Esta carta proporciona 2 Energías Lightning solo mientras esta carta esté unida a un Pokémon.",
 				it: "Una sola volta durante il tuo turno, prima di attaccare, puoi mettere KO questo Pokémon e assegnarlo a uno dei tuoi Pokémon Lightning come una carta Energia speciale. Questa carta fornisce due Energie Lightning solo quando è assegnata a un Pokémon.",
 				pt: "Uma vez durante sua vez de jogar (antes de atacar), você pode Nocautear este Pokémon e o ligar a um dos seus Pokémon Lightning como um card de Energia Especial. Este card fornece 2 Energias Lightning somente quando está ligado a um Pokémon.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du dieses Pokémon kampfunfähig machen und an 1 deiner Lightning-Pokémon als 1 Spezial-Energiekarte anlegen. Diese Karte liefert nur dann 2 Lightning-Energien, wenn sie an ein Pokémon angelegt ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du dieses Pokémon kampfunfähig machen und an 1 deiner {L}-Pokémon als 1 Spezial-Energiekarte anlegen. Diese Karte liefert nur dann 2 {L}-Energien, wenn sie an ein Pokémon angelegt ist."
 			},
 		},
 	],
@@ -98,6 +98,7 @@ const card: Card = {
 
 	description: {
 		en: "It explodes in response to even minor stimuli. It is feared, with the nickname of \"The Bomb Ball.\"",
+		de: "Es explodiert schon bei kleinsten Reizen. Sein Spitzname „Die Bombenkugel“ spiegelt die Furcht der Menschen wider."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/41.ts
+++ b/data/XY/Evolutions/41.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Paralizado.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene paralizzato.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente será Paralisado.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Aktive Pokémon deines Gegners jetzt paralysiert."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 			},
 			damage: 10,
 
@@ -71,7 +71,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, este ataque hace 10 puntos de daño más. Si sale cruz, este Pokémon se hace 10 puntos de daño a sí mismo.",
 				it: "Lancia una moneta. Se esce testa, questo attacco infligge 10 danni in più. Se esce croce, questo Pokémon infligge 10 danni a se stesso.",
 				pt: "Jogue uma moeda. Se sair cara, este ataque causará 10 de danos adicionais. Se sair coroa, este Pokémon causará 10 de danos a ele mesmo.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 10 weitere Schadenspunkte zu. Bei \"Zahl\" fügt sich dieses Pokémon selbst 10 Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 weitere Schadenspunkte zu. Bei „Zahl“ fügt sich dieses Pokémon selbst 10 Schadenspunkte zu."
 			},
 			damage: "30+",
 
@@ -96,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "It loves to feed on strong electricity. It occasionally appears around large power plants and so on.",
+		de: "Es konsumiert am liebsten Elektrizität. Gelegentlich sieht man es in der Nähe von Kraftwerken."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/42.ts
+++ b/data/XY/Evolutions/42.ts
@@ -94,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "One of the legendary bird Pokémon. While it is flying, it makes crackling and snapping sounds.",
+		de: "Ein Legendäres Vogel-Pokémon. Beim Fliegen macht es knackende und schnappende Geräusche."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/43.ts
+++ b/data/XY/Evolutions/43.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Lanza 2 monedas. Este ataque hace 10 puntos de daño por cada cara.",
 				it: "Lancia due volte una moneta. Questo attacco infligge 10 danni ogni volta che esce testa.",
 				pt: "Jogue 2 moedas. Este ataque causa 10 de danos vezes o número de caras.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10×",
 
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "Its large ears are flapped like wings when it is listening to distant sounds. It extends toxic barbs when angered.",
+		de: "Seine großen Ohren schlagen wie Flügel, wenn es Geräusche in weiter Entfernung hört. Es fährt giftige Stacheln aus, wenn es verärgert ist."
 	},
 }
 

--- a/data/XY/Evolutions/44.ts
+++ b/data/XY/Evolutions/44.ts
@@ -74,7 +74,7 @@ const card: Card = {
 				es: "Lanza 3 monedas. Este ataque hace 30 puntos de daño por cada cara.",
 				it: "Lancia tre volte una moneta. Questo attacco infligge 30 danni ogni volta che esce testa.",
 				pt: "Jogue 3 moedas. Este ataque causa 30 de danos vezes o número de caras.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 30 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "30×",
 
@@ -92,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "It is easily angered. By swinging its well-developed horn wildly, it can even punch through diamond.",
+		de: "Es kann leicht wütend werden. Durch kräftiges Drehen seines ausgeprägten Horns kann es sogar durch Diamanten bohren."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/45.ts
+++ b/data/XY/Evolutions/45.ts
@@ -100,6 +100,7 @@ const card: Card = {
 
 	description: {
 		en: "It is recognized by its rock-hard hide and its extended horn. Be careful with the horn as it contains venom.",
+		de: "Seine steinharte Haut und sein ausgeprägtes Horn sind seine Markenzeichen. Achte auf das Horn, denn es enthält Gift."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/47.ts
+++ b/data/XY/Evolutions/47.ts
@@ -70,7 +70,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Dormido.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene addormentato.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente ficará Adormecido.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" schläft das Aktive Pokémon deines Gegners jetzt."
+				de: "Wirf 1 Münze. Bei „Kopf“ schläft das Aktive Pokémon deines Gegners jetzt."
 			},
 			damage: 20,
 
@@ -95,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "A being that exists as a thin gas. It can topple an Indian elephant by enveloping the prey in two seconds.",
+		de: "Ein Wesen, das aus Gas besteht. Es kann einen indischen Elefanten umstoßen, indem es ihn innerhalb von zwei Sekunden einhüllt."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/48.ts
+++ b/data/XY/Evolutions/48.ts
@@ -104,6 +104,7 @@ const card: Card = {
 
 	description: {
 		en: "If you get the feeling of being watched in darkness when nobody is around, Haunter is there.",
+		de: "Falls du im Dunkeln das Gefühl hast, beobachtet zu werden und niemand ist zu sehen, ist es bestimmt Alpollo."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/49.ts
+++ b/data/XY/Evolutions/49.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "A descendant of the legendary animal baku, which is said to eat dreams. It is skilled at hypnotism.",
+		de: "Ein Nachfahre des legendären Tieres Baku, das der Legende nach Träume fraß. Dieses Pokémon ist ein begnadeter Hypnotiseur."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/5.ts
+++ b/data/XY/Evolutions/5.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "Often found in forests and grasslands. It has a sharp, toxic barb of around two inches on top of its head.",
+		de: "Es lebt bevorzugt in Wäldern und in hohem Gras. Auf dem Kopf trägt es einen circa 5 cm langen, spitzen, giftigen Stachel."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/50.ts
+++ b/data/XY/Evolutions/50.ts
@@ -48,7 +48,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Envenenado. Si sale cruz, el Pokémon Activo de tu rival pasa a estar Confundido.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene avvelenato. Se esce croce, il Pokémon attivo del tuo avversario viene confuso.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente será Envenenado. Se sair coroa, o Pokémon Ativo do seu oponente ficará Confuso.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Aktive Pokémon deines Gegners jetzt vergiftet. Bei \"Zahl\" ist das Aktive Pokémon deines Gegners jetzt verwirrt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Aktive Pokémon deines Gegners jetzt vergiftet. Bei „Zahl“ ist das Aktive Pokémon deines Gegners jetzt verwirrt."
 			},
 			damage: 10,
 
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "Its thin, balloon-like body is inflated by horribly toxic gases. It reeks when it is nearby.",
+		de: "Sein dünner, ballonartiger Körper ist mit schrecklichem Giftgas gefüllt. Es verbreitet einen heftigen Gestank, wenn es in der Nähe ist."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/51.ts
+++ b/data/XY/Evolutions/51.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon whose genetic code was repeatedly recombined for research. It turned vicious as a result.",
+		de: "Der genetische Code dieses Pokémon wurde wiederholt aus Forschungsgründen umstrukturiert. Daher ist es so bösartig."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/53.ts
+++ b/data/XY/Evolutions/53.ts
@@ -70,7 +70,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Paralizado.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene paralizzato.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente será Paralisado.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Aktive Pokémon deines Gegners jetzt paralysiert."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 			},
 			damage: 30,
 
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "So rare that it is still said to be a mirage by many experts. Only a few people have seen it worldwide.",
+		de: "Viele Experten bezweifeln die Existenz dieses Pokémon. Nur wenige Personen haben es gesehen."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/54.ts
+++ b/data/XY/Evolutions/54.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Si el Pokémon Defensor intenta atacar durante el próximo turno de tu rival, este lanza 1 moneda. Si sale cruz, ese ataque no hace nada.",
 				it: "Se durante il prossimo turno del tuo avversario il Pokémon difensore prova ad attaccare, il tuo avversario lancia una moneta. Se esce croce, quell'attacco non ha effetto.",
 				pt: "Se o Pokémon Defensor tentar atacar durante a próxima vez de jogar do seu oponente, seu oponente jogará uma moeda. Se sair coroa, aquele ataque não fará nada.",
-				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei \"Zahl\" hat jener Angriff keine Auswirkungen."
+				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat jener Angriff keine Auswirkungen."
 			},
 			damage: 10,
 
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It burrows and lives underground. If threatened, it curls itself up into a ball for protection.",
+		de: "Es gräbt und lebt im Erdboden. Bei Gefahr rollt es sich zum Schutz zu einem Ball zusammen."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/55.ts
+++ b/data/XY/Evolutions/55.ts
@@ -87,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "It burrows through the ground at a shallow depth. It leaves raised earth in its wake, making it easy to spot.",
+		de: "Es gräbt sich in geringer Tiefe durch den Erdboden, dadurch hinterlässt es durchwühlte Erde und ist somit leicht zu finden."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/56.ts
+++ b/data/XY/Evolutions/56.ts
@@ -93,6 +93,7 @@ const card: Card = {
 
 	description: {
 		en: "In battle, it digs through the ground and strikes the unsuspecting foe from an unexpected direction.",
+		de: "Im Kampf gräbt es sich ein und attackiert den Gegner aus einer unvorhersehbaren Richtung."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/57.ts
+++ b/data/XY/Evolutions/57.ts
@@ -48,7 +48,7 @@ const card: Card = {
 				es: "Lanza 2 monedas. Este ataque hace 20 puntos de daño por cada cara.",
 				it: "Lancia due volte una moneta. Questo attacco infligge 20 danni ogni volta che esce testa.",
 				pt: "Jogue 2 moedas. Este ataque causa 20 de danos vezes o número de caras.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "Its whole body is composed of muscles. Even though it's the size of a human child, it can hurl 100 grown-ups.",
+		de: "Sein ganzer Körper besteht aus Muskeln. Auch wenn es nur so groß wie ein Menschenkind ist, kann es 100 Erwachsene jonglieren."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/58.ts
+++ b/data/XY/Evolutions/58.ts
@@ -100,6 +100,7 @@ const card: Card = {
 
 	description: {
 		en: "Its formidable body never gets tired. It helps people by doing work such as the moving of heavy goods.",
+		de: "Sein durchtrainierter Körper wird nie müde. Es hilft den Menschen, indem es schwere Sachen trägt."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/59.ts
+++ b/data/XY/Evolutions/59.ts
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "Its four ruggedly developed arms can launch a flurry of 1,000 punches in just two seconds.",
+		de: "Seine markigen Arme können innerhalb von nur zwei Sekunden 1 000 Schläge verteilen."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/6.ts
+++ b/data/XY/Evolutions/6.ts
@@ -80,7 +80,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Envenenado.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene avvelenato.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente será Envenenado.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Aktive Pokémon deines Gegners jetzt vergiftet."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Aktive Pokémon deines Gegners jetzt vergiftet."
 			},
 			damage: 20,
 
@@ -98,6 +98,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon is in a temporary stage while making its body. It is almost completely unable to move on its own.",
+		de: "Dieses Pokémon befindet sich in einer Metamorphose und bildet seinen Körper noch. Es kann sich kaum aus freien Stücken bewegen."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/61.ts
+++ b/data/XY/Evolutions/61.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "It usually lives underground. It searches for food while boring its way through the ground at 50 miles per hour.",
+		de: "Es lebt gewöhnlich unter der Erde. Während es sich mit 80 km/h durchs Erdreich bohrt, sucht es nach Nahrung."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/62.ts
+++ b/data/XY/Evolutions/62.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "The spirit of a pro boxer has infused this Pokémon. It throws punches that are faster than a bullet train.",
+		de: "Der Geist eines Profi-Boxers hat dieses Pokémon inspiriert. Seine Faustschläge sind schneller als ein Hochgeschwindigkeitszug."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/63.ts
+++ b/data/XY/Evolutions/63.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Dormido.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene addormentato.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente ficará Adormecido.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" schläft das Aktive Pokémon deines Gegners jetzt."
+				de: "Wirf 1 Münze. Bei „Kopf“ schläft das Aktive Pokémon deines Gegners jetzt."
 			},
 
 		},
@@ -95,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "Its adorable appearance makes it popular as a pet. However, it is rare and difficult to find.",
+		de: "Sein possierliches Aussehen macht es zu einem beliebten Haustier. Es ist jedoch sehr selten und schwer zu finden."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/66.ts
+++ b/data/XY/Evolutions/66.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "Its fangs are long and very sharp. They grow continuously, so it gnaws on hard things to whittle them down.",
+		de: "Seine Reißzähne sind lang und scharf. Da sie ständig wachsen, nagt es immerzu an etwas, um sie abzuwetzen."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/67.ts
+++ b/data/XY/Evolutions/67.ts
@@ -97,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "Its rear feet have three toes each. They are webbed, enabling it to swim across rivers.",
+		de: "An seinen Hinterläufen hat es je drei Zehen. Da sie mit Häuten überzogen sind, kann es mühelos Flüsse durchqueren."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/68.ts
+++ b/data/XY/Evolutions/68.ts
@@ -90,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "It always walks about with a plant stalk clamped in its beak. The stalk is used for building its nest.",
+		de: "Es läuft stets mit einer Lauchstange umher. Damit baut es sein Nest."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/69.ts
+++ b/data/XY/Evolutions/69.ts
@@ -60,7 +60,7 @@ const card: Card = {
 			es: "Lanza 3 monedas. Este ataque hace 10 puntos de daño por cada cara.",
 			it: "Lancia tre volte una moneta. Questo attacco infligge 10 danni ogni volta che esce testa.",
 			pt: "Jogue 3 moedas. Este ataque causa 10 de danos vezes o número de caras.",
-			de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+			de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 		},
 
 		damage: "10×",
@@ -69,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "A two-headed Pokémon that was discovered as a sudden mutation. It runs at a pace of over 60 miles per hour.",
+		de: "Dieses zweiköpfige Pokémon gilt als plötzliche Mutation. Es rennt bis zu 100 km/h schnell."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/7.ts
+++ b/data/XY/Evolutions/7.ts
@@ -97,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "May appear in a swarm. Flies at violent speeds, all the while stabbing with the toxic stinger on its rear.",
+		de: "Es kann in Schwärmen auftauchen. Während seines rasanten Fluges sticht es mit dem Giftstachel an seinem Hinterteil zu."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/70.ts
+++ b/data/XY/Evolutions/70.ts
@@ -48,7 +48,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, evita todo el daño infligido a este Pokémon por ataques durante el próximo turno de tu rival.",
 				it: "Lancia una moneta. Se esce testa, previeni tutti i danni da attacchi inflitti a questo Pokémon durante il prossimo turno del tuo avversario.",
 				pt: "Jogue uma moeda. Se sair cara, impedirá todos os danos causados a este Pokémon por ataques durante a próxima vez de jogar do seu oponente.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" verhindere allen Schaden, der diesem Pokémon während des nächsten Zuges deines Gegners durch Angriffe zugefügt wird."
+				de: "Wirf 1 Münze. Bei „Kopf“ verhindere allen Schaden, der diesem Pokémon während des nächsten Zuges deines Gegners durch Angriffe zugefügt wird."
 			},
 
 		},
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "It lays several eggs a day. The eggs are apparently rich in nutrients and extremely delicious.",
+		de: "Es legt mehrere Eier am Tag. Sie sind sehr nahrhaft und außerordentlich schmackhaft."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/71.ts
+++ b/data/XY/Evolutions/71.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Elige el tipo Grass, Fire, Water, Lightning, Psychic, Fighting, Darkness, Metal, Fairy o Dragon. La Debilidad del Pokémon Defensor pasa a ser de ese tipo hasta el final de tu próximo turno. (La cantidad de Debilidad no cambia).",
 				it: "Scegli uno dei seguenti tipi: Grass, Fire, Water, Lightning, Psychic, Fighting, Darkness, Metal, Fairy o Dragon. La debolezza del Pokémon difensore diventa di quel tipo fino alla fine del tuo prossimo turno. Quanto è debole non cambia.",
 				pt: "Encolha o tipo Grass, Fire, Water, Lightning, Psychic, Fighting, Darkness, Metal, Fairy ou Dragon. A Fraqueza do Pokémon Defensor passa a ser daquele tipo até o final da sua próxima vez de jogar. (A quantidade de Fraqueza não muda.)",
-				de: "Wähle den Typ Grass, Fire, Water, Lightning, Psychic, Fighting, Darkness, Metal, Fairy oder Dragon. Bis zum Ende deines nächsten Zuges ist die Schwäche des Verteidigenden Pokémon jetzt dieser Typ. (Die Höhe der Schwäche ändert sich nicht.)"
+				de: "Wähle den Typ {G}, {R}, {W}, {L}, {P}, {F}, {D}, {M}, {FAIRY} oder {N}. Bis zum Ende deines nächsten Zuges ist die Schwäche des Verteidigenden Pokémon jetzt dieser Typ. (Die Höhe der Schwäche ändert sich nicht.)"
 			},
 
 		},
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "Using the most advanced technologies, scientists finally succeeded in making the first artificial Pokémon.",
+		de: "Unter Einsatz der neuesten Technologie ist es Forschern endlich gelungen, das erste künstliche POKéMON zu erschaffen."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/73.ts
+++ b/data/XY/Evolutions/73.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Tu turno no termina si el Pokémon al que está unida esta carta se convierte en M-Blastoise-EX.",
 		it: "Il tuo turno non finisce se il Pokémon a cui è assegnata questa carta diventa M Blastoise-EX.",
 		pt: "Sua vez de jogar não terminará se o Pokémon ao qual este card está ligado tornar-se M-Blastoise-EX.",
-		de: "Dein Zug endet nicht, wenn das Pokémon, an das diese Karte angelegt ist, zu M-Turtok-EX wird."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Dein Zug endet nicht, wenn das Pokémon, an das diese Karte angelegt ist, zu M-Turtok-EX wird. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/XY/Evolutions/74.ts
+++ b/data/XY/Evolutions/74.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon, en cualquier combinación, 6 cartas de Pokémon y de Energía Básica de tu pila de descartes en tu baraja y barájalas todas.",
 		it: "Rimischia sei carte Pokémon e Energia base, in qualsiasi combinazione, dalla tua pila degli scarti nel tuo mazzo.",
 		pt: "Embaralhe qualquer combinação de 6 cards entre Pokémon e Energia básica da sua pilha de descarte para o seu baralho.",
-		de: "Mische eine beliebige Kombination aus 6 Pokémon- und Basis-Energiekarten von deinem Ablagestapel zurück in dein Deck."
+		de: "Mische eine beliebige Kombination aus 6 Pokémon- und Basis-Energiekarten von deinem Ablagestapel zurück in dein Deck. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/XY/Evolutions/75.ts
+++ b/data/XY/Evolutions/75.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Tu turno no termina si el Pokémon al que está unida esta carta se convierte en M-Charizard-EX.",
 		it: "Il tuo turno non finisce se il Pokémon a cui è assegnata questa carta diventa M Charizard-EX.",
 		pt: "Sua vez de jogar não terminará se o Pokémon ao qual este card está ligado tornar-se M-Charizard-EX.",
-		de: "Dein Zug endet nicht, wenn das Pokémon, an das diese Karte angelegt ist, zu M-Glurak-EX wird."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Dein Zug endet nicht, wenn das Pokémon, an das diese Karte angelegt ist, zu M-Glurak-EX wird. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/XY/Evolutions/76.ts
+++ b/data/XY/Evolutions/76.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Involuciona a 1 de tus Pokémon evolucionados y pon la carta de Evolución de fase más alta que tenga sobre él en tu mano. (Ese Pokémon no puede evolucionar en este turno).",
 		it: "Annulla l'evoluzione di uno dei tuoi Pokémon evoluti e riprendi in mano la carta Evoluzione di fase più alta. Quel Pokémon non può evolversi in questo turno.",
 		pt: "Reverte cada um dos seus Pokémon evoluídos e coloca o card de Evolução de Estágio mais alto na sua mão. (Aquele Pokémon não pode evoluir nesta vez de jogar.)",
-		de: "Rückentwickle 1 deiner entwickelten Pokémon und nimm die höchste daraufliegende Evolutionskarte auf deine Hand. (Das Pokémon kann sich während dieses Zuges nicht entwickeln.)"
+		de: "Rückentwickle 1 deiner entwickelten Pokémon und nimm die höchste daraufliegende Evolutionskarte auf deine Hand. (Das Pokémon kann sich während dieses Zuges nicht entwickeln.) Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/XY/Evolutions/77.ts
+++ b/data/XY/Evolutions/77.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon 2 cartas de Energía Básica de tu pila de descartes en tu mano.",
 		it: "Prendi due carte Energia base dalla tua pila degli scarti e aggiungile alle carte che hai in mano.",
 		pt: "Coloque 2 cards de Energias básicas da pilha de descarte em sua mão.",
-		de: "Nimm 2 Basis-Energiekarten von deinem Ablagestapel auf deine Hand."
+		de: "Nimm 2 Basis-Energiekarten von deinem Ablagestapel auf deine Hand. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/XY/Evolutions/78.ts
+++ b/data/XY/Evolutions/78.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Elimina todas las Condiciones Especiales de tu Pokémon Activo.",
 		it: "Rimuovi tutte le condizioni speciali dal tuo Pokémon attivo.",
 		pt: "Remova todas as Condições Especiais do seu Pokémon Ativo.",
-		de: "Alle Speziellen Zustände auf deinem Aktiven Pokémon verlieren ihre Wirkung."
+		de: "Alle Speziellen Zustände auf deinem Aktiven Pokémon verlieren ihre Wirkung. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/XY/Evolutions/79.ts
+++ b/data/XY/Evolutions/79.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon 2 cartas de tu mano en tu baraja y barájalas todas. (Si no puedes poner 2 cartas, no puedes jugar esta carta). Después, roba 1 carta.",
 		it: "Rimischia due carte dalla tua mano nel tuo mazzo (se non puoi rimischiare due carte nel tuo mazzo, non potrai giocare questa carta). Poi, pesca una carta.",
 		pt: "Embaralhe 2 cards da sua mão em seu baralho. (Se você não puder embaralhar 2 cards em seu baralho, não poderá jogar esse card.) Em seguida, compre um card.",
-		de: "Mische 2 Karten von deiner Hand in dein Deck. (Wenn du keine 2 Karten in dein Deck mischen kannst, kannst du diese Karte nicht spielen.) Ziehe anschließend 1 Karte."
+		de: "Mische 2 Karten von deiner Hand in dein Deck. (Wenn du keine 2 Karten in dein Deck mischen kannst, kannst du diese Karte nicht spielen.) Ziehe anschließend 1 Karte. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/XY/Evolutions/8.ts
+++ b/data/XY/Evolutions/8.ts
@@ -48,7 +48,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, el Pokémon Activo de tu rival pasa a estar Paralizado.",
 				it: "Lancia una moneta. Se esce testa, il Pokémon attivo del tuo avversario viene paralizzato.",
 				pt: "Jogue uma moeda. Se sair cara, o Pokémon Ativo do seu oponente será Paralisado.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Aktive Pokémon deines Gegners jetzt paralysiert."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 			},
 			damage: 20,
 
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "Blue plant vines cloak the Pokémon's identity in a tangled mass. It entangles anything that gets close.",
+		de: "Blaue Lianen verdecken die wahre Identität dieses Pokémon. Es verheddert alles, was ihm zu nahe kommt."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/80.ts
+++ b/data/XY/Evolutions/80.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta 1 carta de tu mano. Si lo haces, mira las 8 primeras cartas de tu baraja y pon 1 de ellas en tu mano. Pon el resto de cartas de nuevo en tu baraja y barájalas todas.",
 		it: "Scarta una delle carte che hai in mano. Se lo fai, guarda le prime otto carte del tuo mazzo e aggiungi una di esse alle carte che hai in mano. Poi rimischia le altre carte nel tuo mazzo.",
 		pt: "Descarte um card da sua mão. Se fizer isso, olhe os 8 cards de cima do seu baralho e coloque 1 deles na sua mão. Embaralhe os demais cards de volta no seu baralho.",
-		de: "Lege 1 Karte von deiner Hand auf deinen Ablagestapel. Wenn du das machst, schau dir die obersten 8 Karten deines Decks an und nimm 1 davon auf deine Hand. Mische die anderen Karten anschließend in dein Deck."
+		de: "Lege 1 Karte von deiner Hand auf deinen Ablagestapel. Wenn du das machst, schau dir die obersten 8 Karten deines Decks an und nimm 1 davon auf deine Hand. Mische die anderen Karten anschließend in dein Deck. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/XY/Evolutions/81.ts
+++ b/data/XY/Evolutions/81.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Tu turno no termina si el Pokémon al que está unida esta carta se convierte en M-Pidgeot-EX.",
 		it: "Il tuo turno non finisce se il Pokémon a cui è assegnata questa carta diventa M Pidgeot-EX.",
 		pt: "Sua vez de jogar não terminará se o Pokémon ao qual este card está ligado tornar-se M-Pidgeot-EX.",
-		de: "Dein Zug endet nicht, wenn das Pokémon, an das diese Karte angelegt ist, zu M-Tauboss-EX wird."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Dein Zug endet nicht, wenn das Pokémon, an das diese Karte angelegt ist, zu M-Tauboss-EX wird. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/XY/Evolutions/82.ts
+++ b/data/XY/Evolutions/82.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mira las 5 primeras cartas de tu baraja y vuelve a ponerlas en la parte superior de tu baraja en el orden que quieras.",
 		it: "Guarda le prime cinque carte del tuo mazzo e rimettile a posto nell'ordine che preferisci.",
 		pt: "Olhe os 5 primeiros cards do seu baralho e coloque-os de volta em qualquer ordem.",
-		de: "Schau dir die obersten 5 Karten deines Decks an und lege sie in beliebiger Reihenfolge zurück in dein Deck."
+		de: "Schau dir die obersten 5 Karten deines Decks an und lege sie in beliebiger Reihenfolge zurück in dein Deck. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/XY/Evolutions/83.ts
+++ b/data/XY/Evolutions/83.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cura 30 puntos de daño a 1 de tus Pokémon.",
 		it: "Cura uno dei tuoi Pokémon da 30 danni.",
 		pt: "Cure 30 de danos de 1 dos seus Pokémon.",
-		de: "Heile 30 Schadenspunkte bei 1 deiner Pokémon."
+		de: "Heile 30 Schadenspunkte bei 1 deiner Pokémon. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/XY/Evolutions/84.ts
+++ b/data/XY/Evolutions/84.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba cartas hasta que tengas 7 cartas en tu mano. Tu turno termina.",
 		it: "Pesca fino ad avere sette carte in mano. Il tuo turno finisce.",
 		pt: "Compre cards até ter 7 cards em sua mão. Sua vez de jogar termina.",
-		de: "Ziehe so viele Karten, bis du 7 Karten auf der Hand hast. Dein Zug endet."
+		de: "Ziehe so viele Karten, bis du 7 Karten auf der Hand hast. Dein Zug endet. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/XY/Evolutions/85.ts
+++ b/data/XY/Evolutions/85.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon 1 Pokémon Básico de tu pila de descartes en tu Banca.",
 		it: "Prendi un Pokémon Base dalla tua pila degli scarti e mettilo in panchina.",
 		pt: "Coloque um Pokémon Básico da sua pilha de descarte no seu Banco.",
-		de: "Nimm 1 Basis-Pokémon von deinem Ablagestapel und lege es auf deine Bank."
+		de: "Nimm 1 Basis-Pokémon von deinem Ablagestapel und lege es auf deine Bank. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/XY/Evolutions/86.ts
+++ b/data/XY/Evolutions/86.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Tu turno no termina si el Pokémon al que está unida esta carta se convierte en M-Slowbro-EX.",
 		it: "Il tuo turno non finisce se il Pokémon a cui è assegnata questa carta diventa M Slowbro-EX.",
 		pt: "Sua vez de jogar não terminará se o Pokémon ao qual este card está ligado tornar-se M-Slowbro-EX.",
-		de: "Dein Zug endet nicht, wenn das Pokémon, an das diese Karte angelegt ist, zu M-Lahmus-EX wird."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Dein Zug endet nicht, wenn das Pokémon, an das diese Karte angelegt ist, zu M-Lahmus-EX wird. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/XY/Evolutions/87.ts
+++ b/data/XY/Evolutions/87.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cura 60 puntos de daño a 1 de tus Pokémon. Si lo haces, descarta 1 Energía unida a ese Pokémon.",
 		it: "Cura uno dei tuoi Pokémon da 60 danni. Se lo fai, scarta un'Energia assegnata a quel Pokémon.",
 		pt: "Cure 60 de danos de 1 dos seus Pokémon. Se fizer isso, descarte uma Energia ligada àquele Pokémon.",
-		de: "Heile 60 Schadenspunkte bei 1 deiner Pokémon. Wenn du das machst, lege 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel."
+		de: "Heile 60 Schadenspunkte bei 1 deiner Pokémon. Wenn du das machst, lege 1 an dieses Pokémon angelegte Energie auf deinen Ablagestapel. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/XY/Evolutions/88.ts
+++ b/data/XY/Evolutions/88.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cambia tu Pokémon Activo por 1 de tus Pokémon en Banca.",
 		it: "Scambia il tuo Pokémon attivo con uno dei tuoi Pokémon in panchina.",
 		pt: "Troque seu Pokémon Ativo por 1 dos Pokémon no seu Banco.",
-		de: "Tausche dein Aktives Pokémon gegen 1 Pokémon auf deiner Bank aus."
+		de: "Tausche dein Aktives Pokémon gegen 1 Pokémon auf deiner Bank aus. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/XY/Evolutions/89.ts
+++ b/data/XY/Evolutions/89.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Tu turno no termina si el Pokémon al que está unida esta carta se convierte en M-Venusaur-EX.",
 		it: "Il tuo turno non finisce se il Pokémon a cui è assegnata questa carta diventa M Venusaur-EX.",
 		pt: "Sua vez de jogar não terminará se o Pokémon ao qual este card está ligado tornar-se M-Venusaur-EX.",
-		de: "Dein Zug endet nicht, wenn das Pokémon, an das diese Karte angelegt ist, zu M-Bisaflor-EX wird."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Dein Zug endet nicht, wenn das Pokémon, an das diese Karte angelegt ist, zu M-Bisaflor-EX wird. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/XY/Evolutions/9.ts
+++ b/data/XY/Evolutions/9.ts
@@ -64,7 +64,7 @@ const card: Card = {
 				es: "Descarta 1 Energía Fire unida a este Pokémon.",
 				it: "Scarta un'Energia Fire assegnata a questo Pokémon.",
 				pt: "Descarte uma Energia Fire ligada a este Pokémon.",
-				de: "Lege 1 an dieses Pokémon angelegte Fire-Energie auf deinen Ablagestapel."
+				de: "Lege 1 an dieses Pokémon angelegte {R}-Energie auf deinen Ablagestapel."
 			},
 			damage: 30,
 
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "From the time it is born, a flame burns at the tip of its tail. Its life would end if the flame were to go out.",
+		de: "Von Geburt an brennt die Flamme auf seiner Schwanzspitze. Sobald sie erlischt, erlischt auch sein Lebenslicht."
 	},
 
 	thirdParty: {

--- a/data/XY/Evolutions/90.ts
+++ b/data/XY/Evolutions/90.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Doble Energía Incolora proporciona Energía ColorlessColorless.",
 		it: "Un'Energia Incolore doppia fornisce ColorlessColorless.",
 		pt: "A Energia Incolor Dupla fornece Energias ColorlessColorless.",
-		de: "Doppel-Farblos-Energie liefert ColorlessColorless-Energie."
+		de: "Doppel-Farblos-Energie liefert {C}{C}-Energie."
 	},
 
 	energyType: "Special",


### PR DESCRIPTION
## Add missing German translations for xy12

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
