### PR TITLE
Add missing German translations for sm4

### DIFF
--- a/data/Sun & Moon/Crimson Invasion/1.ts
+++ b/data/Sun & Moon/Crimson Invasion/1.ts
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "Often found in forests and grasslands. It has a sharp, toxic barb of around two inches on top of its head.",
+		de: "Es lebt bevorzugt in Wäldern und in hohem Gras. Auf dem Kopf trägt es einen circa 5 cm langen, spitzen, giftigen Stachel."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/10.ts
+++ b/data/Sun & Moon/Crimson Invasion/10.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "Thought to be one of the first Pokémon to live in harmony with humans, it has a placid disposition.",
+		de: "Man sagt, es sei eines der ersten Pokémon, die mit Menschen zusammengelebt haben. Es ist sehr ruhig und friedfertig."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/100.ts
+++ b/data/Sun & Moon/Crimson Invasion/100.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Esta carta proporciona 1 Energía Colorless. \n\nSi te quedan más cartas de Premio que a tu rival y esta carta está unida a un Pokémon que no es un Pokémon-GX o un Pokémon-EX, esta carta proporciona cualquier tipo de Energía, pero proporciona solo 2 Energías a la vez.",
 		it: "Questa carta fornisce Energia Colorless.\n\nSe hai più carte Premio rimanenti del tuo avversario e se questa carta è assegnata a un Pokémon che non è un Pokémon-GX o un Pokémon-EX, essa fornisce Energia di qualsiasi tipo, ma solo due alla volta.",
 		pt: "Esta carta fornece Energia Colorless.\n\nSe você tiver mais cartas de Prêmio restantes do que seu oponente e esta carta estiver ligada a um Pokémon que não seja um Pokémon-GX ou Pokémon-EX, esta carta fornecerá todo tipo de Energia, mas só fornecerá 2 Energias por vez.",
-		de: "Diese Karte liefert Colorless-Energie.\n\nWenn du mehr verbleibende Preiskarten als dein Gegner hast und wenn diese Karte an ein Pokémon angelegt ist, das kein Pokémon-GX oder Pokémon-EX ist, liefert diese Karte jeden beliebigen Energietyp, aber immer nur jeweils 2 Energien."
+		de: "Diese Karte liefert {C}-Energie. Wenn du mehr verbleibende Preiskarten als dein Gegner hast und wenn diese Karte an ein Pokémon angelegt ist, das kein Pokémon-GX oder Pokémon-EX ist, liefert diese Karte jeden beliebigen Energietyp, aber immer nur jeweils 2 Energien."
 	},
 
 	energyType: "Special",

--- a/data/Sun & Moon/Crimson Invasion/101.ts
+++ b/data/Sun & Moon/Crimson Invasion/101.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Magikarp",
 		fr: "Magicarpe",
+		de: "Karpador"
 	},
 
 	suffix: "GX",
@@ -89,7 +90,7 @@ const card: Card = {
 				es: "Tormenta Temor GX",
 				it: "Tempesta Malefica-GX",
 				pt: "Tempestade de Temor GX",
-				de: "Sturm des Schreckens GX"
+				de: "Sturm des Schreckens-GX"
 			},
 			effect: {
 				en: "Discard an Energy from each of your opponent’s Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Crimson Invasion/102.ts
+++ b/data/Sun & Moon/Crimson Invasion/102.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Alolan Graveler",
 		fr: "Gravalanch d’Alola",
+		de: "Alola-Georok"
 	},
 
 	suffix: "GX",
@@ -91,7 +92,7 @@ const card: Card = {
 				es: "Roca Pesada GX",
 				it: "Macigno Ponderoso-GX",
 				pt: "Rocha Pesada GX",
-				de: "Schwerer Felsen GX"
+				de: "Schwerer Felsen-GX"
 			},
 			effect: {
 				en: "Your opponent can’t play any cards from their hand during their next turn. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Crimson Invasion/103.ts
+++ b/data/Sun & Moon/Crimson Invasion/103.ts
@@ -88,7 +88,7 @@ const card: Card = {
 				es: "Parásito GX",
 				it: "Parasitus-GX",
 				pt: "Parasita GX",
-				de: "Schmarotzer GX"
+				de: "Schmarotzer-GX"
 			},
 			effect: {
 				en: "Add the top 2 cards of your opponent’s deck to their Prize cards. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Crimson Invasion/104.ts
+++ b/data/Sun & Moon/Crimson Invasion/104.ts
@@ -89,7 +89,7 @@ const card: Card = {
 				es: "Expansión GX",
 				it: "Expansio-GX",
 				pt: "Expansão GX",
-				de: "Expander GX"
+				de: "Expander-GX"
 			},
 			effect: {
 				en: "This attack does 40 damage for each of your remaining Prize cards. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Crimson Invasion/105.ts
+++ b/data/Sun & Moon/Crimson Invasion/105.ts
@@ -85,7 +85,7 @@ const card: Card = {
 				es: "Voracidad GX",
 				it: "Voracitas-GX",
 				pt: "Voracidade GX",
-				de: "Vielfraß GX"
+				de: "Vielfraß-GX"
 			},
 			effect: {
 				en: "If your opponent’s Pokémon is Knocked Out by damage from this attack, take 2 more Prize cards. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Crimson Invasion/106.ts
+++ b/data/Sun & Moon/Crimson Invasion/106.ts
@@ -86,7 +86,7 @@ const card: Card = {
 				es: "Tajo GX",
 				it: "Sectio-GX",
 				pt: "Lâmina GX",
-				de: "Schwerthieb GX"
+				de: "Schwerthieb-GX"
 			},
 			effect: {
 				en: "Take a Prize card. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Crimson Invasion/107.ts
+++ b/data/Sun & Moon/Crimson Invasion/107.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Exeggcute",
 		fr: "Noeunoeuf",
+		de: "Owei"
 	},
 
 	suffix: "GX",
@@ -95,7 +96,7 @@ const card: Card = {
 				es: "Carrusel Torre GX",
 				it: "Girotondo Spilungone-GX",
 				pt: "Carrossel Alto GX",
-				de: "Turmreihum GX"
+				de: "Turmreihum-GX"
 			},
 			effect: {
 				en: "Move any number of Energy from your Pokémon to your other Pokémon in any way you like. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Crimson Invasion/108.ts
+++ b/data/Sun & Moon/Crimson Invasion/108.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Type: Null",
 		fr: "Type:0",
+		de: "Typ:Null"
 	},
 
 	suffix: "GX",
@@ -93,7 +94,7 @@ const card: Card = {
 				es: "Rebelarse GX",
 				it: "Ribelle-GX",
 				pt: "Rebelde GX",
-				de: "Rebellieren GX"
+				de: "Rebellieren-GX"
 			},
 			effect: {
 				en: "This attack does 50 damage for each of your opponent’s Benched Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Crimson Invasion/109.ts
+++ b/data/Sun & Moon/Crimson Invasion/109.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mira tus cartas de Premio que están boca abajo y pon 1 de ellas en tu mano. Después, pon esta carta de Gladio entre tus cartas de Premio restantes, barájalas y vuelve a ponerlas boca abajo. Si no has jugado esta carta de Gladio de tu mano, no hace nada.",
 		it: "Guarda le tue carte Premio coperte e aggiungine una alle carte che hai in mano. Poi rimischia questo Iridio nelle tue carte Premio rimanenti e rimettile a faccia in giù. Se non lo hai giocato dalla tua mano, questo Iridio non ha effetto.",
 		pt: "Olhe as suas cartas de Prêmio viradas para baixo e coloque 1 delas na sua mão. Em seguida, embaralhe este Gladio entre as suas cartas de Prêmio restantes e coloque-as de volta viradas para baixo. Se você não jogou este Gladio da sua mão, ele não fará nada.",
-		de: "Sieh dir deine verdeckten Preiskarten an und nimm 1 von ihnen auf deine Hand. Mische anschließend diese Gladio-Karte in deine verbleibenden Preiskarten und lege sie verdeckt zurück. Wenn du diese Gladio-Karte nicht aus deiner Hand gespielt hast, hat sie keine Auswirkungen."
+		de: "Schau dir deine verdeckten Preiskarten an und nimm 1 von ihnen auf deine Hand. Mische anschließend diese Gladio-Karte in deine verbleibenden Preiskarten und lege sie verdeckt zurück. Wenn du diese Gladio-Karte nicht aus deiner Hand gespielt hast, hat sie keine Auswirkungen. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Crimson Invasion/11.ts
+++ b/data/Sun & Moon/Crimson Invasion/11.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Skiddo",
 		fr: "Cabriolaine",
+		de: "Mähikel"
 	},
 
 	stage: "Stage1",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Los ataques de este Pokémon hacen 80 puntos de daño más a los Pokémon Grass de tu rival (antes de aplicar Debilidad y Resistencia).",
 				it: "Gli attacchi di questo Pokémon infliggono 80 danni in più ai Pokémon Grass del tuo avversario, prima di aver applicato debolezza e resistenza.",
 				pt: "Os ataques deste Pokémon causam 80 pontos de dano a mais aos Pokémon Grass do seu oponente (antes de aplicar Fraqueza e Resistência).",
-				de: "Die Attacken dieses Pokémon fügen den Grass-Pokémon deines Gegners 80 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
+				de: "Die Attacken dieses Pokémon fügen den {G}-Pokémon deines Gegners 80 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 		},
 	],
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "It can tell how its trainer is feeling by subtle shifts in the grip on its horns. This empathetic sense lets them run as if one being.",
+		de: "Es kann die Stimmung seines Trainers an der kleinsten Veränderung dessen Griffes um seine Hörner ablesen und galoppiert sofort los, wenn dieser es wünscht."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/110.ts
+++ b/data/Sun & Moon/Crimson Invasion/110.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon 2 cartas de Partidario y de Estadio, en cualquier combinación, de tu pila de descartes en tu mano.",
 		it: "Prendi due carte Aiuto o Stadio in qualsiasi combinazione dalla tua pila degli scarti e aggiungile a quelle che hai in mano.",
 		pt: "Coloque 2 cartas de Apoiador e de Estádio da sua pilha de descarte na sua mão em qualquer combinação.",
-		de: "Nimm eine beliebige Kombination aus 2 Unterstützer- und Stadionkarten aus deinem Ablagestapel auf deine Hand."
+		de: "Nimm eine beliebige Kombination aus 2 Unterstützer- und Stadionkarten aus deinem Ablagestapel auf deine Hand. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Crimson Invasion/111.ts
+++ b/data/Sun & Moon/Crimson Invasion/111.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 2 Pokémon-GX, enséñalos y ponlos en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo fino a due Pokémon-GX, mostrali e aggiungili alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por até 2 Pokémon-GX no seu baralho, revele-os e coloque-os na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach bis zu 2 Pokémon-GX, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach bis zu 2 Pokémon-GX, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Crimson Invasion/112.ts
+++ b/data/Sun & Moon/Crimson Invasion/112.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Magikarp",
 		fr: "Magicarpe",
+		de: "Karpador"
 	},
 
 	suffix: "GX",
@@ -89,7 +90,7 @@ const card: Card = {
 				es: "Tormenta Temor GX",
 				it: "Tempesta Malefica-GX",
 				pt: "Tempestade de Temor GX",
-				de: "Sturm des Schreckens GX"
+				de: "Sturm des Schreckens-GX"
 			},
 			effect: {
 				en: "Discard an Energy from each of your opponent’s Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Crimson Invasion/113.ts
+++ b/data/Sun & Moon/Crimson Invasion/113.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Alolan Graveler",
 		fr: "Gravalanch d’Alola",
+		de: "Alola-Georok"
 	},
 
 	suffix: "GX",
@@ -91,7 +92,7 @@ const card: Card = {
 				es: "Roca Pesada GX",
 				it: "Macigno Ponderoso-GX",
 				pt: "Rocha Pesada GX",
-				de: "Schwerer Felsen GX"
+				de: "Schwerer Felsen-GX"
 			},
 			effect: {
 				en: "Your opponent can’t play any cards from their hand during their next turn. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Crimson Invasion/114.ts
+++ b/data/Sun & Moon/Crimson Invasion/114.ts
@@ -88,7 +88,7 @@ const card: Card = {
 				es: "Parásito GX",
 				it: "Parasitus-GX",
 				pt: "Parasita GX",
-				de: "Schmarotzer GX"
+				de: "Schmarotzer-GX"
 			},
 			effect: {
 				en: "Add the top 2 cards of your opponent’s deck to their Prize cards. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Crimson Invasion/115.ts
+++ b/data/Sun & Moon/Crimson Invasion/115.ts
@@ -89,7 +89,7 @@ const card: Card = {
 				es: "Expansión GX",
 				it: "Expansio-GX",
 				pt: "Expansão GX",
-				de: "Expander GX"
+				de: "Expander-GX"
 			},
 			effect: {
 				en: "This attack does 40 damage for each of your remaining Prize cards. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Crimson Invasion/116.ts
+++ b/data/Sun & Moon/Crimson Invasion/116.ts
@@ -85,7 +85,7 @@ const card: Card = {
 				es: "Voracidad GX",
 				it: "Voracitas-GX",
 				pt: "Voracidade GX",
-				de: "Vielfraß GX"
+				de: "Vielfraß-GX"
 			},
 			effect: {
 				en: "If your opponent’s Pokémon is Knocked Out by damage from this attack, take 2 more Prize cards. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Crimson Invasion/117.ts
+++ b/data/Sun & Moon/Crimson Invasion/117.ts
@@ -86,7 +86,7 @@ const card: Card = {
 				es: "Tajo GX",
 				it: "Sectio-GX",
 				pt: "Lâmina GX",
-				de: "Schwerthieb GX"
+				de: "Schwerthieb-GX"
 			},
 			effect: {
 				en: "Take a Prize card. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Crimson Invasion/118.ts
+++ b/data/Sun & Moon/Crimson Invasion/118.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Exeggcute",
 		fr: "Noeunoeuf",
+		de: "Owei"
 	},
 
 	suffix: "GX",
@@ -95,7 +96,7 @@ const card: Card = {
 				es: "Carrusel Torre GX",
 				it: "Girotondo Spilungone-GX",
 				pt: "Carrossel Alto GX",
-				de: "Turmreihum GX"
+				de: "Turmreihum-GX"
 			},
 			effect: {
 				en: "Move any number of Energy from your Pokémon to your other Pokémon in any way you like. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Crimson Invasion/119.ts
+++ b/data/Sun & Moon/Crimson Invasion/119.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Type: Null",
 		fr: "Type:0",
+		de: "Typ:Null"
 	},
 
 	suffix: "GX",
@@ -93,7 +94,7 @@ const card: Card = {
 				es: "Rebelarse GX",
 				it: "Ribelle-GX",
 				pt: "Rebelde GX",
-				de: "Rebellieren GX"
+				de: "Rebellieren-GX"
 			},
 			effect: {
 				en: "This attack does 50 damage for each of your opponent’s Benched Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Crimson Invasion/12.ts
+++ b/data/Sun & Moon/Crimson Invasion/12.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cubone",
 		fr: "Osselait",
+		de: "Tragosso"
 	},
 
 	stage: "Stage1",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Por cada Energía unida a los Pokémon de tu rival, une 1 carta de Energía Fire de tu pila de descartes a tus Pokémon de la manera que desees.",
 				it: "Per ogni Energia assegnata ai Pokémon del tuo avversario, assegna a piacimento ai tuoi Pokémon una carta Energia Fire dalla tua pila degli scarti.",
 				pt: "Para cada Energia ligada aos Pokémon do seu oponente, ligue 1 carta de Energia Fire da sua pilha de descarte aos seus Pokémon como desejar.",
-				de: "Lege für jede an die Pokémon deines Gegners angelegte Energie 1 Fire-Energiekarte aus deinem Ablagestapel beliebig an deine Pokémon an."
+				de: "Lege für jede an die Pokémon deines Gegners angelegte Energie 1 {R}-Energiekarte aus deinem Ablagestapel beliebig an deine Pokémon an."
 			},
 
 		},
@@ -92,6 +93,7 @@ const card: Card = {
 
 	description: {
 		en: "The bones it possesses were once its mother's. Its mother's regrets have become like a vengeful spirit protecting this Pokémon.",
+		de: "Die Knochen in seinem Besitz stammen von der Mutter. Nach ihrem Tod wurde ihre Trauer zu Flammen, die Knogga nun schützen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/121.ts
+++ b/data/Sun & Moon/Crimson Invasion/121.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Si el Pokémon al que está unida esta carta es tu Pokémon Activo y queda Fuera de Combate por el daño de un ataque de tu rival, mueve hasta 3 cartas de Energía Básica de ese Pokémon a 1 de tus Pokémon en Banca.",
 		it: "Se il Pokémon a cui è assegnata questa carta è il tuo Pokémon attivo e viene messo KO dai danni inflitti da un attacco del tuo avversario, sposta fino a tre carte Energia base da quel Pokémon a uno di quelli nella tua panchina.",
 		pt: "Se o Pokémon ao qual esta carta está ligada for o seu Pokémon Ativo e ele for Nocauteado pelo dano de um ataque do seu oponente, mova até 3 cartas de Energia básica daquele Pokémon para 1 dos seus Pokémon no Banco.",
-		de: "Wenn das Pokémon, an das diese Karte angelegt ist, dein Aktives Pokémon ist und durch Schaden einer Attacke deines Gegners kampfunfähig wird, verschiebe bis zu 3 Basis-Energiekarten von jenem Pokémon auf 1 Pokémon auf deiner Bank."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn das Pokémon, an das diese Karte angelegt ist, dein Aktives Pokémon ist und durch Schaden einer Attacke deines Gegners kampfunfähig wird, verschiebe bis zu 3 Basis-Energiekarten von jenem Pokémon auf 1 Pokémon auf deiner Bank. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sun & Moon/Crimson Invasion/122.ts
+++ b/data/Sun & Moon/Crimson Invasion/122.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Esta carta proporciona 1 Energía Colorless. \n\nSi te quedan más cartas de Premio que a tu rival y esta carta está unida a un Pokémon que no es un Pokémon-GX o un Pokémon-EX, esta carta proporciona cualquier tipo de Energía, pero proporciona solo 2 Energías a la vez.",
 		it: "Questa carta fornisce Energia Colorless.\n\nSe hai più carte Premio rimanenti del tuo avversario e se questa carta è assegnata a un Pokémon che non è un Pokémon-GX o un Pokémon-EX, essa fornisce Energia di qualsiasi tipo, ma solo due alla volta.",
 		pt: "Esta carta fornece Energia Colorless.\n\nSe você tiver mais cartas de Prêmio restantes do que seu oponente e esta carta estiver ligada a um Pokémon que não seja um Pokémon-GX ou Pokémon-EX, esta carta fornecerá todo tipo de Energia, mas só fornecerá 2 Energias por vez.",
-		de: "Diese Karte liefert Colorless-Energie.\n\nWenn du mehr verbleibende Preiskarten als dein Gegner hast und wenn diese Karte an ein Pokémon angelegt ist, das kein Pokémon-GX oder Pokémon-EX ist, liefert diese Karte jeden beliebigen Energietyp, aber immer nur jeweils 2 Energien."
+		de: "Diese Karte liefert {C}-Energie. Wenn du mehr verbleibende Preiskarten als dein Gegner hast und wenn diese Karte an ein Pokémon angelegt ist, das kein Pokémon-GX oder Pokémon-EX ist, liefert diese Karte jeden beliebigen Energietyp, aber immer nur jeweils 2 Energien."
 	},
 
 	energyType: "Special",

--- a/data/Sun & Moon/Crimson Invasion/123.ts
+++ b/data/Sun & Moon/Crimson Invasion/123.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Esta carta proporciona 1 Energía Colorless.\n\nCuando unas esta carta de tu mano a tu Pokémon Activo, cambia ese Pokémon por 1 de tus Pokémon en Banca.",
 		it: "Questa carta fornisce Energia Colorless. \n\nQuando assegni questa carta dalla tua mano al tuo Pokémon attivo, scambia quel Pokémon con uno della tua panchina.",
 		pt: "Esta carta fornece Energia Colorless. \n\nQuando você liga esta carta da sua mão ao seu Pokémon Ativo, troque aquele Pokémon por 1 dos seus Pokémon no Banco.",
-		de: "Diese Karte liefert Colorless-Energie.\n\nWenn du diese Karte aus deiner Hand an dein Aktives Pokémon anlegst, tausche jenes Pokémon gegen 1 Pokémon auf deiner Bank aus."
+		de: "Diese Karte liefert {C}-Energie. Wenn du diese Karte aus deiner Hand an dein Aktives Pokémon anlegst, tausche jenes Pokémon gegen 1 Pokémon auf deiner Bank aus."
 	},
 
 	energyType: "Special",

--- a/data/Sun & Moon/Crimson Invasion/13.ts
+++ b/data/Sun & Moon/Crimson Invasion/13.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "Its humped back stores intensely hot magma. In rain, the magma cools, slowing its movement.",
+		de: "In seinem Rücken speichert es sehr heißes Magma. Regnet es, kühlt das Magma ab und es wird langsamer."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/14.ts
+++ b/data/Sun & Moon/Crimson Invasion/14.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Numel",
 		fr: "Chamallot",
+		de: "Camaub"
 	},
 
 	stage: "Stage1",
@@ -98,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "The volcanoes on its back have a major eruption every 10 years—or whenever it becomes really angry.",
+		de: "Seine Vulkanhöcker brechen nur alle zehn Jahre aus oder wenn es richtig wütend ist."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/15.ts
+++ b/data/Sun & Moon/Crimson Invasion/15.ts
@@ -58,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "Large numbers of these Pokémon make their home at the seaside. At night, a strange red glow radiates from the center of their bodies.",
+		de: "Es taucht in großer Zahl an Ufern auf. Nachts erstrahlt der Kern in seiner Mitte in einem unheimlichen Rot."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/16.ts
+++ b/data/Sun & Moon/Crimson Invasion/16.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Staryu",
 		fr: "Stari",
+		de: "Sterndu"
 	},
 
 	stage: "Stage1",
@@ -85,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "Its shining core is thought to receive and transmit enigmatic signals. It has been known to cause headaches in those who approach it.",
+		de: "Offenbar sendet und empfängt sein leuchtender Kern mysteriöse Radiowellen. Kommt man ihm zu nahe, löst es eventuell Kopfschmerzen aus."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/17.ts
+++ b/data/Sun & Moon/Crimson Invasion/17.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Mientras este Pokémon esté en tu Banca, evita todo el daño infligido a este Pokémon por ataques (tanto tuyos como de tu rival).",
 				it: "Fintanto che questo Pokémon è nella tua panchina, previeni tutti i danni inflitti a questo Pokémon dagli attacchi, sia tuoi che del tuo avversario.",
 				pt: "Desde que este Pokémon esteja em seu Banco, previne todos os danos causados a este Pokémon por ataques (seus e do seu oponente).",
-				de: "Solang sich dieses Pokémon auf deiner Bank befindet, verhindere allen Schaden, der diesem Pokémon durch Angriffe (deine und die deines Gegners) zugefügt wird."
+				de: "Solang sich dieses Pokémon auf deiner Bank befindet, verhindere allen Schaden, der diesem Pokémon durch Attacken (deine und die deines Gegners) zugefügt wird."
 			},
 		},
 	],
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Although weak and helpless, this Pokémon is incredibly fertile. They exist in such multitudes, you'll soon grow tired of seeing them.",
+		de: "Es ist schwach und unzuverlässig, aber es vermehrt sich unglaublich schnell. Deshalb trifft man es auch öfter an, als einem lieb ist."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/18.ts
+++ b/data/Sun & Moon/Crimson Invasion/18.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Magikarp",
 		fr: "Magicarpe",
+		de: "Karpador"
 	},
 
 	suffix: "GX",
@@ -89,7 +90,7 @@ const card: Card = {
 				es: "Tormenta Temor GX",
 				it: "Tempesta Malefica-GX",
 				pt: "Tempestade de Temor GX",
-				de: "Sturm des Schreckens GX"
+				de: "Sturm des Schreckens-GX"
 			},
 			effect: {
 				en: "Discard an Energy from each of your opponent’s Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Crimson Invasion/19.ts
+++ b/data/Sun & Moon/Crimson Invasion/19.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "It rubs its snout on the ground to find and dig up food. It sometimes discovers hot springs.",
+		de: "Auf Nahrungssuche schnüffelt es am Boden entlang. Es entdeckt dabei manchmal auch heiße Quellen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/2.ts
+++ b/data/Sun & Moon/Crimson Invasion/2.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Weedle",
 		fr: "Aspicot",
+		de: "Hornliu"
 	},
 
 	stage: "Stage1",
@@ -69,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "Almost incapable of moving, this Pokémon can only harden its shell to protect itself when it is in danger.",
+		de: "Dieses Pokémon kann sich kaum bewegen. Bei drohender Gefahr verhärtet es seinen Panzer."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/20.ts
+++ b/data/Sun & Moon/Crimson Invasion/20.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Swinub",
 		fr: "Marcacrin",
+		de: "Quiekel"
 	},
 
 	stage: "Stage1",
@@ -88,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "Although its legs are short, its rugged hooves prevent it from slipping, even on icy ground.",
+		de: "Trotz kurzer Beine rutscht es auf eisigen Flächen nicht aus, da seine Hufe ihm genügend Halt bieten."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/21.ts
+++ b/data/Sun & Moon/Crimson Invasion/21.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Piloswine",
 		fr: "Cochignon",
+		de: "Keifel"
 	},
 
 	stage: "Stage2",
@@ -98,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "A frozen Mamoswine was dug from ice dating back 10,000 years. This Pokémon has been around a long, long, long time.",
+		de: "Es existiert schon seit Urzeiten. Mamutel wurde sogar schon in 10 000 Jahre altem Eis gefunden."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/22.ts
+++ b/data/Sun & Moon/Crimson Invasion/22.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "It has superb accuracy. The water it shoots out can strike even moving prey from more than 300 feet.",
+		de: "Es ist äußerst präzise. Es kann mit seinem Wasserschuss Beute erlegen, die 100 m entfernt ist."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/23.ts
+++ b/data/Sun & Moon/Crimson Invasion/23.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Remoraid",
 		fr: "Rémoraid",
+		de: "Remoraid"
 	},
 
 	stage: "Stage1",
@@ -93,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "It has a tendency to want to be in holes. It prefers rock crags or pots and sprays ink from them before attacking.",
+		de: "Es verkriecht sich gerne in Löchern, von wo aus es Gegner mit Tinte beschießt. Es bevorzugt Felsspalten und Vasen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/24.ts
+++ b/data/Sun & Moon/Crimson Invasion/24.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "No matter how dirty the water in the river, it will adapt and thrive. It has a strong will to survive.",
+		de: "Egal, wie schmutzig der Fluss ist, in dem sie leben, sie passen sich daran an und vermehren sich. Sie sind hart im Nehmen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/25.ts
+++ b/data/Sun & Moon/Crimson Invasion/25.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Corphish",
 		fr: "Écrapince",
+		de: "Krebscorps"
 	},
 
 	stage: "Stage1",
@@ -73,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "It is a ruffian that uses its pincers to pick up and toss out other Pokémon from its pond.",
+		de: "Dieser Grobian ergreift andere Pokémon mit seinen Scheren und wirft sie aus seinem Teich."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/26.ts
+++ b/data/Sun & Moon/Crimson Invasion/26.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "A tough Pokémon that is perfectly fine even in dirty water. However, due to its ragged, shabby appearance, it isn't popular.",
+		de: "Dieses robuste Pokémon fühlt sich selbst in verschmutztem Wasser wohl. So schäbig und zerfetzt es ist, so unbeliebt ist es auch."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/27.ts
+++ b/data/Sun & Moon/Crimson Invasion/27.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Feebas",
 		fr: "Barpau",
+		de: "Barschwa"
 	},
 
 	stage: "Stage1",
@@ -95,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "Milotic has provided inspiration to many artists. It has even been referred to as the most beautiful Pokémon of all.",
+		de: "Milotic soll das schönste aller Pokémon sein. Es hat schon so manchem Künstler als Quelle der Inspiration gedient."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/28.ts
+++ b/data/Sun & Moon/Crimson Invasion/28.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said to have slept in a glacier for thousands of years. Its body can't be melted, even by magma.",
+		de: "Es heißt, es habe Jahrtausende lang im ewigen Eis geschlummert. Selbst Magma schmilzt es nicht."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/29.ts
+++ b/data/Sun & Moon/Crimson Invasion/29.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "For the most part, it makes its home along the seashore. Its color and form differ according to its habitat and the quality of its food.",
+		de: "Es lebt hauptsächlich in Küstengebieten. Seine Form und Farbe ändern sich je nach Lebensraum und Futter."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/3.ts
+++ b/data/Sun & Moon/Crimson Invasion/3.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Kakuna",
 		fr: "Coconfort",
+		de: "Kokuna"
 	},
 
 	stage: "Stage2",
@@ -86,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "May appear in a swarm. Flies at violent speeds, all the while stabbing with the toxic stinger on its rear.",
+		de: "Dieses Pokémon verfügt über drei Giftstachel. Es kann seine Gegner damit wiederholt stechen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/30.ts
+++ b/data/Sun & Moon/Crimson Invasion/30.ts
@@ -95,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "A plan was recently announced to gather many Pikachu and make an electric power plant.",
+		de: "Vor Kurzem wurden Pläne verkündet, mithilfe einer großen Anzahl an Pikachu ein ganzes Kraftwerk zu betreiben."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/31.ts
+++ b/data/Sun & Moon/Crimson Invasion/31.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pikachu",
 		fr: "Pikachu",
+		de: "Pikachu"
 	},
 
 	stage: "Stage1",
@@ -101,6 +102,7 @@ const card: Card = {
 
 	description: {
 		en: "It only evolves to this form in the Alola region. According to researchers, its diet is one of the causes of this change.",
+		de: "Es entwickelt sich nur in Alola zu dieser Form. Forscher behaupten, dass einer der Gründe dafür das dortige Futter sei."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/32.ts
+++ b/data/Sun & Moon/Crimson Invasion/32.ts
@@ -86,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "Its body is a magnetic stone. Iron sand attaches firmly to the portions of its body that are particularly magnetic.",
+		de: "Sein Steinkörper ist von Magnetkraft erfüllt. An den Stellen, wo diese besonders stark wirkt, heften sich Schichten von Eisensand an."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/33.ts
+++ b/data/Sun & Moon/Crimson Invasion/33.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Alolan Geodude",
 		fr: "Racaillou d’Alola",
+		de: "Alola-Kleinstein"
 	},
 
 	stage: "Stage1",
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "Its preferred food is dravite. After it has eaten this mineral, crystals form inside the Pokémon, rising to the surface of part of its body.",
+		de: "Georok ernährt sich vorzugsweise von Draviten. Die verzehrten Teilchen werden zu Kristallen, die an einer Körperstelle hervortreten."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/34.ts
+++ b/data/Sun & Moon/Crimson Invasion/34.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Alolan Graveler",
 		fr: "Gravalanch d’Alola",
+		de: "Alola-Georok"
 	},
 
 	suffix: "GX",
@@ -91,7 +92,7 @@ const card: Card = {
 				es: "Roca Pesada GX",
 				it: "Macigno Ponderoso-GX",
 				pt: "Rocha Pesada GX",
-				de: "Schwerer Felsen GX"
+				de: "Schwerer Felsen-GX"
 			},
 			effect: {
 				en: "Your opponent can’t play any cards from their hand during their next turn. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Crimson Invasion/35.ts
+++ b/data/Sun & Moon/Crimson Invasion/35.ts
@@ -69,7 +69,7 @@ const card: Card = {
 				es: "Cambia este Pokémon por 1 de tus Pokémon Lightning en Banca.",
 				it: "Scambia questo Pokémon con un Pokémon Lightning della tua panchina.",
 				pt: "Troque este Pokémon por 1 dos seus Pokémon Lightning no Banco.",
-				de: "Tausche dieses Pokémon gegen 1 Lightning-Pokémon auf deiner Bank aus."
+				de: "Tausche dieses Pokémon gegen 1 {L}-Pokémon auf deiner Bank aus."
 			},
 			damage: 30,
 
@@ -94,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "It glides using its cape-like membrane. Electrical energy scatters from it, shocking its friends and foes alike.",
+		de: "Es gleitet mit seinen Fluglappen, die einem Cape ähneln, durch die Luft. Es entlädt ständig Strom, der Freund und Feind Stromschläge verpasst."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/36.ts
+++ b/data/Sun & Moon/Crimson Invasion/36.ts
@@ -71,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "Should a strange light be seen flickering in an abandoned building, Gastly is lurking there.",
+		de: "Flackert in einem verlassenen alten Gebäude plötzlich ein rätselhaftes Licht auf, hält sich dort ein Nebulak versteckt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/37.ts
+++ b/data/Sun & Moon/Crimson Invasion/37.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gastly",
 		fr: "Fantominus",
+		de: "Nebulak"
 	},
 
 	stage: "Stage1",
@@ -76,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "It strikes at humans from total darkness. Those licked by its cold tongue grow weaker with each passing day until they die.",
+		de: "Es lauert Menschen im Dunkeln auf und leckt sie mit seiner kalten Zunge. Danach werden sie von Tag zu Tag schwächer, bis sie dahinscheiden."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/38.ts
+++ b/data/Sun & Moon/Crimson Invasion/38.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Haunter",
 		fr: "Spectrum",
+		de: "Alpollo"
 	},
 
 	stage: "Stage2",
@@ -101,6 +102,7 @@ const card: Card = {
 
 	description: {
 		en: "Should you feel yourself attacked by a sudden chill, it is evidence of an approaching Gengar. There is no escaping it. Give up.",
+		de: "Läuft es einem plötzlich eiskalt den Rücken hinunter, wurde man von Gengar als nächstes Opfer auserkoren. Widerstand ist zwecklos."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/39.ts
+++ b/data/Sun & Moon/Crimson Invasion/39.ts
@@ -71,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "It will use any means necessary to frighten people and absorb their life energy. It practices constantly to hone its skill in causing fear.",
+		de: "Es lässt nichts unversucht, um Menschen zu erschrecken und ihnen Lebensenergie abzusaugen. Dafür übt es regelmäßig."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/4.ts
+++ b/data/Sun & Moon/Crimson Invasion/4.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "Its six eggs use telepathy to communicate among themselves. It is believed to carry plant genes and the genes of other species.",
+		de: "Die sechs Eier kommunizieren telepathisch miteinander. Sie tragen das Erbgut von Pflanzen sowie Pokémon eines bestimmten Typs in sich."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/40.ts
+++ b/data/Sun & Moon/Crimson Invasion/40.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Misdreavus",
 		fr: "Feuforêve",
+		de: "Traunfugil"
 	},
 
 	stage: "Stage1",
@@ -102,6 +103,7 @@ const card: Card = {
 
 	description: {
 		en: "It appears as if from nowhere—muttering incantations, placing curses, and giving people terrifying visions.",
+		de: "Es erscheint aus dem Nichts, flüstert Beschwörungen, spricht Flüche aus und erzeugt furchteinflößende Trugbilder."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/41.ts
+++ b/data/Sun & Moon/Crimson Invasion/41.ts
@@ -58,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "It bounces constantly, using its tail like a spring. The shock of bouncing keeps its heart beating.",
+		de: "Es hüpft beständig umher, wobei es seinen Schweif als Feder verwendet. Nur so bleibt sein Herz aktiv."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/42.ts
+++ b/data/Sun & Moon/Crimson Invasion/42.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Spoink",
 		fr: "Spoink",
+		de: "Spoink"
 	},
 
 	stage: "Stage1",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "It uses black pearls to amplify its psychic power. It does a strange dance to control foes' minds.",
+		de: "Mit schwarzen Perlen verstärkt es seine Psycho-Kräfte. Mit einem Tanz kontrolliert es seine Gegner."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/43.ts
+++ b/data/Sun & Moon/Crimson Invasion/43.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It uses the sucker on its head to hang from a tree or from eaves. It can produce seven different tones.",
+		de: "Mit seinem Saugnapf hängt es sich an Äste oder unter Vordächer. Es kennt sieben verschiedene Schreie."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/44.ts
+++ b/data/Sun & Moon/Crimson Invasion/44.ts
@@ -71,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "The pumpkin body is inhabited by a spirit trapped in this world. As the sun sets, it becomes restless and active.",
+		de: "Es entsteht aus der Vereinigung einer in der Welt der Lebenden gefangenen Seele mit einem Kürbis. Es wird erst nach Sonnenuntergang aktiv."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/45.ts
+++ b/data/Sun & Moon/Crimson Invasion/45.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pumpkaboo",
 		fr: "Pitrouille",
+		de: "Irrbis"
 	},
 
 	stage: "Stage1",
@@ -100,6 +101,7 @@ const card: Card = {
 
 	description: {
 		en: "Singing in eerie voices, they wander town streets on the night of the new moon. Anyone who hears their song is cursed.",
+		de: "Unter unheimlichen Gesängen durchstreift es in Neumondnächten Städte und Dörfer. Wer dem unheilvollen Gesang lauscht, wird verflucht."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/46.ts
+++ b/data/Sun & Moon/Crimson Invasion/46.ts
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "It burns its bodily fluids to create a poisonous gas. When its enemies become disoriented from inhaling the gas, it attacks them.",
+		de: "Durch Verbrennung von Körperflüssigkeit erzeugt es ein Gas, das Feinde schwindelig und so zu leichten Zielen macht."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/47.ts
+++ b/data/Sun & Moon/Crimson Invasion/47.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Salandit",
 		fr: "Tritox",
+		de: "Molunk"
 	},
 
 	stage: "Stage1",
@@ -91,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "For some reason, only females have been found. It creates a reverse harem of male Salandit that it lives with.",
+		de: "Bisher wurden nur Weibchen entdeckt. Sie werden von männlichen Molunk verehrt und leben mit einer Gruppe von ihnen zusammen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/48.ts
+++ b/data/Sun & Moon/Crimson Invasion/48.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "Known for its extreme intelligence, this Pokémon will look down on inexperienced Trainers, so it's best suited to veteran Trainers.",
+		de: "Es ist als extrem schlaues Pokémon bekannt. Nicht so beliebt bei unerfahrenen Trainern, doch Veteranen wissen es zu schätzen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/49.ts
+++ b/data/Sun & Moon/Crimson Invasion/49.ts
@@ -88,7 +88,7 @@ const card: Card = {
 				es: "Parásito GX",
 				it: "Parasitus-GX",
 				pt: "Parasita GX",
-				de: "Schmarotzer GX"
+				de: "Schmarotzer-GX"
 			},
 			effect: {
 				en: "Add the top 2 cards of your opponent’s deck to their Prize cards. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Crimson Invasion/5.ts
+++ b/data/Sun & Moon/Crimson Invasion/5.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Si este Pokémon tiene alguna Energía Darkness unida a él, este ataque hace 30 puntos de daño más.",
 				it: "Se questo Pokémon ha delle Energie Darkness assegnate, questo attacco infligge 30 danni in più.",
 				pt: "Se este Pokémon tiver alguma Energia Darkness ligada a ele, este ataque causará 30 pontos de dano a mais.",
-				de: "Wenn an dieses Pokémon mindestens 1 Darkness-Energie angelegt ist, fügt diese Attacke 30 Schadenspunkte mehr zu."
+				de: "Wenn an dieses Pokémon mindestens 1 {D}-Energie angelegt ist, fügt diese Attacke 30 Schadenspunkte mehr zu."
 			},
 			damage: "10+",
 
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives in arid locations. Its yellow flowers bloom once a year.",
+		de: "Es wächst an trockenen Orten mit wenig Niederschlag. Nur einmal im Jahr bildet es eine gelbe Blüte."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/50.ts
+++ b/data/Sun & Moon/Crimson Invasion/50.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It can spontaneously become enraged. Everyone near it clears out as it rampages and the resulting loneliness makes it angrier still.",
+		de: "Es rastet häufig völlig unvermittelt aus. Danach findet es sich oft mutterseelenallein wieder. Das macht es schließlich noch wütender."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/51.ts
+++ b/data/Sun & Moon/Crimson Invasion/51.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Mankey",
 		fr: "Férosinge",
+		de: "Menki"
 	},
 
 	stage: "Stage1",
@@ -88,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It has been known to become so angry that it dies as a result. Its face looks peaceful in death, however.",
+		de: "Manchmal rastet es so aus, dass es auf der Stelle tot umfällt. Sein Gesichtsausdruck ist danach jedoch äußerst friedlich."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/52.ts
+++ b/data/Sun & Moon/Crimson Invasion/52.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "When it thinks of its deceased mother, it weeps loudly. Mandibuzz that hear its cries will attack it from the air.",
+		de: "Denkt es an seine verstorbene Mutter, weint es laut. Hört dies ein Grypheldis, nutzt dieses die Gelegenheit, um es aus der Luft anzugreifen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/53.ts
+++ b/data/Sun & Moon/Crimson Invasion/53.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "Its entire body is made of rock. If any part chips off in battle, it attaches rocks to repair itself.",
+		de: "Sein Körper besteht aus Stein. Bricht im Kampf etwas heraus, wird es durch Stein wieder ersetzt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/54.ts
+++ b/data/Sun & Moon/Crimson Invasion/54.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Shellos",
 		fr: "Sancoki",
+		de: "Schalellos"
 	},
 
 	stage: "Stage1",
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "It has strong regenerative capabilities. Even if parts of it are bitten off by fish Pokémon, it will return to normal within a few hours.",
+		de: "Es hat starke Regenerationskräfte. Selbst wenn Fisch-Pokémon ein Stück von ihm abbeißen, wächst es innerhalb weniger Stunden nach."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/55.ts
+++ b/data/Sun & Moon/Crimson Invasion/55.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "Despite its adorable appearance, when it gets angry and flails about, its arms and legs could knock a pro wrestler sprawling.",
+		de: "Es sieht sehr süß aus, aber wehe, es wird wütend. Mit seinen Armen wirbelnd haut es selbst den stärksten Wrestler um."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/56.ts
+++ b/data/Sun & Moon/Crimson Invasion/56.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Stufful",
 		fr: "Nounourson",
+		de: "Velursi"
 	},
 
 	stage: "Stage1",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Los ataques de los Pokémon no Fire de tu rival hacen 30 puntos de daño menos a este Pokémon (después de aplicar Debilidad y Resistencia).",
 				it: "Questo Pokémon subisce 30 danni in meno dagli attacchi dei Pokémon non di tipo Fire del tuo avversario, dopo aver applicato debolezza e resistenza.",
 				pt: "Este Pokémon recebe 30 pontos de dano a menos de ataques dos Pokémon do seu oponente que não são Pokémon Fire (após a aplicação de Fraqueza e Resistência).",
-				de: "Diesem Pokémon werden durch Attacken der Pokémon deines Gegners, die keine Fire-Pokémon sind, 30 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden)."
+				de: "Diesem Pokémon werden durch Attacken der Pokémon deines Gegners, die keine {R}-Pokémon sind, 30 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 		},
 	],
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "This immensely dangerous Pokémon possesses overwhelming physical strength. Its habitat is generally off-limits.",
+		de: "Dieses Pokémon verfügt über immense Muskelkraft und ist äußerst gefährlich. Sein Habitat ist generell Sperrgebiet."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/57.ts
+++ b/data/Sun & Moon/Crimson Invasion/57.ts
@@ -89,7 +89,7 @@ const card: Card = {
 				es: "Expansión GX",
 				it: "Expansio-GX",
 				pt: "Expansão GX",
-				de: "Expander GX"
+				de: "Expander-GX"
 			},
 			effect: {
 				en: "This attack does 40 damage for each of your remaining Prize cards. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Crimson Invasion/58.ts
+++ b/data/Sun & Moon/Crimson Invasion/58.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "Around dawn, its ominous howl echoes through the area to announce that this is its territory.",
+		de: "Im Morgengrauen schallt sein ominöses Geheule über das Gebiet, das es für sich beansprucht."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/59.ts
+++ b/data/Sun & Moon/Crimson Invasion/59.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Houndour",
 		fr: "Malosse",
+		de: "Hunduster"
 	},
 
 	stage: "Stage1",
@@ -103,6 +104,7 @@ const card: Card = {
 
 	description: {
 		en: "Long ago, people imagined its eerie howls to be the call of the grim reaper.",
+		de: "In alten Zeiten glaubte man, das Heulen dieses Pokémon sei der Ruf des Todes."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/6.ts
+++ b/data/Sun & Moon/Crimson Invasion/6.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cacnea",
 		fr: "Cacnea",
+		de: "Tuska"
 	},
 
 	stage: "Stage1",
@@ -93,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "It becomes active at night, seeking prey that is exhausted from the day's desert heat.",
+		de: "Ein nachtaktives Pokémon, das Beute sucht, die durch die Tageshitze der Wüste bereits erschöpft ist."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/60.ts
+++ b/data/Sun & Moon/Crimson Invasion/60.ts
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "They cannot see, so they tackle and bite to learn about their surroundings. Their bodies are covered in wounds.",
+		de: "Da es nichts sehen kann, sucht es seine Umgebung mit Rempel- und Bissattacken ab und ist immer mit Wunden übersät."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/61.ts
+++ b/data/Sun & Moon/Crimson Invasion/61.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Deino",
 		fr: "Solochi",
+		de: "Kapuno"
 	},
 
 	stage: "Stage1",
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "The two heads do not get along. Whichever head eats more than the other gets to be the leader.",
+		de: "Seine zwei Köpfe sind sich spinnefeind. Beide versuchen, über Fresswettbewerbe die Oberhand zu gewinnen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/62.ts
+++ b/data/Sun & Moon/Crimson Invasion/62.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Zweilous",
 		fr: "Diamat",
+		de: "Duodino"
 	},
 
 	stage: "Stage2",
@@ -101,6 +102,7 @@ const card: Card = {
 
 	description: {
 		en: "The heads on their arms do not have brains. They use all three heads to consume and destroy everything.",
+		de: "Die Köpfe an seinen beiden Armen haben kein eigenes Gehirn. Seine drei Mäuler kauen alles radikal kurz und klein."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/63.ts
+++ b/data/Sun & Moon/Crimson Invasion/63.ts
@@ -85,7 +85,7 @@ const card: Card = {
 				es: "Voracidad GX",
 				it: "Voracitas-GX",
 				pt: "Voracidade GX",
-				de: "Vielfraß GX"
+				de: "Vielfraß-GX"
 			},
 			effect: {
 				en: "If your opponent’s Pokémon is Knocked Out by damage from this attack, take 2 more Prize cards. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Crimson Invasion/63a.ts
+++ b/data/Sun & Moon/Crimson Invasion/63a.ts
@@ -4,7 +4,8 @@ import Set from '../Crimson Invasion'
 const card: Card = {
 	name: {
 		en: "Guzzlord-GX",
-		fr: "Engloutyran-GX"
+		fr: "Engloutyran-GX",
+		de: "Schlingking-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Rare",
@@ -29,11 +30,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Eat Sloppily",
-				fr: "Repas Baveux"
+				fr: "Repas Baveux",
+				de: "Kleckerkost"
 			},
 			effect: {
 				en: "Discard the top 5 cards of your deck. If any of those cards are Energy cards, attach them to this Pokémon.",
-				fr: "Défaussez les 5 cartes du dessus de votre deck. Si vous y trouvez des cartes Énergie, attachez-les à ce Pokémon."
+				fr: "Défaussez les 5 cartes du dessus de votre deck. Si vous y trouvez des cartes Énergie, attachez-les à ce Pokémon.",
+				de: "Lege die obersten 5 Karten von deinem Deck auf deinen Ablagestapel. Wenn unter jenen Karten Energiekarten sind, lege sie an dieses Pokémon an."
 			},
 
 		},
@@ -47,7 +50,8 @@ const card: Card = {
 			],
 			name: {
 				en: "Tyrannical Hole",
-				fr: "Trou Tyrannique"
+				fr: "Trou Tyrannique",
+				de: "Despotischer Schlund"
 			},
 
 			damage: 180,
@@ -63,11 +67,13 @@ const card: Card = {
 			],
 			name: {
 				en: "Glutton-GX",
-				fr: "Gourmandise GX"
+				fr: "Gourmandise GX",
+				de: "Vielfraß-GX"
 			},
 			effect: {
 				en: "If your opponent's Pokémon is Knocked Out by damage from this attack, take 2 more Prize cards. (You can't use more than 1 GX attack in a game.)",
-				fr: "Si le Pokémon de votre adversaire est mis K.O. par les dégâts de cette attaque, récupérez 2 cartes Récompense supplémentaires. (Vous ne pouvez utiliser qu'une attaque GX par partie.)"
+				fr: "Si le Pokémon de votre adversaire est mis K.O. par les dégâts de cette attaque, récupérez 2 cartes Récompense supplémentaires. (Vous ne pouvez utiliser qu'une attaque GX par partie.)",
+				de: "Wenn das Pokémon deines Gegners durch Schaden dieser Attacke kampfunfähig wird, nimm 2 Preiskarten mehr. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: 100,
 

--- a/data/Sun & Moon/Crimson Invasion/64.ts
+++ b/data/Sun & Moon/Crimson Invasion/64.ts
@@ -95,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "It uses its docile-looking face to lull foes into complacency, then bites with its huge, relentless jaws.",
+		de: "Mit seinem friedlichen Gesicht bringt es Gegner zur Selbstgefälligkeit und beißt anschließend mit seinem riesigen Kiefer gnadenlos zu."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/65.ts
+++ b/data/Sun & Moon/Crimson Invasion/65.ts
@@ -83,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "It usually lives deep in mountains. However, hunger may drive it to eat railroad tracks and cars.",
+		de: "Normalerweise lebt es in dunklen Bergen. Ist es hungrig, frisst es auch Eisenbahnschienen und Autos."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/66.ts
+++ b/data/Sun & Moon/Crimson Invasion/66.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Aron",
 		fr: "Galekid",
+		de: "Stollunior"
 	},
 
 	stage: "Stage1",
@@ -89,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "It loves iron ore. Groups of them fight for territory by bashing one another with their steel bodies.",
+		de: "Ist verrückt nach Eisenerz. Bei Revierkämpfen stoßen Stollrak einander mit ihren Stahlkörpern."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/67.ts
+++ b/data/Sun & Moon/Crimson Invasion/67.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Lairon",
 		fr: "Galegon",
+		de: "Stollrak"
 	},
 
 	stage: "Stage2",
@@ -105,6 +106,7 @@ const card: Card = {
 
 	description: {
 		en: "It claims an entire mountain as its own. The more wounds it has, the more it has battled, so don't take it lightly.",
+		de: "Ihre Reviere erstrecken sich über ganze Gebirge. Stolloss, die mit Narben übersät sind, sollte man besser meiden."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/68.ts
+++ b/data/Sun & Moon/Crimson Invasion/68.ts
@@ -97,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "Tempered by pressure underground over tens of thousands of years, its body cannot be scratched.",
+		de: "Im Laufe der Jahrtausende, die es unterirdisch lebte, wurde sein Körper durch Druck und Wärme hart."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/69.ts
+++ b/data/Sun & Moon/Crimson Invasion/69.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Karrablast",
 		fr: "Carabing",
+		de: "Laukaps"
 	},
 
 	stage: "Stage1",
@@ -102,6 +103,7 @@ const card: Card = {
 
 	description: {
 		en: "Wearing the shell covering they stole from Shelmet, they defend themselves and attack with two lances.",
+		de: "Eine von einem Schnuthelm gestohlene Muschel dient ihm als Helm. Es greift Gegner mit seinen beiden Lanzen an."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/7.ts
+++ b/data/Sun & Moon/Crimson Invasion/7.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "These mysterious Pokémon evolve when they receive electrical stimulation while they are in the same place as Shelmet.",
+		de: "Ein mysteriöses Pokémon, das sich entwickelt, wenn es zusammen mit Schnuthelm einen Stromschlag abbekommt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/70.ts
+++ b/data/Sun & Moon/Crimson Invasion/70.ts
@@ -86,7 +86,7 @@ const card: Card = {
 				es: "Tajo GX",
 				it: "Sectio-GX",
 				pt: "Lâmina GX",
-				de: "Schwerthieb GX"
+				de: "Schwerthieb-GX"
 			},
 			effect: {
 				en: "Take a Prize card. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Crimson Invasion/71.ts
+++ b/data/Sun & Moon/Crimson Invasion/71.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It hugely inflates its stomach and sings a mysterious melody. If you hear this melody, you'll become sleepy right away.",
+		de: "Es kann tief einatmen und seinen Bauch mit Luft füllen, um ein sonderbares Lied anzustimmen. Wer dieses hört, schläft auf der Stelle ein."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/72.ts
+++ b/data/Sun & Moon/Crimson Invasion/72.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Jigglypuff",
 		fr: "Rondoudou",
+		de: "Pummeluff"
 	},
 
 	stage: "Stage1",
@@ -78,7 +79,7 @@ const card: Card = {
 				es: "Si alguno de los Pokémon de tu rival tiene alguna Energía Darkness unida a él, este ataque hace 60 puntos de daño más.",
 				it: "Se uno qualsiasi dei Pokémon del tuo avversario ha delle Energie Darkness assegnate, questo attacco infligge 60 danni in più.",
 				pt: "Se algum dos Pokémon do seu oponente tiver alguma Energia Darkness ligada a ele, este ataque causará 60 pontos de dano a mais.",
-				de: "Wenn an die Pokémon deines Gegners mindestens 1 Darkness-Energie angelegt ist, fügt diese Attacke 60 Schadenspunkte mehr zu."
+				de: "Wenn an die Pokémon deines Gegners mindestens 1 {D}-Energie angelegt ist, fügt diese Attacke 60 Schadenspunkte mehr zu."
 			},
 			damage: "60+",
 
@@ -103,6 +104,7 @@ const card: Card = {
 
 	description: {
 		en: "It sheds its fine fur when the seasons change. The fur is gathered and spun into a luxurious yarn.",
+		de: "Pünktlich zum Wechsel der Jahreszeiten streift es sein kuschelig weiches Fell ab. Der Stoff, der sich daraus spinnen lässt, gilt als Luxusgut."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/73.ts
+++ b/data/Sun & Moon/Crimson Invasion/73.ts
@@ -96,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "Legends say it can share eternal life. It slept for a thousand years in the form of a tree before its revival.",
+		de: "Legenden nach kann dieses Pokémon ewiges Leben spenden. In Gestalt eines Baumes ist es aus seinem tausendjährigen Schlaf erwacht."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/74.ts
+++ b/data/Sun & Moon/Crimson Invasion/74.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Exeggcute",
 		fr: "Noeunoeuf",
+		de: "Owei"
 	},
 
 	suffix: "GX",
@@ -95,7 +96,7 @@ const card: Card = {
 				es: "Carrusel Torre GX",
 				it: "Girotondo Spilungone-GX",
 				pt: "Carrossel Alto GX",
-				de: "Turmreihum GX"
+				de: "Turmreihum-GX"
 			},
 			effect: {
 				en: "Move any number of Energy from your Pokémon to your other Pokémon in any way you like. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Crimson Invasion/75.ts
+++ b/data/Sun & Moon/Crimson Invasion/75.ts
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "It expresses its feelings by smacking its scales. Metallic sounds echo through the tall mountains where Jangmo-o lives.",
+		de: "Es übermittelt seine Gefühle durch das Rasseln seiner Schuppen, wodurch im Hochgebirge, in dem es lebt, ein metallisches Geräusch erhallt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/76.ts
+++ b/data/Sun & Moon/Crimson Invasion/76.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Jangmo-o",
 		fr: "Bébécaille",
+		de: "Miniras"
 	},
 
 	stage: "Stage1",
@@ -86,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "It leaps at its prey with a courageous shout. Its scaly punches tear its opponents to shreds.",
+		de: "Mit einem Kampfschrei stürzt es sich auf seine Beute und reißt sie mithilfe seiner Schuppen in kleine Stücke."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/77.ts
+++ b/data/Sun & Moon/Crimson Invasion/77.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Hakamo-o",
 		fr: "Écaïd",
+		de: "Mediras"
 	},
 
 	stage: "Stage2",
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "When it spots enemies, it threatens them by jingling the scales on its tail. Weak opponents will crack and flee in panic.",
+		de: "Wenn es einen Gegner sieht, rasselt es drohend mit seinen Schwanzschuppen. Schwache Gegner verlieren dadurch die Fassung und fliehen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/78.ts
+++ b/data/Sun & Moon/Crimson Invasion/78.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "Its milk is high in calories and packed with nutrients. Therefore, if you drink too much of it, you may wind up with a body like Miltank's.",
+		de: "Seine Milch ist kalorienreich und enthält viele Nährstoffe. Trinkt man zu viel davon, hat man allerdings selbst bald eine Figur wie Miltank."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/79.ts
+++ b/data/Sun & Moon/Crimson Invasion/79.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "For some reason, it likes to land on people's heads softly and act like it's a hat.",
+		de: "Aus irgendeinem Grund setzt es sich gerne auf den Kopf von Menschen und tut so, als sei es ein Hut."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/8.ts
+++ b/data/Sun & Moon/Crimson Invasion/8.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "When it and Karrablast are together, and both receive electrical stimulation, they both evolve.",
+		de: "Hält sich ein Laukaps in seiner Nähe auf und kommen beide mit Strom in Berührung, entwickeln sie sich."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/80.ts
+++ b/data/Sun & Moon/Crimson Invasion/80.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Swablu",
 		fr: "Tylton",
+		de: "Wablu"
 	},
 
 	stage: "Stage1",
@@ -52,7 +53,7 @@ const card: Card = {
 				es: "Lanza 1 moneda. Si sale cara, busca en tu baraja 1 Pokémon Dragon y ponlo en tu Banca. Después, baraja las cartas de tu baraja.",
 				it: "Lancia una moneta. Se esce testa, cerca nel tuo mazzo un Pokémon Dragon e mettilo in panchina. Poi rimischia le carte del tuo mazzo.",
 				pt: "Jogue 1 moeda. Se sair cara, procure por 1 Pokémon Dragon no seu baralho e coloque-o no seu Banco. Em seguida, embaralhe o seu baralho.",
-				de: "Wirf 1 Münze. Durchsuche bei Kopf dein Deck nach 1 Dragon-Pokémon und lege es auf deine Bank. Mische anschließend dein Deck."
+				de: "Wirf 1 Münze. Durchsuche bei Kopf dein Deck nach 1 {N}-Pokémon und lege es auf deine Bank. Mische anschließend dein Deck."
 			},
 
 		},
@@ -99,6 +100,7 @@ const card: Card = {
 
 	description: {
 		en: "It flies gracefully through the sky. Its melodic humming makes you feel like you're in a dream.",
+		de: "Es schwebt gemächlich durch den Himmel. Sein wunderschönes Summen gibt einem das Gefühl zu träumen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/81.ts
+++ b/data/Sun & Moon/Crimson Invasion/81.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "They flock in great numbers. Though small, they flap their wings with great power.",
+		de: "Ihr Schwarm ist stets groß. Obwohl es kleine Pokémon sind, schwingen sie ihre Flügel mit enormer Kraft."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/82.ts
+++ b/data/Sun & Moon/Crimson Invasion/82.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Starly",
 		fr: "Étourmi",
+		de: "Staralili"
 	},
 
 	stage: "Stage1",
@@ -88,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "They maintain huge flocks, although fierce scuffles break out between various flocks.",
+		de: "Es neigt dazu, sich in großen Gruppen zu bewegen. Zwischen ihnen kommt es zu heftigen Kämpfen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/83.ts
+++ b/data/Sun & Moon/Crimson Invasion/83.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Staravia",
 		fr: "Étourvol",
+		de: "Staravia"
 	},
 
 	stage: "Stage2",
@@ -104,6 +105,7 @@ const card: Card = {
 
 	description: {
 		en: "The muscles in its wings and legs are strong. It can easily fly while gripping a small Pokémon.",
+		de: "Die Muskeln in seinen Flügeln und Beinen sind stark. Es kann im Flug sogar ein anderes Pokémon tragen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/84.ts
+++ b/data/Sun & Moon/Crimson Invasion/84.ts
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said to have made Pokémon that look like itself from a special ice mountain, rocks, and magma.",
+		de: "Man sagt, es habe Pokémon aus einem Eisberg, Felsen und Magma nach seinem Abbild geschaffen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/85.ts
+++ b/data/Sun & Moon/Crimson Invasion/85.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "Minccino greet each other by grooming one another thoroughly with their tails.",
+		de: "Sie begrüßen einander, indem sie ihr Gegenüber mithilfe ihres Schweifs säubern."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/86.ts
+++ b/data/Sun & Moon/Crimson Invasion/86.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Minccino",
 		fr: "Chinchidou",
+		de: "Picochilla"
 	},
 
 	stage: "Stage1",
@@ -69,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "Their white fur feels amazing to touch. Their fur repels dust and prevents static electricity from building up.",
+		de: "Sein weißer Flaum fühlt sich wunderbar flauschig an und zieht weder Staub noch statische Elektrizität an."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/87.ts
+++ b/data/Sun & Moon/Crimson Invasion/87.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "They use their large ears to dig burrows. They will dig the whole night through.",
+		de: "Mit seinen großen Ohren schaufelt es sich einen Bau. Es kann die ganze Nacht ohne Pause durchschaufeln."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/88.ts
+++ b/data/Sun & Moon/Crimson Invasion/88.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Bunnelby",
 		fr: "Sapereau",
+		de: "Scoppel"
 	},
 
 	stage: "Stage1",
@@ -98,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "With their powerful ears, they can heft boulders of a ton or more with ease. They can be a big help at construction sites.",
+		de: "Seine großen Ohren besitzen die Kraft, selbst Felsen, die 1 t schwer sind, mühelos hochzuheben. Es wird daher oft auf Baustellen eingesetzt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/89.ts
+++ b/data/Sun & Moon/Crimson Invasion/89.ts
@@ -84,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "The heavy control mask it wears suppresses its intrinsic capabilities. This Pokémon has some hidden special power.",
+		de: "Seine schwere Maske unterdrückt seine wahre Macht. In ihm schlummern nämlich besondere Kräfte."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/9.ts
+++ b/data/Sun & Moon/Crimson Invasion/9.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Shelmet",
 		fr: "Escargaume",
+		de: "Schnuthelm"
 	},
 
 	stage: "Stage1",
@@ -86,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "Having removed its heavy shell, it becomes very light and can fight with ninja-like movements.",
+		de: "Seit es die schwere Muschel abgestreift hat, ist es viel leichter. Nun gleichen seine Kampfbewegungen denen eines Ninja."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Crimson Invasion/90.ts
+++ b/data/Sun & Moon/Crimson Invasion/90.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Type: Null",
 		fr: "Type:0",
+		de: "Typ:Null"
 	},
 
 	suffix: "GX",
@@ -93,7 +94,7 @@ const card: Card = {
 				es: "Rebelarse GX",
 				it: "Ribelle-GX",
 				pt: "Rebelde GX",
-				de: "Rebellieren GX"
+				de: "Rebellieren-GX"
 			},
 			effect: {
 				en: "This attack does 50 damage for each of your opponent’s Benched Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Crimson Invasion/91.ts
+++ b/data/Sun & Moon/Crimson Invasion/91.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Puedes jugar esta carta solo si te quedan más cartas de Premio que a tu rival.\n\nCambia 1 de los Pokémon en Banca de tu rival por su Pokémon Activo.",
 		it: "Puoi giocare questa carta solo se hai più carte Premio rimanenti del tuo avversario.\n\nScambia uno dei Pokémon nella panchina del tuo avversario con il suo Pokémon attivo.",
 		pt: "Você só pode jogar esta carta se tiver mais cartas de Prêmio restantes do que seu oponente.\n\nTroque 1 dos Pokémon no Banco do seu oponente pelo Pokémon Ativo dele(a).",
-		de: "Du kannst diese Karte nur spielen, wenn du mehr verbleibende Preiskarten hast als dein Gegner.\n\nTausche 1 Pokémon auf der Bank deines Gegners gegen sein Aktives Pokémon aus."
+		de: "Du kannst diese Karte nur spielen, wenn du mehr verbleibende Preiskarten hast als dein Gegner. Tausche 1 Pokémon auf der Bank deines Gegners gegen sein Aktives Pokémon aus. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Crimson Invasion/92.ts
+++ b/data/Sun & Moon/Crimson Invasion/92.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Si el Pokémon al que está unida esta carta descarta Energías por su Coste de Retirada, pon esas Energías en tu mano en vez de en la pila de descartes.",
 		it: "Se il Pokémon a cui è assegnata questa carta scarta dell’Energia per il suo costo di ritirata, aggiungi quell’Energia alla tua mano invece che alla pila degli scarti.",
 		pt: "Se o Pokémon ao qual esta carta está ligada descartar Energia para cobrir seu custo de Recuo, coloque aquelas Energias na sua mão ao invés de colocá-las na pilha de descarte.",
-		de: "Wenn du für das Pokémon, an das diese Karte angelegt ist, Energie für seine Rückzugskosten auf deinen Ablagestapel legst, nimm jene Energie stattdessen auf deine Hand."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn du für das Pokémon, an das diese Karte angelegt ist, Energie für seine Rückzugskosten auf deinen Ablagestapel legst, nimm jene Energie stattdessen auf deine Hand. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sun & Moon/Crimson Invasion/93.ts
+++ b/data/Sun & Moon/Crimson Invasion/93.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Los ataques de los Pokémon Darkness y Pokémon Dragon (tantos tuyos como de tu rival) hacen 10 puntos de daño más al Pokémon Activo del rival (antes de aplicar Debilidad y Resistencia).",
 		it: "Gli attacchi dei Pokémon Darkness e dei Pokémon Dragon, sia tuoi che del tuo avversario, infliggono 10 danni in più al Pokémon attivo dell’avversario, prima di aver applicato debolezza e resistenza.",
 		pt: "Os ataques dos Pokémon Darkness e Pokémon Dragon (seus e do seu oponente) causam 10 pontos de dano a mais ao Pokémon Ativo do oponente (antes de aplicar Fraqueza e Resistência).",
-		de: "Die Attacken der Darkness-Pokémon und Dragon-Pokémon (deiner und der deines Gegners) fügen dem Aktiven Pokémon deines Gegners 10 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
+		de: "Die Attacken der {D}-Pokémon und {N}-Pokémon (deiner und der deines Gegners) fügen dem Aktiven Pokémon deines Gegners 10 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden). Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 
 	trainerType: "Stadium",

--- a/data/Sun & Moon/Crimson Invasion/94.ts
+++ b/data/Sun & Moon/Crimson Invasion/94.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "El Silvally-GX al que está unida esta carta es un Pokémon Fighting.",
 		it: "Il Silvally-GX a cui è assegnata questa carta è di tipo Fighting.",
 		pt: "O Pokémon Silvally-GX ao qual esta carta está ligada é um Pokémon Fighting.",
-		de: "Das Amigento-GX, an das diese Karte angelegt ist, ist ein Fighting-Pokémon."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Das Amigento-GX, an das diese Karte angelegt ist, ist ein {F}-Pokémon. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sun & Moon/Crimson Invasion/95.ts
+++ b/data/Sun & Moon/Crimson Invasion/95.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mira tus cartas de Premio que están boca abajo y pon 1 de ellas en tu mano. Después, pon esta carta de Gladio entre tus cartas de Premio restantes, barájalas y vuelve a ponerlas boca abajo. Si no has jugado esta carta de Gladio de tu mano, no hace nada.",
 		it: "Guarda le tue carte Premio coperte e aggiungine una alle carte che hai in mano. Poi rimischia questo Iridio nelle tue carte Premio rimanenti e rimettile a faccia in giù. Se non lo hai giocato dalla tua mano, questo Iridio non ha effetto.",
 		pt: "Olhe as suas cartas de Prêmio viradas para baixo e coloque 1 delas na sua mão. Em seguida, embaralhe este Gladio entre as suas cartas de Prêmio restantes e coloque-as de volta viradas para baixo. Se você não jogou este Gladio da sua mão, ele não fará nada.",
-		de: "Sieh dir deine verdeckten Preiskarten an und nimm 1 von ihnen auf deine Hand. Mische anschließend diese Gladio-Karte in deine verbleibenden Preiskarten und lege sie verdeckt zurück. Wenn du diese Gladio-Karte nicht aus deiner Hand gespielt hast, hat sie keine Auswirkungen."
+		de: "Schau dir deine verdeckten Preiskarten an und nimm 1 von ihnen auf deine Hand. Mische anschließend diese Gladio-Karte in deine verbleibenden Preiskarten und lege sie verdeckt zurück. Wenn du diese Gladio-Karte nicht aus deiner Hand gespielt hast, hat sie keine Auswirkungen. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Crimson Invasion/96.ts
+++ b/data/Sun & Moon/Crimson Invasion/96.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon 2 cartas de Partidario y de Estadio, en cualquier combinación, de tu pila de descartes en tu mano.",
 		it: "Prendi due carte Aiuto o Stadio in qualsiasi combinazione dalla tua pila degli scarti e aggiungile a quelle che hai in mano.",
 		pt: "Coloque 2 cartas de Apoiador e de Estádio da sua pilha de descarte na sua mão em qualquer combinação.",
-		de: "Nimm eine beliebige Kombination aus 2 Unterstützer- und Stadionkarten aus deinem Ablagestapel auf deine Hand."
+		de: "Nimm eine beliebige Kombination aus 2 Unterstützer- und Stadionkarten aus deinem Ablagestapel auf deine Hand. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Crimson Invasion/97.ts
+++ b/data/Sun & Moon/Crimson Invasion/97.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Tu rival enseña las cartas de su mano. Puedes hacer que tu rival cuente las cartas de su mano, las ponga en su baraja y las baraje todas, y después robe la misma cantidad de cartas.",
 		it: "Il tuo avversario mostra le carte che ha in mano. Puoi fargliele contare e rimischiare nel suo mazzo e poi fargli pescare lo stesso numero di carte.",
 		pt: "Seu oponente revela a própria mão. Você pode fazer com que o seu oponente conte as cartas na própria mão, embaralhe aquelas cartas no baralho dele(a) e então compre aquele mesmo número de cartas.",
-		de: "Dein Gegner zeigt dir seine Handkarten. Du kannst deinen Gegner dazu veranlassen, die Karten auf seiner Hand zu zählen, jene Karten in sein Deck zu mischen und anschließend dieselbe Anzahl Karten zu ziehen."
+		de: "Dein Gegner zeigt dir seine Handkarten. Du kannst deinen Gegner dazu veranlassen, die Karten auf seiner Hand zu zählen, jene Karten in sein Deck zu mischen und anschließend dieselbe Anzahl Karten zu ziehen. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Crimson Invasion/98.ts
+++ b/data/Sun & Moon/Crimson Invasion/98.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "El Silvally-GX al que está unida esta carta es un Pokémon Psychic.",
 		it: "Il Silvally-GX a cui è assegnata questa carta è di tipo Psychic.",
 		pt: "O Pokémon Silvally-GX ao qual esta carta está ligada é um Pokémon Psychic.",
-		de: "Das Amigento-GX, an das diese Karte angelegt ist, ist ein Psychic-Pokémon."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Das Amigento-GX, an das diese Karte angelegt ist, ist ein {P}-Pokémon. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sun & Moon/Crimson Invasion/99.ts
+++ b/data/Sun & Moon/Crimson Invasion/99.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "No se eliminan las Condiciones Especiales cuando evolucionan o involucionan Pokémon (tanto tuyos como de tu rival).",
 		it: "Le condizioni speciali non vengono rimosse quando i Pokémon, sia tuoi che del tuo avversario, si evolvono o se ne annulla l’evoluzione.",
 		pt: "As Condições Especiais não são removidas quando os Pokémon (seus e do seu oponente) evoluem ou revertem sua evolução.",
-		de: "Spezielle Zustände verlieren ihre Wirkung nicht, wenn Pokémon (deine und die deines Gegners) sich entwickeln oder rückentwicklen."
+		de: "Spezielle Zustände verlieren ihre Wirkung nicht, wenn Pokémon (deine und die deines Gegners) sich entwickeln oder rückentwicklen. Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 
 	trainerType: "Stadium",


### PR DESCRIPTION
## Add missing German translations for sm4

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
