### PR TITLE
Add missing German translations for sm1

### DIFF
--- a/data/Sun & Moon/Sun & Moon/1.ts
+++ b/data/Sun & Moon/Sun & Moon/1.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "When attacked by bird Pokémon, it resists by releasing a terrifically strong odor from its antennae, but it often becomes their prey.",
+		de: "Es versucht, angreifende Vogel-Pokémon mit dem Gestank aus seinen Antennen in die Flucht zu schlagen. Das gelingt ihm aber nicht immer."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/10.ts
+++ b/data/Sun & Moon/Sun & Moon/10.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Rowlet",
 		fr: "Brindibou",
+		de: "Bauz"
 	},
 
 	stage: "Stage1",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "A bit of a dandy, it spends its free time preening its wings. Its preoccupation with any dirt on its plumage can leave it unable to battle.",
+		de: "Dieses affektierte Pokémon pflegt sein Gefieder, wann immer es kann. Mit verschmutzten Federn hat es nämlich oft keine Lust zu kämpfen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/101.ts
+++ b/data/Sun & Moon/Sun & Moon/101.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Cuando unas 1 carta de Energía Básica de tu mano a este Pokémon, puedes buscar en tu baraja 1 carta que evolucione de este Pokémon y que sea del mismo tipo que esa carta de Energía y puedes ponerla sobre este Pokémon. (Esto equivale a hacer evolucionar a este Pokémon). Baraja las cartas de tu baraja después.",
 				it: "Quando assegni una carta Energia base dalla tua mano a questo Pokémon, puoi cercare nel tuo mazzo una carta che si evolve da questo Pokémon che sia dello stesso tipo della carta Energia che hai assegnato a questo Pokémon e mettergliela sopra (quest’azione vale come evoluzione del Pokémon). Poi rimischia le carte del tuo mazzo.",
 				pt: "Ao ligar um card de Energia básica da sua mão a este Pokémon, você poderá procurar em seu baralho um card que evolua desse Pokémon e seja do mesmo tipo que esse card de Energia e, em seguida, colocá-lo nesse Pokémon. (Isso conta como evoluir esse Pokémon.) Em seguida, embaralhe seus cards.",
-				de: "Wenn du 1 Basis-Energiekarte von deiner Hand an dieses Pokémon anlegst, kannst du dein Deck nach 1 Karte, die sich aus diesem Pokémon entwickelt und die denselben Energietyp wie diese Energiekarte hat, durchsuchen und sie auf dieses Pokémon legen. (Dies zählt als Entwicklung dieses Pokémon.) Mische anschließend dein Deck."
+				de: "Wenn du während deines Zuges 1 Basis-Energiekarte aus deiner Hand an dieses Pokémon anlegst, kannst du dein Deck nach 1 Karte, die sich aus diesem Pokémon entwickelt und die denselben Typ wie jene Energiekarte hat, durchsuchen und sie auf dieses Pokémon legen, um es zu entwickeln. Mische anschließend dein Deck."
 			},
 		},
 	],
@@ -86,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "Possessing an unbalanced and unstable genetic makeup, it conceals many possible evolutions.",
+		de: "Sein instabiles Erbmaterial ermöglicht es ihm, sich zu verschiedenen Pokémon zu entwickeln."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/102.ts
+++ b/data/Sun & Moon/Sun & Moon/102.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "Its steps are staggering and unsteady, but Spinda thinks it's walking in a straight line.",
+		de: "Pandir hat einen unsicheren, schwankenden Gang, obwohl es sich große Mühe gibt, geradeaus zu gehen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/103.ts
+++ b/data/Sun & Moon/Sun & Moon/103.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Because it doesn't yelp, it's extremely popular with Trainers who live in apartment buildings.",
+		de: "Es jault nicht, weswegen es bei Trainern, die in Apartmenthäusern wohnen, sehr beliebt ist."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/104.ts
+++ b/data/Sun & Moon/Sun & Moon/104.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Lillipup",
 		fr: "Ponchiot",
+		de: "Yorkleff"
 	},
 
 	stage: "Stage1",
@@ -87,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Its dense black fur grows continuously. The high cost of keeping its hard fur properly groomed make this a troublesome Pokémon to train.",
+		de: "Sein dunkles Fell ist sehr widerstandsfähig und wächst schnell. Dadurch sind die Kosten für das Trimmen sehr hoch."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/105.ts
+++ b/data/Sun & Moon/Sun & Moon/105.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Herdier",
 		fr: "Ponchien",
+		de: "Terribark"
 	},
 
 	stage: "Stage2",
@@ -91,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "Intelligent, good-natured, and valiant, it's a trustworthy partner on rescue teams.",
+		de: "Es ist ein kluges, sanftmütiges und tapferes Pokémon. Für Mitglieder von Rettungstruppen stellt es einen zuverlässigen Partner dar."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/106.ts
+++ b/data/Sun & Moon/Sun & Moon/106.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon feeds on berries, whose leftover seeds become the ammunition for the attacks it fires off from its mouth.",
+		de: "Dieses Pokémon ernährt sich von Beeren. Die Samen verschießt es später als Munition aus seinem Schnabel."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/107.ts
+++ b/data/Sun & Moon/Sun & Moon/107.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pikipek",
 		fr: "Picassaut",
+		de: "Peppeck"
 	},
 
 	stage: "Stage1",
@@ -77,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "By bending its beak, it can produce a variety of call and brand itself a noisy nuisance for its neighbors.",
+		de: "Indem es seinen Schnabel verformt, kann es eine große Bandbreite an Lauten ausstoßen. Der Alptraum eines jeden Nachbarn."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/108.ts
+++ b/data/Sun & Moon/Sun & Moon/108.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Trumbeak",
 		fr: "Piclairon",
+		de: "Trompeck"
 	},
 
 	stage: "Stage2",
@@ -103,6 +104,7 @@ const card: Card = {
 
 	description: {
 		en: "Within its beak, its internal gas ignites, explosively launching seeds with enough power to pulverize boulders.",
+		de: "Lässt körpereigene Gase in seinem Schnabel explodieren, um Samen zu verschießen. Selbst große Felsen kann es damit zerstören."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/109.ts
+++ b/data/Sun & Moon/Sun & Moon/109.ts
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "With its sharp fangs, it will bite anything. It did not originally live in Alola but was imported from another region.",
+		de: "Mit seinen scharfen Zähnen schnappt es nach allem. Es lebte ursprünglich nicht in Alola und wurde aus einer anderen Region eingeführt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/11.ts
+++ b/data/Sun & Moon/Sun & Moon/11.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Dartrix",
 		fr: "Efflèche",
+		de: "Arboretoss"
 	},
 
 	stage: "Stage2",
@@ -95,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "It fires arrow quills from its wings with such precision, they can pierce a pebble at distances over a hundred yards.",
+		de: "Dieses Pokémon kann die Federn seiner Flügel wie Pfeile verschießen. Dabei ist es so präzise, dass es einen Kiesel auf 100 m durchbohrt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/110.ts
+++ b/data/Sun & Moon/Sun & Moon/110.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Yungoos",
 		fr: "Manglouton",
+		de: "Mangunior"
 	},
 
 	suffix: "GX",
@@ -84,7 +85,7 @@ const card: Card = {
 				es: "Oportunidad Detective GX",
 				it: "Occasione Investigativa-GX",
 				pt: "Sorte do Detetive GX",
-				de: "Manguspektorfall GX"
+				de: "Manguspektorfall-GX"
 			},
 			effect: {
 				en: "This attack does 50 more damage times the amount of Energy attached to your opponent’s Active Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Sun & Moon/111.ts
+++ b/data/Sun & Moon/Sun & Moon/111.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "Despite its adorable appearance, when it gets angry and flails about, its arms and legs could knock a pro wrestler sprawling.",
+		de: "Es sieht sehr süß aus, aber wehe, es wird wütend. Mit seinen Armen wirbelnd haut es selbst den stärksten Wrestler um."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/112.ts
+++ b/data/Sun & Moon/Sun & Moon/112.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Stufful",
 		fr: "Nounourson",
+		de: "Velursi"
 	},
 
 	stage: "Stage1",
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "This immensely dangerous Pokémon possesses overwhelming physical strength. Its habitat is generally off-limits.",
+		de: "Dieses Pokémon verfügt über immense Muskelkraft und ist äußerst gefährlich. Sein Habitat ist generell Sperrgebiet."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/113.ts
+++ b/data/Sun & Moon/Sun & Moon/113.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "Deep in the jungle, high in the lofty canopy, this Pokémon abides. On rare occasions, it shows up at the beach to match wits with Slowking.",
+		de: "Lebt auf Baumwipfeln im tiefsten Dschungel. Ab und an erscheint es am Strand, um sich epische Quiz-Duelle mit Laschoking zu liefern."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/114.ts
+++ b/data/Sun & Moon/Sun & Moon/114.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cura 20 puntos de daño y elimina 1 Condición Especial de tu Pokémon Activo.",
 		it: "Cura il tuo Pokémon attivo da 20 danni e rimuovi una condizione speciale che lo influenza.",
 		pt: "Cure 20 pontos de dano e remova 1 Condição Especial do seu Pokémon Ativo.",
-		de: "Heile 20 Schadenspunkte und entferne 1 Speziellen Zustand von deinem Aktiven Pokémon."
+		de: "Heile 20 Schadenspunkte und entferne 1 Speziellen Zustand von deinem Aktiven Pokémon. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Sun & Moon/115.ts
+++ b/data/Sun & Moon/Sun & Moon/115.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Lanza 1 moneda. Si sale cara, descarta 1 Energía de 1 de los Pokémon de tu rival.",
 		it: "Lancia una moneta. Se esce testa, scarta un’Energia assegnata a uno dei Pokémon del tuo avversario.",
 		pt: "Jogue 1 moeda. Se sair cara, descarte 1 Energia de 1 dos Pokémon do seu oponente.",
-		de: "Wirf 1 Münze. Lege bei Kopf 1 Energie von 1 Pokémon deines Gegners auf seinen Ablagestapel."
+		de: "Wirf 1 Münze. Lege bei Kopf 1 Energie von 1 Pokémon deines Gegners auf seinen Ablagestapel. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Sun & Moon/116.ts
+++ b/data/Sun & Moon/Sun & Moon/116.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon 2 cartas de Energía Básica de tu pila de descartes en tu mano.",
 		it: "Prendi due carte Energia base dalla tua pila degli scarti e aggiungile alle carte che hai in mano.",
 		pt: "Coloque 2 cartas de Energia básica da sua pilha de descarte na sua mão.",
-		de: "Nimm 2 Basis-Energiekarten aus deinem Ablagestapel auf deine Hand."
+		de: "Nimm 2 Basis-Energiekarten aus deinem Ablagestapel auf deine Hand. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Sun & Moon/117.ts
+++ b/data/Sun & Moon/Sun & Moon/117.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mueve 1 Energía Básica de 1 de tus Pokémon a otro de tus Pokémon.",
 		it: "Sposta un’Energia base da uno dei tuoi Pokémon a un altro.",
 		pt: "Mova 1 Energia básica de 1 dos seus Pokémon para outro Pokémon seu.",
-		de: "Verschiebe 1 Basis-Energie von 1 deiner Pokémon auf 1 anderes deiner Pokémon."
+		de: "Verschiebe 1 Basis-Energie von 1 deiner Pokémon auf 1 anderes deiner Pokémon. Du kannst während deines Zuges (bevor zu angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Sun & Moon/118.ts
+++ b/data/Sun & Moon/Sun & Moon/118.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cuando tu Pokémon Activo queda Fuera de Combate por el daño de un ataque de tu rival, puedes mover 1 carta de Energía Básica de ese Pokémon al Pokémon al que esté unida esta carta.",
 		it: "Quando il tuo Pokémon attivo viene messo KO dai danni inflitti da un attacco del tuo avversario, puoi spostare una carta Energia base che gli era stata assegnata sul Pokémon a cui è assegnata questa carta.",
 		pt: "Quando o seu Pokémon Ativo é Nocauteado pelo dano de um ataque do seu oponente, você pode mover 1 carta de Energia básica daquele Pokémon para o Pokémon ao qual esta carta está ligada.",
-		de: "Wenn dein Aktives Pokémon durch den Schaden einer Attacke deines Gegners kampfunfähig wird, kannst du 1 an jenes Pokémon angelegte Basis-Energiekarte auf das Pokémon verschieben, an das diese Karte angelegt ist."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn dein Aktives Pokémon durch den Schaden einer Attacke deines Gegners kampfunfähig wird, kannst du 1 an jenes Pokémon angelegte Basis-Energiekarte auf das Pokémon verschieben, an das diese Karte angelegt ist. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sun & Moon/Sun & Moon/119.ts
+++ b/data/Sun & Moon/Sun & Moon/119.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mira las 7 primeras cartas de tu baraja. Puedes enseñar 1 Pokémon que encuentres entre ellas y ponerlo en tu mano. Pon el resto de cartas de nuevo en tu baraja y barájalas todas.",
 		it: "Guarda le prime sette carte del tuo mazzo. Puoi mostrare un Pokémon che hai trovato e aggiungerlo alle carte che hai in mano. Poi rimischia le altre carte nel tuo mazzo.",
 		pt: "Olhe as 7 primeiras cartas do seu baralho. Você poderá revelar 1 Pokémon que encontrar lá e colocá-lo em sua mão. Embaralhe as demais cartas de volta no seu baralho.",
-		de: "Schau dir die obersten 7 Karten deines Decks an. Du kannst 1 Pokémon, das du dort findest, deinem Gegner zeigen und auf deine Hand nehmen. Mische die anderen Karten zurück in dein Deck."
+		de: "Schau dir die obersten 7 Karten deines Decks an. Du kannst 1 Pokémon, das du dort findest, deinem Gegner zeigen und auf deine Hand nehmen. Mische die anderen Karten zurück in dein Deck. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Sun & Moon/12.ts
+++ b/data/Sun & Moon/Sun & Moon/12.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Dartrix",
 		fr: "Efflèche",
+		de: "Arboretoss"
 	},
 
 	suffix: "GX",

--- a/data/Sun & Moon/Sun & Moon/120.ts
+++ b/data/Sun & Moon/Sun & Moon/120.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba 3 cartas.",
 		it: "Pesca tre carte.",
 		pt: "Compre 3 cartas.",
-		de: "Ziehe 3 Karten."
+		de: "Ziehe 3 Karten. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Sun & Moon/121.ts
+++ b/data/Sun & Moon/Sun & Moon/121.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cada jugador pone las cartas de su mano en su baraja, las baraja todas y lanza 1 moneda. Si sale cara, ese jugador roba 6 cartas. Si sale cruz, roba 3 cartas.",
 		it: "Entrambi i giocatori mettono le carte che hanno in mano nel loro mazzo e lo rimischiano, poi lanciano una moneta. Se a un giocatore esce testa, pesca sei carte. Se gli esce croce, pesca tre carte.",
 		pt: "Cada jogador embaralha a própria mão no próprio baralho e joga 1 moeda. Se sair cara, o jogador comprará 6 cartas. Se sair coroa, o jogador comprará 3 cartas.",
-		de: "Jeder Spieler mischt seine Handkarten in sein Deck und wirft 1 Münze. Bei Kopf zieht der Spieler 6 Karten. Bei Zahl zieht der Spieler 3 Karten."
+		de: "Jeder Spieler mischt seine Handkarten in sein Deck und wirft 1 Münze. Bei Kopf zieht der Spieler 6 Karten. Bei Zahl zieht der Spieler 3 Karten. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Sun & Moon/122.ts
+++ b/data/Sun & Moon/Sun & Moon/122.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba cartas hasta que tengas 6 cartas en tu mano. Si es tu primer turno, roba cartas hasta que tengas 8 cartas en tu mano.",
 		it: "Pesca fino ad avere sei carte in mano. Se è il tuo primo turno, pesca fino ad avere otto carte in mano.",
 		pt: "Compre cartas até ter 6 cartas na sua mão. Se for a sua primeira vez de jogar, compre cartas até ter 8 cartas na sua mão.",
-		de: "Ziehe so lange Karten, bis du 6 Karten auf der Hand hast. Wenn es dein erster Zug ist, ziehe so lange Karten, bis du 8 Karten auf der Hand hast."
+		de: "Ziehe so lange Karten, bis du 6 Karten auf der Hand hast. Wenn es dein erster Zug ist, ziehe so lange Karten, bis du 8 Karten auf der Hand hast. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Sun & Moon/123.ts
+++ b/data/Sun & Moon/Sun & Moon/123.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja 1 Pokémon Básico y ponlo en tu Banca. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo un Pokémon Base e mettilo nella tua panchina. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por 1 Pokémon Básico no seu baralho e coloque-o no seu Banco. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach 1 Basis-Pokémon und lege es auf deine Bank. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach 1 Basis-Pokémon und lege es auf deine Bank. Mische anschließend dein Deck. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Sun & Moon/124.ts
+++ b/data/Sun & Moon/Sun & Moon/124.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Si el Pokémon al que está unida esta carta es tu Pokémon Activo y resulta dañado por un ataque de tu rival (incluso si este Pokémon queda Fuera de Combate), el Pokémon Atacante pasa a estar Envenenado.",
 		it: "Se il Pokémon a cui è assegnata questa carta è il tuo Pokémon attivo e viene danneggiato da un attacco del tuo avversario, anche se viene messo KO, il Pokémon attaccante viene avvelenato.",
 		pt: "Se o Pokémon ao qual esta carta está ligada for o seu Pokémon Ativo e ele for danificado por um ataque do seu oponente (mesmo que este Pokémon seja Nocauteado), o Pokémon Atacante será Envenenado.",
-		de: "Wenn das Pokémon, an das diese Karte angelegt ist, dein Aktives Pokémon ist und durch eine Attacke deines Gegners Schaden erhält (auch wenn dieses Pokémon dadurch kampfunfähig wird), ist das Angreifende Pokémon jetzt vergiftet."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn das Pokémon, an das diese Karte angelegt ist, dein Aktives Pokémon ist und durch eine Attacke deines Gegners Schaden erhält (auch wenn dieses Pokémon dadurch kampfunfähig wird), ist das Angreifende Pokémon jetzt vergiftet. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sun & Moon/Sun & Moon/125.ts
+++ b/data/Sun & Moon/Sun & Moon/125.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Lanza 1 moneda. Si sale cara, busca en tu baraja 1 Pokémon, enséñalo y ponlo en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Lancia una moneta. Se esce testa, cerca nel tuo mazzo un Pokémon, mostralo e aggiungilo alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Jogue 1 moeda. Se sair cara, procure por 1 Pokémon no seu baralho, revele-o e coloque-o na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Wirf 1 Münze. Durchsuche bei Kopf dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck."
+		de: "Wirf 1 Münze. Durchsuche bei Kopf dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Sun & Moon/126.ts
+++ b/data/Sun & Moon/Sun & Moon/126.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Lanza 1 moneda. Si sale cara, cambia 1 de los Pokémon en Banca de tu rival por su Pokémon Activo.",
 		it: "Lancia una moneta. Se esce testa, scambia uno dei Pokémon nella panchina del tuo avversario con il suo Pokémon attivo.",
 		pt: "Jogue 1 moeda. Se sair cara, troque 1 dos Pokémon no Banco do seu oponente pelo Pokémon Ativo dele(a).",
-		de: "Wirf 1 Münze. Tausche bei Kopf 1 Pokémon auf der Bank deines Gegners gegen sein Aktives Pokémon aus."
+		de: "Wirf 1 Münze. Tausche bei Kopf 1 Pokémon auf der Bank deines Gegners gegen sein Aktives Pokémon aus. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Sun & Moon/127.ts
+++ b/data/Sun & Moon/Sun & Moon/127.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cura 30 puntos de daño a 1 de tus Pokémon.",
 		it: "Cura uno dei tuoi Pokémon da 30 danni.",
 		pt: "Cure 30 pontos de dano de 1 dos seus Pokémon.",
-		de: "Heile 30 Schadenspunkte bei 1 deiner Pokémon."
+		de: "Heile 30 Schadenspunkte bei 1 deiner Pokémon. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Sun & Moon/128.ts
+++ b/data/Sun & Moon/Sun & Moon/128.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba 2 cartas. Durante este turno, los ataques de tus Pokémon hacen 20 puntos de daño más al Pokémon Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
 		it: "Pesca due carte. Durante questo turno, gli attacchi dei tuoi Pokémon infliggono 20 danni in più al Pokémon attivo del tuo avversario, prima di aver applicato debolezza e resistenza.",
 		pt: "Compre 2 cartas. Durante esta rodada, os ataques dos seus Pokémon causam 20 pontos de dano a mais ao Pokémon Ativo do seu oponente (antes de aplicar Fraqueza e Resistência).",
-		de: "Ziehe 2 Karten. Während dieses Zuges fügen die Attacken deiner Pokémon dem Aktiven Pokémon deines Gegners 20 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
+		de: "Ziehe 2 Karten. Während dieses Zuges fügen die Attacken deiner Pokémon dem Aktiven Pokémon deines Gegners 20 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden). Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Sun & Moon/129.ts
+++ b/data/Sun & Moon/Sun & Moon/129.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Elige 1 de tus Pokémon Básicos en juego. Si tienes en tu mano 1 carta de Fase 2 que evolucione de ese Pokémon, pon esa carta sobre el Pokémon Básico para que evolucione. No puedes usar esta carta durante tu primer turno o sobre un Pokémon Básico que se haya puesto en juego en este turno.",
 		it: "Scegli uno dei tuoi Pokémon Base in gioco. Se hai in mano una carta di Fase 2 che si evolve da quel Pokémon, metticela sopra per farlo evolvere. Non puoi usare questa carta durante il tuo primo turno o su un Pokémon Base che hai messo in gioco nel turno in corso.",
 		pt: "Escolha 1 dos seus Pokémon Básicos em jogo. Se você tiver 1 carta de Estágio 2 na sua mão que evolua daquele Pokémon, coloque aquela carta sobre o Pokémon Básico para evoluí-lo. Você não pode usar esta carta durante a sua primeira vez de jogar ou colocá-la sobre um Pokémon Básico que foi colocado em jogo nesta rodada.",
-		de: "Wähle 1 deiner Basis-Pokémon im Spiel. Wenn du eine Phase-2-Karte auf der Hand hast, die sich aus jenem Pokémon entwickelt, lege sie auf das Basis-Pokémon, um es zu entwickeln. Du kannst diese Karte nicht während deines ersten Zuges oder für ein Basis-Pokémon, das in diesem Zug ins Spiel gebracht wurde, verwenden."
+		de: "Wähle 1 deiner Basis-Pokémon im Spiel. Wenn du eine Phase-2-Karte auf der Hand hast, die sich aus jenem Pokémon entwickelt, lege sie auf das Basis-Pokémon, um es zu entwickeln. Du kannst diese Karte nicht während deines ersten Zuges oder für ein Basis-Pokémon, das in diesem Zug ins Spiel gebracht wurde, verwenden. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Sun & Moon/13.ts
+++ b/data/Sun & Moon/Sun & Moon/13.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "They often gather near places frequented by electric Pokémon in order to avoid being attacked by bird Pokémon.",
+		de: "Um nicht von Vogel-Pokémon angegriffen zu werden, zieht es Orte vor, an denen Elektro-Pokémon leben."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/130.ts
+++ b/data/Sun & Moon/Sun & Moon/130.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Tu rival cambia su Pokémon Activo por 1 de sus Pokémon en Banca.",
 		it: "Il tuo avversario scambia il suo Pokémon attivo con uno dei suoi Pokémon in panchina.",
 		pt: "Seu oponente troca o próprio Pokémon Ativo por 1 dos Pokémon no Banco dele(a).",
-		de: "Dein Gegner tauscht sein Aktives Pokémon gegen 1 Pokémon auf seiner Bank aus."
+		de: "Dein Gegner tauscht sein Aktives Pokémon gegen 1 Pokémon auf seiner Bank aus. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Sun & Moon/131.ts
+++ b/data/Sun & Moon/Sun & Moon/131.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Después de contar tus cartas de Premio, ponlas en tu baraja y barájalas todas. Después, coge la misma cantidad de cartas de la parte superior de tu baraja y ponlas boca abajo como tus cartas de Premio.",
 		it: "Dopo aver contato le tue carte Premio, rimischiale nel tuo mazzo. Poi prendi la stessa quantità di carte dalle carte in cima al tuo mazzo e mettile a faccia in giù come carte Premio.",
 		pt: "Após contar as suas cartas de Prêmio, embaralhe-as no seu baralho. Em seguida, pegue aquele mesmo número de cartas de cima do seu baralho e coloque-as viradas para baixo como as suas cartas de Prêmio.",
-		de: "Mische deine Preiskarten in dein Deck, nachdem du sie gezählt hast. Nimm anschließend dieselbe Anzahl Karten von deinem Deck und lege sie als deine verdeckten Preiskarten ab."
+		de: "Mische deine Preiskarten in dein Deck, nachdem du sie gezählt hast. Nimm anschließend dieselbe Anzahl Karten von deinem Deck und lege sie als deine verdeckten Preiskarten ab. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Sun & Moon/132.ts
+++ b/data/Sun & Moon/Sun & Moon/132.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cambia tu Pokémon Activo por 1 de tus Pokémon en Banca.",
 		it: "Scambia il tuo Pokémon attivo con uno dei tuoi Pokémon in panchina.",
 		pt: "Troque o seu Pokémon Ativo por 1 dos seus Pokémon no Banco.",
-		de: "Tausche dein Aktives Pokémon gegen 1 Pokémon auf deiner Bank aus."
+		de: "Tausche dein Aktives Pokémon gegen 1 Pokémon auf deiner Bank aus. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Sun & Moon/133.ts
+++ b/data/Sun & Moon/Sun & Moon/133.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Tu rival enseña las cartas de su mano. Descarta 2 de sus cartas de Energía.",
 		it: "Il tuo avversario mostra le carte che ha in mano. Scarta due carte Energia tra esse.",
 		pt: "Seu oponente revela a própria mão. Descarte 2 cartas de Energia da mão dele(a).",
-		de: "Dein Gegner zeigt dir seine Handkarten. Lege 2 Energiekarten aus der Hand deines Gegners auf seinen Ablagestapel."
+		de: "Dein Gegner zeigt dir seine Handkarten. Lege 2 Energiekarten aus der Hand deines Gegners auf seinen Ablagestapel. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Sun & Moon/134.ts
+++ b/data/Sun & Moon/Sun & Moon/134.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Lanza 2 monedas. Por cada cara, busca en tu baraja 1 Pokémon Evolución, enséñalo y ponlo en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Lancia due volte una moneta. Ogni volta che esce testa, cerca nel tuo mazzo un Pokémon Evoluzione, mostralo e aggiungilo alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Jogue 2 moedas. Para cada cara, procure por 1 Pokémon de Evolução no seu baralho, revele-o e coloque-o na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Wirf 2 Münzen. Durchsuche pro Kopf dein Deck nach 1 Entwicklungs-Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck."
+		de: "Wirf 2 Münzen. Durchsuche pro Kopf dein Deck nach 1 Entwicklungs-Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Sun & Moon/135.ts
+++ b/data/Sun & Moon/Sun & Moon/135.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta 2 cartas de tu mano. Si lo haces, busca en tu baraja 1 Pokémon, enséñalo y ponlo en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Scarta due delle carte che hai in mano. Se lo fai, cerca nel tuo mazzo un Pokémon, mostralo e aggiungilo alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Descarte 2 cartas da sua mão. Se fizer isto, procure por 1 Pokémon no seu baralho, revele-o e coloque-o na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Lege 2 Karten aus deiner Hand auf deinen Ablagestapel. Wenn du das machst, durchsuche dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck."
+		de: "Lege 2 Karten aus deiner Hand auf deinen Ablagestapel. Wenn du das machst, durchsuche dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Sun & Moon/136.ts
+++ b/data/Sun & Moon/Sun & Moon/136.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Esta carta proporciona 2 Energías Colorless.",
 		it: "Un’Energia Incolore doppia fornisce ColorlessColorless.",
 		pt: "A Energia Incolor Dupla fornece Energias ColorlessColorless.",
-		de: "Doppel-Farblos-Energie liefert ColorlessColorless-Energie."
+		de: "Doppel-Farblos-Energie liefert {C}{C}-Energie."
 	},
 
 	energyType: "Special",

--- a/data/Sun & Moon/Sun & Moon/137.ts
+++ b/data/Sun & Moon/Sun & Moon/137.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Esta carta proporciona Energía Colorless. Mientras está en juego, esta carta proporciona todos los tipos de Energía, pero solo proporciona 1 Energía a la vez. Cuando unas esta carta de tu mano a 1 de tus Pokémon, pon 1 contador de daño en ese Pokémon.",
 		it: "Questa carta fornisce Energia Colorless. Fintanto che è in gioco, fornisce un’Energia di un tipo qualsiasi, ma solo una alla volta. Quando assegni questa carta dalla tua mano a uno dei tuoi Pokémon, metti un segnalino danno su quel Pokémon.",
 		pt: "Esta carta fornece Energia Colorless. Enquanto estiver em jogo, esta carta fornece todo tipo de Energia, mas só fornece 1 Energia de cada vez. Quando você liga esta carta da sua mão a 1 dos seus Pokémon, coloque 1 contador de dano naquele Pokémon.",
-		de: "Diese Karte liefert Colorless-Energie. Ist sie im Spiel, zählt sie als jeder beliebige Energietyp, spendet aber immer nur jeweils 1 Energie. Wenn du diese Karte aus deiner Hand an 1 deiner Pokémon anlegst, lege 1 Schadensmarke auf jenes Pokémon."
+		de: "Diese Karte liefert {C}-Energie. Ist sie im Spiel, zählt sie als jeder beliebige Energietyp, spendet aber immer nur jeweils 1 Energie. Wenn du diese Karte aus deiner Hand an 1 deiner Pokémon anlegst, lege 1 Schadensmarke auf jenes Pokémon."
 	},
 
 	energyType: "Special",

--- a/data/Sun & Moon/Sun & Moon/138.ts
+++ b/data/Sun & Moon/Sun & Moon/138.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Fomantis",
 		fr: "Mimantis",
+		de: "Imantis"
 	},
 
 	suffix: "GX",
@@ -92,7 +93,7 @@ const card: Card = {
 				es: "Cloroguadaña GX",
 				it: "Clorofalce-GX",
 				pt: "Foice de Clorofila GX",
-				de: "Chlorosense GX"
+				de: "Chlorosense-GX"
 			},
 			effect: {
 				en: "This attack does 50 damage times the amount of Grass Energy attached to this Pokémon. (You can’t use more than 1 GX attack in a game.)",
@@ -100,7 +101,7 @@ const card: Card = {
 				es: "Este ataque hace 50 puntos de daño por cada Energía Grass unida a este Pokémon. (No puedes usar más de 1 ataque GX en una partida).",
 				it: "Questo attacco infligge 50 danni per ogni Energia Grass assegnata a questo Pokémon. Non puoi usare più di un attacco GX a partita.",
 				pt: "Este ataque causa 50 pontos de dano vezes a quantidade de Energia Grass ligada a este Pokémon (você não pode usar mais de 1 ataque GX por partida).",
-				de: "Diese Attacke fügt 50 Schadenspunkte mal der Anzahl der an dieses Pokémon angelegten Grass-Energien zu. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
+				de: "Diese Attacke fügt 50 Schadenspunkte mal der Anzahl der an dieses Pokémon angelegten {G}-Energien zu. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: "50×",
 

--- a/data/Sun & Moon/Sun & Moon/14.ts
+++ b/data/Sun & Moon/Sun & Moon/14.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Busca en tu baraja 1 carta de Energía Grass y únela a 1 de tus Pokémon. Después, baraja las cartas de tu baraja.",
 				it: "Cerca nel tuo mazzo una carta Energia Grass e assegnala a uno dei tuoi Pokémon. Poi rimischia le carte del tuo mazzo.",
 				pt: "Procure por 1 carta de Energia Grass no seu baralho e ligue-a a 1 dos seus Pokémon. Em seguida, embaralhe o seu baralho.",
-				de: "Durchsuche dein Deck nach 1 Grass-Energiekarte und lege sie an 1 deiner Pokémon an. Mische anschließend dein Deck."
+				de: "Durchsuche dein Deck nach 1 {G}-Energiekarte und lege sie an 1 deiner Pokémon an. Mische anschließend dein Deck."
 			},
 
 		},
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "They give off a sweet and refreshing scent. Cutiefly often gather near the tall grass where Fomantis are hiding.",
+		de: "Dieses Pokémon duftet frisch und lieblich. Im hohen Gras, wo sich Imantis gern versteckt, halten sich oft auch viele Wommel auf."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/140.ts
+++ b/data/Sun & Moon/Sun & Moon/140.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	suffix: "GX",

--- a/data/Sun & Moon/Sun & Moon/141.ts
+++ b/data/Sun & Moon/Sun & Moon/141.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cosmoem",
 		fr: "Cosmovum",
+		de: "Cosmovum"
 	},
 
 	suffix: "GX",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Todas las veces que quieras durante tu turno (antes de tu ataque), puedes mover 1 Energía Psychic de 1 de tus Pokémon a otro de tus Pokémon.",
 				it: "Durante il tuo turno, prima di attaccare, puoi spostare un’Energia Psychic da uno a un altro dei tuoi Pokémon tutte le volte che vuoi.",
 				pt: "Quantas vezes desejar durante a sua vez de jogar (antes de atacar), você pode mover 1 Energia Psychic de 1 dos seus Pokémon para outro Pokémon seu.",
-				de: "Beliebig oft während deines Zuges (bevor du angreifst) kannst du 1 Psychic-Energie von 1 deiner Pokémon auf 1 anderes deiner Pokémon verschieben."
+				de: "Beliebig oft während deines Zuges (bevor du angreifst) kannst du 1 {P}-Energie von 1 deiner Pokémon auf 1 anderes deiner Pokémon verschieben."
 			},
 		},
 	],

--- a/data/Sun & Moon/Sun & Moon/142.ts
+++ b/data/Sun & Moon/Sun & Moon/142.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	suffix: "GX",

--- a/data/Sun & Moon/Sun & Moon/143.ts
+++ b/data/Sun & Moon/Sun & Moon/143.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cosmoem",
 		fr: "Cosmovum",
+		de: "Cosmovum"
 	},
 
 	suffix: "GX",

--- a/data/Sun & Moon/Sun & Moon/145.ts
+++ b/data/Sun & Moon/Sun & Moon/145.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Yungoos",
 		fr: "Manglouton",
+		de: "Mangunior"
 	},
 
 	suffix: "GX",
@@ -84,7 +85,7 @@ const card: Card = {
 				es: "Oportunidad Detective GX",
 				it: "Occasione Investigativa-GX",
 				pt: "Sorte do Detetive GX",
-				de: "Manguspektorfall GX"
+				de: "Manguspektorfall-GX"
 			},
 			effect: {
 				en: "This attack does 50 more damage times the amount of Energy attached to your opponent’s Active Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Sun & Moon/146.ts
+++ b/data/Sun & Moon/Sun & Moon/146.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cada jugador pone las cartas de su mano en su baraja, las baraja todas y lanza 1 moneda. Si sale cara, ese jugador roba 6 cartas. Si sale cruz, roba 3 cartas.",
 		it: "Entrambi i giocatori mettono le carte che hanno in mano nel loro mazzo e lo rimischiano, poi lanciano una moneta. Se a un giocatore esce testa, pesca sei carte. Se gli esce croce, pesca tre carte.",
 		pt: "Cada jogador embaralha a própria mão no próprio baralho e joga 1 moeda. Se sair cara, o jogador comprará 6 cartas. Se sair coroa, o jogador comprará 3 cartas.",
-		de: "Jeder Spieler mischt seine Handkarten in sein Deck und wirft 1 Münze. Bei Kopf zieht der Spieler 6 Karten. Bei Zahl zieht der Spieler 3 Karten."
+		de: "Jeder Spieler mischt seine Handkarten in sein Deck und wirft 1 Münze. Bei Kopf zieht der Spieler 6 Karten. Bei Zahl zieht der Spieler 3 Karten. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Sun & Moon/147.ts
+++ b/data/Sun & Moon/Sun & Moon/147.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba cartas hasta que tengas 6 cartas en tu mano. Si es tu primer turno, roba cartas hasta que tengas 8 cartas en tu mano.",
 		it: "Pesca fino ad avere sei carte in mano. Se è il tuo primo turno, pesca fino ad avere otto carte in mano.",
 		pt: "Compre cartas até ter 6 cartas na sua mão. Se for a sua primeira vez de jogar, compre cartas até ter 8 cartas na sua mão.",
-		de: "Ziehe so lange Karten, bis du 6 Karten auf der Hand hast. Wenn es dein erster Zug ist, ziehe so lange Karten, bis du 8 Karten auf der Hand hast."
+		de: "Ziehe so lange Karten, bis du 6 Karten auf der Hand hast. Wenn es dein erster Zug ist, ziehe so lange Karten, bis du 8 Karten auf der Hand hast. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Sun & Moon/148.ts
+++ b/data/Sun & Moon/Sun & Moon/148.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba 2 cartas. Durante este turno, los ataques de tus Pokémon hacen 20 puntos de daño más al Pokémon Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
 		it: "Pesca due carte. Durante questo turno, gli attacchi dei tuoi Pokémon infliggono 20 danni in più al Pokémon attivo del tuo avversario, prima di aver applicato debolezza e resistenza.",
 		pt: "Compre 2 cartas. Durante esta rodada, os ataques dos seus Pokémon causam 20 pontos de dano a mais ao Pokémon Ativo do seu oponente (antes de aplicar Fraqueza e Resistência).",
-		de: "Ziehe 2 Karten. Während dieses Zuges fügen die Attacken deiner Pokémon dem Aktiven Pokémon deines Gegners 20 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
+		de: "Ziehe 2 Karten. Während dieses Zuges fügen die Attacken deiner Pokémon dem Aktiven Pokémon deines Gegners 20 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden). Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Sun & Moon/149.ts
+++ b/data/Sun & Moon/Sun & Moon/149.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Tu rival enseña las cartas de su mano. Descarta 2 de sus cartas de Energía.",
 		it: "Il tuo avversario mostra le carte che ha in mano. Scarta due carte Energia tra esse.",
 		pt: "Seu oponente revela a própria mão. Descarte 2 cartas de Energia da mão dele(a).",
-		de: "Dein Gegner zeigt dir seine Handkarten. Lege 2 Energiekarten aus der Hand deines Gegners auf seinen Ablagestapel."
+		de: "Dein Gegner zeigt dir seine Handkarten. Lege 2 Energiekarten aus der Hand deines Gegners auf seinen Ablagestapel. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Sun & Moon/15.ts
+++ b/data/Sun & Moon/Sun & Moon/15.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Fomantis",
 		fr: "Mimantis",
+		de: "Imantis"
 	},
 
 	suffix: "GX",
@@ -92,7 +93,7 @@ const card: Card = {
 				es: "Cloroguadaña GX",
 				it: "Clorofalce-GX",
 				pt: "Foice de Clorofila GX",
-				de: "Chlorosense GX"
+				de: "Chlorosense-GX"
 			},
 			effect: {
 				en: "This attack does 50 damage times the amount of Grass Energy attached to this Pokémon. (You can’t use more than 1 GX attack in a game.)",
@@ -100,7 +101,7 @@ const card: Card = {
 				es: "Este ataque hace 50 puntos de daño por cada Energía Grass unida a este Pokémon. (No puedes usar más de 1 ataque GX en una partida).",
 				it: "Questo attacco infligge 50 danni per ogni Energia Grass assegnata a questo Pokémon. Non puoi usare più di un attacco GX a partita.",
 				pt: "Este ataque causa 50 pontos de dano vezes a quantidade de Energia Grass ligada a este Pokémon (você não pode usar mais de 1 ataque GX por partida).",
-				de: "Diese Attacke fügt 50 Schadenspunkte mal der Anzahl der an dieses Pokémon angelegten Grass-Energien zu. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
+				de: "Diese Attacke fügt 50 Schadenspunkte mal der Anzahl der an dieses Pokémon angelegten {G}-Energien zu. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: "50×",
 

--- a/data/Sun & Moon/Sun & Moon/150.ts
+++ b/data/Sun & Moon/Sun & Moon/150.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Fomantis",
 		fr: "Mimantis",
+		de: "Imantis"
 	},
 
 	suffix: "GX",
@@ -92,7 +93,7 @@ const card: Card = {
 				es: "Cloroguadaña GX",
 				it: "Clorofalce-GX",
 				pt: "Foice de Clorofila GX",
-				de: "Chlorosense GX"
+				de: "Chlorosense-GX"
 			},
 			effect: {
 				en: "This attack does 50 damage times the amount of Grass Energy attached to this Pokémon. (You can’t use more than 1 GX attack in a game.)",
@@ -100,7 +101,7 @@ const card: Card = {
 				es: "Este ataque hace 50 puntos de daño por cada Energía Grass unida a este Pokémon. (No puedes usar más de 1 ataque GX en una partida).",
 				it: "Questo attacco infligge 50 danni per ogni Energia Grass assegnata a questo Pokémon. Non puoi usare più di un attacco GX a partita.",
 				pt: "Este ataque causa 50 pontos de dano vezes a quantidade de Energia Grass ligada a este Pokémon (você não pode usar mais de 1 ataque GX por partida).",
-				de: "Diese Attacke fügt 50 Schadenspunkte mal der Anzahl der an dieses Pokémon angelegten Grass-Energien zu. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
+				de: "Diese Attacke fügt 50 Schadenspunkte mal der Anzahl der an dieses Pokémon angelegten {G}-Energien zu. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: "50×",
 

--- a/data/Sun & Moon/Sun & Moon/152.ts
+++ b/data/Sun & Moon/Sun & Moon/152.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	suffix: "GX",

--- a/data/Sun & Moon/Sun & Moon/153.ts
+++ b/data/Sun & Moon/Sun & Moon/153.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cosmoem",
 		fr: "Cosmovum",
+		de: "Cosmovum"
 	},
 
 	suffix: "GX",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Todas las veces que quieras durante tu turno (antes de tu ataque), puedes mover 1 Energía Psychic de 1 de tus Pokémon a otro de tus Pokémon.",
 				it: "Durante il tuo turno, prima di attaccare, puoi spostare un’Energia Psychic da uno a un altro dei tuoi Pokémon tutte le volte che vuoi.",
 				pt: "Quantas vezes desejar durante a sua vez de jogar (antes de atacar), você pode mover 1 Energia Psychic de 1 dos seus Pokémon para outro Pokémon seu.",
-				de: "Beliebig oft während deines Zuges (bevor du angreifst) kannst du 1 Psychic-Energie von 1 deiner Pokémon auf 1 anderes deiner Pokémon verschieben."
+				de: "Beliebig oft während deines Zuges (bevor du angreifst) kannst du 1 {P}-Energie von 1 deiner Pokémon auf 1 anderes deiner Pokémon verschieben."
 			},
 		},
 	],

--- a/data/Sun & Moon/Sun & Moon/154.ts
+++ b/data/Sun & Moon/Sun & Moon/154.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	suffix: "GX",

--- a/data/Sun & Moon/Sun & Moon/155.ts
+++ b/data/Sun & Moon/Sun & Moon/155.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cosmoem",
 		fr: "Cosmovum",
+		de: "Cosmovum"
 	},
 
 	suffix: "GX",

--- a/data/Sun & Moon/Sun & Moon/157.ts
+++ b/data/Sun & Moon/Sun & Moon/157.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Yungoos",
 		fr: "Manglouton",
+		de: "Mangunior"
 	},
 
 	suffix: "GX",
@@ -84,7 +85,7 @@ const card: Card = {
 				es: "Oportunidad Detective GX",
 				it: "Occasione Investigativa-GX",
 				pt: "Sorte do Detetive GX",
-				de: "Manguspektorfall GX"
+				de: "Manguspektorfall-GX"
 			},
 			effect: {
 				en: "This attack does 50 more damage times the amount of Energy attached to your opponent’s Active Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Sun & Moon/158.ts
+++ b/data/Sun & Moon/Sun & Moon/158.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja 1 Pokémon Básico y ponlo en tu Banca. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo un Pokémon Base e mettilo nella tua panchina. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por 1 Pokémon Básico no seu baralho e coloque-o no seu Banco. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach 1 Basis-Pokémon und lege es auf deine Bank. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach 1 Basis-Pokémon und lege es auf deine Bank. Mische anschließend dein Deck. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Sun & Moon/159.ts
+++ b/data/Sun & Moon/Sun & Moon/159.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Después de contar tus cartas de Premio, ponlas en tu baraja y barájalas todas. Después, coge la misma cantidad de cartas de la parte superior de tu baraja y ponlas boca abajo como tus cartas de Premio.",
 		it: "Dopo aver contato le tue carte Premio, rimischiale nel tuo mazzo. Poi prendi la stessa quantità di carte dalle carte in cima al tuo mazzo e mettile a faccia in giù come carte Premio.",
 		pt: "Após contar as suas cartas de Prêmio, embaralhe-as no seu baralho. Em seguida, pegue aquele mesmo número de cartas de cima do seu baralho e coloque-as viradas para baixo como as suas cartas de Prêmio.",
-		de: "Mische deine Preiskarten in dein Deck, nachdem du sie gezählt hast. Nimm anschließend dieselbe Anzahl Karten von deinem Deck und lege sie als deine verdeckten Preiskarten ab."
+		de: "Mische deine Preiskarten in dein Deck, nachdem du sie gezählt hast. Nimm anschließend dieselbe Anzahl Karten von deinem Deck und lege sie als deine verdeckten Preiskarten ab. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Sun & Moon/16.ts
+++ b/data/Sun & Moon/Sun & Moon/16.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "As it drowses the day away, it nourishes itself by sucking from tree roots. It wakens at the fall of night, wandering off in search of a new tree.",
+		de: "Tagsüber saugt es im Schlaf Nährstoffe aus den Wurzeln der Bäume. Nachts wacht es auf und macht sich auf die Suche nach frischen Bäumen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/160.ts
+++ b/data/Sun & Moon/Sun & Moon/160.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cambia tu Pokémon Activo por 1 de tus Pokémon en Banca.",
 		it: "Scambia il tuo Pokémon attivo con uno dei tuoi Pokémon in panchina.",
 		pt: "Troque o seu Pokémon Ativo por 1 dos seus Pokémon no Banco.",
-		de: "Tausche dein Aktives Pokémon gegen 1 Pokémon auf deiner Bank aus."
+		de: "Tausche dein Aktives Pokémon gegen 1 Pokémon auf deiner Bank aus. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Sun & Moon/161.ts
+++ b/data/Sun & Moon/Sun & Moon/161.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta 2 cartas de tu mano. Si lo haces, busca en tu baraja 1 Pokémon, enséñalo y ponlo en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Scarta due delle carte che hai in mano. Se lo fai, cerca nel tuo mazzo un Pokémon, mostralo e aggiungilo alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Descarte 2 cartas da sua mão. Se fizer isto, procure por 1 Pokémon no seu baralho, revele-o e coloque-o na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Lege 2 Karten aus deiner Hand auf deinen Ablagestapel. Wenn du das machst, durchsuche dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck."
+		de: "Lege 2 Karten aus deiner Hand auf deinen Ablagestapel. Wenn du das machst, durchsuche dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Sun & Moon/164.ts
+++ b/data/Sun & Moon/Sun & Moon/164.ts
@@ -4,6 +4,7 @@ import Set from '../Sun & Moon'
 const card: Card = {
 	name: {
 		en: "Grass Energy",
+		de: "Pflanzen-Energie"
 	},
 
 	illustrator: undefined,

--- a/data/Sun & Moon/Sun & Moon/165.ts
+++ b/data/Sun & Moon/Sun & Moon/165.ts
@@ -4,6 +4,7 @@ import Set from '../Sun & Moon'
 const card: Card = {
 	name: {
 		en: "Fire Energy",
+		de: "Feuer-Energie"
 	},
 
 	illustrator: undefined,

--- a/data/Sun & Moon/Sun & Moon/166.ts
+++ b/data/Sun & Moon/Sun & Moon/166.ts
@@ -4,6 +4,7 @@ import Set from '../Sun & Moon'
 const card: Card = {
 	name: {
 		en: "Water Energy",
+		de: "Wasser-Energie"
 	},
 
 	illustrator: undefined,

--- a/data/Sun & Moon/Sun & Moon/167.ts
+++ b/data/Sun & Moon/Sun & Moon/167.ts
@@ -4,6 +4,7 @@ import Set from '../Sun & Moon'
 const card: Card = {
 	name: {
 		en: "Lightning Energy",
+		de: "Elektro-Energie"
 	},
 
 	illustrator: undefined,

--- a/data/Sun & Moon/Sun & Moon/168.ts
+++ b/data/Sun & Moon/Sun & Moon/168.ts
@@ -4,6 +4,7 @@ import Set from '../Sun & Moon'
 const card: Card = {
 	name: {
 		en: "Psychic Energy",
+		de: "Psycho-Energie"
 	},
 
 	illustrator: undefined,

--- a/data/Sun & Moon/Sun & Moon/169.ts
+++ b/data/Sun & Moon/Sun & Moon/169.ts
@@ -4,6 +4,7 @@ import Set from '../Sun & Moon'
 const card: Card = {
 	name: {
 		en: "Fighting Energy",
+		de: "Kampf-Energie"
 	},
 
 	illustrator: undefined,

--- a/data/Sun & Moon/Sun & Moon/17.ts
+++ b/data/Sun & Moon/Sun & Moon/17.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Morelull",
 		fr: "Spododo",
+		de: "Bubungus"
 	},
 
 	stage: "Stage1",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Una vez durante tu turno (antes de tu ataque), puedes buscar en tu baraja 1 Pokémon Grass, enseñarlo y ponerlo en tu mano. Después, baraja las cartas de tu baraja.",
 				it: "Una sola volta durante il tuo turno, prima di attaccare, puoi cercare nel tuo mazzo un Pokémon Grass, mostrarlo e aggiungerlo alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 				pt: "Uma vez durante a sua vez de jogar (antes de atacar), você pode procurar por 1 Pokémon Grass no seu baralho, revelá-lo e colocá-lo na sua mão. Em seguida, embaralhe o seu baralho.",
-				de: "Einmal während deines Zuges (bevor du angreifst) kannst du dein Deck nach 1 Grass-Pokémon durchsuchen, es deinem Gegner zeigen und auf deine Hand nehmen. Mische anschließend dein Deck."
+				de: "Einmal während deines Zuges (bevor du angreifst) kannst du dein Deck nach 1 {G}-Pokémon durchsuchen, es deinem Gegner zeigen und auf deine Hand nehmen. Mische anschließend dein Deck."
 			},
 		},
 	],
@@ -93,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "It emits flickering spores that cause drowsiness. When its prey succumb to sleep, this Pokémon feeds on them by sucking in their energy.",
+		de: "Speit blinkende Sporen, die eine einschläfernde Wirkung haben. Schläft die Beute ein, wird ihr die Lebenskraft ausgesaugt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/170.ts
+++ b/data/Sun & Moon/Sun & Moon/170.ts
@@ -4,6 +4,7 @@ import Set from '../Sun & Moon'
 const card: Card = {
 	name: {
 		en: "Darkness Energy",
+		de: "Finsternis-Energie"
 	},
 
 	illustrator: undefined,

--- a/data/Sun & Moon/Sun & Moon/171.ts
+++ b/data/Sun & Moon/Sun & Moon/171.ts
@@ -4,6 +4,7 @@ import Set from '../Sun & Moon'
 const card: Card = {
 	name: {
 		en: "Metal Energy",
+		de: "Metall-Energie"
 	},
 
 	illustrator: undefined,

--- a/data/Sun & Moon/Sun & Moon/172.ts
+++ b/data/Sun & Moon/Sun & Moon/172.ts
@@ -4,6 +4,7 @@ import Set from '../Sun & Moon'
 const card: Card = {
 	name: {
 		en: "Fairy Energy",
+		de: "Feen-Energie"
 	},
 
 	illustrator: undefined,

--- a/data/Sun & Moon/Sun & Moon/18.ts
+++ b/data/Sun & Moon/Sun & Moon/18.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "A delectable aroma pours from its body. They are often swallowed whole by Toucannon lured by that wafting deliciousness.",
+		de: "Sein Körper verströmt einen köstlichen Duft, der leider seinen Fressfeind Tukanon anlockt. Dem kommt ein aromatischer Snack höchst gelegen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/19.ts
+++ b/data/Sun & Moon/Sun & Moon/19.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Bounsweet",
 		fr: "Croquine",
+		de: "Frubberl"
 	},
 
 	stage: "Stage1",
@@ -93,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "The sepals on its head developed to protect its body. These are quite hard, so even if pecked by bird Pokémon, this Pokémon is totally fine.",
+		de: "Seinen Blütenkelch hat es zum Selbstschutz ausgebildet. Er ist so hart, dass selbst das Picken von Vogel-Pokémon es nicht stört."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/2.ts
+++ b/data/Sun & Moon/Sun & Moon/2.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Caterpie",
 		fr: "Chenipan",
+		de: "Raupy"
 	},
 
 	stage: "Stage1",
@@ -87,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Its shell is filled with its soft innards. It doesn't move much because of the risk it might carelessly spill its innards out.",
+		de: "Sein harter Panzer birgt ein weiches Inneres. Um zu vermeiden, dass dieses versehentlich ausläuft, bewegt es sich kaum."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/20.ts
+++ b/data/Sun & Moon/Sun & Moon/20.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Steenee",
 		fr: "Candine",
+		de: "Frubaila"
 	},
 
 	stage: "Stage2",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "Its long, striking legs aren't just for show but to be used to kick with skill. In victory, it shows off by kicking the defeated, laughing boisterously.",
+		de: "Dieses Pokémon ist für seine heftigen Tritte bekannt. Oft tritt es auch noch nach und lacht, um seinen Sieg an die große Glocke zu hängen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/21.ts
+++ b/data/Sun & Moon/Sun & Moon/21.ts
@@ -67,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "It's both clever and loyal, but if a stranger tries to invade its territory, it barks threateningly.",
+		de: "Es ist klug und loyal. Sein Revier verteidigt es jedoch mit lautem Bellen gegen Fremde und Eindringlinge."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/22.ts
+++ b/data/Sun & Moon/Sun & Moon/22.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Growlithe",
 		fr: "Caninos",
+		de: "Fukano"
 	},
 
 	stage: "Stage1",
@@ -80,7 +81,7 @@ const card: Card = {
 				es: "Descarta 3 Energías Fire de este Pokémon.",
 				it: "Scarta tre Energie Fire assegnate a questo Pokémon.",
 				pt: "Descarte 3 Energias Fire deste Pokémon.",
-				de: "Lege 3 Fire-Energien von diesem Pokémon auf deinen Ablagestapel."
+				de: "Lege 3 {R}-Energien von diesem Pokémon auf deinen Ablagestapel."
 			},
 			damage: 190,
 
@@ -98,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "Overflowing with beauty and majesty, this strong Pokémon appears in ancient Eastern folklore.",
+		de: "Ein anmutiges Pokémon, das Kraft und Stolz ausstrahlt. Bereits in alten Legenden aus dem weit entfernten Osten wurde von ihm berichtet."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/23.ts
+++ b/data/Sun & Moon/Sun & Moon/23.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Coal is the source of Torkoal's energy. Large amounts of coal can be found in the mounts where they live.",
+		de: "Kohle ist die Quelle seiner Energie. Ein Glück, dass in den von Qurtel bewohnten Bergen große Kohlevorkommen schlummern."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/24.ts
+++ b/data/Sun & Moon/Sun & Moon/24.ts
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "While grooming itself, it builds up fur inside its stomach. It sets the fur alight and spews fiery attacks, which change based on how it coughs.",
+		de: "Es verbrennt Haare, die es bei der Körperpflege verschluckt hat, indem es Feuer speit. Die Flammen variieren je nach Art des Speiens."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/25.ts
+++ b/data/Sun & Moon/Sun & Moon/25.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Litten",
 		fr: "Flamiaou",
+		de: "Flamiau"
 	},
 
 	stage: "Stage1",
@@ -95,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "At its throat, it bears a bell of fire. The bell rings brightly whenever this Pokémon spits fire.",
+		de: "Es trägt ein feuriges Glöckchen um den Hals. Immer, wenn es Flammen ausstößt, ertönt ein helles Läuten."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/26.ts
+++ b/data/Sun & Moon/Sun & Moon/26.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Torracat",
 		fr: "Matoufeu",
+		de: "Miezunder"
 	},
 
 	stage: "Stage2",
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon has a violent, selfish disposition. If it's not in the mood to listen, it will ignore its Trainer's orders with complete nonchalance.",
+		de: "Ein raues und selbstsüchtiges Pokémon. Wenn es keine Lust hat, ignoriert es auch schon mal die Befehle seines Trainers."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/27.ts
+++ b/data/Sun & Moon/Sun & Moon/27.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Torracat",
 		fr: "Matoufeu",
+		de: "Miezunder"
 	},
 
 	suffix: "GX",
@@ -52,7 +53,7 @@ const card: Card = {
 				es: "Este ataque hace 20 puntos de daño más por cada uno de tus Pokémon Fire en Banca.",
 				it: "Questo attacco infligge 20 danni in più per ogni Pokémon Fire nella tua panchina.",
 				pt: "Este ataque causa 20 pontos de dano a mais para cada Pokémon Fire no seu Banco.",
-				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der Fire-Pokémon auf deiner Bank zu."
+				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der {R}-Pokémon auf deiner Bank zu."
 			},
 			damage: "10+",
 

--- a/data/Sun & Moon/Sun & Moon/28.ts
+++ b/data/Sun & Moon/Sun & Moon/28.ts
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "As a result of headaches so fierce they cause it to cry, it sometimes uses psychokinesis without meaning to.",
+		de: "Es weint oft, da es immer unter Kopfschmerzen leidet und seine Psycho-Kräfte von Zeit zu Zeit gegen seinen Willen ausgelöst werden."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/29.ts
+++ b/data/Sun & Moon/Sun & Moon/29.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Psyduck",
 		fr: "Psykokwak",
+		de: "Enton"
 	},
 
 	stage: "Stage1",
@@ -68,7 +69,7 @@ const card: Card = {
 				es: "Descarta hasta 2 cartas de Energía Water de tu mano. Este ataque hace 60 puntos de daño por cada carta que hayas descartado de esta manera.",
 				it: "Scarta fino a due Energie Water dalla tua mano. Questo attacco infligge 60 danni per ogni carta che hai scartato in questo modo.",
 				pt: "Descarte até 2 cartas de Energia Water da sua mão. Este ataque causa 60 pontos de dano para cada carta descartada desta forma.",
-				de: "Lege bis zu 2 Water-Energiekarten aus deiner Hand auf deinen Ablagestapel. Diese Attacke fügt 60 Schadenspunkte mal der Anzahl der auf diese Weise auf deinen Ablagestapel gelegten Karten zu."
+				de: "Lege bis zu 2 {W}-Energiekarten aus deiner Hand auf deinen Ablagestapel. Diese Attacke fügt 60 Schadenspunkte mal der Anzahl der auf diese Weise auf deinen Ablagestapel gelegten Karten zu."
 			},
 			damage: "60×",
 
@@ -86,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said that the red part of its forehead grants supernatural powers to those who posses one, so it was over-hunted in the past.",
+		de: "Besitzt man den roten Fortsatz seiner Stirn, erhält man angeblich telekinetische Kräfte. Einst war es sehr selten, da es maßlos gejagt wurde."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/3.ts
+++ b/data/Sun & Moon/Sun & Moon/3.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Metapod",
 		fr: "Chrysacier",
+		de: "Safcon"
 	},
 
 	stage: "Stage2",
@@ -95,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "Close examination of its large eyes reveals that each eye is composed of a myriad of tiny eyes.",
+		de: "Bei genauerer Betrachtung zeigt sich, dass seine zwei großen Augen jeweils aus einer Vielzahl an kleineren Augen bestehen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/30.ts
+++ b/data/Sun & Moon/Sun & Moon/30.ts
@@ -65,7 +65,7 @@ const card: Card = {
 				es: "Este ataque hace 10 puntos de daño más por cada Energía Water unida a este Pokémon.",
 				it: "Questo attacco infligge 10 danni in più per ogni Energia Water assegnata a questo Pokémon.",
 				pt: "Este ataque causa 10 pontos de dano a mais vezes a quantidade de Energia Water ligada a este Pokémon.",
-				de: "Diese Attacke fügt 10 Schadenspunkte mehr mal der Anzahl der an dieses Pokémon angelegten Water-Energien zu."
+				de: "Diese Attacke fügt 10 Schadenspunkte mehr mal der Anzahl der an dieses Pokémon angelegten {W}-Energien zu."
 			},
 			damage: "30+",
 
@@ -83,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "It's still not very good at walking. Its Trainers should train this Pokémon to walk every day.",
+		de: "Es kann noch nicht gut laufen. Sein Trainer sollte daher jeden Tag Laufübungen mit ihm durchführen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/31.ts
+++ b/data/Sun & Moon/Sun & Moon/31.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Poliwag",
 		fr: "Ptitard",
+		de: "Quapsel"
 	},
 
 	stage: "Stage1",
@@ -89,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "It marches over the land in search of bug Pokémon to eat. Then it takes them underwater so it can dine on them where it's safe.",
+		de: "Es geht an Land, um sich auf die Suche nach Käfer-Pokémon zu machen. Diese nimmt es als Beute mit ins Wasser, wo es sie verzehrt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/32.ts
+++ b/data/Sun & Moon/Sun & Moon/32.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Poliwhirl",
 		fr: "Têtarte",
+		de: "Quaputzi"
 	},
 
 	stage: "Stage2",
@@ -95,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "Its percentage of body fat is nearly zero. Its body is entirely muscle, which makes it heavy and forces its swimming prowess to develop.",
+		de: "Sein Körperfettanteil geht gegen null. Es ist sehr schwer, besteht aber fast nur aus Muskeln. So konnte es seine Schwimmfähigkeiten ausbauen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/33.ts
+++ b/data/Sun & Moon/Sun & Moon/33.ts
@@ -58,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "The hardness of its shell surpasses the hardness of a diamond. In days gone by, people used the shells to make shields.",
+		de: "Ihre Schalen sind härter als Diamanten. Vor langer Zeit sammelte man die Schalen von Muschas und machte Schilde daraus."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/34.ts
+++ b/data/Sun & Moon/Sun & Moon/34.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Shellder",
 		fr: "Kokiyas",
+		de: "Muschas"
 	},
 
 	stage: "Stage1",
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "Its hard shell cannot be shattered—not even by a bomb. The contents of the shell remain unknown.",
+		de: "Seine Schale ist so hart, dass nicht einmal eine Bombe sie zerschmettern kann. Bis heute weiß niemand, wie das Innere seiner Schale aussieht."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/36.ts
+++ b/data/Sun & Moon/Sun & Moon/36.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "Pursued by Mareanie for the branches on its head, this Pokémon will sometimes snap its own branches off as a diversion while it escapes.",
+		de: "Drohen die Arme auf seinem Kopf von einem Garstella verschlungen zu werden, wirft es diese ab und sucht das Weite."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/37.ts
+++ b/data/Sun & Moon/Sun & Moon/37.ts
@@ -71,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "Fishermen keep an eye out for Wingull in the sky, because wherever they're circling, the ocean sure to be is teeming with fish Pokémon.",
+		de: "Fischer halten gerne Ausschau nach Wingull, denn wo diese ihre Kreise ziehen, scharen sich unter Wasser Schwärme von Fisch-Pokémon."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/38.ts
+++ b/data/Sun & Moon/Sun & Moon/38.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Wingull",
 		fr: "Goélise",
+		de: "Wingull"
 	},
 
 	stage: "Stage1",
@@ -102,6 +103,7 @@ const card: Card = {
 
 	description: {
 		en: "Gathering food is the work of young males. They store food in their capacious beaks and carry it back to others waiting in the nest.",
+		de: "Die jungen Männchen beschaffen die Nahrung. Sie sammeln die Beute in ihrem großen Schnabel und bringen sie zurück ins Nest zu den anderen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/39.ts
+++ b/data/Sun & Moon/Sun & Moon/39.ts
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon snorts body fluids from its nose, blowing balloons to smash into its foes. It's famous for being a hard worker.",
+		de: "Dieses Pokémon ist für seine Willensstärke bekannt. Bläst es Körperflüssigkeit durch die Nase, entsteht eine Blase, die als Waffe fungiert."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/4.ts
+++ b/data/Sun & Moon/Sun & Moon/4.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "No matter how much it eats, the mushrooms growing on its back steal away most of the nutrients it consumes.",
+		de: "Egal, wie viel Nahrung es auch zu sich nimmt, die Pilze, die auf seinem Rücken wachsen, entziehen ihm so gut wie alle Nährstoffe."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/40.ts
+++ b/data/Sun & Moon/Sun & Moon/40.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Popplio",
 		fr: "Otaquin",
+		de: "Robball"
 	},
 
 	stage: "Stage1",
@@ -89,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "A skillful dancer, it creates a sequence of water balloons as it dances, and briskly bombards it enemies.",
+		de: "Dieser begnadete Tänzer erzeugt beim Tanzen eine Wasserblase nach der anderen und greift damit seine Feinde an."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/41.ts
+++ b/data/Sun & Moon/Sun & Moon/41.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Brionne",
 		fr: "Otarlette",
+		de: "Marikeck"
 	},
 
 	stage: "Stage2",
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "It controls its water balloons with song. The melody is learning from others of its kind and is passed down from one generation to the next.",
+		de: "Es kontrolliert mit seinem Gesang Wasserblasen. Die Melodie, die über Generationen im Rudel überliefert wird, lernt es von seinen Kameraden."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/42.ts
+++ b/data/Sun & Moon/Sun & Moon/42.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Brionne",
 		fr: "Otarlette",
+		de: "Marikeck"
 	},
 
 	suffix: "GX",
@@ -53,7 +54,7 @@ const card: Card = {
 				es: "Este ataque hace 20 puntos de daño más por cada Energía Water unida a tus Pokémon.",
 				it: "Questo attacco infligge 20 danni in più per ogni Energia Water assegnata ai tuoi Pokémon.",
 				pt: "Este ataque causa 20 pontos de dano a mais vezes a quantidade de Energia Water ligada aos seus Pokémon.",
-				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der an deine Pokémon angelegten Water-Energien zu."
+				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der an deine Pokémon angelegten {W}-Energien zu."
 			},
 			damage: "10+",
 

--- a/data/Sun & Moon/Sun & Moon/43.ts
+++ b/data/Sun & Moon/Sun & Moon/43.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Crabrawler",
 		fr: "Crabagarre",
+		de: "Krabbox"
 	},
 
 	stage: "Stage1",
@@ -91,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "It just throws punches indiscriminately. In times of desperation, it can lop off its own pincers and fire them like rockets.",
+		de: "Schlägt erst einmal wahllos zu. Kommt es hart auf hart, stößt es seine Scheren ab und verschießt sie wie Raketen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/44.ts
+++ b/data/Sun & Moon/Sun & Moon/44.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "When it's in trouble, its eyes moisten and begin to shine. The shining light attracts its comrades, and they stand together against their enemies.",
+		de: "Gerät es in Not, tränen seine Augen. Ihr Glänzen lockt Artgenossen an, mit denen es dann im Verbund den Feind angreift."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/45.ts
+++ b/data/Sun & Moon/Sun & Moon/45.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It crawls onto the land in search of food. Its water bubble allows it to breathe and protects its soft head.",
+		de: "Die Futtersuche treibt es an Land. Eine Wasserblase versorgt es mit Atemluft und schützt zugleich seinen weichen Kopf."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/46.ts
+++ b/data/Sun & Moon/Sun & Moon/46.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Dewpider",
 		fr: "Araqua",
+		de: "Araqua"
 	},
 
 	stage: "Stage1",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Evita todo el daño infligido a este Pokémon por ataques de los Pokémon Fire de tu rival.",
 				it: "Previeni tutti i danni da attacchi inflitti a questo Pokémon dai Pokémon Fire del tuo avversario.",
 				pt: "Previne todo o dano causado a este Pokémon por ataques dos Pokémon Fire do seu oponente.",
-				de: "Verhindere allen Schaden, der diesem Pokémon durch Attacken von Fire-Pokémon deines Gegners zugefügt wird."
+				de: "Verhindere allen Schaden, der diesem Pokémon durch Attacken von {R}-Pokémon deines Gegners zugefügt wird."
 			},
 		},
 	],
@@ -87,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It delivers headbutts with the water bubble on its head. Small Pokémon get sucked into the bubble, where they drown.",
+		de: "Es verteilt mit seiner Wasserblase Kopfstöße. Kleine Pokémon werden dabei hineingezogen und ertrinken."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/47.ts
+++ b/data/Sun & Moon/Sun & Moon/47.ts
@@ -87,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives in shallow seas, such as areas near a beach. It can eject its internal organs, which it uses to engulf its prey or battle enemies.",
+		de: "Es lebt an Stränden oder in flachen Gewässern. Im Kampf und zum Schnappen von Beute lässt es seine Organe hervorschnellen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/48.ts
+++ b/data/Sun & Moon/Sun & Moon/48.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It stuns its prey with psychokinesis and then grinds them to mush with its strong teeth. Even Shellder's shell is no match for it.",
+		de: "Es lähmt seine Beute mit Psycho-Kräften und zerkaut sie mit seinen kräftigen Zähnen. Auch die Schale von Muschas knackt es problemlos."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/49.ts
+++ b/data/Sun & Moon/Sun & Moon/49.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives in the depths beyond the reach of sunlight. It flashes lights on its antennae to communicate with others of its kind.",
+		de: "Es lebt in den Tiefen des Meeres, zu denen kein Licht durchdringt. Es kommuniziert mit anderen Lampi, indem es seine Antennen aufblitzen lässt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/5.ts
+++ b/data/Sun & Moon/Sun & Moon/5.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Paras",
 		fr: "Paras",
+		de: "Paras"
 	},
 
 	stage: "Stage1",
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "The large mushroom on its back controls it. It often fights over territory with Shiinotic.",
+		de: "Parasek wird von dem Pilz auf seinen Rücken kontrolliert. Es ist oft mit Lamellux in Revierstreitigkeiten verstrickt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/50.ts
+++ b/data/Sun & Moon/Sun & Moon/50.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Chinchou",
 		fr: "Loupio",
+		de: "Lampi"
 	},
 
 	stage: "Stage1",
@@ -76,7 +77,7 @@ const card: Card = {
 				es: "Si este Pokémon tiene alguna Energía Water unida a él, este ataque hace 60 puntos de daño más.",
 				it: "Se questo Pokémon ha delle Energie Water assegnate, questo attacco infligge 60 danni in più.",
 				pt: "Se este Pokémon possuir alguma Energia Water ligada a ele, este ataque causará 60 pontos de dano a mais.",
-				de: "Wenn an dieses Pokémon mindestens 1 Water-Energie angelegt ist, fügt diese Attacke 60 Schadenspunkte mehr zu."
+				de: "Wenn an dieses Pokémon mindestens 1 {W}-Energie angelegt ist, fügt diese Attacke 60 Schadenspunkte mehr zu."
 			},
 			damage: "60+",
 
@@ -101,6 +102,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon flashes a bright light that blinds its prey. This creates an opening for it to deliver an electrical attack.",
+		de: "Es blendet seine Beute mit einem starken Blitz. Sieht es eine Chance zuzuschlagen, greift es sie mit Elektrizität an."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/51.ts
+++ b/data/Sun & Moon/Sun & Moon/51.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Grubbin",
 		fr: "Larvibule",
+		de: "Mabula"
 	},
 
 	stage: "Stage1",
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "From the food it digests, it generates electricity, and it stores this energy in its electric sac.",
+		de: "Beim Verdauen der Nahrung entsteht elektrische Energie, die es in seinem Strombeutel speichert."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/52.ts
+++ b/data/Sun & Moon/Sun & Moon/52.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Charjabug",
 		fr: "Chrysapile",
+		de: "Akkup"
 	},
 
 	stage: "Stage2",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Una vez durante tu turno (antes de tu ataque), puedes buscar en tu baraja 1 carta de Energía Grass y 1 carta de Energía Lightning, y unirlas a tus Pokémon de la manera que desees. Después, baraja las cartas de tu baraja.",
 				it: "Una sola volta durante il tuo turno, prima di attaccare, puoi cercare nel tuo mazzo una carta Energia Grass e una carta Energia Lightning e assegnarle a piacimento ai tuoi Pokémon. Poi rimischia le carte del tuo mazzo.",
 				pt: "Uma vez durante a sua vez de jogar (antes de atacar), você pode procurar por 1 carta de Energia Grass e por 1 carta de Energia Lightning no seu baralho e ligá-las aos seus Pokémon como desejar. Em seguida, embaralhe o seu baralho.",
-				de: "Einmal während deines Zuges (bevor du angreifst) kannst du dein Deck nach 1 Grass-Energiekarte und 1 Lightning-Energiekarte durchsuchen und sie beliebig an deine Pokémon anlegen. Mische anschließend dein Deck."
+				de: "Einmal während deines Zuges (bevor du angreifst) kannst du dein Deck nach 1 {G}-Energiekarte und 1 {L}-Energiekarte durchsuchen und sie beliebig an deine Pokémon anlegen. Mische anschließend dein Deck."
 			},
 		},
 	],
@@ -102,6 +103,7 @@ const card: Card = {
 
 	description: {
 		en: "It produces electricity via an electrical organ in its abdomen. It overwhelms bird Pokémon with shocking beams of electrical energy.",
+		de: "In seinem Bauch hat es ein elektrisches Organ, welches Strom erzeugt. Mit seinem Elektrostrahl kann es auch Vogel-Pokémon überwältigen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/53.ts
+++ b/data/Sun & Moon/Sun & Moon/53.ts
@@ -69,7 +69,7 @@ const card: Card = {
 				es: "Descarta todas las Energías Lightning de este Pokémon. Este ataque hace 30 puntos de daño por cada carta que hayas descartado de esta manera.",
 				it: "Scarta tutte le Energie Lightning assegnate a questo Pokémon. Questo attacco infligge 30 danni per ogni carta che hai scartato in questo modo.",
 				pt: "Descarte todas as Energias Lightning deste Pokémon. Este ataque causa 30 pontos de dano para cada carta descartada desta forma.",
-				de: "Lege alle Lightning-Energien von diesem Pokémon auf deinen Ablagestapel. Diese Attacke fügt 30 Schadenspunkte mal der Anzahl der auf diese Weise auf deinen Ablagestapel gelegten Karten zu."
+				de: "Lege alle {L}-Energien von diesem Pokémon auf deinen Ablagestapel. Diese Attacke fügt 30 Schadenspunkte mal der Anzahl der auf diese Weise auf deinen Ablagestapel gelegten Karten zu."
 			},
 			damage: "30×",
 
@@ -94,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "The long hairs on its back act as lightning rods. The bolts of lightning it attracts are stored as energy in its electric sac.",
+		de: "Sein langer Stachel fungiert als Blitzableiter. Damit zieht es Blitze auf sich, die es dann in seinen Elektrotaschen speichert."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/54.ts
+++ b/data/Sun & Moon/Sun & Moon/54.ts
@@ -71,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "It sleeps in caves during the day. It has no eyes, so to check its surroundings while flying, it emits ultrasonic waves.",
+		de: "Tagsüber schläft es in Höhlen. Da es keine Augen hat, erschließt es sich seine Umgebung im Flug durch das Aussenden von Schallwellen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/55.ts
+++ b/data/Sun & Moon/Sun & Moon/55.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Zubat",
 		fr: "Nosferapti",
+		de: "Zubat"
 	},
 
 	stage: "Stage1",
@@ -100,6 +101,7 @@ const card: Card = {
 
 	description: {
 		en: "Its thick fangs are hollow like straws, making them unexpectedly fragile. These fangs are specialized for sucking blood.",
+		de: "Seine dicken Reißzähne sind im Inneren hohl wie Strohhalme und zerbrechlich. Sie sind das Produkt seiner Entwicklung zum Blutsauger."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/56.ts
+++ b/data/Sun & Moon/Sun & Moon/56.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Golbat",
 		fr: "Nosferalto",
+		de: "Golbat"
 	},
 
 	stage: "Stage2",
@@ -95,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "Both its legs became wings, and as a result, it can't move well on the ground. All it can do is crawl around.",
+		de: "Es kann sich nur schwer am Boden fortbewegen, da aus seinen zwei Beinen Flügel geworden sind. Daher ist es nur zu Kriechbewegungen fähig."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/57.ts
+++ b/data/Sun & Moon/Sun & Moon/57.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "The crystals on Grimer's body are lumps of toxins. If one falls off, lethal poisons leak out.",
+		de: "Seine Kristalle bestehen aus verklumpten Toxinen. Fallen sie von seinem Körper ab, entweichen die tödlichen Giftstoffe."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/58.ts
+++ b/data/Sun & Moon/Sun & Moon/58.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Alolan Grimer",
 		fr: "Tadmorv d’Alola",
+		de: "Alola-Sleima"
 	},
 
 	stage: "Stage1",
@@ -95,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "While it's unexpectedly quiet and friendly, if it's not fed any trash for a while, it will smash its Trainer's furnishings and eat up the fragments.",
+		de: "Es kann sich unerwartet zahm verhalten, aber wenn man ihm lange keinen Müll zu fressen gibt, zerstört und verschlingt es die Möbel im Haus."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/59.ts
+++ b/data/Sun & Moon/Sun & Moon/59.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It finds really fun dreams tasty. When it makes friends with people, it may show them the most delicious dreams it's ever eaten.",
+		de: "Lustige Träume schmecken ihm am besten. Ist man nett zu ihm, zeigt es einem ab und an Träume, die ihm besonders gemundet haben."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/6.ts
+++ b/data/Sun & Moon/Sun & Moon/6.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "One solid blow from its horns is enough to split apart a large tree. Its greatest rival in Alola is Vikavolt.",
+		de: "Ein Stoß mit seinen Hörnern reicht, um große Bäume zu zersplittern. In Alola ist Donarion sein größter Rivale."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/60.ts
+++ b/data/Sun & Moon/Sun & Moon/60.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Drowzee",
 		fr: "Soporifik",
+		de: "Traumato"
 	},
 
 	stage: "Stage1",
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "As a matter of course, it makes anyone it meets fall asleep and has a taste of their dreams. Anyone having a good dream, it carries off.",
+		de: "Es versetzt jeden, dem es begegnet, sofort in Schlaf und kostet seine Träume. Schmeckt ihm ein Traum, nimmt es die Person mit."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/61.ts
+++ b/data/Sun & Moon/Sun & Moon/61.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	suffix: "GX",

--- a/data/Sun & Moon/Sun & Moon/62.ts
+++ b/data/Sun & Moon/Sun & Moon/62.ts
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "It plunges the poison spike on its head into its prey. When the prey has weakened, Mareanie deals the finishing blow with its 10 tentacles.",
+		de: "Mit seinem Giftstachel am Kopf attackiert es Beute. Ist diese geschwächt, umschlingt es sie mit seinen zehn Tentakeln und gibt ihr den Rest."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/63.ts
+++ b/data/Sun & Moon/Sun & Moon/63.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Mareanie",
 		fr: "Vorastérie",
+		de: "Garstella"
 	},
 
 	stage: "Stage1",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "Toxapex crawls along the ocean floor on its 12 legs. It leaves a trail of Corsola bits scattered in its wake.",
+		de: "Kriecht mit seinen zwölf Beinen über den Meeresboden. Es hinterlässt oft etliche Überreste von Corasonn."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/64.ts
+++ b/data/Sun & Moon/Sun & Moon/64.ts
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "Its body is gaseous and frail. It slowly grows as it collects dust from the atmosphere.",
+		de: "Sein Körper besteht aus flüchtigem Gas. Es wächst durch das Sammeln von Staub aus der Luft."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/65.ts
+++ b/data/Sun & Moon/Sun & Moon/65.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cosmog",
 		fr: "Cosmog",
+		de: "Cosmog"
 	},
 
 	stage: "Stage1",
@@ -69,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "Motionless as if dead, its body is faintly warm to the touch. In the distant past, it was called the cocoon of the stars.",
+		de: "Es ist völlig reglos, als wäre es tot. Berührt man es, fühlt es sich jedoch leicht warm an. Vor langer Zeit wurde es „Sternenkokon“ genannt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/66.ts
+++ b/data/Sun & Moon/Sun & Moon/66.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cosmoem",
 		fr: "Cosmovum",
+		de: "Cosmovum"
 	},
 
 	suffix: "GX",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Todas las veces que quieras durante tu turno (antes de tu ataque), puedes mover 1 Energía Psychic de 1 de tus Pokémon a otro de tus Pokémon.",
 				it: "Durante il tuo turno, prima di attaccare, puoi spostare un’Energia Psychic da uno a un altro dei tuoi Pokémon tutte le volte che vuoi.",
 				pt: "Quantas vezes desejar durante a sua vez de jogar (antes de atacar), você pode mover 1 Energia Psychic de 1 dos seus Pokémon para outro Pokémon seu.",
-				de: "Beliebig oft während deines Zuges (bevor du angreifst) kannst du 1 Psychic-Energie von 1 deiner Pokémon auf 1 anderes deiner Pokémon verschieben."
+				de: "Beliebig oft während deines Zuges (bevor du angreifst) kannst du 1 {P}-Energie von 1 deiner Pokémon auf 1 anderes deiner Pokémon verschieben."
 			},
 		},
 	],

--- a/data/Sun & Moon/Sun & Moon/67.ts
+++ b/data/Sun & Moon/Sun & Moon/67.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It was originally brought in from another region, but now Makuhita from Alola are more famous.",
+		de: "Obwohl sie ursprünglich aus einer anderen Region kommen, sind Alola-Makuhita heute bekannter als ihre übrigen Artgenossen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/68.ts
+++ b/data/Sun & Moon/Sun & Moon/68.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Makuhita",
 		fr: "Makuhita",
+		de: "Makuhita"
 	},
 
 	stage: "Stage1",
@@ -91,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "It is known for its fantastic strength, but as it grows older, it focuses more on training Makuhita.",
+		de: "Es ist für seine unglaubliche Stärke bekannt, lässt das Kämpfen mit dem Alter aber sein und trainiert stattdessen Makuhita."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/69.ts
+++ b/data/Sun & Moon/Sun & Moon/69.ts
@@ -48,7 +48,7 @@ const card: Card = {
 				es: "Si el Pokémon Activo de tu rival tiene Resistencia a Fighting, este ataque hace 50 puntos de daño más.",
 				it: "Se il Pokémon attivo del tuo avversario ha resistenza al tipo Fighting, questo attacco infligge 50 danni in più.",
 				pt: "Se o Pokémon Ativo do seu oponente tiver Resistência Fighting, este ataque causará 50 pontos de dano a mais.",
-				de: "Wenn das Aktive Pokémon deines Gegners eine Resistenz gegenüber Fighting-Pokémon hat, fügt diese Attacke 50 Schadenspunkte mehr zu."
+				de: "Wenn das Aktive Pokémon deines Gegners eine Resistenz gegenüber {F}-Pokémon hat, fügt diese Attacke 50 Schadenspunkte mehr zu."
 			},
 			damage: "20+",
 
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "The hexagonal cavity is its ear. It walks in the direction of sounds it hears, but if the sounds cease, it panics and topples over.",
+		de: "Die sechseckige Aushöhlung dient ihm als Ohr. Es bewegt sich immer auf Geräusche zu, fällt jedoch ratlos um, sobald diese verstummen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/7.ts
+++ b/data/Sun & Moon/Sun & Moon/7.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "When this Pokémon senses danger, a sweet fluid oozes from the tip of its heads. The taste of it disgusts bird Pokémon.",
+		de: "Wittert es Gefahr, scheidet es eine süßliche Flüssigkeit aus seinem Kopf aus. Vogel-Pokémon behagt dieser Geschmack überhaupt nicht."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/70.ts
+++ b/data/Sun & Moon/Sun & Moon/70.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Roggenrola",
 		fr: "Nodulithe",
+		de: "Kiesling"
 	},
 
 	stage: "Stage1",
@@ -89,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "It explores caves in search of underground water. It's not comfortable around water, so this Pokémon takes great care in lapping it up.",
+		de: "Es sucht in Höhlen nach Grundwasser. Da es Wasser nicht gut verträgt, leckt es dieses ganz behutsam auf."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/71.ts
+++ b/data/Sun & Moon/Sun & Moon/71.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Boldore",
 		fr: "Géolithe",
+		de: "Sedimantur"
 	},
 
 	stage: "Stage2",
@@ -53,7 +54,7 @@ const card: Card = {
 				es: "Descarta cualquier cantidad de Energías Fighting de tus Pokémon. Este ataque hace 50 puntos de daño por cada carta que hayas descartado de esta manera.",
 				it: "Scarta tutte le Energie Fighting che vuoi assegnate ai tuoi Pokémon. Questo attacco infligge 50 danni per ogni carta che hai scartato in questo modo.",
 				pt: "Descarte qualquer quantidade de Energia Fighting dos seus Pokémon. Este ataque causa 50 pontos de dano para cada carta descartada desta forma.",
-				de: "Lege beliebig viele Fighting-Energien von deinen Pokémon auf deinen Ablagestapel. Diese Attacke fügt 50 Schadenspunkte mal der Anzahl der auf diese Weise auf deinen Ablagestapel gelegten Karten zu."
+				de: "Lege beliebig viele {F}-Energien von deinen Pokémon auf deinen Ablagestapel. Diese Attacke fügt 50 Schadenspunkte mal der Anzahl der auf diese Weise auf deinen Ablagestapel gelegten Karten zu."
 			},
 			damage: "50×",
 
@@ -97,6 +98,7 @@ const card: Card = {
 
 	description: {
 		en: "Known for its hefty horsepower, this Pokémon is a popular partner for construction workers.",
+		de: "Es verfügt über gewaltige Stärke und ist deshalb bei Bauarbeitern sehr beliebt. Diese wählen es oft als Partner-Pokémon."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/72.ts
+++ b/data/Sun & Moon/Sun & Moon/72.ts
@@ -77,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "It punches so much, its pincers often come off from overuse, but they grow back quickly. What little meat they contain is rich and delicious.",
+		de: "Es verliert oft seine Scheren im Kampf, aber sie wachsen schnell nach. Obwohl diese nur wenig Fleisch enthalten, gelten sie als Delikatesse."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/73.ts
+++ b/data/Sun & Moon/Sun & Moon/73.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "They form groups of roughly 20 individuals. Their mutual bond is remarkable—they will never let down a comrade.",
+		de: "Es gründet Gruppen von etwa 20 Exemplaren. Der Zusammenhalt der Gruppe ist extrem stark, kein Kamerad wird jemals im Stich gelassen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/74.ts
+++ b/data/Sun & Moon/Sun & Moon/74.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Une 1 carta de Energía Fighting de tu pila de descartes a este Pokémon.",
 				it: "Assegna a questo Pokémon una carta Energia Fighting dalla tua pila degli scarti.",
 				pt: "Ligue 1 carta de Energia Fighting da sua pilha de descarte a este Pokémon.",
-				de: "Lege 1 Fighting-Energiekarte aus deinem Ablagestapel an dieses Pokémon an."
+				de: "Lege 1 {F}-Energiekarte aus deinem Ablagestapel an dieses Pokémon an."
 			},
 
 		},
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It takes control of anyone who puts a hand in its mouth. And so it adds to the accumulation of its sand-mound body.",
+		de: "Es kann jeden kontrollieren, der seine Hand in sein Maul steckt, und bringt sie dann dazu, seinen Körper immer weiter zu vergrößern."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/75.ts
+++ b/data/Sun & Moon/Sun & Moon/75.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Sandygast",
 		fr: "Bacabouh",
+		de: "Sankabuh"
 	},
 
 	stage: "Stage1",
@@ -95,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "Buried beneath the castle are masses of dried-up bones from those whose vitality it has drained.",
+		de: "Unter seiner Sandburg liegen zahlreiche Knochen qualvoll Verstorbener, denen die Lebenskraft ausgesaugt wurde."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/76.ts
+++ b/data/Sun & Moon/Sun & Moon/76.ts
@@ -63,6 +63,7 @@ const card: Card = {
 
 	description: {
 		en: "When the sun goes down, it becomes active. It runs around town on a chase for good food for the boss of its nest—Raticate.",
+		de: "Es wird bei Sonnenuntergang aktiv. Für seinen Rudelführer Rattikarl durchstreift es die Stadt auf der Suche nach gutem Futter."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/77.ts
+++ b/data/Sun & Moon/Sun & Moon/77.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Alolan Rattata",
 		fr: "Rattata d’Alola",
+		de: "Alola-Rattfratz"
 	},
 
 	stage: "Stage1",
@@ -102,6 +103,7 @@ const card: Card = {
 
 	description: {
 		en: "This gourmet Pokémon is particular about the taste and freshness of its food. Restaurants where Raticate live have a good reputation.",
+		de: "Ein Gourmet, dem Geschmack und Frische seines Futters wichtig sind. Restaurants gelten als angesehen, wenn sich ein Rattikarl einnistet."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/78.ts
+++ b/data/Sun & Moon/Sun & Moon/78.ts
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon was not originally found in Alola. Human actions caused a surge in their numbers, and they went feral. They're prideful and crafty.",
+		de: "Ursprünglich existierte es in Alola nicht. Durch Menschenhand wurde es verbreitet und ausgewildert. Es ist listig und sehr stolz."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/79.ts
+++ b/data/Sun & Moon/Sun & Moon/79.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Alolan Meowth",
 		fr: "Miaouss d’Alola",
+		de: "Alola-Mauzi"
 	},
 
 	stage: "Stage1",
@@ -97,6 +98,7 @@ const card: Card = {
 
 	description: {
 		en: "Its round face and smooth coat—softer than the most high-class velvet—have made this a very popular Pokémon in Alola.",
+		de: "Sein rundes Gesicht und sein Fell, das weicher ist als erstklassiger Samt, machen es in Alola zu einem sehr beliebten Pokémon."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/8.ts
+++ b/data/Sun & Moon/Sun & Moon/8.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Surskit",
 		fr: "Arakdo",
+		de: "Gehweiher"
 	},
 
 	stage: "Stage1",
@@ -70,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "Its wings and antennae don't cope well with moisture. After a rain, it faces sunward to dry off.",
+		de: "Seine Flügel und Fühler sind empfindlich gegen Feuchtigkeit. Nachdem es geregnet hat, streckt es sie gen Sonne, um sie zu trocknen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/80.ts
+++ b/data/Sun & Moon/Sun & Moon/80.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	suffix: "GX",

--- a/data/Sun & Moon/Sun & Moon/81.ts
+++ b/data/Sun & Moon/Sun & Moon/81.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "If they scent the faintest trace of blood, they rush to attack en masse. When alone, they're rather cowardly.",
+		de: "Wittert es auch nur einen Hauch von Blut, greift es im Schwarm seine Beute an. Alleine ist es hingegen ziemlich furchtsam."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/82.ts
+++ b/data/Sun & Moon/Sun & Moon/82.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Carvanha",
 		fr: "Carvanha",
+		de: "Kanivanha"
 	},
 
 	stage: "Stage1",
@@ -76,7 +77,7 @@ const card: Card = {
 				es: "Este ataque hace 20 puntos de daño más por cada Colorless en el Coste de Retirada del Pokémon Activo de tu rival.",
 				it: "Questo attacco infligge 20 danni in più per ogni Colorless nel costo di ritirata del Pokémon attivo del tuo avversario.",
 				pt: "Este ataque causa 20 pontos de dano a mais para cada Colorless no custo de Recuo do Pokémon Ativo do seu oponente.",
-				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der Colorless-Symbole in den Rückzugskosten des Aktiven Pokémon deines Gegners zu."
+				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der {C}-Symbole in den Rückzugskosten des Aktiven Pokémon deines Gegners zu."
 			},
 			damage: "60+",
 
@@ -101,6 +102,7 @@ const card: Card = {
 
 	description: {
 		en: "It has a sad history. In the past, its dorsal fin was a treasured foodstuff, so this Pokémon became a victim of overfishing.",
+		de: "Tohaido hat eine traurige Vergangenheit: Seine Rückenflosse gilt als Delikatesse, weshalb es lange Zeit gnadenlos überfischt wurde."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/83.ts
+++ b/data/Sun & Moon/Sun & Moon/83.ts
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "It submerges itself in sand and moves as if swimming. This wise behavior keeps its enemies from finding it and maintains its temperature.",
+		de: "Es bewegt sich verborgen im Sand mithilfe von Schwimmbewegungen fort. So versteckt es sich vor Gegnern und bleibt immer schön warm."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/84.ts
+++ b/data/Sun & Moon/Sun & Moon/84.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Sandile",
 		fr: "Mascaïman",
+		de: "Ganovil"
 	},
 
 	stage: "Stage1",
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "They move in groups of a few individuals. A female is often the leader of the group, and the males will gather food.",
+		de: "Es bildet mit mehreren Artgenossen ein Rudel. Meistens führen Weibchen die Gruppe an und Männchen müssen Nahrung beschaffen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/85.ts
+++ b/data/Sun & Moon/Sun & Moon/85.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Krokorok",
 		fr: "Escroco",
+		de: "Rokkaiman"
 	},
 
 	stage: "Stage2",
@@ -103,6 +104,7 @@ const card: Card = {
 
 	description: {
 		en: "Its unique faculty of sight can detect small prey more than 30 miles away, even in the midst of a sandstorm.",
+		de: "Seine Augen sind so außergewöhnlich, dass es sogar in einem Sandsturm kleinste Beute aus 50 km Entfernung entdecken kann."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/86.ts
+++ b/data/Sun & Moon/Sun & Moon/86.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "Its head sports an altered form of whiskers made of metal. When in communication with its comrades, its whiskers wobble to and fro.",
+		de: "Die metallischen Fortsätze auf seinem Kopf waren ursprünglich Haare. Es kommuniziert durch Schwanken mit anderen Digda."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/87.ts
+++ b/data/Sun & Moon/Sun & Moon/87.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Alolan Diglett",
 		fr: "Taupiqueur d’Alola",
+		de: "Alola-Digda"
 	},
 
 	stage: "Stage1",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "El Coste de Retirada del Pokémon Activo de tu rival es de Colorless más.",
 				it: "Il costo di ritirata del Pokémon attivo del tuo avversario aumenta di Colorless.",
 				pt: "O custo de Recuo do Pokémon Ativo do seu oponente é Colorless a mais.",
-				de: "Die Rückzugskosten des Aktiven Pokémon deines Gegners erhöhen sich um Colorless."
+				de: "Die Rückzugskosten des Aktiven Pokémon deines Gegners erhöhen sich um {C}."
 			},
 		},
 	],
@@ -100,6 +101,7 @@ const card: Card = {
 
 	description: {
 		en: "Its shining gold hair provides it with protection. It's reputed that keeping any of its fallen hairs will bring bad luck.",
+		de: "Mit seinen golden leuchtenden Haaren schützt es sich. Es soll Unglück bringen, seine ausgefallenen Haare mitzunehmen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/88.ts
+++ b/data/Sun & Moon/Sun & Moon/88.ts
@@ -97,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "Its feathers, which fall off as it grows, are thin and sharp. In times long past, warriors used them as swords.",
+		de: "Die im Zuge seines Wachstums abgefallenen Federn sind sehr scharf. Krieger verwendeten sie früher als Schwerter."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/89.ts
+++ b/data/Sun & Moon/Sun & Moon/89.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cosmoem",
 		fr: "Cosmovum",
+		de: "Cosmovum"
 	},
 
 	suffix: "GX",

--- a/data/Sun & Moon/Sun & Moon/9.ts
+++ b/data/Sun & Moon/Sun & Moon/9.ts
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "This wary Pokémon uses photosynthesis to store up energy during the day, while becoming active at night.",
+		de: "Ein wachsames und nachtaktives Pokémon. Tagsüber sammelt es per Photosynthese Kräfte, um fit für die Nacht zu sein."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/90.ts
+++ b/data/Sun & Moon/Sun & Moon/90.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "Its growls make its opponents uneasy. This laid-back Pokémon tends to sleep half the day.",
+		de: "Es brüllt, um seine Feinde zu verunsichern. Normalerweise geht es die Dinge gemütlich an und schläft den halben Tag."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/91.ts
+++ b/data/Sun & Moon/Sun & Moon/91.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Snubbull",
 		fr: "Snubbull",
+		de: "Snubbull"
 	},
 
 	stage: "Stage1",
@@ -102,6 +103,7 @@ const card: Card = {
 
 	description: {
 		en: "More timid than Snubbull, this Pokémon is doted on by young people amused at the contrast between its looks and its attitude.",
+		de: "Es ist noch schüchterner als Snubbull. Der Kontrast zwischen seinem Äußeren und seinem Wesen macht es bei jungen Leuten so beliebt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/92.ts
+++ b/data/Sun & Moon/Sun & Moon/92.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "It feeds on the nectar and pollen of flowers. Because it's able to sense auras, it can identify which flowers are about to bloom.",
+		de: "Es ernährt sich von Blütenstaub und Honig. Da es die Aura von Lebewesen wahrnehmen kann, spürt es, wenn eine Blume bald blühen wird."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/93.ts
+++ b/data/Sun & Moon/Sun & Moon/93.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cutiefly",
 		fr: "Bombydou",
+		de: "Wommel"
 	},
 
 	stage: "Stage1",
@@ -92,6 +93,7 @@ const card: Card = {
 
 	description: {
 		en: "It rolls up pollen into puffs. It makes many different varieties, some used as food and others used in battle.",
+		de: "Dieses Pokémon rollt Blütenstaub zu Kugeln. Manche dieser Pollenknödel dienen als Nahrung, andere setzt es aber auch im Kampf ein."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/94.ts
+++ b/data/Sun & Moon/Sun & Moon/94.ts
@@ -61,7 +61,7 @@ const card: Card = {
 				es: "Bofetón Cola",
 				it: "Codasberla",
 				pt: "Ataque de Cauda",
-				de: "Schweifstreich"
+				de: "Schweifschlag"
 			},
 
 			damage: 10,
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "After a 10-hour struggle, a fisherman was able to pull one up and confirm its existence.",
+		de: "Seine Existenz konnte endlich nachgewiesen werden, nachdem es einem Angler gelang, es nach einem zehnstündigen Kampf zu fangen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/95.ts
+++ b/data/Sun & Moon/Sun & Moon/95.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Dratini",
 		fr: "Minidraco",
+		de: "Dratini"
 	},
 
 	stage: "Stage1",
@@ -68,7 +69,7 @@ const card: Card = {
 				es: "Bofetón Cola",
 				it: "Codasberla",
 				pt: "Ataque de Cauda",
-				de: "Schweifstreich"
+				de: "Schweifschlag"
 			},
 
 			damage: 60,
@@ -87,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "From time immemorial, it has been venerated by agricultural peoples as an entity able to control the weather.",
+		de: "Bauern verehren es schon seit Urzeiten, da es die Fähigkeit besitzt, das Wetter zu beeinflussen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/96.ts
+++ b/data/Sun & Moon/Sun & Moon/96.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Dragonair",
 		fr: "Draco",
+		de: "Dragonir"
 	},
 
 	stage: "Stage2",
@@ -53,7 +54,7 @@ const card: Card = {
 				es: "Descarta 1 Energía Grass y 1 Energía Lightning de este Pokémon.",
 				it: "Scarta un’Energia Grass e un’Energia Lightning assegnate a questo Pokémon.",
 				pt: "Descarte 1 Energia Grass e 1 Energia Lightning deste Pokémon.",
-				de: "Lege 1 Grass-Energie sowie 1 Lightning-Energie von diesem Pokémon auf deinen Ablagestapel."
+				de: "Lege 1 {G}-Energie sowie 1 {L}-Energie von diesem Pokémon auf deinen Ablagestapel."
 			},
 			damage: 130,
 
@@ -98,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "Incur the wrath of this normally calm Pokémon at your peril, because it will smash everything to smithereens before it's satisfied.",
+		de: "Eigentlich ist es ein äußerst sanftmütiges Pokémon, aber wenn man es verärgert, schlägt es alles um sich herum kurz und klein."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/97.ts
+++ b/data/Sun & Moon/Sun & Moon/97.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Si el Pokémon Activo de tu rival es un Pokémon Grass, este ataque hace 30 puntos de daño más.",
 				it: "Se il Pokémon attivo del tuo avversario è di tipo Grass, questo attacco infligge 30 danni in più.",
 				pt: "Se o Pokémon Ativo do seu oponente for um Pokémon Grass, este ataque causará 30 pontos de dano a mais.",
-				de: "Wenn das Aktive Pokémon deines Gegners ein Grass-Pokémon ist, fügt diese Attacke 30 Schadenspunkte mehr zu."
+				de: "Wenn das Aktive Pokémon deines Gegners ein {G}-Pokémon ist, fügt diese Attacke 30 Schadenspunkte mehr zu."
 			},
 			damage: "10+",
 
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "Farmers whose fields are troubled by bug Pokémon appreciate Spearow for its vigorous appetite and look after it.",
+		de: "Bauern, deren Felder von Käfer-Pokémon befallen sind, schätzen Habitak wegen seines unstillbaren Appetits ganz besonders."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/98.ts
+++ b/data/Sun & Moon/Sun & Moon/98.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Spearow",
 		fr: "Piafabec",
+		de: "Habitak"
 	},
 
 	stage: "Stage1",
@@ -99,6 +100,7 @@ const card: Card = {
 
 	description: {
 		en: "Drawings of a Pokémon resembling Fearow can be seen in murals from deep in ancient history.",
+		de: "Wie kürzlich bekannt wurde, existieren uralte Wandmalereien, auf denen Pokémon abgebildet sind, die Ähnlichkeiten mit Ibitak aufweisen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Sun & Moon/99.ts
+++ b/data/Sun & Moon/Sun & Moon/99.ts
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "Kangaskhan's maternal love is so deep that it will brave death to protect its offspring.",
+		de: "Die Mutterliebe des ausgewachsenen Kangama ist tief. Es wäre sogar bereit, sein eigenes Leben zu opfern, um sein Junges zu beschützen."
 	},
 
 	thirdParty: {


### PR DESCRIPTION
## Add missing German translations for sm1

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
