### PR TITLE
Add missing German translations for pl1

### DIFF
--- a/data/Platinum/Platinum/1.ts
+++ b/data/Platinum/Platinum/1.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Flaaffy",
-		fr: "Lainergie"
+		fr: "Lainergie",
+		de: "Waaty"
 	},
 
 	stage: "Stage2",
@@ -58,7 +59,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 damage plus 30 more damage. If tails, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts plus 30 dégâts supplémentaires. Si c'est pile, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 30 Schadenspunkte plus 30 weitere Schadenspunkte zu. Bei \"Zahl\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 Schadenspunkte plus 30 weitere Schadenspunkte zu. Bei „Zahl“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: "30+",
 

--- a/data/Platinum/Platinum/10.ts
+++ b/data/Platinum/Platinum/10.ts
@@ -32,12 +32,12 @@ const card: Card = {
 			name: {
 				en: "Over Slash",
 				fr: "Sur-trancher",
-				de: "Over Slash"
+				de: "Überschlitzer"
 			},
 			effect: {
 				en: "This attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon).",
 				fr: "Cette attaque inflige 10 dégâts à chacun des Pokémon de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc).",
-				de: "This attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Dieser Angriff fügt jedem Pokémon deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -49,12 +49,12 @@ const card: Card = {
 			name: {
 				en: "Dark Wing Flaps",
 				fr: "Battements d'ailes obscurs",
-				de: "Dark Wing Flaps"
+				de: "Dunkles Flügelschlagen"
 			},
 			effect: {
 				en: "Choose 1 card from your opponent's hand without looking. Look at the card you chose, then have your opponent shuffle that card into his or her deck.",
 				fr: "Choisissez sans regarder 1 carte de la main de votre adversaire. Regardez-la et demandez à votre adversaire de la mélanger à son deck.",
-				de: "Choose 1 card from your opponent's hand without looking. Look at the card you choe, then have your opponent shuffle that card into his or her deck."
+				de: "Wähle 1 Karte von der Hand deines Gegners (ohne sie vorher anzusehen). Schau dir die Karte an, danach mischt dein Gegner sie in sein Deck."
 			},
 			damage: 20,
 
@@ -68,7 +68,7 @@ const card: Card = {
 			name: {
 				en: "Wrack Down",
 				fr: "Réduire en poussière",
-				de: "Wrack Down"
+				de: "Niederschleudern"
 			},
 
 			damage: 60,

--- a/data/Platinum/Platinum/100.ts
+++ b/data/Platinum/Platinum/100.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Super Singe",
 				fr: "Ça sent le roussi!",
-				de: "Super Singe"
+				de: "Super-Versengung"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Burned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Brûlé.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Burned."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verbrannt."
 			},
 			damage: 10,
 
@@ -50,12 +50,12 @@ const card: Card = {
 			name: {
 				en: "Flame Ball",
 				fr: "Boule de feu",
-				de: "Flame Ball"
+				de: "Flammender Ball"
 			},
 			effect: {
 				en: "Move an Energy card attached to Torkoal to 1 of your Benched Pokémon.",
 				fr: "Déplacez une carte Énergie attachée à Charcor sur 1 des Pokémon de votre Banc.",
-				de: "Move an Energy card attached to Torkoal to 1 of your Benched Pokémon."
+				de: "Entferne 1 an Qurtel angelegte Energiekarte und lege sie an 1 Pokémon auf deiner Bank an."
 			},
 			damage: 40,
 
@@ -72,7 +72,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It burns coal inside its shell for energy. It blows out black soot if it is endangered."
+		en: "It burns coal inside its shell for energy. It blows out black soot if it is endangered.",
+		de: "In seinem Panzer verbrennt es Kohle und gewinnt daraus Energie. Bei Gefahr sondert es Ruß ab."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/101.ts
+++ b/data/Platinum/Platinum/101.ts
@@ -31,7 +31,7 @@ const card: Card = {
 			name: {
 				en: "Ram",
 				fr: "Collision",
-				de: "Ram"
+				de: "Ramme"
 			},
 
 			damage: 10,
@@ -45,12 +45,12 @@ const card: Card = {
 			name: {
 				en: "Body Slam",
 				fr: "Plaquage",
-				de: "Body Slam"
+				de: "Bodyslam"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -74,7 +74,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "The shell on its back is made of soil. On a very healthy TURTWIG, the shell should feel moist."
+		en: "The shell on its back is made of soil. On a very healthy TURTWIG, the shell should feel moist.",
+		de: "Der Panzer auf seinem Rücken besteht aus Erdreich. Bei gesunden CHELAST ist der Panzer feucht."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/102.ts
+++ b/data/Platinum/Platinum/102.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Reheat",
 				fr: "Réchauffer",
-				de: "Reheat"
+				de: "Wiedererwärmen"
 			},
 			effect: {
 				en: "Discard up to 2 Energy cards from your hand. For each card you discarded, draw 2 cards.",
 				fr: "Défaussez jusqu'à 2 cartes Énergie de votre main. Pour chaque carte défaussée, piochez 2 cartes.",
-				de: "Discard up to 2 Energy cards from your hand. For each card you discarded, draw 2 cards."
+				de: "Lege bis zu 2 Energiekarten von deiner Hand auf deinen Ablagestapel. Ziehe für jede auf diese Weise auf den Ablagestapel gelegte Karte 2 Karten."
 			},
 
 		},
@@ -46,12 +46,12 @@ const card: Card = {
 			name: {
 				en: "Confuse Ray",
 				fr: "Onde folie",
-				de: "Confuse Ray"
+				de: "Konfustrahl"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Confused."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: 20,
 
@@ -68,7 +68,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It controls balls of fire. As it grows, its six tails split from their tips to make more tails."
+		en: "It controls balls of fire. As it grows, its six tails split from their tips to make more tails.",
+		de: "Es beherrscht Feuerbälle. Während es wächst, teilen sich seine sechs Schweife, um weitere zu bilden."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/103.ts
+++ b/data/Platinum/Platinum/103.ts
@@ -31,7 +31,7 @@ const card: Card = {
 			name: {
 				en: "Ram",
 				fr: "Collision",
-				de: "Ram"
+				de: "Ramme"
 			},
 
 			damage: 10,
@@ -45,12 +45,12 @@ const card: Card = {
 			name: {
 				en: "Poison Sting",
 				fr: "Dard-venin",
-				de: "Poison Sting"
+				de: "Giftstachel"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Empoisonné.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Poisoned."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet."
 			},
 			damage: 20,
 
@@ -67,7 +67,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Often targeted by bird Pokémon, it desperately resists by releasing poison from its tail spikes."
+		en: "Often targeted by bird Pokémon, it desperately resists by releasing poison from its tail spikes.",
+		de: "Es wird oft von Vogel-Pokémon angegriffen, wehrt sich aber mit Gift aus seinen Schwanzspitzen."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/104.ts
+++ b/data/Platinum/Platinum/104.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card. Each player may evolve a Pokémon that he or she just played or evolved during that turn.",
 		fr: "Chaque joueur peut faire évoluer un Pokémon qu'il ou elle a joué ou fait évolué ce tour-ci.",
-		de: "Each player may evolve a Pokémon that he or she just played or evolved during that turn."
+		de: "Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadion-Karte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen. Spieler können Pokémon im gleichen Zug entwickeln, in dem sie diese gespielt oder bereits entwickelt haben."
 	},
 
 	trainerType: "Stadium",

--- a/data/Platinum/Platinum/105.ts
+++ b/data/Platinum/Platinum/105.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Search your deck for a Supporter card, a basic Energy card, and a Trainer card that has Team Galactic's Invention in its name, show them to your opponent, and put them into your hand. Shuffle your deck afterward.",
 		fr: "Vous ne pouvez jouer qu'une seule carte Supporter par tour. Lorsque vous la jouez, placez-la à côté de votre Pokémon Actif. À la fin du tour, défaussez-la.",
-		de: "Search your deck for a Supporter card, a basic Energy card, and a Trainer card that has Team Galactic's Invention in its name, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Durchsuche dein Deck nach 1 Unterstützerkarte, 1 Basis-Energiekarte und 1 Trainerkarte mit Team Galaktiks Erfindung im Namen, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 	},
 
 	trainerType: "Supporter",

--- a/data/Platinum/Platinum/106.ts
+++ b/data/Platinum/Platinum/106.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card. Whenever any player plays any Pokémon from his or her hand to evolve his or her Pokémon, put 2 damage counters on that Pokémon.",
 		fr: "Lorsqu'1 des joueurs joue un Pokémon de sa main pour faire évoluer son Pokémon, placez 2 marqueurs de dégât sur ce Pokémon.",
-		de: "Whenever any player plays any Pokémon from his or her hand to evolve his or her Pokémon, put 2 damage counters on that Pokémon."
+		de: "Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadion-Karte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen. Immer wenn ein Spieler eine Pokémon-Karte von seiner Hand spielt, um eines seiner Pokémon zu entwickeln, lege 2 Schadensmarken auf dieses Pokémon."
 	},
 
 	trainerType: "Stadium",

--- a/data/Platinum/Platinum/107.ts
+++ b/data/Platinum/Platinum/107.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Flip a coin. If heads, search your deck for a Pokémon LV.X that levels up from 1 of your Pokémon, and put it onto that Pokémon. (This counts as leveling up that Pokémon.) Shuffle your deck afterward.",
 		fr: "Lancez une pièce. Si c'est face, choisissez dans votre deck un Pokémon NIV.X qui change de niveau à partir d'1 de vos Pokémon et placez-le sur ce Pokémon. (Vous le faites ainsi passer au niveau supérieur.) Ensuite, mélangez votre deck.",
-		de: "Flip a coin. If heads, search your deck for a Pokémon LV.X that levels up from 1 of your Pokémon, and put it onto that Pokémon. (This counts as leveling up that Pokémon.) Shuffle your deck afterward."
+		de: "Wirf 1 Münze. Bei „Kopf“ durchsuche dein Deck nach einer Pokémon LV.X-Karte, die auf 1 deiner Pokémon gelegt werden kann, und lege sie auf dieses Pokémon. (Dies zählt als Level-Up dieses Pokémon.) Mische dein Deck danach."
 	},
 
 	trainerType: "Item",

--- a/data/Platinum/Platinum/108.ts
+++ b/data/Platinum/Platinum/108.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Flip a coin. If heads, choose 1 of your Pokémon, and remove all Special Conditions and 6 damage counters from that Pokémon (all if there are less than 6).",
 		fr: "Lancez une pièce. Si c'est face, choisissez 1 de vos Pokémon et retirez-lui tous ses États Spéciaux ainsi que 6 marqueurs de dégât (retirez-les lui tous s'il en a moins de 6).",
-		de: "Flip a coin. If heads, choose 1 of your Pokémon, and remove all Special Conditions and 6 damage counters from that Pokémon (all if there are less than 6)."
+		de: "Wirf 1 Münze. Bei „Kopf“ wähle 1 deiner Pokémon und entferne alle Speziellen Zustände und 6 Schadensmarken vom gewählten Pokémon (alle, falls weniger als 6 auf diesem Pokémon liegen)."
 	},
 
 	trainerType: "Item",

--- a/data/Platinum/Platinum/109.ts
+++ b/data/Platinum/Platinum/109.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Look at your opponent's hand, then choose you or your opponent. That player shuffles his or her hand into his or her deck and draws up to 5 cards.",
 		fr: "Vous ne pouvez jouer qu'une seule carte Supporter par tour. Lorsque vous la jouez, placez-la à côté de votre Pokémon Actif. À la fin du tour, défaussez-la.",
-		de: "Look at your opponent's hand, then choose you or your opponent. That player shuffles his or her hand into his or her deck and draws up to 5 cards."
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Schau dir die Handkarten deines Gegners an, dann wähle einen Spieler (dich oder deinen Gegner). Der gewählte Spieler mischt seine Handkarten in sein Deck und zieht bis zu 5 Karten."
 	},
 
 	trainerType: "Supporter",

--- a/data/Platinum/Platinum/11.ts
+++ b/data/Platinum/Platinum/11.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Electrike",
-		fr: "Dynavolt"
+		fr: "Dynavolt",
+		de: "Frizelbliz"
 	},
 
 	stage: "Stage1",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Electric Barrier",
 				fr: "Barrière électrique",
-				de: "Electric Barrier"
+				de: "Elektrobarriere"
 			},
 			effect: {
 				en: "Prevent all damage done to your Benched Pokémon (excluding any Manectric) by attacks.",
 				fr: "Prévenez tous les dégâts infligés par des attaques à vos Pokémon de Banc (Elecsprint exclus).",
-				de: "Prevent all damage done to your Benched Pokémon (excluding any Manectric) by attacks."
+				de: "Verhindere allen Schaden, der Pokémon auf deiner Bank (außer allen Voltenso) durch Angriffe zugefügt wird."
 			}
 		},
 	],
@@ -52,12 +53,12 @@ const card: Card = {
 			name: {
 				en: "Power Wave",
 				fr: "Vague puissante",
-				de: "Power Wave"
+				de: "Stromwelle"
 			},
 			effect: {
 				en: "This attack does 30 damage to each Pokémon that has any Poké-Powers (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige 30 dégâts à chaque Pokémon possédant des Poké-Powers (les vôtres et ceux de votre adversaire). (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "This attack does 30 damage to each Pokémon that has any Poké-Powers (both yours and your opponent's). (Don't aply Weakness and Resistance for Benched Pokémon.)"
+				de: "Dieser Angriff fügt jedem Pokémon (deinen und denen deines Gegners), das mindestens 1 Poké-Power hat, 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -69,12 +70,12 @@ const card: Card = {
 			name: {
 				en: "Attract Current",
 				fr: "Courant électrique",
-				de: "Attract Current"
+				de: "Stromanziehung"
 			},
 			effect: {
 				en: "Search your deck for a Lightning Energy card and attach it to 1 of your Pokémon. Shuffle your deck afterward.",
 				fr: "Cherchez dans votre deck une carte Énergie Lightning et attachez-la à 1 de vos Pokémon. Ensuite, mélangez votre deck.",
-				de: "Search your deck for a  Energy card and attach it to your Pokémon. Shuffe your deck afterward."
+				de: "Durchsuche dein Deck nach 1 {L}-Energiekarte und lege sie an 1 deiner Pokémon an. Mische dein Deck danach."
 			},
 			damage: 40,
 

--- a/data/Platinum/Platinum/110.ts
+++ b/data/Platinum/Platinum/110.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Attach Memory Berry to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card. The Pokémon this card is attached to can use any attack from its Basic Pokémon or its Stage 1 Evolution card. (You still have to pay for that attack's Energy cost.)",
 		fr: "Attachez Baie de mémoire à 1 de vos Pokémon qui ne possède pas déjà d'Outil Pokémon. Si ce Pokémon est mis K.O, défaussez-la.",
-		de: "The Pokémon this card is attached to can use any attack from its Basic Pokémon or its Stage 1 Evolution card. (You still have to pay for that attack's Energy cost.)"
+		de: "Lege Erinnerungsbeere an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn dieses Pokémon kampfunfähig wird, lege Erinnerungsbeere auf den Ablagestapel. Das Pokémon, an dem diese Karte angelegt ist, kann jeden Angriff seiner Basis- oder Phase 1-Pokémon-Karten verwenden. (Du musst die Energiekosten für diesen Angriff trotzdem bezahlen.)"
 	},
 
 	trainerType: "Tool",

--- a/data/Platinum/Platinum/111.ts
+++ b/data/Platinum/Platinum/111.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card. Whenever any player puts a Basic Pokémon (excluding Grass or Psychic Pokémon) from his or her hand onto his or her Bench, put 2 damage counters on that Pokémon.",
 		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez-la si une autre carte Stade est mise en jeu. Si une autre carte comportant le même nom est en jeu, vous ne pouvez pas jouer cette carte.",
-		de: "Whenever any player puts a Basic Pokémon (excluding  or  Pokémon) from his or her hand onto his or her Bench, put 2 damage counters on that Pokémon."
+		de: "Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadion-Karte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen. Immer wenn ein Spieler ein Basis-Pokémon (außer {G}- oder {P}-Pokémon) von seiner Hand auf seine Bank legt, lege 2 Schadensmarken auf dieses Pokémon."
 	},
 
 	trainerType: "Stadium",

--- a/data/Platinum/Platinum/112.ts
+++ b/data/Platinum/Platinum/112.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Attach PlusPower to 1 of your Pokémon. Discard this card at the end of your turn. If the Pokémon PlusPower is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance).",
 		fr: "Attachez PlusPower à 1 de vos Pokémon. Défaussez cette carte à la fin de votre tour.\n\nSi le Pokémon auquel PlusPower est attachée attaque, cette attaque inflige 10 dégâts supplémentaires au Pokémon Actif (avant application de la Faiblesse et de la Résistance).",
-		de: "Attach PlusPower to 1 of your Pokémon. Discard this card at the end of your turn.\n\nIf the Pokémon PlusPower is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance)."
+		de: "Lege PlusPower an 1 deiner Pokémon an und lege die Karte am Ende deines Zuges auf deinen Ablagestapel. Falls das Pokémon, an das PlusPower angelegt ist, angreift, fügt der Angriff den Aktiven Pokémon 10 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 	},
 
 	trainerType: "Item",

--- a/data/Platinum/Platinum/113.ts
+++ b/data/Platinum/Platinum/113.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Flip a coin. If heads, search your deck for a Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
 		fr: "Lancez une pièce. Si c'est face, choisissez un Pokémon dans votre deck, montrez-le à votre adversaire et placez-le dans votre main. Ensuite, mélangez votre deck.",
-		de: "Flip a coin. If heads, search your deck for a Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
+		de: "Wirf 1 Münze. Bei „Kopf“ durchsuche dein Deck nach 1 Pokémon-Karte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 	},
 
 	trainerType: "Item",

--- a/data/Platinum/Platinum/114.ts
+++ b/data/Platinum/Platinum/114.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Look at the top 2 cards of your deck, choose 1 of them, and put it into your hand. Put the other card on the bottom of your deck.",
 		fr: "Regardez les 2 cartes du dessus de votre deck, choisissez-en 1 et placez-la dans votre main. Replacez l'autre carte au dessous de votre deck.",
-		de: "Look at the top 2 cards of your deck, choose 1 of them, and put it into your hand. Put the other card on the bottom of your deck."
+		de: "Schau dir die obersten 2 Karten deines Decks an, wähle 1 davon und nimm sie auf die Hand. Lege die andere Karte unter dein Deck."
 	},
 
 	trainerType: "Item",

--- a/data/Platinum/Platinum/115.ts
+++ b/data/Platinum/Platinum/115.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Search your discard pile for a Pokémon, show it to your opponent, and put it into your hand.",
 		fr: "Choisissez un Pokémon dans votre pile de défausse, montrez-le à votre adversaire et placez-le dans votre main.",
-		de: "Search your discard pile for a Pokémon, show it to your opponent, and put it into your hand."
+		de: "Durchsuche deinen Ablagestapel nach 1 Pokémon-Karte, zeige sie deinem Gegner und nimm sie auf die Hand."
 	},
 
 	trainerType: "Item",

--- a/data/Platinum/Platinum/116.ts
+++ b/data/Platinum/Platinum/116.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Attach Team Galactic's Invention G-101 Energy Gain to 1 of your Pokémon SP that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card. When the Pokémon this card is attached to is no longer a Pokémon SP, discard this card. As long as Team Galactic's Invention G-101 Energy Gain is attached to a Pokémon, the attack cost of that Pokémon's attacks is Colorless less.",
 		fr: "Attachez Invention G-101 Gain d'Énergie de Team Galaxie à 1 de vos Pokémon SP qui ne possède pas déjà d'Outil Pokémon. Si ce Pokémon est mis K.O, défaussez-la. Lorsque le Pokémon auquel cette carte est attachée n'est plus un Pokémon SP, défaussez-la.",
-		de: "Attach Team Galactic's Invention G-101 Energy Gain to 1 of your Pokémon SP that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card. When the Pokémon this card is attached to is no longer a Pokémon SP, discard this card.\n\nAs long as Team Galactic's Invention G-101 Energy Gain is attached to a Pokémon, the attack cost of that Pokémon's attacks is  less."
+		de: "Lege Team Galaktiks Erfindung G-101 Energiegewinn an 1 deiner Pokémon SP an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn dieses Pokémon kampfunfähig wird, lege diese Karte auf den Ablagestapel. Wenn das Pokémon, an das diese Karte angelegt ist, kein Pokémon SP mehr ist, lege diese Karte auf den Ablagestapel. Solange Team Galaktiks Erfindung G-101 Energiegewinn an 1 Pokémon angelegt ist, kosten die Angriffe dieses Pokémon 1 {C} weniger."
 	},
 
 	trainerType: "Tool",

--- a/data/Platinum/Platinum/117.ts
+++ b/data/Platinum/Platinum/117.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "You may play this card during your opponent's turn when your opponent's Pokémon uses any Poké-Power. Prevent all effects of that Poké-Power. (This counts as that Pokémon using its Poké-Power.) If you have 2 or less Pokémon SP in play, you can't play this card.",
 		fr: "Vous pouvez jouer cette carte lors du tour de votre adversaire lorsque le Pokémon de votre adversaire utilise un Poké-Power. Prévenez tous les effets de ce Poké-Power. (Cela compte comme si ce Pokémon utilisait son Poké-Power.) Si vous avez un maximum de 2 Pokémon SP en jeu, vous ne pouvez pas jouer cette carte.",
-		de: "You may play this card during your opponent's next turn when your opponent's Pokémon uses any Poké-Power: Prevent all effects of that Poké-Power. (This counts as that Pokémon using its Poké-Power). If you have 2 or less Pokémon SP in play, you can't play this card."
+		de: "Du kannst diese Karte im Zug deines Gegners spielen, wenn 1 Pokémon deines Gegners eine Poké-Power benutzt. Verhindere alle Effekte dieser Poké-Power. (Die Poké-Power gilt dennoch als benutzt.) Du kannst diese Karte nicht spielen, wenn du weniger als 3 Pokémon SP im Spiel hast."
 	},
 
 	trainerType: "Item",

--- a/data/Platinum/Platinum/118.ts
+++ b/data/Platinum/Platinum/118.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Return 1 of your Pokémon SP and all cards attached to it to your hand.",
 		fr: "Reprenez dans votre main 1 de vos Pokémon SP ainsi que toutes les cartes qui lui sont attachées.",
-		de: "Return 1 of your Pokémon SP and all cards attached to it to your hand."
+		de: "Nimm 1 deiner Pokémon SP und alle an es angelegten Karten auf deine Hand zurück."
 	},
 
 	trainerType: "Item",

--- a/data/Platinum/Platinum/119.ts
+++ b/data/Platinum/Platinum/119.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "Play Armor Fossil as if it were a Colorless Basic Pokémon. (Armor Fossil counts as a Trainer card as well, but if Armor Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Armor Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Armor Fossil from play. (This doesn't count as a Knocked Out Pokémon.)",
 		fr: "Jouez Fossile armure comme si c'était un Pokémon de base Colorless. (Fossile armure compte aussi comme une carte Dresseur mais si Fossile armure est mise K.O, elle compte comme un Pokémon K.O). Fossile armure ne peut pas être affectée par des États Spéciaux et ne peut pas battre en retraite. N'importe quand lors de votre tour, avant votre attaque, vous pouvez défausser Fossile armure. (Cela ne compte pas comme un Pokémon K.O.)",
-		de: "Play Armor Fossil as if it were a  Basic Pokémon. (Armor Fossil counts as a Trainer card as well, but if Armor Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Armor Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Armor Fossil from play. (This doesn't count as a Knocked Out Pokémon.)"
+		de: "Spiele Panzerfossil wie ein {C}-Basis-Pokémon. (Panzerfossil zählt gleichzeitig als Trainerkarte, aber wenn Panzerfossil kampfunfähig wird, zählt es als kampfunfähig gemachtes Pokémon.) Panzerfossil kann nicht von Speziellen Zuständen betroffen werden und sich nicht zurückziehen. In deinem Zug (vor deinem Angriff) kannst du Panzerfossil auf deinen Ablagestapel legen. (Dies zählt nicht als kampfunfähig gemachtes Pokémon.)"
 	},
 
 	abilities: [
@@ -25,11 +25,11 @@ const card: Card = {
 			type: "Poke-BODY",
 			name: {
 				en: "Armor Stone",
-				de: "Armor Stone"
+				de: "Panzerungsstein"
 			},
 			effect: {
 				en: "Whenever Armor Fossil would be damaged by your opponent's attack, flip a coin until you get tails. For each heads, reduce that damage by 10.",
-				de: "Whenever Armor Fossil would be damaged by your opponent's attack, flip a coin until you get tails. For each heads, reduce that damage by 10."
+				de: "Wenn Panzerfossil durch einen gegnerischen Angriff Schaden zugefügt würde, wirf 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Reduziere den Schaden dieses Angriffs um 10 Schadenspunkte mal der Anzahl „Kopf“."
 			}
 		},
 	],

--- a/data/Platinum/Platinum/12.ts
+++ b/data/Platinum/Platinum/12.ts
@@ -33,12 +33,12 @@ const card: Card = {
 			name: {
 				en: "Splashing Turn",
 				fr: "Tour éclaboussant",
-				de: "Splashing Turn"
+				de: "Platschende Drehung"
 			},
 			effect: {
 				en: "You may switch Palkia G with 1 of your Benched Pokémon.",
 				fr: "Vous pouvez échanger Palkia  avec 1 de vos Pokémon de Banc.",
-				de: "You may switch Palkia G with 1 of your Benched Pokémon."
+				de: "Du kannst Palkia G gegen 1 Pokémon auf deiner Bank austauschen."
 			},
 			damage: 20,
 
@@ -52,12 +52,12 @@ const card: Card = {
 			name: {
 				en: "Pearl Breath",
 				fr: "Haleine de perle",
-				de: "Pearl Breath"
+				de: "Perlhauch"
 			},
 			effect: {
 				en: "Does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à chacun des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc).",
-				de: "Does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Dieser Angriff fügt jedem Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 50,
 

--- a/data/Platinum/Platinum/120.ts
+++ b/data/Platinum/Platinum/120.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "Play Skull Fossil as if it were a Colorless Basic Pokémon. (Skull Fossil counts as a Trainer card as well, but if Skull Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Skull Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Skull Fossil from play. (This doesn't count as a Knocked Out Pokémon.)",
 		fr: "Jouez Fossile crâne comme si c'était un Pokémon de base Colorless. (Fossile crâne compte aussi comme une carte Dresseur mais si Fossile crâne est mise K.O, elle compte comme un Pokémon K.O). Fossile crâne ne peut pas être affectée par des États Spéciaux et ne peut pas battre en retraite. N'importe quand lors de votre tour, avant votre attaque, vous pouvez défausser Fossile crâne. (Cela ne compte pas comme un Pokémon K.O.)",
-		de: "Play Skull Fossil as if it were a  Basic Pokémon. (Skull Fossil counts as a Trainer card as well, but if Skull Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Skull Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Skull Fossil from play. (This doesn't count as a Knocked Out Pokémon.)"
+		de: "Spiele Kopffossil wie ein {C}-Basis-Pokémon. (Kopffossil zählt gleichzeitig als Trainerkarte, aber wenn Kopffossil kampfunfähig wird, zählt es als kampfunfähig gemachtes Pokémon.) Kopffossil kann nicht von Speziellen Zuständen betroffen werden und sich nicht zurückziehen. In deinem Zug (vor deinem Angriff) kannst du Kopffossil auf deinen Ablagestapel legen. (Dies zählt nicht als kampfunfähig gemachtes Pokémon.)"
 	},
 
 	abilities: [
@@ -25,11 +25,11 @@ const card: Card = {
 			type: "Poke-BODY",
 			name: {
 				en: "Skull Stone",
-				de: "Skull Stone"
+				de: "Schädelstein"
 			},
 			effect: {
 				en: "During your opponent's turn, if Skull Fossil would be Knocked Out by damage from an opponent's attack, flip a coin until you get tails. For each heads, put 1 damage counter on the Attacking Pokémon.",
-				de: "During your opponent's turn, if Skull Fossil would be Knocked Out by damage from an opponent's attack, flip a coin until you get tails. For each heads, put 1 damage counter on the Attacking Pokémon."
+				de: "Wenn Kopffossil im Zug deines Gegners durch Schaden eines Angriffs deines Gegners kampfunfähig würde, wirf 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Lege für jedes Mal, wenn die Münze „Kopf“ gezeigt hat, 1 Schadensmarke auf das Angreifende Pokémon."
 			}
 		},
 	],

--- a/data/Platinum/Platinum/121.ts
+++ b/data/Platinum/Platinum/121.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Attach Rainbow Energy to 1 of your Pokémon. While in play, Rainbow Energy provides every type of Energy but provides only 1 Energy at a time. (Has no effect other than providing Energy.) When you attach this card from your hand to 1 of your Pokémon, put 1 damage counter on that Pokémon.",
 		fr: "Attachez Énergie multicolore à 1 de vos Pokémon. Lorsqu'elle est en jeu, Énergie multicolore fournit tous les types d'Énergie mais seulement 1 Énergie à la fois. (Elle n'a pas d'autre effet que de fournir de l'Énergie.) Lorsque vous attachez cette carte de votre main à 1 de vos Pokémon, placez 1 marqueur de dégât sur ce Pokémon.",
-		de: "Attach Rainbow Energy to 1 of your Pokémon. While in play, Rainbow Energy provides every type of Energy but provides only 1 Energy at a time. (Has no effect other than providing Energy.) When you attach this card from your hand to 1 of your Pokémon, put 1 damage counter on that Pokémon."
+		de: "Lege Regenbogen-Energie an 1 deiner Pokémon an. Solange Regenbogen-Energie im Spiel ist, zählt sie als jeder beliebige Basis-Energietyp, spendet aber immer nur eine Energie auf einmal. (Sie hat keinen Effekt, außer dass sie Energie spendet.) Wenn du diese Karte aus deiner Hand an 1 deiner Pokémon anlegst, lege 1 Schadensmarke auf dieses Pokémon."
 	},
 
 	energyType: "Special",

--- a/data/Platinum/Platinum/122.ts
+++ b/data/Platinum/Platinum/122.ts
@@ -30,12 +30,12 @@ const card: Card = {
 			name: {
 				en: "Time Crystal",
 				fr: "Crystal temporel",
-				de: "Time Crystal"
+				de: "Zeitkristall"
 			},
 			effect: {
 				en: "Each Pokémon (both yours and your opponent's) (excluding Pokémon SP) can't use any Poké-Bodies.",
 				fr: "Chaque Pokémon (les vôtres et ceux de votre adversaire) (Pokémon SP exclus) ne peut pas utiliser de Poké-Bodies.",
-				de: "Each Pokémon (both yours and your opponent's) (excluding Pokémon SP) can't use any Poké-Bodies."
+				de: "Pokémon (deine und die deines Gegners) (außer Pokémon SP) können keine Poké-Body benutzen."
 			}
 		},
 	],
@@ -51,12 +51,12 @@ const card: Card = {
 			name: {
 				en: "Remove Lost",
 				fr: "Retire-perte",
-				de: "Remove Lost"
+				de: "Nirgendwo-Absauger"
 			},
 			effect: {
 				en: "Flip a coin until you get tails. For each heads, remove an Energy card attached to the Defending Pokémon and put it in the Lost Zone.",
 				fr: "Lancez une pièce jusqu'à ce que vous obteniez pile. Pour chaque face, retirez au Pokémon Défenseur une carte Énergie et placez-la dans la Zone Perdue.",
-				de: "Flip a coin until you get tails. For each heads, remove an Energy card attached to the Defending Pokémon and put it in the Lost Zone."
+				de: "Wirf so lange 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Entferne pro „Kopf“ 1 Energiekarte vom Verteidigenden Pokémon und lege sie ins Nirgendwo."
 			},
 			damage: 80,
 

--- a/data/Platinum/Platinum/123.ts
+++ b/data/Platinum/Platinum/123.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Tri-Poison",
 				fr: "Tri-poison",
-				de: "Tri-Poison"
+				de: "Dreigift"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may flip a coin. If heads, choose 1 of the Defending Pokémon. That Pokémon is now Poisoned. Put 3 damage counters instead of 1 on that Pokémon between turns. This power can't be used if Drapion is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez lancer une pièce. Si c'est face, choisissez 1 des Pokémon Défenseurs. Il est maintenant Empoisonné. Placez 3 marqueurs de dégât au lieu d'1 sur ce Pokémon entre deux tours. Ce pouvoir ne peut pas être utilisé si Drascore est affecté par un État Spécial.",
-				de: "Once during your turn (before your attack), you may flip a coin. If heads, choose 1 of the Defending Pokémon. That Pokémon is now Poisoned. Put 3 damage counters instead of 1 on that Pokémon between turns. This power can't be used if Drapion if affected by a Special Condition."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 Münze werfen. Bei „Kopf“ wähle 1 Verteidigendes Pokémon. Das gewählte Pokémon ist jetzt vergiftet. Lege zwischen den Zügen 3 Schadensmarken anstelle von 1 Schadensmarke auf das gewählte Pokémon. Diese Poké-Power kann nicht benutzt werden, wenn Piondragi von einem Speziellen Zustand betroffen ist."
 			}
 		},
 	],
@@ -50,12 +50,12 @@ const card: Card = {
 			name: {
 				en: "Sniping Tail",
 				fr: "Queue-sniper",
-				de: "Sniping Tail"
+				de: "Sniper-Schwanz"
 			},
 			effect: {
 				en: "Does 40 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) The Defending Pokémon can't retreat during your opponent's next turn.",
 				fr: "Inflige 40 dégâts à 1 des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.) Le Pokémon Défenseur ne peut pas battre en retraite lors du prochain tour de votre adversaire.",
-				de: "Does 40 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) The Defending Pokémon can't retreat during your opponent's next turn."
+				de: "Dieser Angriff fügt 1 Pokémon auf der Bank deines Gegners 40 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.) Das Verteidigende Pokémon kann sich im nächsten Zug deines Gegners nicht zurückziehen."
 			},
 			damage: 40,
 

--- a/data/Platinum/Platinum/124.ts
+++ b/data/Platinum/Platinum/124.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Invisible Tentacles",
 				fr: "Tentacules invisibles",
-				de: "Invisible Tentacles"
+				de: "Unsichtbare Tentakel"
 			},
 			effect: {
 				en: "Whenever your opponent's Pokémon tries to attack, your opponent discards 1 card from his or her hand. (If your opponent can't discard 1 card, your opponent's Pokémon can't attack.) You can't use more than 1 Invisible Tentacles Poké-Body each turn.",
 				fr: "Lorsqu'1 des Pokémon de votre adversaire essaye d'attaquer, votre adversaire défausse 1 carte de sa main. ( Si votre adversaire ne peut pas défausser de carte, le Pokémon de votre adversaire ne peut pas attaquer.) Vous ne pouvez pas utiliser plus d'1 Poké-Body Tentacules invisibles par tour.",
-				de: "Whenever your opponent's Pokémon tries to attack, your opponent discards 1 card from his or her hand. (If your opponent can't discard 1 card, your opponent's Pokémon can't attack.) You can't use more than 1 Invisible Tentacles Poké-Body each turn."
+				de: "Immer wenn ein gegnerisches Pokémon angreift, legt dein Gegner 1 Karte von seiner Hand auf seinen Ablagestapel. (Wenn dein Gegner keine Karte von seiner Hand auf seinen Ablagestapel legen kann, kann keines seiner Pokémon angreifen.) Du kannst nicht mehr als 1 Unsichtbare Tentakel Poké-Body pro Zug benutzen."
 			}
 		},
 	],
@@ -50,12 +50,12 @@ const card: Card = {
 			name: {
 				en: "Darkness Lost",
 				fr: "Obscurité perdue",
-				de: "Darkness Lost"
+				de: "Finsteres Nirgendwo"
 			},
 			effect: {
 				en: "This attack does 30 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) If any of your opponent's Pokémon would be Knocked Out by damage from this attack, put that Pokémon and all cards attached to it in the Lost Zone instead of discarding it.",
 				fr: "Cette attaque inflige 30 dégâts à chacun des Pokémon de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.) Si les dégâts de cette attaque mettent K.O 1 des Pokémon de votre adversaire, placez ce Pokémon ainsi que toutes les cartes qui lui sont attachées dans la Zone Perdue au lieu de les défausser.",
-				de: "This attack does 30 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) If any of your opponent's Pokémon would be Knocked Out by damage from this attack, put that Pokémon and all cards attached to it in the Lost Zone instead of discarding it."
+				de: "Dieser Angriff fügt allen Pokémon deines Gegners 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.) Wenn ein Pokémon deines Gegners durch diesen Angriff kampfunfähig würde, lege dieses Pokémon und alle Karten, die an es angelegt sind, nicht auf den Ablagestapel, sondern ins Nirgendwo."
 			},
 
 		},

--- a/data/Platinum/Platinum/125.ts
+++ b/data/Platinum/Platinum/125.ts
@@ -30,12 +30,12 @@ const card: Card = {
 			name: {
 				en: "Lost Cyclone",
 				fr: "Cyclone perdu",
-				de: "Lost Cyclone"
+				de: "Nirgendwo-Zyklon"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may use this power. Any player who has 4 or more Benched Pokémon chooses 3 of his or her Benched Pokémon. Put the other Benched Pokémon and all cards attached to them in the Lost Zone. (You choose your Pokémon first.) This power can't be used it Palkia G is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez utiliser ce pouvoir. Les joueurs possédant au moins 4 Pokémon de Banc choisissent 3 de leur Pokémon de Banc. Placez les autres Pokémon de Banc ainsi que toutes les cartes qui leur sont attachées dans la Zone Perdue. (Vous choisissez vos Pokémon en premier.) Ce pouvoir ne peut pas être utilisé si Palkia  est affecté par un État Spécial.",
-				de: "Once during your turn (before your attack), you may use this power. Any player who has 4 or more Benched Pokémon chooses 3 of his or her Benched Pokémon. Put the other Benched Pokémon and all cards attached to them in the Lost Zone. (You choose your Pokémon first.) This power can't be used if Palkia G is affected by a Special Condition."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du diese Poké-Power benutzen. Jeder Spieler, der 4 oder mehr Pokémon auf seiner Bank hat, wählt 3 Pokémon auf seiner Bank und legt alle anderen Pokémon von seiner Bank und alle Karten, die an sie angelegt sind, ins Nirgendwo. (Du wählst deine Pokémon zuerst.) Diese Poké-Power kann nicht benutzt werden, wenn Palkia G von einem Speziellen Zustand betroffen ist."
 			}
 		},
 	],
@@ -51,12 +51,12 @@ const card: Card = {
 			name: {
 				en: "Hydro Shot",
 				fr: "Hydro-coup",
-				de: "Hydro Shot"
+				de: "Hydroschuss"
 			},
 			effect: {
 				en: "Discard 2 Energy attached to Palkia G. Choose 1 of your opponent's Pokémon. This attack does 80 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Défaussez 2 Énergies attachées à Palkia . Choisissez 1 des Pokémon de votre adversaire. Cette attaque lui inflige 80 dégâts. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Discard 2 Energy attached to Palkia G. Choose 1 of your opponent's Pokémon. This attack does 80 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Lege 2 an Palkia G angelegte Energien auf deinen Ablagestapel. Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 80 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},

--- a/data/Platinum/Platinum/126.ts
+++ b/data/Platinum/Platinum/126.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Thankfulness",
 				fr: "Gratitude",
-				de: "Thankfulness"
+				de: "Dankbarkeit"
 			},
 			effect: {
 				en: "Each of your Grass Pokémon (excluding any Shaymin) gets +40 HP. You can't use more than 1 Thankfulness Poké-Body each turn.",
 				fr: "Chacun de vos Pokémon Grass (les Shaymin exclus) obtient 40 PV supplémentaires. Vous ne pouvez pas utiliser plus d'1 Poké-Body Gratitude par tour.",
-				de: "Each of your  Pokémon (excluding Shaymin) gets +40 HP. You can't use more than 1 Thankfulness Poké-Body each turn."
+				de: "Jedes deiner {G}-Pokémon (außer allen Shaymin) erhält +40 KP. Du kannst nicht mehr als 1 Dankbarkeit Poké-Body pro Zug benutzen."
 			}
 		},
 	],
@@ -49,12 +49,12 @@ const card: Card = {
 			name: {
 				en: "Seed Flare",
 				fr: "Fulmigraine",
-				de: "Seed Flare"
+				de: "Schocksamen"
 			},
 			effect: {
 				en: "Choose as many Grass Energy cards from your hand as you like and attach them to your Pokémon in any way you like. If you do, this attack does 40 damage plus 20 more damage for each Grass Energy attached in this way.",
 				fr: "Choisissez autant de cartes Énergie Grass de votre main que vous voulez et attachez-les à vos Pokémon de la façon que vous voulez. Cette attaque inflige alors 40 dégâts plus 20 dégâts supplémentaires pour chaque carte Énergie Grass attachée de cette façon.",
-				de: "Choose as many  Energy cards from your hand as you like and attach them to your Pokémon in any way you like. If you do, this attack does 40 damage plus 20 more damage for each  Energy attached in this way."
+				de: "Wähle beliebig viele {G}-Energiekarten von deiner Hand und lege sie in beliebiger Verteilung an deine Pokémon an. Wenn du das machst, fügt dieser Angriff 40 Schadenspunkte plus 20 weitere Schadenspunkte für jede auf diese Weise angelegte {G}-Energie zu."
 			},
 			damage: "40+",
 

--- a/data/Platinum/Platinum/127.ts
+++ b/data/Platinum/Platinum/127.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Revenge Seed",
 				fr: "Graine vengeresse",
-				de: "Revenge Seed"
+				de: "Vergeltungssamen"
 			},
 			effect: {
 				en: "If any of your Grass Pokémon were Knocked Out by damage from an opponent's attack during his or her last turn, each of Shaymin's attacks does 60 more damage to the Active Pokémon (before applying Weakness and Resistance).",
 				fr: "Si les dégâts d'une attaque de votre adversaire a mis K.O 1 de vos Pokémon Grass lors de son tour précédent, chacune des attaques de Shaymin inflige 60 dégâts supplémentaires au Pokémon Actif (avant application de la Faiblesse et de la Résistance).",
-				de: "If any of your  Pokémon were Knocked Out by damage from an opponent's attack during his or her last turn, each of Shaymin's attacks does 60 more damage to the Active Pokémon (before applying Weakness and Resistance)."
+				de: "Wenn im letzten Zug deines Gegners mindestens 1 deiner {G}-Pokémon durch Schaden eines gegnerischen Angriffs kampfunfähig gemacht wurde, fügen Shaymins Angriffe den Aktiven Pokémon 60 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 			}
 		},
 	],
@@ -48,12 +48,12 @@ const card: Card = {
 			name: {
 				en: "Energy Flare",
 				fr: "Énergie éclatante",
-				de: "Energy Flare"
+				de: "Energiefackel"
 			},
 			effect: {
 				en: "You may move any number of Energy cards attached to your Pokémon to your other Pokémon in any way you like.",
 				fr: "Vous pouvez déplacer autant de cartes Énergie attachées à vos Pokémon que vous voulez sur vos autres Pokémon de la façon que vous voulez.",
-				de: "You may move any number of Energy cards attached to your Pokémon to your other Pokémon in any way you like."
+				de: "Du kannst beliebig viele Energiekarten, die an deinen Pokémon angelegt sind, in beliebiger Verteilung an deine anderen Pokémon anlegen."
 			},
 			damage: 50,
 

--- a/data/Platinum/Platinum/128.ts
+++ b/data/Platinum/Platinum/128.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Thundershock",
 				fr: "Éclair",
-				de: "Thundershock"
+				de: "Donnerschock"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
+				de: "Wirf eine Münze. Bei „Kopf“ ist das verteidigende Pokémon gelähmt."
 			},
 			damage: 10,
 
@@ -49,12 +49,12 @@ const card: Card = {
 			name: {
 				en: "Thunderpunch",
 				fr: "Poing-Éclair",
-				de: "Thunderpunch"
+				de: "Donnerschlag"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 damage plus 10 more damage. If tails, Electabuzz does 10 damage to itself.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts plus 10 dégâts supplémentaires. Si c'est pile, Elektek s'inflige 10 dégâts.",
-				de: "Flip a coin. If heads, this attack does 30 damage plus 10 more damage. If tails, Electabuzz does 10 damage to itself."
+				de: "Wirf eine Münze. Bei „Kopf“ fügt dieser Angriff 30 Schadenspunkte plus 10 weitere Schadenspunkte zu; bei „Zahl“ fügt dieser Angriff 30 Schadenspunkte zu, und Elektek fügt sich selbst 10 Schadenspunkte zu."
 			},
 			damage: "30+",
 
@@ -71,7 +71,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It loves to feed on strong electricity. It occasionally appears around large power plants and so on."
+		en: "It loves to feed on strong electricity. It occasionally appears around large power plants and so on.",
+		de: "Es konsumiert am liebsten Elektrizität. Gelegentlich sieht man es in der Nähe von Kraftwerken."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/129.ts
+++ b/data/Platinum/Platinum/129.ts
@@ -31,7 +31,7 @@ const card: Card = {
 			name: {
 				en: "Jab",
 				fr: "Taquet",
-				de: "Jab"
+				de: "Boxschlag"
 			},
 
 			damage: 20,
@@ -46,7 +46,7 @@ const card: Card = {
 			name: {
 				en: "Special Punch",
 				fr: "Punch spécial",
-				de: "Special Punch"
+				de: "Spezialschlag"
 			},
 
 			damage: 40,
@@ -64,7 +64,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "The spirit of a pro boxer has infused this POKéMON. It throws punches that are faster than a bullet train."
+		en: "The spirit of a pro boxer has infused this POKéMON. It throws punches that are faster than a bullet train.",
+		de: "Der Geist eines Profi-Boxers hat dieses POKéMON inspiriert. Seine Faustschläge sind schneller als ein Hochgeschwindigkeitszug."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/13.ts
+++ b/data/Platinum/Platinum/13.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Cranidos",
-		fr: "Kranidos"
+		fr: "Kranidos",
+		de: "Koknodon"
 	},
 
 	stage: "Stage2",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Iron Skull",
 				fr: "Crâne de fer",
-				de: "Iron Skull"
+				de: "Metallschädel"
 			},
 			effect: {
 				en: "Rampardos's attack's damage isn't affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon.",
 				fr: "Les dégâts de l'attaque de Charkos ne sont pas affectés par la Résistance, les Poké-Powers, les Poké-Bodies ou tout autre effet sur le Pokémon Défenseur.",
-				de: "Rampardos's attack's damage isn't affected by Resistance, Poké-Powers, Poké-Bodies, or any other effects on the Defending Pokémon."
+				de: "Resistenz, Poké-Power, Poké-Body und alle anderen Effekte auf dem Verteidigenden Pokémon haben keine Auswirkungen auf die Schadenspunkte von Rameidons Angriffen."
 			}
 		},
 	],
@@ -52,12 +53,12 @@ const card: Card = {
 			name: {
 				en: "Head Smash",
 				fr: "Fracass'Tête",
-				de: "Head Smash"
+				de: "Kopfstoß"
 			},
 			effect: {
 				en: "If the Defending Pokémon would be Knocked Out by this attack, Rampardos does 40 damage to itself.",
 				fr: "Si le Pokémon Défenseur est mis K.O par cette attaque, Charkos s'inflige 40 dégâts.",
-				de: "If the Defending Pokémon would be Knocked Out by this attack, Rampardos does 40 damage to itself."
+				de: "Wenn das Verteidigende Pokémon durch diesen Angriff kampfunfähig würde, fügt Rameidon sich selbst 40 Schadenspunkte zu."
 			},
 			damage: 80,
 
@@ -70,12 +71,12 @@ const card: Card = {
 			name: {
 				en: "Mold Breaker",
 				fr: "Brise Moule",
-				de: "Mold Breaker"
+				de: "Überbrückung"
 			},
 			effect: {
 				en: "Any damage done to Rampardos by attacks is reduced by 20 (after applying Weakness and Resistance) until the end of your next turn.",
 				fr: "Tous dégâts infligés à Charkos par des attaques sont réduits de 20 (après application de la Faiblesse et de la Résistance) jusqu'à la fin de votre prochain tour.",
-				de: "Any damage done to Rampardos by attacks is reduced by 20 (after applying Weakness and Resistance) until the end of your next turn."
+				de: "Bis zum Ende deines nächsten Zuges wird Schaden, den Rameidon durch Angriffe erhalten soll, um 20 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 			damage: 40,
 

--- a/data/Platinum/Platinum/130.ts
+++ b/data/Platinum/Platinum/130.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Swords Dance",
 				fr: "Danse-lames",
-				de: "Swords Dance"
+				de: "Schwerttanz"
 			},
 			effect: {
 				en: "During your next turn, Scyther's Slash attack's base damage is 60.",
 				fr: "Lors de votre prochain tour, les dégâts de base de l'attaque Tranche d'Insécateur sont de 60.",
-				de: "During your next turn, Scyther's Slash attack's base damage is 60."
+				de: "In deinem nächsten Zug beträgt der Grundschaden von Sichlors Angriff Schlitzer 60 Schadenspunkte."
 			},
 
 		},
@@ -49,7 +49,7 @@ const card: Card = {
 			name: {
 				en: "Slash",
 				fr: "Tranche",
-				de: "Slash"
+				de: "Schlitzer"
 			},
 
 			damage: 30,
@@ -72,7 +72,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "It tears and shreds prey with its wickedly sharp scythes. It very rarely spreads its wings to fly."
+		en: "It tears and shreds prey with its wickedly sharp scythes. It very rarely spreads its wings to fly.",
+		de: "Es zerreißt und zerkleinert seine Beute mit seinen unglaublich scharfen Sicheln. Selten breitet es seine Flügel aus, um zu fliegen."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/14.ts
+++ b/data/Platinum/Platinum/14.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Flower Aroma",
 				fr: "Arôme floral",
-				de: "Flower Aroma"
+				de: "Blumenduft"
 			},
 			effect: {
 				en: "Remove 2 damage counters from Shaymin. The Defending Pokémon is now Asleep.",
 				fr: "Retirez à Shaymin 2 marqueurs de dégât. Le Pokémon Défenseur est maintenant Endormi.",
-				de: "Remove 2 damge counters from Shaymin. The Defending Pokémon is now Asleep."
+				de: "Entferne 2 Schadensmarken von Shaymin. Das Verteidigende Pokémon schläft jetzt."
 			},
 			damage: 10,
 
@@ -49,12 +49,12 @@ const card: Card = {
 			name: {
 				en: "Damage Aid",
 				fr: "Aide aux dégâts",
-				de: "Damage Aid"
+				de: "Schadensbeistand"
 			},
 			effect: {
 				en: "If the Defending Pokémon is affected by a Special Condition, this attack does 30 damage plus 50 more damage. Then, remove all Special Conditions from the Defending Pokémon.",
 				fr: "Si le Pokémon Défenseur est affecté par un État Spécial, cette attaque inflige 30 dégâts plus 50 dégâts supplémentaires. Ensuite, retirez au Pokémon Défenseur tous ses États Spéciaux.",
-				de: "If the Defending Pokémon is affected by a Special Condition, this attack does 30 damage plus 50 more damage. Then, remove all Special Conditions from the Defending Pokémon."
+				de: "Wenn das Verteidigende Pokémon von einem Speziellen Zustand betroffen ist, fügt dieser Angriff 30 Schadenspunkte plus 50 weitere Schadenspunkte zu. Danach entferne alle Speziellen Zustände vom Verteidigenden Pokémon."
 			},
 			damage: "30+",
 
@@ -78,7 +78,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It lives in flower patches and avoids detection by curling up to look like a flowering plant."
+		en: "It lives in flower patches and avoids detection by curling up to look like a flowering plant.",
+		de: "Es lebt auf Blumenwiesen und rollt sich ein, um wie eine Blume auszusehen und nicht entdeckt zu werden."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/15.ts
+++ b/data/Platinum/Platinum/15.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Growth",
 				fr: "Croissance",
-				de: "Growth"
+				de: "Wachstum"
 			},
 			effect: {
 				en: "Attach a Grass Energy card from your hand to Shaymin.",
 				fr: "Attachez à Shaymin une carte Énergie Grass de votre main",
-				de: "Attach a  Energy card from your hand to Shaymin."
+				de: "Lege 1 {G}-Energiekarte von deiner Hand an Shaymin an."
 			},
 
 		},
@@ -46,12 +46,12 @@ const card: Card = {
 			name: {
 				en: "Air Slash",
 				fr: "Lame d'Air",
-				de: "Air Slash"
+				de: "Luftschnitt"
 			},
 			effect: {
 				en: "Flip a coin. If tails, discard an Energy attached to Shaymin.",
 				fr: "Lancez une pièce. Si c'est pile, défaussez une Énergie attachée à Shaymin.",
-				de: "Flip a coin. If tails, discard all Energy attached to Shaymin."
+				de: "Wirf 1 Münze. Bei „Zahl“ entferne 1 Energie, die an Shaymin angelegt ist, und lege sie auf deinen Ablagestapel."
 			},
 			damage: 40,
 
@@ -75,7 +75,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "The flowers all over its body burst into bloom if it is lovingly hugged and senses gratitude."
+		en: "The flowers all over its body burst into bloom if it is lovingly hugged and senses gratitude.",
+		de: "Wird es umarmt, empfindet es Dankbarkeit, was wiederum dazu führt, dass seine Blumen blühen."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/16.ts
+++ b/data/Platinum/Platinum/16.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Vigoroth",
-		fr: "Vigoroth"
+		fr: "Vigoroth",
+		de: "Muntier"
 	},
 
 	stage: "Stage2",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Lazy Paunch",
 				fr: "Ventre paresseux",
-				de: "Lazy Paunch"
+				de: "Träge Wampe"
 			},
 			effect: {
 				en: "If Slaking used any attacks during your last turn, Slaking can't attack.",
 				fr: "Si Monaflemit a utilisé des attaques lors de votre tour précédent, il ne peut pas attaquer.",
-				de: "If Slaking used any attacks during your last turn, Slaking can't attack."
+				de: "Wenn Letarking in deinem letzten Zug einen Angriff eingesetzt hat, kann Letarking nicht angreifen."
 			}
 		},
 	],
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Best Dash",
 				fr: "Meilleure ruée",
-				de: "Best Dash"
+				de: "Endspurt"
 			},
 			effect: {
 				en: "During your opponent's next turn, any damage done to Slaking by attacks is increased by 50 (after applying Weakness and Resistance).",
 				fr: "Lors du prochain tour de votre adversaire, tous dégâts infligés à Monaflemit par des attaques sont augmentés de 50 (après application de la Faiblesse et de la Résistance).",
-				de: "During your opponent's next turn, any damage done to Slaking by attacks is increased by 50 (after applying Weakness and Resistance)."
+				de: "Während des nächsten Zuges deines Gegners wird Schaden, der Letarking durch Angriffe zugefügt wird, um 50 Schadenspunkte erhöht (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 			damage: 150,
 
@@ -77,7 +78,8 @@ const card: Card = {
 	retreat: 4,
 
 	description: {
-		en: "The world's laziest Pokémon. When it is lounging, it is actually saving energy for striking back."
+		en: "The world's laziest Pokémon. When it is lounging, it is actually saving energy for striking back.",
+		de: "Das faulste PKMN der Welt. Wenn es faulenzt, sammelt es in Wahrheit Energie, um zuzuschlagen."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/17.ts
+++ b/data/Platinum/Platinum/17.ts
@@ -30,12 +30,12 @@ const card: Card = {
 			name: {
 				en: "Call for Family",
 				fr: "Appel à la famille",
-				de: "Call for Family"
+				de: "Familienruf"
 			},
 			effect: {
 				en: "Search your deck for up to 2 basic Pokémon SP and put them onto your Bench. Shuffle your deck afterward.",
 				fr: "Cherchez dans votre deck jusqu'à 2 Pokémon de base SP et placez-les sur votre Banc. Ensuite, mélangez votre deck.",
-				de: "Search your deck for up to 2 basic Pokémon SP and put them onto your Bench. Shuffle your deck afterward."
+				de: "Durchsuche dein Deck nach bis zu 2 Basis-Pokémon SP-Karten und lege sie auf deine Bank. Mische dein Deck danach."
 			},
 
 		},
@@ -48,12 +48,12 @@ const card: Card = {
 			name: {
 				en: "Team Attack",
 				fr: "Attaque de groupe",
-				de: "Team Attack"
+				de: "Teamangriff"
 			},
 			effect: {
 				en: "Does 10 damage plus 10 more damage for each Pokémon SP you have in play.",
 				fr: "Inflige 10 dégâts plus 10 dégâts supplémentaires pour chaque Pokémon SP que vous avez en jeu.",
-				de: "Does 10 damage plus 10 more damage for each Pokémon SP you have in play."
+				de: "Dieser Angriff fügt 10 Schadenspunkte plus 10 weitere Schadenspunkte für jedes Pokémon SP, das du im Spiel hast, zu."
 			},
 			damage: "10+",
 

--- a/data/Platinum/Platinum/18.ts
+++ b/data/Platinum/Platinum/18.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Swablu",
-		fr: "Tylton"
+		fr: "Tylton",
+		de: "Wablu"
 	},
 
 	stage: "Stage1",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Midnight Eyes",
 				fr: "Yeux de minuit",
-				de: "Midnight Eyes"
+				de: "Mitternachtsaugen"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
-				de: "The Defending Pokémon is now Asleep."
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 			damage: 20,
 
@@ -54,12 +55,12 @@ const card: Card = {
 			name: {
 				en: "Perish Song",
 				fr: "Requiem",
-				de: "Perish Song"
+				de: "Abgesang"
 			},
 			effect: {
 				en: "If the Defending Pokémon is Asleep and was damaged or affected by Midnight Eyes during your last turn, the Defending Pokémon is Knocked Out.",
 				fr: "Si le Pokémon Défenseur est Endormi et que l'attaque Yeux de minuit lui a infligé des dégâts lors de votre tour précédent, il est mis K.O.",
-				de: "If the Defending Pokémo is Asleep and was damaged or affected by Midnight Eyes during your last turn, the Defending Pokémon is Knocked Out."
+				de: "Wenn das Verteidigende Pokémon schläft und in deinem letzten Zug durch Mitternachtsaugen Schaden erhalten hat oder von dessen Effekt betroffen wurde, ist das Verteidigende Pokémon jetzt kampfunfähig."
 			},
 
 		},
@@ -71,12 +72,12 @@ const card: Card = {
 			name: {
 				en: "Healing Song",
 				fr: "Chanson guérisseuse",
-				de: "Healing Song"
+				de: "Heilgesang"
 			},
 			effect: {
 				en: "Remove 1 damage counter from each of your Pokémon.",
 				fr: "Retirez à chacun de vos Pokémon 1 marqueur de dégât.",
-				de: "Remove 1 damage counter from each of your Pokémon."
+				de: "Entferne 1 Schadensmarke von jedem deiner Pokémon."
 			},
 			damage: 40,
 

--- a/data/Platinum/Platinum/19.ts
+++ b/data/Platinum/Platinum/19.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Shuppet",
-		fr: "Polychombr"
+		fr: "Polychombr",
+		de: "Shuppet"
 	},
 
 	stage: "Stage1",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Temper Tantrum",
 				fr: "Piquer une colère",
-				de: "Temper Tantrum"
+				de: "Ausraster"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may discard as many cards as you like from your hand. If you do, put that many damage counters on Banette. This power can't be used if Banette is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez défausser de votre main autant de cartes que vous voulez. Vous pouvez alors placer autant de marqueurs de dégât sur Branette. Ce pouvoir ne peut pas être utilisé si Branette est affecté par un État Spécial.",
-				de: "Once during your turn (before your attack), you may discard as many cards as you like from your hand. I you do, put that many damage counters on Banette. This power can't be used if Banette is affected by a Special Condition."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du beliebig viele Karten von deiner Hand auf deinen Ablagestapel legen. Wenn du das machst, lege die gleiche Anzahl Schadensmarken auf Banette. Diese Poké-Power kann nicht benutzt werden, wenn Banette von einem Speziellen Zustand betroffen ist."
 			}
 		},
 	],
@@ -52,12 +53,12 @@ const card: Card = {
 			name: {
 				en: "Darkness Switch",
 				fr: "Échange obscurité",
-				de: "Darkness Switch"
+				de: "Finsterer Tausch"
 			},
 			effect: {
 				en: "Discard an Energy card attached to Banette, and then switch all damage counters on Banette with those on the Defending Pokémon. (If an effect of this attack is prevented, this attack does nothing.)",
 				fr: "Défaussez une carte Énergie attachée à Branette puis échangez tous les marqueurs de dégât se trouvant sur Branette avec ceux du Pokémon Défenseur. (Si un effet de cette attaque est contré, cette attaque est sans effet.)",
-				de: "Discard an Energy card attached to Banette, and then switch all daage counters on Banette with those on the Defending Pokémon. (If an effect of this attack is prevented, this attack does nothing.)"
+				de: "Lege 1 an Banette angelegte Energiekarte auf deinen Ablagestapel und tausche danach alle Schadensmarken, die auf Banette liegen, mit den Schadensmarken auf dem Verteidigenden Pokémon aus. (Wenn ein Effekt dieses Angriffs verhindert wird, hat dieser Angriff keine Auswirkungen.)"
 			},
 
 		},
@@ -69,12 +70,12 @@ const card: Card = {
 			name: {
 				en: "Loneliness",
 				fr: "Solitude",
-				de: "Loneliness"
+				de: "Vereinsamung"
 			},
 			effect: {
 				en: "You may show your hand to your opponent. If you do and if you don't have any Pokémon in your hand, this attack does 30 damage plus 30 more damage.",
 				fr: "Vous pouvez montrer votre main à votre adversaire. Si vous ne possédez pas de Pokémon, cette attaque inflige alors 30 dégâts plus 30 dégâts supplémentaires.",
-				de: "You may show your hand to your opponent. If you do and if you don't have any Pokémon in your hand, this attack does 30 damage plus 30 more damage."
+				de: "Du kannst deinem Gegner deine Handkarten zeigen. Wenn du das machst und sich keine Pokémon-Karten darunter befinden, fügt dieser Angriff 30 Schadenspunkte plus 30 weitere Schadenspunkte zu."
 			},
 			damage: "30+",
 

--- a/data/Platinum/Platinum/2.ts
+++ b/data/Platinum/Platinum/2.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Wartortle",
-		fr: "Carabaffe"
+		fr: "Carabaffe",
+		de: "Schillok"
 	},
 
 	stage: "Stage2",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Dig Well",
 				fr: "Puits creusé",
-				de: "Dig Well"
+				de: "Brunnen graben"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may look at the top 3 cards of your deck, choose as many Water Energy cards as you like, and attach them to your Pokémon in any way you like. Discard the other cards. This power can't be used if Blastoise is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez regarder les 3 cartes du dessus de votre deck. Choisissez autant de cartes Énergie Water que vous voulez et attachez-les à vos Pokémon de la façon que vous voulez. Défaussez les autres cartes. Ce pouvoir ne peut pas être utilisé si Tortank est affecté par un État Spécial.",
-				de: "Once during your turn (before your attack), you may look at the top 3 cards of your deck, choose as many  Energy cards as you like, and attach them to your Pokémon in any way you like. Discard all other cards. This power can't be used if Blastoise is affected by a Special Condition."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du dir die obersten 3 Karten deines Decks anschauen. Wähle beliebig viele {W}-Energiekarten, die du dort gefunden hast, und lege sie in beliebiger Verteilung an deine Pokémon an. Lege die anderen Karten auf deinen Ablagestapel. Diese Poké-Power kann nicht benutzt werden, wenn Turtok von einem Speziellen Zustand betroffen ist."
 			}
 		},
 	],
@@ -53,12 +54,12 @@ const card: Card = {
 			name: {
 				en: "Aqua Press",
 				fr: "Aqua presse",
-				de: "Aqua Press"
+				de: "Aquapresse"
 			},
 			effect: {
 				en: "Does 20 damage plus 10 more damage for each Energy attached to all Pokémon (both yours and your opponent's).",
 				fr: "Inflige 20 dégâts plus 10 dégâts supplémentaires pour chaque Énergie Water attachée à tous les Pokémon (les vôtres et ceux de votre adversaire).",
-				de: "Does 20 damage plus 10 more damage for each  Energy attached to all Pokémon (both yours and your opponent's)."
+				de: "Dieser Angriff fügt 20 Schadenspunkte plus 10 weitere Schadenspunkte für jede {W}-Energie, die an allen Pokémon (deinen und denen deines Gegners) angelegt ist, zu."
 			},
 			damage: "20+",
 
@@ -73,12 +74,12 @@ const card: Card = {
 			name: {
 				en: "Double Launcher",
 				fr: "Double lanceur",
-				de: "Double Launcher"
+				de: "Zwillingswerfer"
 			},
 			effect: {
 				en: "Discard 2 Energy attached to Blastoise. Choose 2 of your opponent's Benched Pokémon. This attack does 60 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.) Blastoise can't use Double Launcher during your next turn.",
 				fr: "Défaussez 2 Énergies Water attachées à Tortank. Choisissez 2 des Pokémon de Banc de votre adversaire. Cette attaque leur inflige 60 dégâts chacun. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.) Tortank ne peut pas utiliser Double Lanceur lors de votre prochain tour.",
-				de: "Discard 2  Energy attached to Blastoise. Choose 2 of your opponent's Benched Pokémon. This attack does 60 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.) Blastoise can't use Double Launcher during your next turn."
+				de: "Lege 2 an Turtok angelegte {W}-Energien auf deinen Ablagestapel. Wähle 2 Pokémon auf der Bank deines Gegners. Dieser Angriff fügt den gewählten Pokémon 60 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.) Turtok kann Zwillingswerfer in deinem nächsten Zug nicht einsetzen."
 			},
 
 		},

--- a/data/Platinum/Platinum/20.ts
+++ b/data/Platinum/Platinum/20.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Shieldon",
-		fr: "Dinoclier"
+		fr: "Dinoclier",
+		de: "Schilterus"
 	},
 
 	stage: "Stage2",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Metal Trait",
 				fr: "Trait métallique",
-				de: "Metal Trait"
+				de: "Metallcharakter"
 			},
 			effect: {
 				en: "As long as Bastiodon has a Pokémon Tool attached to it, remove 1 damage counter from Bastiodon between turns.",
 				fr: "Tant que Bastiodon possède un Outil Pokémon, retirez-lui 1 marqueur de dégât entre 2 tours.",
-				de: "As long as Bastiodon has a Pokémon Tool attached to it, remove 1 damage counter from Bastiodon between turns."
+				de: "Solange an Bollterus 1 Pokémon-Ausrüstung angelegt ist, entferne zwischen den Zügen 1 Schadensmarke von Bollterus."
 			}
 		},
 	],
@@ -54,12 +55,12 @@ const card: Card = {
 			name: {
 				en: "Iron Defense",
 				fr: "Mur de fer",
-				de: "Iron Defense"
+				de: "Eisenabwehr"
 			},
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Bastiodon during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, prévenez tous les effets d'une attaque, dégâts inclus, infligés à Bastiodon lors du prochain tour de votre adversaire.",
-				de: "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Bastiodon during your opponent's next turn."
+				de: "Wirf 1 Münze. Bei „Kopf“ verhindere während des nächsten Zuges deines Gegners alle Effekte eines Angriffs, einschließlich Schaden, die Bollterus zugefügt würden."
 			},
 			damage: 30,
 
@@ -74,12 +75,12 @@ const card: Card = {
 			name: {
 				en: "Iron Tackle",
 				fr: "Charge de fer",
-				de: "Iron Tackle"
+				de: "Eisentackle"
 			},
 			effect: {
 				en: "Bastiodon does 30 damage to itself.",
 				fr: "Bastiodon s'inflige 30 dégâts.",
-				de: "Bastiodon does 30 damage to itself."
+				de: "Bollterus fügt sich selbst 30 Schadenspunkte zu."
 			},
 			damage: 80,
 

--- a/data/Platinum/Platinum/21.ts
+++ b/data/Platinum/Platinum/21.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Silcoon",
-		fr: "Armulys"
+		fr: "Armulys",
+		de: "Schaloko"
 	},
 
 	stage: "Stage2",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Colorful Powder",
 				fr: "Poudre colorée",
-				de: "Colorful Powder"
+				de: "Farbpuder"
 			},
 			effect: {
 				en: "If Beautifly has 2 or less Energy attached to it, the Defending Pokémon is now Poisoned. If Beautifly has 3 Energy attached to it, the Defending Pokémon is now Burned and Poisoned. If Beautifly has 4 or more Energy attached to it, this attack does 20 damage plus 40 more damage and the Defending Pokémon is now Asleep, Burned, and Poisoned.",
 				fr: "Si Charmillon possède un maximum de 2 Énergies, le Pokémon Défenseur est maintenant Empoisonné. Si Charmillon possède 3 Énergies, le Pokémon Défenseur est maintenant Brûlé et Empoisonné. Si Charmillon possède au moins 4 Énergies, cette attaque inflige 20 dégâts plus 40 dégâts supplémentaires et le Pokémon Défenseur est maintenant Endormi, Brûlé et Empoisonné.",
-				de: "If Beautifly has 2 or less Energy attached to it, the Defending Pokémon is now Poisoned. If Beautifly has 3 Energy attached to it, the Defending Pokémon is now Burned and Poisoned. If Beautifly has 4 or more Energy attached to it, this attack does 20 damage plus 40 more damage and the Defending Pokémon is now Asleep, Burned, and Poisoned."
+				de: "Wenn an Papinella 2 oder weniger Energien angelegt sind, ist das Verteidigende Pokémon jetzt vergiftet. Wenn an Papinella 3 Energien angelegt sind, ist das Verteidigende Pokémon jetzt verbrannt und vergiftet. Wenn an Papinella 4 oder mehr Energien angelegt sind, fügt dieser Angriff 20 Schadenspunkte plus 40 weitere Schadenspunkte zu und das Verteidigende Pokémon schläft jetzt und ist verbrannt und vergiftet."
 			},
 			damage: "20+",
 
@@ -53,12 +54,12 @@ const card: Card = {
 			name: {
 				en: "Silver Scale",
 				fr: "Écaille argentée",
-				de: "Silver Scale"
+				de: "Silberschuppe"
 			},
 			effect: {
 				en: "If the Defending Pokémon has any Resistance, this attack's base damage is 60 damage instead of 30.",
 				fr: "Si le Pokémon Défenseur possède une Résistance, les dégâts de base de cette attaque sont de 60 au lieu de 30.",
-				de: "If the Defending Pokémon has any Resistance, this attack's base damage is 60 instead of 30."
+				de: "Wenn das Verteidigende Pokémon mindestens eine Resistenz hat, beträgt der Grundschaden dieses Angriffs 60 Schadenspunkte anstelle von 30 Schadenspunkten."
 			},
 			damage: 30,
 
@@ -80,7 +81,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "Despite its looks, it is aggressive. It jabs with its long, thin mouth if disturbed while collecting pollen."
+		en: "Despite its looks, it is aggressive. It jabs with its long, thin mouth if disturbed while collecting pollen.",
+		de: "Stört man es, während es Pollen sucht, stößt es mit seinem langen, dünnen Mund zu."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/22.ts
+++ b/data/Platinum/Platinum/22.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Chansey",
-		fr: "Leveinard"
+		fr: "Leveinard",
+		de: "Chaneira"
 	},
 
 	stage: "Stage1",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Nurse Call",
 				fr: "Appel à l'infirmière",
-				de: "Nurse Call"
+				de: "Pflegeruf"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may discard a card from your hand. If you do, remove 2 damage counters from 1 of your Pokémon. You can't use more than 1 Nurse Call Poké-Power each turn. This power can't be used if Blissey is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez défausser une carte de votre main. Retirez alors à 1 de vos Pokémon 2 marqueurs de dégât. Vous ne pouvez pas utiliser plus d'1 Poké-Power Appel à l'infirmière par tour. Ce pouvoir ne peut pas être utilisé si Leuphorie est affecté par un État Spécial.",
-				de: "Once during your turn (before your attack), you may discard a card from your hand. If you do, remove 2 damage counters from 1 of your Pokémon. You can't use more than 1 Nurse Call Poké-Power each turn. This power can't be used if Blissey is affected by a Special Condition."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 Karte von deiner Hand auf deinen Ablagestapel legen. Wenn du das machst, entferne 2 Schadensmarken von 1 deiner Pokémon. Du kannst nicht mehr als 1 Pflegeruf Poké-Power pro Zug benutzen. Diese Poké-Power kann nicht benutzt werden, wenn Heiteira von einem Speziellen Zustand betroffen ist."
 			}
 		},
 	],
@@ -52,12 +53,12 @@ const card: Card = {
 			name: {
 				en: "Return",
 				fr: "Retour",
-				de: "Return"
+				de: "Rückkehr"
 			},
 			effect: {
 				en: "Draw cards until you have 6 cards in your hand.",
 				fr: "Piochez des cartes jusqu'à ce que vous ayez 6 cartes en main.",
-				de: "Draw cards until you have 6 cards in your hand."
+				de: "Ziehe so viele Karten, bis du 6 Karten auf der Hand hast."
 			},
 			damage: 20,
 
@@ -72,12 +73,12 @@ const card: Card = {
 			name: {
 				en: "Double-edge",
 				fr: "Damoclès",
-				de: "Double-edge"
+				de: "Risikotackle"
 			},
 			effect: {
 				en: "Blissey does 60 damage to itself.",
 				fr: "Leuphorie s'inflige 60 dégâts.",
-				de: "Blissey does 60 damage to itself."
+				de: "Heiteira fügt sich selbst 60 Schadenspunkte zu."
 			},
 			damage: 100,
 

--- a/data/Platinum/Platinum/23.ts
+++ b/data/Platinum/Platinum/23.ts
@@ -32,12 +32,12 @@ const card: Card = {
 			name: {
 				en: "Energy Stream",
 				fr: "Courant d'énergie",
-				de: "Energy Stream"
+				de: "Energiestrom"
 			},
 			effect: {
 				en: "Flip a coin. If heads, search your discard pile for a basic Energy card and attach it to Dialga.",
 				fr: "Lancez une pièce. Si c'est face, choisissez dans votre pile de défausse une carte Énergie de base et attachez-la à Dialga.",
-				de: "Flip a coin. If heads, search your discard pile for a basic Energy card and attach it to Dialga."
+				de: "Wirf 1 Münze. Bei „Kopf“ durchsuche deinen Ablagestapel nach 1 Basis-Energiekarte und lege sie an Dialga an."
 			},
 			damage: 20,
 
@@ -52,12 +52,12 @@ const card: Card = {
 			name: {
 				en: "Diamond Blow",
 				fr: "Coup diamant",
-				de: "Diamond Blow"
+				de: "Diamantschlag"
 			},
 			effect: {
 				en: "Dialga can't attack during your next turn.",
 				fr: "Dialga ne peut pas attaquer lors de votre prochain tour.",
-				de: "Dialga can't attack during your next turn."
+				de: "Dialga kann in deinem nächsten Zug nicht angreifen."
 			},
 			damage: 100,
 
@@ -81,7 +81,8 @@ const card: Card = {
 	retreat: 3,
 
 	description: {
-		en: "A legendary Pokémon of Sinnoh. It is said that time flows when Dialga's heart beats."
+		en: "A legendary Pokémon of Sinnoh. It is said that time flows when Dialga's heart beats.",
+		de: "Ein Legendäres Pokémon aus der Sinnoh-Region. Schlägt das Herz von DIALGA, läuft die Zeit normal."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/24.ts
+++ b/data/Platinum/Platinum/24.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Diglett",
-		fr: "Taupiqueur"
+		fr: "Taupiqueur",
+		de: "Digda"
 	},
 
 	stage: "Stage1",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Sinkhole",
 				fr: "Chausse-trappe",
-				de: "Sinkhole"
+				de: "Erdloch"
 			},
 			effect: {
 				en: "If your opponent's Active Pokémon retreats, put 2 damage counters on that Pokémon.",
 				fr: "Si le Pokémon Actif de votre adversaire bat en retraite, placez 2 marqueurs de dégât sur ce Pokémon.",
-				de: "If your opponent's Active Pokémon retreats, put 2 damage counters on that Pokémon."
+				de: "Wenn sich das Aktive Pokémon deines Gegners zurückzieht, lege 2 Schadensmarken auf dieses Pokémon."
 			}
 		},
 	],
@@ -53,12 +54,12 @@ const card: Card = {
 			name: {
 				en: "Push Down",
 				fr: "Renverser",
-				de: "Push Down"
+				de: "Runterdrücken"
 			},
 			effect: {
 				en: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon.",
 				fr: "Votre adversaire échange le Pokémon Défenseur avec 1 de ses Pokémon de Banc.",
-				de: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon."
+				de: "Dein Gegner tauscht das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
 			},
 			damage: 30,
 
@@ -72,12 +73,12 @@ const card: Card = {
 			name: {
 				en: "Magnitude",
 				fr: "Ampleur",
-				de: "Magnitude"
+				de: "Intensität"
 			},
 			effect: {
 				en: "Does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à chacun des Pokémon de Banc (les vôtres et ceux de votre adversaire). (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Dieser Angriff fügt jedem Pokémon auf der Bank (deinen und denen deines Gegners) 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 70,
 

--- a/data/Platinum/Platinum/25.ts
+++ b/data/Platinum/Platinum/25.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Cascoon",
-		fr: "Blindalys"
+		fr: "Blindalys",
+		de: "Panekon"
 	},
 
 	stage: "Stage2",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Camouflage Pattern",
 				fr: "Motif camouflage",
-				de: "Camouflage Pattern"
+				de: "Tarnmuster"
 			},
 			effect: {
 				en: "Prevent all effects of attacks, including damage, done to Dustox by your opponent's Pokémon that is affected by 2 or more Special Conditions.",
 				fr: "Prévenez tous les effets d'attaques, dégâts inclus, infligés à Papinox par des Pokémon de votre adversaire étant affectés par au moins 2 États Spéciaux.",
-				de: "Prevent all effects of attacks, including damage, done to Dustox by your opponent's Pokémon that is affected by 2 or more Special Conditions."
+				de: "Verhindere alle Effekte von Angriffen, einschließlich Schaden, die Pudox von gegnerischen Pokémon, die von mindestens 2 Speziellen Zuständen betroffen sind, zugefügt würden."
 			}
 		},
 	],
@@ -53,12 +54,12 @@ const card: Card = {
 			name: {
 				en: "Smogscreen",
 				fr: "Para-brouillard",
-				de: "Smogscreen"
+				de: "Rauchwolke"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned. If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné. Si le Pokémon Défenseur essaye d'attaquer lors du prochain tour de votre adversaire, celui-ci lance une pièce. Si c'est pile, cette attaque est sans effet.",
-				de: "The Defending Pokémon is now Poisoned. If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet. Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 20,
 
@@ -72,12 +73,12 @@ const card: Card = {
 			name: {
 				en: "Chemical Scale",
 				fr: "Écaille chimique",
-				de: "Chemical Scale"
+				de: "Chemische Schuppe"
 			},
 			effect: {
 				en: "If the Defending Pokémon has any Poké-Powers or Poké-Bodies, the Defending Pokémon is now Burned and Confused.",
 				fr: "Si le Pokémon Défenseur possède des Poké-Powers ou des Poké-Bodies, il est maintenant Brûlé et Confus.",
-				de: "If the Defending Pokémon has any Poké-Powers or Poké-Bodies, the Defending Pokémon is now Burned and Confused."
+				de: "Wenn das Verteidigende Pokémon mindestens 1 Poké-Power oder Poké-Body hat, ist es jetzt verbrannt und verwirrt."
 			},
 			damage: 60,
 

--- a/data/Platinum/Platinum/26.ts
+++ b/data/Platinum/Platinum/26.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Prinplup",
-		fr: "Prinplouf"
+		fr: "Prinplouf",
+		de: "Pliprin"
 	},
 
 	stage: "Stage2",
@@ -37,12 +38,12 @@ const card: Card = {
 			name: {
 				en: "Knock Off",
 				fr: "Sabotage",
-				de: "Knock Off"
+				de: "Abschlag"
 			},
 			effect: {
 				en: "Choose 1 card from your opponent's hand without looking and discard it.",
 				fr: "Choisissez sans regarder 1 carte de la main de votre adversaire et défaussez-la.",
-				de: "Choose 1 card from your opponent's hand without looking and discard it."
+				de: "Wähle 1 Karte von der Hand deines Gegners (ohne sie vorher anzusehen) und lege sie auf seinen Ablagestapel."
 			},
 			damage: 40,
 
@@ -56,12 +57,12 @@ const card: Card = {
 			name: {
 				en: "Jet Smash",
 				fr: "Éclat'jet",
-				de: "Jet Smash"
+				de: "Schmetterdüse"
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon. This attack does 70 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Empoleon can't use Jet Smash during your next turn.",
 				fr: "Choisissez 1 des Pokémon de votre adversaire. Cette attaque lui inflige 70 dégâts. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.) Pingoléon ne peut pas utiliser Écras'jet lors de votre prochain tour.",
-				de: "Choose 1 of your opponent's Pokémon. This attack does 70 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Empoleon can't use Jet Smash during your next turn."
+				de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 70 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.) Impoleon kann Schmetterdüse in deinem nächsten Zug nicht einsetzen."
 			},
 
 		},
@@ -77,7 +78,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "If anyone were to hurt its pride, it would slash them with wings that can cleave through an ice floe."
+		en: "If anyone were to hurt its pride, it would slash them with wings that can cleave through an ice floe.",
+		de: "Würde jemand seine Ehre verletzen, so würde es mit Flügeln angreifen, die Eis zerschneiden können."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/27.ts
+++ b/data/Platinum/Platinum/27.ts
@@ -32,12 +32,12 @@ const card: Card = {
 			name: {
 				en: "Strafe",
 				fr: "Bombarder",
-				de: "Strafe"
+				de: "Beharken"
 			},
 			effect: {
 				en: "You may switch Giratina with 1 of your Benched Pokémon.",
 				fr: "Vous pouvez échanger Giratina avec 1 de vos Pokémon de Banc.",
-				de: "You may switch Giratina with 1 of your Benched Pokémon."
+				de: "Du kannst Giratina gegen 1 Pokémon auf deiner Bank austauschen."
 			},
 			damage: 20,
 
@@ -51,12 +51,12 @@ const card: Card = {
 			name: {
 				en: "Broken-space Blow",
 				fr: "Coup espace-brisé",
-				de: "Broken-space Blow"
+				de: "Raumzerfetzschlag"
 			},
 			effect: {
 				en: "If the Defending Pokémon is Knocked Out by this attack, put the Defending Pokémon and all cards attached to in the Lost Zone instead of the discard pile.",
 				fr: "Si le Pokémon Défenseur est mis K.O par cette attaque, placez le Pokémon Défenseur ainsi que toutes les cartes qui lui sont attachées dans la Zone Perdue au lieu de les défausser.",
-				de: "If the Defending Pokémon is Knocked Out by this attack, put the Defending Pokémon and all cards attached to it in the Lost Zone instead of discarding them."
+				de: "Wenn das Verteidigende Pokémon durch diesen Angriff kampfunfähig wird, legt dein Gegner dieses Pokémon und alle Karten, die an es angelegt sind, nicht auf den Ablagestapel, sondern ins Nirgendwo."
 			},
 			damage: 50,
 
@@ -80,7 +80,8 @@ const card: Card = {
 	retreat: 3,
 
 	description: {
-		en: "A Pokémon that is said to live in a world on the reverse side of ours. It appears in an ancient cemetery."
+		en: "A Pokémon that is said to live in a world on the reverse side of ours. It appears in an ancient cemetery.",
+		de: "Ein PKMN, von dem man sagt, es lebt in der Spiegelwelt unserer Welt. Es erscheint auf alten Friedhöfen."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/28.ts
+++ b/data/Platinum/Platinum/28.ts
@@ -32,7 +32,7 @@ const card: Card = {
 			name: {
 				en: "Dragon Claw",
 				fr: "Dracogriffe",
-				de: "Dragon Claw"
+				de: "Drachenklaue"
 			},
 
 			damage: 30,
@@ -47,12 +47,12 @@ const card: Card = {
 			name: {
 				en: "Dragonbreath",
 				fr: "Dracosouffle",
-				de: "Dragonbreath"
+				de: "Feuerodem"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Flip a coin. If tails, this attack does nothing. If heads, the Defending Pokémon is now Paralyzed."
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 80,
 
@@ -76,7 +76,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It was banished for its violence. It silently gazed upon the old world from the Distortion World."
+		en: "It was banished for its violence. It silently gazed upon the old world from the Distortion World.",
+		de: "Es wurde aufgrund seines Verhaltens verbannt. Aus der Zerrwelt schaut es auf die alte Welt."
 	},
 
 	variants: [		{

--- a/data/Platinum/Platinum/29.ts
+++ b/data/Platinum/Platinum/29.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Psyduck",
-		fr: "Psykokwak"
+		fr: "Psykokwak",
+		de: "Enton"
 	},
 
 	stage: "Stage1",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Swim",
 				fr: "Nager",
-				de: "Swim"
+				de: "Schwimmen"
 			},
 			effect: {
 				en: "If your opponent has any Water Energy attached to any of his or her Pokémon, you may do 30 damage to any 1 Benched Pokémon instead. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Si les Pokémon de votre adversaire possèdent de l'Énergie Water, vous pouvez infliger 30 dégâts à n'importe lequel des Pokémon de Banc. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc).",
-				de: "If your opponent has any  Energy attached to any of his or her Pokémon, you may do 30 damage to any 1 Benched Pokémon instead. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Wenn an den gegnerischen Pokémon mindestens 1 {W}-Energie angelegt ist, kannst du 1 beliebigen Pokémon auf der Bank 30 Schadenspunkte zufügen, anstelle dem Verteidigenden Pokémon Schaden zuzufügen. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 30,
 
@@ -52,12 +53,12 @@ const card: Card = {
 			name: {
 				en: "Water Slide",
 				fr: "Toboggan d'O",
-				de: "Water Slide"
+				de: "Wasserrutsche"
 			},
 			effect: {
 				en: "You may move all Energy cards attached to Golduck to 1 of your Benched Pokémon. If you do, this attack does 40 damage plus 20 more damage.",
 				fr: "Vous pouvez déplacer toutes les cartes Énergie attachées à Akwakwak sur 1 de vos Pokémon de Banc. Cette attaque inflige alors 40 dégâts plus 20 dégâts supplémentaires.",
-				de: "You may move all Energy cards attached to Golduck to 1 of your Benched Pokémon. If you do, this attack does 40 damage plus 20 more damage."
+				de: "Du kannst alle an Entoron angelegten Energiekarten entfernen und sie an 1 Pokémon auf deiner Bank anlegen. Wenn du das machst, fügt dieser Angriff 40 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "40+",
 
@@ -72,7 +73,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "It is seen swimming dynamically and elegantly using its well-developed limbs and flippers."
+		en: "It is seen swimming dynamically and elegantly using its well-developed limbs and flippers.",
+		de: "Die gut ausgeprägten Flossen ermöglichen einen sowohl eleganten als auch dynamischen Schwimmstil."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/3.ts
+++ b/data/Platinum/Platinum/3.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Combusken",
-		fr: "Galifeu"
+		fr: "Galifeu",
+		de: "Jungglut"
 	},
 
 	stage: "Stage2",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Fire Breath",
 				fr: "Haleine de feu",
-				de: "Fire Breath"
+				de: "Feueratem"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may choose 1 of the Defending Pokémon. That Pokémon is now Burned. This power can't be used if Blaziken is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez choisir 1 des Pokémon Défenseurs. Ce Pokémon est maintenant Brûlé. Ce pouvoir ne peut pas être utilisé si Brasegali est affecté par un État Spécial.",
-				de: "Once during your turn (before your attack), you may choose 1 of the Defending Pokémon. That Pokémon is now Burned. This power can't be used if Blaziken is affected by a Special Condition."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 Verteidigendes Pokémon wählen. Das gewählte Pokémon ist jetzt verbrannt. Diese Poké-Power kann nicht benutzt werden, wenn Lohgock von einem Speziellen Zustand betroffen ist."
 			}
 		},
 	],
@@ -53,12 +54,12 @@ const card: Card = {
 			name: {
 				en: "Clutch",
 				fr: "Serre",
-				de: "Clutch"
+				de: "Greifer"
 			},
 			effect: {
 				en: "The Defending Pokémon can't retreat during your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas battre en retraite lors du prochain tour de votre adversaire.",
-				de: "The Defending Pokémon can't retreat during your opponent's next turn."
+				de: "Das Verteidigende Pokémon kann sich im nächsten Zug deines Gegners nicht zurückziehen."
 			},
 			damage: 40,
 
@@ -72,12 +73,12 @@ const card: Card = {
 			name: {
 				en: "Fire Spin",
 				fr: "Danseflamme",
-				de: "Fire Spin"
+				de: "Feuerwirbel"
 			},
 			effect: {
 				en: "Discard 2 Energy attached to Blaziken.",
 				fr: "Défaussez 2 Énergies attachées à Brasegali.",
-				de: "Discard 2 Energy attached to Blaziken."
+				de: "Lege 2 an Lohgock angelegte Energien auf deinen Ablagestapel."
 			},
 			damage: 100,
 

--- a/data/Platinum/Platinum/30.ts
+++ b/data/Platinum/Platinum/30.ts
@@ -34,12 +34,12 @@ const card: Card = {
 			name: {
 				en: "Wriggle",
 				fr: "Se tortiller",
-				de: "Wriggle"
+				de: "Drehen und Winden"
 			},
 			effect: {
 				en: "Flip a coin for each of your opponent's Pokémon. If that coin flip is heads, this attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Lancez une pièce pour chaque Pokémon de votre adversaire. Si vous obtenez une face, cette attaque inflige 30 dégâts à ce Pokémon. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Flip a coin for each of your opponent's Pokémon. If that coin flip is heads, this attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Wirf für jedes Pokémon deines Gegners jeweils 1 Münze. Dieser Angriff fügt jedem Pokémon, für das auf diese Weise „Kopf“ geworfen wurde, 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -53,12 +53,12 @@ const card: Card = {
 			name: {
 				en: "Dwindling Wave",
 				fr: "Vague diminutrice",
-				de: "Dwindling Wave"
+				de: "Schwindende Welle"
 			},
 			effect: {
 				en: "Does 100 damage minus 10 damage for each damage counter on Gyarados G.",
 				fr: "Inflige 100 dégâts moins 10 dégâts pour chaque marqueur de dégât sur Leviator .",
-				de: "Does 100 damage minus 10 damage for each damage counter on Gyarados G."
+				de: "Dieser Angriff fügt 100 Schadenspunkte minus 10 Schadenspunkte für jede Schadensmarke auf Garados G zu."
 			},
 			damage: "100-",
 

--- a/data/Platinum/Platinum/31.ts
+++ b/data/Platinum/Platinum/31.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Monferno",
-		fr: "Chimpenfeu"
+		fr: "Chimpenfeu",
+		de: "Panpyro"
 	},
 
 	stage: "Stage2",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Rushing Flames",
 				fr: "Flammes dévorantes",
-				de: "Rushing Flames"
+				de: "Brausende Flammen"
 			},
 			effect: {
 				en: "Discard as many Fire Energy cards as you like attached to your Pokémon in play. Flip a coin for each Energy card you discarded. This attack does 80 damage times the number of heads.",
 				fr: "Défaussez autant d'Énergies Fire attachées à vos Pokémon en jeu que vous voulez. Lancez une pièce pour chaque carte Énergie défaussée. Cette attaque inflige 80 dégâts multipliés par le nombre de faces.",
-				de: "Discard as many  Energy as you like attached to your Pokémon in play. Flip a coin for each Energy card you discarded. This attack does 80 damage times the number of heads."
+				de: "Entferne beliebig viele {R}-Energien von deinen Pokémon und lege sie auf deinen Ablagestapel. Wirf für jede auf diese Weise auf deinen Ablagestapel gelegte Energiekarte 1 Münze. Dieser Angriff fügt 80 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "80×",
 
@@ -54,12 +55,12 @@ const card: Card = {
 			name: {
 				en: "Rage",
 				fr: "Frénésie",
-				de: "Rage"
+				de: "Raserei"
 			},
 			effect: {
 				en: "Does 30 damage plus 10 more damage for each damage counter on Infernape.",
 				fr: "Inflige 30 dégâts plus 10 dégâts supplémentaires pour chaque marqueur de dégât sur Simiabraz.",
-				de: "Does 30 damage plus 10 more damage for each damage counter on Infernape."
+				de: "Dieser Angriff fügt 30 Schadenspunkte plus 10 weitere Schadenspunkte für jede Schadensmarke auf Panferno zu."
 			},
 			damage: "30+",
 
@@ -74,7 +75,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "It uses unique fighting moves with fires on its hands and feet. It will take on any opponent."
+		en: "It uses unique fighting moves with fires on its hands and feet. It will take on any opponent.",
+		de: "Es verwendet einzigartige Attacken mit dem Feuer an seinen Händen und Füßen. Stellt sich jedem Gegner."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/32.ts
+++ b/data/Platinum/Platinum/32.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Kricketot",
-		fr: "Crikzik"
+		fr: "Crikzik",
+		de: "Zirpurze"
 	},
 
 	stage: "Stage1",
@@ -37,12 +38,12 @@ const card: Card = {
 			name: {
 				en: "Revenge Melody",
 				fr: "Mélodie vengeresse",
-				de: "Revenge Melody"
+				de: "Vergeltungsmelodie"
 			},
 			effect: {
 				en: "Does 20 damage times the number of Kricketot and Kricketune in your discard pile.",
 				fr: "Inflige 20 dégâts multipliés par le nombre de Crikzik et Mélokrik dans votre pile de défausse.",
-				de: "Does 20 damage times the number of Kricketot and Kricketune in your discard pile."
+				de: "Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl Zirpurze- und Zirpeise-Karten in deinem Ablagestapel zu."
 			},
 			damage: "20×",
 
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Bug Buzz",
 				fr: "Bourdon",
-				de: "Bug Buzz"
+				de: "Käfergebrumm"
 			},
 			effect: {
 				en: "If the Defending Pokémon is Asleep, this attack does 50 damage plus 30 more damage. Remove the Special Condition Asleep from the Defending Pokémon.",
 				fr: "Si le Pokémon Défenseur est Endormi, cette attaque inflige 50 dégâts plus 30 dégâts supplémentaires. Retirez-lui l'État Spécial Endormi.",
-				de: "If the Defending Pokémon is Asleep, this attack does 50 damage plus 30 more damage. Remove the Special Condition Asleep from the Defending Pokémon."
+				de: "Wenn das Verteidigende Pokémon schläft, fügt dieser Angriff 50 Schadenspunkte plus 30 weitere Schadenspunkte zu. Entferne den Speziellen Zustand „schlafend“ vom Verteidigenden Pokémon."
 			},
 			damage: "50+",
 
@@ -77,7 +78,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "There is a village that hosts a contest based on the amazingly variable cries of this Pokémon."
+		en: "There is a village that hosts a contest based on the amazingly variable cries of this Pokémon.",
+		de: "Es gibt ein Dorf, das basierend auf den imposanten Rufen dieses PKMN einen Wettbewerb veranstaltet."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/33.ts
+++ b/data/Platinum/Platinum/33.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Lickitung",
-		fr: "Excelangue"
+		fr: "Excelangue",
+		de: "Schlurp"
 	},
 
 	stage: "Stage1",
@@ -38,12 +39,12 @@ const card: Card = {
 			name: {
 				en: "Harrumph",
 				fr: "Se racler la gorge",
-				de: "Harrumph"
+				de: "Grumpf"
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Before doing damage, discard all Trainer cards attached to that Pokémon.",
 				fr: "Choisissez 1 des Pokémon de votre adversaire. Cette attaque lui inflige 40 dégâts. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.) Avant d'infliger des dégâts, défaussez toutes les cartes Dresseur attachées à ce Pokémon.",
-				de: "Choose 1 of your opponent's Pokémon. This attack does 40 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Before doing damage, discard all Trainer cards attached to that Pokémon."
+				de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 40 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.) Bevor der Schaden zugefügt wird, entferne alle Trainerkarten, die an dem gewählten Pokémon angelegt sind, und lege sie auf den Ablagestapel deines Gegners."
 			},
 
 		},
@@ -57,12 +58,12 @@ const card: Card = {
 			name: {
 				en: "Body Press",
 				fr: "Presse corporelle",
-				de: "Body Press"
+				de: "Platt drücken"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed and discard an Energy card attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé. Défaussez une carte Énergie attachée au Pokémon Défenseur.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed and discard an Energy card attached to the Defending Pokémon."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt und lege 1 am Verteidigenden Pokémon angelegte Energiekarte auf den Ablagestapel deines Gegners."
 			},
 			damage: 60,
 
@@ -79,7 +80,8 @@ const card: Card = {
 	retreat: 4,
 
 	description: {
-		en: "The long tongue is always soggy with slobber. The saliva contains a solvent that causes numbness."
+		en: "The long tongue is always soggy with slobber. The saliva contains a solvent that causes numbness.",
+		de: "Die lange Zunge ist immer feucht. Ihr Speichel enthält eine Substanz, die Taubheit hervorrufen kann."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/34.ts
+++ b/data/Platinum/Platinum/34.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Lombre",
-		fr: "Lombre"
+		fr: "Lombre",
+		de: "Lombrero"
 	},
 
 	stage: "Stage2",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Cheerful Voice",
 				fr: "Voix joyeuse",
-				de: "Cheerful Voice"
+				de: "Fröhliche Stimme"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may use this power. If you do, your turn ends. During your next turn, each of Ludicolo's attacks does 60 more damage to the Defending Pokémon (before applying Weakness and Resistance). This power can't be used if Ludicolo is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez utiliser ce pouvoir. Votre tour est alors terminé. Lors de votre prochain tour, chacune des attaques de Ludicolo inflige 60 dégâts supplémentaires au Pokémon Défenseur (avant application de la Faiblesse et de la Résistance). Ce pouvoir ne peut pas être utilisé si Ludicolo est affecté par un État Spécial.",
-				de: "Once during your turn (before your attack), you may use this power. If you do, your turn ends. During your next turn, each of Ludicolo's attacks does 60 more damage to the Defending Pokémon (before applying Weakness and Resistance). This power can't be used if Ludicolo is affected by a Special Condition."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du diese Poké-Power benutzen. Wenn du das machst, ist dein Zug beendet. In deinem nächsten Zug fügen Kappalores' Angriffe dem Verteidigenden Pokémon 60 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden). Diese Poké-Power kann nicht benutzt werden, wenn Kappalores von einem Speziellen Zustand betroffen ist."
 			}
 		},
 	],
@@ -53,12 +54,12 @@ const card: Card = {
 			name: {
 				en: "Mad Dance",
 				fr: "Danse de fou",
-				de: "Mad Dance"
+				de: "Wilder Tanz"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Confused.",
 				fr: "Le Pokémon Défenseur est maintenant Confus.",
-				de: "The Defending Pokémon is now Confused."
+				de: "Das Verteidigende Pokémon ist jetzt verwirrt."
 			},
 			damage: 20,
 
@@ -72,12 +73,12 @@ const card: Card = {
 			name: {
 				en: "Best Dance",
 				fr: "Meilleure danse",
-				de: "Best Dance"
+				de: "Bester Tanz"
 			},
 			effect: {
 				en: "After doing damage, remove from Ludicolo the number of damage counters equal to the damage you did to the Defending Pokémon. Ludicolo can't use Best Dance during your next turn.",
 				fr: "Après avoir infligé des dégâts, retirez à Ludicolo autant de marqueurs de dégât que vous avez infligé de dégâts au Pokémon Défenseur. Ludicolo ne peut pas utiliser Meilleure danse lors de votre prochain tour.",
-				de: "After doing damage, remove from Ludicolo the number of damage counters equal to the damage you did to the Defending Pokémon. Ludicolo can't use Best Dance during your next turn."
+				de: "Nachdem der Schaden zugefügt wurde, entferne Schadensmarken von Kappalores entsprechend der Höhe der Schadenspunkte, die dem Verteidigenden Pokémon zugefügt wurden. Kappalores kann Bester Tanz in deinem nächsten Zug nicht einsetzen."
 			},
 			damage: 60,
 

--- a/data/Platinum/Platinum/35.ts
+++ b/data/Platinum/Platinum/35.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Love Call",
 				fr: "Appel amoureux",
-				de: "Love Call"
+				de: "Liebesruf"
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon. Search your deck for a Pokémon that is the same type as the Pokémon you chose, show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
 				fr: "Choisissez 1 des Pokémon de votre adversaire. Choisissez dans votre deck un Pokémon du même type que le Pokémon que vous avez choisi, montrez-le à votre adversaire et placez-le dans votre main. Ensuite, mélangez votre deck.",
-				de: "Choose 1 of your opponent's Pokémon. Search your deck for a Pokémon that is the same type as the Pokémon you chose, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
+				de: "Wähle 1 Pokémon deines Gegners. Durchsuche dein Deck nach 1 Pokémon-Karte, die den gleichen Typ wie das gewählte Pokémon hat, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 			},
 
 		},
@@ -45,12 +45,12 @@ const card: Card = {
 			name: {
 				en: "Sweet Kiss",
 				fr: "Doux baiser",
-				de: "Sweet Kiss"
+				de: "Bitterkuss"
 			},
 			effect: {
 				en: "Your opponent may draw a card.",
 				fr: "Votre adversaire peut piocher une carte.",
-				de: "Your opponent may draw a card."
+				de: "Dein Gegner kann 1 Karte ziehen."
 			},
 			damage: 30,
 
@@ -67,7 +67,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It lives in warm seas. It is said that a couple finding this Pokémon will be blessed with eternal love."
+		en: "It lives in warm seas. It is said that a couple finding this Pokémon will be blessed with eternal love.",
+		de: "Es lebt in warmen Meeren. Man sagt, dass Verliebte, die es sehen, mit ewiger Liebe gesegnet sind."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/36.ts
+++ b/data/Platinum/Platinum/36.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Vulpix",
-		fr: "Goupix"
+		fr: "Goupix",
+		de: "Vulpix"
 	},
 
 	stage: "Stage1",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Flame Bash",
 				fr: "Coup de flammes",
-				de: "Flame Bash"
+				de: "Flammen schlagen"
 			},
 			effect: {
 				en: "Flip a coin until you get tails. Search your deck for a number of basic Fire Energy cards up to the number of heads and attach them to any of your Pokémon in any way you like. Shuffle your deck afterward.",
 				fr: "Lancez une pièce jusqu'à ce que vous obteniez pile. Cherchez dans votre deck autant de cartes Énergie Fire que vous avez obtenu de faces et attachez-les à n'importe lequel de vos Pokémon de la façon que vous voulez. Ensuite, mélangez votre deck.",
-				de: "Flip a coin until you get tails. Search your deck for a number of  Energy cards up to the number of heads and attach them to any of your Pokémon in any way you like. Shuffle your deck afterward."
+				de: "Wirf so lange 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Durchsuche dein Deck nach einer Anzahl {R}-Energiekarten, die höchstens der Anzahl „Kopf“ entspricht, und lege sie in beliebiger Verteilung an deine Pokémon an. Mische dein Deck danach."
 			},
 
 		},
@@ -51,12 +52,12 @@ const card: Card = {
 			name: {
 				en: "Mysterious Flames",
 				fr: "Flammes mystérieuses",
-				de: "Mysterious Flames"
+				de: "Geheimnisvolle Flammen"
 			},
 			effect: {
 				en: "If you have more Energy in play than your opponent, the Defending Pokémon is now Burned and Confused.",
 				fr: "Si vous possédez plus d'Énergie en jeu que votre adversaire, le Pokémon Défenseur est maintenant Brûlé et Confus.",
-				de: "If you have more Energy in play than your opponent, the Defending Pokémon is now Burned and Confused."
+				de: "Wenn du mehr Energie im Spiel hast als dein Gegner, ist das Verteidigende Pokémon jetzt verbrannt und verwirrt."
 			},
 			damage: 40,
 
@@ -71,7 +72,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "Its nine tails are said to be imbued with a mystic power. It can live for a thousand years."
+		en: "Its nine tails are said to be imbued with a mystic power. It can live for a thousand years.",
+		de: "Seine neun Schweife sollen mystische Kräfte besitzen. Es kann tausend Jahre leben."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/37.ts
+++ b/data/Platinum/Platinum/37.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			effect: {
 				en: "Does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à chacun des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Dieser Angriff fügt jedem Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 10,
 
@@ -51,12 +51,12 @@ const card: Card = {
 			name: {
 				en: "Water Pulse",
 				fr: "Vibraqua",
-				de: "Water Pulse"
+				de: "Aquawelle"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Asleep.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Endormi.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Asleep."
+				de: "Wirf 1 Münze. Bei „Kopf“ schläft das Verteidigende Pokémon jetzt."
 			},
 			damage: 60,
 
@@ -73,7 +73,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "A legendary Pokémon of Sinnoh. It is said that space becomes more stable with PALKIA's every breath."
+		en: "A legendary Pokémon of Sinnoh. It is said that space becomes more stable with PALKIA's every breath.",
+		de: "Ein Legendäres Pokémon aus der Sinnoh-Region. Mit dem Atem von PALKIA wird das Universum stabiler."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/38.ts
+++ b/data/Platinum/Platinum/38.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Energy Blow",
 				fr: "Coup d'énergie",
-				de: "Energy Blow"
+				de: "Energieschlag"
 			},
 			effect: {
 				en: "Does 10 damage plus 10 more damage for each Energy attached to Shaymin.",
 				fr: "Inflige 10 dégâts plus 10 dégâts supplémentaires pour chaque Énergie attachée à Shaymin.",
-				de: "Does 10 damage plus 10 more damage for each Energy attached to Shaymin."
+				de: "Dieser Angriff fügt 10 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Shaymin angelegte Energie zu."
 			},
 			damage: "10+",
 
@@ -48,12 +48,12 @@ const card: Card = {
 			name: {
 				en: "Aromatherapy",
 				fr: "Aromathérapi",
-				de: "Aromatherapy"
+				de: "Aromakur"
 			},
 			effect: {
 				en: "Remove 2 damage counters from each of your Pokémon.",
 				fr: "Retirez à chacun de vos Pokémon 2 marqueurs de dégât.",
-				de: "Remove 2 damage counters from each of your Pokémon."
+				de: "Entferne 2 Schadensmarken von jedem deiner Pokémon."
 			},
 			damage: 40,
 
@@ -77,7 +77,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It lives in flower patches and avoids detection by curling up to look like a flowering plant."
+		en: "It lives in flower patches and avoids detection by curling up to look like a flowering plant.",
+		de: "Es lebt auf Blumenwiesen und rollt sich ein, um wie eine Blume auszusehen und nicht entdeckt zu werden."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/39.ts
+++ b/data/Platinum/Platinum/39.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Grotle",
-		fr: "Boskara"
+		fr: "Boskara",
+		de: "Chelcarain"
 	},
 
 	stage: "Stage2",
@@ -38,12 +39,12 @@ const card: Card = {
 			name: {
 				en: "Green Blast",
 				fr: "Explosion verte",
-				de: "Green Blast"
+				de: "Naturstoß"
 			},
 			effect: {
 				en: "Does 40 damage plus 10 more damage for each Grass Energy attached to all of your Pokémon.",
 				fr: "Inflige 40 dégâts plus 10 dégâts supplémentaires pour chaque Énergie Grass attachée à tous vos Pokémon.",
-				de: "Does 40 damage plus 10 more damage for each  Energy attached to all of your Pokémon."
+				de: "Dieser Angriff fügt 40 Schadenspunkte plus 10 weitere Schadenspunkte für jede {G}-Energie, die an allen deinen Pokémon angelegt ist, zu."
 			},
 			damage: "40+",
 
@@ -58,12 +59,12 @@ const card: Card = {
 			name: {
 				en: "Soothing Scent",
 				fr: "Senteur apaisante",
-				de: "Soothing Scent"
+				de: "Beruhigender Duft"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
-				de: "The Defending Pokémon is now Asleep."
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 			damage: 80,
 
@@ -80,7 +81,8 @@ const card: Card = {
 	retreat: 4,
 
 	description: {
-		en: "Some Pokémon are born on a TORTERRA's back and spend their entire life there."
+		en: "Some Pokémon are born on a TORTERRA's back and spend their entire life there.",
+		de: "Manche PKMN werden auf dem Rücken eines CHELTERRAR geboren und verbringen ihr ganzes Leben dort."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/4.ts
+++ b/data/Platinum/Platinum/4.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Skitty",
-		fr: "Skitty"
+		fr: "Skitty",
+		de: "Eneco"
 	},
 
 	stage: "Stage1",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Power Circulation",
 				fr: "Circulation de puissance",
-				de: "Power Circulation"
+				de: "Kraft-Kreislauf"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may search your discard pile for up to 2 basic Energy cards, show them to your opponent, and put those cards on top of your deck in any order. If you do, put 2 damage counters on Delcatty. This power can't be used if Delcatty is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez choisir dans votre pile de défausse jusqu'à 2 cartes Énergie de base. Montrez-les à votre adversaire et placez-les au dessus de votre deck dans n'importe quel ordre. Placez alors 2 marqueurs de dégât sur Delcatty. Ce pouvoir ne peut pas être utilisé si Delcatty est affecté par un État Spécial.",
-				de: "Once during your turn (before your attack), you may search your discard pile for up to 2 basic Energy cards, show them to your opponent, and put them on top of your deck in any order. If you do, put 2 damage counters on Delcatty. This power can't be used if Delcatty is affected by a Special Condition."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du deinen Ablagestapel nach bis zu 2 Basis-Energiekarten durchsuchen, sie deinem Gegner zeigen und in beliebiger Reihenfolge auf dein Deck legen. Wenn du das machst, lege 2 Schadensmarken auf Enekoro. Diese Poké-Power kann nicht benutzt werden, wenn Enekoro von einem Speziellen Zustand betroffen ist."
 			}
 		},
 	],
@@ -52,12 +53,12 @@ const card: Card = {
 			name: {
 				en: "Power Heal",
 				fr: "Pouvoir guérissant",
-				de: "Power Heal"
+				de: "Heilkraft"
 			},
 			effect: {
 				en: "Does 10 damage plus 10 more damage for each damage counter on Delcatty. Then, remove 2 damage counters from Delcatty.",
 				fr: "Inflige 10 dégâts plus 10 dégâts supplémentaires pour chaque marqueur de dégât sur Delcatty. Ensuite, retirez à Delcatty 2 marqueurs de dégât.",
-				de: "Does 10 damage plus 10 more damage for each damage counter on Delcatty. Then, remove 2 damage counters from Delcatty."
+				de: "Dieser Angriff fügt 10 Schadenspunkte plus 10 weitere Schadenspunkte für jede Schadensmarke auf Enekoro zu. Danach entferne 2 Schadensmarken von Enekoro."
 			},
 			damage: "10+",
 
@@ -71,7 +72,7 @@ const card: Card = {
 			name: {
 				en: "Rear Kick",
 				fr: "Pouvoir guérisseur",
-				de: "Rear Kick"
+				de: "Rückwärtskick"
 			},
 
 			damage: 60,

--- a/data/Platinum/Platinum/40.ts
+++ b/data/Platinum/Platinum/40.ts
@@ -30,12 +30,12 @@ const card: Card = {
 			name: {
 				en: "Anticipation",
 				fr: "Anticipation",
-				de: "Anticipation"
+				de: "Vorahnung"
 			},
 			effect: {
 				en: "Prevent all effects of attacks, excluding damage, done to Toxicroak G.",
 				fr: "Prévenez tous les effets d'attaques, dégâts exclus, infligés à Coatox .",
-				de: "Prevent all effects of attacks, excluding damage, done to Toxicroak G."
+				de: "Verhindere alle Effekte von Angriffen, außer Schaden, die Toxiquak G zugefügt würden."
 			}
 		},
 	],
@@ -49,12 +49,12 @@ const card: Card = {
 			name: {
 				en: "Deep Poison",
 				fr: "Poison profond",
-				de: "Deep Poison"
+				de: "Tiefengift"
 			},
 			effect: {
 				en: "If the Defending Pokémon is Poisoned, this attack does 20 damage plus 40 more damage.",
 				fr: "Si le Pokémon Défenseur est Empoisonné, cette attaque inflige 20 dégâts plus 40 dégâts supplémentaires.",
-				de: "If the Defending Pokémon is Poisoned, this attack does 20 damage plus 40 more damage."
+				de: "Wenn das Verteidigende Pokémon vergiftet ist, fügt dieser Angriff 20 Schadenspunkte plus 40 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 

--- a/data/Platinum/Platinum/41.ts
+++ b/data/Platinum/Platinum/41.ts
@@ -30,12 +30,12 @@ const card: Card = {
 			name: {
 				en: "Galactic Switch",
 				fr: "Échange galactique",
-				de: "Galactic Switch"
+				de: "Galaktischer Tausch"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may move an Energy card attached to 1 of your Pokémon SP to another of your Pokémon. Then, put 2 damage counters on Bronzong G. This power can't be used if Bronzong G is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez déplacer une carte Énergie attachée à 1 de vos Pokémon SP sur un autre de vos Pokémon. Ensuite, placez 2 marqueurs de dégât sur Archéodong . Ce pouvoir ne peut pas être utilisé si Archéodong  est affecté par un État Spécial.",
-				de: "Once during your turn (before your attack), you may move an Energy card attached to 1 of your Pokémon SP to another of your Pokémon. Then, put 2 damage counters on Bronzong G. This power can't be used if Bronzong G is affected by a Special Condition."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 Energiekarte, die an 1 deiner Pokémon SP angelegt ist, an 1 anderes deiner Pokémon anlegen. Danach lege 2 Schadensmarken auf Bronzong G. Diese Poké-Power kann nicht benutzt werden, wenn Bronzong G von einem Speziellen Zustand betroffen ist."
 			}
 		},
 	],
@@ -50,12 +50,12 @@ const card: Card = {
 			name: {
 				en: "Psychic Pulse",
 				fr: "Vibration psy",
-				de: "Psychic Pulse"
+				de: "Psychopuls"
 			},
 			effect: {
 				en: "Does 10 damage to each of your opponent's Benched Pokémon that has any damage counters on it. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à chacun des Pokémon de Banc de votre adversaire possédant des marqueurs de dégât. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Does 10 damage to each of your opponent's Benched Pokémon that has any damage counters on it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Dieser Angriff fügt jedem Pokémon auf der Bank deines Gegners, auf dem bereits mindestens 1 Schadensmarke liegt, 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 40,
 

--- a/data/Platinum/Platinum/42.ts
+++ b/data/Platinum/Platinum/42.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Cacnea",
-		fr: "Cacnea"
+		fr: "Cacnea",
+		de: "Tuska"
 	},
 
 	stage: "Stage1",
@@ -37,12 +38,12 @@ const card: Card = {
 			name: {
 				en: "Spike Wound",
 				fr: "Blessure pointue",
-				de: "Spike Wound"
+				de: "Stachelwunde"
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon that has any damage counters on it. This attack does 50 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Choisissez 1 des Pokémon de votre adversaire possédant des marqueurs de dégât. Cette attaque lui inflige 50 dégâts. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Choose 1 of your opponent's Pokémon that has any damage counters on it. This attack does 50 damage to that Pokémon. (Don't apply Weakness and resistance for benched Pokémon.)"
+				de: "Wähle 1 Pokémon deines Gegners, auf dem mindestens 1 Schadensmarke liegt. Dieser Angriff fügt dem gewählten Pokémon 50 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -54,12 +55,12 @@ const card: Card = {
 			name: {
 				en: "Poison Experiment",
 				fr: "Expérimentation empoisonnée",
-				de: "Poison Experiment"
+				de: "Giftexperiment"
 			},
 			effect: {
 				en: "You may discard a Grass or Darkness Energy attached to Cacturne. If you discard a Grass Energy, the Defending Pokémon is now Poisoned. If you discard a Darkness Energy, the Defending Pokémon is now Paralyzed.",
 				fr: "Vous pouvez défausser une Énergie Grass ou Darkness attachée à Cacturne. Si vous défaussez une Énergie Grass, le Pokémon Défenseur est maintenant Empoisonné. Si vous défaussez une Énergie Darkness, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "You may discard a  or  Energy attached to Cacturne. If you discard a  Energy, the Defending Pokémon is now Poisoned. If you discard a  Energy, the Defending Pokémon is now Paralyzed."
+				de: "Du kannst 1 an Noktuska angelegte {G}- oder {D}-Energie auf deinen Ablagestapel legen. Wenn du 1 {G}-Energie auf deinen Ablagestapel legst, ist das Verteidigende Pokémon jetzt vergiftet. Wenn du 1 {D}-Energie auf deinen Ablagestapel legst, ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -76,7 +77,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It becomes active at night, seeking prey that is exhausted from the day's desert heat."
+		en: "It becomes active at night, seeking prey that is exhausted from the day's desert heat.",
+		de: "Ein nachtaktives PKMN, das Beute sucht, die durch die Tageshitze der Wüste bereits erschöpft ist."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/43.ts
+++ b/data/Platinum/Platinum/43.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Stretch Vine",
 				fr: "Longue Liane",
-				de: "Stretch Vine"
+				de: "Streckranke"
 			},
 			effect: {
 				en: "Choose 2 of your opponent's Benched Pokémon. This attack does 10 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Choisissez 2 des Pokémon de Banc de votre adversaire. Cette attaque inflige 10 dégâts à chacun. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Choose 2 of your opponent's benched Pokémon. This attack does 10 damage to each of them. (Don't apply Weakness and Resistance for Benched pokémon.)"
+				de: "Wähle 2 Pokémon auf der Bank deines Gegners. Dieser Angriff fügt den gewählten Pokémon 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -48,12 +48,12 @@ const card: Card = {
 			name: {
 				en: "Absorb",
 				fr: "Vol-vie",
-				de: "Absorb"
+				de: "Absorber"
 			},
 			effect: {
 				en: "Remove 2 damage counters from Carnivine.",
 				fr: "Retirez à Vortente 2 marqueurs de dégât.",
-				de: "Remove 2 damage counters from Carnivine."
+				de: "Entferne 2 Schadensmarken von Venuflibis."
 			},
 			damage: 20,
 
@@ -71,7 +71,7 @@ const card: Card = {
 			effect: {
 				en: "If the Defending Pokémon already has any damage counters on it, the Defending Pokémon is now Burned and Poisoned.",
 				fr: "Si le Pokémon Défenseur possède déjà des marqueurs de dégât, il est maintenant Brûlé et Empoisonné.",
-				de: "If the Defending Pokémon already has any damage counters on it, the Defending Pokémon is now Burned and poisoned."
+				de: "Wenn auf dem Verteidigenden Pokémon mindestens 1 Schadensmarke liegt, ist das Verteidigende Pokémon jetzt verbrannt und vergiftet."
 			},
 			damage: 30,
 

--- a/data/Platinum/Platinum/44.ts
+++ b/data/Platinum/Platinum/44.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Wurmple",
-		fr: "Chenipotte"
+		fr: "Chenipotte",
+		de: "Waumpel"
 	},
 
 	stage: "Stage1",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Ascension",
 				fr: "Ascension",
-				de: "Ascension"
+				de: "Aufstieg"
 			},
 			effect: {
 				en: "Search your deck for a card that evolves from Cascoon and put it onto Cascoon. (This counts as evolving Cascoon.) Shuffle your deck afterward.",
 				fr: "Choisissez dans votre deck une carte qui évolue de Blindalys et placez-la sur Blindalys. (Vous le faites ainsi évoluer.) Ensuite, mélangez votre deck.",
-				de: "Search your deck for a card that evolves from Cascoon and put it onto Cascoon. (This counts as evolving Cascoon.) Shuffle your deck afterward."
+				de: "Durchsuche dein Deck nach einer Karte, die sich aus Panekon entwickelt, und lege diese auf Panekon. (Dies zählt als Entwickeln von Panekon.) Mische dein Deck danach."
 			},
 
 		},
@@ -51,12 +52,12 @@ const card: Card = {
 			name: {
 				en: "Poison Thread",
 				fr: "Fil empoisonné",
-				de: "Poison Thread"
+				de: "Giftiger Faden"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné.",
-				de: "The Defending Pokémon is now Poisoned."
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet."
 			},
 			damage: 20,
 
@@ -73,7 +74,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It never forgets any attack it endured while in the cocoon. After evolution, it seeks payback."
+		en: "It never forgets any attack it endured while in the cocoon. After evolution, it seeks payback.",
+		de: "Es vergisst keinen Angriff, den es im Kokon erdulden musste. Nach der Entwicklung sinnt es auf Rache."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/45.ts
+++ b/data/Platinum/Platinum/45.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Torchic",
-		fr: "Poussifeu"
+		fr: "Poussifeu",
+		de: "Flemmli"
 	},
 
 	stage: "Stage1",
@@ -37,12 +38,12 @@ const card: Card = {
 			name: {
 				en: "Firebreathing",
 				fr: "Souffle-feu",
-				de: "Firebreathing"
+				de: "Feuerhauch"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts plus 20 dégâts supplémentaires.",
-				de: "Flip a coin. If heads, this attack does 20 damage plus 20 more damage."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -56,7 +57,7 @@ const card: Card = {
 			name: {
 				en: "High Jump Kick",
 				fr: "Pied voltige",
-				de: "High Jump Kick"
+				de: "Turmkick"
 			},
 
 			damage: 60,
@@ -74,7 +75,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Its kicking mastery lets it loose 10 kicks per second. It emits sharp cries to intimidate foes."
+		en: "Its kicking mastery lets it loose 10 kicks per second. It emits sharp cries to intimidate foes.",
+		de: "Es kann 10 Tritte pro Sekunde austeilen. Es gibt schrille Schreie von sich, um Gegner einzuschüchtern."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/46.ts
+++ b/data/Platinum/Platinum/46.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Skull Fossil",
-		fr: "Fossile Crâne"
+		fr: "Fossile Crâne",
+		de: "Kopffossil"
 	},
 
 	stage: "Stage1",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Rock Smash",
 				fr: "Éclate-roc",
-				de: "Rock Smash"
+				de: "Zertrümmerer"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts plus 20 dégâts supplémentaires.",
-				de: "Flip a coin. If heads, this attack does 20 damage plus 20 more damage."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -54,12 +55,12 @@ const card: Card = {
 			name: {
 				en: "Knock Over",
 				fr: "Culbute",
-				de: "Knock Over"
+				de: "Umwerfen"
 			},
 			effect: {
 				en: "You may discard any Stadium card in play.",
 				fr: "Vous pouvez défausser n'importe quelle carte Stade en jeu.",
-				de: "You may discard any Stadium card in play."
+				de: "Du kannst eine beliebige Stadion-Karte aus dem Spiel auf den Ablagestapel legen."
 			},
 			damage: 40,
 
@@ -76,7 +77,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "A lifelong jungle dweller from 100 million years ago, it would snap obstructing trees with head butts."
+		en: "A lifelong jungle dweller from 100 million years ago, it would snap obstructing trees with head butts.",
+		de: "Es lebt seit Urzeiten im Dschungel. Kann im Weg befindliche Bäume mit Kopfstößen aus dem Weg räumen."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/47.ts
+++ b/data/Platinum/Platinum/47.ts
@@ -30,12 +30,12 @@ const card: Card = {
 			name: {
 				en: "Flash Bite",
 				fr: "Morsure flash",
-				de: "Flash Bite"
+				de: "Blitzbiss"
 			},
 			effect: {
 				en: "Once during your turn, when you put Crobat G from your hand onto your Bench, you may put 1 damage counter on 1 of your opponent's Pokémon.",
 				fr: "Une seule fois lors de votre tour, lorsque vous placez Nostenfert  de votre main sur votre Banc, vous pouvez placer 1 marqueur de dégât sur 1 des Pokémon de votre adversaire.",
-				de: "One during your turn, when you put Crobat G from your hand onto your Bench, you may put 1 damage counter on 1 of your opponent's Pokémon."
+				de: "Einmal während deines Zuges kannst du, wenn du Iksbat G von deiner Hand auf deine Bank legst, 1 Schadensmarke auf 1 Pokémon deines Gegners legen."
 			}
 		},
 	],
@@ -49,12 +49,12 @@ const card: Card = {
 			name: {
 				en: "Toxic Fang",
 				fr: "Croc toxik",
-				de: "Toxic Fang"
+				de: "Giftiger Reißzahn"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned. Put 2 damage counters instead of 1 on the Defending Pokémon between turns.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné. Placez 2 marqueurs de dégât au lieu d'1 sur le Pokémon Défenseur entre deux tours.",
-				de: "The Defending pokémon is now Poisoned. Put 2 damage counters instead of 1 on the Defending Pokémon between turns."
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet. Lege zwischen den Zügen 2 Schadensmarken anstelle von 1 Schadensmarke auf das Verteidigende Pokémon."
 			},
 
 		},

--- a/data/Platinum/Platinum/48.ts
+++ b/data/Platinum/Platinum/48.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Mareep",
-		fr: "Wattouat"
+		fr: "Wattouat",
+		de: "Voltilamm"
 	},
 
 	stage: "Stage1",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Spark",
 				fr: "Étincelle",
-				de: "Spark"
+				de: "Funkensprung"
 			},
 			effect: {
 				en: "Does 10 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à 2 des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Does 10 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for benched Pokémon.)"
+				de: "Dieser Angriff fügt 2 Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 10,
 
@@ -54,12 +55,12 @@ const card: Card = {
 			name: {
 				en: "Tail Code",
 				fr: "Queue codée",
-				de: "Tail Code"
+				de: "Schweifcode"
 			},
 			effect: {
 				en: "Move an Energy card attached to the Defending Pokémon to another of your opponent's Pokémon.",
 				fr: "Déplacez une carte Énergie attachée au Pokémon Défenseur sur un autre des Pokémon de votre adversaire.",
-				de: "Move an Energy card attached to the Defending Pokémon to another of your opponent's Pokémon."
+				de: "Entferne 1 an das Verteidigende Pokémon angelegte Energiekarte und lege sie an 1 anderes Pokémon deines Gegners an."
 			},
 			damage: 30,
 
@@ -83,7 +84,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "If its coat becomes fully charged with electricity, its tail lights up. It fires hair that zaps on impact."
+		en: "If its coat becomes fully charged with electricity, its tail lights up. It fires hair that zaps on impact.",
+		de: "Hat es sich mit Elektrizität aufgeladen, leuchtet sein Schweif und es feuert Haare ab, die sich entladen."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/49.ts
+++ b/data/Platinum/Platinum/49.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Turtwig",
-		fr: "Tortipouss"
+		fr: "Tortipouss",
+		de: "Chelast"
 	},
 
 	stage: "Stage1",
@@ -37,12 +38,12 @@ const card: Card = {
 			name: {
 				en: "Absorb",
 				fr: "Vol-vie",
-				de: "Absorb"
+				de: "Absorber"
 			},
 			effect: {
 				en: "Remove 1 damage counter from Grotle.",
 				fr: "Retirez à Boskara 1 marqueur de dégât.",
-				de: "Remove 1 damage counter from Grotle."
+				de: "Entferne 1 Schadensmarke von Chelcarain."
 			},
 			damage: 30,
 
@@ -56,7 +57,7 @@ const card: Card = {
 			name: {
 				en: "Razor Leaf",
 				fr: "Tranch'herbe",
-				de: "Razor Leaf"
+				de: "Rasierblatt"
 			},
 
 			damage: 60,
@@ -81,7 +82,8 @@ const card: Card = {
 	retreat: 3,
 
 	description: {
-		en: "It knows where pure water wells up. It carries fellow Pokémon there on its back."
+		en: "It knows where pure water wells up. It carries fellow Pokémon there on its back.",
+		de: "Es weiß, wo es reinstes Quellwasser finden kann. Trägt andere Pokémon auf seinem Rücken dorthin."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/5.ts
+++ b/data/Platinum/Platinum/5.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Reverse Time",
 				fr: "Temps inverse",
-				de: "Reverse Time"
+				de: "Zeitumkehr"
 			},
 			effect: {
 				en: "Once during your turn, when you put Dialga from your hand onto your Bench, you may search your discard pile for up to 3 in any combination of Pokémon (excluding Pokémon LV.X) and basic Energy cards. Show them to your opponent and put them on top of your deck in any order.",
 				fr: "Une seule fois lors de votre tour, lorsque vous placez Dialga de votre main sur votre Banc, vous pouvez chercher dans votre pile de défausse n'importe quelle combinaison de jusqu'à 3 Pokémon (Pokémon NIV.X exclus) et cartes Énergie de base. Montrez-les à votre adversaire et placez-les au dessus de votre deck dans n'importe quel ordre.",
-				de: "Once during your turn, when you put Dialga from your hand onto your Bench, you may search your discard pile for up to 3 in any combination of Pokémon (excluding Pokémon LV.X) and basic Energy cards. Show them to your opponent and put them on top of your deck in any order."
+				de: "Einmal während deines Zuges kannst du, wenn du Dialga von deiner Hand auf deine Bank legst, deinen Ablagestapel nach bis zu 3 Karten in beliebiger Kombination aus Pokémon- (außer Pokémon LV.X) und Basis-Energiekarten durchsuchen. Zeige sie deinem Gegner und lege sie in beliebiger Reihenfolge auf dein Deck."
 			}
 		},
 	],
@@ -49,12 +49,12 @@ const card: Card = {
 			name: {
 				en: "Time-Space Traveling",
 				fr: "Voyage espace-temps",
-				de: "Time-Space Traveling"
+				de: "Durch die Zeit reisen"
 			},
 			effect: {
 				en: "Draw cards until you have 7 cards in your hand.",
 				fr: "Piochez des cartes jusqu'à ce que vous ayez 7 cartes en main.",
-				de: "Draw cards until you have 7 cards in your hand."
+				de: "Ziehe so viele Karten, bis du 7 Karten auf der Hand hast."
 			},
 			damage: 50,
 
@@ -78,7 +78,8 @@ const card: Card = {
 	retreat: 3,
 
 	description: {
-		en: "It has the power to control time. It appears in Sinnoh-region myths as an ancient deity."
+		en: "It has the power to control time. It appears in Sinnoh-region myths as an ancient deity.",
+		de: "Es besitzt die Macht, die Zeit zu kontrollieren. In den Mythen von Sinnoh erscheint es als Gottheit."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/50.ts
+++ b/data/Platinum/Platinum/50.ts
@@ -33,12 +33,12 @@ const card: Card = {
 			name: {
 				en: "Black Cry",
 				fr: "Cri noir",
-				de: "Black Cry"
+				de: "Schwarzer Schrei"
 			},
 			effect: {
 				en: "The Defending Pokémon can't retreat or use any Poké-Powers during your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas battre en retraite ou utiliser de Poké-Powers lors du prochain tour de votre adversaire.",
-				de: "The Defending Pokémon can't retreat or use any Poke-Powers during your opponent's next turn."
+				de: "Das Verteidigende Pokémon kann sich im nächsten Zug deines Gegners nicht zurückziehen und keine Poké-Power benutzen."
 			},
 			damage: 20,
 
@@ -52,12 +52,12 @@ const card: Card = {
 			name: {
 				en: "Dark Slash",
 				fr: "Entaille",
-				de: "Dark Slash"
+				de: "Dunkler Hieb"
 			},
 			effect: {
 				en: "You may discard a Darkness Energy attached to Houndoom G. If you do, this attack does 40 damage plus 20 more damage.",
 				fr: "Vous pouvez défausser une Énergie Darkness attachée à Demolosse . Cette attaque inflige alors 40 dégâts plus 20 dégâts supplémentaires.",
-				de: "You may discard a  Energy attached to Houndoom G. If you do, this attack does 40 damage plus 20 more damage."
+				de: "Du kannst 1{D}-Energie von Hundemon G entfernen und auf deinen Ablagestapel legen. Wenn du das machst, fügt dieser Angriff 40 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "40+",
 

--- a/data/Platinum/Platinum/51.ts
+++ b/data/Platinum/Platinum/51.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Ralts",
-		fr: "Tarsal"
+		fr: "Tarsal",
+		de: "Trasla"
 	},
 
 	stage: "Stage1",
@@ -37,12 +38,12 @@ const card: Card = {
 			name: {
 				en: "Teleportation Burst",
 				fr: "Téléportation explosive",
-				de: "Teleportation Burst"
+				de: "Blitz-Teleportation"
 			},
 			effect: {
 				en: "You may switch Kirlia with 1 of your Benched Pokémon.",
 				fr: "Vous pouvez échanger Kirlia avec 1 des Pokémon de Banc de votre adversaire.",
-				de: "You may switch Kirlia with 1 of your Benched Pokémon."
+				de: "Du kannst Kirlia gegen 1 Pokémon auf deiner Bank austauschen."
 			},
 			damage: 30,
 
@@ -56,7 +57,7 @@ const card: Card = {
 			name: {
 				en: "Super Psy Bolt",
 				fr: "Super psy",
-				de: "Super Psy Bolt"
+				de: "Super-Psischlag"
 			},
 
 			damage: 60,
@@ -74,7 +75,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "If its Trainer becomes happy, it overflows with energy, dancing joyously while spinning about."
+		en: "If its Trainer becomes happy, it overflows with energy, dancing joyously while spinning about.",
+		de: "Ist sein Trainer glücklich, tanzt es in einem Schwall von Energie fröhlich umher."
 	},
 
 	variants: [		{

--- a/data/Platinum/Platinum/52.ts
+++ b/data/Platinum/Platinum/52.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Lotad",
-		fr: "Nénupiot"
+		fr: "Nénupiot",
+		de: "Loturzel"
 	},
 
 	stage: "Stage1",
@@ -37,12 +38,12 @@ const card: Card = {
 			name: {
 				en: "Interrupt",
 				fr: "Interruption",
-				de: "Interrupt"
+				de: "Stören"
 			},
 			effect: {
 				en: "Flip a coin. If heads, look at your opponent's hand and choose 1 card, then have your opponent shuffle that card into his or her deck.",
 				fr: "Lancez une pièce. Si c'est face, regardez la main de votre adversaire et choisissez-y une carte. Ensuite, demandez à votre adversaire de la mélanger à son deck.",
-				de: "Flip a coin. If heads, look at your opponent's hand and choose 1 card, then have your opponent shuffle that card into his or her deck."
+				de: "Wirf 1 Münze. Bei „Kopf“ schau dir die Handkarten deines Gegners an und wähle 1 davon. Dein Gegner mischt die gewählte Karte in sein Deck."
 			},
 			damage: 20,
 
@@ -56,7 +57,7 @@ const card: Card = {
 			name: {
 				en: "Gentle Slap",
 				fr: "Gifle douce",
-				de: "Gentle Slap"
+				de: "Sanfter Hieb"
 			},
 
 			damage: 60,
@@ -74,7 +75,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It has a mischievous spirit. If it spots an angler, it will tug on the fishing line to interfere."
+		en: "It has a mischievous spirit. If it spots an angler, it will tug on the fishing line to interfere.",
+		de: "Es hat ein spitzbübisches Wesen. Sieht es einen Angler, zieht es an der Angelschnur, um ihn zu ärgern."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/53.ts
+++ b/data/Platinum/Platinum/53.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Riolu",
-		fr: "Riolu"
+		fr: "Riolu",
+		de: "Riolu"
 	},
 
 	stage: "Stage1",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Aura Sphere",
 				fr: "Aurasphère",
-				de: "Aura Sphere"
+				de: "Aurasphäre"
 			},
 			effect: {
 				en: "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à 1 des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Does 10 damage to 1 of your opponent's benched Pokémon. (Don't apply Weakness and Resistance for benched Pokémon.)"
+				de: "Dieser Angriff fügt 1 Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 30,
 
@@ -54,12 +55,12 @@ const card: Card = {
 			name: {
 				en: "Do the Wave",
 				fr: "Faites la vague",
-				de: "Do the Wave"
+				de: "Wellenreiten"
 			},
 			effect: {
 				en: "Does 20 damage plus 10 more damage for each of your Benched Pokémon.",
 				fr: "Inflige 20 dégâts plus 10 dégâts supplémentaires pour chacun des Pokémon de votre Banc.",
-				de: "Does 20 damage plus 10 more damage for each of your Benched Pokémon."
+				de: "Dieser Angriff fügt 20 Schadenspunkte plus 10 weitere Schadenspunkte für jedes Pokémon auf deiner Bank zu."
 			},
 			damage: "20+",
 
@@ -74,7 +75,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "A well-trained one can sense auras to identify and take in the feelings of creatures over half a mile away."
+		en: "A well-trained one can sense auras to identify and take in the feelings of creatures over half a mile away.",
+		de: "Ist es trainiert, spürt es Auren, um Gefühle entfernter Kreaturen zu erkennen und aufzunehmen."
 	},
 
 	variants: [		{

--- a/data/Platinum/Platinum/54.ts
+++ b/data/Platinum/Platinum/54.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Poochyena",
-		fr: "Medhyena"
+		fr: "Medhyena",
+		de: "Fiffyen"
 	},
 
 	stage: "Stage1",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Cold Feet",
 				fr: "Pieds froids",
-				de: "Cold Feet"
+				de: "Kalte Füße"
 			},
 			effect: {
 				en: "If Mightyena is affected by a Special Condition, ignore all Energy necessary to use Mightyena's attacks.",
 				fr: "Si Grahyena est affecté par un État Spécial, ignorez toutes les Énergies nécessaires pour utiliser les attaques de Grahyena.",
-				de: "If Mightyena is affected by a Special Condition, ignore all Energy nessesary to use Mightyena's attacks."
+				de: "Wenn Magnayen von einem Speziellen Zustand betroffen ist, ignoriere alle Energiekosten von Magnayens Angriffen."
 			}
 		},
 	],
@@ -53,12 +54,12 @@ const card: Card = {
 			name: {
 				en: "Collude",
 				fr: "Association louche",
-				de: "Collude"
+				de: "Verschwören"
 			},
 			effect: {
 				en: "If you played any Supporter card from your hand during this turn, this attack does 20 damage plus 20 more damage.",
 				fr: "Si vous avez joué une carte Supporter de votre main ce tour-ci, cette attaque inflige 20 dégâts plus 20 dégâts supplémentaires.",
-				de: "If you played any Supporter card from your hand during this turn, this attack does 20 damage plus 20 more damage."
+				de: "Wenn du in diesem Zug mindestens 1 Unterstützerkarte von deiner Hand gespielt hast, fügt dieser Angriff 20 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -72,12 +73,12 @@ const card: Card = {
 			name: {
 				en: "Desperate Attack",
 				fr: "Attaque désespérée",
-				de: "Desperate Attack"
+				de: "Verzweifelter Angriff"
 			},
 			effect: {
 				en: "If Mightyena has less Energy attached to it than the Defending Pokémon, this attack does 50 damage plus 30 more damage.",
 				fr: "Si Grahyena possède moins d'Énergie que le Pokémon Défenseur, cette attaque inflige 50 dégâts plus 30 dégâts supplémentaires.",
-				de: "If Mightyena has less Energy attached to it than the Defending Pokémon, this attack does 30 more damage."
+				de: "Wenn an das Verteidigende Pokémon mehr Energie angelegt ist als an Magnayen, fügt dieser Angriff 50 Schadenspunkte plus 30 weitere Schadenspunkte zu."
 			},
 			damage: "50+",
 

--- a/data/Platinum/Platinum/55.ts
+++ b/data/Platinum/Platinum/55.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Misdreavus",
-		fr: "Feuforêve"
+		fr: "Feuforêve",
+		de: "Traunfugil"
 	},
 
 	stage: "Stage1",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Upper Hand",
 				fr: "Tourmente",
-				de: "Upper Hand"
+				de: "Oberhand"
 			},
 			effect: {
 				en: "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn.",
 				fr: "Choisissez 1 des attaques du Pokémon Défenseur. Il ne peut pas l'utiliser lors du prochain tour de votre adversaire.",
-				de: "Choose 1 of the Defending Pokémon's attacks. That Pokémon can't use that attack during your opponent's next turn."
+				de: "Wähle 1 Angriff des Verteidigenden Pokémon. Dieses Pokémon kann im nächsten Zug deines Gegners den gewählten Angriff nicht einsetzen."
 			},
 			damage: 30,
 
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Psybeam",
 				fr: "Rafale psy",
-				de: "Psybeam"
+				de: "Psystrahl"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Confused."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: 60,
 
@@ -84,7 +85,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Its cry sounds like an incantation. It is said the cry may rarely be imbued with happiness-giving power."
+		en: "Its cry sounds like an incantation. It is said the cry may rarely be imbued with happiness-giving power.",
+		de: "Sein Ruf ähnelt einer Beschwörung. Man sagt, dass er manchmal über die Kraft verfüge, glücklich zu machen."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/56.ts
+++ b/data/Platinum/Platinum/56.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Chimchar",
-		fr: "Ouisticram"
+		fr: "Ouisticram",
+		de: "Panflam"
 	},
 
 	stage: "Stage1",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Fire Tail Slap",
 				fr: "Coup de queue enflammé",
-				de: "Fire Tail Slap"
+				de: "Feuerschweifschlag"
 			},
 			effect: {
 				en: "Flip a coin. If tails, discard a Fire Energy attached to Monferno.",
 				fr: "Lancez une pièce. Si c'est pile, défaussez une Énergie Fire attachée à Chimpenfeu.",
-				de: "Flip a coin. If tails, discard a  Energy attached to Monferno."
+				de: "Wirf 1 Münze. Bei „Zahl“ entferne 1 {R}-Energie, die an Panpyro angelegt ist, und lege sie auf deinen Ablagestapel."
 			},
 			damage: 40,
 
@@ -54,12 +55,12 @@ const card: Card = {
 			name: {
 				en: "Paralyzing Gaze",
 				fr: "Regard paralysant",
-				de: "Paralyzing Gaze"
+				de: "Lähmender Blick"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -74,7 +75,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "It skillfully control the intensity of the fire on its tail to keep its foes at an ideal distance."
+		en: "It skillfully control the intensity of the fire on its tail to keep its foes at an ideal distance.",
+		de: "Es kontrolliert die Stärke des Feuers auf seinem Schweif geschickt, um Gegner auf Distanz zu halten."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/57.ts
+++ b/data/Platinum/Platinum/57.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Grimer",
-		fr: "Tadmorv"
+		fr: "Tadmorv",
+		de: "Sleima"
 	},
 
 	stage: "Stage1",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Sludge Cell",
 				fr: "Celllule vaseuse",
-				de: "Sludge Cell"
+				de: "Schlammbecken"
 			},
 			effect: {
 				en: "If Muk remains affected by any Special Conditions between turns, remove 2 damage counters from Muk.",
 				fr: "Au début du tour de chaque joueur, si Grotadmorv est affecté par un État Spécial, retirez-lui 2 marqueurs de dégât.",
-				de: "If Muk remains affected by any Special Condition between turns, remove 2 damage counters from Muk."
+				de: "Wenn Sleimok zwischen den Zügen von einem Speziellen Zustand betroffen bleibt, entferne 2 Schadensmarken von Sleimok."
 			}
 		},
 	],
@@ -53,12 +54,12 @@ const card: Card = {
 			name: {
 				en: "Strange Poison",
 				fr: "Poison étrange",
-				de: "Strange Poison"
+				de: "Seltsames Gift"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned. If tails, Muk is now Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Empoisonné. Si c'est pile, Grotadmorv est maintenant Empoisonné.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Poisoned. If tails, Muk is now Poisonened."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet. Bei „Zahl“ ist Sleimok jetzt vergiftet."
 			},
 			damage: 30,
 
@@ -72,12 +73,12 @@ const card: Card = {
 			name: {
 				en: "Strange Sludge",
 				fr: "Vase étrange",
-				de: "Strange Sludge"
+				de: "Seltsamer Schlamm"
 			},
 			effect: {
 				en: "If Muk is Poisoned, this attack does 50 damage plus 20 more damage and the Defending Pokémon is now Confused.",
 				fr: "Si Grotadmorv est Empoisonné, cette attaque inflige 50 dégâts plus 20 dégâts supplémentaires et le Pokémon Défenseur est maintenant Confus.",
-				de: "If Muk is Poisoned, this attack does 50 damage plus 20 more damage and the Defending Pokémon is now Confused."
+				de: "Wenn Sleimok vergiftet ist, fügt dieser Angriff 50 Schadenspunkte plus 20 weitere Schadenspunkte zu und das Verteidigende Pokémon ist jetzt verwirrt."
 			},
 			damage: "50+",
 

--- a/data/Platinum/Platinum/58.ts
+++ b/data/Platinum/Platinum/58.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Remoraid",
-		fr: "Rémoraid"
+		fr: "Rémoraid",
+		de: "Remoraid"
 	},
 
 	stage: "Stage1",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Water Vein",
 				fr: "Filon d'eau",
-				de: "Water Vein"
+				de: "Wasserader"
 			},
 			effect: {
 				en: "Reveal the top 5 cards of your deck. Flip a coin for each Energy card you find there. This attack does 50 damage times the number of heads. Shuffle the revealed cards back into your deck.",
 				fr: "Retournez les 5 cartes du dessus de votre deck. Lancez une pièce pour chaque carte Énergie que vous y trouvez. Cette attaque inflige 50 dégâts multipliés par le nombre de faces. Mélangez les cartes retournées à votre deck.",
-				de: "Reveal the top 5 cards of your deck. Flip a coin for each Energy card you find there. This attack does 50 damage times the number of heads. Shuffle the revealed cards back into your deck."
+				de: "Decke die obersten 5 Karten deines Decks auf. Wirf für jede Energiekarte, die auf diese Weise aufgedeckt wurde, 1 Münze. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl „Kopf“ zu. Mische die aufgedeckten Karten zurück in dein Deck."
 			},
 			damage: "50×",
 
@@ -57,7 +58,7 @@ const card: Card = {
 			effect: {
 				en: "Any time the Defending Pokémon tries to attack, your opponent flips a coin. If tails, that attack does nothing. (If the Defending Pokémon is no longer your opponent's Active Pokémon, this effect ends.)",
 				fr: "Chaque fois que le Pokémon Défenseur essaye d'attaquer, votre adversaire lance une pièce. Si c'est pile, cette attaque est sans effet. (Si le Pokémon Défenseur n'est plus le Pokémon Actif de votre adversaire, cet effet se termine.)",
-				de: "Any time the Defending Pokémon tries to attack, your opponent flips a coin. If tails, the attack does nothing. (If the Defending Pokémon is no longer your opponent 's Pokémon, this effect ends.)"
+				de: "Immer wenn das Verteidigende Pokémon angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen. (Dieser Effekt endet, sobald das Verteidigende Pokémon nicht mehr das Aktive Pokémon deines Gegners ist.)"
 			},
 			damage: 40,
 
@@ -74,7 +75,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It loves to lurk inside holes in rocks. It sometimes sprays ink on prey by sticking out only its mouth."
+		en: "It loves to lurk inside holes in rocks. It sometimes sprays ink on prey by sticking out only its mouth.",
+		de: "Es lauert gerne in den Löchern von Felsen, um vorbeischwimmende Beute mit Tinte zu bespritzen."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/59.ts
+++ b/data/Platinum/Platinum/59.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Piplup",
-		fr: "Tiplouf"
+		fr: "Tiplouf",
+		de: "Plinfa"
 	},
 
 	stage: "Stage1",
@@ -36,7 +37,7 @@ const card: Card = {
 			name: {
 				en: "Surf",
 				fr: "Surf",
-				de: "Surf"
+				de: "Surfer"
 			},
 
 			damage: 30,
@@ -51,12 +52,12 @@ const card: Card = {
 			name: {
 				en: "Bubblebeam",
 				fr: "Bulles d'O",
-				de: "Bubblebeam"
+				de: "Blubbstrahl"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 50,
 
@@ -73,7 +74,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Because every PRINPLUP considers itself to be the most important, they can never form a group."
+		en: "Because every PRINPLUP considers itself to be the most important, they can never form a group.",
+		de: "Jedes PLIPRIN geht davon aus, dass es das wichtigste ist. Daher können sie keine Gruppen bilden."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/6.ts
+++ b/data/Platinum/Platinum/6.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Time Aura",
 				fr: "Aura temporelle",
-				de: "Time Aura"
+				de: "Zeitaura"
 			},
 			effect: {
 				en: "As long as Dialga is your Active Pokémon, your opponent can't play any Pokémon from his or her hand to evolve his or her Active Pokémon.",
 				fr: "Tant que Dialga est votre Pokémon Actif, votre adversaire ne peut pas jouer de Pokémon de sa main pour faire évoluer son Pokémon Actif.",
-				de: "As long as Dialga is your Active Pokémon, your opponent can't play any Pokémon from his or her hand to evolve his or her Active Pokémon."
+				de: "Solange Dialga dein Aktives Pokémon ist, kann dein Gegner keine Pokémon-Karten von seiner Hand spielen, um sein Aktives Pokémon zu entwickeln."
 			}
 		},
 	],
@@ -50,12 +50,12 @@ const card: Card = {
 			name: {
 				en: "Metal Burn",
 				fr: "Brûlure métallique",
-				de: "Metal Burn"
+				de: "Metallbrand"
 			},
 			effect: {
 				en: "Discard all Metal Energy attached to Dialga.",
 				fr: "Défaussez toutes les Énergies Metal attachées à Dialga.",
-				de: "Discard all  Energy attached to Dialga."
+				de: "Lege alle an Dialga angelegten {M}-Energien auf deinen Ablagestapel."
 			},
 			damage: 100,
 
@@ -79,7 +79,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It has the power to control time. It appears in Sinnoh-region myths as an ancient deity."
+		en: "It has the power to control time. It appears in Sinnoh-region myths as an ancient deity.",
+		de: "Es besitzt die Macht die Zeit zu kontrollieren. In den Mythen von Sinnoh erscheint es als Gottheit."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/60.ts
+++ b/data/Platinum/Platinum/60.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Nosepass",
-		fr: "Tarinor"
+		fr: "Tarinor",
+		de: "Nasgnet"
 	},
 
 	stage: "Stage1",
@@ -37,12 +38,12 @@ const card: Card = {
 			name: {
 				en: "Stealth Rock",
 				fr: "Piège de Roc",
-				de: "Stealth Rock"
+				de: "Tarnsteine"
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Choisissez 1 des Pokémon de votre adversaire. Cette attaque lui inflige 30 dégâts. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Choose 1 of your opponent's Pokémon. This attack does 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Hyper Beam",
 				fr: "Ultralaser",
-				de: "Hyper Beam"
+				de: "Hyperstrahl"
 			},
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy card attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, défaussez une carte Énergie attachée au Pokémon Défenseur.",
-				de: "Flip a coin. If heads, discard an Energy card attached to the Defending Pokémon."
+				de: "Wirf 1 Münze. Bei „Kopf“ lege 1 Energiekarte, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
 			},
 			damage: 70,
 
@@ -77,7 +78,8 @@ const card: Card = {
 	retreat: 3,
 
 	description: {
-		en: "It freely controls three small units called Mini-Noses using magnetic force."
+		en: "It freely controls three small units called Mini-Noses using magnetic force.",
+		de: "Es steuert drei kleine Einheiten mithilfe von starkem Magnetismus. Man nennt sie Mininasen."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/61.ts
+++ b/data/Platinum/Platinum/61.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Shed Skin",
 				fr: "Mue",
-				de: "Shed Skin"
+				de: "Expidermis"
 			},
 			effect: {
 				en: "Remove 4 damage counters from Seviper.",
 				fr: "Retirez à Seviper 4 marqueurs de dégât.",
-				de: "Remove 4 damage counters from Seviper."
+				de: "Entferne 4 Schadensmarken von Vipitis."
 			},
 
 		},
@@ -45,12 +45,12 @@ const card: Card = {
 			name: {
 				en: "Bite and Escape",
 				fr: "Mordre avant de s'échapper",
-				de: "Bite and Escape"
+				de: "Beißen und Abhauen"
 			},
 			effect: {
 				en: "You may switch Seviper with 1 of your Benched Pokémon.",
 				fr: "Vous pouvez échanger Seviper avec 1 des Pokémon de votre Banc.",
-				de: "You may switch Seviper with 1 of your Benched Pokémon."
+				de: "Du kannst Vipitis gegen 1 Pokémon auf deiner Bank austauschen."
 			},
 			damage: 20,
 
@@ -64,12 +64,12 @@ const card: Card = {
 			name: {
 				en: "Paralyze Poison",
 				fr: "Poison paralysant",
-				de: "Paralyze Poison"
+				de: "Lähmendes Gift"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned. Flip a coin. If heads, the Defending Pokémon is now Paralyzed and Poisoned.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné. Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé et Empoisonné.",
-				de: "The Defending Pokémon is now Poisoned. Flip a coin. If heads, the Defending Pokémon is now Paralyzed and Poisened."
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet. Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt und vergiftet."
 			},
 			damage: 40,
 

--- a/data/Platinum/Platinum/62.ts
+++ b/data/Platinum/Platinum/62.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Armor Fossil",
-		fr: "Fossile Armure"
+		fr: "Fossile Armure",
+		de: "Panzerfossil"
 	},
 
 	stage: "Stage1",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Endure",
 				fr: "Ténacité",
-				de: "Endure"
+				de: "Ausdauer"
 			},
 			effect: {
 				en: "Flip a coin. If heads, during your opponent's next turn, if Shieldon would be Knocked Out by damage from an attack, Shieldon is not Knocked Out and its remaining HP becomes 10 instead.",
 				fr: "Lancez une pièce. Si c'est face, lors du prochain tour de votre adversaire, si Dinoclier est mis K.O par les dégâts d'une attaque, il n'est pas mis K.O mais il ne lui reste que 10 PV.",
-				de: "Flip a coin. If heads, during your opponent's next turn, if Shieldon would be Knocked Out by damage from an attack, Shieldon is not Knocked Out and its remaining HP becomes 10 instead."
+				de: "Wirf 1 Münze. Bei „Kopf“ wird Schilterus, wenn es im nächsten Zug deines Gegners durch Schaden eines Angriffs kampfunfähig würde, nicht kampfunfähig und hat stattdessen 10 verbliebene KP."
 			},
 
 		},
@@ -53,12 +54,12 @@ const card: Card = {
 			name: {
 				en: "Rock Slide",
 				fr: "Éboulement",
-				de: "Rock Slide"
+				de: "Steinhagel"
 			},
 			effect: {
 				en: "Does 10 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à 2 des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Does 10 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Dieser Angriff fügt 2 Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 30,
 
@@ -82,7 +83,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It is outstandingly armored. As a result, it can eat grass and berries without having to fight."
+		en: "It is outstandingly armored. As a result, it can eat grass and berries without having to fight.",
+		de: "Es ist sehr gut gepanzert und muss daher während des Essens von Gras und Beeren keinen Kampf fürchten."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/63.ts
+++ b/data/Platinum/Platinum/63.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Wurmple",
-		fr: "Chenipotte"
+		fr: "Chenipotte",
+		de: "Waumpel"
 	},
 
 	stage: "Stage1",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Ascension",
 				fr: "Ascension",
-				de: "Ascension"
+				de: "Aufstieg"
 			},
 			effect: {
 				en: "Search your deck for a card that evolves from Silcoon and put it onto Silcoon. (This counts as evolving Silcoon.) Shuffle your deck afterward.",
 				fr: "Choisissez dans votre deck une carte qui évolue d'Armulys et placez-la sur Armulys. (Vous le faites ainsi évoluer.) Ensuite, mélangez votre deck.",
-				de: "Search your deck for a card that evolves from Silcoon and put it onto Silcoon. (This counts as evolving Silcoon.) Shuffle your deck afterward."
+				de: "Durchsuche dein Deck nach einer Karte, die sich aus Schaloko entwickelt, und lege diese auf Schaloko. (Dies zählt als Entwickeln von Schaloko.) Mische dein Deck danach."
 			},
 
 		},
@@ -51,12 +52,12 @@ const card: Card = {
 			name: {
 				en: "Sticky String",
 				fr: "Ficelle collante",
-				de: "Sticky String"
+				de: "Klebfaden"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -73,7 +74,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It wraps silk around the branches of a tree. It drinks rainwater on its silk while awaiting evolution."
+		en: "It wraps silk around the branches of a tree. It drinks rainwater on its silk while awaiting evolution.",
+		de: "Es bindet sich mit Seide an Äste und trinkt Regenwasser, während es starr auf seine Entwicklung wartet."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/64.ts
+++ b/data/Platinum/Platinum/64.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Slakoth",
-		fr: "Parecool"
+		fr: "Parecool",
+		de: "Bummelz"
 	},
 
 	stage: "Stage1",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Reckless Charge",
 				fr: "Attaque imprudente",
-				de: "Reckless Charge"
+				de: "Waghalsiger Sturmangriff"
 			},
 			effect: {
 				en: "Flip a coin. If tails, Vigoroth does 10 damage to itself.",
 				fr: "Lancez une pièce. Si c'est pile, Vigoroth s'inflige 10 dégâts.",
-				de: "Flip a coin. If tails, Vigoroth does 10 damage to itself."
+				de: "Wirf 1 Münze. Bei „Zahl“ fügt Muntier sich selbst 10 Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -55,12 +56,12 @@ const card: Card = {
 			name: {
 				en: "Fight Back",
 				fr: "Rendre les coups",
-				de: "Fight Back"
+				de: "Zur Wehr setzen"
 			},
 			effect: {
 				en: "If Vigoroth has any damage counters on it, this attack does 50 damage plus 20 more damage.",
 				fr: "Si Vigoroth possède des marqueurs de dégât, cette attaque inflige 50 dégâts plus 20 dégâts supplémentaires.",
-				de: "If Vigoroth has any damage counters on it, this attack does 50 damage plus 20 more damage."
+				de: "Wenn auf Muntier mindestens 1 Schadensmarke liegt, fügt dieser Angriff 50 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "50+",
 
@@ -77,7 +78,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Its heart beats at a tenfold tempo, so it cannot sit still even for a moment."
+		en: "Its heart beats at a tenfold tempo, so it cannot sit still even for a moment.",
+		de: "Sein Herz schlägt schneller als das anderer Lebewesen. Daher kann es nicht für einen Moment still sitzen."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/65.ts
+++ b/data/Platinum/Platinum/65.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Squirtle",
-		fr: "Carapuce"
+		fr: "Carapuce",
+		de: "Schiggy"
 	},
 
 	stage: "Stage1",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Double Slap",
 				fr: "Torgnoles",
-				de: "Double Slap"
+				de: "Duplexhieb"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Flip 2 coins. This attack does 20 damage times the number of heads."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 
@@ -54,12 +55,12 @@ const card: Card = {
 			name: {
 				en: "Rocket Tackle",
 				fr: "Lance roquette",
-				de: "Rocket Tackle"
+				de: "Raketenstart"
 			},
 			effect: {
 				en: "Wartortle does 10 damage to itself. Flip a coin. If heads, prevent all damage done to Wartortle by attacks during your opponent's next turn.",
 				fr: "Carabaffe s'inflige 10 dégâts. Lancez une pièce. Si c'est face, prévenez tous les dégâts infligés à Carabaffe par des attaques lors du prochain tour de votre adversaire.",
-				de: "Wartotle does 10 damage to itself. Flip a coin. If heads, prevent all damage done to Wartortle by attacks during your opponent's next turn."
+				de: "Schillok fügt sich selbst 10 Schadenspunkte zu. Wirf 1 Münze. Bei „Kopf“ verhindere allen Schaden, der Schillok im nächsten Zug deines Gegners durch Angriffe zugefügt würde."
 			},
 			damage: 30,
 
@@ -76,7 +77,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It is said to live 10,000 years. Its furry tail is popular as a symbol of longevity."
+		en: "It is said to live 10,000 years. Its furry tail is popular as a symbol of longevity.",
+		de: "Man sagt, es werde 10 000 Jahre alt. Sein buschiger Schweif ist ein Symbol für langes Leben."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/66.ts
+++ b/data/Platinum/Platinum/66.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Thick Skin",
 				fr: "Dur à cuir",
-				de: "Thik Skin"
+				de: "Dicke Haut"
 			},
 			effect: {
 				en: "Zangoose can't be affected by any Special Conditions.",
 				fr: "Mangriff ne peut pas être affecté par des États Spéciaux.",
-				de: "Zangoose can't be affected by any Special Conditions."
+				de: "Sengo kann nicht von Speziellen Zuständen betroffen werden."
 			}
 		},
 	],
@@ -47,12 +47,12 @@ const card: Card = {
 			name: {
 				en: "Invite and Strike",
 				fr: "Inviter et frapper",
-				de: "Invite and Strike"
+				de: "Einladen und Zuschlagen"
 			},
 			effect: {
 				en: "Switch the Defending Pokémon with 1 of your opponent's Benched Pokémon. This attack does 20 damage to the new Defending Pokémon.",
 				fr: "Échangez le Pokémon Défenseur avec 1 des Pokémon de Banc de votre adversaire. Cette attaque inflige 20 dégâts au nouveau Pokémon Défenseur.",
-				de: "Switch the Defending Pokémon with one of your opponent's Benched Pokémon. This attack does 20 damage to the new Defending Pokémon."
+				de: "Tausche das Verteidigende Pokémon gegen 1 Pokémon auf der Bank deines Gegners aus. Dieser Angriff fügt dem neuen Verteidigenden Pokémon 20 Schadenspunkte zu."
 			},
 
 		},
@@ -65,12 +65,12 @@ const card: Card = {
 			name: {
 				en: "Chop Up",
 				fr: "Découper",
-				de: "Chop Up"
+				de: "Zerstückeln"
 			},
 			effect: {
 				en: "Does 10 damage to each of your opponent's Benched Pokémon that has any damage counters on it. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à chacun des Pokémon de Banc de votre adversaire possédant des marqueurs de dégât. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Does 10 damage to each of your opponent's Benched Pokémon that has any damage counters on it. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Dieser Angriff fügt jedem Pokémon auf der Bank deines Gegners, auf dem bereits mindestens 1 Schadensmarke liegt, 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 50,
 

--- a/data/Platinum/Platinum/67.ts
+++ b/data/Platinum/Platinum/67.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Sneaky Attack",
 				fr: "Coup Bas",
-				de: "Sneaky Attack"
+				de: "Hinterhältiger Angriff"
 			},
 			effect: {
 				en: "If Cacnea has any Darkness Energy attached to it, this attack does 10 damage plus 10 more damage.",
 				fr: "Si Cacnea possède de l'Énergie Darkness, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires.",
-				de: "If Cacnea has any  Energy attached to it, this attack does 10 damage plus 10 more damage."
+				de: "Wenn an Tuska mindestens 1 {D}-Energie angelegt ist, fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -48,12 +48,12 @@ const card: Card = {
 			name: {
 				en: "Shoot Needle",
 				fr: "Coup de dard",
-				de: "Shoot Needle"
+				de: "Stachelschuss"
 			},
 			effect: {
 				en: "Flip 2 coins. For each heads, choose 1 of your opponent's Pokémon and this attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can choose the same Pokémon more than once, but you can't do more than 10 damage to that Pokémon in this way.)",
 				fr: "Lancez 2 pièces. Pour chaque face, choisissez 1 des Pokémon de votre adversaire. Cette attaque lui inflige 10 dégâts. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.) (Vous pouvez choisir le même Pokémon plus d'une fois mais vous ne pouvez pas lui infliger plus de 10 dégâts de cette façon).",
-				de: "Flip 2 coins. For each heads, choose 1 of your opponent's Pokémon and this attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can choose the same Pokémon more than once, but you can't do more than 10 damage to that Pokémon in this way.)"
+				de: "Wirf 2 Münzen. Wähle für jedes Mal, wenn die Münze „Kopf“ gezeigt hat, 1 gegnerisches Pokémon und dieser Angriff fügt dem gewählten Pokémon 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.) (Du kannst das gleiche Pokémon mehrmals wählen, aber dem gewählten Pokémon können auf diese Weise nicht mehr als 10 Schadenspunkte zugefügt werden.)"
 			},
 
 		},
@@ -76,7 +76,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "By storing water in its body, this desert dweller can survive 30 days without water."
+		en: "By storing water in its body, this desert dweller can survive 30 days without water.",
+		de: "Dieser Wüstenbewohner speichert Wasser in seinem Körper. So kann er 30 Tage ohne Wasser überleben."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/68.ts
+++ b/data/Platinum/Platinum/68.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Poison Breath",
 				fr: "Haleine empoisonnée",
-				de: "Poison Breath"
+				de: "Gifthauch"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Empoisonné.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Poisoned."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet."
 			},
 
 		},
@@ -46,12 +46,12 @@ const card: Card = {
 			name: {
 				en: "Sweet Saliva",
 				fr: "Douce salive",
-				de: "Sweet Saliva"
+				de: "Süßer Sabber"
 			},
 			effect: {
 				en: "Remove 1 damage counter from each of your Benched Pokémon.",
 				fr: "Retirez 1 marqueur de dégât à chacun de vos Pokémon de Banc.",
-				de: "Remove 1 damage counter from each of your Benched Pokémon."
+				de: "Entferne 1 Schadensmarke von jedem Pokémon auf deiner Bank."
 			},
 			damage: 20,
 
@@ -75,7 +75,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It binds itself to trees in marshes. It attracts prey with its sweet-smelling drool and gulps them down."
+		en: "It binds itself to trees in marshes. It attracts prey with its sweet-smelling drool and gulps them down.",
+		de: "Klammert sich an Bäume in Sümpfen. Lockt Beute mit seinem süßlichen Speichel an und schluckt sie dann."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/69.ts
+++ b/data/Platinum/Platinum/69.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Healing Trial",
 				fr: "Défi guérison",
-				de: "Healing Trial"
+				de: "Heilprobe"
 			},
 			effect: {
 				en: "Flip a coin. If heads, remove 3 damage counters from Chansey. If tails, remove 3 damage counters from the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, retirez à Leveinard 3 marqueurs de dégât. Si c'est pile, retirez au Pokémon Défenseur 3 marqueurs de dégât.",
-				de: "Flip a coin. If heads, remove 3 damage counters from Chansey. If tails, remove 3 damage counters from the Defending Pokémon."
+				de: "Wirf 1 Münze. Bei „Kopf“ entferne 3 Schadensmarken von Chaneira. Bei „Zahl“ entferne 3 Schadensmarken vom Verteidigenden Pokémon."
 			},
 
 		},
@@ -48,12 +48,12 @@ const card: Card = {
 			name: {
 				en: "Pulled Punch",
 				fr: "Poing-doux",
-				de: "Pulled Punch"
+				de: "Verhaltener Schlag"
 			},
 			effect: {
 				en: "If the Defending Pokémon already has any damage counters on it, this attack's base damage is 10 instead of 40.",
 				fr: "Si le Pokémon Défenseur possède déjà des marqueurs de dégât, les dégâts de base de cette attaque sont de 10 au lieu de 40.",
-				de: "If the Defending Pokémon already has any damage counters on it, this attack's base damage is 10 instead of 40."
+				de: "Wenn auf dem Verteidigenden Pokémon bereits mindestens 1 Schadensmarke liegt, beträgt der Grundschaden dieses Angriffs 10 Schadenspunkte anstelle von 40 Schadenspunkten."
 			},
 			damage: 40,
 
@@ -70,7 +70,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "A kindly Pokémon that lays highly nutritious eggs and shares them with injured Pokémon or people."
+		en: "A kindly Pokémon that lays highly nutritious eggs and shares them with injured Pokémon or people.",
+		de: "Ein freundliches Pokémon, das seine nahrhaften Eier mit verletzten Pokémon und Menschen teilt."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/7.ts
+++ b/data/Platinum/Platinum/7.ts
@@ -33,12 +33,12 @@ const card: Card = {
 			name: {
 				en: "Deafen",
 				fr: "Rendre sourd",
-				de: "Deafen"
+				de: "Ohren betäuben"
 			},
 			effect: {
 				en: "Your opponent can't play any Trainer cards or Stadium cards from his or her hand during your opponent's next turn.",
 				fr: "Votre adversaire ne peut pas jouer de cartes Dresseur ou Stade de sa main lors de son prochain tour.",
-				de: "Your opponent can't play any Trainer cards or Stadium cards from his or her hand during your opponent's next turn."
+				de: "Dein Gegner kann in seinem nächsten Zug keine Trainer- oder Stadion-Karten von seiner Hand spielen."
 			},
 			damage: 10,
 
@@ -52,12 +52,12 @@ const card: Card = {
 			name: {
 				en: "Second Strike",
 				fr: "Deuxième coup",
-				de: "Second Strike"
+				de: "Sekundärschlag"
 			},
 			effect: {
 				en: "If the Defending Pokémon already has 2 or more damage counters on it, this attack does 50 damage plus 20 more damage.",
 				fr: "Si le Pokémon Défenseur possède déjà au moins 2 marqueurs de dégât, cette attaque inflige 50 dégâts plus 20 dégâts supplémentaires.",
-				de: "If the Defending Pokémon already has 2 or more damage counters on it, this attack does 50 damage plus 20 more damage."
+				de: "Wenn auf dem Verteidigenden Pokémon bereits mindestens 2 Schadensmarken liegen, fügt dieser Angriff 50 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "50+",
 

--- a/data/Platinum/Platinum/70.ts
+++ b/data/Platinum/Platinum/70.ts
@@ -31,7 +31,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
-				de: "Bite"
+				de: "Biss"
 			},
 
 			damage: 10,
@@ -45,7 +45,7 @@ const card: Card = {
 			name: {
 				en: "Fire Punch",
 				fr: "Poing de feu",
-				de: "Fire Punch"
+				de: "Feuerschlag"
 			},
 
 			damage: 20,
@@ -63,7 +63,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It is very agile. Before going to sleep, it extinguishes the flame on its tail to prevent fires."
+		en: "It is very agile. Before going to sleep, it extinguishes the flame on its tail to prevent fires.",
+		de: "Dieses flinke PKMN löscht vor dem Schlafengehen die Flamme auf seinem Schweif, um Feuer zu verhindern."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/71.ts
+++ b/data/Platinum/Platinum/71.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Collect",
 				fr: "Collectionner",
-				de: "Collect"
+				de: "Sammeln"
 			},
 			effect: {
 				en: "Draw a card.",
 				fr: "Piochez une carte.",
-				de: "Draw a card."
+				de: "Ziehe 1 Karte."
 			},
 
 		},
@@ -46,12 +46,12 @@ const card: Card = {
 			name: {
 				en: "Shoot Through",
 				fr: "Passer à travers",
-				de: "Shoot Through"
+				de: "Durchschießen"
 			},
 			effect: {
 				en: "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à 1 des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Dieser Angriff fügt 1 Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 20,
 
@@ -75,7 +75,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "The trio is together from birth. It constantly gathers honey from flowers to please VESPIQUEN."
+		en: "The trio is together from birth. It constantly gathers honey from flowers to please VESPIQUEN.",
+		de: "Dieses Trio ist von Geburt an zusammen. Fleißig bringt es Blütenhonig zu HONWEISEL."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/72.ts
+++ b/data/Platinum/Platinum/72.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Dig Under",
 				fr: "Terrassement",
-				de: "Dig Under"
+				de: "Schaufel unter"
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Benched Pokémon. This attack does 10 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance.",
 				fr: "Choisissez 1 des Pokémon de votre adversaire. Cette attaque lui inflige 10 dégâts. Les dégâts de cette attaque ne sont pas affectés par la Faiblesse ou la Résistance.",
-				de: "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+				de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 10 Schadenspunkte zu. Der Schaden dieses Angriffs wird durch Schwäche und Resistenz nicht verändert."
 			},
 
 		},
@@ -48,12 +48,12 @@ const card: Card = {
 			name: {
 				en: "Trip Over",
 				fr: "Croche-pied",
-				de: "Trip Over"
+				de: "Stolperer"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts plus 20 dégâts supplémentaires.",
-				de: "Flip a coin. If heads, this attack does 20 damage plus 20 more damage."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -77,7 +77,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "A Pokémon that lives underground. Because of its dark habitat, it is repelled by bright sunlight."
+		en: "A Pokémon that lives underground. Because of its dark habitat, it is repelled by bright sunlight.",
+		de: "Dieses Pokémon lebt unterirdisch. Da es an Dunkelheit gewöhnt ist, schreckt helles Licht es ab."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/73.ts
+++ b/data/Platinum/Platinum/73.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Call for Family",
 				fr: "Appel à la famille",
-				de: "Call for Family"
+				de: "Familienruf"
 			},
 			effect: {
 				en: "Search your deck for a Basic Pokémon and put it onto your Bench. Shuffle your deck afterward.",
 				fr: "Choisissez dans votre deck un Pokémon de base et placez-le sur votre Banc. Ensuite, mélangez votre deck.",
-				de: "Search your deck for a Basic Pokémon and put it onto your Bench. Shuffle your deck afterward."
+				de: "Durchsuche dein Deck nach einer Basis-Pokémon-Karte und lege sie auf deine Bank. Mische dein Deck danach."
 			},
 
 		},
@@ -45,12 +45,12 @@ const card: Card = {
 			name: {
 				en: "Spring Out",
 				fr: "Surgir",
-				de: "Spring Out"
+				de: "Rausspringen"
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Benched Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Choisissez 1 des Pokémon de votre adversaire. Cette attaque lui inflige 10 dégâts. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -66,7 +66,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It digs into the ground with its tail and makes a mazelike nest. It can fly just a little."
+		en: "It digs into the ground with its tail and makes a mazelike nest. It can fly just a little.",
+		de: "Es gräbt sich mit seinem Schweif in die Erde und baut ein labyrinthartiges Nest. Es kann kaum fliegen."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/74.ts
+++ b/data/Platinum/Platinum/74.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Roar",
 				fr: "Hurlement",
-				de: "Roar"
+				de: "Gebrüll"
 			},
 			effect: {
 				en: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon.",
 				fr: "Votre adversaire échange le Pokémon Défenseur avec 1 de ses Pokémon de Banc.",
-				de: "Your opponent switches the Defending Pokémon with 1 of his or her Benched Pokémon."
+				de: "Dein Gegner tauscht das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank aus."
 			},
 
 		},
@@ -48,12 +48,12 @@ const card: Card = {
 			name: {
 				en: "Thunder Fang",
 				fr: "Crocs Éclair",
-				de: "Thunder Fang"
+				de: "Donnerzahn"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -75,7 +75,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "Using electricity stored in its fur, it stimulates its muscles to heighten its reaction speed."
+		en: "Using electricity stored in its fur, it stimulates its muscles to heighten its reaction speed.",
+		de: "Die Elektrizität, die es im Fell speichert, nutzt es, um seine Muskeln zu stimulieren."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/75.ts
+++ b/data/Platinum/Platinum/75.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Division",
 				fr: "Division",
-				de: "Division"
+				de: "Teilung"
 			},
 			effect: {
 				en: "Search your deck for Grimer and put it onto your Bench. Shuffle your deck afterward.",
 				fr: "Cherchez Tadmorv dans votre deck et placez-le sur votre Banc. Ensuite, mélangez votre deck.",
-				de: "Search your deck for Grimer and put it onto your Bench. Shuffle your deck afterward."
+				de: "Durchsuche dein Deck nach einer Sleima-Karte und lege sie auf deine Bank. Mische dein Deck danach."
 			},
 
 		},
@@ -45,12 +45,12 @@ const card: Card = {
 			name: {
 				en: "Poison Gas",
 				fr: "Gaz toxik",
-				de: "Poison Gas"
+				de: "Giftwolke"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned.",
 				fr: "Le Pokémon Défenseur est maintenant Empoisonné.",
-				de: "The Defending Pokémon is now Poisoned."
+				de: "Das Verteidigende Pokémon ist jetzt vergiftet."
 			},
 
 		},
@@ -66,7 +66,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It was born when sludge in a dirty stream was exposed to the moon's X-rays. It appears among filth."
+		en: "It was born when sludge in a dirty stream was exposed to the moon's X-rays. It appears among filth.",
+		de: "Es wurde geboren, als Schlamm von den Strahlen des Mondes getroffen wurde. Es erscheint, wo Unrat ist."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/76.ts
+++ b/data/Platinum/Platinum/76.ts
@@ -34,7 +34,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may put Chansey from your hand onto Happiny (this counts as evolving Happiny) and remove all damage counters from Happiny.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez placer Leveinard de votre main sur Ptiravi (vous le faites ainsi évoluer) et retirer à Ptiravi tous ses marqueurs de dégât.",
-				de: "Once during your turn (before your attack), you may put Chansey from your hand onto Happiny (this counts as evolving Happiny) and remove all damage counters from Happiny."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du Chaneira von deiner Hand auf Wonneira legen (das zählt als Entwickeln von Wonneira). Entferne alle Schadensmarken von Wonneira."
 			}
 		},
 	],
@@ -45,12 +45,12 @@ const card: Card = {
 			name: {
 				en: "Hospitality",
 				fr: "Hospitalité",
-				de: "Hospitality"
+				de: "Gastfreundschaft"
 			},
 			effect: {
 				en: "Switch the Defending Pokémon with 1 of your opponent's Benched Pokémon. Remove 2 damage counters from the new Defending Pokémon.",
 				fr: "Échangez le Pokémon Défenseur avec 1 des Pokémon de Banc de votre adversaire. Retirez 2 marqueurs de dégât au nouveau Pokémon Défenseur.",
-				de: "Switch the Defending Pokémon with 1 of your opponent's Benched Pokémon. Remove 2 damage counters from the new Defending Pokémon."
+				de: "Tausche das Verteidigende Pokémon gegen 1 Pokémon auf der Bank deines Gegners aus. Entferne 2 Schadensmarken vom neuen Verteidigenden Pokémon."
 			},
 
 		},
@@ -66,7 +66,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It likes to carry around a small rock. It may wander around others' feet and cause them to stumble."
+		en: "It likes to carry around a small rock. It may wander around others' feet and cause them to stumble.",
+		de: "Hat immer einen kleinen Felsen bei sich. Wandelt zwischen den Füßen anderer, was diese stolpern lässt."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/77.ts
+++ b/data/Platinum/Platinum/77.ts
@@ -30,12 +30,12 @@ const card: Card = {
 			name: {
 				en: "Honcho's Command",
 				fr: "L'ordre d'Honcho",
-				de: "Honcho's Command"
+				de: "Befehl vom Chef"
 			},
 			effect: {
 				en: "Search your deck for up to 2 in any combination of Stadium cards or Trainer cards that has Team Galactic's Invention in its name, show them to your opponent, and put them into your hand. Shuffle your deck afterward.",
 				fr: "Choisissez dans votre deck n'importe quelle combinaison de jusqu'à 2 cartes Stade ou cartes Dresseur dont le nom comporte Invention de Team Galaxie. Montrez-les à votre adversaire et placez-les dans votre main. Ensuite, mélangez votre deck.",
-				de: "Search your deck for up to 2 in any combination of Stadium cards or Trainer cards that has Team Galactic's Invention in its name, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
+				de: "Durchsuche dein Deck nach bis zu 2 Karten in beliebiger Kombination aus Trainerkarten mit Team Galaktiks Erfindung im Namen und Stadion-Karten, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 			},
 
 		},
@@ -47,12 +47,12 @@ const card: Card = {
 			name: {
 				en: "Target Attack",
 				fr: "Attaque ciblée",
-				de: "Target Attack"
+				de: "Gezielter Angriff"
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. If that Pokémon already has any damage counters on it, this attack does 20 damage plus 20 more damage. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Choisissez 1 des Pokémon de votre adversaire. Cette attaque lui inflige 20 dégâts. Si ce Pokémon possède déjà des marqueurs de dégât, cette attaque inflige 20 dégâts plus 20 dégâts supplémentaires. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. If that Pokémon already has any damage counters on it, this attack does 20 damage plus 20 more damage. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 20 Schadenspunkte zu. Wenn auf dem gewählten Pokémon bereits mindestens 1 Schadensmarke liegt, fügt dieser Angriff 20 Schadenspunkte plus 20 weitere Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},

--- a/data/Platinum/Platinum/78.ts
+++ b/data/Platinum/Platinum/78.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Lullaby",
 				fr: "Comptine",
-				de: "Lullaby"
+				de: "Wiegenlied"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
-				de: "The Defending Pokémon is now Asleep."
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 			damage: 10,
 
@@ -49,7 +49,7 @@ const card: Card = {
 			name: {
 				en: "Rollout",
 				fr: "Roulade",
-				de: "Rollout"
+				de: "Walzer"
 			},
 
 			damage: 20,
@@ -67,7 +67,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Its legs are short. Whenever it stumbles, its stiff antennae clack with a xylophone-like sound."
+		en: "Its legs are short. Whenever it stumbles, its stiff antennae clack with a xylophone-like sound.",
+		de: "Seine Beine sind kurz. Stolpert es, klappern seine starren Antennen und klingen wie ein Xylophon."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/79.ts
+++ b/data/Platinum/Platinum/79.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Grind",
 				fr: "Écrase",
-				de: "Grind"
+				de: "Zermahlen"
 			},
 			effect: {
 				en: "Does 10 damage times the amount of Energy attached to Lapras.",
 				fr: "Inflige 10 dégâts multipliés par le nombre d'Énergies attachées à Lokhlass",
-				de: "Does 10 damage times the amount of Energy attached to Lapras."
+				de: "Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl der an Lapras angelegten Energien zu."
 			},
 			damage: "10×",
 
@@ -50,12 +50,12 @@ const card: Card = {
 			name: {
 				en: "Ice Beam",
 				fr: "Laser glace",
-				de: "Ice Beam"
+				de: "Eisstrahl"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 30,
 
@@ -72,7 +72,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "It loves crossing the sea with people and Pokémon on its back. It understands human speech."
+		en: "It loves crossing the sea with people and Pokémon on its back. It understands human speech.",
+		de: "Es liebt es, das Meer mit PKMN und Menschen auf dem Rücken zu überqueren. Es versteht die Menschen."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/8.ts
+++ b/data/Platinum/Platinum/8.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Kirlia",
-		fr: "Kirlia"
+		fr: "Kirlia",
+		de: "Kirlia"
 	},
 
 	stage: "Stage2",
@@ -34,12 +35,12 @@ const card: Card = {
 			name: {
 				en: "Psychic Connect",
 				fr: "Connection psy",
-				de: "Psychic Connect"
+				de: "Psychoverbindung"
 			},
 			effect: {
 				en: "As often as you like during your turn (before your attack), you may move a Psychic Energy attached to 1 of your Benched Pokémon to your Active Pokémon. This power can't be used if Gardevoir is affected by a Special Condition.",
 				fr: "Autant de fois que vous le voulez lors de votre tour (avant votre attaque), vous pouvez déplacer une Énergie Psychic attachée à 1 des Pokémon de votre Banc sur votre Pokémon Actif. Ce pouvoir ne peut pas être utilisé si Gardevoir est affecté par un État Spécial.",
-				de: "As often as you like during your turn (before your attack), you may move a  Energy attached to 1 of your Benched Pokémon to your Active Pokémon. This power can't be used if Guardevoir is affected by a Special Condition."
+				de: "Beliebig oft während deines Zuges (vor deinem Angriff) kannst du 1 {P}-Energie, die an 1 Pokémon auf deiner Bank angelegt ist, an dein Aktives Pokémon anlegen. Diese Poké-Power kann nicht benutzt werden, wenn Guardevoir von einem Speziellen Zustand betroffen ist."
 			}
 		},
 	],
@@ -52,12 +53,12 @@ const card: Card = {
 			name: {
 				en: "Energy Burst",
 				fr: "Explosion d'énergie",
-				de: "Energy Burst"
+				de: "Energieausbruch"
 			},
 			effect: {
 				en: "Does 20 damage plus 10 more damage for each Energy attached to Gardevoir and the Defending Pokémon.",
 				fr: "Inflige 20 dégâts plus 10 dégâts supplémentaires pour chaque Énergie attachée à Gardevoir et au Pokémon Défenseur.",
-				de: "Does 20 damage plus 10 more damage for each Energy attached to Guardevoir and the Defending Pokémon."
+				de: "Dieser Angriff fügt 20 Schadenspunkte plus 10 weitere Schadenspunkte für jede Energie, die an Guardevoir und dem Verteidigenden Pokémon angelegt ist, zu."
 			},
 			damage: "20+",
 
@@ -71,12 +72,12 @@ const card: Card = {
 			name: {
 				en: "Psychic Protection",
 				fr: "Protection psy",
-				de: "Psychic Protection"
+				de: "Psychoschützer"
 			},
 			effect: {
 				en: "Gardevoir has no Weakness during your opponent's next turn.",
 				fr: "Gardevoir ne possède pas de Faiblesse lors du prochain tour de votre adversaire.",
-				de: "Guardevoir has no Weakness during your opponent's next turn."
+				de: "Während des nächsten Zuges deines Gegners hat Guardevoir keine Schwäche."
 			},
 			damage: 60,
 

--- a/data/Platinum/Platinum/80.ts
+++ b/data/Platinum/Platinum/80.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Stretch Tongue",
 				fr: "Langue à rallonge",
-				de: "Stretch Tongue"
+				de: "Streckzunge"
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance.",
 				fr: "Choisissez 1 des Pokémon de votre adversaire. Cette attaque lui inflige 10 dégâts. Les dégâts de cette attaque ne sont pas affectés par la Faiblesse ou la Résistance.",
-				de: "Choose 1 of your opponent's Pokémon. This attack does 10 damage to that Pokémon. This attack's damage isn't affected by Weakness or Resistance."
+				de: "Wähle 1 Pokémon deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 10 Schadenspunkte zu. Der Schaden dieses Angriffs wird durch Schwäche und Resistenz nicht verändert."
 			},
 
 		},
@@ -49,12 +49,12 @@ const card: Card = {
 			name: {
 				en: "Knock Off",
 				fr: "Sabotage",
-				de: "Knock Off"
+				de: "Abschlag"
 			},
 			effect: {
 				en: "Choose 1 card from your opponent's hand without looking and discard it.",
 				fr: "Choisissez sans regarder une carte de la main de votre adversaire et défaussez-la.",
-				de: "Choose 1 card from your opponent's hand without looking and discard it."
+				de: "Wähle 1 Karte von der Hand deines Gegners (ohne sie vorher anzusehen) und lege sie auf seinen Ablagestapel."
 			},
 			damage: 40,
 
@@ -71,7 +71,8 @@ const card: Card = {
 	retreat: 3,
 
 	description: {
-		en: "When it extends its over-six-foot-long tongue, its tail quivers. There is a possibility they are connected."
+		en: "When it extends its over-six-foot-long tongue, its tail quivers. There is a possibility they are connected.",
+		de: "Streckt es seine ca. zwei Meter lange Zunge, zittert sein Schweif. Sie scheinen verbunden zu sein."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/81.ts
+++ b/data/Platinum/Platinum/81.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Energy Ball",
 				fr: "Eco-Sphère",
-				de: "Energy Ball"
+				de: "Energieball"
 			},
 			effect: {
 				en: "Does 10 damage plus 10 more damage for each Energy attached to Lotad but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way.",
 				fr: "Inflige 10 dégâts plus 10 dégâts supplémentaires pour chaque Énergie attachée à Nénupiot qui n'a pas été utilisée pour payer le coût en Énergie de cette attaque. Vous ne pouvez pas ajouter plus de 20 dégâts de cette façon.",
-				de: "Does 10 damage plus 10 more damage for each Energy attached to Lotad but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
+				de: "Dieser Angriff fügt 10 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Loturzel angelegte Energie zu, die nicht zum Bezahlen der Energiekosten für diesen Angriff verwendet wurde. Es lassen sich so nicht mehr als 20 Schadenspunkte hinzufügen."
 			},
 			damage: "10+",
 
@@ -48,12 +48,12 @@ const card: Card = {
 			name: {
 				en: "Synthesis",
 				fr: "Synthèse",
-				de: "Synthesis"
+				de: "Synthese"
 			},
 			effect: {
 				en: "Flip a coin. If heads, search your deck for a Grass Energy card and attach it to 1 of your Pokémon. Shuffle your deck afterward.",
 				fr: "Lancez une pièce. Si c'est face, choisissez dans votre deck une carte Énergie Grass et attachez-la à 1 de vos Pokémon. Ensuite, mélangez votre deck.",
-				de: "Flip a coin. If heads, search your deck for a  Energy card and attach it to 1 of your Pokémon. Shuffle your deck afterward."
+				de: "Wirf 1 Münze. Bei „Kopf“ durchsuche dein Deck nach 1 {G}-Energiekarte und lege sie an 1 deiner Pokémon an. Mische dein Deck danach."
 			},
 
 		},
@@ -69,7 +69,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It looks like an aquatic plant and serves as a ferry to Pokémon that can't swim."
+		en: "It looks like an aquatic plant and serves as a ferry to Pokémon that can't swim.",
+		de: "Es sieht aus wie eine Wasserpflanze. Es dient den PKMN, die nicht schwimmen können, als Fähre."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/82.ts
+++ b/data/Platinum/Platinum/82.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Minor Errand-Running",
 				fr: "Rendez-vous mineur",
-				de: "Minor Errand-Running"
+				de: "Kleine Besorgung"
 			},
 			effect: {
 				en: "Search your deck for a basic Energy card, show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
 				fr: "Choisissez dans votre deck une carte Énergie de base. Montrez-la à votre adversaire et placez-la dans votre main. Ensuite, mélangez votre deck.",
-				de: "Search your deck for a basic Energy card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
+				de: "Durchsuche dein Deck nach 1 Basis-Energiekarte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 			},
 
 		},
@@ -45,12 +45,12 @@ const card: Card = {
 			name: {
 				en: "Expand",
 				fr: "Pousstoidla",
-				de: "Expand"
+				de: "Ausdehnen"
 			},
 			effect: {
 				en: "During your opponent's next turn, any damage done to Mareep by attacks is reduced by 10 (after applying Weakness and Resistance).",
 				fr: "Lors du prochain tour de votre adversaire, tous dégâts infligés à Wattouat par des attaques sont réduits de 10 (après application de la Faiblesse et de la Résistance).",
-				de: "During your opponent's next turn, any damage done to Mareep by attacks is reduced by 10 (after applying Weakness and Resistance)."
+				de: "Während des nächsten Zuges deines Gegners wird Schaden, der Voltilamm durch Angriffe zugefügt wird, um 10 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 			damage: 10,
 
@@ -74,7 +74,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Its fluffy coat swells to double when static electricity builds up. Touching it can be shocking."
+		en: "Its fluffy coat swells to double when static electricity builds up. Touching it can be shocking.",
+		de: "Sein weiches Fell wird doppelt so dick, wenn sich Elektrizität aufbaut."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/83.ts
+++ b/data/Platinum/Platinum/83.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Take Back",
 				fr: "Reprendre",
-				de: "Take Back"
+				de: "Zurücknehmen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, search your discard pile for a Trainer card, show it to your opponent, and put it into your hand.",
 				fr: "Lancez une pièce. Si c'est face, choisissez dans votre pile de défausse une carte Dresseur, montrez-la à votre adversaire et placez-la dans votre main.",
-				de: "Flip a coin. If heads, search your discard pile for a Trainer card, show it to your opponent, and put it into your hand."
+				de: "Wirf 1 Münze. Bei „Kopf“ durchsuche deinen Ablagestapel nach 1 Trainerkarte, zeige sie deinem Gegner und nimm sie auf die Hand."
 			},
 
 		},
@@ -70,7 +70,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "A Pokémon that startles people in the middle of the night. It gathers fear as its energy."
+		en: "A Pokémon that startles people in the middle of the night. It gathers fear as its energy.",
+		de: "Ein Pokémon, das Menschen mitten in der Nacht erschreckt. Es sammelt die Angst als seine Energie."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/84.ts
+++ b/data/Platinum/Platinum/84.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Pull",
 				fr: "Tirer",
-				de: "Pull"
+				de: "Ziehen"
 			},
 			effect: {
 				en: "Switch the Defending Pokémon with 1 of your opponent's Benched Pokémon.",
 				fr: "Échangez le Pokémon Défenseur avec 1 des Pokémon de Banc de votre adversaire.",
-				de: "Switch the Defending Pokémon with 1 of your opponent's Benched Pokémon."
+				de: "Tausche das Verteidigende Pokémon gegen 1 Pokémon auf der Bank deines Gegners aus."
 			},
 
 		},
@@ -48,7 +48,7 @@ const card: Card = {
 			name: {
 				en: "Rollout",
 				fr: "Roulade",
-				de: "Rollout"
+				de: "Walzer"
 			},
 
 			damage: 20,
@@ -66,7 +66,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "When endangered, it may protect itself by raising its magnetism and drawing iron objects to its body."
+		en: "When endangered, it may protect itself by raising its magnetism and drawing iron objects to its body.",
+		de: "Es schützt sich bei Gefahr durch Gegenstände aus Eisen, die es mit erhöhtem Magnetismus an sich zieht."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/85.ts
+++ b/data/Platinum/Platinum/85.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Muddy Water",
 				fr: "Ocroupi",
-				de: "Muddy Water"
+				de: "Lehmbrühe"
 			},
 			effect: {
 				en: "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à 1 des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Does 10 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Dieser Angriff fügt 1 Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 10,
 
@@ -49,7 +49,7 @@ const card: Card = {
 			name: {
 				en: "Pound",
 				fr: "Écras'face",
-				de: "Pound"
+				de: "Pfund"
 			},
 
 			damage: 20,
@@ -67,7 +67,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "A poor walker, it often falls down. However, its strong pride makes it puff up its chest without a care."
+		en: "A poor walker, it often falls down. However, its strong pride makes it puff up its chest without a care.",
+		de: "Es fällt leider oft hin. Allerdings ist es sehr stolz und so rappelt es sich immer wieder ohne Sorge auf."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/86.ts
+++ b/data/Platinum/Platinum/86.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Howl",
 				fr: "Grondement",
-				de: "Howl"
+				de: "Jauler"
 			},
 			effect: {
 				en: "Search your deck for Poochyena and put it onto your Bench. Shuffle your deck afterward.",
 				fr: "Cherchez Medhyena dans votre deck et placez-le sur votre Banc. Ensuite, mélangez votre deck.",
-				de: "Search your deck for Poochyena and put it onto your Bench. Shuffle your deck afterward."
+				de: "Durchsuche dein Deck nach einer Fiffyen-Karte und lege sie auf deine Bank. Mische dein Deck danach."
 			},
 
 		},
@@ -45,12 +45,12 @@ const card: Card = {
 			name: {
 				en: "Lunge",
 				fr: "Coup rapide",
-				de: "Lunge"
+				de: "Ausfall"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet.",
-				de: "Flip a coin. If tails, this attack does nothing."
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 20,
 
@@ -74,7 +74,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "A Pokémon with persistent nature, it chases its prey until the prey becomes exhausted."
+		en: "A Pokémon with persistent nature, it chases its prey until the prey becomes exhausted.",
+		de: "Ein beharrliches PKMN, das seine Beute jagt, bis diese erschöpft ist."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/87.ts
+++ b/data/Platinum/Platinum/87.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Headache",
 				fr: "Migraine",
-				de: "Headache"
+				de: "Kopfweh"
 			},
 			effect: {
 				en: "Flip a coin. If heads, your opponent can't play any Trainer, Supporter, or Stadium cards from his or her hand during his or her next turn.",
 				fr: "Lancez une pièce. Si c'est face, votre adversaire ne peut pas jouer de cartes Dresseur, Supporter ou Stade de sa main lors de son prochain tour.",
-				de: "Flip a coin. If heads, your opponent can't play any Trainer, Supporter, or Stadium cards from his or her hand during his or her next turn."
+				de: "Wirf 1 Münze. Bei „Kopf“ kann dein Gegner in seinem nächsten Zug keine Trainer-, Unterstützer- und Stadion-Karten von seiner Hand spielen."
 			},
 
 		},
@@ -45,12 +45,12 @@ const card: Card = {
 			name: {
 				en: "Latent Power",
 				fr: "Puissance dormante",
-				de: "Latent Power"
+				de: "Schlummernde Kräfte"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does no damage to the Defending Pokémon. Instead, Psyduck is now Confused.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque n'inflige pas de dégâts au Pokémon Défenseur. Psykokwak est alors Confus.",
-				de: "Flip a coin. If tails, this attack does no damage to the Defending Pokémon. Instead, Psyduck is now Confused."
+				de: "Wirf 1 Münze. Bei „Zahl“ fügt dieser Angriff dem Verteidigenden Pokémon keinen Schaden zu, stattdessen ist Enton jetzt verwirrt."
 			},
 			damage: 30,
 
@@ -67,7 +67,8 @@ const card: Card = {
 	retreat: 2,
 
 	description: {
-		en: "Overwhelmed by enigmatic abilities, it suffers a constant headache. It sometimes uses mysterious powers."
+		en: "Overwhelmed by enigmatic abilities, it suffers a constant headache. It sometimes uses mysterious powers.",
+		de: "Leidet unter stetigem Kopfschmerz, ausgelöst durch seltsame Kräfte, die es aber auch einsetzen kann."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/88.ts
+++ b/data/Platinum/Platinum/88.ts
@@ -32,12 +32,12 @@ const card: Card = {
 			name: {
 				en: "Chip Off",
 				fr: "Grignoter",
-				de: "Chip Off"
+				de: "Abspalten"
 			},
 			effect: {
 				en: "If your opponent has 6 or more cards in his or her hand, discard a number of cards without looking until your opponent has 5 cards left in his or her hand.",
 				fr: "Si votre adversaire possède plus de 6 cartes en main, défaussez des cartes sans regarder jusqu'à ce qu'il ne reste à votre adversaire que 5 cartes en main.",
-				de: "If your opponent has 6 or more cards in his or her hand, discard a number of cards without looking until your opponent has 5 cards left in his or her hand."
+				de: "Wenn dein Gegner mindestens 6 Karten auf der Hand hat, wähle davon so viele Karten (ohne sie dir vorher anzusehen) und lege sie auf den Ablagestapel deines Gegners, bis dein Gegner nur noch 5 Karten auf der Hand hat."
 			},
 			damage: 20,
 
@@ -52,12 +52,12 @@ const card: Card = {
 			name: {
 				en: "Poor Sleep",
 				fr: "Sommeil agité",
-				de: "Poor Sleep"
+				de: "Unruhiger Schlaf"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 50 damage plus 30 more damage and Purugly G is now Asleep.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 50 dégâts plus 30 dégâts supplémentaires et Chaffreux  est maintenant Endormi.",
-				de: "Flip a coin. If heads, this attack does 50 damage plus 30 more damage and Purugly G is now Asleep."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 50 Schadenspunkte plus 30 weitere Schadenspunkte zu und Shnurgarst G schläft jetzt."
 			},
 			damage: "50+",
 

--- a/data/Platinum/Platinum/89.ts
+++ b/data/Platinum/Platinum/89.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Future Sight",
 				fr: "Prescience",
-				de: "Future Sight"
+				de: "Seher"
 			},
 			effect: {
 				en: "Look at the top 5 cards in either player's deck and put them back on top of that player's deck in any order.",
 				fr: "Regardez les 5 cartes du dessus du deck de chaque joueur et replacez-les au dessus du deck de chaque joueur dans n'importe quel ordre.",
-				de: "Look at the top 5 cards of either player's deck and put them back on top of that player's deck in any order."
+				de: "Schau dir die obersten 5 Karten des Decks eines Spielers an und lege die Karten in beliebiger Reihenfolge auf das Deck dieses Spielers zurück."
 			},
 
 		},
@@ -45,12 +45,12 @@ const card: Card = {
 			name: {
 				en: "Hypnoblast",
 				fr: "Hypnoblast",
-				de: "Hypnoblast"
+				de: "Hypnoschuss"
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Asleep.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Endormi.",
-				de: "Flip a coin. If heads, the Defending Pokémon is now Asleep."
+				de: "Wirf 1 Münze. Bei „Kopf“ schläft das Verteidigende Pokémon jetzt."
 			},
 			damage: 10,
 
@@ -67,7 +67,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "If its horns capture the warm feelings of people or Pokémon, its body warms up slightly."
+		en: "If its horns capture the warm feelings of people or Pokémon, its body warms up slightly.",
+		de: "Es erfasst warme Gefühle von Menschen und PKMN mit seinen Hörnern und wärmt sich daran auf."
 	},
 
 	variants: [		{

--- a/data/Platinum/Platinum/9.ts
+++ b/data/Platinum/Platinum/9.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Let Loose",
 				fr: "Libérer",
-				de: "Let Loose"
+				de: "Loslassen"
 			},
 			effect: {
 				en: "Once during your turn, when you put Giratina from your hand onto your Bench, you may use this power. Each player shuffles his or her hand into his or her deck and draws up to 4 cards. (You draw your cards first.)",
 				fr: "Une seule fois lors de votre tour, lorsque vous placez Giratina de votre main sur votre Banc, vous pouvez utiliser ce pouvoir. Chaque joueur mélange sa main à son deck et pioche jusqu'à 4 cartes. (Vous piochez vos cartes en premier.)",
-				de: "Once during your turn, when you put Giratina from your hand onto your Bench, you may use this power. Eac player shuffles his or her hand into his or her deck and draws up to 4 cards. (You draw your cards first.)"
+				de: "Einmal während deines Zuges kannst du, wenn du Giratina von deiner Hand auf deine Bank legst, diese Poké-Power benutzen. Jeder Spieler mischt seine Handkarten in sein Deck. Danach zieht jeder Spieler bis zu 4 Karten. (Du ziehst zuerst.)"
 			}
 		},
 	],
@@ -49,12 +49,12 @@ const card: Card = {
 			name: {
 				en: "Earth Power",
 				fr: "Telluriforce",
-				de: "Earth Power"
+				de: "Erdkräfte"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 10 damage times the number of heads to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Lancez 2 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de faces à chacun des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Flip 2 coins. This attack does 10 damage times the number of heads to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Wirf 2 Münzen. Dieser Angriff fügt jedem Pokémon auf der Bank deines Gegners 10 Schadenspunkte mal der Anzahl „Kopf“ zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 60,
 

--- a/data/Platinum/Platinum/90.ts
+++ b/data/Platinum/Platinum/90.ts
@@ -31,7 +31,7 @@ const card: Card = {
 			name: {
 				en: "Splash",
 				fr: "Trempette",
-				de: "Splash"
+				de: "Platscher"
 			},
 
 			damage: 10,
@@ -45,12 +45,12 @@ const card: Card = {
 			name: {
 				en: "Trickle",
 				fr: "Goutte à goutte",
-				de: "Trickle"
+				de: "Rieseln"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Flip 2 coins. This attack does 20 damage times the number of heads."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20×",
 
@@ -67,7 +67,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It forcefully squirts water. The water jet never misses prey even if the REMORAID is deep in the sea."
+		en: "It forcefully squirts water. The water jet never misses prey even if the REMORAID is deep in the sea.",
+		de: "Sein starker Wasserstrahl verfehlt seine Gegner auch dann nicht, wenn das REMORAID unter Wasser ist."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/91.ts
+++ b/data/Platinum/Platinum/91.ts
@@ -29,7 +29,7 @@ const card: Card = {
 			name: {
 				en: "Light Punch",
 				fr: "Poing léger",
-				de: "Light Punch"
+				de: "Leichter Hieb"
 			},
 
 			damage: 10,
@@ -43,12 +43,12 @@ const card: Card = {
 			name: {
 				en: "Steady Punch",
 				fr: "Poing énergétique",
-				de: "Steady Punch"
+				de: "Ruhiger Schlag"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires.",
-				de: "Flip a coin. If heads, this attack does 20 damage plus 10 more damage."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -65,7 +65,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It has the peculiar power of being able to see emotions such as joy and rage in the form of waves."
+		en: "It has the peculiar power of being able to see emotions such as joy and rage in the form of waves.",
+		de: "Es hat die eigenartige Fähigkeit, Gefühle wie Freude oder Wut in Wellenform zu sehen."
 	},
 
 	variants: [		{

--- a/data/Platinum/Platinum/92.ts
+++ b/data/Platinum/Platinum/92.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Hypnotic Gaze",
 				fr: "Regard hypnotique",
-				de: "Hypnotic Gaze"
+				de: "Hypnotischer Blick"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
-				de: "The Defending Pokémon is now Asleep."
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 
 		},
@@ -45,12 +45,12 @@ const card: Card = {
 			name: {
 				en: "Fade Out",
 				fr: "Faiblir",
-				de: "Fade Out"
+				de: "Ausblenden"
 			},
 			effect: {
 				en: "Return Shuppet and all cards attached to it to your hand. (If you don't have any Benched Pokémon, this attack does nothing.)",
 				fr: "Reprenez dans votre main Polychombr ainsi que toutes les cartes qui lui sont attachées. (Si vous ne possédez pas de Pokémon de Banc, cette attaque est sans effet.)",
-				de: "Return Shuppet and all cards attached to it to your hand. (If you don't have any Benched Pokémon, this attack does nothing.)"
+				de: "Nimm Shuppet und alle daran angelegten Karten zurück auf die Hand. (Dieser Angriff hat keine Auswirkungen, wenn du keine Pokémon auf deiner Bank hast.)"
 			},
 			damage: 30,
 
@@ -74,7 +74,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It loves vengeful emotions and hangs in rows under the eaves of houses where vengeful people live."
+		en: "It loves vengeful emotions and hangs in rows under the eaves of houses where vengeful people live.",
+		de: "Es liebt Rachegefühle. Diese PKMN hängen sich an Dachrinnen von Häusern, in denen Rachsüchtige leben."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/93.ts
+++ b/data/Platinum/Platinum/93.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Heal Bell",
 				fr: "Glas de soin",
-				de: "Heal Bell"
+				de: "Vitalglocke"
 			},
 			effect: {
 				en: "Remove 1 damage counter from each of your Pokémon.",
 				fr: "Retirez à chacun de vos Pokémon 1 marqueur de dégât.",
-				de: "Remove 1 damage counter from each of your Pokémon."
+				de: "Entferne 1 Schadensmarke von jedem deiner Pokémon."
 			},
 
 		},
@@ -45,12 +45,12 @@ const card: Card = {
 			name: {
 				en: "Take Down",
 				fr: "Bélier",
-				de: "Take Down"
+				de: "Bodycheck"
 			},
 			effect: {
 				en: "Skitty does 10 damage to itself.",
 				fr: "Skitty s'inflige 10 dégâts.",
-				de: "Skitty does 10 damage to itself."
+				de: "Eneco fügt sich selbst 10 Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -67,7 +67,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It can't stop itself from chasing moving things, and it runs in a circle, chasing its own tail."
+		en: "It can't stop itself from chasing moving things, and it runs in a circle, chasing its own tail.",
+		de: "Es muss Dinge, die sich bewegen, einfach jagen. Es rennt oft im Kreis und jagt seinen eigenen Schweif."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/94.ts
+++ b/data/Platinum/Platinum/94.ts
@@ -30,12 +30,12 @@ const card: Card = {
 			name: {
 				en: "Poison Structure",
 				fr: "Structure poison",
-				de: "Poison Structure"
+				de: "Giftige Struktur"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), if you have a Stadium card in play, you may use this power. Each Active Pokémon (both yours and your opponent's) (excluding Pokémon SP) is now Poisoned. This power can't be used if Skuntank is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), si vous avez une carte Stade en jeu, vous pouvez utiliser ce pouvoir. Chaque Pokémon Actif (les vôtres et ceux de votre adversaire) (Pokémon SP exclus) est maintenant Empoisonné. Ce pouvoir ne peut pas être utilisé si Moufflair  est affecté par un État Spécial.",
-				de: "Once during your turn (before your attack), if you have a Stadium card in play, you may use this power. Each Active Pokémon (both yours and your opponent's) (excluding Pokémon SP) is now Poisoned. This power can't be used if Skuntank G is affected by a Special Condition."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn du 1 Stadion-Karte im Spiel hast, diese Poké-Power benutzen. Alle Aktiven Pokémon (deine und die deines Gegners) (außer Pokémon SP) sind jetzt vergiftet. Diese Poké-Power kann nicht benutzt werden, wenn Skuntank G von einem Speziellen Zustand betroffen ist."
 			}
 		},
 	],
@@ -49,12 +49,12 @@ const card: Card = {
 			name: {
 				en: "Smokescreen",
 				fr: "Brouillard",
-				de: "Smokescreen"
+				de: "Rauchwolke"
 			},
 			effect: {
 				en: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, this attack does nothing.",
 				fr: "Si le Pokémon Défenseur essaye d'attaquer lors du prochain tour de votre adversaire, celui-ci lance une pièce. Si c'est pile, cette attaque est sans effet.",
-				de: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing."
+				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 20,
 

--- a/data/Platinum/Platinum/95.ts
+++ b/data/Platinum/Platinum/95.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Flail",
 				fr: "Fléau",
-				de: "Flail"
+				de: "Dreschflegel"
 			},
 			effect: {
 				en: "Does 10 damage times the number of damage counters on Slakoth.",
 				fr: "Inflige 10 dégâts multipliés par le nombre de marqueurs de dégât sur Parecool.",
-				de: "Does 10 damage times the number of damage counters on Slakoth."
+				de: "Dieser Angriff fügt 10 Schadenspunkte für jede Schadensmarke auf Bummelz zu."
 			},
 			damage: "10×",
 
@@ -49,12 +49,12 @@ const card: Card = {
 			name: {
 				en: "Slack Off",
 				fr: "Paresse",
-				de: "Slack Off"
+				de: "Tagedieb"
 			},
 			effect: {
 				en: "Remove all damage counters from Slakoth. Slakoth can't attack during your next turn.",
 				fr: "Retirez à Parecool tous ses marqueurs de dégât. Parecool ne peut pas attaquer lors de votre prochain tour.",
-				de: "Remove all damage counters from Slakoth. Slakoth can't attack during your next turn."
+				de: "Entferne alle Schadensmarken von Bummelz. Bummelz kann in deinem nächsten Zug nicht angreifen."
 			},
 
 		},
@@ -70,7 +70,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It spends nearly all its time in a day sprawled out. Just seeing it makes one drowsy."
+		en: "It spends nearly all its time in a day sprawled out. Just seeing it makes one drowsy.",
+		de: "Es verbringt fast den ganzen Tag mit Faulenzen und Schlafen. Selbst sein Anblick macht bereits müde."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/96.ts
+++ b/data/Platinum/Platinum/96.ts
@@ -31,7 +31,7 @@ const card: Card = {
 			name: {
 				en: "Skull Bash",
 				fr: "Coud'krane",
-				de: "Skull Bash"
+				de: "Schädelwumme"
 			},
 
 			damage: 10,
@@ -45,7 +45,7 @@ const card: Card = {
 			name: {
 				en: "Bite",
 				fr: "Morsure",
-				de: "Bite"
+				de: "Biss"
 			},
 
 			damage: 20,
@@ -63,7 +63,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "It shelters itself in its shell, then strikes back with spouts of water at every opportunity."
+		en: "It shelters itself in its shell, then strikes back with spouts of water at every opportunity.",
+		de: "Es zieht sich in seinen Panzer zurück und greift dann mit Wasserstrahlen seine Gegner an."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/97.ts
+++ b/data/Platinum/Platinum/97.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Sing",
 				fr: "Berceuse",
-				de: "Sing"
+				de: "Gesang"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Asleep.",
 				fr: "Le Pokémon Défenseur est maintenant Endormi.",
-				de: "The Defending Pokémon is now Asleep."
+				de: "Das Verteidigende Pokémon schläft jetzt."
 			},
 
 		},
@@ -47,12 +47,12 @@ const card: Card = {
 			name: {
 				en: "Run Around",
 				fr: "Courir dans tous les sens",
-				de: "Run Around"
+				de: "Herumrennen"
 			},
 			effect: {
 				en: "You may switch Swablu with 1 of your Benched Pokémon.",
 				fr: "Vous pouvez échanger Tylton avec 1 des Pokémon de votre Banc.",
-				de: "You may switch Swablu with 1 of your Benched Pokémon."
+				de: "Du kannst Wablu gegen 1 Pokémon auf deiner Bank austauschen."
 			},
 			damage: 10,
 
@@ -74,7 +74,8 @@ const card: Card = {
 	],
 
 	description: {
-		en: "It can't relax if it or its surroundings are not clean. It wipes off dirt with its wings."
+		en: "It can't relax if it or its surroundings are not clean. It wipes off dirt with its wings.",
+		de: "Es kann nicht entspannen, wenn es oder seine Umgebung dreckig ist. Säubert alles mit den Flügeln."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/98.ts
+++ b/data/Platinum/Platinum/98.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Show Off",
 				fr: "Crâneur",
-				de: "Show Off"
+				de: "Vorzeigen"
 			},
 			effect: {
 				en: "Search your deck for a basic Energy card, show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
 				fr: "Choisissez dans votre deck une carte Énergie de base. Montrez-la à votre adversaire et placez-la dans votre main. Ensuite, mélangez votre deck.",
-				de: "Search your deck for a basic Energy card, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
+				de: "Durchsuche dein Deck nach 1 Basis-Energiekarte, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 			},
 
 		},
@@ -45,12 +45,12 @@ const card: Card = {
 			name: {
 				en: "Take Down",
 				fr: "Bélier",
-				de: "Take Down"
+				de: "Bodycheck"
 			},
 			effect: {
 				en: "Flip a coin. If tails, Tauros does 10 damage to itself.",
 				fr: "Lancez une pièce. Si c'est pile, Tauros s'inflige 10 dégâts.",
-				de: "Flip a coin. If tails, Tauros does 10 damage to itself."
+				de: "Wirf 1 Münze. Bei „Zahl“ fügt Tauros sich selbst 10 Schadenspunkte zu."
 			},
 			damage: 20,
 
@@ -67,7 +67,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "Once it takes aim at its foe, it makes a headlong charge. It is famous for its violent nature."
+		en: "Once it takes aim at its foe, it makes a headlong charge. It is famous for its violent nature.",
+		de: "Sobald es einen Gegner ins Visier genommen hat, rennt es mit dem Kopf voran auf ihn zu."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/99.ts
+++ b/data/Platinum/Platinum/99.ts
@@ -29,12 +29,12 @@ const card: Card = {
 			name: {
 				en: "Focus Energy",
 				fr: "Puissance",
-				de: "Focus Energy"
+				de: "Energiefokus"
 			},
 			effect: {
 				en: "During your next turn, Torchic's Fire Shard attack's base damage is 80.",
 				fr: "Lors de votre prochain tour, les dégâts de base de l'attaque Écharde de feu de Poussifeu sont de 80.",
-				de: "During your next turn, Torchic's Fire Shard attack's base damage is 80."
+				de: "In deinem nächsten Zug beträgt der Grundschaden von Flemmlis Angriff Feuerscherben 80 Schadenspunkte."
 			},
 
 		},
@@ -45,12 +45,12 @@ const card: Card = {
 			name: {
 				en: "Fire Shard",
 				fr: "Écharde de feu",
-				de: "Fire Shard"
+				de: "Feuerscherben"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet.",
-				de: "Flip a coin. If tails, this attack does nothing."
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 			damage: 20,
 
@@ -67,7 +67,8 @@ const card: Card = {
 	retreat: 1,
 
 	description: {
-		en: "A fire burns inside, so it feels very warm to hug. It launches fireballs of 1,800 degrees F."
+		en: "A fire burns inside, so it feels very warm to hug. It launches fireballs of 1,800 degrees F.",
+		de: "In seinem Inneren lodert ein Feuer. Es schleudert 1 000 Grad heiße Feuerbälle."
 	},
 
 	variants: [

--- a/data/Platinum/Platinum/SH4.ts
+++ b/data/Platinum/Platinum/SH4.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Swift Swim",
 				fr: "Glissade",
-				de: "Swift Swim"
+				de: "Wassertempo"
 			},
 			effect: {
 				en: "If Lotad has any Water Energy attached to it, Lotad's Retreat Cost is 0.",
 				fr: "Si Nénupiot possède de l'Énergie Water, son coût de retraite est de 0.",
-				de: "If Lotad has any  Energy attached to it, Lotad's Retreat Cost is 0."
+				de: "Wenn an Loturzel mindestens 1 {W}-Energie angelegt ist, hat Loturzel Rückzugskosten 0."
 			},
 		},
 	],
@@ -49,12 +49,12 @@ const card: Card = {
 			name: {
 				en: "Blot",
 				fr: "Pâté",
-				de: "Blot"
+				de: "Klecks"
 			},
 			effect: {
 				en: "Remove 1 damage counter from Lotad.",
 				fr: "Retirez à Nénupiot 1 marqueur de dégât.",
-				de: "Remove 1 damage counter from Lotad."
+				de: "Entferne 1 Schadensmarke von Loturzel."
 			},
 			damage: 10,
 
@@ -67,12 +67,12 @@ const card: Card = {
 			name: {
 				en: "Jump On",
 				fr: "Sauter",
-				de: "Jump On"
+				de: "Draufspringen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires.",
-				de: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 

--- a/data/Platinum/Platinum/SH5.ts
+++ b/data/Platinum/Platinum/SH5.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Roost",
 				fr: "Atterrissage",
-				de: "Roost"
+				de: "Ruheort"
 			},
 			effect: {
 				en: "Remove 4 damage counters from Swablu. Swablu can't retreat during your next turn.",
 				fr: "Retirez à Tylton 4 marqueurs de dégât. Tylton ne peut pas battre en retraite lors de votre prochain tour.",
-				de: "Remove 4 damage counters from Swablu. Swablu can't retreat during your next turn."
+				de: "Entferne 4 Schadensmarken von Wablu. Wablu kann sich in deinem nächsten Zug nicht zurückziehen."
 			},
 
 		},
@@ -47,12 +47,12 @@ const card: Card = {
 			name: {
 				en: "Mirror Move",
 				fr: "Mimique",
-				de: "Mirror Move"
+				de: "Spiegeltrick"
 			},
 			effect: {
 				en: "If Swablu was damaged by an attack during your opponent's last turn, this attack does the same amount of damage done to Swablu to the Defending Pokémon.",
 				fr: "Si une attaque a infligé des dégâts à Tylton lors du tour précédent de votre adversaire, cette attaque inflige le même nombre de dégâts au Pokémon Défenseur.",
-				de: "If Swablu was damaged by an attack during your opponent's last turn, this attack does the same amount of damage done to Swablu to the Defending Pokémon."
+				de: "Wenn Wablu im letzten Zug deines Gegners durch einen Angriff Schaden zugefügt wurde, fügt dieser Angriff dem Verteidigenden Pokémon die gleiche Anzahl Schadenspunkte, die Wablu zugefügt wurde, zu."
 			},
 
 		},
@@ -63,12 +63,12 @@ const card: Card = {
 			name: {
 				en: "Fury Attack",
 				fr: "Furie",
-				de: "Fury Attack"
+				de: "Furienschlag"
 			},
 			effect: {
 				en: "Flip 3 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de faces.",
-				de: "Flip 3 coins. This attack does 10 damage times the number of heads."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10x",
 

--- a/data/Platinum/Platinum/SH6.ts
+++ b/data/Platinum/Platinum/SH6.ts
@@ -31,12 +31,12 @@ const card: Card = {
 			name: {
 				en: "Find Wildfire",
 				fr: "Traqueur de feu de forêt",
-				de: "Find Wildfire"
+				de: "Lauffeuer finden"
 			},
 			effect: {
 				en: "Search your deck for up to 2 Fire Energy cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward.",
 				fr: "Choisissez dans votre deck jusqu'à 2 cartes Énergie Fire. Montrez-les à votre adversaire et placez-les dans votre main. Ensuite, mélangez votre deck.",
-				de: "Search your deck for up to 2  Energy cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward."
+				de: "Durchsuche dein Deck nach bis zu 2 {R}-Energiekarten, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 			},
 
 		},
@@ -47,12 +47,12 @@ const card: Card = {
 			name: {
 				en: "Brushfire",
 				fr: "Feu de broussailles",
-				de: "Brushfire"
+				de: "Buschfeuer"
 			},
 			effect: {
 				en: "Does 10 damage to each of your opponent's Benched Grass Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Inflige 10 dégâts à chacun des Pokémon de Banc Grass de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Does 10 damage to each of your opponent's Benched  Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				de: "Dieser Angriff fügt jedem {G}-Pokémon auf der Bank deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 10,
 
@@ -65,12 +65,12 @@ const card: Card = {
 			name: {
 				en: "Inflame",
 				fr: "Mettre le feu",
-				de: "Inflame"
+				de: "Entflammen"
 			},
 			effect: {
 				en: "Discard a Fire Energy card from your hand. (If you can't discard a card from your hand, this attack does nothing.)",
 				fr: "Défaussez une carte Énergie Fire de votre main. (Si vous ne pouvez pas défausser de carte de votre main, cette attaque est sans effet.)",
-				de: "Discard a  Energy card from your hand. (If you can't discard a card from your hand, this attack does nothing.)"
+				de: "Lege 1 {R}-Energiekarte von deiner Hand auf deinen Ablagestapel. (Wenn du das nicht machen kannst, hat dieser Angriff keine Auswirkungen.)"
 			},
 			damage: 30,
 


### PR DESCRIPTION
## Add missing German translations for pl1

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
