### PR TITLE
Remove the `thirdParty` deepOmit

### DIFF
--- a/server/src/V2/Components/Card.ts
+++ b/server/src/V2/Components/Card.ts
@@ -149,7 +149,7 @@ async function loadCard(lang: SupportedLanguages, id: string): Promise<SDKCard |
 	// console.timeEnd('loading providers')
 	// console.time('remapping card')
 	const res = {
-		...deepOmit(card, 'thirdParty'),
+		...card,
 		pricing: {
 			cardmarket: cardmarket,
 			tcgplayer: tcgplayer

--- a/server/src/V2/Components/Card.ts
+++ b/server/src/V2/Components/Card.ts
@@ -22,7 +22,6 @@ import zhtw from '../../../generated/zh-tw/cards.json'
 import { getCardMarketPrice } from '../../libs/providers/cardmarket'
 import { getTCGPlayerPrice } from '../../libs/providers/tcgplayer'
 import { executeQuery, type Query } from '../../libs/QueryEngine/filter'
-// import { deepOmit } from "../../util";
 
 // any is CompiledCard that is currently not mapped correctly
 const list: Record<`${string | any}${SupportedLanguages | string}`, any> = {}

--- a/server/src/V2/Components/Card.ts
+++ b/server/src/V2/Components/Card.ts
@@ -22,7 +22,7 @@ import zhtw from '../../../generated/zh-tw/cards.json'
 import { getCardMarketPrice } from '../../libs/providers/cardmarket'
 import { getTCGPlayerPrice } from '../../libs/providers/tcgplayer'
 import { executeQuery, type Query } from '../../libs/QueryEngine/filter'
-import { deepOmit } from "../../util";
+// import { deepOmit } from "../../util";
 
 // any is CompiledCard that is currently not mapped correctly
 const list: Record<`${string | any}${SupportedLanguages | string}`, any> = {}


### PR DESCRIPTION
## Changes

Remove the `deepOmit` stripping out thirdParty IDs from card responses. 

## Details 

Only change to this for V2, 
Rework #1993 for V3 
