### PR TITLE
patch(data): recategorize three Pokémon filed as Trainer

### DIFF
--- a/data/Diamond & Pearl/DP Black Star Promos/DP13.ts
+++ b/data/Diamond & Pearl/DP Black Star Promos/DP13.ts
@@ -9,7 +9,7 @@ const card: Card = {
 
 	illustrator: "Mitsuhiro Arita",
 	rarity: "Common",
-	category: "Trainer",
+	category: "Pokemon",
 	set: Set,
 
 	dexId: [

--- a/data/Diamond & Pearl/Majestic Dawn/65.ts
+++ b/data/Diamond & Pearl/Majestic Dawn/65.ts
@@ -10,7 +10,7 @@ const card: Card = {
 
 	illustrator: "Masakazu Fukuda",
 	rarity: "Common",
-	category: "Trainer",
+	category: "Pokemon",
 	set: Set,
 
 	dexId: [

--- a/data/POP/Nintendo Black Star Promos/9.ts
+++ b/data/POP/Nintendo Black Star Promos/9.ts
@@ -8,7 +8,7 @@ const card: Card = {
 	},
 	illustrator: "Kouki Saitou",
 	rarity: "Common",
-	category: "Trainer",
+	category: "Pokemon",
 
 	set: Set,
 	dexId: [


### PR DESCRIPTION
Three cards are declared `category: "Trainer"` while carrying `hp`, `types`, `stage` and attacks/weaknesses — they are Pokémon cards:

- **Glameow** — `data/Diamond & Pearl/Majestic Dawn/65.ts`
- **Buizel** — `data/Diamond & Pearl/DP Black Star Promos/DP13.ts`
- **Combusken** — `data/POP/Nintendo Black Star Promos/9.ts`

Each file's own body contradicts its category (a Trainer has no stage or weaknesses), and the printed cards are ordinary Pokémon. One-line change per file: `"Trainer"` → `"Pokemon"`.

Spotted because these three surface as untyped Trainers in a downstream consumer's trainer-type facet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)