### PR TITLE
Add missing German translations for swsh6

### DIFF
--- a/data/Sword & Shield/Chilling Reign/1.ts
+++ b/data/Sword & Shield/Chilling Reign/1.ts
@@ -46,7 +46,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Its poison stinger is very powerful. Its bright-colored body is intended to warn off its enemies."
+		en: "Its poison stinger is very powerful. Its bright-colored body is intended to warn off its enemies.",
+		de: "Sein Giftstachel ist gefährlich. Sein hellleuchtender Körper soll Feinde abschrecken."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/10.ts
+++ b/data/Sword & Shield/Chilling Reign/10.ts
@@ -77,7 +77,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "This Pokémon is known to bring blizzards. A shake of its massive body is enough to cause whiteout conditions."
+		en: "This Pokémon is known to bring blizzards. A shake of its massive body is enough to cause whiteout conditions.",
+		de: "Dieses Pokémon löst Blizzards aus. Wenn es seinen großen Körper schüttelt, wird in seiner Umgebung alles sofort schneeweiß."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/101.ts
+++ b/data/Sword & Shield/Chilling Reign/101.ts
@@ -77,7 +77,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "The small spikes covering its body developed from scales. They inject a toxin that causes fainting."
+		en: "The small spikes covering its body developed from scales. They inject a toxin that causes fainting.",
+		de: "Die kleinen Stacheln an seinem Körper sind aus Schuppen entstanden. Damit injiziert es Gift, das zu Ohnmacht führt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/102.ts
+++ b/data/Sword & Shield/Chilling Reign/102.ts
@@ -55,7 +55,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Constant polishing makes the edge of the blade on its tail extremely sharp. It's Zangoose's archrival."
+		en: "Constant polishing makes the edge of the blade on its tail extremely sharp. It's Zangoose's archrival.",
+		de: "Es hält die Klinge an seinem Schweif scharf, indem es sie ständig an Steinen wetzt. Es ist der Erzfeind von Sengo."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/103.ts
+++ b/data/Sword & Shield/Chilling Reign/103.ts
@@ -66,7 +66,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It was bound to a fissure in an Odd Keystone as punishment for misdeeds 500 years ago."
+		en: "It was bound to a fissure in an Odd Keystone as punishment for misdeeds 500 years ago.",
+		de: "Es wurde in einen Spalt eines Steins gebannt, als Sühne für Untaten, die es vor 500 Jahren begangen hatte."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/104.ts
+++ b/data/Sword & Shield/Chilling Reign/104.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			es: "Cuando juegas este Pokémon de tu mano a tu Banca durante tu turno, puedes descartar 1 Herramienta Pokémon de 1 Pokémon (tuyo o de tu rival).",
 			it: "Quando giochi questo Pokémon dalla tua mano e lo metti in panchina durante il tuo turno, puoi scartare una carta Oggetto Pokémon da un Pokémon, tuo o del tuo avversario.",
 			pt: "Quando você jogar este Pokémon da sua mão para o seu Banco durante o seu turno, você poderá descartar 1 Ferramenta Pokémon de 1 Pokémon (seu ou do seu oponente).",
-			de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand auf deine Bank spielst, kannst du 1 Pokémon-Ausrüstung von 1 Pokémon (deinem oder dem deines Gegners) auf den Ablagestapel legen."
+			de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand auf deine Bank spielst, kannst du 1 Pokémon-Ausrüstung von 1 Pokémon (deine oder dem deines Gegners) auf den Ablagestapel legen."
 		}
 	}],
 

--- a/data/Sword & Shield/Chilling Reign/105.ts
+++ b/data/Sword & Shield/Chilling Reign/105.ts
@@ -55,7 +55,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Its bite injects a potent poison, enough to paralyze large bird Pokémon that try to prey on it."
+		en: "Its bite injects a potent poison, enough to paralyze large bird Pokémon that try to prey on it.",
+		de: "Es beißt Angreifer und injiziert ihnen Gift, das selbst große Vogel-Pokémon, seine natürlichen Feinde, lähmt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/106.ts
+++ b/data/Sword & Shield/Chilling Reign/106.ts
@@ -76,7 +76,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It is usually motionless, but when attacked, it rotates at high speed and then crashes into its opponent."
+		en: "It is usually motionless, but when attacked, it rotates at high speed and then crashes into its opponent.",
+		de: "An sich ist es harmlos. Bringt man es jedoch in Bedrängnis, setzt es sich mit blitzschnellen Rollattacken zur Wehr."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/107.ts
+++ b/data/Sword & Shield/Chilling Reign/107.ts
@@ -85,7 +85,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "With quick movements, it chases down its foes, attacking relentlessly with its horns until it prevails."
+		en: "With quick movements, it chases down its foes, attacking relentlessly with its horns until it prevails.",
+		de: "Holt Gegner flinken Fußes ein und greift sie mit den Hörnern an seinem Kopf an. Gnade ist ihm ein Fremdwort."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/108.ts
+++ b/data/Sword & Shield/Chilling Reign/108.ts
@@ -85,7 +85,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Inhabiting the mountains of a distant region, this Pokémon races across sheer cliffs, training its legs and refining its moves."
+		en: "Inhabiting the mountains of a distant region, this Pokémon races across sheer cliffs, training its legs and refining its moves.",
+		de: "Wulaosu lebt in den Bergen einer fernen Region. Um die Beine zu stählen und seine Kampftechnik zu verbessern, rennt es steile Klippen entlang."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/109.ts
+++ b/data/Sword & Shield/Chilling Reign/109.ts
@@ -63,7 +63,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "When it evolves, it sheds the steel carapace that covered its whole body and develops a new one."
+		en: "When it evolves, it sheds the steel carapace that covered its whole body and develops a new one.",
+		de: "Entwickelt es sich, wirft es seinen alten Stahlpanzer ab und bildet einen neuen aus."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/11.ts
+++ b/data/Sword & Shield/Chilling Reign/11.ts
@@ -66,7 +66,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "The turning of the seasons changes the color and scent of this Pokémon's fur. People use it to mark the seasons."
+		en: "The turning of the seasons changes the color and scent of this Pokémon's fur. People use it to mark the seasons.",
+		de: "Sein Fell und sein Geruch ändern sich mit dem Wechsel der Jahreszeiten. Es ist der Bote des Saisonwechsels."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/110.ts
+++ b/data/Sword & Shield/Chilling Reign/110.ts
@@ -72,7 +72,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It habitually shows off its strength with the size of sparks it creates by ramming its steel body into boulders."
+		en: "It habitually shows off its strength with the size of sparks it creates by ramming its steel body into boulders.",
+		de: "Gelegentlich demonstriert es seine Kraft, indem es mit der Größe der Funken angibt, die entstehen, wenn es seinen stählernen Körper in Felsen rammt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/111.ts
+++ b/data/Sword & Shield/Chilling Reign/111.ts
@@ -90,7 +90,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "While seeking iron for food, it digs tunnels by breaking through bedrock with its steel horns."
+		en: "While seeking iron for food, it digs tunnels by breaking through bedrock with its steel horns.",
+		de: "Auf der Suche nach Eisen, seiner Nahrung, gräbt es mit seinen Stahlhörnern sogar Tunnel durch Felsen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/114.ts
+++ b/data/Sword & Shield/Chilling Reign/114.ts
@@ -72,7 +72,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It has a body and heart of steel. It worked with its allies to punish people when they hurt Pokémon."
+		en: "It has a body and heart of steel. It worked with its allies to punish people when they hurt Pokémon.",
+		de: "Sein Körper und Herz sind aus Stahl. Gemeinsam mit seinen Gefährten bestrafte es alle Menschen, die Pokémon verletzen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/115.ts
+++ b/data/Sword & Shield/Chilling Reign/115.ts
@@ -76,7 +76,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "They live in groups. The one with the longest, thickest, and most-scarred horns is the boss of the herd."
+		en: "They live in groups. The one with the longest, thickest, and most-scarred horns is the boss of the herd.",
+		de: "Sie leben in Herden. Ihr Anführer ist das Tauros mit den kräftigsten und längsten Hörnern sowie den meisten Kampfspuren darauf."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/116.ts
+++ b/data/Sword & Shield/Chilling Reign/116.ts
@@ -46,7 +46,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It was built 20 years ago by scientists who dreamed of exploring space. Their dreams have yet to come true."
+		en: "It was built 20 years ago by scientists who dreamed of exploring space. Their dreams have yet to come true.",
+		de: "Es wurde vor 20 Jahren von Wissenschaftlern erschaffen, die vom Erforschen des Weltraums träumten. Ihr Traum hat sich bisher nicht erfüllt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/117.ts
+++ b/data/Sword & Shield/Chilling Reign/117.ts
@@ -64,7 +64,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Even though it doesn't die in the vacuum of space, it can't move around very well in zero gravity."
+		en: "Even though it doesn't die in the vacuum of space, it can't move around very well in zero gravity.",
+		de: "Es ist zwar imstande, auch im All zu überleben, aber in der Schwerelosigkeit kann es sich nicht gut fortbewegen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/118.ts
+++ b/data/Sword & Shield/Chilling Reign/118.ts
@@ -86,7 +86,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "A faulty update was added to its programming. Its behavior is noticeably strange, so the experiment may have been a failure."
+		en: "A faulty update was added to its programming. Its behavior is noticeably strange, so the experiment may have been a failure.",
+		de: "Eine fehlerhafte neue Software führte zu seinem auffällig seltsamen Verhalten. Vermutlich handelt es sich um ein verkorkstes Experiment."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/119.ts
+++ b/data/Sword & Shield/Chilling Reign/119.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			es: "Cada vez que unas 1 carta de Energía de tu mano a este Pokémon, elimina todas sus Condiciones Especiales.",
 			it: "Ogni volta che assegni una carta Energia a questo Pokémon dalla tua mano, rimuovi tutte le condizioni speciali che lo influenzano.",
 			pt: "Sempre que ligar 1 carta de Energia da sua mão a este Pokémon, remova todas as Condições Especiais dele.",
-			de: "Jedes Mal, wenn du 1 Energiekarte aus deiner Hand an dieses Pokémon anlegst, verlieren alle Speziellen Zustände auf diesem Pokémon ihre Wirkung."
+			de: "Jedes Mal, wenn du 1 Energiekarte aus deiner Hand an dieses Pokémon anlegst, erholt es sich von allen Speziellen Zuständen."
 		}
 	}],
 

--- a/data/Sword & Shield/Chilling Reign/12.ts
+++ b/data/Sword & Shield/Chilling Reign/12.ts
@@ -76,7 +76,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "They migrate according to the seasons. People can tell the season by looking at Sawsbuck's horns."
+		en: "They migrate according to the seasons. People can tell the season by looking at Sawsbuck's horns.",
+		de: "Mancherorts sagt man, sie brächten den Frühling, da sie je nach Jahreszeit ihr Revier wechseln."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/120.ts
+++ b/data/Sword & Shield/Chilling Reign/120.ts
@@ -55,7 +55,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Its fur would all stand on end if it smelled a Seviper nearby. Its sharp claws tear up its foes."
+		en: "Its fur would all stand on end if it smelled a Seviper nearby. Its sharp claws tear up its foes.",
+		de: "Vipitis’ Geruch lässt ihm alle Haare zu Berge stehen. Mit seinen scharfen Klauen kratzt es seine Feinde."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/121.ts
+++ b/data/Sword & Shield/Chilling Reign/121.ts
@@ -26,7 +26,8 @@ const card: Card = {
 
 	description: {
 		en: "Its form changes depending on the weather. The rougher conditions get, the rougher Castform's disposition!",
-		fr: 'Il n\'y a pas que son apparence qui change en\nfonction de la météo: son tempérament aussi !\nPlus il y a de vent, plus il se montre agressif.'
+		fr: 'Il n\'y a pas que son apparence qui change en\nfonction de la météo: son tempérament aussi !\nPlus il y a de vent, plus il se montre agressif.',
+		de: "Seine Gestalt ändert sich abhängig vom Wetter. Je ungestümer dieses ist, desto gröber wird auch sein Charakter."
 	},
 
 	abilities: [{

--- a/data/Sword & Shield/Chilling Reign/122.ts
+++ b/data/Sword & Shield/Chilling Reign/122.ts
@@ -68,7 +68,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Its color changes for concealment and also when its mood or health changes. The darker the color, the healthier it is."
+		en: "Its color changes for concealment and also when its mood or health changes. The darker the color, the healthier it is.",
+		de: "Seine Färbung ändert sich nicht nur zur Tarnung, sondern auch je nach Laune und Verfassung. Je kräftiger seine Farben sind, desto vitaler ist es."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/123.ts
+++ b/data/Sword & Shield/Chilling Reign/123.ts
@@ -81,7 +81,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "The blooming of Gracidea flowers confers the power of flight upon it. Feelings of gratitude are the message it delivers."
+		en: "The blooming of Gracidea flowers confers the power of flight upon it. Feelings of gratitude are the message it delivers.",
+		de: "Es heißt, wenn die Gracidea blühen, drückt es seine Dankbarkeit aus, indem es hoch in die Lüfte fliegt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/125.ts
+++ b/data/Sword & Shield/Chilling Reign/125.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		es: "Tornadus V",
 		it: "Tornadus-V",
 		pt: "Tornadus V",
-		de: "Boreos-V"
+		de: "Boreos VMAX"
 	},
 
 	attacks: [{

--- a/data/Sword & Shield/Chilling Reign/126.ts
+++ b/data/Sword & Shield/Chilling Reign/126.ts
@@ -75,7 +75,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Left alone, its fur will grow longer and longer, but it will only allow someone it trusts to cut it."
+		en: "Left alone, its fur will grow longer and longer, but it will only allow someone it trusts to cut it.",
+		de: "Trimmt man sein Fell nicht regelmäßig, wächst es ohne Unterlass. Allerdings lässt es sich nur von jemandem frisieren, dem es traut."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/127.ts
+++ b/data/Sword & Shield/Chilling Reign/127.ts
@@ -66,7 +66,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It eats berries nonstop—a habit that has made it more resilient than it looks. It'll show up on farms, searching for yet more berries."
+		en: "It eats berries nonstop—a habit that has made it more resilient than it looks. It'll show up on farms, searching for yet more berries.",
+		de: "Da es unentwegt Beeren futtert, ist es zäher als es aussieht. Man sieht es oft auf Feldern, wo es nach Beeren sucht."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/128.ts
+++ b/data/Sword & Shield/Chilling Reign/128.ts
@@ -77,7 +77,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Common throughout the Galar region, this Pokémon has strong teeth and can chew through the toughest of berry shells."
+		en: "Common throughout the Galar region, this Pokémon has strong teeth and can chew through the toughest of berry shells.",
+		de: "Diesem Pokémon begegnet man häufig in Galar. Es ist sehr stolz auf seine Zähne, mit denen es jede noch so harte Beerenschale knacken kann."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/129.ts
+++ b/data/Sword & Shield/Chilling Reign/129.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Mueve hasta 3 contadores de daño de tu Pokémon Activo al Pokémon Activo de tu rival.",
 		it: "Sposta fino a tre segnalini danno dal tuo Pokémon attivo al Pokémon attivo del tuo avversario.",
 		pt: "Mova até 3 contadores de dano do seu Pokémon Ativo para o Pokémon Ativo do seu oponente.",
-		de: "Verschiebe bis zu 3 Schadensmarken von deinem Aktiven Pokémon auf das Aktive Pokémon deines Gegners."
+		de: "Verschiebe bis zu 3 Schadensmarken von deinem Aktiven Pokémon auf das Aktive Pokémon deines Gegners. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/13.ts
+++ b/data/Sword & Shield/Chilling Reign/13.ts
@@ -46,7 +46,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "When under attack, it secretes a sweet and delicious sweat. The scent only calls more enemies to it."
+		en: "When under attack, it secretes a sweet and delicious sweat. The scent only calls more enemies to it.",
+		de: "Wenn es angegriffen wird, sondert es einen köstlich süß duftenden Angstschweiß ab, der leider meist nur noch weitere Feinde anlockt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/130.ts
+++ b/data/Sword & Shield/Chilling Reign/130.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Roba 3 cartas. Si has robado alguna carta de esta manera, tu rival descarta Pokémon de su Banca hasta que tenga 3.",
 		it: "Pesca tre carte. Se hai pescato delle carte in questo modo, il tuo avversario scarta i Pokémon dalla sua panchina fino ad averne tre.",
 		pt: "Compre 3 cartas. Se você comprar qualquer carta desta forma, o seu oponente descartará Pokémon do próprio Banco até ter 3 Pokémon no Banco.",
-		de: "Ziehe 3 Karten. Wenn du auf diese Weise mindestens 1 Karte gezogen hast, legt dein Gegner so lange Pokémon von seiner Bank auf seinen Ablagestapel, bis er 3 Pokémon auf seiner Bank hat."
+		de: "Ziehe 3 Karten. Wenn du auf diese Weise mindestens 1 Karte gezogen hast, legt dein Gegner so lange Pokémon von seiner Bank auf seinen Ablagestapel, bis er 3 Pokémon auf seiner Bank hat. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/131.ts
+++ b/data/Sword & Shield/Chilling Reign/131.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 3 Pokémon Golpe Fluido Básicos y ponlos en tu Banca. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo fino a tre Pokémon Base Colpo Rapido e mettili nella tua panchina. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por até 3 Pokémon Golpe Fluido Básicos no seu baralho e coloque-os no seu Banco. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach bis zu 3 Basis-Fließender-Angriff-Pokémon und lege sie auf deine Bank. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach bis zu 3 Basis-Fließender-Angriff-Pokémon und lege sie auf deine Bank. Mische anschließend dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/132.ts
+++ b/data/Sword & Shield/Chilling Reign/132.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Pon cualquier cantidad de cartas de tu mano en la parte inferior de tu baraja en el orden que quieras. Después, roba esa misma cantidad de cartas.",
 		it: "Prendi un numero qualsiasi di carte dalla tua mano e mettile in fondo al tuo mazzo nell'ordine che preferisci. Poi pesca lo stesso numero di carte.",
 		pt: "Coloque qualquer número de cartas da sua mão como as cartas de baixo do seu baralho em qualquer ordem. Em seguida, compre aquele mesmo número de cartas.",
-		de: "Lege beliebig viele Karten aus deiner Hand in beliebiger Reihenfolge unter dein Deck. Ziehe anschließend genauso viele Karten."
+		de: "Lege beliebig viele Karten aus deiner Hand in beliebiger Reihenfolge unter dein Deck. Ziehe anschließend genauso viele Karten. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/133.ts
+++ b/data/Sword & Shield/Chilling Reign/133.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Los ataques del Pokémon al que esté unida esta carta hacen 30 puntos de daño más al Pokémon Metal Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
 		it: "Gli attacchi del Pokémon a cui è assegnata questa carta infliggono 30 danni in più al Pokémon attivo Metal del tuo avversario, prima di aver applicato debolezza e resistenza.",
 		pt: "Os ataques do Pokémon ao qual esta carta está ligada causam 30 pontos de dano a mais ao Pokémon Metal Ativo do seu oponente (antes de aplicar Fraqueza e Resistência).",
-		de: "Die Attacken des Pokémon, an das diese Karte angelegt ist, fügen dem Aktiven Metal-Pokémon deines Gegners 30 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Die Attacken des Pokémon, an das diese Karte angelegt ist, fügen dem Aktiven {M}-Pokémon deines Gegners 30 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden). Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sword & Shield/Chilling Reign/135.ts
+++ b/data/Sword & Shield/Chilling Reign/135.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Los Pokémon (tanto tuyos como de tu rival) no pueden ser curados.",
 		it: "I Pokémon, sia tuoi che del tuo avversario, non possono essere curati.",
 		pt: "Os Pokémon (seus e do seu oponente) não podem ser curados.",
-		de: "Pokémon (deine und die deines Gegners) können nicht geheilt werden."
+		de: "Pokémon (deine und die deines Gegners) können nicht geheilt werden. Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 
 	trainerType: "Stadium",

--- a/data/Sword & Shield/Chilling Reign/136.ts
+++ b/data/Sword & Shield/Chilling Reign/136.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Pon 1 Pokémon Básico de la pila de descartes de tu rival en su Banca.",
 		it: "Prendi un Pokémon Base dalla pila degli scarti del tuo avversario e mettilo nella sua panchina.",
 		pt: "Coloque 1 Pokémon Básico da pilha de descarte do seu oponente no Banco dele(a).",
-		de: "Lege 1 Basis-Pokémon aus dem Ablagestapel deines Gegners auf seine Bank."
+		de: "Lege 1 Basis-Pokémon aus dem Ablagestapel deines Gegners auf seine Bank. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Chilling Reign/137.ts
+++ b/data/Sword & Shield/Chilling Reign/137.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Mira las 3 últimas cartas de tu baraja y ponlas en la parte superior de tu baraja en el orden que quieras.",
 		it: "Guarda le ultime tre carte del tuo mazzo e mettile in cima nell'ordine che preferisci.",
 		pt: "Olhe as 3 cartas de baixo do seu baralho e coloque-as como as cartas de cima do seu baralho em qualquer ordem.",
-		de: "Schau dir die untersten 3 Karten deines Decks an und lege sie in beliebiger Reihenfolge auf dein Deck."
+		de: "Schau dir die untersten 3 Karten deines Decks an und lege sie in beliebiger Reihenfolge auf dein Deck. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Chilling Reign/138.ts
+++ b/data/Sword & Shield/Chilling Reign/138.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Los ataques del Pokémon al que esté unida esta carta hacen 30 puntos de daño más al Pokémon Fire Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
 		it: "Gli attacchi del Pokémon a cui è assegnata questa carta infliggono 30 danni in più al Pokémon attivo Fire del tuo avversario, prima di aver applicato debolezza e resistenza.",
 		pt: "Os ataques do Pokémon ao qual esta carta está ligada causam 30 pontos de dano a mais ao Pokémon Fire Ativo do seu oponente (antes de aplicar Fraqueza e Resistência).",
-		de: "Die Attacken des Pokémon, an das diese Karte angelegt ist, fügen dem Aktiven Fire-Pokémon deines Gegners 30 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Die Attacken des Pokémon, an das diese Karte angelegt ist, fügen dem Aktiven {R}-Pokémon deines Gegners 30 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden). Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sword & Shield/Chilling Reign/139.ts
+++ b/data/Sword & Shield/Chilling Reign/139.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Descarta 1 Energía Especial de 1 de los Pokémon de tu rival y descarta un Estadio en juego.",
 		it: "Scarta un'Energia speciale da uno dei Pokémon del tuo avversario e una carta Stadio in gioco.",
 		pt: "Descarte 1 Energia Especial de 1 dos Pokémon do seu oponente e descarte 1 Estádio em jogo.",
-		de: "Lege 1 Spezial-Energie von 1 Pokémon deines Gegners auf seinen Ablagestapel und lege 1 Stadionkarte im Spiel auf den Ablagestapel."
+		de: "Lege 1 Spezial-Energie von 1 Pokémon deines Gegners auf seinen Ablagestapel und lege 1 Stadionkarte im Spiel auf deinen Ablagestapel. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/14.ts
+++ b/data/Sword & Shield/Chilling Reign/14.ts
@@ -76,7 +76,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Any Corvisquire that pecks at this Pokémon will be greeted with a smack from its sepals followed by a sharp kick."
+		en: "Any Corvisquire that pecks at this Pokémon will be greeted with a smack from its sepals followed by a sharp kick.",
+		de: "Nach ihm pickende Kranoviz greift es mit dem Blütenkelch auf seinem Kopf an, bevor es sie mit agilen Kicktechniken bearbeitet."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/140.ts
+++ b/data/Sword & Shield/Chilling Reign/140.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Busca en tu baraja 1 carta de Energía Psychic o 1 Pokémon Psychic Básico, enseña esa carta y ponla en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo una carta Energia Psychic o un Pokémon Base Psychic, mostra la carta e aggiungila a quelle che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por 1 carta de Energia Psychic ou por 1 Pokémon Psychic Básico no seu baralho, revele-o e coloque-o na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach 1 Psychic-Energiekarte oder 1 Basis-Psychic-Pokémon, zeige jene Karte deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach 1 {P}-Energiekarte oder 1 Basis-{P}-Pokémon, zeige jene Karte deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	regulationMark: "E",

--- a/data/Sword & Shield/Chilling Reign/141.ts
+++ b/data/Sword & Shield/Chilling Reign/141.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Si el Pokémon al que está unida esta carta tiene \"de Galar\" en su nombre, los ataques de los Pokémon de tu rival le hacen 30 puntos de daño menos (después de aplicar Debilidad y Resistencia).",
 		it: "Se il Pokémon a cui è assegnata questa carta ha \"di Galar\" nel nome, subisce 30 danni in meno dagli attacchi dei Pokémon del tuo avversario, dopo aver applicato debolezza e resistenza.",
 		pt: "Se o Pokémon ao qual esta carta está ligada tiver \"de Galar\" em seu nome, ele receberá 30 pontos de dano a menos dos ataques dos Pokémon do seu oponente (depois de aplicar Fraqueza e Resistência).",
-		de: "Wenn bei dem Pokémon, an das diese Karte angelegt ist, \"Galar\" zum Namen gehört, werden ihm durch Attacken der Pokémon deines Gegners 30 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden)."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn bei dem Pokémon, an das diese Karte angelegt ist, „Galar“ zum Namen gehört, werden ihm durch Attacken der Pokémon deines Gegners 30 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden). Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sword & Shield/Chilling Reign/142.ts
+++ b/data/Sword & Shield/Chilling Reign/142.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Roba 1 carta por cada uno de los Pokémon V en Banca de tu rival.",
 		it: "Pesca una carta per ciascuno dei Pokémon-V nella panchina del tuo avversario.",
 		pt: "Compre 1 carta para cada Pokémon V no Banco do seu oponente.",
-		de: "Ziehe 1 Karte für jedes Pokémon-V auf der Bank deines Gegners."
+		de: "Ziehe 1 Karte für jedes Pokémon-V auf der Bank deines Gegners. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/143.ts
+++ b/data/Sword & Shield/Chilling Reign/143.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Los ataques del Pokémon al que esté unida esta carta hacen 30 puntos de daño más al Pokémon Darkness Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
 		it: "Gli attacchi del Pokémon a cui è assegnata questa carta infliggono 30 danni in più al Pokémon attivo Darkness del tuo avversario, prima di aver applicato debolezza e resistenza.",
 		pt: "Os ataques do Pokémon ao qual esta carta está ligada causam 30 pontos de dano a mais ao Pokémon Darkness Ativo do seu oponente (antes de aplicar Fraqueza e Resistência).",
-		de: "Die Attacken des Pokémon, an das diese Karte angelegt ist, fügen dem Aktiven Darkness-Pokémon deines Gegners 30 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Die Attacken des Pokémon, an das diese Karte angelegt ist, fügen dem Aktiven {D}-Pokémon deines Gegners 30 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden). Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sword & Shield/Chilling Reign/144.ts
+++ b/data/Sword & Shield/Chilling Reign/144.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Durante este turno, los ataques de tus Pokémon Golpe Brusco hacen 20 puntos de daño más al Pokémon Activo de tu rival por cada carta de Premio que haya cogido tu rival (antes de aplicar Debilidad y Resistencia).",
 		it: "Durante questo turno, gli attacchi dei tuoi Pokémon Colpo Singolo infliggono 20 danni in più al Pokémon attivo del tuo avversario per ogni carta Premio che ha preso, prima di aver applicato debolezza e resistenza.",
 		pt: "Durante este turno, os ataques dos seus Pokémon Golpe Decisivo causam 20 pontos de dano a mais ao Pokémon Ativo do seu oponente para cada carta de Prêmio que ele(a) pegou (antes de aplicar Fraqueza e Resistência).",
-		de: "Während dieses Zuges fügen die Attacken deiner Fokussierter-Angriff-Pokémon dem Aktiven Pokémon deines Gegners für jede von deinem Gegner genommene Preiskarte 20 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
+		de: "Während dieses Zuges fügen die Attacken deiner Fokussierter-Angriff-Pokémon dem Aktiven Pokémon deines Gegners für jede von deinem Gegner genommene Preiskarte 20 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden). Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/145.ts
+++ b/data/Sword & Shield/Chilling Reign/145.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Elige 1 o ambas opciones:\n• Pon hasta 2 Pokémon de tu pila de descartes en tu mano.\n• Pon hasta 2 cartas de Energía Básica de tu pila de descartes en tu mano.",
 		it: "Scegli uno o entrambi gli effetti:\n• Prendi fino a due Pokémon dalla tua pila degli scarti e aggiungili alle carte che hai in mano.\n• Prendi fino a due carte Energia base dalla tua pila degli scarti e aggiungile alle carte che hai in mano.",
 		pt: "Escolha 1 ou ambas:\n• Coloque até 2 Pokémon da sua pilha de descarte na sua mão.\n• Coloque até 2 cartas de Energia básica da sua pilha de descarte na sua mão.",
-		de: "Wähle 1 oder beide aus:\n• Nimm bis zu 2 Pokémon aus deinem Ablagestapel auf deine Hand.\n• Nimm bis zu 2 Basis-Energiekarten aus deinem Ablagestapel auf deine Hand."
+		de: "Wähle 1 oder beide aus: Nimm bis zu 2 Pokémon aus deinem Ablagestapel auf deine Hand. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen. Nimm bis zu 2 Basis-Energiekarten aus deinem Ablagestapel auf deine Hand."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/146.ts
+++ b/data/Sword & Shield/Chilling Reign/146.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Une 1 carta de Energía Water de tu pila de descartes a 1 de tus Pokémon V. Si lo haces, roba 3 cartas.",
 		it: "Assegna una carta Energia Water dalla tua pila degli scarti a uno dei tuoi Pokémon-V. Se lo fai, pesca tre carte.",
 		pt: "Ligue 1 carta de Energia Water da sua pilha de descarte a 1 dos seus Pokémon V. Se fizer isto, compre 3 cartas.",
-		de: "Lege 1 Water-Energiekarte aus deinem Ablagestapel an 1 deiner Pokémon-V an. Wenn du das machst, ziehe 3 Karten."
+		de: "Lege 1 {W}-Energiekarte aus deinem Ablagestapel an 1 deiner Pokémon-V an. Wenn du das machst, ziehe 3 Karten. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/147.ts
+++ b/data/Sword & Shield/Chilling Reign/147.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Cada vez que algún jugador una 1 carta de Energía de su mano a 1 de sus Pokémon no Psychic, pon 2 contadores de daño en ese Pokémon.",
 		it: "Ogni volta che un giocatore assegna a uno dei suoi Pokémon non di tipo Psychic una carta Energia dalla propria mano, metti due segnalini danno su quel Pokémon.",
 		pt: "Sempre que algum jogador ligar 1 carta de Energia da própria mão a 1 dos próprios Pokémon que não seja de tipo Psychic, coloque 2 contadores de dano naquele Pokémon.",
-		de: "Lege jedes Mal, wenn ein Spieler 1 Energiekarte aus seiner Hand an 1 seiner Pokémon, das kein Psychic-Pokémon ist, anlegt, 2 Schadensmarken auf jenes Pokémon."
+		de: "Lege jedes Mal, wenn ein Spieler 1 Energiekarte aus seiner Hand an 1 seiner Pokémon, das kein {P}-Pokémon ist, anlegt, 2 Schadensmarken auf jenes Pokémon. Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 
 	regulationMark: "E",

--- a/data/Sword & Shield/Chilling Reign/148.ts
+++ b/data/Sword & Shield/Chilling Reign/148.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Los Pokémon con un recuadro de regla en juego (tanto tuyos como de tu rival) no tienen ninguna habilidad. (Pokémon V, Pokémon-GX, etc. tienen recuadros de regla).",
 		it: "I Pokémon in gioco che hanno una regola speciale, sia tuoi che del tuo avversario, non hanno abilità. I Pokémon-V, i Pokémon-GX, ecc. hanno regole speciali.",
 		pt: "Pokémon em jogo que tenham uma Caixa de Regras (seus e do seu oponente) não têm Habilidades (Pokémon V, Pokémon-GX, etc. têm Caixas de Regras).",
-		de: "Pokémon im Spiel (deine und die deines Gegners), die ein Regelfeld haben, haben keine Fähigkeiten. (Pokémon-V, Pokémon-GX usw. haben Regelfelder.)"
+		de: "Pokémon im Spiel (deine und die deines Gegners), die ein Regelfeld haben, haben keine Fähigkeiten. (Pokémon-V, Pokémon-GX usw. haben Regelfelder.) Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte auf den Ablagestapel, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit demselben Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 
 	trainerType: "Stadium",

--- a/data/Sword & Shield/Chilling Reign/149.ts
+++ b/data/Sword & Shield/Chilling Reign/149.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Pon hasta 3 cartas de Premio en tu mano. Después, por cada carta de Premio que hayas puesto en tu mano de esta manera, pon 1 carta de tu mano boca abajo como carta de Premio.",
 		it: "Aggiungi fino a tre carte Premio a quelle che hai in mano. Poi, per ogni carta Premio aggiunta a quelle che hai in mano in questo modo, prendine una dalla tua mano e mettila a faccia in giù come carta Premio.",
 		pt: "Coloque até 3 cartas de Prêmio na sua mão. Em seguida, para cada carta de Prêmio que você colocou em sua mão desta forma, coloque uma carta da sua mão virada para baixo como uma carta de Prêmio.",
-		de: "Nimm bis zu 3 Preiskarten auf deine Hand. Lege anschließend für jede auf diese Weise auf deine Hand genommene Preiskarte 1 Karte aus deiner Hand verdeckt als Preiskarte ab."
+		de: "Nimm bis zu 3 Preiskarten auf deine Hand. Lege anschließend für jede auf diese Weise auf deine Hand genommene Preiskarte 1 Karte aus deiner Hand verdeckt als Preiskarte ab. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/15.ts
+++ b/data/Sword & Shield/Chilling Reign/15.ts
@@ -45,7 +45,7 @@ const card: Card = {
 			es: "Este ataque hace 50 puntos de daño más por cada Colorless en el Coste de Retirada del Pokémon Activo de tu rival.",
 			it: "Questo attacco infligge 50 danni in più per ogni Colorless nel costo di ritirata del Pokémon attivo del tuo avversario.",
 			pt: "Este ataque causa 50 pontos de dano a mais para cada Colorless no custo de Recuo do Pokémon Ativo do seu oponente.",
-			de: "Diese Attacke fügt für jedes Colorless in den Rückzugskosten des Aktiven Pokémon deines Gegners 50 Schadenspunkte mehr zu."
+			de: "Diese Attacke fügt für jedes {C} in den Rückzugskosten des Aktiven Pokémon deines Gegners 50 Schadenspunkte mehr zu."
 		},
 
 		damage: "10+",
@@ -76,7 +76,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "A kick from the hardened tips of this Pokémon's legs leaves a wound in the opponent's body and soul that will never heal."
+		en: "A kick from the hardened tips of this Pokémon's legs leaves a wound in the opponent's body and soul that will never heal.",
+		de: "Es tritt mit seinen harten Fußspitzen auf seine Gegner ein und hinterlässt dabei sowohl körperliche als auch seelische Narben."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/150.ts
+++ b/data/Sword & Shield/Chilling Reign/150.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Descarta las cartas de tu mano y busca en tu baraja hasta 2 cartas de Entrenador, enséñalas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Scarta le carte che hai in mano e cerca nel tuo mazzo fino a due carte Allenatore, mostrale e aggiungile alla tua mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Descarte a sua mão e procure por até 2 cartas de Treinador no seu baralho, revele-as e coloque-as na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Lege deine Handkarten auf deinen Ablagestapel und durchsuche dein Deck nach bis zu 2 Trainerkarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Lege deine Handkarten auf deinen Ablagestapel und durchsuche dein Deck nach bis zu 2 Trainerkarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/151.ts
+++ b/data/Sword & Shield/Chilling Reign/151.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "El Pokémon Golpe Fluido al que esté unida esta carta puede usar el ataque de esta carta. (Sigues necesitando las Energías necesarias para usar este ataque).",
 		it: "Il Pokémon Colpo Rapido a cui è assegnata questa carta può usare l'attacco di questa carta. Devi comunque avere l'Energia necessaria per usare questo attacco.",
 		pt: "O Pokémon Golpe Fluido ao qual esta carta está ligada pode usar o ataque desta carta (você ainda precisa da Energia necessária para usar este ataque).",
-		de: "Das Fließender-Angriff-Pokémon, an das diese Karte angelegt ist, kann die Attacke auf dieser Karte einsetzen. (Du benötigst jedoch die für diese Attacke notwendige Energie.)"
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Das Fließender-Angriff-Pokémon, an das diese Karte angelegt ist, kann die Attacke auf dieser Karte einsetzen. (Du benötigst jedoch die für diese Attacke notwendige Energie.) Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sword & Shield/Chilling Reign/152.ts
+++ b/data/Sword & Shield/Chilling Reign/152.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Si el Pokémon al que está unida esta carta está en el Puesto Activo y resulta dañado por un ataque de los Pokémon de tu rival (incluso si queda Fuera de Combate), pon 1 Energía unida al Pokémon Atacante en la mano de tu rival.",
 		it: "Se il Pokémon a cui è assegnata questa carta è in posizione attiva e viene danneggiato da un attacco di un Pokémon del tuo avversario, anche se viene messo KO, prendi un'Energia assegnata al Pokémon attaccante e aggiungila alla mano del tuo avversario.",
 		pt: "Se o Pokémon ao qual esta carta está ligada estiver no Campo Ativo e for danificado por um ataque dos Pokémon do seu oponente (mesmo que ele seja Nocauteado), coloque 1 Energia ligada ao Pokémon Atacante na mão do seu oponente.",
-		de: "Wenn das Pokémon, an das diese Karte angelegt ist, in der Aktiven Position ist und durch eine Attacke von Pokémon deines Gegners Schaden erhält (auch wenn es dadurch kampfunfähig wird), gib deinem Gegner 1 an das Angreifende Pokémon angelegte Energie auf seine Hand."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn das Pokémon, an das diese Karte angelegt ist, in der Aktiven Position ist und durch eine Attacke von Pokémon deines Gegners Schaden erhält (auch wenn dieses Pokémon dadurch kampfunfähig wird), gib dem Gegner 1 an das Angreifende Pokémon angelegte Energie auf seine Hand. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sword & Shield/Chilling Reign/153.ts
+++ b/data/Sword & Shield/Chilling Reign/153.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Elige hasta 2 de tus Pokémon Golpe Fluido y cura 60 puntos de daño a cada uno de ellos.",
 		it: "Scegli fino a due dei tuoi Pokémon Colpo Rapido e cura ciascuno di essi da 60 danni.",
 		pt: "Escolha até 2 dos seus Pokémon Golpe Fluido e cure 60 pontos de dano de cada um deles.",
-		de: "Wähle bis zu 2 deiner Fließender-Angriff-Pokémon und heile bei jedem von ihnen 60 Schadenspunkte."
+		de: "Wähle bis zu 2 deiner Fließender-Angriff-Pokémon und heile bei jedem von ihnen 60 Schadenspunkte. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/154.ts
+++ b/data/Sword & Shield/Chilling Reign/154.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "El Pokémon Golpe Brusco al que esté unida esta carta puede usar el ataque de esta carta. (Sigues necesitando las Energías necesarias para usar este ataque).",
 		it: "Il Pokémon Colpo Singolo a cui è assegnata questa carta può usare l'attacco di questa carta. Devi comunque avere l'Energia necessaria per usare questo attacco.",
 		pt: "O Pokémon Golpe Decisivo ao qual esta carta está ligada pode usar o ataque desta carta (você ainda precisa da Energia necessária para usar este ataque).",
-		de: "Das Fokussierter-Angriff-Pokémon, an das diese Karte angelegt ist, kann die Attacke auf dieser Karte einsetzen. (Du benötigst jedoch die für diese Attacke notwendige Energie.)"
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Das Fokussierter-Angriff-Pokémon, an das diese Karte angelegt ist, kann die Attacke auf dieser Karte einsetzen. (Du benötigst jedoch die für diese Attacke notwendige Energie.) Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sword & Shield/Chilling Reign/155.ts
+++ b/data/Sword & Shield/Chilling Reign/155.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Los ataques del Pokémon al que esté unida esta carta hacen 30 puntos de daño más al Pokémon Grass Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
 		it: "Gli attacchi del Pokémon a cui è assegnata questa carta infliggono 30 danni in più al Pokémon attivo Grass del tuo avversario, prima di aver applicato debolezza e resistenza.",
 		pt: "Os ataques do Pokémon ao qual esta carta está ligada causam 30 pontos de dano a mais ao Pokémon Grass Ativo do seu oponente (antes de aplicar Fraqueza e Resistência).",
-		de: "Die Attacken des Pokémon, an das diese Karte angelegt ist, fügen dem Aktiven Grass-Pokémon deines Gegners 30 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Die Attacken des Pokémon, an das diese Karte angelegt ist, fügen dem Aktiven {G}-Pokémon deines Gegners 30 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden). Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sword & Shield/Chilling Reign/156.ts
+++ b/data/Sword & Shield/Chilling Reign/156.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Pon 1 carta de Partidario de Golpe Brusco de tu pila de descartes en tu mano.",
 		it: "Prendi una carta Aiuto Colpo Singolo dalla tua pila degli scarti e aggiungila alle carte che hai in mano.",
 		pt: "Coloque uma carta de Apoiador Golpe Decisivo da sua pilha de descarte na sua mão.",
-		de: "Nimm 1 Fokussierter-Angriff-Unterstützerkarte aus deinem Ablagestapel auf deine Hand."
+		de: "Nimm 1 Fokussierter-Angriff-Unterstützerkarte aus deinem Ablagestapel auf deine Hand. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Chilling Reign/158.ts
+++ b/data/Sword & Shield/Chilling Reign/158.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mientras esta carta esté unida a 1 Pokémon, proporciona 1 Energía Colorless.\nSi el Pokémon al que está unida esta carta está en el Puesto Activo y resulta dañado por un ataque de los Pokémon de tu rival\n(incluso si queda Fuera de Combate), roba 1 carta.",
 		it: "Fintanto che questa carta è assegnata a un Pokémon, fornisce Energia Colorless.\nSe il Pokémon a cui è assegnata questa carta è in posizione attiva e viene danneggiato da un attacco di un Pokémon del tuo avversario, anche se viene messo KO, pesca una carta.",
 		pt: "Enquanto esta carta estiver ligada a um Pokémon, ela fornecerá Energia Colorless.\nSe o Pokémon ao qual esta carta está ligada estiver no Campo Ativo e for danificado por um ataque do Pokémon do seu oponente\n(mesmo que ele seja Nocauteado), compre 1 carta.",
-		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie Colorless-Energie.\nWenn das Pokémon, an das diese Karte angelegt ist, in der Aktiven Position ist und durch eine Attacke von Pokémon deines Gegners Schaden erhält\n(auch wenn es dadurch kampfunfähig wird), ziehe 1 Karte."
+		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie {C}-Energie. Wenn das Pokémon, an das diese Karte angelegt ist, in der Aktiven Position ist und durch eine Attacke von Pokémon deines Gegners Schaden erhält (auch wenn es dadurch kampfunfähig wird), ziehe 1 Karte."
 	},
 
 	energyType: "Special",

--- a/data/Sword & Shield/Chilling Reign/16.ts
+++ b/data/Sword & Shield/Chilling Reign/16.ts
@@ -27,7 +27,7 @@ const card: Card = {
 			es: "Doble Redoble",
 			it: "Doppia Botta",
 			pt: "Batida Dupla",
-			de: "Zweimal zuschlagen"
+			de: "Zweimal Schlagen"
 		},
 
 		effect: {
@@ -55,7 +55,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It attacks with rapid beats of its stick. As it strikes with amazing speed, it gets more and more pumped."
+		en: "It attacks with rapid beats of its stick. As it strikes with amazing speed, it gets more and more pumped.",
+		de: "Es greift an, indem es wiederholt seinen Schlägel schwingt. Diese rasanten Trommelbewegungen bringen es immer mehr in Fahrt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/160.ts
+++ b/data/Sword & Shield/Chilling Reign/160.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			es: "Une cualquier cantidad de cartas de Energía Grass de tu mano a tus Pokémon de la manera que desees.",
 			it: "Assegna ai tuoi Pokémon un numero qualsiasi di carte Energia Grass dalla tua mano nel modo che preferisci.",
 			pt: "Ligue qualquer número de cartas de Energia Grass da sua mão aos seus Pokémon como desejar.",
-			de: "Lege beliebig viele Grass-Energiekarten aus deiner Hand beliebig an deine Pokémon an."
+			de: "Lege beliebig viele {G}-Energiekarten aus deiner Hand beliebig an deine Pokémon an."
 		},
 
 		cost: ["Grass"]

--- a/data/Sword & Shield/Chilling Reign/17.ts
+++ b/data/Sword & Shield/Chilling Reign/17.ts
@@ -64,7 +64,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "When it's drumming out rapid beats in battle, it gets so caught up in the rhythm that it won't even notice that it's already knocked out its opponent."
+		en: "When it's drumming out rapid beats in battle, it gets so caught up in the rhythm that it won't even notice that it's already knocked out its opponent.",
+		de: "Verliert es sich im Kampf in seinem wilden Beat, bemerkt es ab und zu nicht mal, dass sein Gegner bereits zu Boden gegangen ist."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/173.ts
+++ b/data/Sword & Shield/Chilling Reign/173.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			es: "Los ataques de este Pokémon cuestan Colorless menos por cada uno de los Pokémon V en juego de tu rival.",
 			it: "Il costo degli attacchi di questo Pokémon è ridotto di Colorless per ogni Pokémon-V in gioco del tuo avversario.",
 			pt: "Os ataques deste Pokémon custam Colorless a menos para cada Pokémon V do seu oponente em jogo.",
-			de: "Die Kosten der Attacken dieses Pokémon verringern sich für jedes Pokémon-V deines Gegners im Spiel um Colorless."
+			de: "Die Kosten der Attacken dieses Pokémon verringern sich für jedes Pokémon-V deines Gegners im Spiel um {C}."
 		}
 	}],
 

--- a/data/Sword & Shield/Chilling Reign/174.ts
+++ b/data/Sword & Shield/Chilling Reign/174.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			es: "Los ataques de este Pokémon cuestan Colorless menos por cada uno de los Pokémon V en juego de tu rival.",
 			it: "Il costo degli attacchi di questo Pokémon è ridotto di Colorless per ogni Pokémon-V in gioco del tuo avversario.",
 			pt: "Os ataques deste Pokémon custam Colorless a menos para cada Pokémon V do seu oponente em jogo.",
-			de: "Die Kosten der Attacken dieses Pokémon verringern sich für jedes Pokémon-V deines Gegners im Spiel um Colorless."
+			de: "Die Kosten der Attacken dieses Pokémon verringern sich für jedes Pokémon-V deines Gegners im Spiel um {C}."
 		}
 	}],
 

--- a/data/Sword & Shield/Chilling Reign/176.ts
+++ b/data/Sword & Shield/Chilling Reign/176.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			es: "Una vez durante tu turno, puedes unir 1 carta de Energía Darkness de tu pila de descartes a este Pokémon. No puedes usar más de 1 habilidad Alas Incendiarias en cada turno.",
 			it: "Una sola volta durante il tuo turno, puoi assegnare a questo Pokémon una carta Energia Darkness dalla tua pila degli scarti. Puoi usare l'abilità Ali Estremafiamma solo una volta per turno.",
 			pt: "Uma vez durante o seu turno, você poderá ligar 1 carta de Energia Darkness da sua pilha de descarte a este Pokémon. Você não pode usar mais de 1 Habilidade Asas de Fogaréu por turno.",
-			de: "Einmal während deines Zuges kannst du 1 Darkness-Energiekarte aus deinem Ablagestapel an dieses Pokémon anlegen. Du kannst immer nur jeweils 1 Fähigkeit Flammende Schattenflügel einsetzen."
+			de: "Einmal während deines Zuges kannst du 1 {D}-Energiekarte aus deinem Ablagestapel an dieses Pokémon anlegen. Du kannst immer nur jeweils 1 Fähigkeit Flammende Schattenflügel einsetzen."
 		}
 	}],
 

--- a/data/Sword & Shield/Chilling Reign/177.ts
+++ b/data/Sword & Shield/Chilling Reign/177.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			es: "Una vez durante tu turno, puedes unir 1 carta de Energía Darkness de tu pila de descartes a este Pokémon. No puedes usar más de 1 habilidad Alas Incendiarias en cada turno.",
 			it: "Una sola volta durante il tuo turno, puoi assegnare a questo Pokémon una carta Energia Darkness dalla tua pila degli scarti. Puoi usare l'abilità Ali Estremafiamma solo una volta per turno.",
 			pt: "Uma vez durante o seu turno, você poderá ligar 1 carta de Energia Darkness da sua pilha de descarte a este Pokémon. Você não pode usar mais de 1 Habilidade Asas de Fogaréu por turno.",
-			de: "Einmal während deines Zuges kannst du 1 Darkness-Energiekarte aus deinem Ablagestapel an dieses Pokémon anlegen. Du kannst immer nur jeweils 1 Fähigkeit Flammende Schattenflügel einsetzen."
+			de: "Einmal während deines Zuges kannst du 1 {D}-Energiekarte aus deinem Ablagestapel an dieses Pokémon anlegen. Du kannst immer nur jeweils 1 Fähigkeit Flammende Schattenflügel einsetzen."
 		}
 	}],
 

--- a/data/Sword & Shield/Chilling Reign/18.ts
+++ b/data/Sword & Shield/Chilling Reign/18.ts
@@ -85,7 +85,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "The one with the best drumming techniques becomes the boss of the troop. It has a gentle disposition and values harmony among its group."
+		en: "The one with the best drumming techniques becomes the boss of the troop. It has a gentle disposition and values harmony among its group.",
+		de: "Wer die beste Trommeltechnik hat, wird zum Anführer. Da es ein ruhiges Gemüt hat, legt es viel Wert auf Harmonie in der Gruppe."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/180.ts
+++ b/data/Sword & Shield/Chilling Reign/180.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			es: "Cuando juegas este Pokémon de tu mano a tu Banca durante tu turno, puedes descartar 1 Herramienta Pokémon de 1 Pokémon (tuyo o de tu rival).",
 			it: "Quando giochi questo Pokémon dalla tua mano e lo metti in panchina durante il tuo turno, puoi scartare una carta Oggetto Pokémon da un Pokémon, tuo o del tuo avversario.",
 			pt: "Quando você jogar este Pokémon da sua mão para o seu Banco durante o seu turno, você poderá descartar 1 Ferramenta Pokémon de 1 Pokémon (seu ou do seu oponente).",
-			de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand auf deine Bank spielst, kannst du 1 Pokémon-Ausrüstung von 1 Pokémon (deinem oder dem deines Gegners) auf den Ablagestapel legen."
+			de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand auf deine Bank spielst, kannst du 1 Pokémon-Ausrüstung von 1 Pokémon (deine oder dem deines Gegners) auf den Ablagestapel legen."
 		}
 	}],
 

--- a/data/Sword & Shield/Chilling Reign/182.ts
+++ b/data/Sword & Shield/Chilling Reign/182.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			es: "Cada vez que unas 1 carta de Energía de tu mano a este Pokémon, elimina todas sus Condiciones Especiales.",
 			it: "Ogni volta che assegni una carta Energia a questo Pokémon dalla tua mano, rimuovi tutte le condizioni speciali che lo influenzano.",
 			pt: "Sempre que ligar 1 carta de Energia da sua mão a este Pokémon, remova todas as Condições Especiais dele.",
-			de: "Jedes Mal, wenn du 1 Energiekarte aus deiner Hand an dieses Pokémon anlegst, verlieren alle Speziellen Zustände auf diesem Pokémon ihre Wirkung."
+			de: "Jedes Mal, wenn du 1 Energiekarte aus deiner Hand an dieses Pokémon anlegst, erholt es sich von allen Speziellen Zuständen."
 		}
 	}],
 

--- a/data/Sword & Shield/Chilling Reign/183.ts
+++ b/data/Sword & Shield/Chilling Reign/183.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			es: "Cada vez que unas 1 carta de Energía de tu mano a este Pokémon, elimina todas sus Condiciones Especiales.",
 			it: "Ogni volta che assegni una carta Energia a questo Pokémon dalla tua mano, rimuovi tutte le condizioni speciali che lo influenzano.",
 			pt: "Sempre que ligar 1 carta de Energia da sua mão a este Pokémon, remova todas as Condições Especiais dele.",
-			de: "Jedes Mal, wenn du 1 Energiekarte aus deiner Hand an dieses Pokémon anlegst, verlieren alle Speziellen Zustände auf diesem Pokémon ihre Wirkung."
+			de: "Jedes Mal, wenn du 1 Energiekarte aus deiner Hand an dieses Pokémon anlegst, erholt es sich von allen Speziellen Zuständen."
 		}
 	}],
 

--- a/data/Sword & Shield/Chilling Reign/186.ts
+++ b/data/Sword & Shield/Chilling Reign/186.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Mueve hasta 3 contadores de daño de tu Pokémon Activo al Pokémon Activo de tu rival.",
 		it: "Sposta fino a tre segnalini danno dal tuo Pokémon attivo al Pokémon attivo del tuo avversario.",
 		pt: "Mova até 3 contadores de dano do seu Pokémon Ativo para o Pokémon Ativo do seu oponente.",
-		de: "Verschiebe bis zu 3 Schadensmarken von deinem Aktiven Pokémon auf das Aktive Pokémon deines Gegners."
+		de: "Verschiebe bis zu 3 Schadensmarken von deinem Aktiven Pokémon auf das Aktive Pokémon deines Gegners. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/187.ts
+++ b/data/Sword & Shield/Chilling Reign/187.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Roba 3 cartas. Si has robado alguna carta de esta manera, tu rival descarta Pokémon de su Banca hasta que tenga 3.",
 		it: "Pesca tre carte. Se hai pescato delle carte in questo modo, il tuo avversario scarta i Pokémon dalla sua panchina fino ad averne tre.",
 		pt: "Compre 3 cartas. Se você comprar qualquer carta desta forma, o seu oponente descartará Pokémon do próprio Banco até ter 3 Pokémon no Banco.",
-		de: "Ziehe 3 Karten. Wenn du auf diese Weise mindestens 1 Karte gezogen hast, legt dein Gegner so lange Pokémon von seiner Bank auf seinen Ablagestapel, bis er 3 Pokémon auf seiner Bank hat."
+		de: "Ziehe 3 Karten. Wenn du auf diese Weise mindestens 1 Karte gezogen hast, legt dein Gegner so lange Pokémon von seiner Bank auf seinen Ablagestapel, bis er 3 Pokémon auf seiner Bank hat. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/188.ts
+++ b/data/Sword & Shield/Chilling Reign/188.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 3 Pokémon Golpe Fluido Básicos y ponlos en tu Banca. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo fino a tre Pokémon Base Colpo Rapido e mettili nella tua panchina. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por até 3 Pokémon Golpe Fluido Básicos no seu baralho e coloque-os no seu Banco. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach bis zu 3 Basis-Fließender-Angriff-Pokémon und lege sie auf deine Bank. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach bis zu 3 Basis-Fließender-Angriff-Pokémon und lege sie auf deine Bank. Mische anschließend dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/19.ts
+++ b/data/Sword & Shield/Chilling Reign/19.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			es: "Busca en tu baraja 1 Pokémon Grass, enséñalo y ponlo en tu mano. Si sales segundo y es tu primer turno, busca hasta 3 Pokémon Grass en vez de 1. Después, baraja las cartas de tu baraja.",
 			it: "Cerca nel tuo mazzo un Pokémon Grass, mostralo e aggiungilo alle carte che hai in mano. Se inizi per secondo ed è il tuo primo turno, cerca fino a tre Pokémon Grass invece di uno. Poi rimischia le carte del tuo mazzo.",
 			pt: "Procure por 1 Pokémon Grass no seu baralho, revele-o e coloque-o na sua mão. Se você for o segundo a jogar e este for o seu primeiro turno, procure por até 3 Pokémon Grass ao invés de 1. Em seguida, embaralhe o seu baralho.",
-			de: "Durchsuche dein Deck nach 1 Grass-Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Wenn du als Zweiter am Zug bist und es dein erster Zug ist, durchsuche dein Deck nach bis zu 3 Grass-Pokémon anstelle von 1. Mische anschließend dein Deck."
+			de: "Durchsuche dein Deck nach 1 {G}-Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Wenn du als Zweiter am Zug bist und es dein erster Zug ist, durchsuche dein Deck nach bis zu 3 {G}-Pokémon anstelle von 1. Mische anschließend dein Deck."
 		},
 
 		cost: ["Grass"]
@@ -56,7 +56,7 @@ const card: Card = {
 			es: "Este ataque hace 20 puntos de daño más por cada Energía Grass unida a este Pokémon.",
 			it: "Questo attacco infligge 20 danni in più per ogni Energia Grass assegnata a questo Pokémon.",
 			pt: "Este ataque causa 20 pontos de dano a mais para cada Energia Grass ligada a este Pokémon.",
-			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte Grass-Energie 20 Schadenspunkte mehr zu."
+			de: "Diese Attacke fügt für jede an dieses Pokémon angelegten {G}-Energie 20 Schadenspunkte mehr zu."
 		},
 
 		damage: "60+",
@@ -75,7 +75,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Once the vines on Zarude's body tear off, they become nutrients in the soil. This helps the plants of the forest grow."
+		en: "Once the vines on Zarude's body tear off, they become nutrients in the soil. This helps the plants of the forest grow.",
+		de: "Reißen die an seinem Körper wachsenden Ranken ab, werden sie zu Nährstoffen für den Boden, was den Pflanzen im Wald zum Wachstum verhilft."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/191.ts
+++ b/data/Sword & Shield/Chilling Reign/191.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Descarta 1 Energía Especial de 1 de los Pokémon de tu rival y descarta un Estadio en juego.",
 		it: "Scarta un'Energia speciale da uno dei Pokémon del tuo avversario e una carta Stadio in gioco.",
 		pt: "Descarte 1 Energia Especial de 1 dos Pokémon do seu oponente e descarte 1 Estádio em jogo.",
-		de: "Lege 1 Spezial-Energie von 1 Pokémon deines Gegners auf seinen Ablagestapel und lege 1 Stadionkarte im Spiel auf den Ablagestapel."
+		de: "Lege 1 Spezial-Energie von 1 Pokémon deines Gegners auf seinen Ablagestapel und lege 1 Stadionkarte im Spiel auf deinen Ablagestapel. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/192.ts
+++ b/data/Sword & Shield/Chilling Reign/192.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Roba 1 carta por cada uno de los Pokémon V en Banca de tu rival.",
 		it: "Pesca una carta per ciascuno dei Pokémon-V nella panchina del tuo avversario.",
 		pt: "Compre 1 carta para cada Pokémon V no Banco do seu oponente.",
-		de: "Ziehe 1 Karte für jedes Pokémon-V auf der Bank deines Gegners."
+		de: "Ziehe 1 Karte für jedes Pokémon-V auf der Bank deines Gegners. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/193.ts
+++ b/data/Sword & Shield/Chilling Reign/193.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Durante este turno, los ataques de tus Pokémon Golpe Brusco hacen 20 puntos de daño más al Pokémon Activo de tu rival por cada carta de Premio que haya cogido tu rival (antes de aplicar Debilidad y Resistencia).",
 		it: "Durante questo turno, gli attacchi dei tuoi Pokémon Colpo Singolo infliggono 20 danni in più al Pokémon attivo del tuo avversario per ogni carta Premio che ha preso, prima di aver applicato debolezza e resistenza.",
 		pt: "Durante este turno, os ataques dos seus Pokémon Golpe Decisivo causam 20 pontos de dano a mais ao Pokémon Ativo do seu oponente para cada carta de Prêmio que ele(a) pegou (antes de aplicar Fraqueza e Resistência).",
-		de: "Während dieses Zuges fügen die Attacken deiner Fokussierter-Angriff-Pokémon dem Aktiven Pokémon deines Gegners für jede von deinem Gegner genommene Preiskarte 20 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
+		de: "Während dieses Zuges fügen die Attacken deiner Fokussierter-Angriff-Pokémon dem Aktiven Pokémon deines Gegners für jede von deinem Gegner genommene Preiskarte 20 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden). Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/194.ts
+++ b/data/Sword & Shield/Chilling Reign/194.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Elige 1 o ambas opciones:\n• Pon hasta 2 Pokémon de tu pila de descartes en tu mano.\n• Pon hasta 2 cartas de Energía Básica de tu pila de descartes en tu mano.",
 		it: "Scegli uno o entrambi gli effetti:\n• Prendi fino a due Pokémon dalla tua pila degli scarti e aggiungili alle carte che hai in mano.\n• Prendi fino a due carte Energia base dalla tua pila degli scarti e aggiungile alle carte che hai in mano.",
 		pt: "Escolha 1 ou ambas:\n• Coloque até 2 Pokémon da sua pilha de descarte na sua mão.\n• Coloque até 2 cartas de Energia básica da sua pilha de descarte na sua mão.",
-		de: "Wähle 1 oder beide aus:\n• Nimm bis zu 2 Pokémon aus deinem Ablagestapel auf deine Hand.\n• Nimm bis zu 2 Basis-Energiekarten aus deinem Ablagestapel auf deine Hand."
+		de: "Wähle 1 oder beide aus: Nimm bis zu 2 Pokémon aus deinem Ablagestapel auf deine Hand. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen. Nimm bis zu 2 Basis-Energiekarten aus deinem Ablagestapel auf deine Hand."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/195.ts
+++ b/data/Sword & Shield/Chilling Reign/195.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Une 1 carta de Energía Water de tu pila de descartes a 1 de tus Pokémon V. Si lo haces, roba 3 cartas.",
 		it: "Assegna una carta Energia Water dalla tua pila degli scarti a uno dei tuoi Pokémon-V. Se lo fai, pesca tre carte.",
 		pt: "Ligue 1 carta de Energia Water da sua pilha de descarte a 1 dos seus Pokémon V. Se fizer isto, compre 3 cartas.",
-		de: "Lege 1 Water-Energiekarte aus deinem Ablagestapel an 1 deiner Pokémon-V an. Wenn du das machst, ziehe 3 Karten."
+		de: "Lege 1 {W}-Energiekarte aus deinem Ablagestapel an 1 deiner Pokémon-V an. Wenn du das machst, ziehe 3 Karten. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/196.ts
+++ b/data/Sword & Shield/Chilling Reign/196.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Pon hasta 3 cartas de Premio en tu mano. Después, por cada carta de Premio que hayas puesto en tu mano de esta manera, pon 1 carta de tu mano boca abajo como carta de Premio.",
 		it: "Aggiungi fino a tre carte Premio a quelle che hai in mano. Poi, per ogni carta Premio aggiunta a quelle che hai in mano in questo modo, prendine una dalla tua mano e mettila a faccia in giù come carta Premio.",
 		pt: "Coloque até 3 cartas de Prêmio na sua mão. Em seguida, para cada carta de Prêmio que você colocou em sua mão desta forma, coloque uma carta da sua mão virada para baixo como uma carta de Prêmio.",
-		de: "Nimm bis zu 3 Preiskarten auf deine Hand. Lege anschließend für jede auf diese Weise auf deine Hand genommene Preiskarte 1 Karte aus deiner Hand verdeckt als Preiskarte ab."
+		de: "Nimm bis zu 3 Preiskarten auf deine Hand. Lege anschließend für jede auf diese Weise auf deine Hand genommene Preiskarte 1 Karte aus deiner Hand verdeckt als Preiskarte ab. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/197.ts
+++ b/data/Sword & Shield/Chilling Reign/197.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Descarta las cartas de tu mano y busca en tu baraja hasta 2 cartas de Entrenador, enséñalas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Scarta le carte che hai in mano e cerca nel tuo mazzo fino a due carte Allenatore, mostrale e aggiungile alla tua mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Descarte a sua mão e procure por até 2 cartas de Treinador no seu baralho, revele-as e coloque-as na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Lege deine Handkarten auf deinen Ablagestapel und durchsuche dein Deck nach bis zu 2 Trainerkarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Lege deine Handkarten auf deinen Ablagestapel und durchsuche dein Deck nach bis zu 2 Trainerkarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/198.ts
+++ b/data/Sword & Shield/Chilling Reign/198.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Elige hasta 2 de tus Pokémon Golpe Fluido y cura 60 puntos de daño a cada uno de ellos.",
 		it: "Scegli fino a due dei tuoi Pokémon Colpo Rapido e cura ciascuno di essi da 60 danni.",
 		pt: "Escolha até 2 dos seus Pokémon Golpe Fluido e cure 60 pontos de dano de cada um deles.",
-		de: "Wähle bis zu 2 deiner Fließender-Angriff-Pokémon und heile bei jedem von ihnen 60 Schadenspunkte."
+		de: "Wähle bis zu 2 deiner Fließender-Angriff-Pokémon und heile bei jedem von ihnen 60 Schadenspunkte. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/199.ts
+++ b/data/Sword & Shield/Chilling Reign/199.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			es: "Una vez durante tu turno, puedes curar 20 puntos de daño a cada uno de tus Pokémon Grass.",
 			it: "Una sola volta durante il tuo turno, puoi curare ciascuno dei tuoi Pokémon Grass da 20 danni.",
 			pt: "Uma vez durante o seu turno, você poderá curar 20 pontos de dano de cada um dos seus Pokémon Grass.",
-			de: "Einmal während deines Zuges kannst du 20 Schadenspunkte bei jedem deiner Grass-Pokémon heilen."
+			de: "Einmal während deines Zuges kannst du 20 Schadenspunkte bei jedem deiner {G}-Pokémon heilen."
 		}
 	}],
 
@@ -82,7 +82,7 @@ const card: Card = {
 		es: "Celebi V",
 		it: "Celebi-V",
 		pt: "Celebi V",
-		de: "Celebi-V"
+		de: "Celebi VMAX"
 	},
 
 	regulationMark: "E",

--- a/data/Sword & Shield/Chilling Reign/2.ts
+++ b/data/Sword & Shield/Chilling Reign/2.ts
@@ -63,7 +63,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "While awaiting evolution, it hides from predators under leaves and in nooks of branches."
+		en: "While awaiting evolution, it hides from predators under leaves and in nooks of branches.",
+		de: "Während es auf seine Entwicklung wartet, versteckt es sich unter Blättern und zwischen Ästen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/204.ts
+++ b/data/Sword & Shield/Chilling Reign/204.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			es: "Una vez durante tu turno, puedes unir 1 carta de Energía Psychic de tu mano a 1 de tus Pokémon Psychic en Banca. Si has unido Energía a un Pokémon de esta manera, roba 2 cartas.",
 			it: "Una sola volta durante il tuo turno, puoi assegnare a uno dei tuoi Pokémon Psychic in panchina una carta Energia Psychic dalla tua mano. Se hai assegnato dell'Energia a un Pokémon in questo modo, pesca due carte.",
 			pt: "Uma vez durante o seu turno, você poderá ligar 1 carta de Energia Psychic da sua mão a 1 dos seus Pokémon Psychic no Banco. Se você ligou Energia a um Pokémon desta forma, compre 2 cartas.",
-			de: "Einmal während deines Zuges kannst du 1 Psychic-Energiekarte aus deiner Hand an 1 Psychic-Pokémon auf deiner Bank anlegen. Wenn du auf diese Weise Energie an ein Pokémon angelegt hast, ziehe 2 Karten."
+			de: "Einmal während deines Zuges kannst du 1 {P}-Energiekarte aus deiner Hand an 1 {P}-Pokémon auf deiner Bank anlegen. Wenn du auf diese Weise Energie an ein Pokémon angelegt hast, ziehe 2 Karten."
 		}
 	}],
 
@@ -59,7 +59,7 @@ const card: Card = {
 			es: "Este ataque hace 30 puntos de daño más por cada Energía Psychic unida a todos tus Pokémon.",
 			it: "Questo attacco infligge 30 danni in più per ogni Energia Psychic assegnata ai tuoi Pokémon.",
 			pt: "Este ataque causa 30 pontos de dano a mais para cada Energia Psychic ligada a todos os seus Pokémon.",
-			de: "Diese Attacke fügt für jede an alle deine Pokémon angelegte Psychic-Energie 30 Schadenspunkte mehr zu."
+			de: "Diese Attacke fügt für jede an alle deine Pokémon angelegte {P}-Energie 30 Schadenspunkte mehr zu."
 		},
 
 		cost: ["Colorless", "Colorless", "Colorless"]

--- a/data/Sword & Shield/Chilling Reign/205.ts
+++ b/data/Sword & Shield/Chilling Reign/205.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			es: "Una vez durante tu turno, puedes unir 1 carta de Energía Psychic de tu mano a 1 de tus Pokémon Psychic en Banca. Si has unido Energía a un Pokémon de esta manera, roba 2 cartas.",
 			it: "Una sola volta durante il tuo turno, puoi assegnare a uno dei tuoi Pokémon Psychic in panchina una carta Energia Psychic dalla tua mano. Se hai assegnato dell'Energia a un Pokémon in questo modo, pesca due carte.",
 			pt: "Uma vez durante o seu turno, você poderá ligar 1 carta de Energia Psychic da sua mão a 1 dos seus Pokémon Psychic no Banco. Se você ligou Energia a um Pokémon desta forma, compre 2 cartas.",
-			de: "Einmal während deines Zuges kannst du 1 Psychic-Energiekarte aus deiner Hand an 1 Psychic-Pokémon auf deiner Bank anlegen. Wenn du auf diese Weise Energie an ein Pokémon angelegt hast, ziehe 2 Karten."
+			de: "Einmal während deines Zuges kannst du 1 {P}-Energiekarte aus deiner Hand an 1 {P}-Pokémon auf deiner Bank anlegen. Wenn du auf diese Weise Energie an ein Pokémon angelegt hast, ziehe 2 Karten."
 		}
 	}],
 
@@ -59,7 +59,7 @@ const card: Card = {
 			es: "Este ataque hace 30 puntos de daño más por cada Energía Psychic unida a todos tus Pokémon.",
 			it: "Questo attacco infligge 30 danni in più per ogni Energia Psychic assegnata ai tuoi Pokémon.",
 			pt: "Este ataque causa 30 pontos de dano a mais para cada Energia Psychic ligada a todos os seus Pokémon.",
-			de: "Diese Attacke fügt für jede an alle deine Pokémon angelegte Psychic-Energie 30 Schadenspunkte mehr zu."
+			de: "Diese Attacke fügt für jede an alle deine Pokémon angelegte {P}-Energie 30 Schadenspunkte mehr zu."
 		},
 
 		cost: ["Colorless", "Colorless", "Colorless"]

--- a/data/Sword & Shield/Chilling Reign/209.ts
+++ b/data/Sword & Shield/Chilling Reign/209.ts
@@ -77,7 +77,7 @@ const card: Card = {
 		es: "Tornadus V",
 		it: "Tornadus-V",
 		pt: "Tornadus V",
-		de: "Boreos-V"
+		de: "Boreos VMAX"
 	},
 
 	regulationMark: "E",

--- a/data/Sword & Shield/Chilling Reign/210.ts
+++ b/data/Sword & Shield/Chilling Reign/210.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mueve hasta 3 contadores de daño de tu Pokémon Activo al Pokémon Activo de tu rival.",
 		it: "Sposta fino a tre segnalini danno dal tuo Pokémon attivo al Pokémon attivo del tuo avversario.",
 		pt: "Mova até 3 contadores de dano do seu Pokémon Ativo para o Pokémon Ativo do seu oponente.",
-		de: "Verschiebe bis zu 3 Schadensmarken von deinem Aktiven Pokémon auf das Aktive Pokémon deines Gegners."
+		de: "Verschiebe bis zu 3 Schadensmarken von deinem Aktiven Pokémon auf das Aktive Pokémon deines Gegners. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/211.ts
+++ b/data/Sword & Shield/Chilling Reign/211.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba 3 cartas. Si has robado alguna carta de esta manera, tu rival descarta Pokémon de su Banca hasta que tenga 3.",
 		it: "Pesca tre carte. Se hai pescato delle carte in questo modo, il tuo avversario scarta i Pokémon dalla sua panchina fino ad averne tre.",
 		pt: "Compre 3 cartas. Se você comprar qualquer carta desta forma, o seu oponente descartará Pokémon do próprio Banco até ter 3 Pokémon no Banco.",
-		de: "Ziehe 3 Karten. Wenn du auf diese Weise mindestens 1 Karte gezogen hast, legt dein Gegner so lange Pokémon von seiner Bank auf seinen Ablagestapel, bis er 3 Pokémon auf seiner Bank hat."
+		de: "Ziehe 3 Karten. Wenn du auf diese Weise mindestens 1 Karte gezogen hast, legt dein Gegner so lange Pokémon von seiner Bank auf seinen Ablagestapel, bis er 3 Pokémon auf seiner Bank hat. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/212.ts
+++ b/data/Sword & Shield/Chilling Reign/212.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 3 Pokémon Golpe Fluido Básicos y ponlos en tu Banca. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo fino a tre Pokémon Base Colpo Rapido e mettili nella tua panchina. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por até 3 Pokémon Golpe Fluido Básicos no seu baralho e coloque-os no seu Banco. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach bis zu 3 Basis-Fließender-Angriff-Pokémon und lege sie auf deine Bank. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach bis zu 3 Basis-Fließender-Angriff-Pokémon und lege sie auf deine Bank. Mische anschließend dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/215.ts
+++ b/data/Sword & Shield/Chilling Reign/215.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta 1 Energía Especial de 1 de los Pokémon de tu rival y descarta un Estadio en juego.",
 		it: "Scarta un'Energia speciale da uno dei Pokémon del tuo avversario e una carta Stadio in gioco.",
 		pt: "Descarte 1 Energia Especial de 1 dos Pokémon do seu oponente e descarte 1 Estádio em jogo.",
-		de: "Lege 1 Spezial-Energie von 1 Pokémon deines Gegners auf seinen Ablagestapel und lege 1 Stadionkarte im Spiel auf den Ablagestapel."
+		de: "Lege 1 Spezial-Energie von 1 Pokémon deines Gegners auf seinen Ablagestapel und lege 1 Stadionkarte im Spiel auf deinen Ablagestapel. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/216.ts
+++ b/data/Sword & Shield/Chilling Reign/216.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Durante este turno, los ataques de tus Pokémon Golpe Brusco hacen 20 puntos de daño más al Pokémon Activo de tu rival por cada carta de Premio que haya cogido tu rival (antes de aplicar Debilidad y Resistencia).",
 		it: "Durante questo turno, gli attacchi dei tuoi Pokémon Colpo Singolo infliggono 20 danni in più al Pokémon attivo del tuo avversario per ogni carta Premio che ha preso, prima di aver applicato debolezza e resistenza.",
 		pt: "Durante este turno, os ataques dos seus Pokémon Golpe Decisivo causam 20 pontos de dano a mais ao Pokémon Ativo do seu oponente para cada carta de Prêmio que ele(a) pegou (antes de aplicar Fraqueza e Resistência).",
-		de: "Während dieses Zuges fügen die Attacken deiner Fokussierter-Angriff-Pokémon dem Aktiven Pokémon deines Gegners für jede von deinem Gegner genommene Preiskarte 20 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
+		de: "Während dieses Zuges fügen die Attacken deiner Fokussierter-Angriff-Pokémon dem Aktiven Pokémon deines Gegners für jede von deinem Gegner genommene Preiskarte 20 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden). Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/217.ts
+++ b/data/Sword & Shield/Chilling Reign/217.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Elige 1 o ambas opciones:\n• Pon hasta 2 Pokémon de tu pila de descartes en tu mano.\n• Pon hasta 2 cartas de Energía Básica de tu pila de descartes en tu mano.",
 		it: "Scegli uno o entrambi gli effetti:\n• Prendi fino a due Pokémon dalla tua pila degli scarti e aggiungili alle carte che hai in mano.\n• Prendi fino a due carte Energia base dalla tua pila degli scarti e aggiungile alle carte che hai in mano.",
 		pt: "Escolha 1 ou ambas:\n• Coloque até 2 Pokémon da sua pilha de descarte na sua mão.\n• Coloque até 2 cartas de Energia básica da sua pilha de descarte na sua mão.",
-		de: "Wähle 1 oder beide aus:\n• Nimm bis zu 2 Pokémon aus deinem Ablagestapel auf deine Hand.\n• Nimm bis zu 2 Basis-Energiekarten aus deinem Ablagestapel auf deine Hand."
+		de: "Wähle 1 oder beide aus: Nimm bis zu 2 Pokémon aus deinem Ablagestapel auf deine Hand. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen. Nimm bis zu 2 Basis-Energiekarten aus deinem Ablagestapel auf deine Hand."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/218.ts
+++ b/data/Sword & Shield/Chilling Reign/218.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Une 1 carta de Energía Water de tu pila de descartes a 1 de tus Pokémon V. Si lo haces, roba 3 cartas.",
 		it: "Assegna una carta Energia Water dalla tua pila degli scarti a uno dei tuoi Pokémon-V. Se lo fai, pesca tre carte.",
 		pt: "Ligue 1 carta de Energia Water da sua pilha de descarte a 1 dos seus Pokémon V. Se fizer isto, compre 3 cartas.",
-		de: "Lege 1 Water-Energiekarte aus deinem Ablagestapel an 1 deiner Pokémon-V an. Wenn du das machst, ziehe 3 Karten."
+		de: "Lege 1 {W}-Energiekarte aus deinem Ablagestapel an 1 deiner Pokémon-V an. Wenn du das machst, ziehe 3 Karten. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/219.ts
+++ b/data/Sword & Shield/Chilling Reign/219.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon hasta 3 cartas de Premio en tu mano. Después, por cada carta de Premio que hayas puesto en tu mano de esta manera, pon 1 carta de tu mano boca abajo como carta de Premio.",
 		it: "Aggiungi fino a tre carte Premio a quelle che hai in mano. Poi, per ogni carta Premio aggiunta a quelle che hai in mano in questo modo, prendine una dalla tua mano e mettila a faccia in giù come carta Premio.",
 		pt: "Coloque até 3 cartas de Prêmio na sua mão. Em seguida, para cada carta de Prêmio que você colocou em sua mão desta forma, coloque uma carta da sua mão virada para baixo como uma carta de Prêmio.",
-		de: "Nimm bis zu 3 Preiskarten auf deine Hand. Lege anschließend für jede auf diese Weise auf deine Hand genommene Preiskarte 1 Karte aus deiner Hand verdeckt als Preiskarte ab."
+		de: "Nimm bis zu 3 Preiskarten auf deine Hand. Lege anschließend für jede auf diese Weise auf deine Hand genommene Preiskarte 1 Karte aus deiner Hand verdeckt als Preiskarte ab. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/22.ts
+++ b/data/Sword & Shield/Chilling Reign/22.ts
@@ -26,7 +26,8 @@ const card: Card = {
 
 	description: {
 		en: "Castform changes to this form when it basks in bright sunlight. When you touch its glowing skin, it feels all dried out!",
-		fr: 'Morphéo adopte cette apparence lorsqu\'il y a du soleil.\nSon corps rougeoyant est très sec au toucher.'
+		fr: 'Morphéo adopte cette apparence lorsqu\'il y a du soleil.\nSon corps rougeoyant est très sec au toucher.',
+		de: "Diese Gestalt nimmt Formeo bei einem heißen Sonnenbad an. Sein glühender Körper fühlt sich sehr trocken an."
 	},
 
 	abilities: [{

--- a/data/Sword & Shield/Chilling Reign/220.ts
+++ b/data/Sword & Shield/Chilling Reign/220.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta las cartas de tu mano y busca en tu baraja hasta 2 cartas de Entrenador, enséñalas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Scarta le carte che hai in mano e cerca nel tuo mazzo fino a due carte Allenatore, mostrale e aggiungile alla tua mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Descarte a sua mão e procure por até 2 cartas de Treinador no seu baralho, revele-as e coloque-as na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Lege deine Handkarten auf deinen Ablagestapel und durchsuche dein Deck nach bis zu 2 Trainerkarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Lege deine Handkarten auf deinen Ablagestapel und durchsuche dein Deck nach bis zu 2 Trainerkarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/221.ts
+++ b/data/Sword & Shield/Chilling Reign/221.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Elige hasta 2 de tus Pokémon Golpe Fluido y cura 60 puntos de daño a cada uno de ellos.",
 		it: "Scegli fino a due dei tuoi Pokémon Colpo Rapido e cura ciascuno di essi da 60 danni.",
 		pt: "Escolha até 2 dos seus Pokémon Golpe Fluido e cure 60 pontos de dano de cada um deles.",
-		de: "Wähle bis zu 2 deiner Fließender-Angriff-Pokémon und heile bei jedem von ihnen 60 Schadenspunkte."
+		de: "Wähle bis zu 2 deiner Fließender-Angriff-Pokémon und heile bei jedem von ihnen 60 Schadenspunkte. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Chilling Reign/222.ts
+++ b/data/Sword & Shield/Chilling Reign/222.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			es: "Una vez durante tu turno, si este Pokémon está en tu Banca, puedes buscar en tu baraja hasta 2 cartas de Energía Lightning y unirlas a tus Pokémon Lightning de la manera que desees. Después, baraja las cartas de tu baraja. Si has buscado en tu baraja de esta manera, este Pokémon queda Fuera de Combate.",
 			it: "Una sola volta durante il tuo turno, se questo Pokémon è nella tua panchina, puoi cercare nel tuo mazzo fino a due carte Energia Lightning e assegnarle ai tuoi Pokémon Lightning nel modo che preferisci. Poi rimischia le carte del tuo mazzo. Se hai cercato nel tuo mazzo in questo modo, questo Pokémon viene messo KO.",
 			pt: "Uma vez durante o seu turno, se este Pokémon estiver no seu Banco, você poderá procurar por até 2 cartas de Energia Lightning no seu baralho e ligá-las aos seus Pokémon Lightning como desejar. Em seguida, embaralhe o seu baralho. Se você procurar no seu baralho desta forma, este Pokémon será Nocauteado.",
-			de: "Einmal während deines Zuges, wenn sich dieses Pokémon auf deiner Bank befindet, kannst du dein Deck nach bis zu 2 Lightning-Energiekarten durchsuchen und sie beliebig an deine Lightning-Pokémon anlegen. Mische anschließend dein Deck. Wenn du auf diese Weise dein Deck durchsucht hast, ist dieses Pokémon kampfunfähig."
+			de: "Einmal während deines Zuges, wenn sich dieses Pokémon auf deiner Bank befindet, kannst du dein Deck nach bis zu 2 {L}-Energiekarten durchsuchen und sie beliebig an deine {L}-Pokémon anlegen. Mische anschließend dein Deck. Wenn du auf diese Weise dein Deck durchsucht hast, ist dieses Pokémon kampfunfähig."
 		}
 	}],
 
@@ -67,7 +67,8 @@ const card: Card = {
 	illustrator: "Ryo Ueda",
 
 	description: {
-		en: "It stores an overflowing amount of electric energy inside its body. Even a small shock makes it explode."
+		en: "It stores an overflowing amount of electric energy inside its body. Even a small shock makes it explode.",
+		de: "Es speichert eine riesige Menge Elektrizität in seinem Körper. Es explodiert beim kleinsten Ruck."
 	},
 
 	evolveFrom: {

--- a/data/Sword & Shield/Chilling Reign/223.ts
+++ b/data/Sword & Shield/Chilling Reign/223.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			es: "Todas las veces que quieras durante tu turno, puedes mover 1 Energía Metal de 1 de tus Pokémon a otro de tus Pokémon.",
 			it: "Durante il tuo turno, puoi spostare un'Energia Metal da uno a un altro dei tuoi Pokémon tutte le volte che vuoi.",
 			pt: "Quantas vezes desejar durante o seu turno, você poderá mover 1 Energia Metal de 1 dos seus Pokémon para outro Pokémon seu.",
-			de: "Beliebig oft während deines Zuges kannst du 1 Metal-Energie von 1 deiner Pokémon auf 1 anderes deiner Pokémon verschieben."
+			de: "Beliebig oft während deines Zuges kannst du 1 {M}-Energie von 1 deiner Pokémon auf 1 anderes deiner Pokémon verschieben."
 		}
 	}],
 
@@ -72,7 +72,8 @@ const card: Card = {
 	illustrator: "Eske Yoshinob",
 
 	description: {
-		en: "Many scientists suspect that this Pokémon originated outside the Galar region, based on the patterns on its body."
+		en: "Many scientists suspect that this Pokémon originated outside the Galar region, based on the patterns on its body.",
+		de: "Wegen seinem Muster denken viele Forscher, dass dieses Pokémon ursprünglich nicht aus Galar stammt."
 	},
 
 	evolveFrom: {

--- a/data/Sword & Shield/Chilling Reign/224.ts
+++ b/data/Sword & Shield/Chilling Reign/224.ts
@@ -77,7 +77,8 @@ const card: Card = {
 	illustrator: "Saki Hayashiro",
 
 	description: {
-		en: "It is not satisfied unless it eats over 880 pounds of food every day. When it is done eating, it goes promptly to sleep."
+		en: "It is not satisfied unless it eats over 880 pounds of food every day. When it is done eating, it goes promptly to sleep.",
+		de: "Es ist erst satt wenn es über 400 kg Nahrung am Tag gefressen hat. Ist es mit dem Essen fertig, schläft es sofort ein."
 	},
 
 	regulationMark: "D",

--- a/data/Sword & Shield/Chilling Reign/225.ts
+++ b/data/Sword & Shield/Chilling Reign/225.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon 1 Pokémon Básico de la pila de descartes de tu rival en su Banca.",
 		it: "Prendi un Pokémon Base dalla pila degli scarti del tuo avversario e mettilo nella sua panchina.",
 		pt: "Coloque 1 Pokémon Básico da pilha de descarte do seu oponente no Banco dele(a).",
-		de: "Lege 1 Basis-Pokémon aus dem Ablagestapel deines Gegners auf seine Bank."
+		de: "Lege 1 Basis-Pokémon aus dem Ablagestapel deines Gegners auf seine Bank. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Chilling Reign/226.ts
+++ b/data/Sword & Shield/Chilling Reign/226.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon 1 Energía Especial unida a 1 de los Pokémon de tu rival en la parte inferior de su baraja.",
 		it: "Prendi un'Energia speciale assegnata a uno dei Pokémon del tuo avversario e mettila in fondo al suo mazzo.",
 		pt: "Coloque 1 Energia Especial ligada a 1 dos Pokémon do seu oponente como a carta de baixo do baralho dele(a).",
-		de: "Lege 1 an ein Pokémon deines Gegners angelegte Spezial-Energie unter sein Deck."
+		de: "Lege 1 an ein Pokémon deines Gegners angelegte Spezial-Energie unter sein Deck. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Chilling Reign/227.ts
+++ b/data/Sword & Shield/Chilling Reign/227.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja 1 carta de Energía Psychic o 1 Pokémon Psychic Básico, enseña esa carta y ponla en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo una carta Energia Psychic o un Pokémon Base Psychic, mostra la carta e aggiungila a quelle che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por 1 carta de Energia Psychic ou por 1 Pokémon Psychic Básico no seu baralho, revele-o e coloque-o na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach 1 Psychic-Energiekarte oder 1 Basis-Psychic-Pokémon, zeige jene Karte deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach 1 {P}-Energiekarte oder 1 Basis-{P}-Pokémon, zeige jene Karte deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Chilling Reign/228.ts
+++ b/data/Sword & Shield/Chilling Reign/228.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Si el Pokémon al que está unida esta carta está en el Puesto Activo y resulta dañado por un ataque de los Pokémon de tu rival (incluso si queda Fuera de Combate), pon 1 Energía unida al Pokémon Atacante en la mano de tu rival.",
 		it: "Se il Pokémon a cui è assegnata questa carta è in posizione attiva e viene danneggiato da un attacco di un Pokémon del tuo avversario, anche se viene messo KO, prendi un'Energia assegnata al Pokémon attaccante e aggiungila alla mano del tuo avversario.",
 		pt: "Se o Pokémon ao qual esta carta está ligada estiver no Campo Ativo e for danificado por um ataque dos Pokémon do seu oponente (mesmo que ele seja Nocauteado), coloque 1 Energia ligada ao Pokémon Atacante na mão do seu oponente.",
-		de: "Wenn das Pokémon, an das diese Karte angelegt ist, in der Aktiven Position ist und durch eine Attacke von Pokémon deines Gegners Schaden erhält (auch wenn es dadurch kampfunfähig wird), gib deinem Gegner 1 an das Angreifende Pokémon angelegte Energie auf seine Hand."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn das Pokémon, an das diese Karte angelegt ist, in der Aktiven Position ist und durch eine Attacke von Pokémon deines Gegners Schaden erhält (auch wenn dieses Pokémon dadurch kampfunfähig wird), gib dem Gegner 1 an das Angreifende Pokémon angelegte Energie auf seine Hand. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sword & Shield/Chilling Reign/229.ts
+++ b/data/Sword & Shield/Chilling Reign/229.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon hasta 2 cartas de Energía Golpe Brusco de tu pila de descartes en tu baraja y barájalas todas.",
 		it: "Rimischia fino a due carte Energia Colpo Singolo dalla tua pila degli scarti nel tuo mazzo.",
 		pt: "Embaralhe até 2 cartas de Energia Golpe Decisivo da sua pilha de descarte no seu baralho.",
-		de: "Mische bis zu 2 Fokussierter-Angriff-Energiekarten aus deinem Ablagestapel in dein Deck."
+		de: "Mische bis zu 2 Fokussierter-Angriff-Energiekarten aus deinem Ablagestapel in dein Deck. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Chilling Reign/23.ts
+++ b/data/Sword & Shield/Chilling Reign/23.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			es: "Busca en tu baraja 1 carta de Energía Fire y únela a este Pokémon. Después, baraja las cartas de tu baraja.",
 			it: "Cerca nel tuo mazzo una carta Energia Fire e assegnala a questo Pokémon. Poi rimischia le carte del tuo mazzo.",
 			pt: "Procure por 1 carta de Energia Fire no seu baralho e ligue-a a este Pokémon. Em seguida, embaralhe o seu baralho.",
-			de: "Durchsuche dein Deck nach 1 Fire-Energiekarte und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
+			de: "Durchsuche dein Deck nach 1 {R}-Energiekarte und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
 		},
 
 		damage: 10,
@@ -55,7 +55,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It protects itself with flame. Long years ago, people believed Larvesta had a nest on the sun."
+		en: "It protects itself with flame. Long years ago, people believed Larvesta had a nest on the sun.",
+		de: "Es schützt sich mithilfe von Flammen. Früher glaubte man, dass sich sein Nest in der Sonne selbst befände."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/230.ts
+++ b/data/Sword & Shield/Chilling Reign/230.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon 1 carta de Partidario de Golpe Brusco de tu pila de descartes en tu mano.",
 		it: "Prendi una carta Aiuto Colpo Singolo dalla tua pila degli scarti e aggiungila alle carte che hai in mano.",
 		pt: "Coloque uma carta de Apoiador Golpe Decisivo da sua pilha de descarte na sua mão.",
-		de: "Nimm 1 Fokussierter-Angriff-Unterstützerkarte aus deinem Ablagestapel auf deine Hand."
+		de: "Nimm 1 Fokussierter-Angriff-Unterstützerkarte aus deinem Ablagestapel auf deine Hand. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Chilling Reign/24.ts
+++ b/data/Sword & Shield/Chilling Reign/24.ts
@@ -76,7 +76,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "According to legends, it was hatched from a flaming cocoon to save people and Pokémon that were suffering from the cold."
+		en: "According to legends, it was hatched from a flaming cocoon to save people and Pokémon that were suffering from the cold.",
+		de: "Alten Legenden zufolge wurde es aus einem lodernden Kokon geboren, um von Kälte bedrohte Menschen und Pokémon zu retten."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/26.ts
+++ b/data/Sword & Shield/Chilling Reign/26.ts
@@ -46,7 +46,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It has special pads on the backs of its feet, and one on its nose. Once it's raring to fight, these pads radiate tremendous heat."
+		en: "It has special pads on the backs of its feet, and one on its nose. Once it's raring to fight, these pads radiate tremendous heat.",
+		de: "Ist es kampfbereit, verströmt es von seiner Nasenspitze und von den Ballen an seinen Läufen Hitze."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/27.ts
+++ b/data/Sword & Shield/Chilling Reign/27.ts
@@ -64,7 +64,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It kicks berries right off the branches of trees and then juggles them with its feet, practicing its footwork."
+		en: "It kicks berries right off the branches of trees and then juggles them with its feet, practicing its footwork.",
+		de: "Es pflückt Beeren von Ästen, ohne seine Hände zu benutzen, und jongliert sie mit den Füßen. Damit trainiert es seine Fußfertigkeiten."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/28.ts
+++ b/data/Sword & Shield/Chilling Reign/28.ts
@@ -86,7 +86,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "It's skilled at both offense and defense, and it gets pumped up when cheered on. But if it starts showboating, it could put itself in a tough spot."
+		en: "It's skilled at both offense and defense, and it gets pumped up when cheered on. But if it starts showboating, it could put itself in a tough spot.",
+		de: "Jubel für besonders gelungene Spielzüge schüren seinen Enthusiasmus. Spielt es aber zu sehr für die Publikumswirkung, geht dies oft nach hinten los."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/29.ts
+++ b/data/Sword & Shield/Chilling Reign/29.ts
@@ -75,7 +75,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Crossing icy seas is no issue for this cold-resistant Pokémon. Its smooth skin is a little cool to the touch."
+		en: "Crossing icy seas is no issue for this cold-resistant Pokémon. Its smooth skin is a little cool to the touch.",
+		de: "Es kommt gut mit Kälte zurecht und kann auch in eisigen Meeren problemlos schwimmen. Seine Haut fühlt sich glatt und kühl an."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/3.ts
+++ b/data/Sword & Shield/Chilling Reign/3.ts
@@ -84,7 +84,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "May appear in a swarm. Flies at violent speeds, all the while stabbing with the toxic stinger on its rear."
+		en: "May appear in a swarm. Flies at violent speeds, all the while stabbing with the toxic stinger on its rear.",
+		de: "Es kann in Schwärmen auftauchen. Während seines rasanten Fluges sticht es mit dem Giftstachel an seinem Hinterteil zu."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/30.ts
+++ b/data/Sword & Shield/Chilling Reign/30.ts
@@ -54,7 +54,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It has a cunning yet savage disposition. It waits for parents to leave their nests, and then it sneaks in to steal their eggs."
+		en: "It has a cunning yet savage disposition. It waits for parents to leave their nests, and then it sneaks in to steal their eggs.",
+		de: "Dieses durchtriebene und gewissenlose Pokémon beobachtet Nester, bis die Eltern ausgeflogen sind, und stiehlt dann deren Eier."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/31.ts
+++ b/data/Sword & Shield/Chilling Reign/31.ts
@@ -83,7 +83,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "With its claws, it leaves behind signs for its friends to find. The number of distinct signs is said to be over 500."
+		en: "With its claws, it leaves behind signs for its friends to find. The number of distinct signs is said to be over 500.",
+		de: "Sie kommunizieren miteinander, indem sie Zeichen mit ihren Krallen hinterlassen. Es soll über 500 davon geben."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/32.ts
+++ b/data/Sword & Shield/Chilling Reign/32.ts
@@ -48,7 +48,7 @@ const card: Card = {
 			es: "Pon este Pokémon y todas las cartas unidas a él en tu baraja. Si lo haces, busca en tu baraja 1 carta y ponla en tu mano. Después, baraja las cartas de tu baraja.",
 			it: "Metti questo Pokémon e tutte le carte a esso assegnate nel tuo mazzo. Se lo fai, cerca nel tuo mazzo una carta e aggiungila a quelle che hai in mano. Poi rimischia le carte del tuo mazzo.",
 			pt: "Coloque este Pokémon e todas as cartas ligadas a ele no seu baralho. Se fizer isto, procure por 1 carta no seu baralho e coloque-a na sua mão. Em seguida, embaralhe o seu baralho.",
-			de: "Lege dieses Pokémon und alle angelegten Karten in dein Deck. Wenn du das machst, durchsuche dein Deck nach 1 Karte und nimm sie auf deine Hand. Mische anschließend dein Deck."
+			de: "Lege dieses Pokémon und alle angelegten Karten in dein Deck. Wenn du das machst, durchsuche anschließend dein Deck nach 1 Karte und nimm sie auf deine Hand. Mische anschließend dein Deck."
 		},
 
 		cost: ["Colorless", "Colorless"]
@@ -66,7 +66,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It has a generous habit of sharing its food with people and Pokémon, so it's always scrounging around for more food."
+		en: "It has a generous habit of sharing its food with people and Pokémon, so it's always scrounging around for more food.",
+		de: "Es hat die Angewohnheit, seine eigene Nahrung mit Menschen und Pokémon zu teilen, und ist deshalb stets unterwegs auf Futtersuche."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/33.ts
+++ b/data/Sword & Shield/Chilling Reign/33.ts
@@ -26,7 +26,8 @@ const card: Card = {
 
 	description: {
 		en: "This is Castform's form when pelted by rain. In an experiment where it was placed in a shower, this Pokémon didn't change to this form.",
-		fr: 'Morphéo adopte cette apparence uniquement\n les jours de pluie. On a tenté de reproduire ce\nphénomène sous une douche, sans succès.'
+		fr: 'Morphéo adopte cette apparence uniquement\n les jours de pluie. On a tenté de reproduire ce\nphénomène sous une douche, sans succès.',
+		de: "Diese Gestalt nimmt Formeo an Regentagen an. Versuche, diesen Wandel künstlich mithilfe einer Dusche herbeizuführen, schlugen fehl."
 	},
 
 	abilities: [{

--- a/data/Sword & Shield/Chilling Reign/34.ts
+++ b/data/Sword & Shield/Chilling Reign/34.ts
@@ -26,7 +26,8 @@ const card: Card = {
 
 	description: {
 		en: "This is Castform's form when caught in a hailstorm. Its whole body is chilled, and its skin is partially frozen!",
-		fr: 'Morphéo adopte cette apparence quand\n il est frappé par la grèle. Tout son corps est froid et sa peau est légèrement givrée.'
+		fr: 'Morphéo adopte cette apparence quand\n il est frappé par la grèle. Tout son corps est froid et sa peau est légèrement givrée.',
+		de: "Diese Gestalt nimmt Formeo an, wenn es von Hagel getroffen wird. Sein Körper ist so kalt, dass seine Haut leicht gefriert."
 	},
 
 	abilities: [{

--- a/data/Sword & Shield/Chilling Reign/35.ts
+++ b/data/Sword & Shield/Chilling Reign/35.ts
@@ -46,7 +46,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It can only survive in cold areas. It bounces happily around, even in environments as cold as −150 degrees Fahrenheit."
+		en: "It can only survive in cold areas. It bounces happily around, even in environments as cold as −150 degrees Fahrenheit.",
+		de: "Schneppke kann nur in besonders kalten Gebieten leben. Selbst bei -100 ºC hopst es munter umher."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/36.ts
+++ b/data/Sword & Shield/Chilling Reign/36.ts
@@ -47,7 +47,7 @@ const card: Card = {
 			es: "Cuando juegas este Pokémon de tu mano para hacer evolucionar a 1 de tus Pokémon durante tu turno, puedes unir 1 carta de Energía Water de tu pila de descartes a 1 de tus Pokémon.",
 			it: "Quando giochi questo Pokémon dalla tua mano per far evolvere uno dei tuoi Pokémon durante il tuo turno, puoi assegnare a uno dei tuoi Pokémon una carta Energia Water dalla tua pila degli scarti.",
 			pt: "Quando você jogar este Pokémon da sua mão para evoluir 1 dos seus Pokémon durante o seu turno, você poderá ligar 1 carta de Energia Water da sua pilha de descarte a 1 dos seus Pokémon.",
-			de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand spielst, um 1 deiner Pokémon zu entwickeln, kannst du 1 Water-Energiekarte aus deinem Ablagestapel an 1 deiner Pokémon anlegen."
+			de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand spielst, um 1 deiner Pokémon zu entwickeln, kannst du 1 {W}-Energiekarte aus deinem Ablagestapel an 1 deiner Pokémon anlegen."
 		}
 	}],
 
@@ -86,7 +86,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It spits out cold air of nearly −60 degrees Fahrenheit to freeze its quarry. It brings frozen prey back to its lair and neatly lines them up."
+		en: "It spits out cold air of nearly −60 degrees Fahrenheit to freeze its quarry. It brings frozen prey back to its lair and neatly lines them up.",
+		de: "Es friert seine Beute mit -50 ºC kalter Luft ein, nimmt sie dann in seinen Unterschlupf mit und reiht sie dort fein säuberlich auf."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/37.ts
+++ b/data/Sword & Shield/Chilling Reign/37.ts
@@ -46,7 +46,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Its body is covered in fluffy fur. The fur keeps it from feeling cold while it is rolling on ice."
+		en: "Its body is covered in fluffy fur. The fur keeps it from feeling cold while it is rolling on ice.",
+		de: "Sein Körper ist mit flauschigem Fell bedeckt. Das Fell sorgt dafür, dass es nicht friert, auch wenn es sich auf dem Eis hin und her rollt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/38.ts
+++ b/data/Sword & Shield/Chilling Reign/38.ts
@@ -67,7 +67,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Be it Spheal or a Poké Ball, it will spin any round object on its nose with the greatest of ease."
+		en: "Be it Spheal or a Poké Ball, it will spin any round object on its nose with the greatest of ease.",
+		de: "Pokébälle, Seemops und alles, was sonst noch rund ist, balanciert es mit großem Geschick auf seiner Nasenspitze."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/39.ts
+++ b/data/Sword & Shield/Chilling Reign/39.ts
@@ -76,7 +76,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "It shatters drift ice with its strong tusks. Its thick layer of blubber repels enemy attacks."
+		en: "It shatters drift ice with its strong tusks. Its thick layer of blubber repels enemy attacks.",
+		de: "Seine kräftigen Stoßzähne können Eisschollen zerschmettern. Sein dicker Speck wehrt Angriffe ab."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/4.ts
+++ b/data/Sword & Shield/Chilling Reign/4.ts
@@ -66,7 +66,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "These very cowardly Pokémon join together and use Reflect to protect their nest."
+		en: "These very cowardly Pokémon join together and use Reflect to protect their nest.",
+		de: "Es ist ein sehr scheues Pokémon. Gemeinsam mit seinen Artgenossen nutzt es Reflektor, um sein Nest zu beschützen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/40.ts
+++ b/data/Sword & Shield/Chilling Reign/40.ts
@@ -76,7 +76,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Although it's called a guardian deity, terrible calamities sometimes befall those who recklessly approach Tapu Fini."
+		en: "Although it's called a guardian deity, terrible calamities sometimes befall those who recklessly approach Tapu Fini.",
+		de: "Man bezeichnet es zwar als Schutzpatron, doch all jene, die sich ihm unbedacht nähern, werden von furchtbaren Katastrophen heimgesucht."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/41.ts
+++ b/data/Sword & Shield/Chilling Reign/41.ts
@@ -75,7 +75,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "When it gets wet, its skin changes color, and this Pokémon becomes invisible as if it were camouflaged."
+		en: "When it gets wet, its skin changes color, and this Pokémon becomes invisible as if it were camouflaged.",
+		de: "Wird seine Haut feucht, ändert sich ihre Farbe. Dies dient ihm zur Tarnung, da man es dann nicht mehr sehen kann."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/42.ts
+++ b/data/Sword & Shield/Chilling Reign/42.ts
@@ -64,7 +64,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Highly intelligent but also very lazy, it keeps enemies out of its territory by laying traps everywhere."
+		en: "Highly intelligent but also very lazy, it keeps enemies out of its territory by laying traps everywhere.",
+		de: "Es ist intelligent, fühlt sich aber schnell von jeder Kleinigkeit genervt. Damit kein Feind in sein Revier eindringt, stellt es überall Fallen auf."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/43.ts
+++ b/data/Sword & Shield/Chilling Reign/43.ts
@@ -77,7 +77,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "Its nictitating membranes let it pick out foes' weak points so it can precisely blast them with water that shoots from its fingertips at Mach 3."
+		en: "Its nictitating membranes let it pick out foes' weak points so it can precisely blast them with water that shoots from its fingertips at Mach 3.",
+		de: "Die Wasserschüsse aus seinen Fingern erreichen Geschwindigkeiten von bis zu Mach 3. Mit seiner Nickhaut erkennt es Schwachpunkte des Gegners."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/44.ts
+++ b/data/Sword & Shield/Chilling Reign/44.ts
@@ -76,7 +76,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "This form of Urshifu is a strong believer in defeating foes by raining many blows down on them. Its strikes are nonstop, flowing like a river."
+		en: "This form of Urshifu is a strong believer in defeating foes by raining many blows down on them. Its strikes are nonstop, flowing like a river.",
+		de: "Es ist darauf spezialisiert, Gegner mit vielen Treffern zu besiegen, indem es wie ein reißender Fluss Schläge auf sie niederprasseln lässt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/47.ts
+++ b/data/Sword & Shield/Chilling Reign/47.ts
@@ -66,7 +66,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Rubbing its fleece generates electricity. You'll want to pet it because it's cute, but if you use your bare hand, you'll get a painful shock."
+		en: "Rubbing its fleece generates electricity. You'll want to pet it because it's cute, but if you use your bare hand, you'll get a painful shock.",
+		de: "Seine Wolle lädt sich durch Reibung elektrisch auf. Streichelt man dieses süße Pokémon mit bloßer Hand, bekommt man einen Elektroschock."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/48.ts
+++ b/data/Sword & Shield/Chilling Reign/48.ts
@@ -55,7 +55,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It stores electricity in its fluffy fleece. If it stores up too much, it will start to go bald in those patches."
+		en: "It stores electricity in its fluffy fleece. If it stores up too much, it will start to go bald in those patches.",
+		de: "Sein flauschiges Fell speichert Elektrizität. Zu große Mengen bewirkten aber stellenweise einen Haarausfall, wo nun glatte Haut freiliegt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/49.ts
+++ b/data/Sword & Shield/Chilling Reign/49.ts
@@ -85,7 +85,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "Its tail shines bright and strong. It has been prized since long ago as a beacon for sailors."
+		en: "Its tail shines bright and strong. It has been prized since long ago as a beacon for sailors.",
+		de: "Seine Schweifspitze strahlt ein starkes, helles Licht aus. Auf See gilt dieses Leuchten von alters her als bedeutender Wegweiser."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/5.ts
+++ b/data/Sword & Shield/Chilling Reign/5.ts
@@ -85,7 +85,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It flies through the night sky, sprinkling sparkly dust. According to some, if that dust sticks to you, good things will happen to you."
+		en: "It flies through the night sky, sprinkling sparkly dust. According to some, if that dust sticks to you, good things will happen to you.",
+		de: "Nachts fliegt Ledian durch die Gegend und verstreut glitzernden Puder. Es soll Glück bringen, wenn man etwas davon abbekommt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/50.ts
+++ b/data/Sword & Shield/Chilling Reign/50.ts
@@ -54,7 +54,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Its mane shines when it discharges electricity. They use the frequency and rhythm of these flashes to communicate."
+		en: "Its mane shines when it discharges electricity. They use the frequency and rhythm of these flashes to communicate.",
+		de: "Um mit Artgenossen zu kommunizieren, nutzt es das Aufblitzen seiner Mähne beim Entladen von Strom als Morsecode."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/51.ts
+++ b/data/Sword & Shield/Chilling Reign/51.ts
@@ -85,7 +85,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "They have lightning-like movements. When Zebstrika run at full speed, the sound of thunder reverberates."
+		en: "They have lightning-like movements. When Zebstrika run at full speed, the sound of thunder reverberates.",
+		de: "Es ist explosiv wie ein Blitz. Galoppiert es mit voller Geschwindigkeit drauflos, kann man Donnerhall vernehmen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/52.ts
+++ b/data/Sword & Shield/Chilling Reign/52.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			es: "Puedes unir 1 carta de Energía Lightning de tu mano a 1 de tus Pokémon en Banca.",
 			it: "Puoi assegnare a uno dei tuoi Pokémon in panchina una carta Energia Lightning dalla tua mano.",
 			pt: "Você pode ligar 1 carta de Energia Lightning da sua mão a 1 dos seus Pokémon no Banco.",
-			de: "Du kannst 1 Lightning-Energiekarte aus deiner Hand an 1 Pokémon auf deiner Bank anlegen."
+			de: "Du kannst 1 {L}-Energiekarte aus deiner Hand an 1 Pokémon auf deiner Bank anlegen."
 		},
 
 		damage: 30,
@@ -76,7 +76,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "As it flies around, it shoots lightning all over the place and causes forest fires. It is therefore disliked."
+		en: "As it flies around, it shoots lightning all over the place and causes forest fires. It is therefore disliked.",
+		de: "Es ist bei den Leuten verhasst, weil es auf seinen Rundflügen immer wieder Blitze erzeugt, die Waldbrände verursachen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/54.ts
+++ b/data/Sword & Shield/Chilling Reign/54.ts
@@ -63,7 +63,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Because Galarian Slowpoke eat the seeds of a plant that grows only in Galar, their tails have developed a spicy flavor."
+		en: "Because Galarian Slowpoke eat the seeds of a plant that grows only in Galar, their tails have developed a spicy flavor.",
+		de: "Seine Nahrung aus Samen von Pflanzen, die nur in der Galar-Region wachsen, verleiht seiner Rute einen würzig-pikanten Geschmack."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/55.ts
+++ b/data/Sword & Shield/Chilling Reign/55.ts
@@ -60,7 +60,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "With its gas-like body, it can sneak into any place it desires. However, it can be blown away by wind."
+		en: "With its gas-like body, it can sneak into any place it desires. However, it can be blown away by wind.",
+		de: "Aufgrund seines an Gas erinnernden Körpers kommt es an jeden Ort. Es kann jedoch vom Wind davongeweht werden."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/56.ts
+++ b/data/Sword & Shield/Chilling Reign/56.ts
@@ -60,7 +60,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "If you get the feeling of being watched in darkness when nobody is around, Haunter is there."
+		en: "If you get the feeling of being watched in darkness when nobody is around, Haunter is there.",
+		de: "Falls du im Dunkeln das Gefühl hast, beobachtet zu werden, und niemand ist zu sehen, ist es bestimmt Alpollo."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/57.ts
+++ b/data/Sword & Shield/Chilling Reign/57.ts
@@ -91,7 +91,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "It is said to emerge from darkness to steal the lives of those who become lost in mountains."
+		en: "It is said to emerge from darkness to steal the lives of those who become lost in mountains.",
+		de: "Man sagt, es sei aus Dunkelheit entstanden, um denjenigen, die sich in den Bergen verirrt haben, das Leben zu rauben."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/59.ts
+++ b/data/Sword & Shield/Chilling Reign/59.ts
@@ -54,7 +54,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "If its horns capture the warm feelings of people or Pokémon, its body warms up slightly."
+		en: "If its horns capture the warm feelings of people or Pokémon, its body warms up slightly.",
+		de: "Wenn es mit seinen roten Hörnern freundliche Gefühle von Menschen oder Pokémon erfasst, erwärmt sich sein ganzer Körper ein bisschen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/6.ts
+++ b/data/Sword & Shield/Chilling Reign/6.ts
@@ -67,7 +67,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It roams through forests searching for sweet nectar. Although it boasts fantastic physical strength, it's not that good at flying."
+		en: "It roams through forests searching for sweet nectar. Although it boasts fantastic physical strength, it's not that good at flying.",
+		de: "Auf der Suche nach süßem Honig durchstreift es die Wälder. Es ist stolz auf seine Stärke, aber fliegen kann es nicht besonders gut."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/60.ts
+++ b/data/Sword & Shield/Chilling Reign/60.ts
@@ -63,7 +63,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It has a psychic power that enables it to distort the space around it and see into the future."
+		en: "It has a psychic power that enables it to distort the space around it and see into the future.",
+		de: "Seine Psycho-Kräfte erlauben es ihm, den Raum um sich selbst zu verformen und so in die Zukunft zu sehen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/61.ts
+++ b/data/Sword & Shield/Chilling Reign/61.ts
@@ -67,7 +67,7 @@ const card: Card = {
 			es: "Este ataque hace 30 puntos de daño más por cada Energía Psychic unida a este Pokémon.",
 			it: "Questo attacco infligge 30 danni in più per ogni Energia Psychic assegnata a questo Pokémon.",
 			pt: "Este ataque causa 30 pontos de dano a mais para cada Energia Psychic ligada a este Pokémon.",
-			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte Psychic-Energie 30 Schadenspunkte mehr zu."
+			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte {P}-Energie 30 Schadenspunkte mehr zu."
 		},
 
 		damage: "60+",
@@ -86,7 +86,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "To protect its Trainer, it will expend all its psychic power to create a small black hole."
+		en: "To protect its Trainer, it will expend all its psychic power to create a small black hole.",
+		de: "Wenn es seinen Trainer schützen will, nimmt es all seine Psycho-Kräfte zusammen, um so ein kleines schwarzes Loch zu erzeugen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/62.ts
+++ b/data/Sword & Shield/Chilling Reign/62.ts
@@ -51,7 +51,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "There's a proverb that says, \"Shun the house where Shuppet gather in the growing dusk.\""
+		en: "There's a proverb that says, \"Shun the house where Shuppet gather in the growing dusk.\"",
+		de: "Einem alten Sprichwort zufolge soll man sich von Häusern fernhalten, an denen sich bei Einbruch der Dunkelheit Shuppet aneinanderreihen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/63.ts
+++ b/data/Sword & Shield/Chilling Reign/63.ts
@@ -90,7 +90,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Resentment at being cast off made it spring into being. Some say that treating it well will satisfy it, and it will once more become a stuffed toy."
+		en: "Resentment at being cast off made it spring into being. Some say that treating it well will satisfy it, and it will once more become a stuffed toy.",
+		de: "Geboren aus Hass, weil es weggeworfen wurde, soll es sich wieder in eine Plüschpuppe zurückverwandeln, wenn es sich geliebt fühlt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/64.ts
+++ b/data/Sword & Shield/Chilling Reign/64.ts
@@ -26,7 +26,8 @@ const card: Card = {
 
 	description: {
 		en: "Those who sleep holding Cresselia's feather are assured of joyful dreams. It is said to represent the crescent moon.",
-		fr: "Dormir aec une de ses plumes à la main\npermet de faire de beaux rêves. On le\nsurnomme « avatar d croissant de lune »."
+		fr: "Dormir aec une de ses plumes à la main\npermet de faire de beaux rêves. On le\nsurnomme « avatar d croissant de lune ».",
+		de: "Hält man eine seiner Federn, träumt man süß. Manche glauben, es sei die Verkörperung der Mondsichel."
 	},
 
 	attacks: [
@@ -48,7 +49,7 @@ const card: Card = {
 				es: "Busca en tu baraja 1 carta de Energía Psychic y únela a 1 de tus Pokémon. Si sales segundo y es tu primer turno, busca hasta 3 cartas de Energía Psychic en vez de 1 y únelas a 1 de tus Pokémon. Después, baraja las cartas de tu baraja.",
 				it: "Cerca nel tuo mazzo una carta Energia Psychic e assegnala a uno dei tuoi Pokémon. Se inizi per secondo ed è il tuo primo turno, invece cerca fino a tre carte Energia Psychic e assegnale a uno dei tuoi Pokémon. Poi rimischia le carte del tuo mazzo.",
 				pt: "Procure por 1 carta de Energia Psychic no seu baralho e ligue-a a 1 dos seus Pokémon. Se você for o segundo a jogar e este for o seu primeiro turno, procure por até 3 cartas de Energia Psychic ao invés de 1 e ligue-as a 1 dos seus Pokémon. Em seguida, embaralhe o seu baralho.",
-				de: "Durchsuche dein Deck nach 1 Psychic-Energiekarte und lege sie an 1 deiner Pokémon an. Wenn du als Zweiter am Zug bist und es dein erster Zug ist, durchsuche dein Deck stattdessen nach bis zu 3 Psychic-Energiekarten und lege sie an 1 deiner Pokémon an. Mische anschließend dein Deck."
+				de: "Durchsuche dein Deck nach 1 {P}-Energiekarte und lege sie an 1 deiner Pokémon an. Wenn du als Zweiter am Zug bist und es dein erster Zug ist, durchsuche dein Deck stattdessen nach bis zu 3 {P}-Energiekarten und lege sie beliebig an deine Pokémon an. Mische anschließend dein Deck."
 			}
 		},
 		{
@@ -70,7 +71,7 @@ const card: Card = {
 				es: "Si tienes por lo menos 5 Energías en juego, este ataque hace 90 puntos de daño más.",
 				it: "Se hai almeno cinque Energie in gioco, questo attacco infligge 90 danni in più.",
 				pt: "Se você tiver pelo menos 5 Energias em jogo, este ataque causará 90 pontos de dano a mais.",
-				de: "Wenn du mindestens 5 Energien im Spiel hast, fügt diese Attacke 90 Schadenspunkte mehr zu."
+				de: "Wenn du mindestens 5 Energiekarten im Spiel hast, fügt diese Attacke 90 Schadenspunkte mehr zu."
 			},
 			damage: '30+'
 		}

--- a/data/Sword & Shield/Chilling Reign/65.ts
+++ b/data/Sword & Shield/Chilling Reign/65.ts
@@ -63,7 +63,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "This Pokémon was created from clay. It received orders from its master many thousands of years ago, and it still follows those orders to this day."
+		en: "This Pokémon was created from clay. It received orders from its master many thousands of years ago, and it still follows those orders to this day.",
+		de: "Golbit wurde aus Lehm erschaffen. Es führt heute noch Befehle aus, die ihm vor Jahrtausenden von seinem Meister aufgetragen wurden."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/66.ts
+++ b/data/Sword & Shield/Chilling Reign/66.ts
@@ -90,7 +90,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "There's a theory that inside Golurk is a perpetual motion machine that produces limitless energy, but this belief hasn't been proven."
+		en: "There's a theory that inside Golurk is a perpetual motion machine that produces limitless energy, but this belief hasn't been proven.",
+		de: "Man sagt, in seinem Körper befinde sich eine unerschöpfliche Energiequelle, doch bisher ist es niemandem gelungen, dies nachzuweisen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/67.ts
+++ b/data/Sword & Shield/Chilling Reign/67.ts
@@ -55,7 +55,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "The sweet smell of cotton candy perfumes Swirlix's fluffy fur. This Pokémon spits out sticky string to tangle up its enemies."
+		en: "The sweet smell of cotton candy perfumes Swirlix's fluffy fur. This Pokémon spits out sticky string to tangle up its enemies.",
+		de: "Sein flauschiges Fell duftet süß wie Zuckerwatte. Es stößt klebrige Fäden aus, mit denen es seine Gegner umwickelt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/68.ts
+++ b/data/Sword & Shield/Chilling Reign/68.ts
@@ -75,7 +75,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Slurpuff's fur contains a lot of air, making it soft to the touch and lighter than it looks."
+		en: "Slurpuff's fur contains a lot of air, making it soft to the touch and lighter than it looks.",
+		de: "Da in seinem Fell eine Menge Luft eingeschlossen ist, fühlt es sich unheimlich weich an und ist leichter, als es auf den ersten Blick aussieht."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/69.ts
+++ b/data/Sword & Shield/Chilling Reign/69.ts
@@ -51,7 +51,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "By exposing foes to the blinking of its luminescent spots, Inkay demoralizes them, and then it seizes the chance to flee."
+		en: "By exposing foes to the blinking of its luminescent spots, Inkay demoralizes them, and then it seizes the chance to flee.",
+		de: "Es lässt die Punkte auf seinem Körper blinken, um Gegnern den Kampfeswillen zu rauben. Diesen Moment nutzt es dann, um zu fliehen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/7.ts
+++ b/data/Sword & Shield/Chilling Reign/7.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			es: "Une cualquier cantidad de cartas de Energía Grass de tu mano a tus Pokémon de la manera que desees.",
 			it: "Assegna ai tuoi Pokémon un numero qualsiasi di carte Energia Grass dalla tua mano nel modo che preferisci.",
 			pt: "Ligue qualquer número de cartas de Energia Grass da sua mão aos seus Pokémon como desejar.",
-			de: "Lege beliebig viele Grass-Energiekarten aus deiner Hand beliebig an deine Pokémon an."
+			de: "Lege beliebig viele {G}-Energiekarten aus deiner Hand beliebig an deine Pokémon an."
 		},
 
 		cost: ["Grass"]

--- a/data/Sword & Shield/Chilling Reign/70.ts
+++ b/data/Sword & Shield/Chilling Reign/70.ts
@@ -45,7 +45,7 @@ const card: Card = {
 			es: "Enseña cualquier cantidad de cartas de Golpe Fluido de tu mano. Este ataque hace 40 puntos de daño por cada carta que hayas enseñado de esta manera. Después, pon esas cartas en tu baraja y barájalas todas.",
 			it: "Mostra un numero qualsiasi di carte Colpo Rapido che hai in mano. Questo attacco infligge 40 danni per ogni carta che hai mostrato in questo modo. Poi rimischia quelle carte nel tuo mazzo.",
 			pt: "Revele qualquer número de cartas Golpe Fluido da sua mão. Este ataque causa 40 pontos de dano para cada carta revelada desta forma. Em seguida, embaralhe aquelas cartas no seu baralho.",
-			de: "Zeige deinem Gegner beliebig viele Fließender-Angriff-Karten auf deiner Hand. Diese Attacke fügt für jede auf diese Weise gezeigte Karte 40 Schadenspunkte zu. Mische jene Karten anschließend in dein Deck."
+			de: "Zeige deinem Gegner beliebig viele Fließender-Angriff-Karten aus deiner Hand. Diese Attacke fügt für jede auf diese Weise gezeigte Karte 40 Schadenspunkte zu. Mische jene Karten anschließend in dein Deck."
 		},
 
 		damage: "40×",
@@ -69,7 +69,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It's said that Malamar's hypnotic powers played a role in certain history-changing events."
+		en: "It's said that Malamar's hypnotic powers played a role in certain history-changing events.",
+		de: "Man erzählt sich, dass die hypnotischen Kräfte dieses Pokémon mit einigen geschichtsträchtigen Ereignissen in Verbindung stehen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/71.ts
+++ b/data/Sword & Shield/Chilling Reign/71.ts
@@ -51,7 +51,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "If this Pokémon senses a strong emotion, it will run away as fast as it can. It prefers areas without people."
+		en: "If this Pokémon senses a strong emotion, it will run away as fast as it can. It prefers areas without people.",
+		de: "Es liebt Orte, wo sonst niemand ist. Nimmt es starke Emotionen wahr, macht es sich so schnell es kann aus dem Staub."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/72.ts
+++ b/data/Sword & Shield/Chilling Reign/72.ts
@@ -69,7 +69,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Using the braids on its head, it pummels foes to get them to quiet down. One blow from those braids would knock out a professional boxer."
+		en: "Using the braids on its head, it pummels foes to get them to quiet down. One blow from those braids would knock out a professional boxer.",
+		de: "Ein Schlag mit den Quasten an seinem Kopf bringt Gegner zum Schweigen. Ein Treffer genügt, um einen Profiboxer auf die Bretter zu schicken."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/73.ts
+++ b/data/Sword & Shield/Chilling Reign/73.ts
@@ -91,7 +91,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "If you're too loud around it, you risk being torn apart by the claws on its tentacle. This Pokémon is also known as the Forest Witch."
+		en: "If you're too loud around it, you risk being torn apart by the claws on its tentacle. This Pokémon is also known as the Forest Witch.",
+		de: "Es wird auch „Hexe des Waldes“ genannt. Wer Lärm veranstaltet, wird unter Umständen von der Klaue an seinem Fühler auseinandergenommen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/75.ts
+++ b/data/Sword & Shield/Chilling Reign/75.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			es: "Una vez durante tu turno, puedes unir 1 carta de Energía Psychic de tu mano a 1 de tus Pokémon Psychic en Banca. Si has unido Energía a un Pokémon de esta manera, roba 2 cartas.",
 			it: "Una sola volta durante il tuo turno, puoi assegnare a uno dei tuoi Pokémon Psychic in panchina una carta Energia Psychic dalla tua mano. Se hai assegnato dell'Energia a un Pokémon in questo modo, pesca due carte.",
 			pt: "Uma vez durante o seu turno, você poderá ligar 1 carta de Energia Psychic da sua mão a 1 dos seus Pokémon Psychic no Banco. Se você ligou Energia a um Pokémon desta forma, compre 2 cartas.",
-			de: "Einmal während deines Zuges kannst du 1 Psychic-Energiekarte aus deiner Hand an 1 Psychic-Pokémon auf deiner Bank anlegen. Wenn du auf diese Weise Energie an ein Pokémon angelegt hast, ziehe 2 Karten."
+			de: "Einmal während deines Zuges kannst du 1 {P}-Energiekarte aus deiner Hand an 1 {P}-Pokémon auf deiner Bank anlegen. Wenn du auf diese Weise Energie an ein Pokémon angelegt hast, ziehe 2 Karten."
 		}
 	}],
 
@@ -74,7 +74,7 @@ const card: Card = {
 				es: "Este ataque hace 30 puntos de daño más por cada Energía Psychic unida a todos tus Pokémon.",
 				it: "Questo attacco infligge 30 danni in più per ogni Energia Psychic assegnata ai tuoi Pokémon.",
 				pt: "Este ataque causa 30 pontos de dano a mais para cada Energia Psychic ligada a todos os seus Pokémon.",
-				de: "Diese Attacke fügt für jede an alle deine Pokémon angelegte Psychic-Energie 30 Schadenspunkte mehr zu."
+				de: "Diese Attacke fügt für jede an alle deine Pokémon angelegte {P}-Energie 30 Schadenspunkte mehr zu."
 			},
 			damage: '10+'
 		}

--- a/data/Sword & Shield/Chilling Reign/76.ts
+++ b/data/Sword & Shield/Chilling Reign/76.ts
@@ -55,7 +55,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It burrows through the ground at a shallow depth. It leaves raised earth in its wake, making it easy to spot."
+		en: "It burrows through the ground at a shallow depth. It leaves raised earth in its wake, making it easy to spot.",
+		de: "Es gräbt sich in geringer Tiefe durch den Erdboden. Da es dabei durchwühlte Erde an der Oberfläche hinterlässt, ist es leicht zu finden."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/77.ts
+++ b/data/Sword & Shield/Chilling Reign/77.ts
@@ -64,7 +64,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "These Diglett triplets dig over 60 miles below sea level. No one knows what it's like underground."
+		en: "These Diglett triplets dig over 60 miles below sea level. No one knows what it's like underground.",
+		de: "Diese kraftvollen Digda-Drillinge graben bis zu 100 km tief. Keiner weiß, wie sie unter der Erde aussehen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/78.ts
+++ b/data/Sword & Shield/Chilling Reign/78.ts
@@ -55,7 +55,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "The stalks of leeks are thicker and longer in the Galar region. Farfetch'd that adapted to these stalks took on a unique form."
+		en: "The stalks of leeks are thicker and longer in the Galar region. Farfetch'd that adapted to these stalks took on a unique form.",
+		de: "Diese besondere Form nahm Porenta an, nachdem es über lange Zeit die dicken, langen Lauchstangen Galars verwendet hatte."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/79.ts
+++ b/data/Sword & Shield/Chilling Reign/79.ts
@@ -76,7 +76,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "After deflecting attacks with its hard leaf shield, it strikes back with its sharp leek stalk. The leek stalk is both weapon and food."
+		en: "After deflecting attacks with its hard leaf shield, it strikes back with its sharp leek stalk. The leek stalk is both weapon and food.",
+		de: "Der Lauch dient ihm als Waffe und zur Abwehr, aber viele essen ihn auch. Mit den harten Blättern pariert es und mit der scharfen Stange kontert es."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/8.ts
+++ b/data/Sword & Shield/Chilling Reign/8.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		es: "Celebi V",
 		it: "Celebi-V",
 		pt: "Celebi V",
-		de: "Celebi-V"
+		de: "Celebi VMAX"
 	},
 
 	abilities: [{
@@ -47,7 +47,7 @@ const card: Card = {
 			es: "Una vez durante tu turno, puedes curar 20 puntos de daño a cada uno de tus Pokémon Grass.",
 			it: "Una sola volta durante il tuo turno, puoi curare ciascuno dei tuoi Pokémon Grass da 20 danni.",
 			pt: "Uma vez durante o seu turno, você poderá curar 20 pontos de dano de cada um dos seus Pokémon Grass.",
-			de: "Einmal während deines Zuges kannst du 20 Schadenspunkte bei jedem deiner Grass-Pokémon heilen."
+			de: "Einmal während deines Zuges kannst du 20 Schadenspunkte bei jedem deiner {G}-Pokémon heilen."
 		}
 	}],
 

--- a/data/Sword & Shield/Chilling Reign/80.ts
+++ b/data/Sword & Shield/Chilling Reign/80.ts
@@ -41,7 +41,7 @@ const card: Card = {
 			es: "Los ataques de este Pokémon cuestan Colorless menos por cada uno de los Pokémon V en juego de tu rival.",
 			it: "Il costo degli attacchi di questo Pokémon è ridotto di Colorless per ogni Pokémon-V in gioco del tuo avversario.",
 			pt: "Os ataques deste Pokémon custam Colorless a menos para cada Pokémon V do seu oponente em jogo.",
-			de: "Die Kosten der Attacken dieses Pokémon verringern sich für jedes Pokémon-V deines Gegners im Spiel um Colorless."
+			de: "Die Kosten der Attacken dieses Pokémon verringern sich für jedes Pokémon-V deines Gegners im Spiel um {C}."
 		}
 	}],
 

--- a/data/Sword & Shield/Chilling Reign/81.ts
+++ b/data/Sword & Shield/Chilling Reign/81.ts
@@ -85,7 +85,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "Sharply attuned to others' wishes for help, this Pokémon seeks out those in need and aids them in battle."
+		en: "Sharply attuned to others' wishes for help, this Pokémon seeks out those in need and aids them in battle.",
+		de: "Es spürt sofort, wenn jemand in Not ist, und eilt ihm unverzüglich zu Hilfe."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/82.ts
+++ b/data/Sword & Shield/Chilling Reign/82.ts
@@ -55,7 +55,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It's said that this Pokémon was formed when an ancient clay tablet was drawn to a vengeful spirit."
+		en: "It's said that this Pokémon was formed when an ancient clay tablet was drawn to a vengeful spirit.",
+		de: "Es heißt, dieses Pokémon sei entstanden, als eine verbitterte Seele Besitz von einer uralten Tontafel ergriff."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/83.ts
+++ b/data/Sword & Shield/Chilling Reign/83.ts
@@ -86,7 +86,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Never touch its shadowlike body, or you'll be shown the horrific memories behind the picture carved into it."
+		en: "Never touch its shadowlike body, or you'll be shown the horrific memories behind the picture carved into it.",
+		de: "Man sollte seinen schattenhaften Körper nicht berühren, sonst zeigt es einem die schauerlichen Erinnerungen, die in sein Bild eingraviert wurden."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/84.ts
+++ b/data/Sword & Shield/Chilling Reign/84.ts
@@ -67,7 +67,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Crabrawler has been known to mistake Exeggutor for a coconut tree and climb it. The enraged Exeggutor shakes it off and stomps it."
+		en: "Crabrawler has been known to mistake Exeggutor for a coconut tree and climb it. The enraged Exeggutor shakes it off and stomps it.",
+		de: "Manchmal hält es ein Kokowei für eine Palme und klettert es hinauf. Dieses schüttelt es dann wütend ab und verpasst ihm einen Tritt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/85.ts
+++ b/data/Sword & Shield/Chilling Reign/85.ts
@@ -76,7 +76,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Before it stops to think, it just starts pummeling. There are records of its turning back avalanches with a flurry of punches."
+		en: "Before it stops to think, it just starts pummeling. There are records of its turning back avalanches with a flurry of punches.",
+		de: "Es denkt nicht lange nach und schlägt einfach zu. Laut manchen Berichten kann es mit seinen schnellen Schlägen selbst Lawinen stoppen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/86.ts
+++ b/data/Sword & Shield/Chilling Reign/86.ts
@@ -55,7 +55,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "When it rubs the rocks on its neck against you, that's proof of its love for you. However, the rocks are sharp, so the gesture is quite painful!"
+		en: "When it rubs the rocks on its neck against you, that's proof of its love for you. However, the rocks are sharp, so the gesture is quite painful!",
+		de: "Reibt es seinen steinernen Fellkragen an einem Trainer, ist das ein Zeichen seiner Zuneigung. Da er jedoch scharf ist, besteht Verletzungsgefahr."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/87.ts
+++ b/data/Sword & Shield/Chilling Reign/87.ts
@@ -64,7 +64,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "They live alone without forming packs. They will only listen to orders from Trainers who can draw out their true power."
+		en: "They live alone without forming packs. They will only listen to orders from Trainers who can draw out their true power.",
+		de: "Diese Pokémon sind Einzelgänger und bilden keine Rudel. Sie gehorchen nur Trainern, die es schaffen, ihnen ihre ganze Kraft zu entlocken."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/88.ts
+++ b/data/Sword & Shield/Chilling Reign/88.ts
@@ -76,7 +76,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Passimian live in groups of about 20, with each member performing an assigned role. Through cooperation, the group survives."
+		en: "Passimian live in groups of about 20, with each member performing an assigned role. Through cooperation, the group survives.",
+		de: "Sie bilden Gruppen von 20 Exemplaren. Durch klare Aufgabenteilung haben sie den Gefahren der Natur getrotzt und bis heute überlebt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/9.ts
+++ b/data/Sword & Shield/Chilling Reign/9.ts
@@ -46,7 +46,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "The berries that grow around its belly are like ice pops. Galarian Darumaka absolutely love these berries."
+		en: "The berries that grow around its belly are like ice pops. Galarian Darumaka absolutely love these berries.",
+		de: "Die an Speiseeis erinnernden Beeren, die an seinem Bauch wachsen, sind bei den Flampion Galars ein sehr beliebter Snack."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/91.ts
+++ b/data/Sword & Shield/Chilling Reign/91.ts
@@ -46,7 +46,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Its tentacles tear off easily, but it isn't alarmed when that happens—it knows they'll grow back. It's about as smart as a three-year-old."
+		en: "Its tentacles tear off easily, but it isn't alarmed when that happens—it knows they'll grow back. It's about as smart as a three-year-old.",
+		de: "Sein Verstand ist ungefähr auf dem Level eines dreijährigen Kindes. Es macht ihm nichts aus, dass seine Tentakel oft abreißen, da sie nachwachsen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/92.ts
+++ b/data/Sword & Shield/Chilling Reign/92.ts
@@ -47,7 +47,7 @@ const card: Card = {
 			es: "Mientras este Pokémon esté en el Puesto Activo, el Coste de Retirada del Pokémon Activo de tu rival es de ColorlessColorless más.",
 			it: "Fintanto che questo Pokémon è in posizione attiva, il costo di ritirata del Pokémon attivo del tuo avversario aumenta di Colorless Colorless.",
 			pt: "Enquanto este Pokémon estiver no Campo Ativo, o custo de Recuo do Pokémon Ativo do seu oponente será ColorlessColorless a mais.",
-			de: "Solange dieses Pokémon in der Aktiven Position ist, erhöhen sich die Rückzugskosten des Aktiven Pokémon deines Gegners um ColorlessColorless."
+			de: "Solange dieses Pokémon in der Aktiven Position ist, erhöhen sich die Rückzugskosten des Aktiven Pokémon deines Gegners um {C}{C}."
 		}
 	}],
 
@@ -86,7 +86,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Searching for an opponent to test its skills against, it emerges onto land. Once the battle is over, it returns to the sea."
+		en: "Searching for an opponent to test its skills against, it emerges onto land. Once the battle is over, it returns to the sea.",
+		de: "Um sein Können zu testen, kommt es an Land und begibt sich auf die Suche nach Gegnern. Sind die Kämpfe vorbei, kehrt es ins Meer zurück."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/93.ts
+++ b/data/Sword & Shield/Chilling Reign/93.ts
@@ -66,7 +66,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "If Kubfu pulls the long white hair on its head, its fighting spirit heightens and power wells up from the depths of its belly."
+		en: "If Kubfu pulls the long white hair on its head, its fighting spirit heightens and power wells up from the depths of its belly.",
+		de: "Zieht es an dem langen weißen Fell an seinem Hinterkopf, steigert das seinen Kampfgeist und aus seiner Körpermitte steigt Kraft empor."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/94.ts
+++ b/data/Sword & Shield/Chilling Reign/94.ts
@@ -55,7 +55,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It adores polluted air. Some claim that Koffing used to be more plentiful in the Galar region than they are now."
+		en: "It adores polluted air. Some claim that Koffing used to be more plentiful in the Galar region than they are now.",
+		de: "Angeblich waren diese nach verpesteter Luft gierenden Pokémon früher weitaus häufiger in der Galar-Region anzutreffen als heute."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/95.ts
+++ b/data/Sword & Shield/Chilling Reign/95.ts
@@ -45,7 +45,7 @@ const card: Card = {
 			es: "El Pokémon Activo de tu rival pasa a estar Confundido. Une 1 carta de Energía Darkness de tu pila de descartes a este Pokémon.",
 			it: "Il Pokémon attivo del tuo avversario viene confuso. Assegna a questo Pokémon una carta Energia Darkness dalla tua pila degli scarti.",
 			pt: "O Pokémon Ativo do seu oponente agora está Confuso. Ligue 1 carta de Energia Darkness da sua pilha de descarte a este Pokémon.",
-			de: "Das Aktive Pokémon deines Gegners ist jetzt verwirrt. Lege 1 Darkness-Energiekarte aus deinem Ablagestapel an dieses Pokémon an."
+			de: "Das Aktive Pokémon deines Gegners ist jetzt verwirrt. Lege 1 {D}-Energiekarte aus deinem Ablagestapel an dieses Pokémon an."
 		},
 
 		cost: ["Darkness"]
@@ -65,7 +65,7 @@ const card: Card = {
 			es: "Este ataque hace 20 puntos de daño más por cada Energía Darkness unida a todos tus Pokémon.",
 			it: "Questo attacco infligge 20 danni in più per ogni Energia Darkness assegnata ai tuoi Pokémon.",
 			pt: "Este ataque causa 20 pontos de dano a mais para cada Energia Darkness ligada a todos os seus Pokémon.",
-			de: "Diese Attacke fügt für jede an alle deine Pokémon angelegte Darkness-Energie 20 Schadenspunkte mehr zu."
+			de: "Diese Attacke fügt für jede an alle deine Pokémon angelegte {D}-Energie 20 Schadenspunkte mehr zu."
 		},
 
 		damage: "20+",
@@ -84,7 +84,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Very rarely, a sudden mutation can result in two small Koffing twins becoming conjoined as a Weezing."
+		en: "Very rarely, a sudden mutation can result in two small Koffing twins becoming conjoined as a Weezing.",
+		de: "Sehr selten führt eine plötzliche Mutation eines Zwillings-Smogon zu einer Verbindung zu Smogmog."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/96.ts
+++ b/data/Sword & Shield/Chilling Reign/96.ts
@@ -47,7 +47,7 @@ const card: Card = {
 			es: "Cada Energía Darkness Básica unida a tus Pokémon que tengan “Weezing” en su nombre proporciona 2 Energías Darkness. No puedes aplicar más de 1 habilidad Fábrica de Energía a la vez.",
 			it: "Ogni Energia base Darkness assegnata ai tuoi Pokémon con “Weezing” nel nome fornisce Energia Darkness Darkness. Non puoi applicare più di un'abilità Fabbrica di Energia alla volta.",
 			pt: "Cada Energia Darkness básica ligada aos seus Pokémon que tenham “Weezing” em seu nome fornece Energia DarknessDarkness. Você não pode usar mais de 1 Habilidade Fábrica de Energia por vez.",
-			de: "Jede Basis-Darkness-Energie, die an deine Pokémon, bei denen das Wort „Smogmog“ zum Namen gehört, angelegt ist, liefert DarknessDarkness-Energie. Du kannst immer nur jeweils 1 Fähigkeit Energiefabrik einsetzen."
+			de: "Jede Basis-{D}-Energie, die an deine Pokémon, bei denen das Wort „Smogmog“ zum Namen gehört, angelegt ist, liefert {D}{D}-Energie. Du kannst immer nur jeweils 1 Fähigkeit Energiewerk einsetzen."
 		}
 	}],
 
@@ -77,7 +77,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Long ago, during a time when droves of factories fouled the air with pollution, Weezing changed into this form for some reason."
+		en: "Long ago, during a time when droves of factories fouled the air with pollution, Weezing changed into this form for some reason.",
+		de: "Als vor langer Zeit viele Fabriken die Luft mit Industrieabgasen verpesteten, nahm es diese Form aus unbekannten Gründen das erste Mal an."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Chilling Reign/97.ts
+++ b/data/Sword & Shield/Chilling Reign/97.ts
@@ -41,7 +41,7 @@ const card: Card = {
 			es: "Una vez durante tu turno, puedes unir 1 carta de Energía Darkness de tu pila de descartes a este Pokémon. No puedes usar más de 1 habilidad Alas Incendiarias en cada turno.",
 			it: "Una sola volta durante il tuo turno, puoi assegnare a questo Pokémon una carta Energia Darkness dalla tua pila degli scarti. Puoi usare l'abilità Ali Estremafiamma solo una volta per turno.",
 			pt: "Uma vez durante o seu turno, você poderá ligar 1 carta de Energia Darkness da sua pilha de descarte a este Pokémon. Você não pode usar mais de 1 Habilidade Asas de Fogaréu por turno.",
-			de: "Einmal während deines Zuges kannst du 1 Darkness-Energiekarte aus deinem Ablagestapel an dieses Pokémon anlegen. Du kannst immer nur jeweils 1 Fähigkeit Flammende Schattenflügel einsetzen."
+			de: "Einmal während deines Zuges kannst du 1 {D}-Energiekarte aus deinem Ablagestapel an dieses Pokémon anlegen. Du kannst immer nur jeweils 1 Fähigkeit Flammende Schattenflügel einsetzen."
 		}
 	}],
 

--- a/data/Sword & Shield/Chilling Reign/98.ts
+++ b/data/Sword & Shield/Chilling Reign/98.ts
@@ -77,7 +77,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "While chanting strange spells, this Pokémon combines its internal toxins with what it's eaten, creating strange potions."
+		en: "While chanting strange spells, this Pokémon combines its internal toxins with what it's eaten, creating strange potions.",
+		de: "Es murmelt unheimliche Beschwörungen, während es seinen Mageninhalt mit körpereigenen Toxinen mischt, um eine sonderbare Arznei herzustellen."
 	},
 
 	variants: [


### PR DESCRIPTION
## Add missing German translations for swsh6

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
