### PR TITLE
Add missing German translations for sm2

### DIFF
--- a/data/Sun & Moon/Guardians Rising/1.ts
+++ b/data/Sun & Moon/Guardians Rising/1.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "Even though its body is extremely skinny, it is blindingly fast when catching its prey.",
+		de: "Obwohl sein Körper sehr schmal ist, schnappt es blitzschnell nach Beute."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/10.ts
+++ b/data/Sun & Moon/Guardians Rising/10.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Una vez durante tu turno, después de lanzar cualquier moneda para un ataque, puedes ignorar todos los efectos de esos lanzamientos de monedas y empezar a lanzar esas monedas de nuevo. No puedes usar más de 1 Habilidad Tinovictoria en cada turno.",
 				it: "Una sola volta durante il tuo turno, dopo aver lanciato la moneta tutte le volte richieste da un attacco, puoi ignorare tutti gli effetti di quei lanci e lanciare nuovamente la moneta. Puoi usare l’abilità Vittorstella solo una volta per turno.",
 				pt: "Uma vez durante sua vez de jogar, após jogar quaisquer moedas para um ataque, você pode ignorar todos os efeitos das moedas jogadas e começar a jogá-las novamente. Não é possível usar mais de 1 Habilidade Estrela da Vitória por vez de jogar.",
-				de: "Einmal während deines Zuges, nachdem du Münzen für eine Attacke geworfen hast, kannst du alle daraus resultierenden Effekte ignorieren und die Münzen erneut werfen. Du kannst die Fähigkeit Triumphstern nur einmal pro Zug einsetzen."
+				de: "Einmal während deines Zuges, nachdem du mindestens 1 Münze für eine Attacke geworfen hast, kannst du alle Ergebnisse jenes Münzwurfs bzw. jener Münzwürfe ignorieren und jene Münze bzw. jene Münzen erneut werfen. Du kannst die Fähigkeit Triumphstern nur einmal pro Zug einsetzen."
 			},
 		},
 	],
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon brings victory. It is said that Trainers with Victini always win, regardless of the type of encounter.",
+		de: "Ein siegverheißendes Pokémon. Man sagt, Trainer, die ein Victini in ihrem Team haben, seien unschlagbar."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/100.ts
+++ b/data/Sun & Moon/Guardians Rising/100.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Hakamo-o",
 		fr: "Écaïd",
+		de: "Mediras"
 	},
 
 	suffix: "GX",
@@ -96,7 +97,7 @@ const card: Card = {
 				es: "Ultragancho GX",
 				it: "Ultramontante-GX",
 				pt: "Ultradireto GX",
-				de: "Ultrahieb GX"
+				de: "Ultrahieb-GX"
 			},
 			effect: {
 				en: "(You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Guardians Rising/101.ts
+++ b/data/Sun & Moon/Guardians Rising/101.ts
@@ -84,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "The eggs laid by Chansey are rich in nutrients and a favorite food of many Pokémon.",
+		de: "Die Eier, die es legt, sind ausgesprochen nahrhaft. Sie sind die Leibspeise vieler Pokémon."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/102.ts
+++ b/data/Sun & Moon/Guardians Rising/102.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Chansey",
 		fr: "Leveinard",
+		de: "Chaneira"
 	},
 
 	stage: "Stage1",
@@ -95,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "Even the most ferocious Pokémon become calm when they eat Blissey's egg, which is said to be filled with happiness.",
+		de: "Ein Bissen von seinem Glücks-Ei, das voller Fröhlichkeit steckt, lässt selbst das wildeste Pokémon ganz sanft und ruhig werden."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/103.ts
+++ b/data/Sun & Moon/Guardians Rising/103.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "It has a gutsy spirit that makes it bravely take on tough foes. It flies in search of warm climates.",
+		de: "Es ist sehr mutig und stellt sich auch starken Gegnern. Es sucht ständig nach warmen Regionen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/104.ts
+++ b/data/Sun & Moon/Guardians Rising/104.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Taillow",
 		fr: "Nirondelle",
+		de: "Schwalbini"
 	},
 
 	stage: "Stage1",
@@ -100,6 +101,7 @@ const card: Card = {
 
 	description: {
 		en: "If its two tail feathers are standing at attention, it is proof of good health. It soars elegantly in the sky.",
+		de: "Wenn seine beiden Schwanzfedern aufrecht stehen, zeigt das, dass es bei bester Gesundheit ist. Es fliegt elegant in den Himmel empor."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/105.ts
+++ b/data/Sun & Moon/Guardians Rising/105.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It changes its form depending on the weather. Changes in the temperature or humidity appear to affect its cellular structure.",
+		de: "Es ändert seine Erscheinung je nach Wetter. Seine Zellen reagieren anscheinend auf Temperatur- und Feuchtigkeitsschwankungen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/106.ts
+++ b/data/Sun & Moon/Guardians Rising/106.ts
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives in the ozone layer far above the clouds and cannot be seen from the ground.",
+		de: "Es lebt in der Ozonschicht hoch über den Wolken und kann vom Boden aus nicht gesehen werden."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/107.ts
+++ b/data/Sun & Moon/Guardians Rising/107.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Using food stored in cheek pouches, they can keep watch for days. They use their tails to communicate with others.",
+		de: "Hortet in seinen Backentaschen Futter, um tagelang Wache stehen zu können, und gibt Kameraden über seine Rute Signale."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/108.ts
+++ b/data/Sun & Moon/Guardians Rising/108.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Patrat",
 		fr: "Ratentif",
+		de: "Nagelotz"
 	},
 
 	stage: "Stage1",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "Using luminescent matter, it makes its eyes and body glow and stuns attacking opponents.",
+		de: "Es kann mit einer körpereigenen Substanz seine Augen und seinen Torso aufleuchten lassen, um Gegner zu erschrecken."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/109.ts
+++ b/data/Sun & Moon/Guardians Rising/109.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "This amiable Pokémon is easy to train. But when battle is joined, it shows its ferocious side.",
+		de: "Ein sehr zutrauliches und pflegeleichtes Pokémon, das im Kampf jedoch erstaunlich wild und ungestüm agiert."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/11.ts
+++ b/data/Sun & Moon/Guardians Rising/11.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "While shining a light and pretending to be a guide, it leeches off the life force of any who follow it.",
+		de: "Es entzündet ein Licht und gibt vor, dem Gegner den Weg zu weisen, doch eigentlich saugt es ihm seine Lebensenergie ab."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/110.ts
+++ b/data/Sun & Moon/Guardians Rising/110.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Fletchling",
 		fr: "Passerouge",
+		de: "Dartiri"
 	},
 
 	stage: "Stage1",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "From its beak, it fires embers at its prey. Once it has caught them, it grills them at high heat before feasting upon them.",
+		de: "Es speit Funken aus seinem Schnabel und schreckt so die Beute auf. Einmal gefangen, wird sie geröstet und dann verspeist."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/111.ts
+++ b/data/Sun & Moon/Guardians Rising/111.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Fletchinder",
 		fr: "Braisillon",
+		de: "Dartignis"
 	},
 
 	stage: "Stage2",
@@ -52,7 +53,7 @@ const card: Card = {
 				es: "Busca en tu baraja 1 carta de Energía Fire y únela a este Pokémon. Después, baraja las cartas de tu baraja.",
 				it: "Cerca nel tuo mazzo una carta Energia Fire e assegnala a questo Pokémon. Poi rimischia le carte del tuo mazzo.",
 				pt: "Procure por 1 carta de Energia Fire no seu baralho e ligue-a a este Pokémon. Em seguida, embaralhe o seu baralho.",
-				de: "Durchsuche dein Deck nach 1 Fire-Energiekarte und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
+				de: "Durchsuche dein Deck nach 1 {R}-Energiekarte und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
 			},
 			damage: 30,
 
@@ -101,6 +102,7 @@ const card: Card = {
 
 	description: {
 		en: "Its favorite foods are Wingull and Pikipek. It attacks with a powerful kick and grasps them firmly in its talons.",
+		de: "Auf seinem Speiseplan stehen bevorzugt Wingull und Peppeck. Es schaltet seine Beute mit einem kräftigen Tritt aus, um sie sich dann zu krallen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/112.ts
+++ b/data/Sun & Moon/Guardians Rising/112.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "Despite its adorable appearance, when it gets angry and flails about, its arms and legs could knock a pro wrestler sprawling.",
+		de: "Es sieht sehr süß aus, aber wehe, es wird wütend. Mit seinen Armen wirbelnd haut es selbst den stärksten Wrestler um."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/113.ts
+++ b/data/Sun & Moon/Guardians Rising/113.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Stufful",
 		fr: "Nounourson",
+		de: "Velursi"
 	},
 
 	stage: "Stage1",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "This immensely dangerous Pokémon possesses overwhelming physical strength. Its habitat is generally off-limits.",
+		de: "Dieses Pokémon verfügt über immense Muskelkraft und ist äußerst gefährlich. Sein Habitat ist generell Sperrgebiet."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/114.ts
+++ b/data/Sun & Moon/Guardians Rising/114.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It is born asleep, and it dies asleep. All its movements are apparently no more than the results of it tossing and turning in its dreams.",
+		de: "Es wird schlafend geboren und stirbt schlafend. Sein ganzes Leben ist ein Traum, seine einzige körperliche Aktivität das Umdrehen im Schlaf."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/115.ts
+++ b/data/Sun & Moon/Guardians Rising/115.ts
@@ -87,7 +87,7 @@ const card: Card = {
 				es: "Gran Rueda GX",
 				it: "Gran Carosello-GX",
 				pt: "Roda Grande GX",
-				de: "Riesenrad GX"
+				de: "Riesenrad-GX"
 			},
 			effect: {
 				en: "Shuffle your hand into your deck. Then, draw 10 cards. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Guardians Rising/116.ts
+++ b/data/Sun & Moon/Guardians Rising/116.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Los ataques del rival hacen 30 puntos de daño menos a los Pokémon Grass Básicos y los Pokémon Lightning Básicos (tanto tuyos como de tu rival) (después de aplicar Debilidad y Resistencia).",
 		it: "I Pokémon Base Grass e i Pokémon Base Lightning, sia tuoi che del tuo avversario, subiscono 30 danni in meno dagli attacchi dell’avversario dopo aver applicato debolezza e resistenza.",
 		pt: "Os Pokémon Grass Básicos e os Pokémon Lightning Básicos (seus e do seu oponente) recebem 30 pontos de dano a menos de ataques do oponente (após a aplicação de Fraqueza e Resistência).",
-		de: "Grass-Basis-Pokémon und Lightning-Basis-Pokémon (deine und die deines Gegners) werden durch Attacken des Gegners 30 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden)."
+		de: "{G}-Basis-Pokémon und {L}-Basis-Pokémon (deine und die deines Gegners) werden durch Attacken des Gegners 30 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden). Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 
 	trainerType: "Stadium",

--- a/data/Sun & Moon/Guardians Rising/117.ts
+++ b/data/Sun & Moon/Guardians Rising/117.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "El Coste de Retirada de cada Pokémon (tanto tuyos como de tu rival) que tenga alguna Energía Psychic o Darkness unida a él es de ColorlessColorless menos.",
 		it: "Il costo di ritirata dei Pokémon, sia tuoi che del tuo avversario, che hanno delle Energie Psychic o Darkness assegnate è ridotto di ColorlessColorless.",
 		pt: "O custo de Recuo de cada Pokémon (seus e do seu oponente) que tiver alguma Energia Psychic ou Darkness ligada a ele será ColorlessColorless a menos.",
-		de: "Die Rückzugskosten jedes Pokémon (deine und die deines Gegners), an das mindestens 1 Psychic- oder 1 Darkness-Energie angelegt ist, verringern sich um ColorlessColorless."
+		de: "Die Rückzugskosten jedes Pokémon (deine und die deines Gegners), an das mindestens 1 {P}- oder 1 {D}-Energie angelegt ist, verringern sich um {C}{C}. Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 
 	trainerType: "Stadium",

--- a/data/Sun & Moon/Guardians Rising/118.ts
+++ b/data/Sun & Moon/Guardians Rising/118.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Los Pokémon Fire y los Pokémon Metal (tanto tuyos como de tu rival) no tienen Debilidad.",
 		it: "I Pokémon Fire e i Pokémon Metal, sia tuoi che del tuo avversario, non hanno debolezza.",
 		pt: "Os Pokémon Fire e os Pokémon Metal (seus e do seu oponente) não têm Fraqueza.",
-		de: "Fire-Pokémon und Metal-Pokémon (deine und die deines Gegners) haben keine Schwäche."
+		de: "{R}-Pokémon und {M}-Pokémon (deine und die deines Gegners) haben keine Schwäche. Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 
 	trainerType: "Stadium",

--- a/data/Sun & Moon/Guardians Rising/119.ts
+++ b/data/Sun & Moon/Guardians Rising/119.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Une 1 carta de Energía Water de tu pila de descartes a 1 de tus Pokémon Water en Banca.",
 		it: "Assegna a uno dei tuoi Pokémon Water in panchina una carta Energia Water dalla tua pila degli scarti.",
 		pt: "Ligue 1 carta de Energia Water da sua pilha de descarte a 1 dos seus Pokémon Water no Banco.",
-		de: "Lege 1 Water-Energiekarte aus deinem Ablagestapel an 1 Water-Pokémon auf deiner Bank an."
+		de: "Lege 1 {W}-Energiekarte aus deinem Ablagestapel an 1 {W}-Pokémon auf deiner Bank an. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Guardians Rising/12.ts
+++ b/data/Sun & Moon/Guardians Rising/12.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Litwick",
 		fr: "Funécire",
+		de: "Lichtel"
 	},
 
 	stage: "Stage1",
@@ -63,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "The spirits it absorbs fuel its baleful fire. It hangs around hospitals waiting for people to pass on.",
+		de: "Es nährt seine Flamme mit den Seelen seiner Opfer. Heutzutage irrt es auf der Suche nach Seelen durch Krankenhäuser."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/120.ts
+++ b/data/Sun & Moon/Guardians Rising/120.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Una vez durante el turno de cada jugador, ese jugador puede buscar en su baraja 1 Pokémon Water Básico o 1 Pokémon Fighting Básico, ponerlo en su Banca y barajar las cartas de su baraja.",
 		it: "Una sola volta durante il turno di ciascun giocatore, quel giocatore può cercare nel suo mazzo un Pokémon Base Water o un Pokémon Base Fighting, metterlo nella sua panchina e rimischiare le carte del suo mazzo.",
 		pt: "Uma vez durante a vez de jogar de cada jogador, aquele jogador pode procurar por 1 Pokémon Water Básico ou por 1 Pokémon Fighting Básico no próprio baralho, colocá-lo no próprio Banco e embaralhar o próprio baralho.",
-		de: "Einmal während des Zuges jedes Spielers kann der Spieler sein Deck nach 1 Water-Basis-Pokémon oder 1 Fighting-Basis-Pokémon durchsuchen, es auf seine Bank legen und sein Deck mischen."
+		de: "Einmal während des Zuges jedes Spielers kann der Spieler sein Deck nach 1 {W}-Basis-Pokémon oder 1 {F}-Basis-Pokémon durchsuchen, es auf seine Bank legen und sein Deck mischen. Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 
 	trainerType: "Stadium",

--- a/data/Sun & Moon/Guardians Rising/121.ts
+++ b/data/Sun & Moon/Guardians Rising/121.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Los ataques del Pokémon al que esté unida esta carta hacen 30 puntos de daño más al Pokémon-GX Activo o Pokémon-EX Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
 		it: "Gli attacchi del Pokémon a cui è assegnata questa carta infliggono 30 danni in più al Pokémon GX attivo o al PokémonEX attivo del tuo avversario, prima di aver applicato debolezza e resistenza.",
 		pt: "Os ataques do Pokémon ao qual esta carta está ligada causam 30 pontos de dano a mais ao Pokémon-GX Ativo ou ao Pokémon-EX Ativo do seu oponente (antes de aplicar Fraqueza e Resistência).",
-		de: "Die Attacken des Pokémon, an das diese Karte angelegt ist, fügen dem Aktiven Pokémon-GX oder Aktiven Pokémon-EX deines Gegners 30 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Die Attacken des Pokémon, an das diese Karte angelegt ist, fügen dem Aktiven Pokémon-GX oder Aktiven Pokémon-EX deines Gegners 30 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden). Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sun & Moon/Guardians Rising/122.ts
+++ b/data/Sun & Moon/Guardians Rising/122.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mira las 7 primeras cartas de tu baraja. Puedes enseñar 1 carta de Energía que encuentres entre ellas y ponerla en tu mano. Pon el resto de cartas de nuevo en tu baraja y barájalas todas.",
 		it: "Guarda le prime sette carte del tuo mazzo. Puoi mostrare una carta Energia che hai trovato e aggiungerla alle carte che hai in mano. Poi rimischia le altre carte nel tuo mazzo.",
 		pt: "Olhe as 7 primeiras cartas do seu baralho. Você poderá revelar 1 carta de Energia que encontrar lá e colocá-la na sua mão. Embaralhe as demais cartas de volta no seu baralho.",
-		de: "Schau dir die obersten 7 Karten deines Decks an. Du kannst 1 Energiekarte, die du dort findest, deinem Gegner zeigen und auf deine Hand nehmen. Mische die anderen Karten zurück in dein Deck."
+		de: "Schau dir die obersten 7 Karten deines Decks an. Du kannst 1 Energiekarte, die du dort findest, deinem Gegner zeigen und auf deine Hand nehmen. Mische die anderen Karten zurück in dein Deck. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Guardians Rising/123.ts
+++ b/data/Sun & Moon/Guardians Rising/123.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon 5 cartas de Energía Básica de tu pila de descartes en tu baraja y barájalas todas.",
 		it: "Rimischia cinque carte Energia base dalla tua pila degli scarti nel tuo mazzo.",
 		pt: "Embaralhe 5 cartas de Energia básica da sua pilha de descarte no seu baralho.",
-		de: "Mische 5 Basis-Energiekarten aus deinem Ablagestapel in dein Deck."
+		de: "Mische 5 Basis-Energiekarten aus deinem Ablagestapel in dein Deck. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Guardians Rising/124.ts
+++ b/data/Sun & Moon/Guardians Rising/124.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta 1 Energía Especial de 1 de los Pokémon de tu rival.",
 		it: "Scarta un’Energia speciale assegnata a uno dei Pokémon del tuo avversario.",
 		pt: "Descarte 1 Energia Especial de 1 dos Pokémon do seu oponente.",
-		de: "Lege 1 Spezial-Energie von 1 Pokémon deines Gegners auf seinen Ablagestapel."
+		de: "Lege 1 Spezial-Energie von 1 Pokémon deines Gegners auf seinen Ablagestapel. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Guardians Rising/125.ts
+++ b/data/Sun & Moon/Guardians Rising/125.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Elige, en cualquier combinación, hasta 2 cartas de Herramienta Pokémon y cartas de Estadio en juego (tuyas o de tu rival) y descártalas.",
 		it: "Scegli fino a due carte Oggetto Pokémon o Stadio in gioco, in qualsiasi combinazione, tue o del tuo avversario, e scartale.",
 		pt: "Escolha até 2 cartas de Ferramenta Pokémon e de Estádio em jogo em qualquer combinação (suas e do seu oponente) e descarte-as.",
-		de: "Wähle eine beliebige Kombination aus bis zu 2 Pokémon-Ausrüstungen und Stadionkarten im Spiel (deine oder die deines Gegners) und lege sie auf den Ablagestapel."
+		de: "Wähle eine beliebige Kombination aus bis zu 2 Pokémon-Ausrüstungen und Stadionkarten im Spiel (deine oder die deines Gegners) und lege sie auf den Ablagestapel. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Guardians Rising/126.ts
+++ b/data/Sun & Moon/Guardians Rising/126.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon las cartas de tu mano en tu baraja y barájalas todas. Si has usado tu ataque GX, roba 7 cartas. Si no, roba 4 cartas.",
 		it: "Rimischia le carte che hai in mano nel tuo mazzo. Se hai usato un attacco GX, pesca sette carte. Altrimenti, pesca quattro carte.",
 		pt: "Embaralhe a sua mão no seu baralho. Se você usou o seu ataque GX, compre 7 cartas. Caso contrário, compre 4 cartas.",
-		de: "Mische deine Handkarten in dein Deck. Wenn du deine GX-Attacke eingesetzt hast, ziehe 7 Karten. Wenn nicht, ziehe 4 Karten."
+		de: "Mische deine Handkarten in dein Deck. Wenn du deine GX-Attacke eingesetzt hast, ziehe 7 Karten. Wenn nicht, ziehe 4 Karten. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Guardians Rising/127.ts
+++ b/data/Sun & Moon/Guardians Rising/127.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja 2 cartas, baraja las cartas de tu baraja y, después, pon esas cartas en la parte superior de tu baraja en el orden que quieras.",
 		it: "Cerca due carte nel tuo mazzo, rimischia le carte del tuo mazzo, poi rimetti quelle due carte in cima al tuo mazzo nell’ordine che preferisci.",
 		pt: "Procure por 2 cartas no seu baralho, embaralhe-o e então coloque-as no topo em qualquer ordem.",
-		de: "Durchsuche dein Deck nach 2 Karten, mische dein Deck und lege jene Karten anschließend in beliebiger Reihenfolge auf dein Deck."
+		de: "Durchsuche dein Deck nach 2 Karten, mische dein Deck und lege jene Karten anschließend in beliebiger Reihenfolge auf dein Deck. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Guardians Rising/128.ts
+++ b/data/Sun & Moon/Guardians Rising/128.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cura todos los puntos de daño a 1 de tus Pokémon. Si lo haces, descarta todas las Energías unidas a ese Pokémon.",
 		it: "Cura uno dei tuoi Pokémon da tutti i danni. Se lo fai, scarta tutte le Energie assegnate a quel Pokémon.",
 		pt: "Cure todo o dano de 1 dos seus Pokémon. Se fizer isto, descarte todas as Energias ligadas àquele Pokémon.",
-		de: "Heile allen Schaden bei 1 deiner Pokémon. Wenn du das machst, lege alle Energien von jenem Pokémon auf deinen Ablagestapel."
+		de: "Heile allen Schaden bei 1 deiner Pokémon. Wenn du das machst, lege alle Energien von jenem Pokémon auf deinen Ablagestapel. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Guardians Rising/129.ts
+++ b/data/Sun & Moon/Guardians Rising/129.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mueve 1 Energía de 1 de tus Pokémon en Banca a tu Pokémon Activo.",
 		it: "Sposta un’Energia da uno dei tuoi Pokémon in panchina al tuo Pokémon attivo.",
 		pt: "Mova 1 Energia de 1 dos seus Pokémon no Banco para o seu Pokémon Ativo.",
-		de: "Verschiebe 1 Energie von 1 Pokémon auf deiner Bank auf dein Aktives Pokémon."
+		de: "Verschiebe 1 Energie von 1 Pokémon auf deiner Bank auf dein Aktives Pokémon. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Guardians Rising/13.ts
+++ b/data/Sun & Moon/Guardians Rising/13.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Lampent",
 		fr: "Mélancolux",
+		de: "Laternecto"
 	},
 
 	stage: "Stage2",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Once during your turn (before your attack), you may move 1 damage counter from 1 Pokémon to another Pokémon.",
 				it: "d",
 				pt: "Once during your turn (before your attack), you may move 1 damage counter from 1 Pokémon to another Pokémon.",
-				de: "Once during your turn (before your attack), you may move 1 damage counter from 1 Pokémon to another Pokémon."
+				de: "Einmal während deines Zuges (bevor du angreifst) kannst du 1 Schadensmarke von 1 Pokémon auf 1 anderes Pokémon verschieben."
 			},
 		},
 	],
@@ -92,6 +93,7 @@ const card: Card = {
 
 	description: {
 		en: "Being consumed in Chandelure's flame burns up the spirit, leaving the body behind.",
+		de: "Es saugt die Seele eines jeden auf, der in seinen Feuerkranz gerät, bis nur noch eine leere Hülle von ihm übrig ist."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/130.ts
+++ b/data/Sun & Moon/Guardians Rising/130.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Elige 1 opción:\n\n• Pon 1 Pokémon de tu pila de descartes en tu mano.\n• Pon 3 Pokémon de tu pila de descartes en tu baraja y baraja todas las cartas.",
 		it: "Scegli:\n\n• Prendi un Pokémon dalla tua pila degli scarti e aggiungilo alle carte che hai in mano.\n• Rimischia tre Pokémon dalla tua pila degli scarti nel tuo mazzo.",
 		pt: "Escolha 1:\n\n• Coloque 1 Pokémon da sua pilha de descarte na sua mão.\n• Embaralhe 3 Pokémon da sua pilha de descarte no seu baralho.",
-		de: "Wähle 1 aus:\n\n• Nimm 1 Pokémon aus deinem Ablagestapel auf deine Hand.\n• Mische 3 Pokémon aus deinem Ablagestapel in dein Deck."
+		de: "Wähle 1 aus: Nimm 1 Pokémon aus deinem Ablagestapel auf deine Hand. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen. Mische 3 Pokémon aus deinem Ablagestapel in dein Deck."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Guardians Rising/131.ts
+++ b/data/Sun & Moon/Guardians Rising/131.ts
@@ -73,7 +73,7 @@ const card: Card = {
 				es: "Descarta 2 Energías Fire de este Pokémon.",
 				it: "Scarta due Energie Fire assegnate a questo Pokémon.",
 				pt: "Descarte 2 Energias Fire deste Pokémon.",
-				de: "Lege 2 Fire-Energien von diesem Pokémon auf deinen Ablagestapel."
+				de: "Lege 2 {R}-Energien von diesem Pokémon auf deinen Ablagestapel."
 			},
 			damage: 160,
 
@@ -88,7 +88,7 @@ const card: Card = {
 				es: "Nitrotanque GX",
 				it: "Serbatoio Nitrico-GX",
 				pt: "Tanque de Nitro GX",
-				de: "Nitrotank GX"
+				de: "Nitrotank-GX"
 			},
 			effect: {
 				en: "Attach 5 Fire Energy cards from your discard pile to your Pokémon in any way you like. (You can’t use more than 1 GX attack in a game.)",
@@ -96,7 +96,7 @@ const card: Card = {
 				es: "Une 5 cartas de Energía Fire de tu pila de descartes a tus Pokémon de la manera que desees. (No puedes usar más de 1 ataque GX en una partida).",
 				it: "Assegna a piacimento ai tuoi Pokémon cinque carte Energia Fire dalla tua pila degli scarti. Non puoi usare più di un attacco GX a partita.",
 				pt: "Ligue 5 cartas de Energia Fire da sua pilha de descarte aos seus Pokémon como desejar (você não pode usar mais de 1 ataque GX por partida).",
-				de: "Lege 5 Fire-Energiekarten aus deinem Ablagestapel beliebig an deine Pokémon an. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
+				de: "Lege 5 {R}-Energiekarten aus deinem Ablagestapel beliebig an deine Pokémon an. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Guardians Rising/132.ts
+++ b/data/Sun & Moon/Guardians Rising/132.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Alolan Vulpix",
 		fr: "Goupix d’Alola",
+		de: "Alola-Vulpix"
 	},
 
 	suffix: "GX",

--- a/data/Sun & Moon/Guardians Rising/134.ts
+++ b/data/Sun & Moon/Guardians Rising/134.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Charjabug",
 		fr: "Chrysapile",
+		de: "Akkup"
 	},
 
 	suffix: "GX",
@@ -96,7 +97,7 @@ const card: Card = {
 				es: "Gigatrón GX",
 				it: "Gigatrone-GX",
 				pt: "Gigatron GX",
-				de: "Gigatron GX"
+				de: "Gigatron-GX"
 			},
 			effect: {
 				en: "This attack does 60 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Guardians Rising/135.ts
+++ b/data/Sun & Moon/Guardians Rising/135.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Cuando juegues este Pokémon de tu mano a tu Banca durante tu turno, puedes mover cualquier cantidad de Energía Lightning de tus otros Pokémon a este Pokémon. Si lo haces, cambia este Pokémon por tu Pokémon Activo.",
 				it: "Quando giochi questo Pokémon dalla tua mano e lo metti in panchina durante il tuo turno, puoi spostare un numero qualsiasi di Energie Lightning assegnate ai tuoi altri Pokémon su questo Pokémon. Se lo fai, scambialo con il tuo Pokémon attivo.",
 				pt: "Quando você joga este Pokémon da sua mão para o seu banco durante a sua vez de jogar, você pode mover qualquer número de Energia Lightning de outros Pokémon seus para este Pokémon. Se fizer isto, troque este Pokémon pelo seu Pokémon Ativo.",
-				de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand auf deine Bank spielst, kannst du beliebig viele Lightning-Energien von deinen anderen Pokémon auf dieses Pokémon verschieben. Wenn du das machst, tausche dieses Pokémon gegen dein Aktives Pokémon aus."
+				de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand auf deine Bank spielst, kannst du beliebig viele {L}-Energien von deinen anderen Pokémon auf dieses Pokémon verschieben. Wenn du das machst, tausche dieses Pokémon gegen dein Aktives Pokémon aus."
 			},
 		},
 	],

--- a/data/Sun & Moon/Guardians Rising/136.ts
+++ b/data/Sun & Moon/Guardians Rising/136.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Mareanie",
 		fr: "Vorastérie",
+		de: "Garstella"
 	},
 
 	suffix: "GX",
@@ -93,7 +94,7 @@ const card: Card = {
 				es: "Protección Total GX",
 				it: "Rifugio Totale-GX",
 				pt: "Proteção Total GX",
-				de: "Vollschutz GX"
+				de: "Vollschutz-GX"
 			},
 			effect: {
 				en: "Prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Guardians Rising/137.ts
+++ b/data/Sun & Moon/Guardians Rising/137.ts
@@ -85,7 +85,7 @@ const card: Card = {
 				es: "Cura Tapu GX",
 				it: "Tapucura-GX",
 				pt: "Cura Tapu GX",
-				de: "Kapu-Heilung GX"
+				de: "Kapu-Heilung-GX"
 			},
 			effect: {
 				en: "Heal all damage from 2 of your Benched Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Guardians Rising/138.ts
+++ b/data/Sun & Moon/Guardians Rising/138.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Rockruff",
 		fr: "Rocabot",
+		de: "Wuffels"
 	},
 
 	suffix: "GX",
@@ -85,7 +86,7 @@ const card: Card = {
 				es: "Pícaro Peligroso GX",
 				it: "Pericolo Ferale-GX",
 				pt: "Trapaceiro Perigoso GX",
-				de: "Gaunergefahr GX"
+				de: "Gaunergefahr-GX"
 			},
 			effect: {
 				en: "This attack does 50 damage for each of your opponent’s Benched Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Guardians Rising/139.ts
+++ b/data/Sun & Moon/Guardians Rising/139.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Metang",
 		fr: "Métang",
+		de: "Metang"
 	},
 
 	suffix: "GX",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Una vez durante tu turno (antes de tu ataque), puedes unir 1 carta de Energía Psychic o Metal de tu pila de descartes a tu Pokémon Activo.",
 				it: "Una sola volta durante il tuo turno, prima di attaccare, puoi assegnare al tuo Pokémon attivo una carta Energia Psychic o Metal dalla tua pila degli scarti.",
 				pt: "Uma vez durante a sua vez de jogar (antes de atacar), você pode ligar 1 carta de Energia Psychic ou Metal da sua pilha de descarte ao seu Pokémon Ativo.",
-				de: "Einmal während deines Zuges (bevor du angreifst) kannst du 1 Psychic- oder 1 Metal-Energiekarte aus deinem Ablagestapel an dein Aktives Pokémon anlegen."
+				de: "Einmal während deines Zuges (bevor du angreifst) kannst du 1 {P}- oder 1 {M}-Energiekarte aus deinem Ablagestapel an dein Aktives Pokémon anlegen."
 			},
 		},
 	],

--- a/data/Sun & Moon/Guardians Rising/14.ts
+++ b/data/Sun & Moon/Guardians Rising/14.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Busca en tu baraja hasta 3 Pokémon Fire Básicos y ponlos en tu Banca. Después, baraja las cartas de tu baraja.",
 				it: "Cerca nel tuo mazzo fino a tre Pokémon Base Fire e mettili nella tua panchina. Poi rimischia le carte del tuo mazzo.",
 				pt: "Procure por até 3 Pokémon Fire Básicos no seu baralho e coloque-os no seu Banco. Em seguida, embaralhe o seu baralho.",
-				de: "Durchsuche dein Deck nach bis zu 3 Fire-Basis-Pokémon und lege sie auf deine Bank. Mische anschließend dein Deck."
+				de: "Durchsuche dein Deck nach bis zu 3 {R}-Basis-Pokémon und lege sie auf deine Bank. Mische anschließend dein Deck."
 			},
 
 		},
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It beats its wings together to create fire. As it moves in the steps of its beautiful dance, it bathes opponents in intense flames.",
+		de: "Schlägt es mit den Flügeln, gibt es Zunder! Mit eleganten Ausfallschritten lässt es dann Feuer auf seine Gegner herabregnen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/140.ts
+++ b/data/Sun & Moon/Guardians Rising/140.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	suffix: "GX",
@@ -86,7 +87,7 @@ const card: Card = {
 				es: "Ruego GX",
 				it: "Istanza-GX",
 				pt: "Apelo GX",
-				de: "Anflehen GX"
+				de: "Anflehen-GX"
 			},
 			effect: {
 				en: "Put 2 of your opponent’s Benched Pokémon and all cards attached to them into your opponent’s hand. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Guardians Rising/141.ts
+++ b/data/Sun & Moon/Guardians Rising/141.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Hakamo-o",
 		fr: "Écaïd",
+		de: "Mediras"
 	},
 
 	suffix: "GX",
@@ -96,7 +97,7 @@ const card: Card = {
 				es: "Ultragancho GX",
 				it: "Ultramontante-GX",
 				pt: "Ultradireto GX",
-				de: "Ultrahieb GX"
+				de: "Ultrahieb-GX"
 			},
 			effect: {
 				en: "(You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Guardians Rising/142.ts
+++ b/data/Sun & Moon/Guardians Rising/142.ts
@@ -87,7 +87,7 @@ const card: Card = {
 				es: "Gran Rueda GX",
 				it: "Gran Carosello-GX",
 				pt: "Roda Grande GX",
-				de: "Riesenrad GX"
+				de: "Riesenrad-GX"
 			},
 			effect: {
 				en: "Shuffle your hand into your deck. Then, draw 10 cards. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Guardians Rising/143.ts
+++ b/data/Sun & Moon/Guardians Rising/143.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon las cartas de tu mano en tu baraja y barájalas todas. Si has usado tu ataque GX, roba 7 cartas. Si no, roba 4 cartas.",
 		it: "Rimischia le carte che hai in mano nel tuo mazzo. Se hai usato un attacco GX, pesca sette carte. Altrimenti, pesca quattro carte.",
 		pt: "Embaralhe a sua mão no seu baralho. Se você usou o seu ataque GX, compre 7 cartas. Caso contrário, compre 4 cartas.",
-		de: "Mische deine Handkarten in dein Deck. Wenn du deine GX-Attacke eingesetzt hast, ziehe 7 Karten. Wenn nicht, ziehe 4 Karten."
+		de: "Mische deine Handkarten in dein Deck. Wenn du deine GX-Attacke eingesetzt hast, ziehe 7 Karten. Wenn nicht, ziehe 4 Karten. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Guardians Rising/144.ts
+++ b/data/Sun & Moon/Guardians Rising/144.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba 3 cartas.",
 		it: "Pesca tre carte.",
 		pt: "Compre 3 cartas.",
-		de: "Ziehe 3 Karten."
+		de: "Ziehe 3 Karten. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Guardians Rising/145.ts
+++ b/data/Sun & Moon/Guardians Rising/145.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja 2 cartas, baraja las cartas de tu baraja y, después, pon esas cartas en la parte superior de tu baraja en el orden que quieras.",
 		it: "Cerca due carte nel tuo mazzo, rimischia le carte del tuo mazzo, poi rimetti quelle due carte in cima al tuo mazzo nell’ordine che preferisci.",
 		pt: "Procure por 2 cartas no seu baralho, embaralhe-o e então coloque-as no topo em qualquer ordem.",
-		de: "Durchsuche dein Deck nach 2 Karten, mische dein Deck und lege jene Karten anschließend in beliebiger Reihenfolge auf dein Deck."
+		de: "Durchsuche dein Deck nach 2 Karten, mische dein Deck und lege jene Karten anschließend in beliebiger Reihenfolge auf dein Deck. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Guardians Rising/146.ts
+++ b/data/Sun & Moon/Guardians Rising/146.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Dartrix",
 		fr: "Efflèche",
+		de: "Arboretoss"
 	},
 
 	suffix: "GX",

--- a/data/Sun & Moon/Guardians Rising/147.ts
+++ b/data/Sun & Moon/Guardians Rising/147.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Torracat",
 		fr: "Matoufeu",
+		de: "Miezunder"
 	},
 
 	suffix: "GX",
@@ -52,7 +53,7 @@ const card: Card = {
 				es: "Este ataque hace 20 puntos de daño más por cada uno de tus Pokémon Fire en Banca.",
 				it: "Questo attacco infligge 20 danni in più per ogni Pokémon Fire nella tua panchina.",
 				pt: "Este ataque causa 20 pontos de dano a mais para cada Pokémon Fire no seu Banco.",
-				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der Fire-Pokémon auf deiner Bank zu."
+				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der {R}-Pokémon auf deiner Bank zu."
 			},
 			damage: "10+",
 

--- a/data/Sun & Moon/Guardians Rising/148.ts
+++ b/data/Sun & Moon/Guardians Rising/148.ts
@@ -73,7 +73,7 @@ const card: Card = {
 				es: "Descarta 2 Energías Fire de este Pokémon.",
 				it: "Scarta due Energie Fire assegnate a questo Pokémon.",
 				pt: "Descarte 2 Energias Fire deste Pokémon.",
-				de: "Lege 2 Fire-Energien von diesem Pokémon auf deinen Ablagestapel."
+				de: "Lege 2 {R}-Energien von diesem Pokémon auf deinen Ablagestapel."
 			},
 			damage: 160,
 
@@ -88,7 +88,7 @@ const card: Card = {
 				es: "Nitrotanque GX",
 				it: "Serbatoio Nitrico-GX",
 				pt: "Tanque de Nitro GX",
-				de: "Nitrotank GX"
+				de: "Nitrotank-GX"
 			},
 			effect: {
 				en: "Attach 5 Fire Energy cards from your discard pile to your Pokémon in any way you like. (You can’t use more than 1 GX attack in a game.)",
@@ -96,7 +96,7 @@ const card: Card = {
 				es: "Une 5 cartas de Energía Fire de tu pila de descartes a tus Pokémon de la manera que desees. (No puedes usar más de 1 ataque GX en una partida).",
 				it: "Assegna a piacimento ai tuoi Pokémon cinque carte Energia Fire dalla tua pila degli scarti. Non puoi usare più di un attacco GX a partita.",
 				pt: "Ligue 5 cartas de Energia Fire da sua pilha de descarte aos seus Pokémon como desejar (você não pode usar mais de 1 ataque GX por partida).",
-				de: "Lege 5 Fire-Energiekarten aus deinem Ablagestapel beliebig an deine Pokémon an. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
+				de: "Lege 5 {R}-Energiekarten aus deinem Ablagestapel beliebig an deine Pokémon an. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Guardians Rising/149.ts
+++ b/data/Sun & Moon/Guardians Rising/149.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Brionne",
 		fr: "Otarlette",
+		de: "Marikeck"
 	},
 
 	suffix: "GX",
@@ -53,7 +54,7 @@ const card: Card = {
 				es: "Este ataque hace 20 puntos de daño más por cada Energía Water unida a tus Pokémon.",
 				it: "Questo attacco infligge 20 danni in più per ogni Energia Water assegnata ai tuoi Pokémon.",
 				pt: "Este ataque causa 20 pontos de dano a mais vezes a quantidade de Energia Water ligada aos seus Pokémon.",
-				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der an deine Pokémon angelegten Water-Energien zu."
+				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der an deine Pokémon angelegten {W}-Energien zu."
 			},
 			damage: "10+",
 

--- a/data/Sun & Moon/Guardians Rising/15.ts
+++ b/data/Sun & Moon/Guardians Rising/15.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It burns its bodily fluids to create a poisonous gas. When its enemies become disoriented from inhaling the gas, it attacks them.",
+		de: "Durch Verbrennung von Körperflüssigkeit erzeugt es ein Gas, das Feinde schwindelig und so zu leichten Zielen macht."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/150.ts
+++ b/data/Sun & Moon/Guardians Rising/150.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Alolan Vulpix",
 		fr: "Goupix d’Alola",
+		de: "Alola-Vulpix"
 	},
 
 	suffix: "GX",

--- a/data/Sun & Moon/Guardians Rising/152.ts
+++ b/data/Sun & Moon/Guardians Rising/152.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Charjabug",
 		fr: "Chrysapile",
+		de: "Akkup"
 	},
 
 	suffix: "GX",
@@ -96,7 +97,7 @@ const card: Card = {
 				es: "Gigatrón GX",
 				it: "Gigatrone-GX",
 				pt: "Gigatron GX",
-				de: "Gigatron GX"
+				de: "Gigatron-GX"
 			},
 			effect: {
 				en: "This attack does 60 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Guardians Rising/153.ts
+++ b/data/Sun & Moon/Guardians Rising/153.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Cuando juegues este Pokémon de tu mano a tu Banca durante tu turno, puedes mover cualquier cantidad de Energía Lightning de tus otros Pokémon a este Pokémon. Si lo haces, cambia este Pokémon por tu Pokémon Activo.",
 				it: "Quando giochi questo Pokémon dalla tua mano e lo metti in panchina durante il tuo turno, puoi spostare un numero qualsiasi di Energie Lightning assegnate ai tuoi altri Pokémon su questo Pokémon. Se lo fai, scambialo con il tuo Pokémon attivo.",
 				pt: "Quando você joga este Pokémon da sua mão para o seu banco durante a sua vez de jogar, você pode mover qualquer número de Energia Lightning de outros Pokémon seus para este Pokémon. Se fizer isto, troque este Pokémon pelo seu Pokémon Ativo.",
-				de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand auf deine Bank spielst, kannst du beliebig viele Lightning-Energien von deinen anderen Pokémon auf dieses Pokémon verschieben. Wenn du das machst, tausche dieses Pokémon gegen dein Aktives Pokémon aus."
+				de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand auf deine Bank spielst, kannst du beliebig viele {L}-Energien von deinen anderen Pokémon auf dieses Pokémon verschieben. Wenn du das machst, tausche dieses Pokémon gegen dein Aktives Pokémon aus."
 			},
 		},
 	],

--- a/data/Sun & Moon/Guardians Rising/154.ts
+++ b/data/Sun & Moon/Guardians Rising/154.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Mareanie",
 		fr: "Vorastérie",
+		de: "Garstella"
 	},
 
 	suffix: "GX",
@@ -93,7 +94,7 @@ const card: Card = {
 				es: "Protección Total GX",
 				it: "Rifugio Totale-GX",
 				pt: "Proteção Total GX",
-				de: "Vollschutz GX"
+				de: "Vollschutz-GX"
 			},
 			effect: {
 				en: "Prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Guardians Rising/155.ts
+++ b/data/Sun & Moon/Guardians Rising/155.ts
@@ -85,7 +85,7 @@ const card: Card = {
 				es: "Cura Tapu GX",
 				it: "Tapucura-GX",
 				pt: "Cura Tapu GX",
-				de: "Kapu-Heilung GX"
+				de: "Kapu-Heilung-GX"
 			},
 			effect: {
 				en: "Heal all damage from 2 of your Benched Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Guardians Rising/156.ts
+++ b/data/Sun & Moon/Guardians Rising/156.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Rockruff",
 		fr: "Rocabot",
+		de: "Wuffels"
 	},
 
 	suffix: "GX",
@@ -85,7 +86,7 @@ const card: Card = {
 				es: "Pícaro Peligroso GX",
 				it: "Pericolo Ferale-GX",
 				pt: "Trapaceiro Perigoso GX",
-				de: "Gaunergefahr GX"
+				de: "Gaunergefahr-GX"
 			},
 			effect: {
 				en: "This attack does 50 damage for each of your opponent’s Benched Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Guardians Rising/157.ts
+++ b/data/Sun & Moon/Guardians Rising/157.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Metang",
 		fr: "Métang",
+		de: "Metang"
 	},
 
 	suffix: "GX",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Una vez durante tu turno (antes de tu ataque), puedes unir 1 carta de Energía Psychic o Metal de tu pila de descartes a tu Pokémon Activo.",
 				it: "Una sola volta durante il tuo turno, prima di attaccare, puoi assegnare al tuo Pokémon attivo una carta Energia Psychic o Metal dalla tua pila degli scarti.",
 				pt: "Uma vez durante a sua vez de jogar (antes de atacar), você pode ligar 1 carta de Energia Psychic ou Metal da sua pilha de descarte ao seu Pokémon Ativo.",
-				de: "Einmal während deines Zuges (bevor du angreifst) kannst du 1 Psychic- oder 1 Metal-Energiekarte aus deinem Ablagestapel an dein Aktives Pokémon anlegen."
+				de: "Einmal während deines Zuges (bevor du angreifst) kannst du 1 {P}- oder 1 {M}-Energiekarte aus deinem Ablagestapel an dein Aktives Pokémon anlegen."
 			},
 		},
 	],

--- a/data/Sun & Moon/Guardians Rising/158.ts
+++ b/data/Sun & Moon/Guardians Rising/158.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	suffix: "GX",
@@ -86,7 +87,7 @@ const card: Card = {
 				es: "Ruego GX",
 				it: "Istanza-GX",
 				pt: "Apelo GX",
-				de: "Anflehen GX"
+				de: "Anflehen-GX"
 			},
 			effect: {
 				en: "Put 2 of your opponent’s Benched Pokémon and all cards attached to them into your opponent’s hand. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Guardians Rising/159.ts
+++ b/data/Sun & Moon/Guardians Rising/159.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Hakamo-o",
 		fr: "Écaïd",
+		de: "Mediras"
 	},
 
 	suffix: "GX",
@@ -96,7 +97,7 @@ const card: Card = {
 				es: "Ultragancho GX",
 				it: "Ultramontante-GX",
 				pt: "Ultradireto GX",
-				de: "Ultrahieb GX"
+				de: "Ultrahieb-GX"
 			},
 			effect: {
 				en: "(You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Guardians Rising/16.ts
+++ b/data/Sun & Moon/Guardians Rising/16.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Salandit",
 		fr: "Tritox",
+		de: "Molunk"
 	},
 
 	stage: "Stage1",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "For some reason, only females have been found. It creates a reverse harem of male Salandit that it lives with.",
+		de: "Bisher wurden nur Weibchen entdeckt. Sie werden von männlichen Molunk verehrt und leben mit einer Gruppe von ihnen zusammen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/160.ts
+++ b/data/Sun & Moon/Guardians Rising/160.ts
@@ -87,7 +87,7 @@ const card: Card = {
 				es: "Gran Rueda GX",
 				it: "Gran Carosello-GX",
 				pt: "Roda Grande GX",
-				de: "Riesenrad GX"
+				de: "Riesenrad-GX"
 			},
 			effect: {
 				en: "Shuffle your hand into your deck. Then, draw 10 cards. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Guardians Rising/161.ts
+++ b/data/Sun & Moon/Guardians Rising/161.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Une 1 carta de Energía Water de tu pila de descartes a 1 de tus Pokémon Water en Banca.",
 		it: "Assegna a uno dei tuoi Pokémon Water in panchina una carta Energia Water dalla tua pila degli scarti.",
 		pt: "Ligue 1 carta de Energia Water da sua pilha de descarte a 1 dos seus Pokémon Water no Banco.",
-		de: "Lege 1 Water-Energiekarte aus deinem Ablagestapel an 1 Water-Pokémon auf deiner Bank an."
+		de: "Lege 1 {W}-Energiekarte aus deinem Ablagestapel an 1 {W}-Pokémon auf deiner Bank an. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Guardians Rising/162.ts
+++ b/data/Sun & Moon/Guardians Rising/162.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta 1 Energía Especial de 1 de los Pokémon de tu rival.",
 		it: "Scarta un’Energia speciale assegnata a uno dei Pokémon del tuo avversario.",
 		pt: "Descarte 1 Energia Especial de 1 dos Pokémon do seu oponente.",
-		de: "Lege 1 Spezial-Energie von 1 Pokémon deines Gegners auf seinen Ablagestapel."
+		de: "Lege 1 Spezial-Energie von 1 Pokémon deines Gegners auf seinen Ablagestapel. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Guardians Rising/163.ts
+++ b/data/Sun & Moon/Guardians Rising/163.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Elige, en cualquier combinación, hasta 2 cartas de Herramienta Pokémon y cartas de Estadio en juego (tuyas o de tu rival) y descártalas.",
 		it: "Scegli fino a due carte Oggetto Pokémon o Stadio in gioco, in qualsiasi combinazione, tue o del tuo avversario, e scartale.",
 		pt: "Escolha até 2 cartas de Ferramenta Pokémon e de Estádio em jogo em qualquer combinação (suas e do seu oponente) e descarte-as.",
-		de: "Wähle eine beliebige Kombination aus bis zu 2 Pokémon-Ausrüstungen und Stadionkarten im Spiel (deine oder die deines Gegners) und lege sie auf den Ablagestapel."
+		de: "Wähle eine beliebige Kombination aus bis zu 2 Pokémon-Ausrüstungen und Stadionkarten im Spiel (deine oder die deines Gegners) und lege sie auf den Ablagestapel. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Guardians Rising/164.ts
+++ b/data/Sun & Moon/Guardians Rising/164.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cura todos los puntos de daño a 1 de tus Pokémon. Si lo haces, descarta todas las Energías unidas a ese Pokémon.",
 		it: "Cura uno dei tuoi Pokémon da tutti i danni. Se lo fai, scarta tutte le Energie assegnate a quel Pokémon.",
 		pt: "Cure todo o dano de 1 dos seus Pokémon. Se fizer isto, descarte todas as Energias ligadas àquele Pokémon.",
-		de: "Heile allen Schaden bei 1 deiner Pokémon. Wenn du das machst, lege alle Energien von jenem Pokémon auf deinen Ablagestapel."
+		de: "Heile allen Schaden bei 1 deiner Pokémon. Wenn du das machst, lege alle Energien von jenem Pokémon auf deinen Ablagestapel. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Guardians Rising/165.ts
+++ b/data/Sun & Moon/Guardians Rising/165.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Elige 1 de tus Pokémon Básicos en juego. Si tienes en tu mano 1 carta de Fase 2 que evolucione de ese Pokémon, pon esa carta sobre el Pokémon Básico para que evolucione. No puedes usar esta carta durante tu primer turno o sobre un Pokémon Básico que se haya puesto en juego en este turno.",
 		it: "Scegli uno dei tuoi Pokémon Base in gioco. Se hai in mano una carta di Fase 2 che si evolve da quel Pokémon, metticela sopra per farlo evolvere. Non puoi usare questa carta durante il tuo primo turno o su un Pokémon Base che hai messo in gioco nel turno in corso.",
 		pt: "Escolha 1 dos seus Pokémon Básicos em jogo. Se você tiver uma carta de Estágio 2 na sua mão que evolua daquele Pokémon, coloque-a sobre o Pokémon Básico para evoluí-lo. Você não pode usar esta carta durante a sua primeira vez de jogar ou colocá-la sobre um Pokémon Básico que foi colocado em jogo nesta rodada.",
-		de: "Wähle 1 deiner Basis-Pokémon im Spiel. Wenn du eine Phase-2-Karte auf der Hand hast, die sich aus jenem Pokémon entwickelt, lege sie auf das Basis-Pokémon, um es zu entwickeln. Du kannst diese Karte nicht während deines ersten Zuges oder für ein Basis-Pokémon, das in diesem Zug ins Spiel gebracht wurde, verwenden."
+		de: "Wähle 1 deiner Basis-Pokémon im Spiel. Wenn du eine Phase-2-Karte auf der Hand hast, die sich aus jenem Pokémon entwickelt, lege sie auf das Basis-Pokémon, um es zu entwickeln. Du kannst diese Karte nicht während deines ersten Zuges oder für ein Basis-Pokémon, das in diesem Zug ins Spiel gebracht wurde, verwenden. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Guardians Rising/166.ts
+++ b/data/Sun & Moon/Guardians Rising/166.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Esta carta proporciona 2 Energías Colorless.",
 		it: "Un’Energia Incolore doppia fornisce ColorlessColorless.",
 		pt: "A Energia Incolor Dupla fornece Energias ColorlessColorless.",
-		de: "Doppel-Farblos-Energie liefert ColorlessColorless-Energie."
+		de: "Doppel-Farblos-Energie liefert {C}{C}-Energie."
 	},
 
 	energyType: "Special",

--- a/data/Sun & Moon/Guardians Rising/17.ts
+++ b/data/Sun & Moon/Guardians Rising/17.ts
@@ -84,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "The shell on its back is chemically unstable and explodes violently if struck. The hole in its stomach is its weak point.",
+		de: "Sein Rückenpanzer ist explosiv, man sollte ihm also niemals auf den Rücken klopfen. Das Loch in seinem Bauch ist seine Schwachstelle."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/18.ts
+++ b/data/Sun & Moon/Guardians Rising/18.ts
@@ -73,7 +73,7 @@ const card: Card = {
 				es: "Descarta 2 Energías Fire de este Pokémon.",
 				it: "Scarta due Energie Fire assegnate a questo Pokémon.",
 				pt: "Descarte 2 Energias Fire deste Pokémon.",
-				de: "Lege 2 Fire-Energien von diesem Pokémon auf deinen Ablagestapel."
+				de: "Lege 2 {R}-Energien von diesem Pokémon auf deinen Ablagestapel."
 			},
 			damage: 160,
 
@@ -88,7 +88,7 @@ const card: Card = {
 				es: "Nitrotanque GX",
 				it: "Serbatoio Nitrico-GX",
 				pt: "Tanque de Nitro GX",
-				de: "Nitrotank GX"
+				de: "Nitrotank-GX"
 			},
 			effect: {
 				en: "Attach 5 Fire Energy cards from your discard pile to your Pokémon in any way you like. (You can’t use more than 1 GX attack in a game.)",
@@ -96,7 +96,7 @@ const card: Card = {
 				es: "Une 5 cartas de Energía Fire de tu pila de descartes a tus Pokémon de la manera que desees. (No puedes usar más de 1 ataque GX en una partida).",
 				it: "Assegna a piacimento ai tuoi Pokémon cinque carte Energia Fire dalla tua pila degli scarti. Non puoi usare più di un attacco GX a partita.",
 				pt: "Ligue 5 cartas de Energia Fire da sua pilha de descarte aos seus Pokémon como desejar (você não pode usar mais de 1 ataque GX por partida).",
-				de: "Lege 5 Fire-Energiekarten aus deinem Ablagestapel beliebig an deine Pokémon an. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
+				de: "Lege 5 {R}-Energiekarten aus deinem Ablagestapel beliebig an deine Pokémon an. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Guardians Rising/19.ts
+++ b/data/Sun & Moon/Guardians Rising/19.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives on snowy mountains. Its steel shell is very hard—so much so, it can't roll its body up into a ball.",
+		de: "Es lebt auf verschneiten Bergen. Sein Panzer ist zwar robust, aber so hart, dass es seinen Körper nicht vollständig zusammenrollen kann."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/2.ts
+++ b/data/Sun & Moon/Guardians Rising/2.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Bellsprout",
 		fr: "Chétiflor",
+		de: "Knofensa"
 	},
 
 	stage: "Stage1",
@@ -71,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "The leafy parts act as cutters for slashing foes. It spits a fluid that dissolves everything.",
+		de: "Die Blätter werden eingesetzt, um Gegner aufzuschlitzen. Dieses Pokémon spuckt eine Flüssigkeit, die alles auflöst."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/20.ts
+++ b/data/Sun & Moon/Guardians Rising/20.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Alolan Sandshrew",
 		fr: "Sabelette d’Alola",
+		de: "Alola-Sandan"
 	},
 
 	stage: "Stage1",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "Fleeing a volcanic eruption, it settled on a snowy mountain. As it races through the snowfields, it sends up a spray of snow.",
+		de: "Auf der Flucht vor Vulkanausbrüchen hat es sich auf verschneiten Bergen angesiedelt. Rast es durch den Schnee, wirbelt es Flocken auf."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/21.ts
+++ b/data/Sun & Moon/Guardians Rising/21.ts
@@ -79,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "It exhales air colder than -58 degrees Fahrenheit. Elderly people in Alola call this Pokémon by an older name—Keokeo.",
+		de: "Sein eisiger Atem beträgt -50 °C. Einige der älteren Einwohner von Alola nennen es bei seinem früheren Namen „Ke’oke’o“."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/22.ts
+++ b/data/Sun & Moon/Guardians Rising/22.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Alolan Vulpix",
 		fr: "Goupix d’Alola",
+		de: "Alola-Vulpix"
 	},
 
 	suffix: "GX",

--- a/data/Sun & Moon/Guardians Rising/23.ts
+++ b/data/Sun & Moon/Guardians Rising/23.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "They can be found lying dehydrated on beaches, but they are often still alive. When soaked in water, they will revive.",
+		de: "Am Strand kann man oft stark ausgetrocknete Exemplare finden, die aber noch leben. Taucht man sie in Wasser, werden sie wieder topfit."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/24.ts
+++ b/data/Sun & Moon/Guardians Rising/24.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Tentacool",
 		fr: "Tentacool",
+		de: "Tentacha"
 	},
 
 	stage: "Stage1",
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "Normally, it has 80 poisonous tentacles. The longer one has been alive, the fewer tentacles it will have.",
+		de: "Es hat für gewöhnlich 80 giftige Tentakel. Mit dem Alter verliert es diese jedoch nach und nach."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/25.ts
+++ b/data/Sun & Moon/Guardians Rising/25.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Poliwhirl",
 		fr: "Têtarte",
+		de: "Quaputzi"
 	},
 
 	stage: "Stage2",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "They gather on moonlit nights to form a large chorus. Their cries sound angry and not at all pleasant, but they are certainly distinctive.",
+		de: "In klaren Mondnächten versammeln sie sich und singen im Chor. Ihr Gesang ist zwar nicht schön und klingt eher wie Geschrei, aber er hat Stil."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/26.ts
+++ b/data/Sun & Moon/Guardians Rising/26.ts
@@ -87,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "Although it naturally prefers colder locales, Delibird in Alola seem able to withstand the heat to a certain extent.",
+		de: "Sie bevorzugen eigentlich kühle Gegenden, aber die Botogel Alolas können bis zu einem gewissen Grad auch heißes Klima ertragen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/27.ts
+++ b/data/Sun & Moon/Guardians Rising/27.ts
@@ -58,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "Each school has its own territory. Any intruders are mercilessly attacked with fangs bared.",
+		de: "Schwärme von Kanivanha schützen ihr Revier, indem sie sich mit gefletschten Zähnen gnadenlos auf Eindringlinge stürzen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/28.ts
+++ b/data/Sun & Moon/Guardians Rising/28.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Carvanha",
 		fr: "Carvanha",
+		de: "Kanivanha"
 	},
 
 	stage: "Stage1",
@@ -64,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It pursues its prey at speeds of 75 mph and finishes them off with fangs that can crush iron. It is known as the bully of the sea.",
+		de: "Es jagt mit 120 km/h seine Beute und erlegt sie mithilfe seiner Zähne, die selbst Eisen durchdringen. Sein Spitzname ist „Tyrann des Meeres“."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/29.ts
+++ b/data/Sun & Moon/Guardians Rising/29.ts
@@ -78,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "It loves to startle people. It fills itself up with seawater and plays by bouncing around like a ball.",
+		de: "Wailmer liebt es, Menschen zu erschrecken. Es trinkt so viel Meerwasser, dass es sich in einen Ball verwandeln und herumhüpfen kann."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/3.ts
+++ b/data/Sun & Moon/Guardians Rising/3.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Weepinbell",
 		fr: "Boustiflor",
+		de: "Ultrigaria"
 	},
 
 	stage: "Stage2",
@@ -95,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "Said to live in huge colonies deep in jungles, although no one has ever returned from there.",
+		de: "Dieses Pokémon soll in großen Kolonien tief im Dschungel leben, doch niemand kann dies bestätigen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/30.ts
+++ b/data/Sun & Moon/Guardians Rising/30.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Wailmer",
 		fr: "Wailmer",
+		de: "Wailmer"
 	},
 
 	stage: "Stage1",
@@ -80,7 +81,7 @@ const card: Card = {
 				es: "Cura 30 puntos de daño a cada uno de tus Pokémon Water.",
 				it: "Cura ciascuno dei tuoi Pokémon Water da 30 danni.",
 				pt: "Cure 30 pontos de dano de cada um dos seus Pokémon Water.",
-				de: "Heile 30 Schadenspunkte bei jedem deiner Water-Pokémon."
+				de: "Heile 30 Schadenspunkte bei jedem deiner {W}-Pokémon."
 			},
 			damage: 80,
 
@@ -98,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "Wailord pursue their prey in pods. With their large mouths, they can swallow entire schools of Wishiwashi whole.",
+		de: "Wailord jagt seine Beute in der Gruppe. Mit seinem enormen Maul kann es ganze Schwärme von Lusardin auf einmal verschlingen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/31.ts
+++ b/data/Sun & Moon/Guardians Rising/31.ts
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "Their numbers seem to have rapidly increased in Alola. Custom has it that houses where Snorunt live will be prosperous for generations to come.",
+		de: "Schneppke hat sich rasant in Alola verbreitet. Es heißt, das Haus, in dem es lebt, werde über viele Generationen blühen und gedeihen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/32.ts
+++ b/data/Sun & Moon/Guardians Rising/32.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Snorunt",
 		fr: "Stalgamin",
+		de: "Schneppke"
 	},
 
 	stage: "Stage1",
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "Legend says a boulder on an icy mountain absorbed the distress and regrets of a stranded mountaineer, giving rise to Glalie.",
+		de: "Man sagt, Firnontor sei aus dem Unmut verunglückter Bergsteiger geboren, der von einem Felsen Besitz ergriff."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/33.ts
+++ b/data/Sun & Moon/Guardians Rising/33.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "Born of an icicle, this Pokémon uses its frosty breath to make ice crystals, causing snow to fall.",
+		de: "Dieses Pokémon ist aus einem Eiszapfen entstanden. Mit seinem kalten Odem erzeugt es Eiskristalle und lässt es schneien."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/34.ts
+++ b/data/Sun & Moon/Guardians Rising/34.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Vanillite",
 		fr: "Sorbébé",
+		de: "Gelatini"
 	},
 
 	stage: "Stage1",
@@ -52,7 +53,7 @@ const card: Card = {
 				es: "Si el Pokémon Activo de tu rival es un Pokémon Fighting, este ataque hace 30 puntos de daño más.",
 				it: "Se il Pokémon attivo del tuo avversario è di tipo Fighting, questo attacco infligge 30 danni in più.",
 				pt: "Se o Pokémon Ativo do seu oponente for um Pokémon Fighting, este ataque causará 30 pontos de dano a mais.",
-				de: "Wenn das Aktive Pokémon deines Gegners ein Fighting-Pokémon ist, fügt diese Attacke 30 Schadenspunkte mehr zu."
+				de: "Wenn das Aktive Pokémon deines Gegners ein {F}-Pokémon ist, fügt diese Attacke 30 Schadenspunkte mehr zu."
 			},
 			damage: "30+",
 
@@ -70,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "Hot days cause its body to melt. It can be restored by refreezing it, but the process leaves its body slightly warped.",
+		de: "An heißen Tagen schmilzt sein Körper. Friert man es ein, nimmt es seine alte Gestalt wieder an, aber sein Körper ist leicht verbogen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/35.ts
+++ b/data/Sun & Moon/Guardians Rising/35.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Vanillish",
 		fr: "Sorboul",
+		de: "Gelatroppo"
 	},
 
 	stage: "Stage2",
@@ -76,7 +77,7 @@ const card: Card = {
 				es: "Puedes descartar 2 Energías Water de este Pokémon. Si lo haces, el Pokémon Activo de tu rival pasa a estar Paralizado.",
 				it: "Puoi scartare due Energie Water assegnate a questo Pokémon. Se lo fai, il Pokémon attivo del tuo avversario viene paralizzato.",
 				pt: "Você pode descartar 2 Energias Water deste Pokémon. Se fizer isto, o Pokémon Ativo do seu oponente será Paralisado.",
-				de: "Du kannst 2 Water-Energien von diesem Pokémon auf deinen Ablagestapel legen. Wenn du das machst, ist das Aktive Pokémon deines Gegners jetzt paralysiert."
+				de: "Du kannst 2 {W}-Energien von diesem Pokémon auf deinen Ablagestapel legen. Wenn du das machst, ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 			},
 			damage: 80,
 
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "Each of its two heads has a brain, and when they are in agreement, it attacks its enemies by exhaling a violent blizzard.",
+		de: "Seine zwei Köpfe haben je ein eigenes Gehirn. Sind sich beide einig, greifen sie den Gegner an, indem sie heftige Eisböen ausstoßen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/36.ts
+++ b/data/Sun & Moon/Guardians Rising/36.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It uses its special mucus to close the wounds of injured Pokémon. The reason for this behavior remains unknown.",
+		de: "Es umarmt verletzte Pokémon und bedeckt ihre Wunden mit einem speziellen Schleim. Niemand weiß, warum es das tut."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/37.ts
+++ b/data/Sun & Moon/Guardians Rising/37.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Una vez durante tu turno (antes de tu ataque), puedes cambiar este Pokémon por un Wishiwashi GX de tu mano. Todas las cartas unidas a este Pokémon, los contadores de daño, las Condiciones Especiales, los turnos de juego y todos los demás efectos permanecen en el nuevo Pokémon.",
 				it: "Una sola volta durante il tuo turno, prima di attaccare, puoi scambiare questo Pokémon con un Wishiwashi GX nella tua mano. Le carte assegnate, i segnalini danno, le condizioni speciali, il numero di turni da cui è in gioco e qualsiasi altro effetto restano sul nuovo Pokémon.",
 				pt: "Uma vez durante a sua vez de jogar (antes de atacar), você pode trocar este Pokémon por 1 Wishiwashi GX na sua mão. Quaisquer cartas ligadas, contadores de dano, Condições Especiais, vezes em jogo e quaisquer outros efeitos permanecem no novo Pokémon.",
-				de: "Einmal während deines Zuges (bevor du angreifst) kannst du dieses Pokémon gegen 1 Lusardin GX auf deiner Hand austauschen. Alle an es angelegten Karten, Schadensmarken, Speziellen Zustände, Spielzüge sowie alle anderen Effekte verbleiben auf dem neuen Pokémon."
+				de: "Einmal während deines Zuges (bevor du angreifst) kannst du dieses Pokémon gegen 1 Lusardin-GX auf deiner Hand austauschen. Alle an es angelegten Karten, Schadensmarken, Speziellen Zustände, Spielzüge sowie alle anderen Effekte verbleiben auf dem neuen Pokémon."
 			},
 		},
 	],
@@ -86,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "When it's in trouble, its eyes moisten and begin to shine. The shining light attracts its comrades, and they stand together against their enemies.",
+		de: "Gerät es in Not, tränen seine Augen. Ihr Glänzen lockt Artgenossen an, mit denen es dann im Verbund den Feind angreift."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/39.ts
+++ b/data/Sun & Moon/Guardians Rising/39.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It plunges the poison spike on its head into its prey. When the prey has weakened, Mareanie deals the finishing blow with its 10 tentacles.",
+		de: "Mit seinem Giftstachel am Kopf attackiert es Beute. Ist diese geschwächt, umschlingt es sie mit seinen zehn Tentakeln und gibt ihr den Rest."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/4.ts
+++ b/data/Sun & Moon/Guardians Rising/4.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "Although the leaves on its head are bitter enough to cause dizziness, they provide relief from weariness—even more so when boiled.",
+		de: "Die Blätter auf seinem Kopf sind furchtbar bitter, helfen aber bei Erschöpfung. Als Tee zubereitet, sind sie noch wirksamer."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/40.ts
+++ b/data/Sun & Moon/Guardians Rising/40.ts
@@ -87,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "Its body is a magnetic stone. Iron sand attaches firmly to the portions of its body that are particularly magnetic.",
+		de: "Sein Steinkörper ist von Magnetkraft erfüllt. An den Stellen, wo diese besonders stark wirkt, heften sich Schichten aus Eisensand an."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/41.ts
+++ b/data/Sun & Moon/Guardians Rising/41.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Alolan Geodude",
 		fr: "Racaillou d’Alola",
+		de: "Alola-Kleinstein"
 	},
 
 	stage: "Stage1",
@@ -105,6 +106,7 @@ const card: Card = {
 
 	description: {
 		en: "Its preferred food is dravite. After it has eaten this mineral, crystals form inside the Pokémon, rising to the surface of part of its body.",
+		de: "Georok ernährt sich vorzugsweise von Draviten. Die verzehrten Teilchen werden zu Kristallen, die an einer Körperstelle hervortreten."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/42.ts
+++ b/data/Sun & Moon/Guardians Rising/42.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Alolan Graveler",
 		fr: "Gravalanch d’Alola",
+		de: "Alola-Georok"
 	},
 
 	stage: "Stage2",
@@ -54,7 +55,7 @@ const card: Card = {
 				es: "Lanza 1 moneda por cada Energía Lightning unida a este Pokémon. Este ataque hace 80 puntos de daño por cada cara.",
 				it: "Lancia una moneta per ogni Energia Lightning assegnata a questo Pokémon. Questo attacco infligge 80 danni ogni volta che esce testa.",
 				pt: "Jogue 1 moeda para cada Energia Lightning ligada a este Pokémon. Este ataque causa 80 pontos de dano para cada cara.",
-				de: "Wirf 1 Münze für jede an dieses Pokémon angelegte Lightning-Energie. Diese Attacke fügt 80 Schadenspunkte pro Kopf zu."
+				de: "Wirf 1 Münze für jede an dieses Pokémon angelegte {L}-Energie. Diese Attacke fügt 80 Schadenspunkte pro Kopf zu."
 			},
 			damage: "80×",
 
@@ -80,7 +81,7 @@ const card: Card = {
 				es: "Este ataque hace 30 puntos de daño menos por cada Colorless en el Coste de Retirada del Pokémon Activo de tu rival.",
 				it: "Questo attacco infligge 30 danni in meno per ogni Colorless nel costo di ritirata del Pokémon attivo del tuo avversario.",
 				pt: "Este ataque causa 30 pontos de dano a menos para cada Colorless no custo de Recuo do Pokémon Ativo do seu oponente.",
-				de: "Diese Attacke fügt 30 Schadenspunkte weniger mal der Anzahl der Colorless-Symbole in den Rückzugskosten des Aktiven Pokémon deines Gegners zu."
+				de: "Diese Attacke fügt 30 Schadenspunkte weniger mal der Anzahl der {C}-Symbole in den Rückzugskosten des Aktiven Pokémon deines Gegners zu."
 			},
 			damage: "200-",
 
@@ -105,6 +106,7 @@ const card: Card = {
 
 	description: {
 		en: "It fires rocks charged with electricity. Even if the rock isn't fired that accurately, just grazing an opponent will cause numbness and fainting.",
+		de: "Es feuert elektrisch geladene Felsen ab. Selbst eine Schramme genügt, um seine Gegner damit bewusstlos zu machen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/43.ts
+++ b/data/Sun & Moon/Guardians Rising/43.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "They make their home in deserts. They can generate their energy from basking in the sun, so eating food is not a requirement.",
+		de: "Es ist in der Wüste zu Hause und wandelt die Energie der Sonne in Körperkraft um, wodurch es auch ohne Nahrung auskommt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/44.ts
+++ b/data/Sun & Moon/Guardians Rising/44.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Helioptile",
 		fr: "Galvaran",
+		de: "Eguana"
 	},
 
 	stage: "Stage1",
@@ -102,6 +103,7 @@ const card: Card = {
 
 	description: {
 		en: "They flare their frills and generate energy. A single Heliolisk can generate sufficient electricity to power a skyscraper.",
+		de: "Die Strommenge, die ein Elezard mit ausgebreiteten Hautlappen durch Umwandlung von Sonnenstrahlen erzeugt, genügt zur Versorgung eines Wolkenkratzers."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/45.ts
+++ b/data/Sun & Moon/Guardians Rising/45.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Charjabug",
 		fr: "Chrysapile",
+		de: "Akkup"
 	},
 
 	suffix: "GX",
@@ -96,7 +97,7 @@ const card: Card = {
 				es: "Gigatrón GX",
 				it: "Gigatrone-GX",
 				pt: "Gigatron GX",
-				de: "Gigatron GX"
+				de: "Gigatron-GX"
 			},
 			effect: {
 				en: "This attack does 60 damage to each of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Guardians Rising/46.ts
+++ b/data/Sun & Moon/Guardians Rising/46.ts
@@ -87,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "This Oricorio has sipped bright yellow nectar. Its bright, cheerful dance melts the hearts of its enemies.",
+		de: "Ein Choreogel, das gelben Nektar geschlürft hat. Mit seinem heiteren Tanz kann es selbst die Herzen seiner Gegner mit Wonne erfüllen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/47.ts
+++ b/data/Sun & Moon/Guardians Rising/47.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Cuando juegues este Pokémon de tu mano a tu Banca durante tu turno, puedes mover cualquier cantidad de Energía Lightning de tus otros Pokémon a este Pokémon. Si lo haces, cambia este Pokémon por tu Pokémon Activo.",
 				it: "Quando giochi questo Pokémon dalla tua mano e lo metti in panchina durante il tuo turno, puoi spostare un numero qualsiasi di Energie Lightning assegnate ai tuoi altri Pokémon su questo Pokémon. Se lo fai, scambialo con il tuo Pokémon attivo.",
 				pt: "Quando você joga este Pokémon da sua mão para o seu banco durante a sua vez de jogar, você pode mover qualquer número de Energia Lightning de outros Pokémon seus para este Pokémon. Se fizer isto, troque este Pokémon pelo seu Pokémon Ativo.",
-				de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand auf deine Bank spielst, kannst du beliebig viele Lightning-Energien von deinen anderen Pokémon auf dieses Pokémon verschieben. Wenn du das machst, tausche dieses Pokémon gegen dein Aktives Pokémon aus."
+				de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand auf deine Bank spielst, kannst du beliebig viele {L}-Energien von deinen anderen Pokémon auf dieses Pokémon verschieben. Wenn du das machst, tausche dieses Pokémon gegen dein Aktives Pokémon aus."
 			},
 		},
 	],

--- a/data/Sun & Moon/Guardians Rising/48.ts
+++ b/data/Sun & Moon/Guardians Rising/48.ts
@@ -83,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "Its long tail often breaks off. It doesn't really feel any pain, though, and the tail grows back, so Slowpoke isn't particularly bothered.",
+		de: "Seine Rute bricht sehr leicht ab. Dies kümmert es jedoch wenig, da es dabei keine Schmerzen spürt und sie sofort wieder nachwächst."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/49.ts
+++ b/data/Sun & Moon/Guardians Rising/49.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Slowpoke",
 		fr: "Ramoloss",
+		de: "Flegmon"
 	},
 
 	stage: "Stage1",
@@ -95,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "It spaces out while gazing at the sea. With Shellder's poison flowing through its body, it becomes even spacier.",
+		de: "Es betrachtet oft mit leerem Blick das Meer. Das Gift, das Muschas in seinen Körper injiziert, erhöht seine Begriffsstutzigkeit noch weiter."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/5.ts
+++ b/data/Sun & Moon/Guardians Rising/5.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Petilil",
 		fr: "Chlorobule",
+		de: "Lilminip"
 	},
 
 	stage: "Stage1",
@@ -93,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "No matter how much time and money is spent raising it, its flowers are the most beautiful when they bloom in the wild.",
+		de: "Egal, wie viel Mühe und Geld investiert wird, sein Blumenschmuck ist wild gewachsen immer schöner als von Menschenhand gezüchtet."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/50.ts
+++ b/data/Sun & Moon/Guardians Rising/50.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "Unsanitary places are what they like best. They can be spotted in Alola, often with Grimer in hot pursuit.",
+		de: "Es liebt schmutzige Orte. In Alola sieht man oft, wie es von Sleima verfolgt wird."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/51.ts
+++ b/data/Sun & Moon/Guardians Rising/51.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Trubbish",
 		fr: "Miamiasme",
+		de: "Unratütox"
 	},
 
 	stage: "Stage1",
@@ -95,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "Beware the poisonous liquid it shoots from its right arm. If even a little of it gets on you, you'll experience the effects of the unidentified toxin.",
+		de: "Vorsicht vor dem Gift, das es aus seinem rechten Arm sprüht! Kleinste Mengen genügen, um einen unbekannten Giftstoff zu übertragen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/52.ts
+++ b/data/Sun & Moon/Guardians Rising/52.ts
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "Their ribbonlike feelers increase their psychic power. They are always staring at something.",
+		de: "Die schleifenförmigen Fühler erhöhen seine Psycho-Kräfte. Es scheint stets irgendetwas anzustarren."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/53.ts
+++ b/data/Sun & Moon/Guardians Rising/53.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gothita",
 		fr: "Scrutella",
+		de: "Mollimorba"
 	},
 
 	stage: "Stage1",
@@ -87,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Starlight is the source of their power. At night, they mark star positions by using psychic power to float stones.",
+		de: "Zieht seine Energie aus dem Sternenlicht. Bei Nacht bringt es Steine zum Schweben und bildet damit Sternzeichen nach."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/54.ts
+++ b/data/Sun & Moon/Guardians Rising/54.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gothorita",
 		fr: "Mesmérella",
+		de: "Hypnomorba"
 	},
 
 	stage: "Stage2",
@@ -93,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "Starry skies thousands of light-years away are visible in the space distorted by their intense psychic power.",
+		de: "Durch seine mächtigen Psycho-Kräfte krümmt sich der Raum und Bilder eines Lichtjahre entfernten Ortes erscheinen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/55.ts
+++ b/data/Sun & Moon/Guardians Rising/55.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "This Oricorio relaxes by swaying gently. This increases its psychic energy, which it then fires at its enemies.",
+		de: "Es entspannt sich durch sanft kreisende Bewegungen. Dies verstärkt seine Psycho-Kräfte, welche es auf den Gegner abfeuert."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/56.ts
+++ b/data/Sun & Moon/Guardians Rising/56.ts
@@ -94,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "This Oricorio has sipped purple nectar. Its elegant, attractive dance will send the minds and hearts of its enemies to another world.",
+		de: "Ein Choreogel, das purpurnen Nektar geschlürft hat. Mit seinem anmutigen Tanz entführt es seine Gegner buchstäblich in eine andere Welt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/57.ts
+++ b/data/Sun & Moon/Guardians Rising/57.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Mareanie",
 		fr: "Vorastérie",
+		de: "Garstella"
 	},
 
 	suffix: "GX",
@@ -93,7 +94,7 @@ const card: Card = {
 				es: "Protección Total GX",
 				it: "Rifugio Totale-GX",
 				pt: "Proteção Total GX",
-				de: "Vollschutz GX"
+				de: "Vollschutz-GX"
 			},
 			effect: {
 				en: "Prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Guardians Rising/58.ts
+++ b/data/Sun & Moon/Guardians Rising/58.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "Its actual appearance is unknown. A scholar who saw what was under its rag was overwhelmed by horror and died of the shock.",
+		de: "Niemand weiß, wie es wirklich aussieht. Ein Forscher, der unter seinen Lumpen blickte, soll sich buchstäblich zu Tode erschreckt haben."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/59.ts
+++ b/data/Sun & Moon/Guardians Rising/59.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Los ataques de tus Pokémon Metal hacen 10 puntos de daño más al Pokémon Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
 				it: "Gli attacchi dei tuoi Pokémon Metal infliggono 10 danni in più al Pokémon attivo del tuo avversario, prima di aver applicato debolezza e resistenza.",
 				pt: "Os ataques dos seus Pokémon Metal causam 10 pontos de dano a mais ao Pokémon Ativo do seu oponente (antes de aplicar Fraqueza e Resistência).",
-				de: "Die Attacken deiner Metal-Pokémon fügen dem Aktiven Pokémon deines Gegners 10 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
+				de: "Die Attacken deiner {M}-Pokémon fügen dem Aktiven Pokémon deines Gegners 10 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 		},
 	],
@@ -96,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "Swinging its massive anchor, it can KO Wailord in a single blow. What appears to be green seaweed is actually its body.",
+		de: "Wenn es seinen riesigen Anker schwingt, kann es sogar ein Wailord mit einem Schlag K.O. hauen. Der grüne Seetang ist sein Körper."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/6.ts
+++ b/data/Sun & Moon/Guardians Rising/6.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "These Pokémon are stumps possessed by the spirits of children who died in the forest. Their cries sound like eerie screams.",
+		de: "Es ist die Seele eines im Wald gestorbenen Kindes, die von einem Baumstumpf Besitz ergriffen hat. Sein Ruf gleicht einem Schluchzen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/60.ts
+++ b/data/Sun & Moon/Guardians Rising/60.ts
@@ -85,7 +85,7 @@ const card: Card = {
 				es: "Cura Tapu GX",
 				it: "Tapucura-GX",
 				pt: "Cura Tapu GX",
-				de: "Kapu-Heilung GX"
+				de: "Kapu-Heilung-GX"
 			},
 			effect: {
 				en: "Heal all damage from 2 of your Benched Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Guardians Rising/61.ts
+++ b/data/Sun & Moon/Guardians Rising/61.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cosmoem",
 		fr: "Cosmovum",
+		de: "Cosmovum"
 	},
 
 	stage: "Stage2",
@@ -52,7 +53,7 @@ const card: Card = {
 				es: "Este ataque hace 40 puntos de daño por cada Energía Psychic unida a este Pokémon.",
 				it: "Questo attacco infligge 40 danni per ogni Energia Psychic assegnata a questo Pokémon.",
 				pt: "Este ataque causa 40 pontos de dano vezes a quantidade de Energia Psychic ligada a este Pokémon.",
-				de: "Diese Attacke fügt 40 Schadenspunkte mal der Anzahl der an dieses Pokémon angelegten Psychic-Energien zu."
+				de: "Diese Attacke fügt 40 Schadenspunkte mal der Anzahl der an dieses Pokémon angelegten {P}-Energien zu."
 			},
 			damage: "40×",
 
@@ -102,6 +103,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said to be a female evolution of Cosmog. When its third eye activates, away it flies to another world.",
+		de: "Es heißt, es sei die weibliche Endstufe der Entwicklungsreihe von Cosmog. Ist sein drittes Auge aktiviert, zieht es in eine andere Welt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/62.ts
+++ b/data/Sun & Moon/Guardians Rising/62.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "It loves working out. As it gazes at its muscles, which continue to swell day by day, it becomes more and more dedicated to its training.",
+		de: "Es liebt Muskelaufbautraining und verfolgt jeden Tag das Wachstum seiner Muskeln. Dies spornt es zu noch intensiverem Training an."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/63.ts
+++ b/data/Sun & Moon/Guardians Rising/63.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "It loves working out. As it gazes at its muscles, which continue to swell day by day, it becomes more and more dedicated to its training.",
+		de: "Es liebt Muskelaufbautraining und verfolgt jeden Tag das Wachstum seiner Muskeln. Dies spornt es zu noch intensiverem Training an."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/64.ts
+++ b/data/Sun & Moon/Guardians Rising/64.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Machop",
 		fr: "Machoc",
+		de: "Machollo"
 	},
 
 	stage: "Stage1",
@@ -93,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "As a result of its continual workouts, it has developed tremendous power. It uses that power to help people with their work.",
+		de: "Es hat sich durch unerbittliches Training unglaubliche Kräfte angeeignet, mit denen es die Menschen bei der Arbeit unterstützt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/65.ts
+++ b/data/Sun & Moon/Guardians Rising/65.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Machoke",
 		fr: "Machopeur",
+		de: "Maschock"
 	},
 
 	stage: "Stage2",
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "It unleashes megaton-level punches that send opponents flying clear over the horizon.",
+		de: "Gegner, die sich ihm in den Weg stellen, werden mit einem Faustschlag, dessen Wucht 1 Million Tonnen übersteigt, gen Horizont geschleudert."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/66.ts
+++ b/data/Sun & Moon/Guardians Rising/66.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "To avoid attack, it mimics a tree. It will run off if splashed with water, which it hates.",
+		de: "Es tarnt sich als Baum, um Angriffen aus dem Weg zu gehen. Es hasst jedoch Wasser und ergreift die Flucht, wenn man es nass macht."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/67.ts
+++ b/data/Sun & Moon/Guardians Rising/67.ts
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "It usually clings to cliffs. When it spots its prey, it spreads its wings and glides down to attack.",
+		de: "Es hängt meist an Klippen. Erspäht es Beute, spreizt es seine Flügel und greift diese sofort an."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/68.ts
+++ b/data/Sun & Moon/Guardians Rising/68.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gligar",
 		fr: "Scorplane",
+		de: "Skorgla"
 	},
 
 	stage: "Stage1",
@@ -88,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It observes prey while hanging inverted from branches. When the chance presents itself, it swoops!",
+		de: "Es hängt kopfüber von einem Ast und beobachtet seine Beute. Bei Gelegenheit stürzt es sich auf sie."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/69.ts
+++ b/data/Sun & Moon/Guardians Rising/69.ts
@@ -84,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "The magnet in Nosepass's nose provides an unerring compass, making it an excellent partner for Trainers going on a journey.",
+		de: "Seine magnetische Nase ist unbeirrbar und erweist sich daher als ganz hervorragender Partner für Pokémon-Trainer auf Reisen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/7.ts
+++ b/data/Sun & Moon/Guardians Rising/7.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Phantump",
 		fr: "Brocélôme",
+		de: "Paragoni"
 	},
 
 	stage: "Stage1",
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon is said to devour anyone daring to ravage the forest. To the creatures dwelling in the forest, it offers great kindness.",
+		de: "Menschen, die dem Wald Schaden zufügen, soll es angeblich auffressen. Es ist nett zu allen Lebewesen, die im Wald leben."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/70.ts
+++ b/data/Sun & Moon/Guardians Rising/70.ts
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "Its two whiskers provide a sensitive radar. Even in muddy waters, it can detect its prey's location.",
+		de: "Seine zwei Barthaare dienen als empfindliches Radarsystem. Selbst in schlammigem Wasser kennt es so die Position seiner Beute."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/71.ts
+++ b/data/Sun & Moon/Guardians Rising/71.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Barboach",
 		fr: "Barloche",
+		de: "Schmerbe"
 	},
 
 	stage: "Stage1",
@@ -98,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "A glutton that devours anything that moves, it quietly lurks at the bottom of swamps, lying in wait for prey.",
+		de: "Es frisst einfach alles, was ihm vor die Kiemen kommt. Normalerweise verharrt es im Schlamm und wartet auf Beute."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/72.ts
+++ b/data/Sun & Moon/Guardians Rising/72.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "It grows up imitating the behavior of Pangoro, which it looks up to as a leader.",
+		de: "Pandagro ist sein großes Vorbild, das es stets nachahmt. Dabei ist es so eifrig, dass es daran wächst."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/73.ts
+++ b/data/Sun & Moon/Guardians Rising/73.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It's considered to be a good Pokémon for beginners because of its friendliness, but its disposition grows rougher as it grows up.",
+		de: "Dieses sehr zutrauliche Pokémon wird oft frischgebackenen Trainern empfohlen. Mit dem Alter wird es jedoch immer wilder."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/74.ts
+++ b/data/Sun & Moon/Guardians Rising/74.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Rockruff",
 		fr: "Rocabot",
+		de: "Wuffels"
 	},
 
 	suffix: "GX",
@@ -85,7 +86,7 @@ const card: Card = {
 				es: "Pícaro Peligroso GX",
 				it: "Pericolo Ferale-GX",
 				pt: "Trapaceiro Perigoso GX",
-				de: "Gaunergefahr GX"
+				de: "Gaunergefahr-GX"
 			},
 			effect: {
 				en: "This attack does 50 damage for each of your opponent’s Benched Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Guardians Rising/75.ts
+++ b/data/Sun & Moon/Guardians Rising/75.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "The mud stuck to Mudbray's hooves enhances its grip and its powerful running gait.",
+		de: "Der ganze Schlamm an seinen Füßen sorgt für die nötige Bodenhaftung, die es für seinen kraftvollen Lauf braucht."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/76.ts
+++ b/data/Sun & Moon/Guardians Rising/76.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Mudbray",
 		fr: "Tiboudet",
+		de: "Pampuli"
 	},
 
 	stage: "Stage1",
@@ -98,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "It spits a mud that provides resistance to both wind and rain, so the walls of old houses were often coated with it.",
+		de: "Der Schlamm, den es ausspuckt, schützt gegen Wind und Wetter, wenn er hart wird. Deshalb hat man früher auch Hauswände damit verstärkt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/77.ts
+++ b/data/Sun & Moon/Guardians Rising/77.ts
@@ -97,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "It eats dust in the atmosphere. The composition of the dust determines the color of its core.",
+		de: "Es ernährt sich von Partikeln in der Atmosphäre. Die Farbe seines Kerns ist abhängig von der Zusammensetzung der Partikeln, die es frisst."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/78.ts
+++ b/data/Sun & Moon/Guardians Rising/78.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "They awaken at dusk and take wing in the twilight, leading to the expression, \"Get home before the Murkrow fly.\"",
+		de: "Es wacht bei Dämmerung auf und fliegt durch die Nacht. Daher das Sprichwort: „Flugs nach Haus, mein Kind, wenn Kramurx am Himmel sind!“"
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/79.ts
+++ b/data/Sun & Moon/Guardians Rising/79.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Murkrow",
 		fr: "Cornèbre",
+		de: "Kramurx"
 	},
 
 	stage: "Stage1",
@@ -100,6 +101,7 @@ const card: Card = {
 
 	description: {
 		en: "A single cry from this nocturnal Pokémon, and more than a hundred of its Murkrow cronies will assemble.",
+		de: "Dieses nachtaktive Pokémon kann mit einem einzigen Ruf über 100 seiner untergebenen Kramurx versammeln."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/8.ts
+++ b/data/Sun & Moon/Guardians Rising/8.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon is a coward. As it desperately dashes off, the flailing of its many legs leaves a sparkling clean path in its wake.",
+		de: "Es ist so feige, dass es wild mit seinen vielen Füßen herumschlägt und verzweifelt davonläuft. Nach seiner Flucht glänzt der Boden herrlich."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/80.ts
+++ b/data/Sun & Moon/Guardians Rising/80.ts
@@ -73,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "It's a fiend for gemstones, so it stalks Carbink. Unfortunately, Gabite almost always grabs them first.",
+		de: "Seine Liebe zu Edelsteinen treibt es dazu, Rocara nachzustellen. Knarksel kommt ihm allerdings immer zuvor."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/81.ts
+++ b/data/Sun & Moon/Guardians Rising/81.ts
@@ -94,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "Long ago, superstitions were spread about it, saying it brought disaster. This fed a hatred of it, and it was driven deep into the mountains.",
+		de: "Aus Aberglauben war Absol einst als Unheilsbote verhasst und wurde in die tiefsten Berge vertrieben."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/82.ts
+++ b/data/Sun & Moon/Guardians Rising/82.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pancham",
 		fr: "Pandespiègle",
+		de: "Pam-Pam"
 	},
 
 	stage: "Stage1",
@@ -98,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "It boasts superb physical strength. Those who wish to become Pangoro's Trainer have no choice but to converse with their fists.",
+		de: "Seine mächtigen Arme sind sehr imposant. Wer als Pandagro-Trainer Karriere machen will, muss wohl die Fäuste sprechen lassen!"
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/83.ts
+++ b/data/Sun & Moon/Guardians Rising/83.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Descarta 1 Energía Metal de este Pokémon.",
 				it: "Scarta un’Energia Metal assegnata a questo Pokémon.",
 				pt: "Descarte 1 Energia Metal deste Pokémon.",
-				de: "Lege 1 Metal-Energie von diesem Pokémon auf deinen Ablagestapel."
+				de: "Lege 1 {M}-Energie von diesem Pokémon auf deinen Ablagestapel."
 			},
 			damage: 20,
 
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "Its cells are all magnets. It uses magnetism to communicate with others of its kind.",
+		de: "Seine Zellen sind magnetisch geladen. Es kommuniziert mit anderen, indem es magnetische Impulse aussendet."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/84.ts
+++ b/data/Sun & Moon/Guardians Rising/84.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Beldum",
 		fr: "Terhal",
+		de: "Tanhel"
 	},
 
 	stage: "Stage1",
@@ -70,7 +71,7 @@ const card: Card = {
 				es: "Descarta 1 Energía Metal de este Pokémon.",
 				it: "Scarta un’Energia Metal assegnata a questo Pokémon.",
 				pt: "Descarte 1 Energia Metal deste Pokémon.",
-				de: "Lege 1 Metal-Energie von diesem Pokémon auf deinen Ablagestapel."
+				de: "Lege 1 {M}-Energie von diesem Pokémon auf deinen Ablagestapel."
 			},
 			damage: 80,
 
@@ -95,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "When two Beldum link together, their psychic power is doubled. Their intelligence, however, remains unchanged.",
+		de: "Zwei Tanhel haben sich vereinigt und so ihre Psycho-Kräfte verdoppelt. Ihre Denkfähigkeit bleibt dabei aber unverändert."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/85.ts
+++ b/data/Sun & Moon/Guardians Rising/85.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Metang",
 		fr: "Métang",
+		de: "Metang"
 	},
 
 	suffix: "GX",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Una vez durante tu turno (antes de tu ataque), puedes unir 1 carta de Energía Psychic o Metal de tu pila de descartes a tu Pokémon Activo.",
 				it: "Una sola volta durante il tuo turno, prima di attaccare, puoi assegnare al tuo Pokémon attivo una carta Energia Psychic o Metal dalla tua pila degli scarti.",
 				pt: "Uma vez durante a sua vez de jogar (antes de atacar), você pode ligar 1 carta de Energia Psychic ou Metal da sua pilha de descarte ao seu Pokémon Ativo.",
-				de: "Einmal während deines Zuges (bevor du angreifst) kannst du 1 Psychic- oder 1 Metal-Energiekarte aus deinem Ablagestapel an dein Aktives Pokémon anlegen."
+				de: "Einmal während deines Zuges (bevor du angreifst) kannst du 1 {P}- oder 1 {M}-Energiekarte aus deinem Ablagestapel an dein Aktives Pokémon anlegen."
 			},
 		},
 	],

--- a/data/Sun & Moon/Guardians Rising/86.ts
+++ b/data/Sun & Moon/Guardians Rising/86.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Nosepass",
 		fr: "Tarinor",
+		de: "Nasgnet"
 	},
 
 	stage: "Stage1",
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "It radiates such a powerful magnetic field that nearby electrical appliances become unusable.",
+		de: "Durch seinen starken Magnetismus macht es Elektrogeräte in seiner Nähe kaputt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/87.ts
+++ b/data/Sun & Moon/Guardians Rising/87.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cosmoem",
 		fr: "Cosmovum",
+		de: "Cosmovum"
 	},
 
 	stage: "Stage2",
@@ -102,6 +103,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said to live in another world. The intense light it radiates from the surface of its body can make the darkest of nights light up like midday.",
+		de: "Es heißt, es komme aus einer anderen Welt. Sein ganzer Körper leuchtet strahlend hell und macht die finsterste Nacht zum Tage."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/88.ts
+++ b/data/Sun & Moon/Guardians Rising/88.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Its adorable behavior and appearance make it popular with men and women, young and old. Its numbers are few, however.",
+		de: "Dank seiner verspielten Art und seines süßen Aussehens ist es bei Jung und Alt sehr beliebt. Dieses Pokémon ist jedoch selten."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/89.ts
+++ b/data/Sun & Moon/Guardians Rising/89.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Clefairy",
 		fr: "Mélofée",
+		de: "Piepi"
 	},
 
 	stage: "Stage1",
@@ -102,6 +103,7 @@ const card: Card = {
 
 	description: {
 		en: "They don't like to reveal themselves in front of people. They live quietly in packs deep in the mountains.",
+		de: "Es zeigt sich Menschen nur ungern und führt zusammen mit anderen Artgenossen ein abgeschiedenes Leben tief in den Bergen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/9.ts
+++ b/data/Sun & Moon/Guardians Rising/9.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Wimpod",
 		fr: "Sovkipou",
+		de: "Reißlaus"
 	},
 
 	stage: "Stage1",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "With a flashing slash of its giant sharp claws, it cleaves seawater—or even air—right in two.",
+		de: "Mithilfe seiner riesigen, glitzernden Klauen zerteilt es selbst Luft und Salzwasser mit einem Hieb."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/90.ts
+++ b/data/Sun & Moon/Guardians Rising/90.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "When it finds others of its kind, they all stick together. When enough of them have collected, the mass resembles a cumulonimbus cloud.",
+		de: "Begegnen sie Freunden, hängen sie eng aufeinander. Wenn sich zu viele versammeln, sehen sie aus wie eine Gewitterwolke."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/91.ts
+++ b/data/Sun & Moon/Guardians Rising/91.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cottonee",
 		fr: "Doudouvet",
+		de: "Waumboll"
 	},
 
 	stage: "Stage1",
@@ -92,6 +93,7 @@ const card: Card = {
 
 	description: {
 		en: "It rides on the wind and slips into people's homes. After it has turned a room into a cotton-filled mess, it giggles to itself and takes off.",
+		de: "Über Luftzüge dringt es in Häuser ein, verstreut in allen Zimmern Watte und macht sich dann lächelnd davon."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/92.ts
+++ b/data/Sun & Moon/Guardians Rising/92.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	suffix: "GX",
@@ -86,7 +87,7 @@ const card: Card = {
 				es: "Ruego GX",
 				it: "Istanza-GX",
 				pt: "Apelo GX",
-				de: "Anflehen GX"
+				de: "Anflehen-GX"
 			},
 			effect: {
 				en: "Put 2 of your opponent’s Benched Pokémon and all cards attached to them into your opponent’s hand. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Guardians Rising/93.ts
+++ b/data/Sun & Moon/Guardians Rising/93.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Cada uno de tus Pokémon que tenga alguna Energía Fairy unida a él no se puede ver afectado por ninguna Condición Especial. Elimina cualquier Condición Especial que afecte a esos Pokémon.",
 				it: "Nessuno dei tuoi Pokémon che ha delle Energie Fairy assegnate può essere influenzato da condizioni speciali. Rimuovi tutte le condizioni speciali che influenzano tali Pokémon.",
 				pt: "Cada um dos seus Pokémon que tiver alguma Energia Fairy ligada a ele não poderá ser afetado por quaisquer Condições Especiais. Remova todas as Condições Especiais que afetem aqueles Pokémon.",
-				de: "Jedes deiner Pokémon, an das mindestens 1 Fairy-Energie angelegt ist, kann nicht von Speziellen Zuständen betroffen werden. Alle Speziellen Zustände auf jenen Pokémon verlieren ihre Wirkung."
+				de: "Jedes deiner Pokémon, an das mindestens 1 {FAIRY}-Energie angelegt ist, kann nicht von Speziellen Zuständen betroffen werden. Alle Speziellen Zustände auf jenen Pokémon verlieren ihre Wirkung."
 			},
 		},
 	],
@@ -95,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "It attaches flowers to its highly nutritious vine. This revitalizes the flowers, and they give off an aromatic scent.",
+		de: "Dieses Pokémon sieht aus, als hätte man Blüten an einer nahrhaften Ranke angebracht. Diese blühen auf und sind äußerst wohlriechend."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/94.ts
+++ b/data/Sun & Moon/Guardians Rising/94.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "The weakest of all Dragon-type Pokémon, it's unable to breathe if its skin dries out, so it sticks to shady places.",
+		de: "Das schwächste aller Drachen-Pokémon. Wenn seine Haut austrocknet, erstickt es. Daher hält es sich bevorzugt im Schatten auf."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/95.ts
+++ b/data/Sun & Moon/Guardians Rising/95.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Goomy",
 		fr: "Mucuscule",
+		de: "Viscora"
 	},
 
 	stage: "Stage1",
@@ -86,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "It has trouble drawing a line between friends and food. It will calmly try to melt and eat even those it gets along well with.",
+		de: "Die Grenze zwischen Freund und Fressen ist bei diesem Pokémon fließend. Als Freund geschätzt, zu Suppe zersetzt!"
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/96.ts
+++ b/data/Sun & Moon/Guardians Rising/96.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Sliggoo",
 		fr: "Colimucus",
+		de: "Viscargot"
 	},
 
 	stage: "Stage2",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "An amazingly friendly Pokémon, but if left to itself, loneliness overcomes it, and it oozes gooey tears.",
+		de: "Dieses äußerst freundliche Pokémon benötigt sehr viel Aufmerksamkeit, sonst fühlt es sich einsam und weint schleimige Tränen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/97.ts
+++ b/data/Sun & Moon/Guardians Rising/97.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It has a compassionate personality, but if it is angered, it will completely destroy its surroundings with its intense breath.",
+		de: "Es hat ein freundliches Wesen, aber wenn es zur Weißglut gebracht wird, zerstört es mit einem heftigen Hauch die gesamte Umgebung."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/98.ts
+++ b/data/Sun & Moon/Guardians Rising/98.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "It expresses its feelings by smacking its scales. Metallic sounds echo through the tall mountains where Jangmo-o lives.",
+		de: "Es übermittelt seine Gefühle durch das Rasseln seiner Schuppen, wodurch im Hochgebirge, in dem es lebt, ein metallisches Geräusch erhallt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Guardians Rising/99.ts
+++ b/data/Sun & Moon/Guardians Rising/99.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Jangmo-o",
 		fr: "Bébécaille",
+		de: "Miniras"
 	},
 
 	stage: "Stage1",
@@ -81,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It leaps at its prey with a courageous shout. Its scaly punches tear its opponents to shreds.",
+		de: "Mit einem Kampfschrei stürzt es sich auf seine Beute und reißt sie mithilfe seiner Schuppen in kleine Stücke."
 	},
 
 	thirdParty: {


### PR DESCRIPTION
## Add missing German translations for sm2

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
