### PR TITLE
Add missing German translations for sm7.5

### DIFF
--- a/data/Sun & Moon/Dragon Majesty/1.ts
+++ b/data/Sun & Moon/Dragon Majesty/1.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "From the time it is born, a flame burns at the tip of its tail. Its life would end if the flame were to go out.",
+		de: "Von Geburt an brennt die Flamme auf seiner Schwanzspitze. Sobald sie erlischt, erlischt auch sein Lebenslicht."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/10.ts
+++ b/data/Sun & Moon/Dragon Majesty/10.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It draws in air through its tail, transforms it into fire, and uses it like a tongue. It melts Durant and eats them.",
+		de: "Über den Schweif aufgesaugte Luft wird in eine Feuerzunge verwandelt, um damit Fermicula zu schmelzen und zu fressen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/11.ts
+++ b/data/Sun & Moon/Dragon Majesty/11.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Busca en tu baraja hasta 2 cartas de Energía Fire y únelas a este Pokémon. Después, baraja las cartas de tu baraja.",
 				it: "Cerca nel tuo mazzo fino a due carte Energia Fire e assegnale a questo Pokémon. Poi rimischia le carte del tuo mazzo.",
 				pt: "Procure por até 2 cartas de Energia Fire no seu baralho e ligue-as a este Pokémon. Em seguida, embaralhe o seu baralho.",
-				de: "Durchsuche dein Deck nach bis zu 2 Fire-Energiekarten und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
+				de: "Durchsuche dein Deck nach bis zu 2 {R}-Energiekarten und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
 			},
 
 		},
@@ -98,7 +98,7 @@ const card: Card = {
 				es: "Puedes unir hasta 5 cartas de Energía Fire de tu mano a tus Pokémon de la manera que desees. (No puedes usar más de 1 ataque GX en una partida).",
 				it: "Puoi assegnare a piacimento ai tuoi Pokémon fino a cinque carte Energia Fire dalla tua mano. Non puoi usare più di un attacco GX a partita.",
 				pt: "Você pode ligar até 5 cartas de Energia Fire da sua mão aos seus Pokémon como desejar (você não pode usar mais de 1 ataque GX por partida).",
-				de: "Du kannst bis zu 5 Fire-Energiekarten aus deiner Hand beliebig an deine Pokémon anlegen. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
+				de: "Du kannst bis zu 5 {R}-Energiekarten aus deiner Hand beliebig an deine Pokémon anlegen. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: 180,
 

--- a/data/Sun & Moon/Dragon Majesty/12.ts
+++ b/data/Sun & Moon/Dragon Majesty/12.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "While grooming itself, it builds up fur inside its stomach. It sets the fur alight and spews fiery attacks, which change based on how it coughs.",
+		de: "Es verbrennt Haare, die es bei der Körperpflege verschluckt hat, indem es Feuer speit. Die Flammen variieren je nach Art des Speiens."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/13.ts
+++ b/data/Sun & Moon/Dragon Majesty/13.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Volcanoes or dry, craggy places are its home. It emanates a sweet-smelling poisonous gas that attracts bug Pokémon, then attacks them.",
+		de: "Lebt in Vulkanen und trockenen Felsgebieten. Mit seinem süßlich duftenden Giftgas lockt es Käfer-Pokémon an, um sie anzugreifen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/14.ts
+++ b/data/Sun & Moon/Dragon Majesty/14.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Salandit",
 		fr: "Tritox",
+		de: "Molunk"
 	},
 
 	stage: "Stage1",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "Filled with pheromones, its poisonous gas can be diluted to use in the production of luscious perfumes.",
+		de: "Ihr Giftgas enthält viele Pheromone. Verdünnt man es, lässt sich daraus ein sinnliches Parfüm herstellen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/15.ts
+++ b/data/Sun & Moon/Dragon Majesty/15.ts
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "It makes its nest in the shade of corals. If it senses danger, it spits murky ink and flees.",
+		de: "Im Schatten von Korallen legt es sein Nest an. Bei Gefahr versprüht es Tinte und flieht."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/16.ts
+++ b/data/Sun & Moon/Dragon Majesty/16.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Este ataque hace 10 puntos de daño más por cada Energía Water unida a este Pokémon.",
 				it: "Questo attacco infligge 10 danni in più per ogni Energia Water assegnata a questo Pokémon.",
 				pt: "Este ataque causa 10 pontos de dano a mais vezes a quantidade de Energia Water ligada a este Pokémon.",
-				de: "Diese Attacke fügt 10 Schadenspunkte mehr mal der Anzahl der an dieses Pokémon angelegten Water-Energien zu."
+				de: "Diese Attacke fügt 10 Schadenspunkte mehr mal der Anzahl der an dieses Pokémon angelegten {W}-Energien zu."
 			},
 			damage: "10+",
 
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It makes its nest in the shade of corals. If it senses danger, it spits murky ink and flees.",
+		de: "Im Schatten von Korallen legt es sein Nest an. Bei Gefahr versprüht es Tinte und flieht."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/17.ts
+++ b/data/Sun & Moon/Dragon Majesty/17.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Horsea",
 		fr: "Hypotrempe",
+		de: "Seeper"
 	},
 
 	stage: "Stage1",
@@ -52,7 +53,7 @@ const card: Card = {
 				es: "Este ataque hace 20 puntos de daño más por cada Energía Water unida a este Pokémon.",
 				it: "Questo attacco infligge 20 danni in più per ogni Energia Water assegnata a questo Pokémon.",
 				pt: "Este ataque causa 20 pontos de dano a mais vezes a quantidade de Energia Water ligada a este Pokémon.",
-				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der an dieses Pokémon angelegten Water-Energien zu."
+				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der an dieses Pokémon angelegten {W}-Energien zu."
 			},
 			damage: "10+",
 
@@ -70,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "It is capable of swimming backwards by rapidly flapping its winglike pectoral fins and stout tail.",
+		de: "Dieses Pokémon kann rückwärts schwimmen, indem es Flügel und Schwanz als Flossen einsetzt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/18.ts
+++ b/data/Sun & Moon/Dragon Majesty/18.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Seadra",
 		fr: "Hypocéan",
+		de: "Seemon"
 	},
 
 	suffix: "GX",
@@ -52,7 +53,7 @@ const card: Card = {
 				es: "Este ataque hace 50 puntos de daño más por cada Energía Water unida a este Pokémon.",
 				it: "Questo attacco infligge 50 danni in più per ogni Energia Water assegnata a questo Pokémon.",
 				pt: "Este ataque causa 50 pontos de dano a mais vezes a quantidade de Energia Water ligada a este Pokémon.",
-				de: "Diese Attacke fügt 50 Schadenspunkte mehr mal der Anzahl der an dieses Pokémon angelegten Water-Energien zu."
+				de: "Diese Attacke fügt 50 Schadenspunkte mehr mal der Anzahl der an dieses Pokémon angelegten {W}-Energien zu."
 			},
 			damage: "10+",
 

--- a/data/Sun & Moon/Dragon Majesty/19.ts
+++ b/data/Sun & Moon/Dragon Majesty/19.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "Its reckless leaps make it easy pickings for predators. On the bright side, many Pokémon enjoy longer life spans, thanks to Magikarp.",
+		de: "Da es immer nur leichtsinnig herumplatscht, ist es leichte Beute für hungrige Pokémon. Für viele ist es daher ein Lebensretter."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/2.ts
+++ b/data/Sun & Moon/Dragon Majesty/2.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Charmander",
 		fr: "Salamèche",
+		de: "Glumanda"
 	},
 
 	stage: "Stage1",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Cuando juegues este Pokémon de tu mano para hacer evolucionar a 1 de tus Pokémon durante tu turno, puedes descartar las 5 primeras cartas de tu baraja. Si entre esas cartas hay cartas de Energía Fire, únelas a este Pokémon.",
 				it: "Quando giochi questo Pokémon dalla tua mano per far evolvere uno dei tuoi Pokémon durante il tuo turno, puoi scartare le prime cinque carte del tuo mazzo. Se fra queste ci sono delle carte Energia Fire, assegnale a questo Pokémon.",
 				pt: "Quando você joga este Pokémon da sua mão para evoluir 1 dos seus Pokémon durante a sua vez de jogar, você pode descartar as 5 primeiras cartas do seu baralho. Se houver cartas de Energia Fire entre elas, ligue-as a este Pokémon.",
-				de: "Wenn du dieses Pokémon aus deiner Hand spielst, um 1 deiner Pokémon während deines Zuges zu entwickeln, kannst du die obersten 5 Karten deines Decks auf deinen Ablagestapel legen. Wenn unter jenen Karten Fire-Energiekarten sind, lege sie an dieses Pokémon an."
+				de: "Wenn du dieses Pokémon aus deiner Hand spielst, um 1 deiner Pokémon während deines Zuges zu entwickeln, kannst du die obersten 5 Karten deines Decks auf deinen Ablagestapel legen. Wenn unter jenen Karten {R}-Energiekarten sind, lege sie an dieses Pokémon an."
 			},
 		},
 	],
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "When it swings its burning tail, it elevates the air temperature to unbearably high levels.",
+		de: "Wenn Glutexo mit seinem Schwanz schwingt, steigt die Temperatur ins Unermessliche."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/20.ts
+++ b/data/Sun & Moon/Dragon Majesty/20.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Magikarp",
 		fr: "Magicarpe",
+		de: "Karpador"
 	},
 
 	stage: "Stage1",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "There are people who swear that any place Gyarados appears is fated for destruction.",
+		de: "Manche Menschen sind fest davon überzeugt, dass Orte, an denen ein Garados erscheint, dem Untergang geweiht sind."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/21.ts
+++ b/data/Sun & Moon/Dragon Majesty/21.ts
@@ -72,7 +72,7 @@ const card: Card = {
 				es: "Este ataque hace 10 puntos de daño más por cada Energía Water unida a este Pokémon.",
 				it: "Questo attacco infligge 10 danni in più per ogni Energia Water assegnata a questo Pokémon.",
 				pt: "Este ataque causa 10 pontos de dano a mais vezes a quantidade de Energia Water ligada a este Pokémon.",
-				de: "Diese Attacke fügt 10 Schadenspunkte mehr mal der Anzahl der an dieses Pokémon angelegten Water-Energien zu."
+				de: "Diese Attacke fügt 10 Schadenspunkte mehr mal der Anzahl der an dieses Pokémon angelegten {W}-Energien zu."
 			},
 			damage: "70+",
 
@@ -90,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "These Pokémon were once near extinction due to poaching. Following protective regulations, there is now an overabundance of them.",
+		de: "Es wäre einst durch übermäßiges Fischen fast ausgestorben. Durch ein strenges Abkommen zum Artenschutz gibt es nun fast zu viele."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/22.ts
+++ b/data/Sun & Moon/Dragon Majesty/22.ts
@@ -87,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "Its powerful, well-developed jaws are capable of crushing anything. Even its Trainer must be careful.",
+		de: "Seine starken Kiefer können alles zermalmen. Selbst sein Trainer muss sich vor ihm in Acht nehmen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/23.ts
+++ b/data/Sun & Moon/Dragon Majesty/23.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Totodile",
 		fr: "Kaiminus",
+		de: "Karnimani"
 	},
 
 	stage: "Stage1",
@@ -89,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "Once it bites down, it won't let go until it loses its fangs. New fangs quickly grow into place.",
+		de: "Hat es einmal zugebissen, lässt es erst los, wenn es seine Zähne verliert, die schnell nachwachsen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/24.ts
+++ b/data/Sun & Moon/Dragon Majesty/24.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Croconaw",
 		fr: "Crocrodil",
+		de: "Tyracroc"
 	},
 
 	stage: "Stage2",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Todas las veces que quieras durante tu turno (antes de tu ataque), puedes descartar 1 carta de Energía Water de tu mano.",
 				it: "Durante il tuo turno, prima di attaccare, puoi scartare una carta Energia Water che hai in mano tutte le volte che vuoi.",
 				pt: "Quantas vezes desejar durante a sua vez de jogar (antes de atacar), você pode descartar 1 carta de Energia Water da sua mão.",
-				de: "Beliebig oft während deines Zuges (bevor du angreifst) kannst du 1 Water-Energiekarte aus deiner Hand auf deinen Ablagestapel legen."
+				de: "Beliebig oft während deines Zuges (bevor du angreifst) kannst du 1 {W}-Energiekarte aus deiner Hand auf deinen Ablagestapel legen."
 			},
 		},
 	],
@@ -75,7 +76,7 @@ const card: Card = {
 				es: "Este ataque hace 20 puntos de daño más por cada carta de Energía Water en tu pila de descartes. Después, pon esas cartas en tu baraja y barájalas todas.",
 				it: "Questo attacco infligge 20 danni in più per ogni carta Energia Water nella tua pila degli scarti. Poi rimischia quelle carte nel tuo mazzo.",
 				pt: "Este ataque causa 20 pontos de dano a mais para cada carta de Energia Water na sua pilha de descarte. Em seguida, embaralhe aquelas cartas no seu baralho.",
-				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der Water-Energiekarten in deinem Ablagestapel zu. Mische jene Karten anschließend in dein Deck."
+				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der {W}-Energiekarten in deinem Ablagestapel zu. Mische jene Karten anschließend in dein Deck."
 			},
 			damage: "10+",
 
@@ -93,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "When it bites with its massive and powerful jaws, it shakes its head and savagely tears its victim up.",
+		de: "Wenn es mit seinem kräftigen Kiefer zubeißt, schüttelt es seinen Kopf und reißt seine Opfer in Stücke."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/25.ts
+++ b/data/Sun & Moon/Dragon Majesty/25.ts
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "When the temperature cools in the evening, they emerge from water to seek food along the shore.",
+		de: "Wenn es am Abend kühler wird, kommen sie an Land, um nach Nahrung zu suchen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/26.ts
+++ b/data/Sun & Moon/Dragon Majesty/26.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Wooper",
 		fr: "Axoloto",
+		de: "Felino"
 	},
 
 	stage: "Stage1",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Todas las veces que quieras durante tu turno (antes de tu ataque), puedes mover 1 Energía Water de 1 de tus Pokémon en Banca a tu Pokémon Activo.",
 				it: "Durante il tuo turno, prima di attaccare, puoi spostare un’Energia Water da uno dei tuoi Pokémon in panchina al tuo Pokémon attivo tutte le volte che vuoi.",
 				pt: "Quantas vezes desejar durante a sua vez de jogar (antes de atacar), você pode mover 1 Energia Water de 1 dos seus Pokémon no Banco para o seu Pokémon Ativo.",
-				de: "Beliebig oft während deines Zuges (bevor du angreifst) kannst du 1 Water-Energie von 1 Pokémon auf deiner Bank auf dein Aktives Pokémon verschieben."
+				de: "Beliebig oft während deines Zuges (bevor du angreifst) kannst du 1 {W}-Energie von 1 Pokémon auf deiner Bank auf dein Aktives Pokémon verschieben."
 			},
 		},
 	],
@@ -76,7 +77,7 @@ const card: Card = {
 				es: "Este ataque hace 20 puntos de daño más por cada Energía Water unida a este Pokémon.",
 				it: "Questo attacco infligge 20 danni in più per ogni Energia Water assegnata a questo Pokémon.",
 				pt: "Este ataque causa 20 pontos de dano a mais vezes a quantidade de Energia Water ligada a este Pokémon.",
-				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der an dieses Pokémon angelegten Water-Energien zu."
+				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der an dieses Pokémon angelegten {W}-Energien zu."
 			},
 			damage: "60+",
 
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "This carefree Pokémon has an easygoing nature. While swimming, it always bumps into boat hulls.",
+		de: "Dieses genügsame Pokémon ist sehr umgänglich. Beim Schwimmen stößt es immer wieder gegen Schiffe."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/27.ts
+++ b/data/Sun & Moon/Dragon Majesty/27.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Este ataque hace 20 puntos de daño por cada Energía Water unida a este Pokémon a 1 de los Pokémon de tu rival. (No apliques Debilidad y Resistencia a los Pokémon en Banca).",
 				it: "Questo attacco infligge 20 danni a uno dei Pokémon del tuo avversario per ogni Energia Water assegnata a questo Pokémon. Ricorda che non puoi applicare debolezza e resistenza ai Pokémon in panchina.",
 				pt: "Este ataque causa 20 pontos de dano vezes a quantidade de Energia Water ligada a este Pokémon a 1 dos Pokémon do seu oponente (não aplique Fraqueza e Resistência aos Pokémon no Banco).",
-				de: "Diese Attacke fügt 1 Pokémon deines Gegners 20 Schadenspunkte mal der Anzahl der an dieses Pokémon angelegten Water-Energien zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Diese Attacke fügt 1 Pokémon deines Gegners 20 Schadenspunkte mal der Anzahl der an dieses Pokémon angelegten {W}-Energien zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "Pursued by Mareanie for the branches on its head, this Pokémon will sometimes snap its own branches off as a diversion while it escapes.",
+		de: "Drohen die Arme auf seinem Kopf von einem Garstella verschlungen zu werden, wirft es diese ab und sucht das Weite."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/28.ts
+++ b/data/Sun & Moon/Dragon Majesty/28.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Mientras este Pokémon esté en tu Banca, evita todo el daño infligido a este Pokémon por ataques (tanto tuyos como de tu rival).",
 				it: "Fintanto che questo Pokémon è nella tua panchina, previeni tutti i danni inflitti a questo Pokémon dagli attacchi, sia tuoi che del tuo avversario.",
 				pt: "Desde que este Pokémon esteja em seu Banco, previne todos os danos causados a este Pokémon por ataques (seus e do seu oponente).",
-				de: "Solang sich dieses Pokémon auf deiner Bank befindet, verhindere allen Schaden, der diesem Pokémon durch Angriffe (deine und die deines Gegners) zugefügt wird."
+				de: "Solang sich dieses Pokémon auf deiner Bank befindet, verhindere allen Schaden, der diesem Pokémon durch Attacken (deine und die deines Gegners) zugefügt wird."
 			},
 		},
 	],
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "Although unattractive and unpopular, this Pokémon's marvelous vitality has made it a subject of research.",
+		de: "Sein unvorteilhaftes Aussehen macht es zwar unbeliebt, doch seine erstaunliche Lebenskraft hat das Interesse der Forscher an ihm geweckt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/29.ts
+++ b/data/Sun & Moon/Dragon Majesty/29.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Feebas",
 		fr: "Barpau",
+		de: "Barschwa"
 	},
 
 	stage: "Stage1",
@@ -95,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives at the bottom of clear lakes. In times of war, it shows itself, which soothes people's minds and hearts.",
+		de: "Es lebt auf dem Grund von klaren, ungetrübten Seen. Zu Kriegszeiten taucht es empor, um die Menschen zu besänftigen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/3.ts
+++ b/data/Sun & Moon/Dragon Majesty/3.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Charmeleon",
 		fr: "Reptincel",
+		de: "Glutexo"
 	},
 
 	stage: "Stage2",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "Its wings can carry this Pokémon close to an altitude of 4,600 feet. It blows out fire at very high temperatures.",
+		de: "Dieses Pokémon kann mit seinen Flügeln eine Höhe von bis zu 1 400 m erreichen. Es spuckt sehr heißes Feuer."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/30.ts
+++ b/data/Sun & Moon/Dragon Majesty/30.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Tus Pokémon Water no pueden pasar a estar Confundidos. Si esos Pokémon ya están Confundidos, elimina esa Condición Especial.",
 				it: "I tuoi Pokémon Water non possono venire confusi. Se tali Pokémon sono già confusi, rimuovine la condizione speciale.",
 				pt: "Seus Pokémon Water não podem ser Confundidos. Se aqueles Pokémon já estiverem Confusos, remova aquela Condição Especial.",
-				de: "Deine Water-Pokémon können nicht verwirrt werden. Wenn jene Pokémon bereits verwirrt sind, verliert jener Spezielle Zustand seine Wirkung."
+				de: "Deine {W}-Pokémon können nicht verwirrt werden. Wenn jene Pokémon bereits verwirrt sind, verliert jener Spezielle Zustand seine Wirkung."
 			},
 		},
 	],
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It drifts in warm seas. It always returns to where it was born, no matter how far it may have drifted.",
+		de: "Lässt sich in warmen Meeren treiben, kehrt aber immer an den Platz seiner Geburt zurück."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/31.ts
+++ b/data/Sun & Moon/Dragon Majesty/31.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It's awfully weak and notably tasty, so everyone is always out to get it. As it happens, anyone trying to bully it receives a painful lesson.",
+		de: "Ein sehr schwaches und leckeres Pokémon, auf das es stets irgendjemand abgesehen hat. Doch Vorsicht: Wer es ärgert, wird dies bereuen!"
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/32.ts
+++ b/data/Sun & Moon/Dragon Majesty/32.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "As it digs through the sand, its giant jaws crush any rocks that obstruct its path. It builds a funnel-shaped nest.",
+		de: "Es gräbt im Sand und zerquetscht dabei mit seinem gigantischen Kiefer störende Felsen. Sein Bau hat die Form eines Trichters."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/33.ts
+++ b/data/Sun & Moon/Dragon Majesty/33.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Zweilous",
 		fr: "Diamat",
+		de: "Duodino"
 	},
 
 	stage: "Stage2",
@@ -101,6 +102,7 @@ const card: Card = {
 
 	description: {
 		en: "The heads on their arms do not have brains. They use all three heads to consume and destroy everything.",
+		de: "Die Köpfe an seinen beiden Armen haben kein eigenes Gehirn. Seine drei Mäuler kauen alles radikal kurz und klein."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/34.ts
+++ b/data/Sun & Moon/Dragon Majesty/34.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "After a 10-hour struggle, a fisherman was able to pull one up and confirm its existence.",
+		de: "Seine Existenz konnte endlich nachgewiesen werden, nachdem es einem Angler gelang, es nach einem zehnstündigen Kampf zu fangen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/35.ts
+++ b/data/Sun & Moon/Dragon Majesty/35.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "After a 10-hour struggle, a fisherman was able to pull one up and confirm its existence.",
+		de: "Seine Existenz konnte endlich nachgewiesen werden, nachdem es einem Angler gelang, es nach einem zehnstündigen Kampf zu fangen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/36.ts
+++ b/data/Sun & Moon/Dragon Majesty/36.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Dratini",
 		fr: "Minidraco",
+		de: "Dratini"
 	},
 
 	stage: "Stage1",
@@ -91,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "From time immemorial, it has been venerated by agricultural peoples as an entity able to control the weather.",
+		de: "Bauern verehren es schon seit Urzeiten, da es die Fähigkeit besitzt, das Wetter zu beeinflussen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/37.ts
+++ b/data/Sun & Moon/Dragon Majesty/37.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Dragonair",
 		fr: "Draco",
+		de: "Dragonir"
 	},
 
 	suffix: "GX",
@@ -96,7 +97,7 @@ const card: Card = {
 				es: "Pon 3 Pokémon Dragon de tu pila de descartes en tu Banca. (No puedes usar más de 1 ataque GX en una partida).",
 				it: "Prendi tre Pokémon Dragon dalla tua pila degli scarti e mettili nella tua panchina. Non puoi usare più di un attacco GX a partita.",
 				pt: "Coloque 3 Pokémon Dragon da sua pilha de descarte no seu Banco (você não pode usar mais de 1 ataque GX por partida).",
-				de: "Lege 3 Dragon-Pokémon aus deinem Ablagestapel auf deine Bank. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
+				de: "Lege 3 {N}-Pokémon aus deinem Ablagestapel auf deine Bank. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Dragon Majesty/38.ts
+++ b/data/Sun & Moon/Dragon Majesty/38.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Trapinch",
 		fr: "Kraknoix",
+		de: "Knacklion"
 	},
 
 	stage: "Stage1",
@@ -71,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "To help make its wings grow, it dissolves quantities of prey in its digestive juices and guzzles them down every day.",
+		de: "Um das Wachstum seiner Flügel zu fördern, schlürft es täglich große Mengen an Beute, die es zuvor in Säure aufgelöst hat."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/39.ts
+++ b/data/Sun & Moon/Dragon Majesty/39.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Vibrava",
 		fr: "Vibraninf",
+		de: "Vibrava"
 	},
 
 	stage: "Stage2",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Evita todos los efectos de los ataques de tu rival, excepto el daño, infligidos a tus Pokémon Dragon. (No se eliminan los efectos ya existentes).",
 				it: "Previeni tutti gli effetti degli attacchi del tuo avversario, esclusi i danni, inflitti ai tuoi Pokémon Dragon. Gli effetti esistenti non vengono rimossi.",
 				pt: "Previne todos os efeitos de ataques do seu oponente, exceto dano, causados aos seus Pokémon Dragon (efeitos existentes não são removidos).",
-				de: "Verhindere alle Effekte von Attacken deines Gegners, außer Schaden, die deinen Dragon-Pokémon zugefügt werden. (Bestehende Effekte werden nicht entfernt.)"
+				de: "Verhindere alle Effekte von Attacken deines Gegners, außer Schaden, die deinen {N}-Pokémon zugefügt werden. (Bestehende Effekte werden nicht entfernt.)"
 			},
 		},
 	],
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon hides in the heart of sandstorms it creates and seldom appears where people can see it.",
+		de: "Da es sich stets im Zentrum des von ihm entfachten Sandsturms aufhält, bekommen Menschen es so gut wie nie zu Gesicht."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/4.ts
+++ b/data/Sun & Moon/Dragon Majesty/4.ts
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "A fire burns inside, so it feels very warm to hug. It launches fireballs of 1,800 degrees Fahrenheit.",
+		de: "In seinem Inneren lodert ein Feuer. Es schleudert 1 000 °C heiße Feuerbälle."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/40.ts
+++ b/data/Sun & Moon/Dragon Majesty/40.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Swablu",
 		fr: "Tylton",
+		de: "Wablu"
 	},
 
 	stage: "Stage1",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Los ataques de tus Pokémon Dragon hacen 20 puntos de daño más a los Pokémon Activos (antes de aplicar Debilidad y Resistencia).",
 				it: "Gli attacchi dei tuoi Pokémon Dragon infliggono 20 danni in più al Pokémon attivo, prima di aver applicato debolezza e resistenza.",
 				pt: "Os ataques do seu Pokémon Dragon causam 20 de danos adicionais ao Pokémon Ativo (antes da aplicação de Fraqueza e Resistência).",
-				de: "Die Angriffe deiner Dragon-Pokémon fügen den Aktiven Pokémon 20 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
+				de: "Die Attacken deiner {N}-Pokémon fügen dem Aktiven Pokémon deines Gegners 20 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 		},
 	],
@@ -86,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "On sunny days, it flies freely through the sky and blends into the clouds. It sings in a beautiful soprano.",
+		de: "Bei gutem Wetter mischt es sich unter die Wolken und genießt die Freiheit. Es hat eine entzückende Sopranstimme."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/41.ts
+++ b/data/Sun & Moon/Dragon Majesty/41.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Swablu",
 		fr: "Tylton",
+		de: "Wablu"
 	},
 
 	suffix: "GX",

--- a/data/Sun & Moon/Dragon Majesty/42.ts
+++ b/data/Sun & Moon/Dragon Majesty/42.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "With its steel-hard stone head, it headbutts indiscriminately. This is because of the stress it feels at being unable to fly.",
+		de: "Es verteilt oft Kopfstöße mit seinem stahlharten Schädel. Grund ist offenbar der Frust darüber, dass es nicht fliegen kann."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/43.ts
+++ b/data/Sun & Moon/Dragon Majesty/43.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Bagon",
 		fr: "Draby",
+		de: "Kindwurm"
 	},
 
 	stage: "Stage1",
@@ -86,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "They lurk deep within caves—motionless, neither eating nor drinking. Why they don't die is not known.",
+		de: "Es hält sich in den Tiefen einer Höhle versteckt, wo es weder trinkt noch isst. Niemand weiß so recht, wie es eigentlich überleben kann."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/44.ts
+++ b/data/Sun & Moon/Dragon Majesty/44.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Shelgon",
 		fr: "Drackhaus",
+		de: "Draschel"
 	},
 
 	suffix: "GX",

--- a/data/Sun & Moon/Dragon Majesty/45.ts
+++ b/data/Sun & Moon/Dragon Majesty/45.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It warms its body by absorbing sunlight with its wings. When its body temperature falls, it can no longer move.",
+		de: "Es erwärmt seinen Körper, indem es mit den Flügeln das Sonnenlicht einfängt. Kühlt sein Körper ab, erstarrt es."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/46.ts
+++ b/data/Sun & Moon/Dragon Majesty/46.ts
@@ -93,6 +93,7 @@ const card: Card = {
 
 	description: {
 		en: "Concealing itself in lightning clouds, it flies throughout the Unova region. It creates electricity in its tail.",
+		de: "Sein Schweif erzeugt Strom. Es verbirgt sich hinter dichten Gewitterwolken und fliegt durch den Luftraum über Einall."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/47.ts
+++ b/data/Sun & Moon/Dragon Majesty/47.ts
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "It generates a powerful, freezing energy inside itself, but its body became frozen when the energy leaked out.",
+		de: "Sein Körper erzeugt in seinem Inneren gewaltige Mengen an Kälteenergie. Tritt diese jedoch aus, gefriert sein Körper."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/48.ts
+++ b/data/Sun & Moon/Dragon Majesty/48.ts
@@ -90,7 +90,7 @@ const card: Card = {
 				es: "Estrella Dragón-GX",
 				it: "Dragonova-GX",
 				pt: "Supernova do Dragão-GX",
-				de: "Drachen Nova-GX"
+				de: "Drachen-Nova-GX"
 			},
 			effect: {
 				en: "Your opponent’s Active Pokémon is now Burned and Paralyzed. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Dragon Majesty/49.ts
+++ b/data/Sun & Moon/Dragon Majesty/49.ts
@@ -90,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "It's thought to be monitoring the ecosystem. There are rumors that even greater power lies hidden within it.",
+		de: "Man nimmt an, dass es das Ökosystem beobachtet und über geheime Kräfte verfügt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/5.ts
+++ b/data/Sun & Moon/Dragon Majesty/5.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Torchic",
 		fr: "Poussifeu",
+		de: "Flemmli"
 	},
 
 	stage: "Stage1",
@@ -93,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "During a battle, the hot flame in its body increases. Its kicks have outstanding destructive power.",
+		de: "Im Kampf lodert sein inneres Feuer hoch auf. Wo seine mächtigen Tritte landen, wächst kein Gras mehr."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/50.ts
+++ b/data/Sun & Moon/Dragon Majesty/50.ts
@@ -49,7 +49,7 @@ const card: Card = {
 				es: "Descarta cualquier cantidad de Energías Fire de tus Pokémon. Este ataque hace 50 puntos de daño por cada carta que hayas descartado de esta manera.",
 				it: "Scarta tutte le Energie Fire che vuoi assegnate ai tuoi Pokémon. Questo attacco infligge 50 danni per ogni carta che hai scartato in questo modo.",
 				pt: "Descarte qualquer quantidade de Energia Fire dos seus Pokémon. Este ataque causa 50 pontos de dano para cada carta descartada desta forma.",
-				de: "Lege beliebig viele Fire-Energien von deinen Pokémon auf deinen Ablagestapel. Diese Attacke fügt 50 Schadenspunkte mal der Anzahl der auf diese Weise auf deinen Ablagestapel gelegten Karten zu."
+				de: "Lege beliebig viele {R}-Energien von deinen Pokémon auf deinen Ablagestapel. Diese Attacke fügt 50 Schadenspunkte mal der Anzahl der auf diese Weise auf deinen Ablagestapel gelegten Karten zu."
 			},
 			damage: "50×",
 
@@ -67,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "It gushes fire and poisonous gases from its nostrils. Its dung is an explosive substance and can be put to various uses.",
+		de: "Es greift mit Feuer und Giftgas aus den Nasenlöchern an. Sein Kot ist explosiv und vielseitig einsetzbar."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/51.ts
+++ b/data/Sun & Moon/Dragon Majesty/51.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Une 1 carta de Energía Básica de tu pila de descartes a 1 de tus Pokémon Dragon.",
 				it: "Assegna a uno dei tuoi Pokémon Dragon una carta Energia base dalla tua pila degli scarti.",
 				pt: "Ligue 1 carta de Energia básica da sua pilha de descarte a 1 dos seus Pokémon Dragon.",
-				de: "Lege 1 Basis-Energiekarte aus deinem Ablagestapel an 1 deiner Dragon-Pokémon an."
+				de: "Lege 1 Basis-Energiekarte aus deinem Ablagestapel an 1 deiner {N}-Pokémon an."
 			},
 			damage: 20,
 
@@ -83,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon is friendly to people and loves children most of all. It comes from deep in the mountains to play with children it likes in town.",
+		de: "Es ist sehr freundlich und liebt Kinder. Häufig kommt es aus den Bergen herab in die Städte, um mit seinen kleinen Freunden zu spielen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/52.ts
+++ b/data/Sun & Moon/Dragon Majesty/52.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "They live in mountains where no trace of humans can be detected. Jangmo-o grow little by little as they battle one another.",
+		de: "Es lebt auf Bergen, auf die sich kein Mensch wagt. Indem es gegen andere Miniras kämpft, wird es stetig stärker."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/53.ts
+++ b/data/Sun & Moon/Dragon Majesty/53.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Jangmo-o",
 		fr: "Bébécaille",
+		de: "Miniras"
 	},
 
 	stage: "Stage1",
@@ -89,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "It sheds and regrows its scales on a continuous basis. The scales become harder and sharper each time they're regrown.",
+		de: "Seine Schuppen wachsen sehr schnell nach. Jede neue Schuppe ist härter und schärfer als die vorherige."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/54.ts
+++ b/data/Sun & Moon/Dragon Majesty/54.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Hakamo-o",
 		fr: "Écaïd",
+		de: "Mediras"
 	},
 
 	stage: "Stage2",
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "Its rigid scales function as offense and defense. In the past, its scales were processed and used to make weapons and other commodities.",
+		de: "Seine harten Schuppen dienen sowohl Angriff als auch Verteidigung. Früher wurden aus ihnen Waffen und Gebrauchsgüter hergestellt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/55.ts
+++ b/data/Sun & Moon/Dragon Majesty/55.ts
@@ -106,6 +106,7 @@ const card: Card = {
 
 	description: {
 		en: "The child in its pouch leaves home after roughly three years. That is the only time the mother is heard to cry wildly.",
+		de: "Das Junge verlässt den Beutel der Mutter im Alter von drei Jahren. Dies ist der einzige Zeitpunkt, zu dem man die Mutter laut weinen hört."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/56.ts
+++ b/data/Sun & Moon/Dragon Majesty/56.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It constantly grooms its cotton-like wings. It takes a shower to clean itself if it becomes dirty.",
+		de: "Ständig pflegt es seine watteartigen Flügel. Falls es schmutzig wird, nimmt es eine Dusche, um sich zu putzen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/57.ts
+++ b/data/Sun & Moon/Dragon Majesty/57.ts
@@ -71,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "It constantly grooms its cotton-like wings. It takes a shower to clean itself if it becomes dirty.",
+		de: "Ständig pflegt es seine watteartigen Flügel. Falls es schmutzig wird, nimmt es eine Dusche, um sich zu putzen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/58.ts
+++ b/data/Sun & Moon/Dragon Majesty/58.ts
@@ -32,7 +32,7 @@ const card: Card = {
 		es: "Puedes jugar esta carta solo cuando es la última carta en tu mano.\n\nRoba 2 cartas por cada Pokémon Fire que tengas en juego.",
 		it: "Puoi giocare questa carta solo se è l’ultima carta che hai in mano.\n\nPesca due carte per ogni Pokémon Fire che hai in gioco.",
 		pt: "Você só pode jogar esta carta se ela for a última carta na sua mão.\n\nCompre 2 cartas para cada Pokémon Fire que você tiver em jogo.",
-		de: "Du kannst diese Karte nur spielen, wenn sie die letzte Karte auf deiner Hand ist.\n\nZiehe 2 Karten für jedes Fire-Pokémon, das du im Spiel hast."
+		de: "Du kannst diese Karte nur spielen, wenn sie die letzte Karte auf deiner Hand ist. Ziehe 2 Karten für jedes {R}-Pokémon, das du im Spiel hast. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 	trainerType: "Supporter",
 

--- a/data/Sun & Moon/Dragon Majesty/59.ts
+++ b/data/Sun & Moon/Dragon Majesty/59.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Si el Pokémon Dragon al que esté unida esta carta es tu Pokémon Activo y resulta dañado por un ataque de tu rival (incluso si este Pokémon queda Fuera de Combate), pon 3 contadores de daño en el Pokémon Atacante.",
 		it: "Se il Pokémon Dragon a cui è assegnata questa carta è il tuo Pokémon attivo e viene danneggiato da un attacco del tuo avversario, anche se viene messo KO, metti tre segnalini danno sul Pokémon attaccante.",
 		pt: "Se o Pokémon Dragon ao qual esta carta está ligada for o seu Pokémon Ativo e ele for danificado por um ataque do seu oponente (mesmo que este Pokémon seja Nocauteado), coloque 3 contadores de dano no Pokémon Atacante.",
-		de: "Wenn das Dragon-Pokémon, an das diese Karte angelegt ist, dein Aktives Pokémon ist und durch eine Attacke deines Gegners Schaden erhält (auch wenn dieses Pokémon dadurch kampfunfähig wird), lege 3 Schadensmarken auf das Angreifende Pokémon."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn das {N}-Pokémon, an das diese Karte angelegt ist, dein Aktives Pokémon ist und durch eine Attacke deines Gegners Schaden erhält (auch wenn dieses Pokémon dadurch kampfunfähig wird), lege 3 Schadensmarken auf das Angreifende Pokémon. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sun & Moon/Dragon Majesty/6.ts
+++ b/data/Sun & Moon/Dragon Majesty/6.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Combusken",
 		fr: "Galifeu",
+		de: "Jungglut"
 	},
 
 	stage: "Stage2",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Una vez durante tu turno (antes de tu ataque), puedes unir 1 carta de Energía Fire de tu pila de descartes a 1 de tus Pokémon en Banca.",
 				it: "Una sola volta durante il tuo turno, prima di attaccare, puoi assegnare a uno dei tuoi Pokémon in panchina una carta Energia Fire dalla tua pila degli scarti.",
 				pt: "Uma vez durante a sua vez de jogar (antes de atacar), você pode ligar 1 carta de Energia Fire da sua pilha de descarte a 1 dos seus Pokémon no Banco.",
-				de: "Einmal während deines Zuges (bevor du angreifst) kannst du 1 Fire-Energiekarte aus deinem Ablagestapel an 1 Pokémon auf deiner Bank anlegen."
+				de: "Einmal während deines Zuges (bevor du angreifst) kannst du 1 {R}-Energiekarte aus deinem Ablagestapel an 1 Pokémon auf deiner Bank anlegen."
 			},
 		},
 	],
@@ -76,7 +77,7 @@ const card: Card = {
 				es: "Descarta 1 Energía Fire de este Pokémon. Este ataque hace 20 puntos de daño a cada uno de los Pokémon en Banca de tu rival. (No apliques Debilidad y Resistencia a los Pokémon en Banca).",
 				it: "Scarta un’Energia Fire assegnata a questo Pokémon. Questo attacco infligge 20 danni a ciascun Pokémon nella panchina del tuo avversario. Ricorda che non puoi applicare debolezza e resistenza ai Pokémon in panchina.",
 				pt: "Descarte 1 Energia Fire deste Pokémon. Este ataque causa 20 pontos de dano a cada um dos Pokémon no Banco do seu oponente (não aplique Fraqueza e Resistência aos Pokémon no Banco).",
-				de: "Lege 1 Fire-Energie von diesem Pokémon auf deinen Ablagestapel. Diese Attacke fügt jedem Pokémon auf der Bank deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Lege 1 {R}-Energie von diesem Pokémon auf deinen Ablagestapel. Diese Attacke fügt jedem Pokémon auf der Bank deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 90,
 
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "When facing a tough foe, it looses flames from its wrists. Its powerful legs let it jump clear over buildings.",
+		de: "Trifft es auf einen hartnäckigen Gegner, schießen Flammen aus seinen Handgelenken. Seine starken Beine ermöglichen ihm, über Häuser zu springen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/60.ts
+++ b/data/Sun & Moon/Dragon Majesty/60.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Puedes jugar esta carta solo si descartas otras 2 cartas de tu mano. \n\nBusca en tu baraja hasta 4 cartas de Energía Fire, enséñalas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Puoi giocare questa carta solo se scarti altre due carte che hai in mano.\n\nCerca nel tuo mazzo fino a quattro carte Energia Fire, mostrale e aggiungile a quelle che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Você só pode jogar esta carta se descartar outras 2 cartas da sua mão.\n\nProcure por até 4 cartas de Energia Fire no seu baralho, revele-as e coloque-as na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Du kannst diese Karte nur spielen, wenn du 2 andere Karten aus deiner Hand auf deinen Ablagestapel legst.\n\nDurchsuche dein Deck nach bis zu 4 Fire-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Du kannst diese Karte nur spielen, wenn du 2 andere Karten aus deiner Hand auf deinen Ablagestapel legst. Durchsuche dein Deck nach bis zu 4 {R}-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Dragon Majesty/61.ts
+++ b/data/Sun & Moon/Dragon Majesty/61.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Puedes jugar esta carta solo si 1 de tus Pokémon quedó Fuera de Combate durante el último turno de tu rival.\n\nBusca en tu baraja hasta 2 Pokémon Dragon y ponlos en tu Banca. Después, baraja las cartas de tu baraja.",
 		it: "Puoi giocare questa carta solo se uno dei tuoi Pokémon è stato messo KO durante l’ultimo turno del tuo avversario.\n\nCerca nel tuo mazzo fino a due Pokémon Dragon e mettili nella tua panchina. Poi rimischia le carte del tuo mazzo.",
 		pt: "Você só pode jogar esta carta se 1 dos seus Pokémon tiver sido Nocauteado durante a última vez de jogar do seu oponente.\n\nProcure por até 2 Pokémon Dragon no seu baralho e coloque-os no seu Banco. Em seguida, embaralhe o seu baralho.",
-		de: "Du kannst diese Karte nur spielen, wenn 1 deiner Pokémon während des letzten Zuges deines Gegners kampfunfähig wurde.\n\nDurchsuche dein Deck nach bis zu 2 Dragon-Pokémon und lege sie auf deine Bank. Mische anschließend dein Deck."
+		de: "Du kannst nicht mehr als 1 ◇-Karte mit demselben Namen in deinem Deck haben. Wenn 1 ◇-Karte auf deinen Ablagestapel gelegt würde, lege sie stattdessen ins Nirgendwo. Du kannst diese Karte nur spielen, wenn 1 deiner Pokémon während des letzten Zuges deines Gegners kampfunfähig wurde. Durchsuche dein Deck nach bis zu 2 {N}-Pokémon und lege sie auf deine Bank. Mische anschließend dein Deck. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	}
 }
 

--- a/data/Sun & Moon/Dragon Majesty/62.ts
+++ b/data/Sun & Moon/Dragon Majesty/62.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cambia tu Pokémon Water Activo por 1 de tus Pokémon en Banca. Si lo haces, cura 30 puntos de daño al Pokémon que has movido a tu Banca.",
 		it: "Scambia il tuo Pokémon attivo Water con uno dei tuoi Pokémon in panchina. Se lo fai, cura il Pokémon che hai spostato in panchina da 30 danni.",
 		pt: "Troque o seu Pokémon Water Ativo por 1 dos seus Pokémon no Banco. Se fizer isto, cure 30 pontos de dano do Pokémon que você moveu para o seu Banco.",
-		de: "Tausche dein Aktives Water-Pokémon gegen 1 Pokémon auf deiner Bank aus. Wenn du das machst, heile 30 Schadenspunkte bei dem Pokémon, das du auf deine Bank verschoben hast."
+		de: "Tausche dein Aktives {W}-Pokémon gegen 1 Pokémon auf deiner Bank aus. Wenn du das machst, heile 30 Schadenspunkte bei dem Pokémon, das du auf deine Bank verschoben hast. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Dragon Majesty/63.ts
+++ b/data/Sun & Moon/Dragon Majesty/63.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cada vez que 1 jugador lance 1 moneda para la Condición Especial de Quemado entre turnos, esa Condición Especial no se elimina incluso si sale cara.",
 		it: "Ogni volta che un giocatore lancia una moneta per la condizione speciale di bruciato tra un turno e l’altro, quella condizione speciale non viene rimossa anche se esce testa.",
 		pt: "Sempre que um jogador jogar uma moeda para a Condição Especial de Queimado entre as vezes de jogar, aquela Condição Especial não é removida, mesmo que o resultado seja cara.",
-		de: "Jedes Mal, wenn ein Spieler zwischen den Zügen eine Münze für den Speziellen Zustand Verbrennung wirft, verliert jener Spezielle Zustand seine Wirkung nicht, auch wenn das Ergebnis Kopf ist."
+		de: "Jedes Mal, wenn ein Spieler zwischen den Zügen eine Münze für den Speziellen Zustand Verbrennung wirft, verliert jener Spezielle Zustand seine Wirkung nicht, auch wenn das Ergebnis Kopf ist. Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 
 	trainerType: "Stadium",

--- a/data/Sun & Moon/Dragon Majesty/64.ts
+++ b/data/Sun & Moon/Dragon Majesty/64.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Puedes jugar esta carta solo si 1 de tus Pokémon quedó Fuera de Combate durante el último turno de tu rival.\n\nUne hasta 2 cartas de Energía Básica de tu mano a 1 de tus Pokémon Dragon.",
 		it: "Puoi giocare questa carta solo se uno dei tuoi Pokémon è stato messo KO durante l’ultimo turno del tuo avversario.\n\nAssegna a uno dei tuoi Pokémon Dragon fino a due carte Energia base dalla tua mano.",
 		pt: "Você só pode jogar esta carta se 1 dos seus Pokémon tiver sido Nocauteado durante a última vez de jogar do seu oponente.\n\nLigue até 2 cartas de Energia básica da sua mão a 1 dos seus Pokémon Dragon.",
-		de: "Du kannst diese Karte nur spielen, wenn 1 deiner Pokémon während des letzten Zuges deines Gegners kampfunfähig wurde.\n\nLege bis zu 2 Basis-Energiekarten aus deiner Hand an 1 deiner Dragon-Pokémon an."
+		de: "Du kannst diese Karte nur spielen, wenn 1 deiner Pokémon während des letzten Zuges deines Gegners kampfunfähig wurde. Lege bis zu 2 Basis-Energiekarten aus deiner Hand an 1 deiner {N}-Pokémon an. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Dragon Majesty/65.ts
+++ b/data/Sun & Moon/Dragon Majesty/65.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Busca en tu baraja hasta 2 cartas de Energía Fire y únelas a este Pokémon. Después, baraja las cartas de tu baraja.",
 				it: "Cerca nel tuo mazzo fino a due carte Energia Fire e assegnale a questo Pokémon. Poi rimischia le carte del tuo mazzo.",
 				pt: "Procure por até 2 cartas de Energia Fire no seu baralho e ligue-as a este Pokémon. Em seguida, embaralhe o seu baralho.",
-				de: "Durchsuche dein Deck nach bis zu 2 Fire-Energiekarten und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
+				de: "Durchsuche dein Deck nach bis zu 2 {R}-Energiekarten und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
 			},
 
 		},
@@ -98,7 +98,7 @@ const card: Card = {
 				es: "Puedes unir hasta 5 cartas de Energía Fire de tu mano a tus Pokémon de la manera que desees. (No puedes usar más de 1 ataque GX en una partida).",
 				it: "Puoi assegnare a piacimento ai tuoi Pokémon fino a cinque carte Energia Fire dalla tua mano. Non puoi usare più di un attacco GX a partita.",
 				pt: "Você pode ligar até 5 cartas de Energia Fire da sua mão aos seus Pokémon como desejar (você não pode usar mais de 1 ataque GX por partida).",
-				de: "Du kannst bis zu 5 Fire-Energiekarten aus deiner Hand beliebig an deine Pokémon anlegen. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
+				de: "Du kannst bis zu 5 {R}-Energiekarten aus deiner Hand beliebig an deine Pokémon anlegen. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: 180,
 

--- a/data/Sun & Moon/Dragon Majesty/66.ts
+++ b/data/Sun & Moon/Dragon Majesty/66.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Seadra",
 		fr: "Hypocéan",
+		de: "Seemon"
 	},
 
 	suffix: "GX",
@@ -52,7 +53,7 @@ const card: Card = {
 				es: "Este ataque hace 50 puntos de daño más por cada Energía Water unida a este Pokémon.",
 				it: "Questo attacco infligge 50 danni in più per ogni Energia Water assegnata a questo Pokémon.",
 				pt: "Este ataque causa 50 pontos de dano a mais vezes a quantidade de Energia Water ligada a este Pokémon.",
-				de: "Diese Attacke fügt 50 Schadenspunkte mehr mal der Anzahl der an dieses Pokémon angelegten Water-Energien zu."
+				de: "Diese Attacke fügt 50 Schadenspunkte mehr mal der Anzahl der an dieses Pokémon angelegten {W}-Energien zu."
 			},
 			damage: "10+",
 

--- a/data/Sun & Moon/Dragon Majesty/67.ts
+++ b/data/Sun & Moon/Dragon Majesty/67.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Dragonair",
 		fr: "Draco",
+		de: "Dragonir"
 	},
 
 	suffix: "GX",
@@ -96,7 +97,7 @@ const card: Card = {
 				es: "Pon 3 Pokémon Dragon de tu pila de descartes en tu Banca. (No puedes usar más de 1 ataque GX en una partida).",
 				it: "Prendi tre Pokémon Dragon dalla tua pila degli scarti e mettili nella tua panchina. Non puoi usare più di un attacco GX a partita.",
 				pt: "Coloque 3 Pokémon Dragon da sua pilha de descarte no seu Banco (você não pode usar mais de 1 ataque GX por partida).",
-				de: "Lege 3 Dragon-Pokémon aus deinem Ablagestapel auf deine Bank. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
+				de: "Lege 3 {N}-Pokémon aus deinem Ablagestapel auf deine Bank. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Dragon Majesty/68.ts
+++ b/data/Sun & Moon/Dragon Majesty/68.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Swablu",
 		fr: "Tylton",
+		de: "Wablu"
 	},
 
 	suffix: "GX",

--- a/data/Sun & Moon/Dragon Majesty/69.ts
+++ b/data/Sun & Moon/Dragon Majesty/69.ts
@@ -32,7 +32,7 @@ const card: Card = {
 		es: "Puedes jugar esta carta solo cuando es la última carta en tu mano.\n\nRoba 2 cartas por cada Pokémon Fire que tengas en juego.",
 		it: "Puoi giocare questa carta solo se è l’ultima carta che hai in mano.\n\nPesca due carte per ogni Pokémon Fire che hai in gioco.",
 		pt: "Você só pode jogar esta carta se ela for a última carta na sua mão.\n\nCompre 2 cartas para cada Pokémon Fire que você tiver em jogo.",
-		de: "Du kannst diese Karte nur spielen, wenn sie die letzte Karte auf deiner Hand ist.\n\nZiehe 2 Karten für jedes Fire-Pokémon, das du im Spiel hast."
+		de: "Du kannst diese Karte nur spielen, wenn sie die letzte Karte auf deiner Hand ist. Ziehe 2 Karten für jedes {R}-Pokémon, das du im Spiel hast. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 	trainerType: "Supporter",
 

--- a/data/Sun & Moon/Dragon Majesty/7.ts
+++ b/data/Sun & Moon/Dragon Majesty/7.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "When it shares the infinite energy it creates, that being's entire body will be overflowing with power.",
+		de: "Jeder, dem Victini seine grenzenlose Energie zuteilwerden lässt, strotzt nur so vor Kraft."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/70.ts
+++ b/data/Sun & Moon/Dragon Majesty/70.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Puedes jugar esta carta solo si 1 de tus Pokémon quedó Fuera de Combate durante el último turno de tu rival.\n\nUne hasta 2 cartas de Energía Básica de tu mano a 1 de tus Pokémon Dragon.",
 		it: "Puoi giocare questa carta solo se uno dei tuoi Pokémon è stato messo KO durante l’ultimo turno del tuo avversario.\n\nAssegna a uno dei tuoi Pokémon Dragon fino a due carte Energia base dalla tua mano.",
 		pt: "Você só pode jogar esta carta se 1 dos seus Pokémon tiver sido Nocauteado durante a última vez de jogar do seu oponente.\n\nLigue até 2 cartas de Energia básica da sua mão a 1 dos seus Pokémon Dragon.",
-		de: "Du kannst diese Karte nur spielen, wenn 1 deiner Pokémon während des letzten Zuges deines Gegners kampfunfähig wurde.\n\nLege bis zu 2 Basis-Energiekarten aus deiner Hand an 1 deiner Dragon-Pokémon an."
+		de: "Du kannst diese Karte nur spielen, wenn 1 deiner Pokémon während des letzten Zuges deines Gegners kampfunfähig wurde. Lege bis zu 2 Basis-Energiekarten aus deiner Hand an 1 deiner {N}-Pokémon an. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Dragon Majesty/71.ts
+++ b/data/Sun & Moon/Dragon Majesty/71.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Busca en tu baraja hasta 2 cartas de Energía Fire y únelas a este Pokémon. Después, baraja las cartas de tu baraja.",
 				it: "Cerca nel tuo mazzo fino a due carte Energia Fire e assegnale a questo Pokémon. Poi rimischia le carte del tuo mazzo.",
 				pt: "Procure por até 2 cartas de Energia Fire no seu baralho e ligue-as a este Pokémon. Em seguida, embaralhe o seu baralho.",
-				de: "Durchsuche dein Deck nach bis zu 2 Fire-Energiekarten und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
+				de: "Durchsuche dein Deck nach bis zu 2 {R}-Energiekarten und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
 			},
 
 		},
@@ -98,7 +98,7 @@ const card: Card = {
 				es: "Puedes unir hasta 5 cartas de Energía Fire de tu mano a tus Pokémon de la manera que desees. (No puedes usar más de 1 ataque GX en una partida).",
 				it: "Puoi assegnare a piacimento ai tuoi Pokémon fino a cinque carte Energia Fire dalla tua mano. Non puoi usare più di un attacco GX a partita.",
 				pt: "Você pode ligar até 5 cartas de Energia Fire da sua mão aos seus Pokémon como desejar (você não pode usar mais de 1 ataque GX por partida).",
-				de: "Du kannst bis zu 5 Fire-Energiekarten aus deiner Hand beliebig an deine Pokémon anlegen. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
+				de: "Du kannst bis zu 5 {R}-Energiekarten aus deiner Hand beliebig an deine Pokémon anlegen. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: 180,
 

--- a/data/Sun & Moon/Dragon Majesty/72.ts
+++ b/data/Sun & Moon/Dragon Majesty/72.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Swablu",
 		fr: "Tylton",
+		de: "Wablu"
 	},
 
 	suffix: "GX",

--- a/data/Sun & Moon/Dragon Majesty/73.ts
+++ b/data/Sun & Moon/Dragon Majesty/73.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Shelgon",
 		fr: "Drackhaus",
+		de: "Draschel"
 	},
 
 	suffix: "GX",

--- a/data/Sun & Moon/Dragon Majesty/74.ts
+++ b/data/Sun & Moon/Dragon Majesty/74.ts
@@ -90,7 +90,7 @@ const card: Card = {
 				es: "Estrella Dragón-GX",
 				it: "Dragonova-GX",
 				pt: "Supernova do Dragão-GX",
-				de: "Drachen Nova-GX"
+				de: "Drachen-Nova-GX"
 			},
 			effect: {
 				en: "Your opponent’s Active Pokémon is now Burned and Paralyzed. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Dragon Majesty/75.ts
+++ b/data/Sun & Moon/Dragon Majesty/75.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Si el Pokémon Dragon al que esté unida esta carta es tu Pokémon Activo y resulta dañado por un ataque de tu rival (incluso si este Pokémon queda Fuera de Combate), pon 3 contadores de daño en el Pokémon Atacante.",
 		it: "Se il Pokémon Dragon a cui è assegnata questa carta è il tuo Pokémon attivo e viene danneggiato da un attacco del tuo avversario, anche se viene messo KO, metti tre segnalini danno sul Pokémon attaccante.",
 		pt: "Se o Pokémon Dragon ao qual esta carta está ligada for o seu Pokémon Ativo e ele for danificado por um ataque do seu oponente (mesmo que este Pokémon seja Nocauteado), coloque 3 contadores de dano no Pokémon Atacante.",
-		de: "Wenn das Dragon-Pokémon, an das diese Karte angelegt ist, dein Aktives Pokémon ist und durch eine Attacke deines Gegners Schaden erhält (auch wenn dieses Pokémon dadurch kampfunfähig wird), lege 3 Schadensmarken auf das Angreifende Pokémon."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn das {N}-Pokémon, an das diese Karte angelegt ist, dein Aktives Pokémon ist und durch eine Attacke deines Gegners Schaden erhält (auch wenn dieses Pokémon dadurch kampfunfähig wird), lege 3 Schadensmarken auf das Angreifende Pokémon. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sun & Moon/Dragon Majesty/76.ts
+++ b/data/Sun & Moon/Dragon Majesty/76.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Puedes jugar esta carta solo si descartas otras 2 cartas de tu mano. \n\nBusca en tu baraja hasta 4 cartas de Energía Fire, enséñalas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Puoi giocare questa carta solo se scarti altre due carte che hai in mano.\n\nCerca nel tuo mazzo fino a quattro carte Energia Fire, mostrale e aggiungile a quelle che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Você só pode jogar esta carta se descartar outras 2 cartas da sua mão.\n\nProcure por até 4 cartas de Energia Fire no seu baralho, revele-as e coloque-as na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Du kannst diese Karte nur spielen, wenn du 2 andere Karten aus deiner Hand auf deinen Ablagestapel legst.\n\nDurchsuche dein Deck nach bis zu 4 Fire-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Du kannst diese Karte nur spielen, wenn du 2 andere Karten aus deiner Hand auf deinen Ablagestapel legst. Durchsuche dein Deck nach bis zu 4 {R}-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Dragon Majesty/77.ts
+++ b/data/Sun & Moon/Dragon Majesty/77.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cambia tu Pokémon Water Activo por 1 de tus Pokémon en Banca. Si lo haces, cura 30 puntos de daño al Pokémon que has movido a tu Banca.",
 		it: "Scambia il tuo Pokémon attivo Water con uno dei tuoi Pokémon in panchina. Se lo fai, cura il Pokémon che hai spostato in panchina da 30 danni.",
 		pt: "Troque o seu Pokémon Water Ativo por 1 dos seus Pokémon no Banco. Se fizer isto, cure 30 pontos de dano do Pokémon que você moveu para o seu Banco.",
-		de: "Tausche dein Aktives Water-Pokémon gegen 1 Pokémon auf deiner Bank aus. Wenn du das machst, heile 30 Schadenspunkte bei dem Pokémon, das du auf deine Bank verschoben hast."
+		de: "Tausche dein Aktives {W}-Pokémon gegen 1 Pokémon auf deiner Bank aus. Wenn du das machst, heile 30 Schadenspunkte bei dem Pokémon, das du auf deine Bank verschoben hast. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Dragon Majesty/78.ts
+++ b/data/Sun & Moon/Dragon Majesty/78.ts
@@ -48,7 +48,7 @@ const card: Card = {
 				es: "Descarta todas las Energías Básicas Psychic de este Pokémon. Este ataque hace 80 puntos de daño más por cada carta que hayas descartado de esta manera.",
 				it: "Scarta tutte le Energie base Psychic assegnate a questo Pokémon. Questo attacco infligge 80 danni in più per ogni carta che hai scartato in questo modo.",
 				pt: "Descarte todas as Energias Psychic básicas deste Pokémon. Este ataque causa 80 pontos de dano a mais para cada carta descartada desta forma.",
-				de: "Lege alle Psychic-Basis-Energien von diesem Pokémon auf deinen Ablagestapel. Diese Attacke fügt 80 Schadenspunkte mehr mal der Anzahl der auf diese Weise auf deinen Ablagestapel gelegten Karten zu."
+				de: "Lege alle {P}-Basis-Energien von diesem Pokémon auf deinen Ablagestapel. Diese Attacke fügt 80 Schadenspunkte mehr mal der Anzahl der auf diese Weise auf deinen Ablagestapel gelegten Karten zu."
 			},
 			damage: "20+",
 

--- a/data/Sun & Moon/Dragon Majesty/8.ts
+++ b/data/Sun & Moon/Dragon Majesty/8.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "When it sleeps, it pulls its limbs into its body and its internal fire goes down to 1,100 degrees Fahrenheit.",
+		de: "Zum Schlafen zieht es Arme und Beine ein und senkt seine innere Körpertemperatur auf 600 °C, um sich zu entspannen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Dragon Majesty/9.ts
+++ b/data/Sun & Moon/Dragon Majesty/9.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Darumaka",
 		fr: "Darumarond",
+		de: "Flampion"
 	},
 
 	stage: "Stage1",
@@ -52,7 +53,7 @@ const card: Card = {
 				es: "Une hasta 3 cartas de Energía Fire de tu mano a tus Pokémon de la manera que desees.",
 				it: "Assegna a piacimento ai tuoi Pokémon fino a tre carte Energia Fire dalla tua mano.",
 				pt: "Ligue até 3 cartas de Energia Fire da sua mão aos seus Pokémon como desejar.",
-				de: "Lege bis zu 3 Fire-Energiekarten aus deiner Hand beliebig an deine Pokémon an."
+				de: "Lege bis zu 3 {R}-Energiekarten aus deiner Hand beliebig an deine Pokémon an."
 			},
 
 		},
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "Its internal fire burns at 2,500 degrees Fahrenheit, making enough power that it can destroy a dump truck with one punch.",
+		de: "Erhitzt das Innere seines Körpers auf 1 400 °C und erlangt so die Kraft, um mit der Faust Laster zu zerstören."
 	},
 
 	thirdParty: {


### PR DESCRIPTION
## Add missing German translations for sm7.5

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
