### PR TITLE
(fix) Remove duplicated attacks from Skyridge Trainer cards

### DIFF
--- a/data/E-Card/Skyridge/132.ts
+++ b/data/E-Card/Skyridge/132.ts
@@ -18,16 +18,6 @@ const card: Card = {
 		de: "Immer wenn ein Spieler versucht, in seinem Zug ein Pokémon zurückzuziehen, wirft dieser Spieler eine Münze. Bei \"Kopf\" zieht der Spieler das Pokémon zurück (und legt die Energiekarte ganz normal auf den Ablagestapel). Bei \"Zahl\" kann sich dieses Pokémon in diesem nicht zurückziehen (der Spieler legt keine Energiekarte auf den Ablagestapel)."
 	},
 
-	attacks: [
-		{
-			// name intentionally left blank
-			name: {},
-			effect: {
-				en: 'Whenever a player tries to retreat a Pokémon during his or her turn, that player flips a coin. If heads, that player retreats that Pokémon (and discards Energy normally). If tails, that Pokémon can\'t retreat this turn (the player doesn\'t discard any Energy).'
-			}
-		}
-	],
-
 	variants: [
 		{
 			type: 'normal',

--- a/data/E-Card/Skyridge/137.ts
+++ b/data/E-Card/Skyridge/137.ts
@@ -18,16 +18,6 @@ const card: Card = {
 		de: "Einmal während des Zuges jedes Spielers (vor dem Angriff) kann dieser Spieler, falls er eine Entwicklungskarte auf seiner Hand hat, sein Deck nach einer Basis-Energykarte durchsuchen, sie seinem Gegner zeigen und sie auf die Hand nehmen. Dann wählt dieser Spieler eine Entwicklungskarte von seiner Hand, zeigt sie seinem Gegner und legt sie in sein Deck. Der Spieler mischt sein Deck."
 	},
 
-	attacks: [
-		{
-			// name intentionally left blank
-			name: {},
-			effect: {
-				en: "Once during each player's turn (before he or she attacks), if that player has an Evolution card in his or her hand, he or she may search his or her deck for a basic Energy card, show it to his or her opponent, and put it into his or her hand. Then that player chooses an Evolution card from his or her hand, shows it to his or her opponent, and puts it into his or her deck. That player shuffles his or her deck afterward."
-			}
-		}
-	],
-
 	variants: [
 		{
 			type: 'normal',

--- a/data/E-Card/Skyridge/138.ts
+++ b/data/E-Card/Skyridge/138.ts
@@ -18,16 +18,6 @@ const card: Card = {
 		de: "Wähle 2 Karten aus deinem Deck und mische den Rest deines Decks. Lege die gewählten Karten in beliebiger Reihenfolge oben auf dein Deck."
 	},
 
-	attacks: [
-		{
-			// name intentionally left blank
-			name: {},
-			effect: {
-				en: "Choose 2 cards from your deck and shuffle the rest of your deck. Put the chosen cards on top of your deck in any order."
-			}
-		}
-	],
-
 	variants: [
 		{
 			type: 'normal',

--- a/data/E-Card/Skyridge/139.ts
+++ b/data/E-Card/Skyridge/139.ts
@@ -18,16 +18,6 @@ const card: Card = {
 		de: "Ist zu irgendeinem Zeitpunkt zwischen Zügen das Pokémon an das diese Karte angelegt ist, auf der Bank und hat 2 oder mehr Schadensmarken, durchsuche dein Deck nach einer Entwicklungskarte, in die sich dieses Pokémon entwickelt, und lege sie auf das Pokémon. (Dies zählt als Entwickeln dieses Pokémon.) Mische dein Deck danach. Lege dann das Sternenstück auf deinen Ablagestapel."
 	},
 
-	attacks: [
-		{
-			// name intentionally left blank
-			name: {},
-			effect: {
-				en: "At any time between turns, if the Pokémon this card is attached to is Benched and has 2 or more damage counters on it, search your deck for an Evolution card that Pokémon evolves into and put it on top of that Pokémon. (This counts as evolving that Pokémon.) Shuffle your deck afterward. Then, discard Star Piece."
-			}
-		}
-	],
-
 	variants: [
 		{
 			type: 'normal',

--- a/data/E-Card/Skyridge/140.ts
+++ b/data/E-Card/Skyridge/140.ts
@@ -18,16 +18,6 @@ const card: Card = {
 		de: "Schaue dir die 4 untersten Karten deines Decks an. Nimm 2 dieser Karten auf deine Hand und lege die übrigen Karten in beliebiger Reihenfolge unter dein Deck zurück."
 	},
 
-	attacks: [
-		{
-			// name intentionally left blank
-			name: {},
-			effect: {
-				en: "Look at the bottom 4 cards of your deck. Put 2 of those cards into your hand, and then return the remaining cards to the bottom of your deck in any order."
-			}
-		}
-	],
-
 	variants: [
 		{
 			type: 'normal',

--- a/data/E-Card/Skyridge/141.ts
+++ b/data/E-Card/Skyridge/141.ts
@@ -18,16 +18,6 @@ const card: Card = {
 		de: "Einmal während jedes Zugs eines Spielers kann dieser Spieler eine Amonitas- oder Kabuto-Karte aus seinem Ablagestapel auf seine Bank legen. (Karten, die auf diese Weise auf die Bank gelegt werden, gelten als Basis-Pokémon.)"
 	},
 
-	attacks: [
-		{
-			// name intentionally left blank
-			name: {},
-			effect: {
-				en: "Once during each player's turn, that player may put an Omanyte or a Kabuto card from his or her discard pile onto his or her Bench. (Cards put on the Bench this way are considered Basic Pokémon.)"
-			}
-		}
-	],
-
 	variants: [
 		{
 			type: 'normal',


### PR DESCRIPTION
### What

Six Trainer cards in Skyridge carry an `attacks` entry that should not exist:

- `132` Mirage Stadium (Stadium)
- `137` Mystery Zone (Stadium)
- `138` Oracle (Supporter)
- `139` Star Piece (Tool)
- `140` Underground Expedition (Supporter)
- `141` Underground Lake (Stadium)

On each of them the attack has an empty name (`name: {}`, marked `// name intentionally left blank`) and an English effect that is a verbatim copy of (part of) the card's own Trainer `effect`.

### Where it came from

The blocks arrived with the bulk variants import in #1810. A scan over the whole repository (attack effect text contained verbatim in the Trainer effect) finds exactly these six files, so Skyridge is the full extent of it.
