### PR TITLE
(fix) Remove fr-only stray ability from Groudon (cel25-17)

### DIFF
--- a/data/Sword & Shield/Celebrations/17.ts
+++ b/data/Sword & Shield/Celebrations/17.ts
@@ -21,18 +21,6 @@ const card: Card = {
 	hp: 130,
 	stage: "Basic",
 
-	abilities: [
-		{
-			type: "Poke-POWER",
-			name: {
-				fr: "Rayon Obscur",
-			},
-			effect: {
-				fr: "Une seule fois lors de votre tour, lorsque vous placez Noctali Star de votre main sur votre Banc, vous pouvez choisir 1 carte de la main de votre adversaire sans regarder et la défausser.",
-			},
-		},
-	],
-
 	attacks: [{
 		name: {
 			en: "Magma Volcano",


### PR DESCRIPTION
Groudon (Celebrations 17) prints no ability — it is a Basic Fighting Pokémon with two attacks, Magma Volcano and Massive Rend. Its file nevertheless carries an `abilities` entry with French content only:

```ts
type:      "Poke-POWER"
name.fr:   "Rayon Obscur"
effect.fr: "… lorsque vous placez Noctali Star de votre main sur votre Banc …"
```

OCR of the German print (017/025) reads `BASIS / Groudon / KP 130 / Magmavulkan / Riesiger Riss` and no ability box.

Same defect class as #2136. `npm run validate` passes.