### PR TITLE
Add missing German translations for sm7

### DIFF
--- a/data/Sun & Moon/Celestial Storm/1.ts
+++ b/data/Sun & Moon/Celestial Storm/1.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "Its bud looks like a human face. Because of the bud, it is rumored to be a type of legendary mandrake plant.",
+		de: "Seine Knospe ähnelt einem Menschengesicht. Man sagt, dass es mit der legendären Mandragora verwandt ist."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/10.ts
+++ b/data/Sun & Moon/Celestial Storm/10.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Grovyle",
 		fr: "Massko",
+		de: "Reptain"
 	},
 
 	stage: "Stage2",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Evita todo el daño infligido a tus Pokémon que tengan alguna Energía Grass unida a ellos por ataques de los Ultraentes de tu rival.",
 				it: "Previeni tutti i danni inflitti ai tuoi Pokémon, che hanno delle Energie Grass assegnate, dagli attacchi delle Ultracreature del tuo avversario.",
 				pt: "Previne todo o dano causado aos seus Pokémon que tenham alguma Energia Grass ligada a eles por ataques das Ultracriaturas do seu oponente.",
-				de: "Verhindere allen Schaden, der deinen Pokémon, an die mindestens 1 Grass-Energie angelegt ist, durch Attacken von Ultrabestien deines Gegners zugefügt wird."
+				de: "Verhindere allen Schaden, der deinen Pokémon, an die mindestens 1 {G}-Energie angelegt ist, durch Attacken von Ultrabestien deines Gegners zugefügt wird."
 			},
 		},
 	],
@@ -92,6 +93,7 @@ const card: Card = {
 
 	description: {
 		en: "It agilely leaps about the jungle and uses the sharp leaves on its arms to strike its prey.",
+		de: "Flink zischt es durch den Dschungel. Mit den Blattklingen an seinen Armen schlägt es seine Beute."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/100.ts
+++ b/data/Sun & Moon/Celestial Storm/100.ts
@@ -51,7 +51,7 @@ const card: Card = {
 				es: "Si el total de cartas de Premio que les queden a ambos jugadores es exactamente 6, este ataque se puede usar por 1 Energía Metal.",
 				it: "Se il totale delle carte Premio rimanenti a entrambi i giocatori è esattamente sei, il costo di questo attacco è Metal.",
 				pt: "Se a soma total das cartas de Prêmio restantes de ambos os jogadores for exatamente 6, este ataque poderá ser usado com 1 Energia Metal.",
-				de: "Wenn die Summe der verbleibenden Preiskarten beider Spieler genau 6 ist, kann diese Attacke für Metal eingesetzt werden."
+				de: "Wenn die Summe der verbleibenden Preiskarten beider Spieler genau 6 ist, kann diese Attacke für {M} eingesetzt werden."
 			},
 			damage: 160,
 
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "One kind of Ultra Beast. Witnesses have seen it burn down a forest by expelling gas from its two arms.",
+		de: "Diese Ultrabestie wurde dabei gesichtet, wie sie mithilfe des Gases, das aus ihren beiden Armen strömt, große Waldflächen niederbrannte."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/101.ts
+++ b/data/Sun & Moon/Celestial Storm/101.ts
@@ -73,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "One of the Ultra Beast life-forms, it was observed cutting down a gigantic steel tower with one stroke of its blade.",
+		de: "Diese Ultrabestie wurde dabei beobachtet, wie sie einen riesigen stählernen Turm mit nur einem Hieb ihrer Klingen zerteilte."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/102.ts
+++ b/data/Sun & Moon/Celestial Storm/102.ts
@@ -81,7 +81,7 @@ const card: Card = {
 				es: "UE Bloques GX",
 				it: "Structura-GX",
 				pt: "Montagem GX",
-				de: "Mauerwerk GX"
+				de: "Mauerwerk-GX"
 			},
 			effect: {
 				en: "This attack does 50 more damage for each Prize card you have taken. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Celestial Storm/103.ts
+++ b/data/Sun & Moon/Celestial Storm/103.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "With its steel-hard stone head, it headbutts indiscriminately. This is because of the stress it feels at being unable to fly.",
+		de: "Es verteilt oft Kopfstöße mit seinem stahlharten Schädel. Grund ist offenbar der Frust darüber, dass es nicht fliegen kann."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/104.ts
+++ b/data/Sun & Moon/Celestial Storm/104.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "With its steel-hard stone head, it headbutts indiscriminately. This is because of the stress it feels at being unable to fly.",
+		de: "Es verteilt oft Kopfstöße mit seinem stahlharten Schädel. Grund ist offenbar der Frust darüber, dass es nicht fliegen kann."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/105.ts
+++ b/data/Sun & Moon/Celestial Storm/105.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Bagon",
 		fr: "Draby",
+		de: "Kindwurm"
 	},
 
 	stage: "Stage1",
@@ -71,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "They lurk deep within caves—motionless, neither eating nor drinking. Why they don't die is not known.",
+		de: "Es hält sich in den Tiefen einer Höhle versteckt, wo es weder trinkt noch isst. Niemand weiß so recht, wie es eigentlich überleben kann."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/106.ts
+++ b/data/Sun & Moon/Celestial Storm/106.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Shelgon",
 		fr: "Drackhaus",
+		de: "Draschel"
 	},
 
 	stage: "Stage2",
@@ -88,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It flies around on its wings, which have grown in at last. In its happiness, it gushes hot flames, burning up the fields it passes over.",
+		de: "Nun, da ihm Flügel gewachsen sind, zieht es seine Kreise am Himmel. Vor Freude spuckt es Flammen und hinterlässt eine Brandwüste."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/107.ts
+++ b/data/Sun & Moon/Celestial Storm/107.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Une 1 carta de Energía Básica de tu pila de descartes a cada uno de tus Pokémon Dragon Básicos en Banca.",
 				it: "Assegna a ciascuno dei tuoi Pokémon Base Dragon in panchina una carta Energia base dalla tua pila degli scarti.",
 				pt: "Ligue 1 carta de Energia básica da sua pilha de descarte a cada um dos seus Pokémon Dragon Básicos no Banco.",
-				de: "Lege 1 Basis-Energiekarte aus deinem Ablagestapel an jedes Dragon-Basis-Pokémon auf deiner Bank an."
+				de: "Lege 1 Basis-Energiekarte aus deinem Ablagestapel an jedes {N}-Basis-Pokémon auf deiner Bank an."
 			},
 			damage: 30,
 
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It can telepathically communicate with people. It changes its appearance using its down that refracts light.",
+		de: "Mittels Telepathie kann es mit Menschen kommunizieren. Mit seinen Daunen, die das Licht brechen, kann es sein Aussehen verändern."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/108.ts
+++ b/data/Sun & Moon/Celestial Storm/108.ts
@@ -48,7 +48,7 @@ const card: Card = {
 				es: "Este ataque hace 50 puntos de daño por cada uno de tus Pokémon Dragon Evolución en juego.",
 				it: "Questo attacco infligge 50 danni per ogni tuo Pokémon Evoluzione Dragon in gioco.",
 				pt: "Este ataque causa 50 pontos de dano para cada um dos seus Pokémon Dragon de Evolução em jogo.",
-				de: "Diese Attacke fügt 50 Schadenspunkte mal der Anzahl deiner Dragon-Entwicklungs-Pokémon im Spiel zu."
+				de: "Diese Attacke fügt 50 Schadenspunkte mal der Anzahl deiner {N}-Entwicklungs-Pokémon im Spiel zu."
 			},
 			damage: "50×",
 
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "It understands human speech and is highly intelligent. It is a tender Pokémon that dislikes fighting.",
+		de: "Es ist hochintelligent und versteht sogar die menschliche Sprache. Es ist friedlich und meidet Konflikte."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/109.ts
+++ b/data/Sun & Moon/Celestial Storm/109.ts
@@ -71,7 +71,7 @@ const card: Card = {
 				es: "Este ataque hace 30 puntos de daño por cada Energía Grass Básica y Lightning Básica unida a tus Pokémon.",
 				it: "Questo attacco infligge 30 danni per ogni Energia base Grass o Lightning assegnata ai tuoi Pokémon.",
 				pt: "Este ataque causa 30 pontos de dano vezes a quantidade de Energia Grass básica e Lightning básica ligada aos seus Pokémon.",
-				de: "Diese Attacke fügt 30 Schadenspunkte mal der Anzahl der an deine Pokémon angelegten Grass-Basis-Energien und Lightning-Basis-Energien zu."
+				de: "Diese Attacke fügt 30 Schadenspunkte mal der Anzahl der an deine Pokémon angelegten {G}-Basis-Energien und {L}-Basis-Energien zu."
 			},
 			damage: "30×",
 
@@ -86,7 +86,7 @@ const card: Card = {
 				es: "Tempestad GX",
 				it: "Tempesta-GX",
 				pt: "Vendaval GX",
-				de: "Unwetter GX"
+				de: "Unwetter-GX"
 			},
 			effect: {
 				en: "Discard your hand and draw 10 cards. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Celestial Storm/11.ts
+++ b/data/Sun & Moon/Celestial Storm/11.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "When it dangles from a tree branch, it looks just like an acorn. It enjoys scaring other Pokémon.",
+		de: "Es sieht aus wie eine Eichel, die am Baum hängt. Es liebt es, andere Pokémon zu erschrecken."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/110.ts
+++ b/data/Sun & Moon/Celestial Storm/110.ts
@@ -87,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "It digs into the ground with its tail and makes a mazelike nest. It can fly just a little.",
+		de: "Es gräbt sich mit seinem Schweif in die Erde und baut ein labyrinthartiges Nest. Es kann kaum fliegen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/111.ts
+++ b/data/Sun & Moon/Celestial Storm/111.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "Fishermen keep an eye out for Wingull in the sky, because wherever they're circling, the ocean is sure to be teeming with fish Pokémon.",
+		de: "Fischer halten gerne Ausschau nach Wingull, denn wo diese ihre Kreise ziehen, scharen sich unter Wasser Schwärme von Fisch-Pokémon."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/112.ts
+++ b/data/Sun & Moon/Celestial Storm/112.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Wingull",
 		fr: "Goélise",
+		de: "Wingull"
 	},
 
 	stage: "Stage1",
@@ -52,7 +53,7 @@ const card: Card = {
 				es: "Descarta 1 Energía Fire del Pokémon Activo de tu rival.",
 				it: "Scarta un’Energia Fire assegnata al Pokémon attivo del tuo avversario.",
 				pt: "Descarte 1 Energia Fire do Pokémon Ativo do seu oponente.",
-				de: "Lege 1 Fire-Energie vom Aktiven Pokémon deines Gegners auf seinen Ablagestapel."
+				de: "Lege 1 {R}-Energie vom Aktiven Pokémon deines Gegners auf seinen Ablagestapel."
 			},
 			damage: 30,
 
@@ -102,6 +103,7 @@ const card: Card = {
 
 	description: {
 		en: "Gathering food is the work of young males. They store food in their capacious beaks and carry it back to others waiting in the nest.",
+		de: "Die jungen Männchen beschaffen die Nahrung. Sie sammeln die Beute in ihrem großen Schnabel und bringen sie zurück ins Nest zu den anderen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/113.ts
+++ b/data/Sun & Moon/Celestial Storm/113.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "If it eats just three leaves in a day, it is satisfied. Other than that, it sleeps for 20 hours a day.",
+		de: "Solange es täglich drei Blätter zu essen bekommt, ist es zufrieden. Abgesehen davon schläft es 20 Stunden am Tag."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/114.ts
+++ b/data/Sun & Moon/Celestial Storm/114.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Slakoth",
 		fr: "Parecool",
+		de: "Bummelz"
 	},
 
 	stage: "Stage1",
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "Its stress level rises if it cannot keep moving constantly. Too much stress makes it feel sick.",
+		de: "Würde es sich nicht bewegen, würde sein Stress unerträglich und es ginge ihm augenblicklich schlechter."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/115.ts
+++ b/data/Sun & Moon/Celestial Storm/115.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Vigoroth",
 		fr: "Vigoroth",
+		de: "Muntier"
 	},
 
 	stage: "Stage2",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "It is the world's most slothful Pokémon. However, it can exert horrifying power by releasing pent-up energy all at once.",
+		de: "Es ist das faulste Pokémon der Welt. Doch kann es überaus kräftige Angriffe fahren, wenn es die komplette angestaute Energie auf einmal einsetzt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/116.ts
+++ b/data/Sun & Moon/Celestial Storm/116.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "If it senses danger, it scares the foe by crying out with the volume of a jet-plane engine.",
+		de: "Sein Schrei ist so laut wie ein Düsenflugzeug. Bei Gefahr vertreibt es damit seine Feinde."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/117.ts
+++ b/data/Sun & Moon/Celestial Storm/117.ts
@@ -67,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "If it senses danger, it scares the foe by crying out with the volume of a jet-plane engine.",
+		de: "Sein Schrei ist so laut wie ein Düsenflugzeug. Bei Gefahr vertreibt es damit seine Feinde."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/118.ts
+++ b/data/Sun & Moon/Celestial Storm/118.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Whismur",
 		fr: "Chuchmur",
+		de: "Flurmel"
 	},
 
 	stage: "Stage1",
@@ -72,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "The shock waves from its cries can tip over trucks. It stamps its feet to power up.",
+		de: "Die Schockwellen, die durch sein Rufen entstehen, können einen LKW umkippen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/119.ts
+++ b/data/Sun & Moon/Celestial Storm/119.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Loudred",
 		fr: "Ramboum",
+		de: "Krakeelo"
 	},
 
 	stage: "Stage2",
@@ -91,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "Its roar in battle shakes the ground like a tremor—or like an earthquake has struck.",
+		de: "Sein Grollen, das es während des Kampfs ausstößt, erschüttert den Boden ganz wie bei einem Erdbeben."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/12.ts
+++ b/data/Sun & Moon/Celestial Storm/12.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "When it dangles from a tree branch, it looks just like an acorn. It enjoys scaring other Pokémon.",
+		de: "Es sieht aus wie eine Eichel, die am Baum hängt. Es liebt es, andere Pokémon zu erschrecken."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/120.ts
+++ b/data/Sun & Moon/Celestial Storm/120.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It shows its cute side by chasing its own tail until it gets dizzy.",
+		de: "Es zeigt gerne seine niedliche Seite, indem es seinen eigenen Schweif jagt, bis ihm schwindlig wird."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/121.ts
+++ b/data/Sun & Moon/Celestial Storm/121.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Skitty",
 		fr: "Skitty",
+		de: "Eneco"
 	},
 
 	stage: "Stage1",
@@ -86,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "It is highly popular among female Trainers for its sublime fur. It does not keep a nest.",
+		de: "Dieses Pokémon ist bei weiblichen Trainern aufgrund seines Fells beliebt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/122.ts
+++ b/data/Sun & Moon/Celestial Storm/122.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Mientras este Pokémon tenga alguna carta de Energía Unidad LightningPsychicMetal unida a él, es un Pokémon Lightning, Psychic y Metal.",
 				it: "Fintanto che ha delle carte Energia Unione LightningPsychicMetal assegnate, questo Pokémon è di tipo Lightning, Psychic e Metal.",
 				pt: "Enquanto este Pokémon tiver Energia Unitária LightningPsychicMetal ligada a ele, será um Pokémon Lightning, Psychic e Metal.",
-				de: "Solang an dieses Pokémon Aggregat-Energie LightningPsychicMetal angelegt ist, ist es ein Lightning-, Psychic- und Metal-Pokémon."
+				de: "Solang an dieses Pokémon Aggregat-Energie {L}{P}{M} angelegt ist, ist es ein {L}-, {P}- und {M}-Pokémon."
 			},
 		},
 	],
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It changes its shading to match its surroundings so it can sneak up on prey. Only its belly patterns stay fixed.",
+		de: "Beim Beutefang passt es seine Farbe der Umgebung an. Nur das Muster auf seinem Bauch bleibt gleich."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/123.ts
+++ b/data/Sun & Moon/Celestial Storm/123.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mira las 2 primeras cartas de tu baraja y pon 1 de ellas en tu mano. Descarta la otra carta.",
 		it: "Guarda le prime due carte del tuo mazzo e aggiungi una di esse alle carte che hai in mano. Scarta l’altra carta.",
 		pt: "Olhe as 2 primeiras cartas do seu baralho e coloque 1 delas na sua mão. Descarte a outra carta.",
-		de: "Schau dir die obersten 2 Karten deines Decks an und nimm 1 von ihnen auf deine Hand. Lege die andere Karte auf deinen Ablagestapel."
+		de: "Schau dir die obersten 2 Karten deines Decks an und nimm 1 von ihnen auf deine Hand. Lege die andere Karte auf deinen Ablagestapel. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Celestial Storm/124.ts
+++ b/data/Sun & Moon/Celestial Storm/124.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 2 cartas de Objeto que tengan la palabra \"Ball\" en su nombre, enséñalas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo fino a due carte Strumento con “Ball” nel nome, mostrale e aggiungile alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por até 2 cartas de Item no seu baralho que tenham a palavra “Bola” no seu nome, revele-as e coloque-as na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach bis zu 2 Itemkarten, bei denen das Wort „Ball“ zum Namen gehört, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach bis zu 2 Itemkarten, bei denen das Wort „Ball“ zum Namen gehört, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Celestial Storm/126.ts
+++ b/data/Sun & Moon/Celestial Storm/126.ts
@@ -32,7 +32,7 @@ const card: Card = {
 		es: "Pon 1 carta de tu mano en tu baraja y barájalas todas. Si lo haces, roba 3 cartas.",
 		it: "Rimischia una delle carte che hai in mano nel tuo mazzo. Se lo fai, pesca tre carte.",
 		pt: "Embaralhe 1 carta da sua mão no seu baralho. Se fizer isto, compre 3 cartas.",
-		de: "Mische 1 Karte aus deiner Hand in dein Deck. Wenn du das machst, ziehe 3 Karten."
+		de: "Mische 1 Karte aus deiner Hand in dein Deck. Wenn du das machst, ziehe 3 Karten. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 	trainerType: "Supporter",
 

--- a/data/Sun & Moon/Celestial Storm/127.ts
+++ b/data/Sun & Moon/Celestial Storm/127.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon las cartas de tu mano en tu baraja y barájalas todas. Después, roba 1 carta por cada carta en la mano de tu rival.",
 		it: "Rimischia le carte che hai in mano nel tuo mazzo. Poi pesca una carta per ogni carta nella mano del tuo avversario.",
 		pt: "Embaralhe a sua mão no seu baralho. Em seguida, compre 1 carta para cada carta na mão do seu oponente.",
-		de: "Mische deine Handkarten in dein Deck. Ziehe anschließend 1 Karte für jede Karte auf der Hand deines Gegners."
+		de: "Mische deine Handkarten in dein Deck. Ziehe anschließend 1 Karte für jede Karte auf der Hand deines Gegners. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Celestial Storm/129.ts
+++ b/data/Sun & Moon/Celestial Storm/129.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mueve 1 Energía Básica de 1 de tus Pokémon a otro de tus Pokémon.",
 		it: "Sposta un’Energia base da uno dei tuoi Pokémon a un altro.",
 		pt: "Mova 1 Energia básica de 1 dos seus Pokémon para outro Pokémon seu.",
-		de: "Verschiebe 1 Basis-Energie von 1 deiner Pokémon auf 1 anderes deiner Pokémon."
+		de: "Verschiebe 1 Basis-Energie von 1 deiner Pokémon auf 1 anderes deiner Pokémon. Du kannst während deines Zuges (bevor zu angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Celestial Storm/13.ts
+++ b/data/Sun & Moon/Celestial Storm/13.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Seedot",
 		fr: "Grainipiot",
+		de: "Samurzel"
 	},
 
 	stage: "Stage1",
@@ -86,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives deep in forests. With the leaf on its head, it makes a flute whose song makes listeners uneasy.",
+		de: "Lebt tief im Wald. Es baut sich eine Flöte aus den Blättern seines Kopfes. Ihr Ton verbreitet Schrecken."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/130.ts
+++ b/data/Sun & Moon/Celestial Storm/130.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon 4 cartas de Energía Básica de tu pila de descartes en tu mano.",
 		it: "Prendi quattro carte Energia base dalla tua pila degli scarti e aggiungile alle carte che hai in mano.",
 		pt: "Coloque 4 cartas de Energia básica da sua pilha de descarte na sua mão.",
-		de: "Nimm 4 Basis-Energiekarten aus deinem Ablagestapel auf deine Hand."
+		de: "Nimm 4 Basis-Energiekarten aus deinem Ablagestapel auf deine Hand. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Celestial Storm/131.ts
+++ b/data/Sun & Moon/Celestial Storm/131.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja 1 Pokémon del mismo tipo que 1 de los Pokémon en juego de tu rival, enséñalo y ponlo en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo un Pokémon dello stesso tipo di uno dei Pokémon in gioco del tuo avversario, mostralo e aggiungilo alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por 1 Pokémon no seu baralho que seja do mesmo tipo de 1 dos Pokémon do seu oponente em jogo, revele-o e coloque-o na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach 1 Pokémon, das denselben Typ wie 1 Pokémon deines Gegners im Spiel hat, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach 1 Pokémon, das denselben Typ wie 1 Pokémon deines Gegners im Spiel hat, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Celestial Storm/132.ts
+++ b/data/Sun & Moon/Celestial Storm/132.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba 3 cartas.",
 		it: "Pesca tre carte.",
 		pt: "Compre 3 cartas.",
-		de: "Ziehe 3 Karten."
+		de: "Ziehe 3 Karten. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Celestial Storm/133.ts
+++ b/data/Sun & Moon/Celestial Storm/133.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mira las 5 primeras cartas de la baraja de cualquiera de los jugadores y elige 1 de ellas. Ese jugador pone el resto de cartas de nuevo en su baraja y las baraja todas. Después, pon la carta que has elegido en la parte superior de esa baraja.",
 		it: "Guarda le prime cinque carte del mazzo di uno dei giocatori e scegline una. Quel giocatore rimischia le altre carte nel suo mazzo. Poi metti la carta che hai scelto in cima a quel mazzo.",
 		pt: "Olhe as 5 primeiras cartas do baralho de qualquer um dos jogadores e escolha 1 delas. Aquele jogador embaralha as demais cartas de volta no próprio baralho. Em seguida, coloque a carta escolhida como a primeira carta daquele baralho.",
-		de: "Schau dir die obersten 5 Karten des Decks eines der beiden Spieler an und wähle 1 Karte. Jener Spieler mischt die anderen Karten zurück in sein Deck. Lege anschließend die von dir gewählte Karte oben auf jenes Deck."
+		de: "Schau dir die obersten 5 Karten des Decks eines der beiden Spieler an und wähle 1 Karte. Jener Spieler mischt die anderen Karten zurück in sein Deck. Lege anschließend die von dir gewählte Karte oben auf jenes Deck. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Celestial Storm/134.ts
+++ b/data/Sun & Moon/Celestial Storm/134.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Si al Pokémon al que esté unida esta carta le quedan 30 PS o menos y tiene algún contador de daño sobre él, sus ataques hacen 60 puntos de daño más al Pokémon Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
 		it: "Se il Pokémon a cui è assegnata questa carta ha 30 PS o meno rimanenti e se ha dei segnalini danno, i suoi attacchi infliggono 60 danni in più al Pokémon attivo del tuo avversario, prima di aver applicato debolezza e resistenza.",
 		pt: "Se o Pokémon ao qual esta carta está ligada tiver PS restante de 30 ou menos e tiver algum contador de dano nele, seus ataques causarão 60 pontos de dano a mais ao Pokémon Ativo do seu oponente (antes de aplicar Fraqueza e Resistência).",
-		de: "Wenn die verbleibenden KP des Pokémon, an das diese Karte angelegt ist, 30 oder weniger betragen und auf ihm mindestens 1 Schadensmarke liegt, fügen die Attacken dieses Pokémon dem Aktiven Pokémon deines Gegners 60 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn die verbleibenden KP des Pokémon, an das diese Karte angelegt ist, 30 oder weniger betragen und auf ihm mindestens 1 Schadensmarke liegt, fügen die Attacken dieses Pokémon dem Aktiven Pokémon deines Gegners 60 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden). Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sun & Moon/Celestial Storm/135.ts
+++ b/data/Sun & Moon/Celestial Storm/135.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cura 120 puntos de daño a 1 de tus Pokémon a los que le queden 30 PS o menos.",
 		it: "Cura da 120 danni uno dei tuoi Pokémon che ha 30 PS o meno rimanenti.",
 		pt: "Cure 120 pontos de dano de 1 dos seus Pokémon que tiver PS restante de 30 ou menos.",
-		de: "Heile 120 Schadenspunkte bei 1 deiner Pokémon, dessen verbleibende KP 30 oder weniger betragen."
+		de: "Heile 120 Schadenspunkte bei 1 deiner Pokémon, dessen verbleibende KP 30 oder weniger betragen. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Celestial Storm/136.ts
+++ b/data/Sun & Moon/Celestial Storm/136.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Lanza 1 moneda. Si sale cara, cura 60 puntos de daño y elimina todas las Condiciones Especiales de 1 de tus Pokémon.",
 		it: "Lancia una moneta. Se esce testa, cura uno dei tuoi Pokémon da 60 danni e rimuovi tutte le condizioni speciali che lo influenzano.",
 		pt: "Jogue 1 moeda. Se sair cara, cure 60 pontos de dano e remova todas as Condições Especiais de 1 dos seus Pokémon.",
-		de: "Wirf 1 Münze. Heile bei Kopf 60 Schadenspunkte und entferne alle Speziellen Zustände von 1 deiner Pokémon."
+		de: "Wirf 1 Münze. Heile bei Kopf 60 Schadenspunkte und entferne alle Speziellen Zustände von 1 deiner Pokémon. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Celestial Storm/137.ts
+++ b/data/Sun & Moon/Celestial Storm/137.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 2 cartas de ◇ (Estrella Prisma), enséñalas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo fino a due carte ◇ (stella prisma), mostrale e aggiungile alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por até 2 cartas ◇ (Estrela Prisma) no seu baralho, revele-as e coloque-as na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach bis zu 2 ◇-Karten (Prisma-Stern-Karten), zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach bis zu 2 ◇-Karten (Prisma-Stern-Karten), zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Celestial Storm/138.ts
+++ b/data/Sun & Moon/Celestial Storm/138.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Lanza 3 monedas. Por cada cara, pon 1 Pokémon Evolución de tu pila de descartes en tu mano.",
 		it: "Lancia tre volte una moneta. Ogni volta che esce testa, prendi un Pokémon Evoluzione dalla tua pila degli scarti e aggiungilo alle carte che hai in mano.",
 		pt: "Jogue 3 moedas. Para cada cara, coloque 1 Pokémon de Evolução da sua pilha de descarte na sua mão.",
-		de: "Wirf 3 Münzen. Nimm pro Kopf 1 Entwicklungs-Pokémon aus deinem Ablagestapel auf deine Hand."
+		de: "Wirf 3 Münzen. Nimm pro Kopf 1 Entwicklungs-Pokémon aus deinem Ablagestapel auf deine Hand. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Celestial Storm/139.ts
+++ b/data/Sun & Moon/Celestial Storm/139.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Une 1 carta de Energía Básica de tu mano a 1 de tus Pokémon Grass, Fire o Water de Fase 2.",
 		it: "Assegna a uno dei tuoi Pokémon Grass, Fire o Water di Fase 2 una carta Energia base dalla tua mano.",
 		pt: "Ligue 1 carta de Energia básica da sua mão a 1 dos seus Pokémon Grass, Fire, ou Water Estágio 2.",
-		de: "Lege 1 Basis-Energiekarte aus deiner Hand an 1 deiner Grass-, Fire- oder Water-Phase-2-Pokémon an."
+		de: "Lege 1 Basis-Energiekarte aus deiner Hand an 1 deiner {G}-, {R}-, {W}-Phase-2-Pokémon an. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Celestial Storm/14.ts
+++ b/data/Sun & Moon/Celestial Storm/14.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Nuzleaf",
 		fr: "Pifeuil",
+		de: "Blanas"
 	},
 
 	suffix: "GX",
@@ -94,7 +95,7 @@ const card: Card = {
 				es: "Antro de Perdición GX",
 				it: "Covo Maledetto-GX",
 				pt: "Toca da Crueldade GX",
-				de: "Höhle des Frevels GX"
+				de: "Höhle des Frevels-GX"
 			},
 			effect: {
 				en: "Choose 1 of your opponent’s Pokémon. Your opponent shuffles that Pokémon and all cards attached to it into their deck. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Celestial Storm/140.ts
+++ b/data/Sun & Moon/Celestial Storm/140.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mira las 3 primeras cartas de tu baraja. Puedes enseñar 1 Pokémon o 1 carta de Energía que encuentres entre ellas y poner esa carta en tu mano. Pon el resto de cartas de nuevo en la parte superior de tu baraja en el orden que quieras.",
 		it: "Guarda le prime tre carte del tuo mazzo. Puoi mostrare un Pokémon o una carta Energia presente tra esse e aggiungerla alle carte che hai in mano. Poi rimetti a posto le altre carte nell’ordine che preferisci.",
 		pt: "Olhe as 3 primeiras cartas do seu baralho. Você poderá revelar 1 carta de Pokémon ou Energia que encontrar lá e colocá-la na sua mão. Coloque as demais cartas de volta em qualquer ordem.",
-		de: "Schau dir die obersten 3 Karten deines Decks an. Du kannst 1 Pokémon oder 1 Energiekarte, die du dort findest, deinem Gegner zeigen und auf deine Hand nehmen. Lege die anderen Karten in beliebiger Reihenfolge zurück auf dein Deck."
+		de: "Schau dir die obersten 3 Karten deines Decks an. Du kannst 1 Pokémon oder 1 Energiekarte, die du dort findest, deinem Gegner zeigen und auf deine Hand nehmen. Lege die anderen Karten in beliebiger Reihenfolge zurück auf dein Deck. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Celestial Storm/141.ts
+++ b/data/Sun & Moon/Celestial Storm/141.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Elige 1 carta de Energía unida a 1 de tus Pokémon. Busca en tu baraja 1 carta de Energía Básica y cámbiala por esa carta. Pon la primera carta de Energía en tu baraja y barájalas todas.",
 		it: "Scegli una carta Energia assegnata a uno dei tuoi Pokémon. Cerca una carta Energia base nel tuo mazzo e scambiala con quella carta. Rimischia la prima carta Energia nel tuo mazzo.",
 		pt: "Escolha 1 carta de Energia que está ligada a 1 dos seus Pokémon. Procure por 1 carta de Energia básica no seu baralho e troque-a por aquela carta. Embaralhe a primeira carta de Energia no seu baralho.",
-		de: "Wähle 1 Energiekarte, die an 1 deiner Pokémon angelegt ist. Durchsuche dein Deck nach 1 Basis-Energiekarte und tausche sie gegen jene Karte aus. Mische die erste Energiekarte in dein Deck."
+		de: "Wähle 1 Energiekarte, die an 1 deiner Pokémon angelegt ist. Durchsuche dein Deck nach 1 Basis-Energiekarte und tausche sie gegen jene Karte aus. Mische die erste Energiekarte in dein Deck. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Celestial Storm/142.ts
+++ b/data/Sun & Moon/Celestial Storm/142.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Elige 1 de tus Pokémon Básicos en juego. Si tienes en tu mano 1 carta de Fase 2 que evolucione de ese Pokémon, pon esa carta sobre el Pokémon Básico para que evolucione. No puedes usar esta carta durante tu primer turno o sobre un Pokémon Básico que se haya puesto en juego en este turno.",
 		it: "Scegli uno dei tuoi Pokémon Base in gioco. Se hai in mano una carta di Fase 2 che si evolve da quel Pokémon, metticela sopra per farlo evolvere. Non puoi usare questa carta durante il tuo primo turno o su un Pokémon Base che hai messo in gioco nel turno in corso.",
 		pt: "Escolha 1 dos seus Pokémon Básicos em jogo. Se você tiver 1 carta de Estágio 2 na sua mão que evolua daquele Pokémon, coloque aquela carta sobre o Pokémon Básico para evoluí-lo. Você não pode usar esta carta durante a sua primeira vez de jogar ou colocá-la sobre um Pokémon Básico que foi colocado em jogo nesta rodada.",
-		de: "Wähle 1 deiner Basis-Pokémon im Spiel. Wenn du eine Phase-2-Karte auf der Hand hast, die sich aus jenem Pokémon entwickelt, lege sie auf das Basis-Pokémon, um es zu entwickeln. Du kannst diese Karte nicht während deines ersten Zuges oder für ein Basis-Pokémon, das in diesem Zug ins Spiel gebracht wurde, verwenden."
+		de: "Wähle 1 deiner Basis-Pokémon im Spiel. Wenn du eine Phase-2-Karte auf der Hand hast, die sich aus jenem Pokémon entwickelt, lege sie auf das Basis-Pokémon, um es zu entwickeln. Du kannst diese Karte nicht während deines ersten Zuges oder für ein Basis-Pokémon, das in diesem Zug ins Spiel gebracht wurde, verwenden. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Celestial Storm/144.ts
+++ b/data/Sun & Moon/Celestial Storm/144.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Evita todos los efectos de los ataques del rival, incluido el daño, infligidos a los Pokémon en Banca (tanto tuyos como de tu rival).",
 		it: "Previeni tutti gli effetti degli attacchi del tuo avversario, inclusi i danni, inflitti ai Pokémon in panchina, sia tuoi che del tuo avversario.",
 		pt: "Previne todos os efeitos dos ataques do oponente, incluindo dano, causados aos Pokémon no Banco (seus e do seu oponente).",
-		de: "Verhindere alle Effekte von Attacken deines Gegners, einschließlich Schaden, die Pokémon auf der Bank (deiner und der deines Gegners) zugefügt werden."
+		de: "Verhindere alle Effekte von Attacken deines Gegners, einschließlich Schaden, die Pokémon auf der Bank (deiner und der deines Gegners) zugefügt werden. Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 
 	trainerType: "Stadium",

--- a/data/Sun & Moon/Celestial Storm/145.ts
+++ b/data/Sun & Moon/Celestial Storm/145.ts
@@ -32,7 +32,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 3 cartas y ponlas en tu mano. Después, baraja las cartas de tu baraja. Tu turno termina.",
 		it: "Cerca nel tuo mazzo fino a tre carte e aggiungile alle carte che hai in mano. Poi rimischia le carte del tuo mazzo. Il tuo turno finisce.",
 		pt: "Procure por até 3 cartas no seu baralho e coloque-as na sua mão. Em seguida, embaralhe o seu baralho. A sua vez de jogar acaba.",
-		de: "Durchsuche dein Deck nach bis zu 3 Karten und nimm sie auf deine Hand. Mische anschließend dein Deck. Dein Zug endet."
+		de: "Durchsuche dein Deck nach bis zu 3 Karten und nimm sie auf deine Hand. Mische anschließend dein Deck. Dein Zug endet. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 	trainerType: "Supporter",
 

--- a/data/Sun & Moon/Celestial Storm/146.ts
+++ b/data/Sun & Moon/Celestial Storm/146.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Lanza 1 moneda. Si sale cara, pon 1 de tus Pokémon y todas las cartas unidas a él en tu mano.",
 		it: "Lancia una moneta. Se esce testa, riprendi in mano uno dei tuoi Pokémon e tutte le carte a esso assegnate.",
 		pt: "Jogue 1 moeda. Se sair cara, coloque 1 dos seus Pokémon e todas as cartas ligadas a ele na sua mão.",
-		de: "Wirf 1 Münze. Nimm bei Kopf 1 deiner Pokémon und alle an es angelegten Karten auf deine Hand."
+		de: "Wirf 1 Münze. Nimm bei Kopf 1 deiner Pokémon und alle an es angelegten Karten auf deine Hand. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Celestial Storm/147.ts
+++ b/data/Sun & Moon/Celestial Storm/147.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cambia tu Pokémon Activo por 1 de tus Pokémon en Banca.",
 		it: "Scambia il tuo Pokémon attivo con uno dei tuoi Pokémon in panchina.",
 		pt: "Troque o seu Pokémon Ativo por 1 dos seus Pokémon no Banco.",
-		de: "Tausche dein Aktives Pokémon gegen 1 Pokémon auf deiner Bank aus."
+		de: "Tausche dein Aktives Pokémon gegen 1 Pokémon auf deiner Bank aus. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Celestial Storm/149.ts
+++ b/data/Sun & Moon/Celestial Storm/149.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba 3 cartas. Después, descarta 1 carta de tu mano. Si no tienes ninguna carta en tu baraja, no puedes jugar esta carta.",
 		it: "Pesca tre carte. Poi scarta una delle carte che hai in mano. Se non hai carte nel mazzo, non puoi giocare questa carta.",
 		pt: "Compre 3 cartas. Em seguida, descarte 1 carta da sua mão. Se você não tiver nenhuma carta no seu baralho, não poderá jogar esta carta.",
-		de: "Ziehe 3 Karten. Lege anschließend 1 Karte aus deiner Hand auf deinen Ablagestapel. Wenn du keine Karten in deinem Deck hast, kannst du diese Karte nicht spielen."
+		de: "Ziehe 3 Karten. Lege anschließend 1 Karte aus deiner Hand auf deinen Ablagestapel. Wenn du keine Karten in deinem Deck hast, kannst du diese Karte nicht spielen. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Celestial Storm/15.ts
+++ b/data/Sun & Moon/Celestial Storm/15.ts
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "When this Pokémon senses danger, a sweet fluid oozes from the tip of its head. The taste of it disgusts bird Pokémon.",
+		de: "Wittert es Gefahr, scheidet es eine süßliche Flüssigkeit aus seinem Kopf aus. Vogel-Pokémon behagt dieser Geschmack überhaupt nicht."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/150.ts
+++ b/data/Sun & Moon/Celestial Storm/150.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mira las 4 últimas cartas de tu baraja y pon 2 de ellas en tu mano. Pon el resto de cartas de nuevo en la parte inferior de tu baraja en el orden que quieras.",
 		it: "Guarda le ultime quattro carte del tuo mazzo e aggiungi due di esse alle carte che hai in mano. Poi rimetti le altre carte in fondo al tuo mazzo nell’ordine che preferisci.",
 		pt: "Olhe as 4 últimas cartas do seu baralho e coloque 2 delas na sua mão. Coloque as demais cartas de volta como as últimas cartas do seu baralho em qualquer ordem.",
-		de: "Schau dir die untersten 4 Karten deines Decks an und nimm 2 von ihnen auf deine Hand. Lege die anderen Karten in beliebiger Reihenfolge zurück unter dein Deck."
+		de: "Schau dir die untersten 4 Karten deines Decks an und nimm 2 von ihnen auf deine Hand. Lege die anderen Karten in beliebiger Reihenfolge zurück unter dein Deck. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Celestial Storm/152.ts
+++ b/data/Sun & Moon/Celestial Storm/152.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Nuzleaf",
 		fr: "Pifeuil",
+		de: "Blanas"
 	},
 
 	suffix: "GX",
@@ -94,7 +95,7 @@ const card: Card = {
 				es: "Antro de Perdición GX",
 				it: "Covo Maledetto-GX",
 				pt: "Toca da Crueldade GX",
-				de: "Höhle des Frevels GX"
+				de: "Höhle des Frevels-GX"
 			},
 			effect: {
 				en: "Choose 1 of your opponent’s Pokémon. Your opponent shuffles that Pokémon and all cards attached to it into their deck. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Celestial Storm/153.ts
+++ b/data/Sun & Moon/Celestial Storm/153.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Combusken",
 		fr: "Galifeu",
+		de: "Jungglut"
 	},
 
 	suffix: "GX",
@@ -71,7 +72,7 @@ const card: Card = {
 				es: "Descarta 2 Energías Fire de este Pokémon.",
 				it: "Scarta due Energie Fire assegnate a questo Pokémon.",
 				pt: "Descarte 2 Energias Fire deste Pokémon.",
-				de: "Lege 2 Fire-Energien von diesem Pokémon auf deinen Ablagestapel."
+				de: "Lege 2 {R}-Energien von diesem Pokémon auf deinen Ablagestapel."
 			},
 			damage: 210,
 

--- a/data/Sun & Moon/Celestial Storm/154.ts
+++ b/data/Sun & Moon/Celestial Storm/154.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Cuando juegues este Pokémon de tu mano a tu Banca durante tu turno, puedes cambiarlo por tu Pokémon Activo. Si lo haces, mueve cualquier cantidad de Energías Water de tus otros Pokémon a este Pokémon.",
 				it: "Quando giochi questo Pokémon dalla tua mano e lo metti in panchina durante il tuo turno, puoi scambiarlo con il tuo Pokémon attivo. Se lo fai, sposta un numero qualsiasi di Energie Water assegnate ai tuoi altri Pokémon su questo Pokémon.",
 				pt: "Quando você joga este Pokémon da sua mão para o seu Banco durante a sua vez de jogar, você pode trocá-lo pelo seu Pokémon Ativo. Se fizer isto, mova qualquer número de Energia Water dos seus outros Pokémon para este Pokémon.",
-				de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand auf deine Bank spielst, kannst du es gegen dein Aktives Pokémon austauschen. Wenn du das machst, verschiebe beliebig viele Water-Energien von deinen anderen Pokémon auf dieses Pokémon."
+				de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand auf deine Bank spielst, kannst du es gegen dein Aktives Pokémon austauschen. Wenn du das machst, verschiebe beliebig viele {W}-Energien von deinen anderen Pokémon auf dieses Pokémon."
 			},
 		},
 	],
@@ -79,7 +79,7 @@ const card: Card = {
 				es: "Apretón Frío GX",
 				it: "Freddo Stritolante-GX",
 				pt: "Aperto Frio GX",
-				de: "Eiskalt zerquetscht GX"
+				de: "Eiskalt zerquetscht-GX"
 			},
 			effect: {
 				en: "Discard all Energy from both Active Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Celestial Storm/155.ts
+++ b/data/Sun & Moon/Celestial Storm/155.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Voltorb",
 		fr: "Voltorbe",
+		de: "Voltobal"
 	},
 
 	suffix: "GX",
@@ -84,7 +85,7 @@ const card: Card = {
 				es: "Arrasar y Quemar GX",
 				it: "Spacca e Brucia-GX",
 				pt: "Esmagar e Queimar GX",
-				de: "Falten und Frittieren GX"
+				de: "Falten und Frittieren-GX"
 			},
 			effect: {
 				en: "Discard any amount of Energy from your Pokémon. This attack does 50 more damage for each card you discarded in this way. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Celestial Storm/156.ts
+++ b/data/Sun & Moon/Celestial Storm/156.ts
@@ -84,7 +84,7 @@ const card: Card = {
 				es: "Truco Vital GX",
 				it: "Trucco Vitale-GX",
 				pt: "Truque Revigorante GX",
-				de: "Lebenstrick GX"
+				de: "Lebenstrick-GX"
 			},
 			effect: {
 				en: "Heal all damage from this Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Celestial Storm/157.ts
+++ b/data/Sun & Moon/Celestial Storm/157.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Shuppet",
 		fr: "Polichombr",
+		de: "Shuppet"
 	},
 
 	suffix: "GX",
@@ -89,7 +90,7 @@ const card: Card = {
 				es: "Caza de Tumbas GX",
 				it: "Caccia Sepolcrale-GX",
 				pt: "Caça-túmulos GX",
-				de: "Grabjagd GX"
+				de: "Grabjagd-GX"
 			},
 			effect: {
 				en: "Put 3 cards from your discard pile into your hand. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Celestial Storm/158.ts
+++ b/data/Sun & Moon/Celestial Storm/158.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Scyther",
 		fr: "Insécateur",
+		de: "Sichlor"
 	},
 
 	suffix: "GX",
@@ -92,7 +93,7 @@ const card: Card = {
 				es: "Atajar GX",
 				it: "Fendente Incrociato-GX",
 				pt: "Corte em Cruz GX",
-				de: "Überkreuzzerschneider GX"
+				de: "Überkreuzzerschneider-GX"
 			},
 			effect: {
 				en: "If your opponent’s Active Pokémon is an Evolution Pokémon, this attack does 100 more damage. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Celestial Storm/159.ts
+++ b/data/Sun & Moon/Celestial Storm/159.ts
@@ -81,7 +81,7 @@ const card: Card = {
 				es: "UE Bloques GX",
 				it: "Structura-GX",
 				pt: "Montagem GX",
-				de: "Mauerwerk GX"
+				de: "Mauerwerk-GX"
 			},
 			effect: {
 				en: "This attack does 50 more damage for each Prize card you have taken. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Celestial Storm/16.ts
+++ b/data/Sun & Moon/Celestial Storm/16.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Surskit",
 		fr: "Arakdo",
+		de: "Gehweiher"
 	},
 
 	stage: "Stage1",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "Its wings and antennae don't cope well with moisture. After a rain, it faces sunward to dry off.",
+		de: "Seine Flügel und Fühler sind empfindlich gegen Feuchtigkeit. Nachdem es geregnet hat, streckt es sie gen Sonne, um sie zu trocknen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/160.ts
+++ b/data/Sun & Moon/Celestial Storm/160.ts
@@ -71,7 +71,7 @@ const card: Card = {
 				es: "Este ataque hace 30 puntos de daño por cada Energía Grass Básica y Lightning Básica unida a tus Pokémon.",
 				it: "Questo attacco infligge 30 danni per ogni Energia base Grass o Lightning assegnata ai tuoi Pokémon.",
 				pt: "Este ataque causa 30 pontos de dano vezes a quantidade de Energia Grass básica e Lightning básica ligada aos seus Pokémon.",
-				de: "Diese Attacke fügt 30 Schadenspunkte mal der Anzahl der an deine Pokémon angelegten Grass-Basis-Energien und Lightning-Basis-Energien zu."
+				de: "Diese Attacke fügt 30 Schadenspunkte mal der Anzahl der an deine Pokémon angelegten {G}-Basis-Energien und {L}-Basis-Energien zu."
 			},
 			damage: "30×",
 
@@ -86,7 +86,7 @@ const card: Card = {
 				es: "Tempestad GX",
 				it: "Tempesta-GX",
 				pt: "Vendaval GX",
-				de: "Unwetter GX"
+				de: "Unwetter-GX"
 			},
 			effect: {
 				en: "Discard your hand and draw 10 cards. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Celestial Storm/162.ts
+++ b/data/Sun & Moon/Celestial Storm/162.ts
@@ -32,7 +32,7 @@ const card: Card = {
 		es: "Pon 1 carta de tu mano en tu baraja y barájalas todas. Si lo haces, roba 3 cartas.",
 		it: "Rimischia una delle carte che hai in mano nel tuo mazzo. Se lo fai, pesca tre carte.",
 		pt: "Embaralhe 1 carta da sua mão no seu baralho. Se fizer isto, compre 3 cartas.",
-		de: "Mische 1 Karte aus deiner Hand in dein Deck. Wenn du das machst, ziehe 3 Karten."
+		de: "Mische 1 Karte aus deiner Hand in dein Deck. Wenn du das machst, ziehe 3 Karten. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 	trainerType: "Supporter",
 

--- a/data/Sun & Moon/Celestial Storm/163.ts
+++ b/data/Sun & Moon/Celestial Storm/163.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon las cartas de tu mano en tu baraja y barájalas todas. Después, roba 1 carta por cada carta en la mano de tu rival.",
 		it: "Rimischia le carte che hai in mano nel tuo mazzo. Poi pesca una carta per ogni carta nella mano del tuo avversario.",
 		pt: "Embaralhe a sua mão no seu baralho. Em seguida, compre 1 carta para cada carta na mão do seu oponente.",
-		de: "Mische deine Handkarten in dein Deck. Ziehe anschließend 1 Karte für jede Karte auf der Hand deines Gegners."
+		de: "Mische deine Handkarten in dein Deck. Ziehe anschließend 1 Karte für jede Karte auf der Hand deines Gegners. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Celestial Storm/164.ts
+++ b/data/Sun & Moon/Celestial Storm/164.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 2 cartas de ◇ (Estrella Prisma), enséñalas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo fino a due carte ◇ (stella prisma), mostrale e aggiungile alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por até 2 cartas ◇ (Estrela Prisma) no seu baralho, revele-as e coloque-as na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach bis zu 2 ◇-Karten (Prisma-Stern-Karten), zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach bis zu 2 ◇-Karten (Prisma-Stern-Karten), zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Celestial Storm/165.ts
+++ b/data/Sun & Moon/Celestial Storm/165.ts
@@ -32,7 +32,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 3 cartas y ponlas en tu mano. Después, baraja las cartas de tu baraja. Tu turno termina.",
 		it: "Cerca nel tuo mazzo fino a tre carte e aggiungile alle carte che hai in mano. Poi rimischia le carte del tuo mazzo. Il tuo turno finisce.",
 		pt: "Procure por até 3 cartas no seu baralho e coloque-as na sua mão. Em seguida, embaralhe o seu baralho. A sua vez de jogar acaba.",
-		de: "Durchsuche dein Deck nach bis zu 3 Karten und nimm sie auf deine Hand. Mische anschließend dein Deck. Dein Zug endet."
+		de: "Durchsuche dein Deck nach bis zu 3 Karten und nimm sie auf deine Hand. Mische anschließend dein Deck. Dein Zug endet. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 	trainerType: "Supporter",
 

--- a/data/Sun & Moon/Celestial Storm/167.ts
+++ b/data/Sun & Moon/Celestial Storm/167.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba 3 cartas. Después, descarta 1 carta de tu mano. Si no tienes ninguna carta en tu baraja, no puedes jugar esta carta.",
 		it: "Pesca tre carte. Poi scarta una delle carte che hai in mano. Se non hai carte nel mazzo, non puoi giocare questa carta.",
 		pt: "Compre 3 cartas. Em seguida, descarte 1 carta da sua mão. Se você não tiver nenhuma carta no seu baralho, não poderá jogar esta carta.",
-		de: "Ziehe 3 Karten. Lege anschließend 1 Karte aus deiner Hand auf deinen Ablagestapel. Wenn du keine Karten in deinem Deck hast, kannst du diese Karte nicht spielen."
+		de: "Ziehe 3 Karten. Lege anschließend 1 Karte aus deiner Hand auf deinen Ablagestapel. Wenn du keine Karten in deinem Deck hast, kannst du diese Karte nicht spielen. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Celestial Storm/169.ts
+++ b/data/Sun & Moon/Celestial Storm/169.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Nuzleaf",
 		fr: "Pifeuil",
+		de: "Blanas"
 	},
 
 	suffix: "GX",
@@ -94,7 +95,7 @@ const card: Card = {
 				es: "Antro de Perdición GX",
 				it: "Covo Maledetto-GX",
 				pt: "Toca da Crueldade GX",
-				de: "Höhle des Frevels GX"
+				de: "Höhle des Frevels-GX"
 			},
 			effect: {
 				en: "Choose 1 of your opponent’s Pokémon. Your opponent shuffles that Pokémon and all cards attached to it into their deck. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Celestial Storm/17.ts
+++ b/data/Sun & Moon/Celestial Storm/17.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives around clean ponds. At night, its rear lights up. It converses with others by flashing its light.",
+		de: "Es lebt in der Nähe von reinen Teichen. Nachts leuchtet sein Hinterteil und es kommuniziert durch dessen Blinken mit Artgenossen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/170.ts
+++ b/data/Sun & Moon/Celestial Storm/170.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Combusken",
 		fr: "Galifeu",
+		de: "Jungglut"
 	},
 
 	suffix: "GX",
@@ -71,7 +72,7 @@ const card: Card = {
 				es: "Descarta 2 Energías Fire de este Pokémon.",
 				it: "Scarta due Energie Fire assegnate a questo Pokémon.",
 				pt: "Descarte 2 Energias Fire deste Pokémon.",
-				de: "Lege 2 Fire-Energien von diesem Pokémon auf deinen Ablagestapel."
+				de: "Lege 2 {R}-Energien von diesem Pokémon auf deinen Ablagestapel."
 			},
 			damage: 210,
 

--- a/data/Sun & Moon/Celestial Storm/171.ts
+++ b/data/Sun & Moon/Celestial Storm/171.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Cuando juegues este Pokémon de tu mano a tu Banca durante tu turno, puedes cambiarlo por tu Pokémon Activo. Si lo haces, mueve cualquier cantidad de Energías Water de tus otros Pokémon a este Pokémon.",
 				it: "Quando giochi questo Pokémon dalla tua mano e lo metti in panchina durante il tuo turno, puoi scambiarlo con il tuo Pokémon attivo. Se lo fai, sposta un numero qualsiasi di Energie Water assegnate ai tuoi altri Pokémon su questo Pokémon.",
 				pt: "Quando você joga este Pokémon da sua mão para o seu Banco durante a sua vez de jogar, você pode trocá-lo pelo seu Pokémon Ativo. Se fizer isto, mova qualquer número de Energia Water dos seus outros Pokémon para este Pokémon.",
-				de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand auf deine Bank spielst, kannst du es gegen dein Aktives Pokémon austauschen. Wenn du das machst, verschiebe beliebig viele Water-Energien von deinen anderen Pokémon auf dieses Pokémon."
+				de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand auf deine Bank spielst, kannst du es gegen dein Aktives Pokémon austauschen. Wenn du das machst, verschiebe beliebig viele {W}-Energien von deinen anderen Pokémon auf dieses Pokémon."
 			},
 		},
 	],
@@ -79,7 +79,7 @@ const card: Card = {
 				es: "Apretón Frío GX",
 				it: "Freddo Stritolante-GX",
 				pt: "Aperto Frio GX",
-				de: "Eiskalt zerquetscht GX"
+				de: "Eiskalt zerquetscht-GX"
 			},
 			effect: {
 				en: "Discard all Energy from both Active Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Celestial Storm/172.ts
+++ b/data/Sun & Moon/Celestial Storm/172.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Voltorb",
 		fr: "Voltorbe",
+		de: "Voltobal"
 	},
 
 	suffix: "GX",
@@ -84,7 +85,7 @@ const card: Card = {
 				es: "Arrasar y Quemar GX",
 				it: "Spacca e Brucia-GX",
 				pt: "Esmagar e Queimar GX",
-				de: "Falten und Frittieren GX"
+				de: "Falten und Frittieren-GX"
 			},
 			effect: {
 				en: "Discard any amount of Energy from your Pokémon. This attack does 50 more damage for each card you discarded in this way. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Celestial Storm/173.ts
+++ b/data/Sun & Moon/Celestial Storm/173.ts
@@ -84,7 +84,7 @@ const card: Card = {
 				es: "Truco Vital GX",
 				it: "Trucco Vitale-GX",
 				pt: "Truque Revigorante GX",
-				de: "Lebenstrick GX"
+				de: "Lebenstrick-GX"
 			},
 			effect: {
 				en: "Heal all damage from this Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Celestial Storm/174.ts
+++ b/data/Sun & Moon/Celestial Storm/174.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Shuppet",
 		fr: "Polichombr",
+		de: "Shuppet"
 	},
 
 	suffix: "GX",
@@ -89,7 +90,7 @@ const card: Card = {
 				es: "Caza de Tumbas GX",
 				it: "Caccia Sepolcrale-GX",
 				pt: "Caça-túmulos GX",
-				de: "Grabjagd GX"
+				de: "Grabjagd-GX"
 			},
 			effect: {
 				en: "Put 3 cards from your discard pile into your hand. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Celestial Storm/175.ts
+++ b/data/Sun & Moon/Celestial Storm/175.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Scyther",
 		fr: "Insécateur",
+		de: "Sichlor"
 	},
 
 	suffix: "GX",
@@ -92,7 +93,7 @@ const card: Card = {
 				es: "Atajar GX",
 				it: "Fendente Incrociato-GX",
 				pt: "Corte em Cruz GX",
-				de: "Überkreuzzerschneider GX"
+				de: "Überkreuzzerschneider-GX"
 			},
 			effect: {
 				en: "If your opponent’s Active Pokémon is an Evolution Pokémon, this attack does 100 more damage. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Celestial Storm/176.ts
+++ b/data/Sun & Moon/Celestial Storm/176.ts
@@ -81,7 +81,7 @@ const card: Card = {
 				es: "UE Bloques GX",
 				it: "Structura-GX",
 				pt: "Montagem GX",
-				de: "Mauerwerk GX"
+				de: "Mauerwerk-GX"
 			},
 			effect: {
 				en: "This attack does 50 more damage for each Prize card you have taken. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Celestial Storm/177.ts
+++ b/data/Sun & Moon/Celestial Storm/177.ts
@@ -71,7 +71,7 @@ const card: Card = {
 				es: "Este ataque hace 30 puntos de daño por cada Energía Grass Básica y Lightning Básica unida a tus Pokémon.",
 				it: "Questo attacco infligge 30 danni per ogni Energia base Grass o Lightning assegnata ai tuoi Pokémon.",
 				pt: "Este ataque causa 30 pontos de dano vezes a quantidade de Energia Grass básica e Lightning básica ligada aos seus Pokémon.",
-				de: "Diese Attacke fügt 30 Schadenspunkte mal der Anzahl der an deine Pokémon angelegten Grass-Basis-Energien und Lightning-Basis-Energien zu."
+				de: "Diese Attacke fügt 30 Schadenspunkte mal der Anzahl der an deine Pokémon angelegten {G}-Basis-Energien und {L}-Basis-Energien zu."
 			},
 			damage: "30×",
 
@@ -86,7 +86,7 @@ const card: Card = {
 				es: "Tempestad GX",
 				it: "Tempesta-GX",
 				pt: "Vendaval GX",
-				de: "Unwetter GX"
+				de: "Unwetter-GX"
 			},
 			effect: {
 				en: "Discard your hand and draw 10 cards. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Celestial Storm/179.ts
+++ b/data/Sun & Moon/Celestial Storm/179.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Si al Pokémon al que esté unida esta carta le quedan 30 PS o menos y tiene algún contador de daño sobre él, sus ataques hacen 60 puntos de daño más al Pokémon Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
 		it: "Se il Pokémon a cui è assegnata questa carta ha 30 PS o meno rimanenti e se ha dei segnalini danno, i suoi attacchi infliggono 60 danni in più al Pokémon attivo del tuo avversario, prima di aver applicato debolezza e resistenza.",
 		pt: "Se o Pokémon ao qual esta carta está ligada tiver PS restante de 30 ou menos e tiver algum contador de dano nele, seus ataques causarão 60 pontos de dano a mais ao Pokémon Ativo do seu oponente (antes de aplicar Fraqueza e Resistência).",
-		de: "Wenn die verbleibenden KP des Pokémon, an das diese Karte angelegt ist, 30 oder weniger betragen und auf ihm mindestens 1 Schadensmarke liegt, fügen die Attacken dieses Pokémon dem Aktiven Pokémon deines Gegners 60 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn die verbleibenden KP des Pokémon, an das diese Karte angelegt ist, 30 oder weniger betragen und auf ihm mindestens 1 Schadensmarke liegt, fügen die Attacken dieses Pokémon dem Aktiven Pokémon deines Gegners 60 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden). Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sun & Moon/Celestial Storm/18.ts
+++ b/data/Sun & Moon/Celestial Storm/18.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "With its sweet aroma, it guides Volbeat to draw signs with light in the night sky.",
+		de: "Sein süßer Duft leitet Volbeat an, Zeichen aus Licht an den Nachthimmel zu malen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/182.ts
+++ b/data/Sun & Moon/Celestial Storm/182.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Elige 1 carta de Energía unida a 1 de tus Pokémon. Busca en tu baraja 1 carta de Energía Básica y cámbiala por esa carta. Pon la primera carta de Energía en tu baraja y barájalas todas.",
 		it: "Scegli una carta Energia assegnata a uno dei tuoi Pokémon. Cerca una carta Energia base nel tuo mazzo e scambiala con quella carta. Rimischia la prima carta Energia nel tuo mazzo.",
 		pt: "Escolha 1 carta de Energia que está ligada a 1 dos seus Pokémon. Procure por 1 carta de Energia básica no seu baralho e troque-a por aquela carta. Embaralhe a primeira carta de Energia no seu baralho.",
-		de: "Wähle 1 Energiekarte, die an 1 deiner Pokémon angelegt ist. Durchsuche dein Deck nach 1 Basis-Energiekarte und tausche sie gegen jene Karte aus. Mische die erste Energiekarte in dein Deck."
+		de: "Wähle 1 Energiekarte, die an 1 deiner Pokémon angelegt ist. Durchsuche dein Deck nach 1 Basis-Energiekarte und tausche sie gegen jene Karte aus. Mische die erste Energiekarte in dein Deck. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Celestial Storm/19.ts
+++ b/data/Sun & Moon/Celestial Storm/19.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It prefers harsh environments such as deserts. It can survive for 30 days on water stored in its body.",
+		de: "Es bevorzugt lebenswidrige Gebiete wie Wüsten. Der Wasserspeicher in seinem Körper reicht für bis zu 30 Tage."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/2.ts
+++ b/data/Sun & Moon/Celestial Storm/2.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Bellsprout",
 		fr: "Chétiflor",
+		de: "Knofensa"
 	},
 
 	stage: "Stage1",
@@ -52,7 +53,7 @@ const card: Card = {
 				es: "Une hasta 2 cartas de Energía Grass de tu mano a este Pokémon.",
 				it: "Assegna a questo Pokémon fino a due carte Energia Grass dalla tua mano.",
 				pt: "Ligue até 2 cartas de Energia Grass da sua mão a este Pokémon.",
-				de: "Lege bis zu 2 Grass-Energiekarten aus deiner Hand an dieses Pokémon an."
+				de: "Lege bis zu 2 {G}-Energiekarten aus deiner Hand an dieses Pokémon an."
 			},
 
 		},
@@ -93,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "It spits out Poison Powder to immobilize the enemy and then finishes it with a spray of Acid.",
+		de: "Dieses Pokémon lähmt den Gegner mit Giftpuder, bevor es ihn mit Säure erledigt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/20.ts
+++ b/data/Sun & Moon/Celestial Storm/20.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cacnea",
 		fr: "Cacnea",
+		de: "Tuska"
 	},
 
 	stage: "Stage1",
@@ -93,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "Packs of them follow travelers through the desert until the travelers can no longer move.",
+		de: "Gruppen von Noktuska folgen müden Wüstenreisenden und warten, bis diese bewegungsunfähig werden."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/21.ts
+++ b/data/Sun & Moon/Celestial Storm/21.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "The bunch of fruit around its neck ripens twice a year and is delicious. It's a highly favored tropical snack.",
+		de: "Sein Hals trägt zweimal im Jahr süße Früchte. Kinder in den südlichen Tropen naschen oft davon."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/22.ts
+++ b/data/Sun & Moon/Celestial Storm/22.ts
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "The soul of seaweed adrift in the waves became reborn as this Pokémon. It maintains itself with new infusions of seabed detritus and seaweed.",
+		de: "Es ist die Wiedergeburt der Seelen von im Meer treibendem Seetang. Es schützt seinen Körper, indem es Meeresmüll an Seetang bindet."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/23.ts
+++ b/data/Sun & Moon/Celestial Storm/23.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "Its body is made of magma. If it doesn't keep moving, its body will cool and harden.",
+		de: "Sein Körper besteht aus Magma. Bleibt es nicht ständig in Bewegung, kühlt es aus und verhärtet sich."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/24.ts
+++ b/data/Sun & Moon/Celestial Storm/24.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Slugma",
 		fr: "Limagma",
+		de: "Schneckmag"
 	},
 
 	stage: "Stage1",
@@ -87,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Its body is as hot as lava and is always billowing. Flames will occasionally burst from its shell.",
+		de: "Sein Körper ist heißer als Lava und wogt stets. Manchmal schießen Flammen aus seinem Haus."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/25.ts
+++ b/data/Sun & Moon/Celestial Storm/25.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "A fire burns inside, so it feels very warm to hug. It launches fireballs of 1,800 degrees Fahrenheit.",
+		de: "In seinem Inneren lodert ein Feuer. Es schleudert 1 000 °C heiße Feuerbälle."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/26.ts
+++ b/data/Sun & Moon/Celestial Storm/26.ts
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "A fire burns inside, so it feels very warm to hug. It launches fireballs of 1,800 degrees Fahrenheit.",
+		de: "In seinem Inneren lodert ein Feuer. Es schleudert 1 000 °C heiße Feuerbälle."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/27.ts
+++ b/data/Sun & Moon/Celestial Storm/27.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Torchic",
 		fr: "Poussifeu",
+		de: "Flemmli"
 	},
 
 	stage: "Stage1",
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "During a battle, the hot flame in its body increases. Its kicks have outstanding destructive power.",
+		de: "Im Kampf lodert sein inneres Feuer hoch auf. Wo seine mächtigen Tritte landen, wächst kein Gras mehr."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/28.ts
+++ b/data/Sun & Moon/Celestial Storm/28.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Combusken",
 		fr: "Galifeu",
+		de: "Jungglut"
 	},
 
 	suffix: "GX",
@@ -71,7 +72,7 @@ const card: Card = {
 				es: "Descarta 2 Energías Fire de este Pokémon.",
 				it: "Scarta due Energie Fire assegnate a questo Pokémon.",
 				pt: "Descarte 2 Energias Fire deste Pokémon.",
-				de: "Lege 2 Fire-Energien von diesem Pokémon auf deinen Ablagestapel."
+				de: "Lege 2 {R}-Energien von diesem Pokémon auf deinen Ablagestapel."
 			},
 			damage: 210,
 

--- a/data/Sun & Moon/Celestial Storm/29.ts
+++ b/data/Sun & Moon/Celestial Storm/29.ts
@@ -48,7 +48,7 @@ const card: Card = {
 				es: "Descarta las 4 primeras cartas de tu baraja. Si entre esas cartas hay cartas de Energía Fire, únelas a tus Pokémon de la manera que desees.",
 				it: "Scarta le prime quattro carte del tuo mazzo. Se fra queste ci sono delle carte Energia Fire, assegnale a piacimento ai tuoi Pokémon.",
 				pt: "Descarte as 4 primeiras cartas do seu baralho. Se houver cartas de Energia Fire entre elas, ligue-as aos seus Pokémon como desejar.",
-				de: "Lege die obersten 4 Karten von deinem Deck auf deinen Ablagestapel. Wenn unter jenen Karten Fire-Energiekarten sind, lege sie beliebig an deine Pokémon an."
+				de: "Lege die obersten 4 Karten von deinem Deck auf deinen Ablagestapel. Wenn unter jenen Karten {R}-Energiekarten sind, lege sie beliebig an deine Pokémon an."
 			},
 			damage: 30,
 
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "If the fire burning within its shell goes out, it will die. Those who wish to raise one in their home must always keep something flammable at hand.",
+		de: "Erlöschen die Flammen in seinem Panzer, stirbt es. Will man es bei sich zu Hause halten, braucht man daher stets brennbares Material."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/3.ts
+++ b/data/Sun & Moon/Celestial Storm/3.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Weepinbell",
 		fr: "Boustiflor",
+		de: "Ultrigaria"
 	},
 
 	stage: "Stage2",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "Once ingested into this Pokémon's body, even the hardest object will melt into nothing.",
+		de: "Selbst die härtesten Objekte werden zersetzt, wenn der Körper sie erst aufgenommen hat."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/30.ts
+++ b/data/Sun & Moon/Celestial Storm/30.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "This Oricorio has sipped red nectar. Its passionate dance moves cause its enemies to combust in both body and mind.",
+		de: "Ein Choreogel, das roten Nektar geschlürft hat. Mit seinen hitzigen Tanzschritten versengt es Körper und Geist eines jeden Gegners."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/31.ts
+++ b/data/Sun & Moon/Celestial Storm/31.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Cuando juegues este Pokémon de tu mano a tu Banca durante tu turno, puedes cambiarlo por tu Pokémon Activo. Si lo haces, mueve cualquier cantidad de Energías Water de tus otros Pokémon a este Pokémon.",
 				it: "Quando giochi questo Pokémon dalla tua mano e lo metti in panchina durante il tuo turno, puoi scambiarlo con il tuo Pokémon attivo. Se lo fai, sposta un numero qualsiasi di Energie Water assegnate ai tuoi altri Pokémon su questo Pokémon.",
 				pt: "Quando você joga este Pokémon da sua mão para o seu Banco durante a sua vez de jogar, você pode trocá-lo pelo seu Pokémon Ativo. Se fizer isto, mova qualquer número de Energia Water dos seus outros Pokémon para este Pokémon.",
-				de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand auf deine Bank spielst, kannst du es gegen dein Aktives Pokémon austauschen. Wenn du das machst, verschiebe beliebig viele Water-Energien von deinen anderen Pokémon auf dieses Pokémon."
+				de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand auf deine Bank spielst, kannst du es gegen dein Aktives Pokémon austauschen. Wenn du das machst, verschiebe beliebig viele {W}-Energien von deinen anderen Pokémon auf dieses Pokémon."
 			},
 		},
 	],
@@ -79,7 +79,7 @@ const card: Card = {
 				es: "Apretón Frío GX",
 				it: "Freddo Stritolante-GX",
 				pt: "Aperto Frio GX",
-				de: "Eiskalt zerquetscht GX"
+				de: "Eiskalt zerquetscht-GX"
 			},
 			effect: {
 				en: "Discard all Energy from both Active Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Celestial Storm/32.ts
+++ b/data/Sun & Moon/Celestial Storm/32.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Busca en tu baraja hasta 3 cartas de Energía Water, enséñalas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
 				it: "Cerca nel tuo mazzo fino a tre carte Energia Water, mostrale e aggiungile alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 				pt: "Procure por até 3 cartas de Energia Water no seu baralho, revele-as e coloque-as na sua mão. Em seguida, embaralhe o seu baralho.",
-				de: "Durchsuche dein Deck nach bis zu 3 Water-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+				de: "Durchsuche dein Deck nach bis zu 3 {W}-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
 			},
 
 		},
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "To alert it, the fin on its head senses the flow of water. It has the strength to heft boulders.",
+		de: "Die Flosse auf seinem Kopf prüft die Strömung des Wassers. Dieses Pokémon kann Felsen heben."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/33.ts
+++ b/data/Sun & Moon/Celestial Storm/33.ts
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "To alert it, the fin on its head senses the flow of water. It has the strength to heft boulders.",
+		de: "Die Flosse auf seinem Kopf prüft Strömungen des Wassers. Dieses Pokémon kann Felsen heben."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/34.ts
+++ b/data/Sun & Moon/Celestial Storm/34.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Mudkip",
 		fr: "Gobou",
+		de: "Hydropi"
 	},
 
 	stage: "Stage1",
@@ -89,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "Living on muddy ground that provides poor footing has made its legs sturdy.",
+		de: "Der zähe Morast seiner Heimat hat seine Beine gestählt und ihnen gewaltige Kraft verliehen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/35.ts
+++ b/data/Sun & Moon/Celestial Storm/35.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Marshtomp",
 		fr: "Flobio",
+		de: "Moorabbel"
 	},
 
 	stage: "Stage2",
@@ -76,7 +77,7 @@ const card: Card = {
 				es: "Este ataque hace 20 puntos de daño más por cada Energía Water unida a este Pokémon.",
 				it: "Questo attacco infligge 20 danni in più per ogni Energia Water assegnata a questo Pokémon.",
 				pt: "Este ataque causa 20 pontos de dano a mais vezes a quantidade de Energia Water ligada a este Pokémon.",
-				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der an dieses Pokémon angelegten Water-Energien zu."
+				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der an dieses Pokémon angelegten {W}-Energien zu."
 			},
 			damage: "80+",
 
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "It can swim while towing a large ship. It bashes down foes with a swing of its thick arms.",
+		de: "Es kann im Schwimmen ein großes Schiff ziehen. Seine Gegner schlägt es mit Schlägen seiner Arme zurück."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/36.ts
+++ b/data/Sun & Moon/Celestial Storm/36.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It searches about for clean water. If it does not drink water for too long, the leaf on its head wilts.",
+		de: "Es sucht nach reinem Wasser. Wenn es für längere Zeit kein Wasser trinkt, verwelkt das Blatt auf seinem Kopf."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/37.ts
+++ b/data/Sun & Moon/Celestial Storm/37.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Lotad",
 		fr: "Nénupiot",
+		de: "Loturzel"
 	},
 
 	stage: "Stage1",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Si este Pokémon tiene alguna Energía Water unida a él, no tiene ningún Coste de Retirada.",
 				it: "Se questo Pokémon ha delle Energie Water assegnate, non ha costo di ritirata.",
 				pt: "Se este Pokémon tiver alguma Energia Water ligada a ele, não terá custo de Recuo.",
-				de: "Wenn an dieses Pokémon mindestens 1 Water-Energie angelegt ist, hat es keine Rückzugskosten."
+				de: "Wenn an dieses Pokémon mindestens 1 {W}-Energie angelegt ist, hat es keine Rückzugskosten."
 			},
 		},
 	],
@@ -93,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "It has a mischievous spirit. If it spots an angler, it will tug on the fishing line to interfere.",
+		de: "Es hat ein spitzbübisches Wesen. Sieht es einen Angler, zieht es an der Angelschnur, um ihn zu ärgern."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/38.ts
+++ b/data/Sun & Moon/Celestial Storm/38.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Lombre",
 		fr: "Lombre",
+		de: "Lombrero"
 	},
 
 	stage: "Stage2",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "The rhythm of bright, festive music activates Ludicolo's cells, making it more powerful.",
+		de: "Der Rhythmus von Partymusik bringt das Blut von Kappalores in Wallung und es wird dadurch stärker."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/39.ts
+++ b/data/Sun & Moon/Celestial Storm/39.ts
@@ -67,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "It shows off by spraying jets of seawater from the nostrils above its eyes. It eats a solid ton of Wishiwashi every day.",
+		de: "Es prustet Meerwasser aus den über seinen Augen liegenden Nasenlöchern hinaus. Außerdem frisst es täglich eine Tonne Lusardin."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/4.ts
+++ b/data/Sun & Moon/Celestial Storm/4.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "While young, they live together deep in the mountains, training themselves in how to fight with their scythes and move at high speeds.",
+		de: "Junge Sichlor wohnen in Gruppen tief in den Bergen. Dort trainieren sie ihre Schnelligkeit und üben den Kampf mit Sicheln."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/40.ts
+++ b/data/Sun & Moon/Celestial Storm/40.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Wailmer",
 		fr: "Wailmer",
+		de: "Wailmer"
 	},
 
 	stage: "Stage1",
@@ -73,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "Its immense size is the reason for its popularity. Wailord watching is a favorite sightseeing activity in various parts of the world.",
+		de: "Es ist allein schon aufgrund seiner schieren Größe sehr beliebt. Wailord-Watching gilt vielerorts als beliebte Touristenattraktion."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/41.ts
+++ b/data/Sun & Moon/Celestial Storm/41.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It is protected by a sturdy shell. Once in a lifetime, it makes a magnificent pearl.",
+		de: "Es ist durch einen harten Panzer geschützt. Einmal im Leben stellt es eine bezaubernde Perle her."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/42.ts
+++ b/data/Sun & Moon/Celestial Storm/42.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Clamperl",
 		fr: "Coquiperl",
+		de: "Perlu"
 	},
 
 	stage: "Stage1",
@@ -95,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives deep in the sea. With a tail shaped like a small fish, it attracts unsuspecting prey.",
+		de: "Es lebt tief im Meer. Sein Schweif ist wie ein kleiner Fisch geformt. Mit ihm lockt es Beute an."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/43.ts
+++ b/data/Sun & Moon/Celestial Storm/43.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Clamperl",
 		fr: "Coquiperl",
+		de: "Perlu"
 	},
 
 	stage: "Stage1",
@@ -70,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "Its swimming form is exquisitely elegant. With its thin mouth, it feeds on seaweed that grows between rocks.",
+		de: "Es schwimmt äußerst elegant. Mit seinem dünnen Maul ernährt es sich von Seetang, der zwischen Felsen wächst."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/44.ts
+++ b/data/Sun & Moon/Celestial Storm/44.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Loving couples have a soft spot for this Pokémon, so honeymoon hotels often release this Pokémon into their pools.",
+		de: "Da Liebiskus besonders bei Pärchen beliebt sind, findet man sie oft in Swimmingpools von Hotels für Frischvermählte."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/45.ts
+++ b/data/Sun & Moon/Celestial Storm/45.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "Its body is made of ice from the ice age. It controls frigid air of -328 degrees Fahrenheit.",
+		de: "Sein Körper besteht aus Eis aus der Eiszeit. Es kontrolliert gefrorene Luft, die -200 °C kalt ist."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/46.ts
+++ b/data/Sun & Moon/Celestial Storm/46.ts
@@ -90,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said to have widened the seas by causing downpours. It had been asleep in a marine trench.",
+		de: "Man sagt, es habe die Meere vergrößert, indem es es regnen ließ. Es schlief in einem Meeresgraben."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/47.ts
+++ b/data/Sun & Moon/Celestial Storm/47.ts
@@ -95,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "Usually found in power plants. Easily mistaken for a Poké Ball, it has zapped many people.",
+		de: "Dieses Pokémon wird oftmals mit einem Pokéball verwechselt. Es lebt vorwiegend in Kraftwerken."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/48.ts
+++ b/data/Sun & Moon/Celestial Storm/48.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Voltorb",
 		fr: "Voltorbe",
+		de: "Voltobal"
 	},
 
 	suffix: "GX",
@@ -84,7 +85,7 @@ const card: Card = {
 				es: "Arrasar y Quemar GX",
 				it: "Spacca e Brucia-GX",
 				pt: "Esmagar e Queimar GX",
-				de: "Falten und Frittieren GX"
+				de: "Falten und Frittieren-GX"
 			},
 			effect: {
 				en: "Discard any amount of Energy from your Pokémon. This attack does 50 more damage for each card you discarded in this way. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Celestial Storm/49.ts
+++ b/data/Sun & Moon/Celestial Storm/49.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives in the depths beyond the reach of sunlight. It flashes lights on its antennae to communicate with others of its kind.",
+		de: "Es lebt in den Tiefen des Meeres, zu denen kein Licht durchdringt. Es kommuniziert mit anderen Lampi, indem es seine Antennen aufblitzen lässt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/5.ts
+++ b/data/Sun & Moon/Celestial Storm/5.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Some fishermen weave its sturdy thread into nets to catch fish Pokémon.",
+		de: "Einige Fischer knüpfen sich aus seinem robusten Faden Netze, mit denen sie dann Fisch-Pokémon fangen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/50.ts
+++ b/data/Sun & Moon/Celestial Storm/50.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Chinchou",
 		fr: "Loupio",
+		de: "Lampi"
 	},
 
 	stage: "Stage1",
@@ -76,7 +77,7 @@ const card: Card = {
 				es: "Puedes descartar todas las Energías Lightning de este Pokémon. Si lo haces, este ataque hace 70 puntos de daño más.",
 				it: "Puoi scartare tutte le Energie Lightning assegnate a questo Pokémon. Se lo fai, questo attacco infligge 70 danni in più.",
 				pt: "Você pode descartar todas as Energias Lightning deste Pokémon. Se fizer isto, este ataque causará 70 pontos de dano a mais.",
-				de: "Du kannst alle Lightning-Energien von diesem Pokémon auf deinen Ablagestapel legen. Wenn du das machst, fügt diese Attacke 70 Schadenspunkte mehr zu."
+				de: "Du kannst alle {L}-Energien von diesem Pokémon auf deinen Ablagestapel legen. Wenn du das machst, fügt diese Attacke 70 Schadenspunkte mehr zu."
 			},
 			damage: "70+",
 
@@ -101,6 +102,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon flashes a bright light that blinds its prey. This creates an opening for it to deliver an electrical attack.",
+		de: "Es blendet seine Beute mit einem starken Blitz. Sieht es eine Chance zuzuschlagen, greift es sie mit Elektrizität an."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/51.ts
+++ b/data/Sun & Moon/Celestial Storm/51.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It stores static electricity in its fur for discharging. It gives off sparks if a storm approaches.",
+		de: "In seinem Fell speichert es statische Elektrizität für spätere Entladungen. Braut sich ein Sturm zusammen, entlädt es Funken."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/52.ts
+++ b/data/Sun & Moon/Celestial Storm/52.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Electrike",
 		fr: "Dynavolt",
+		de: "Frizelbliz"
 	},
 
 	stage: "Stage1",
@@ -99,6 +100,7 @@ const card: Card = {
 
 	description: {
 		en: "It discharges electricity from its mane. It creates a thundercloud overhead to drop lightning bolts.",
+		de: "Aus seiner Mähne entlädt es Elektrizität. Es generiert eine Gewitterwolke, aus der es Blitze entlädt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/53.ts
+++ b/data/Sun & Moon/Celestial Storm/53.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It absorbs electricity from telephone poles. It shorts out its body to create crackling noises.",
+		de: "Es holt sich Energie aus Telegrafenmasten. Wenn es diese entlädt, hört man ein lautes Prasseln."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/54.ts
+++ b/data/Sun & Moon/Celestial Storm/54.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It cheers on friends. If its friends are losing, its body lets off more and more sparks.",
+		de: "Es feuert Freunde an. Sind diese im Begriff zu verlieren, gibt sein Körper immer mehr Funken ab."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/55.ts
+++ b/data/Sun & Moon/Celestial Storm/55.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It creates an electric charge by rubbing its feathers together. It dances over to its enemies and delivers shocking electrical punches.",
+		de: "Es reibt seine Federn aneinander, um sich elektrisch aufzuladen. Danach tanzt es zum Gegner und verpasst ihm einen Elektrohieb."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/56.ts
+++ b/data/Sun & Moon/Celestial Storm/56.ts
@@ -84,7 +84,7 @@ const card: Card = {
 				es: "Truco Vital GX",
 				it: "Trucco Vitale-GX",
 				pt: "Truque Revigorante GX",
-				de: "Lebenstrick GX"
+				de: "Lebenstrick-GX"
 			},
 			effect: {
 				en: "Heal all damage from this Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Celestial Storm/57.ts
+++ b/data/Sun & Moon/Celestial Storm/57.ts
@@ -86,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "There is nothing its stomach can't digest. While it is digesting, vile, overpowering gases are expelled.",
+		de: "Es gibt nichts, das sein Magen nicht verdauen könnte. Während des Verdauungsvorgangs werden eklige, penetrante Gase freigesetzt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/58.ts
+++ b/data/Sun & Moon/Celestial Storm/58.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gulpin",
 		fr: "Gloupti",
+		de: "Schluppuck"
 	},
 
 	stage: "Stage1",
@@ -95,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "It gulps anything that fits in its mouth. Its special enzymes can dissolve anything.",
+		de: "Es verschluckt, was in sein Maul passt, und verdaut es mit seiner alles zersetzenden Magensäure."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/59.ts
+++ b/data/Sun & Moon/Celestial Storm/59.ts
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "It bounces around on its tail to keep its heart pumping. It carries a pearl from Clamperl on its head.",
+		de: "Seine Hüpfbewegungen bringen sein Herz zum Schlagen. Es trägt eine Perle von Perlu auf dem Kopf."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/6.ts
+++ b/data/Sun & Moon/Celestial Storm/6.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Spinarak",
 		fr: "Mimigal",
+		de: "Webarak"
 	},
 
 	stage: "Stage1",
@@ -92,6 +93,7 @@ const card: Card = {
 
 	description: {
 		en: "It spins thread from both its rear and its mouth. Then it wraps its prey up in thread and sips their bodily fluids at its leisure.",
+		de: "Es kann mit dem Hinterleib und dem Mund Fäden spinnen. Mit diesen fesselt es seine Beute und entzieht ihr gemächlich alle Flüssigkeit."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/60.ts
+++ b/data/Sun & Moon/Celestial Storm/60.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Spoink",
 		fr: "Spoink",
+		de: "Spoink"
 	},
 
 	stage: "Stage1",
@@ -70,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "It uses black pearls to amplify its psychic power. It does an odd dance to gain control over foes.",
+		de: "Mit schwarzen Perlen verstärkt es seine Psycho-Kräfte. Mit einem Tanz kontrolliert es seine Gegner."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/61.ts
+++ b/data/Sun & Moon/Celestial Storm/61.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Si tienes a Solrock en juego, los Pokémon Fire en juego (tanto tuyos como de tu rival) no tienen ninguna habilidad, excepto los Pokémon-GX y Pokémon-EX.",
 				it: "Se hai Solrock in gioco, le abilità dei Pokémon Fire in gioco, sia tuoi che del tuo avversario, non hanno effetto, a eccezione dei Pokémon-GX e dei Pokémon-EX.",
 				pt: "Se você tiver Solrock em jogo, os Pokémon Fire em jogo (seus e do seu oponente) não têm Habilidades, exceto pelos Pokémon-GX e Pokémon-EX.",
-				de: "Wenn du Sonnfel im Spiel hast, haben Fire-Pokémon im Spiel (deine und die deines Gegners) keine Fähigkeiten, außer Pokémon-GX und Pokémon-EX."
+				de: "Wenn du Sonnfel im Spiel hast, haben {R}-Pokémon im Spiel (deine und die deines Gegners) keine Fähigkeiten, außer Pokémon-GX und Pokémon-EX."
 			},
 		},
 	],
@@ -87,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "It was discovered at the site of a meteor strike 40 years ago. Its stare can lull its foes to sleep.",
+		de: "Wurde erstmals vor 40 Jahren bei einem Meteoritenkrater entdeckt. Sein Blick wirkt einschläfernd."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/62.ts
+++ b/data/Sun & Moon/Celestial Storm/62.ts
@@ -86,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "It absorbs solar energy during the day. Always expressionless, it can sense what its foe is thinking.",
+		de: "Tagsüber absorbiert es Sonnenlicht. Ohne je seinen Ausdruck zu verändern, kann es die Gedanken des Gegners lesen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/63.ts
+++ b/data/Sun & Moon/Celestial Storm/63.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It loves vengeful emotions and hangs in rows under the eaves of houses where vengeful people live.",
+		de: "Es liebt Rachegefühle. Diese Pokémon hängen sich an Dachrinnen von Häusern, in denen Rachsüchtige leben."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/64.ts
+++ b/data/Sun & Moon/Celestial Storm/64.ts
@@ -71,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "It loves vengeful emotions and hangs in rows under the eaves of houses where vengeful people live.",
+		de: "Es liebt Rachegefühle. Diese Pokémon hängen sich an Dachrinnen von Häusern, in denen Rachsüchtige leben."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/65.ts
+++ b/data/Sun & Moon/Celestial Storm/65.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Shuppet",
 		fr: "Polichombr",
+		de: "Shuppet"
 	},
 
 	stage: "Stage1",
@@ -99,6 +100,7 @@ const card: Card = {
 
 	description: {
 		en: "Strong feelings of hatred turned a puppet into a Pokémon. If it opens its mouth, its cursed energy escapes.",
+		de: "Starke Gefühle des Hasses machten aus einer Puppe ein Pokémon. Öffnet es seinen Mund, kann die ganze verfluchte Energie hinaus."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/66.ts
+++ b/data/Sun & Moon/Celestial Storm/66.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Shuppet",
 		fr: "Polichombr",
+		de: "Shuppet"
 	},
 
 	suffix: "GX",
@@ -89,7 +90,7 @@ const card: Card = {
 				es: "Caza de Tumbas GX",
 				it: "Caccia Sepolcrale-GX",
 				pt: "Caça-túmulos GX",
-				de: "Grabjagd GX"
+				de: "Grabjagd-GX"
 			},
 			effect: {
 				en: "Put 3 cards from your discard pile into your hand. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Celestial Storm/67.ts
+++ b/data/Sun & Moon/Celestial Storm/67.ts
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "DNA from a space virus mutated and became a Pokémon. It appears where auroras are seen.",
+		de: "Deoxys ist ein außerirdisches Virus, das zu einem Pokémon mutierte. Es erscheint in der Nähe von Auroras."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/68.ts
+++ b/data/Sun & Moon/Celestial Storm/68.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "DNA from a space virus mutated and became a Pokémon. It appears where auroras are seen.",
+		de: "Deoxys ist ein außerirdisches Virus, das zu einem Pokémon mutierte. Es erscheint in der Nähe von Auroras."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/69.ts
+++ b/data/Sun & Moon/Celestial Storm/69.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "DNA from a space virus mutated and became a Pokémon. It appears where auroras are seen.",
+		de: "Deoxys ist ein außerirdisches Virus, das zu einem Pokémon mutierte. Es erscheint in der Nähe von Auroras."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/7.ts
+++ b/data/Sun & Moon/Celestial Storm/7.ts
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "Small hooks on the bottom of its feet catch on walls and ceilings. That is how it can hang from above.",
+		de: "Dank seiner mit winzigen Stacheln besetzten Sohlen haftet es sogar kopfüber an Wänden und Decken."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/70.ts
+++ b/data/Sun & Moon/Celestial Storm/70.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cosmoem",
 		fr: "Cosmovum",
+		de: "Cosmovum"
 	},
 
 	stage: "Stage2",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Si este Pokémon tiene alguna Energía Psychic unida a él, los ataques le hacen 20 puntos de daño menos (después de aplicar Debilidad y Resistencia).",
 				it: "Se questo Pokémon ha delle Energie Psychic assegnate, subisce 20 danni in meno dagli attacchi, dopo aver applicato debolezza e resistenza.",
 				pt: "Se este Pokémon tiver alguma Energia Psychic ligada a ele, receberá 20 pontos de dano a menos de ataques (após a aplicação de Fraqueza e Resistência).",
-				de: "Wenn an dieses Pokémon mindestens 1 Psychic-Energie angelegt ist, werden ihm durch Attacken 20 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden)."
+				de: "Wenn an dieses Pokémon mindestens 1 {P}-Energie angelegt ist, werden ihm durch Attacken 20 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 		},
 	],
@@ -101,6 +102,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said to be a female evolution of Cosmog. When its third eye activates, away it flies to another world.",
+		de: "Es heißt, es sei die weibliche Endstufe der Entwicklungsreihe von Cosmog. Ist sein drittes Auge aktiviert, zieht es in eine andere Welt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/71.ts
+++ b/data/Sun & Moon/Celestial Storm/71.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It usually lives underground. It searches for food while boring its way through the ground at 50 miles per hour.",
+		de: "Es lebt gewöhnlich unter der Erde. Während es sich mit 80 km/h durchs Erdreich bohrt, sucht es nach Nahrung."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/72.ts
+++ b/data/Sun & Moon/Celestial Storm/72.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It is strong despite its compact size. It can easily pick up and carry an adult human on its back.",
+		de: "Trotz seiner geringen Größe ist es stark. Es kann einen Erwachsenen mühelos auf dem Rücken tragen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/73.ts
+++ b/data/Sun & Moon/Celestial Storm/73.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Phanpy",
 		fr: "Phanpy",
+		de: "Phanpy"
 	},
 
 	stage: "Stage1",
@@ -95,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "The longer and bigger its tusks, the higher its rank in its herd. The tusks take long to grow.",
+		de: "Je größer und länger die Stoßzähne, desto höher ist ihr Rang in der Herde, doch das dauert lange."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/74.ts
+++ b/data/Sun & Moon/Celestial Storm/74.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Born deep underground, it comes aboveground and becomes a pupa once it has finished eating the surrounding soil.",
+		de: "Sie schlüpfen tief unter der Erde und fressen sich durch das Erdreich bis zur Oberfläche durch, wo sie sich verpuppen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/75.ts
+++ b/data/Sun & Moon/Celestial Storm/75.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Larvitar",
 		fr: "Embrylex",
+		de: "Larvitar"
 	},
 
 	stage: "Stage1",
@@ -70,7 +71,7 @@ const card: Card = {
 				es: "Este ataque hace 20 puntos de daño a cada Pokémon no Fighting (tanto tuyos como de tu rival). (No apliques Debilidad y Resistencia a los Pokémon en Banca).",
 				it: "Questo attacco infligge 20 danni a ciascun Pokémon non di tipo Fighting, sia tuo che del tuo avversario. Ricorda che non puoi applicare debolezza e resistenza ai Pokémon in panchina.",
 				pt: "Este ataque causa 20 pontos de dano a cada Pokémon que não for um Pokémon Fighting (seus e do seu oponente). (Não aplique Fraqueza e Resistência aos Pokémon no Banco.)",
-				de: "Diese Attacke fügt jedem Pokémon (deinen und denen deines Gegners), das kein Fighting-Pokémon ist, 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Diese Attacke fügt jedem Pokémon (deinen und denen deines Gegners), das kein {F}-Pokémon ist, 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -87,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Its shell is as hard as sheet rock, and it is also very strong. Its thrashing can topple a mountain.",
+		de: "Es ist sehr stark und sein Panzer ist steinhart. Setzt es Fuchtler ein, kann es einen Berg umstürzen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/76.ts
+++ b/data/Sun & Moon/Celestial Storm/76.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "It eats just one berry a day. By enduring hunger, its spirit is tempered and made sharper.",
+		de: "Es isst gerade mal eine Beere am Tag. Durch Hunger wird sein Geist ruhiger und schärfer."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/77.ts
+++ b/data/Sun & Moon/Celestial Storm/77.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Meditite",
 		fr: "Méditikka",
+		de: "Meditie"
 	},
 
 	stage: "Stage1",
@@ -95,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "Through yoga training, it gained the psychic power to predict its foe's next move.",
+		de: "Mit Yoga-Training hat es seine Psycho-Kräfte geschärft und ahnt so die Attacken seiner Gegner voraus."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/78.ts
+++ b/data/Sun & Moon/Celestial Storm/78.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "It moves by spinning on its foot. It is a rare Pokémon that was discovered in ancient ruins.",
+		de: "Es bewegt sich, indem es sich auf seinem Fuß dreht. Ein seltenes Pokémon, das in alten Ruinen lebte."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/79.ts
+++ b/data/Sun & Moon/Celestial Storm/79.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Baltoy",
 		fr: "Balbuto",
+		de: "Puppance"
 	},
 
 	stage: "Stage1",
@@ -95,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said that it originates from clay dolls made by an ancient civilization.",
+		de: "In die Puppe, die Menschen vor 20 000 Jahren aus Lehm formten, ist anscheinend Leben eingefahren."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/8.ts
+++ b/data/Sun & Moon/Celestial Storm/8.ts
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "Small hooks on the bottom of its feet catch on walls and ceilings. That is how it can hang from above.",
+		de: "Dank seiner mit winzigen Stacheln besetzten Sohlen haftet es sogar kopfüber an Wänden und Decken."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/80.ts
+++ b/data/Sun & Moon/Celestial Storm/80.ts
@@ -90,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "The same rocks that form its body have been found in ground layers around the world.",
+		de: "Die Steine, aus denen sein Körper besteht, stammen aus den unterschiedlichsten Ecken der Welt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/81.ts
+++ b/data/Sun & Moon/Celestial Storm/81.ts
@@ -93,6 +93,7 @@ const card: Card = {
 
 	description: {
 		en: "This legendary Pokémon is said to represent the land. It went to sleep after dueling Kyogre.",
+		de: "Dieses Legendäre Pokémon soll das Land verkörpern. Es ist in einen Schlaf gefallen, nachdem es mit Kyogre gekämpft hat."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/82.ts
+++ b/data/Sun & Moon/Celestial Storm/82.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Sandygast",
 		fr: "Bacabouh",
+		de: "Sankabuh"
 	},
 
 	stage: "Stage1",
@@ -99,7 +100,7 @@ const card: Card = {
 				es: "Temor Arena GX",
 				it: "Terrore Siliceo-GX",
 				pt: "Medo Arenoso GX",
-				de: "Sandfurcht GX"
+				de: "Sandfurcht-GX"
 			},
 			effect: {
 				en: "Look at the top 13 cards of your opponent’s deck and discard any number of Pokémon you find there. This attack does 60 damage for each card you discarded in this way. Your opponent shuffles the other cards back into their deck. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Celestial Storm/83.ts
+++ b/data/Sun & Moon/Celestial Storm/83.ts
@@ -87,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "Strong impacts can knock it out of its shell. This Pokémon was born from mutated nanoparticles.",
+		de: "Heftige Stöße lassen seine Schale abblättern. Eine Mutation von Nanopartikeln brachte dieses Pokémon hervor."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/84.ts
+++ b/data/Sun & Moon/Celestial Storm/84.ts
@@ -86,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "When the sun goes down, it becomes active. It runs around town on a chase for good food for the boss of its nest—Raticate.",
+		de: "Es wird bei Sonnenuntergang aktiv. Für seinen Rudelführer Rattikarl durchstreift es die Stadt auf der Suche nach gutem Futter."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/85.ts
+++ b/data/Sun & Moon/Celestial Storm/85.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Alolan Rattata",
 		fr: "Rattata d’Alola",
+		de: "Alola-Rattfratz"
 	},
 
 	suffix: "GX",
@@ -88,7 +89,7 @@ const card: Card = {
 				es: "Maníaco de Objetos GX",
 				it: "Maniaco degli Strumenti-GX",
 				pt: "Maníaco do Item GX",
-				de: "Item-Fanatiker GX"
+				de: "Item-Fanatiker-GX"
 			},
 			effect: {
 				en: "Search your deck for up to 6 Item cards, reveal them, and put them into your hand. Then, shuffle your deck. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Celestial Storm/86.ts
+++ b/data/Sun & Moon/Celestial Storm/86.ts
@@ -96,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "It uses its claws to poke holes in eggs so it can slurp out the insides. Breeders consider it a scourge and will drive it away or eradicate it.",
+		de: "Es rammt seine Krallen in Eier und schlürft ihren Inhalt aus. Pokémon-Züchter können es aus diesem Grund nicht ausstehen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/87.ts
+++ b/data/Sun & Moon/Celestial Storm/87.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pupitar",
 		fr: "Ymphect",
+		de: "Pupitar"
 	},
 
 	stage: "Stage2",
@@ -105,6 +106,7 @@ const card: Card = {
 
 	description: {
 		en: "If it rampages, it knocks down mountains and buries rivers. Maps must be redrawn afterward.",
+		de: "Bei einem Tobsuchtsanfall zerstört es ganze Gebirge und legt Flüsse trocken."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/88.ts
+++ b/data/Sun & Moon/Celestial Storm/88.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon is feared. When its gemstone eyes begin to glow with a sinister shine, it's believed that Sableye will steal people's spirits away.",
+		de: "Es ist gefürchtet, da man sagt, es stehle die Seelen der Menschen, wenn seine Edelsteinaugen furchterregend funkeln."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/89.ts
+++ b/data/Sun & Moon/Celestial Storm/89.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Onix",
 		fr: "Onix",
+		de: "Onix"
 	},
 
 	stage: "Stage1",
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "It chews its way through boulders with its sturdy jaws. Its eyes can see in the darkness underground.",
+		de: "Es beißt sich mit seinen Kiefern seinen Weg durch Felsen. Es kann auch im Dunkeln sehen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/9.ts
+++ b/data/Sun & Moon/Celestial Storm/9.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Treecko",
 		fr: "Arcko",
+		de: "Geckarbor"
 	},
 
 	stage: "Stage1",
@@ -70,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives in dense jungles. While closing in on its prey, it leaps from branch to branch.",
+		de: "Es lebt im dichten Dschungel. Es springt von Ast zu Ast, wenn es sich einer Beute nähert."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/90.ts
+++ b/data/Sun & Moon/Celestial Storm/90.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Scyther",
 		fr: "Insécateur",
+		de: "Sichlor"
 	},
 
 	suffix: "GX",
@@ -92,7 +93,7 @@ const card: Card = {
 				es: "Atajar GX",
 				it: "Fendente Incrociato-GX",
 				pt: "Corte em Cruz GX",
-				de: "Überkreuzzerschneider GX"
+				de: "Überkreuzzerschneider-GX"
 			},
 			effect: {
 				en: "If your opponent’s Active Pokémon is an Evolution Pokémon, this attack does 100 more damage. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Celestial Storm/91.ts
+++ b/data/Sun & Moon/Celestial Storm/91.ts
@@ -95,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "Attached to its head is a huge set of jaws formed by horns. It can chew through iron beams.",
+		de: "Auf seinem Kopf befindet sich ein riesiger Kiefer, der aus Hörnern besteht. Er kann Eisen zermalmen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/92.ts
+++ b/data/Sun & Moon/Celestial Storm/92.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Mientras este Pokémon sea tu Pokémon Activo, su Coste de Retirada es de Colorless menos por cada Beldum en tu Banca.",
 				it: "Fintanto che questo Pokémon è il tuo Pokémon attivo, il suo costo di ritirata è ridotto di Colorless per ogni Beldum nella tua panchina.",
 				pt: "Enquanto este Pokémon for o seu Pokémon Ativo, seu custo de Recuo será Colorless a menos para cada Beldum no seu Banco.",
-				de: "Solang dieses Pokémon dein Aktives Pokémon ist, verringern sich seine Rückzugskosten um Colorless für jedes Tanhel auf deiner Bank."
+				de: "Solang dieses Pokémon dein Aktives Pokémon ist, verringern sich seine Rückzugskosten um {C} für jedes Tanhel auf deiner Bank."
 			},
 		},
 	],
@@ -87,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "With magnetic traction, it pulls its opponents in close. When they're in range, it slashes them with its rear claws.",
+		de: "Es sendet magnetische Impulse aus, um Gegner zu sich heranzuziehen und sie dann mit den Krallen an seinem Hinterteil aufzuschlitzen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/93.ts
+++ b/data/Sun & Moon/Celestial Storm/93.ts
@@ -73,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "With magnetic traction, it pulls its opponents in close. When they're in range, it slashes them with its rear claws.",
+		de: "Es sendet magnetische Impulse aus, um Gegner zu sich heranzuziehen und sie dann mit den Krallen an seinem Hinterteil aufzuschlitzen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/94.ts
+++ b/data/Sun & Moon/Celestial Storm/94.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Beldum",
 		fr: "Terhal",
+		de: "Tanhel"
 	},
 
 	stage: "Stage1",
@@ -77,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "It adores magnetic minerals, so it pursues Nosepass at speeds exceeding 60 mph.",
+		de: "Es liebt Mineralien, die Magnetfelder erzeugen. Kein Wunder, dass es Nasgnet mit 100 km/h hinterherjagt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/95.ts
+++ b/data/Sun & Moon/Celestial Storm/95.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Metang",
 		fr: "Métang",
+		de: "Metang"
 	},
 
 	stage: "Stage2",
@@ -99,6 +100,7 @@ const card: Card = {
 
 	description: {
 		en: "A linkage of two Metang, this Pokémon can perform any calculation in a flash by utilizing parallel processing in its four brains.",
+		de: "Es ging aus der Verschmelzung zweier Metang hervor. Dank vier Gehirnen und paralleler Datenverarbeitung sind Berechnungen im Nu gelöst."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/96.ts
+++ b/data/Sun & Moon/Celestial Storm/96.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Cualquier daño infligido a este Pokémon por ataques se reduce en 10 (después de aplicar Debilidad y Resistencia).",
 				it: "I danni inflitti a questo Pokémon dagli attacchi sono ridotti di 10, dopo aver applicato debolezza e resistenza.",
 				pt: "Qualquer dano causado a este Pokémon por ataques será reduzido em 10 (após a aplicação de Fraqueza e Resistência).",
-				de: "Schaden, der diesem Pokémon durch Angriffe zugefügt wird, wird um 10 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
+				de: "Diesem Pokémon werden durch Attacken 20 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 		},
 	],
@@ -96,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "Its body is said to be harder than any kind of metal. A study has revealed that its body is hollow.",
+		de: "Sein Körper ist härter als jedes andere Metall. Untersuchungen zufolge ist es innen hohl."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/97.ts
+++ b/data/Sun & Moon/Celestial Storm/97.ts
@@ -96,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said to have the ability to grant any wish for just one week every thousand years.",
+		de: "Man sagt, es kann alle 1 000 Jahre für eine Woche jeden Wunsch erfüllen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/98.ts
+++ b/data/Sun & Moon/Celestial Storm/98.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Mira las 4 primeras cartas de tu baraja y une cualquier cantidad de cartas de Energía Metal que encuentres entre ellas a 1 de tus Pokémon. Pon el resto de cartas de nuevo en tu baraja y barájalas todas.",
 				it: "Guarda le prime quattro carte del tuo mazzo e assegna un numero qualsiasi di carte Energia Metal presenti tra quelle carte a uno dei tuoi Pokémon. Poi rimischia le altre carte nel tuo mazzo.",
 				pt: "Olhe as 4 primeiras cartas do seu baralho e ligue qualquer número de cartas de Energia Metal que encontrar lá a 1 dos seus Pokémon. Embaralhe as demais cartas de volta no seu baralho.",
-				de: "Schau dir die obersten 4 Karten deines Decks an und lege beliebig viele Metal-Energiekarten, die du dort findest, an 1 deiner Pokémon an. Mische die anderen Karten zurück in dein Deck."
+				de: "Schau dir die obersten 4 Karten deines Decks an und lege beliebig viele {M}-Energiekarten, die du dort findest, an 1 deiner Pokémon an. Mische die anderen Karten zurück in dein Deck."
 			},
 
 		},
@@ -97,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "Boiling blood, like magma, circulates through its body. It makes its dwelling place in volcanic caves.",
+		de: "Das Blut, das durch seinen Körper fließt, brodelt heiß wie Magma. Es lebt in vulkanischen Höhlen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Celestial Storm/99.ts
+++ b/data/Sun & Moon/Celestial Storm/99.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cosmoem",
 		fr: "Cosmovum",
+		de: "Cosmovum"
 	},
 
 	stage: "Stage2",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Si este Pokémon tiene alguna Energía Metal unida a él, no tiene ninguna Debilidad.",
 				it: "Se questo Pokémon ha delle Energie Metal assegnate, non ha debolezza.",
 				pt: "Se este Pokémon tiver alguma Energia Metal ligada a ele, não terá Fraqueza.",
-				de: "Wenn an dieses Pokémon mindestens 1 Metal-Energie angelegt ist, hat es keine Schwäche."
+				de: "Wenn an dieses Pokémon mindestens 1 {M}-Energie angelegt ist, hat es keine Schwäche."
 			},
 		},
 	],
@@ -101,6 +102,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said to live in another world. The intense light it radiates from the surface of its body can make the darkest of nights light up like midday.",
+		de: "Es heißt, es komme aus einer anderen Welt. Sein ganzer Körper leuchtet strahlend hell und macht die finsterste Nacht zum Tage."
 	},
 
 	thirdParty: {


### PR DESCRIPTION
## Add missing German translations for sm7

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
