### PR TITLE
Add missing German translations for tk-sm-l

### DIFF
--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/1.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/1.ts
@@ -27,10 +27,12 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
-				en: "Nap"
+				en: "Nap",
+				de: "Nickerchen"
 			},
 			effect: {
-				en: "Heal 20 damage from this Pokémon."
+				en: "Heal 20 damage from this Pokémon.",
+				de: "Heile 20 Schadenspunkte bei diesem Pokémon."
 			}
 		},
 		{
@@ -39,7 +41,8 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
-				en: "Gnaw"
+				en: "Gnaw",
+				de: "Nagen"
 			},
 			damage: 20
 		},

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/11.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/11.ts
@@ -27,10 +27,12 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
-				en: "Growl"
+				en: "Growl",
+				de: "Heuler"
 			},
 			effect: {
-				en: "During your opponent's next turn, the Defending Pokémon's attacks do 20 less damage (before applying Weakness and Resistance)."
+				en: "During your opponent's next turn, the Defending Pokémon's attacks do 20 less damage (before applying Weakness and Resistance).",
+				de: "Während des nächsten Zuges deines Gegners fügen die Attacken des Verteidigenden Pokémon 20 Schadenspunkte weniger zu (bevor Schwäche und Resistenz verrechnet werden)."
 			}
 		},
 		{
@@ -39,7 +41,8 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
-				en: "Flap"
+				en: "Flap",
+				de: "Flattern"
 			},
 			damage: 20
 		},

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/12.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/12.ts
@@ -27,7 +27,8 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
-				en: "Tackle"
+				en: "Tackle",
+				de: "Tackle"
 			},
 			damage: 10
 		},
@@ -37,7 +38,8 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
-				en: "Bite"
+				en: "Bite",
+				de: "Biss"
 			},
 			damage: 20
 		},

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/13.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/13.ts
@@ -37,7 +37,8 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
-				en: "Flap"
+				en: "Flap",
+				de: "Flattern"
 			},
 			damage: 20
 		},
@@ -47,10 +48,12 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
-				en: "Razor Wind"
+				en: "Razor Wind",
+				de: "Klingensturm"
 			},
 			effect: {
-				en: "Flip a coin. If tails, this attack does nothing."
+				en: "Flip a coin. If tails, this attack does nothing.",
+				de: "Wirf 1 Münze. Bei Zahl hat diese Attacke keine Auswirkungen."
 			},
 			damage: 40
 		},

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/14.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/14.ts
@@ -27,7 +27,8 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
-				en: "Tackle"
+				en: "Tackle",
+				de: "Tackle"
 			},
 			damage: 10
 		},
@@ -37,7 +38,8 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
-				en: "Rock Throw"
+				en: "Rock Throw",
+				de: "Steinwurf"
 			},
 			damage: 20
 		},

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/15.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/15.ts
@@ -27,10 +27,12 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
-				en: "Rock Smash"
+				en: "Rock Smash",
+				de: "Zertrümmerer"
 			},
 			effect: {
-				en: "Flip a coin. If heads, this attack does 10 more damage."
+				en: "Flip a coin. If heads, this attack does 10 more damage.",
+				de: "Wirf 1 Münze. Bei Kopf fügt diese Attacke 10 Schadenspunkte mehr zu."
 			},
 			damage: "10+"
 		},

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/16.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/16.ts
@@ -35,20 +35,23 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	description: {
-		en: "The more intimidating the opponent it faces, the more this Pokémon’s blood boils. It will attack with no regard for its own safety."
+		en: "The more intimidating the opponent it faces, the more this Pokémon’s blood boils. It will attack with no regard for its own safety.",
+		de: "Je gefährlicher sein Gegner, desto mehr kommt es in Fahrt. Im Kampf ist es bereit, alles aufs Spiel zu setzen, um den Sieg zu erringen."
 	},
 
 	attacks: [{
 		name: {
 			en: "Bite",
-			fr: "Morsure"
+			fr: "Morsure",
+			de: "Biss"
 		},
 
 		damage: 20
 	}, {
 		name: {
 			en: "Claw Slash",
-			fr: "Tranch'Griffe"
+			fr: "Tranch'Griffe",
+			de: "Klauenschlitzer"
 		},
 
 		damage: 80

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/18.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/18.ts
@@ -27,10 +27,12 @@ const card: Card = {
 				"Fighting",
 			],
 			name: {
-				en: "Surprise Attack"
+				en: "Surprise Attack",
+				de: "Überraschungsangriff"
 			},
 			effect: {
-				en: "Flip a coin. If tails, this attack does nothing."
+				en: "Flip a coin. If tails, this attack does nothing.",
+				de: "Wirf 1 Münze. Bei Zahl hat diese Attacke keine Auswirkungen."
 			},
 			damage: 20
 		},
@@ -40,7 +42,8 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
-				en: "Strength"
+				en: "Strength",
+				de: "Stärke"
 			},
 			damage: 40
 		},

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/19.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/19.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Roba 3 cartas.",
 		it: "Pesca tre carte.",
 		pt: "Compre 3 cartas.",
-		de: "Ziehe 3 Karten."
+		de: "Ziehe 3 Karten. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/22.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/22.ts
@@ -38,10 +38,12 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
-				en: "Echoed Voice"
+				en: "Echoed Voice",
+				de: "Widerhall"
 			},
 			effect: {
-				en: "During your next turn, this Pokémon's Echoed Voice attack does 60 more damage (before applying Weakness and Resistance)."
+				en: "During your next turn, this Pokémon's Echoed Voice attack does 60 more damage (before applying Weakness and Resistance).",
+				de: "Während deines nächsten Zuges fügt die Attacke Widerhall dieses Pokémon 60 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 			damage: 60
 		},
@@ -52,10 +54,12 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
-				en: "Beak Blast"
+				en: "Beak Blast",
+				de: "Schnabelkanone"
 			},
 			effect: {
-				en: "Flip a coin. If heads, your opponent's Active Pokémon is now Burned."
+				en: "Flip a coin. If heads, your opponent's Active Pokémon is now Burned.",
+				de: "Wirf 1 Münze. Bei Kopf ist das Aktive Pokémon deines Gegners jetzt verbrannt."
 			},
 			damage: 100
 		},

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/23.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/23.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Roba 3 cartas.",
 		it: "Pesca tre carte.",
 		pt: "Compre 3 cartas.",
-		de: "Ziehe 3 Karten."
+		de: "Ziehe 3 Karten. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/27.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/27.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Cura 20 puntos de daño y elimina 1 Condición Especial de tu Pokémon Activo.",
 		it: "Cura il tuo Pokémon attivo da 20 danni e rimuovi una condizione speciale che lo influenza.",
 		pt: "Cure 20 pontos de dano e remova 1 Condição Especial do seu Pokémon Ativo.",
-		de: "Heile 20 Schadenspunkte und entferne 1 Speziellen Zustand von deinem Aktiven Pokémon."
+		de: "Heile 20 Schadenspunkte und entferne 1 Speziellen Zustand von deinem Aktiven Pokémon. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/29.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/29.ts
@@ -27,7 +27,8 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
-				en: "Tackle"
+				en: "Tackle",
+				de: "Tackle"
 			},
 			damage: 10
 		},
@@ -37,7 +38,8 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
-				en: "Rock Throw"
+				en: "Rock Throw",
+				de: "Steinwurf"
 			},
 			damage: 20
 		},

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/30.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/30.ts
@@ -35,20 +35,23 @@ const card: Card = {
 	illustrator: "5ban Graphics",
 
 	description: {
-		en: "The more intimidating the opponent it faces, the more this Pokémon’s blood boils. It will attack with no regard for its own safety."
+		en: "The more intimidating the opponent it faces, the more this Pokémon’s blood boils. It will attack with no regard for its own safety.",
+		de: "Je gefährlicher sein Gegner, desto mehr kommt es in Fahrt. Im Kampf ist es bereit, alles aufs Spiel zu setzen, um den Sieg zu erringen."
 	},
 
 	attacks: [{
 		name: {
 			en: "Bite",
-			fr: "Morsure"
+			fr: "Morsure",
+			de: "Biss"
 		},
 
 		damage: 20
 	}, {
 		name: {
 			en: "Claw Slash",
-			fr: "Tranch'Griffe"
+			fr: "Tranch'Griffe",
+			de: "Klauenschlitzer"
 		},
 
 		damage: 80

--- a/data/Trainer kits/SM trainer Kit (Lycanroc)/4.ts
+++ b/data/Trainer kits/SM trainer Kit (Lycanroc)/4.ts
@@ -37,10 +37,12 @@ const card: Card = {
 				"Colorless",
 			],
 			name: {
-				en: "Bullet Seed"
+				en: "Bullet Seed",
+				de: "Kugelsaat"
 			},
 			effect: {
-				en: "Flip 4 coins. This attack does 20 damage for each heads."
+				en: "Flip 4 coins. This attack does 20 damage for each heads.",
+				de: "Wirf 4 Münzen. Diese Attacke fügt 20 Schadenspunkte pro Kopf zu."
 			},
 			damage: "20×"
 		},


### PR DESCRIPTION
## Add missing German translations for tk-sm-l

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
