### PR TITLE
Add missing German translations for swsh9tg

### DIFF
--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG01.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG01.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			es: "Si este Pokémon tiene 1 Cápsula de Memoria unida a él, los Pokémon Grass en juego (tanto tuyos como de tu rival) no tienen ninguna habilidad.",
 			it: "Se questo Pokémon ha una carta Capsula della Memoria assegnata, i Pokémon Grass in gioco, sia tuoi che del tuo avversario, non hanno abilità.",
 			pt: "Se este Pokémon tiver 1 Cápsula de Memória ligada a ele, Pokémon Grass em jogo (seus e do seu oponente) não terão Habilidades.",
-			de: "Wenn an dieses Pokémon eine Gedächtniskapsel angelegt ist, haben Grass-Pokémon im Spiel (deine und die deines Gegners) keine Fähigkeiten."
+			de: "Wenn an dieses Pokémon eine Gedächtniskapsel angelegt ist, haben {G}-Pokémon im Spiel (deine und die deines Gegners) keine Fähigkeiten."
 		}
 	}],
 
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "Once it has stored up enough heat, this Pokémon's body temperature can reach up to 1,700 degrees Fahrenheit.",
+		de: "Wenn die Flamme in seinem Körper heiß genug brennt, kann seine Körpertemperatur bis zu 900 ºC erreichen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG02.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG02.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			es: "Si este Pokémon tiene 1 Cápsula de Memoria unida a él, los Pokémon Fire en juego (tanto tuyos como de tu rival) no tienen ninguna habilidad.",
 			it: "Se questo Pokémon ha una carta Capsula della Memoria assegnata, i Pokémon Fire in gioco, sia tuoi che del tuo avversario, non hanno abilità.",
 			pt: "Se este Pokémon tiver 1 Cápsula de Memória ligada a ele, Pokémon Fire em jogo (seus e do seu oponente) não terão Habilidades.",
-			de: "Wenn an dieses Pokémon eine Gedächtniskapsel angelegt ist, haben Fire-Pokémon im Spiel (deine und die deines Gegners) keine Fähigkeiten."
+			de: "Wenn an dieses Pokémon eine Gedächtniskapsel angelegt ist, haben {R}-Pokémon im Spiel (deine und die deines Gegners) keine Fähigkeiten."
 		}
 	}],
 
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "When Vaporeon's fins begin to vibrate, it is a sign that rain will come within a few hours.",
+		de: "Wenn seine Flossen beginnen zu vibrieren, ist das ein sicheres Zeichen dafür, dass in den nächsten Stunden Regen aufziehen wird."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG03.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG03.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It traps enemies with its suction-cupped tentacles, then smashes them with its rock-hard head.",
+		de: "Es umschlingt Beute mit seinen Tentakeln und verpasst ihr dann eine beherzte Kopfnuss mit seinem steinharten Schädel."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG04.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG04.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			es: "Si este Pokémon tiene 1 Cápsula de Memoria unida a él, los Pokémon Water en juego (tanto tuyos como de tu rival) no tienen ninguna habilidad.",
 			it: "Se questo Pokémon ha una carta Capsula della Memoria assegnata, i Pokémon Water in gioco, sia tuoi che del tuo avversario, non hanno abilità.",
 			pt: "Se este Pokémon tiver 1 Cápsula de Memória ligada a ele, Pokémon Metal em jogo (seus e do seu oponente) não terão Habilidades.",
-			de: "Wenn an dieses Pokémon eine Gedächtniskapsel angelegt ist, haben Water-Pokémon im Spiel (deine und die deines Gegners) keine Fähigkeiten."
+			de: "Wenn an dieses Pokémon eine Gedächtniskapsel angelegt ist, haben {W}-Pokémon im Spiel (deine und die deines Gegners) keine Fähigkeiten."
 		}
 	}],
 
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "If it is angered or startled, the fur all over its body bristles like sharp needles that pierce foes.",
+		de: "Wenn es erschrickt oder wütend wird, stellt sich sein Fell auf wie scharfe Nadeln und sticht den Gegner."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG05.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG05.ts
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "When the interior part of its tail spins like a motor, Zekrom can generate many bolts of lightning to blast its surroundings.",
+		de: "Rotiert das Innere seines Schweifs wie eine Turbine, werden dadurch unzählige Blitze erzeugt, welche die Umgebung durchzucken."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG06.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG06.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			es: "Todas las Energías Especiales unidas a los Pokémon (tanto tuyos como de tu rival) proporcionan 1 Energía Colorless y no tienen ningún otro efecto.",
 			it: "Tutte le Energie speciali assegnate ai Pokémon, sia tuoi che del tuo avversario, forniscono Energia Colorless e non hanno altri effetti.",
 			pt: "Todas as Energias Especiais ligadas aos Pokémon (seus e do seu oponente) fornecem Energia Colorless e não têm nenhum outro efeito.",
-			de: "Alle Spezial-Energien, die an Pokémon (deine und die deines Gegners) angelegt sind, liefern Colorless-Energie und haben keinen anderen Effekt."
+			de: "Alle Spezial-Energien, die an Pokémon (deine und die deines Gegners) angelegt sind, liefern {C}-Energie und haben keinen anderen Effekt."
 		}
 	}],
 
@@ -86,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "At the bidding of transmissions from the spirit world, it steals people and Pokémon away. No one knows whether it has a will of its own.",
+		de: "Niemand weiß, ob es einen eigenen Willen hat. Über Radiowellen empfängt es Befehle aus dem Jenseits, Menschen und Pokémon zu entführen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG07.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG07.ts
@@ -57,6 +57,7 @@ const card: Card = {
 
 	description: {
 		en: "Since Dedenne can't generate as much electricity on its own, it steals electricity from outlets or other electric Pokémon.",
+		de: "Dedenne selbst kann nur wenig Elektrizität erzeugen, weshalb es Strom von anderen Elektro-Pokémon oder aus Steckdosen stiehlt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG08.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG08.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "When Alcremie is content, the cream it secretes from its hands becomes sweeter and richer.",
+		de: "Die Sahne, die Pokusan aus seinen Händen hervorbringt, wird noch süßer und intensiver im Geschmack, wenn es glücklich ist."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG09.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG09.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It spews threads from its mouth to catch its prey. When night falls, it leaves its web to go hunt aggressively.",
+		de: "Seine Beute ergreift es mit einem Seidenfaden. Bei Anbruch der Nacht verlässt es sein Netz und macht sich auf die Jagd."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG10.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG10.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "Identifiable by its eerie howls, people a long time ago thought it was the grim reaper and feared it.",
+		de: "Sein unheimliches Heulen ist unverkennbar. Früher wurde es von den Menschen als Bote des Todes gefürchtet."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG11.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG11.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "Thanks to its unstable genetic makeup, this special Pokémon conceals many different possible evolutions.",
+		de: "Das Erbmaterial dieses besonderen Pokémon ist instabil, weshalb es das Potenzial für viele verschiedene Entwicklungen in sich trägt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG12.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG12.ts
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "It knows the forest inside and out. If it comes across a wounded Pokémon, Oranguru will gather medicinal herbs to treat it.",
+		de: "Es kennt jeden Winkel des Waldes. Trifft es ein verletztes Pokémon, findet es in Windeseile das passende Heilkraut und schreitet zur Behandlung."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG13.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG13.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			es: "Busca en tu baraja hasta 2 cartas de Energía Lightning y únelas a tus Pokémon en Banca de la manera que desees. Después, baraja las cartas de tu baraja.",
 			it: "Cerca nel tuo mazzo fino a due carte Energia Lightning e assegnale ai tuoi Pokémon in panchina nel modo che preferisci. Poi rimischia le carte del tuo mazzo.",
 			pt: "Procure por até 2 cartas de Energia Lightning no seu baralho e ligue-as aos seus Pokémon no Banco como desejar. Em seguida, embaralhe o seu baralho.",
-			de: "Durchsuche dein Deck nach bis zu 2 Lightning-Energiekarten und lege sie beliebig an die Pokémon auf deiner Bank an. Mische anschließend dein Deck."
+			de: "Durchsuche dein Deck nach bis zu 2 {L}-Energiekarten und lege sie beliebig an die Pokémon auf deiner Bank an. Mische anschließend dein Deck."
 		}
 	}, {
 		cost: ["Lightning", "Colorless"],
@@ -60,7 +60,7 @@ const card: Card = {
 			es: "Este ataque hace 30 puntos de daño más por cada Energía Lightning unida a todos tus Pokémon.",
 			it: "Questo attacco infligge 30 danni in più per ogni Energia Lightning assegnata ai tuoi Pokémon.",
 			pt: "Este ataque causa 30 pontos de dano a mais para cada Energia Lightning ligada a todos os seus Pokémon.",
-			de: "Diese Attacke fügt für jede an alle deine Pokémon angelegte Lightning-Energie 30 Schadenspunkte mehr zu."
+			de: "Diese Attacke fügt für jede an alle deine Pokémon angelegte {L}-Energie 30 Schadenspunkte mehr zu."
 		},
 
 		damage: "10+"

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG18.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG18.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			es: "Busca en tu baraja hasta 2 cartas de Energía Fighting y únelas a este Pokémon. Después, baraja las cartas de tu baraja.",
 			it: "Cerca nel tuo mazzo fino a due carte Energia Fighting e assegnale a questo Pokémon. Poi rimischia le carte del tuo mazzo.",
 			pt: "Procure por até 2 cartas de Energia Fighting no seu baralho e ligue-as a este Pokémon. Em seguida, embaralhe o seu baralho.",
-			de: "Durchsuche dein Deck nach bis zu 2 Fighting-Energiekarten und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
+			de: "Durchsuche dein Deck nach bis zu 2 {F}-Energiekarten und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
 		}
 	}, {
 		cost: ["Fighting", "Fighting", "Colorless"],

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG24.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG24.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Tu rival enseña las cartas de su mano, y tú robas 1 carta por cada carta de Entrenador que encuentres entre ellas.",
 		it: "Il tuo avversario mostra le carte che ha in mano e tu peschi una carta per ogni carta Allenatore presente tra quelle carte.",
 		pt: "Seu oponente revela a própria mão e você compra 1 carta para cada carta de Treinador que encontrar lá.",
-		de: "Dein Gegner zeigt dir seine Handkarten und du ziehst 1 Karte für jede Trainerkarte, die du dort findest."
+		de: "Dein Gegner zeigt dir seine Handkarten und du ziehst 1 Karte für jede Trainerkarte, die du dort findest. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG25.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG25.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Elige hasta 3 de tus Pokémon en Banca. Para cada uno de esos Pokémon, busca en tu baraja 1 carta de Energía Básica de tipo diferente y únela a ese Pokémon. Después, baraja las cartas de tu baraja. Tu turno termina.",
 		it: "Scegli fino a tre dei tuoi Pokémon in panchina. Per ognuno di essi, cerca nel tuo mazzo una carta Energia base di tipo diverso e assegnala a quel Pokémon. Poi rimischia le carte del tuo mazzo. Il tuo turno finisce.",
 		pt: "Escolha até 3 dos seus Pokémon no Banco. Para cada um daqueles Pokémon, procure por 1 carta de Energia básica de tipo diferente no seu baralho e ligue-a àquele Pokémon. Em seguida, embaralhe o seu baralho. O seu turno acaba.",
-		de: "Wähle bis zu 3 Pokémon auf deiner Bank. Durchsuche für jedes jener Pokémon dein Deck nach 1 Basis-Energiekarte verschiedenen Typs und lege sie an jenes Pokémon an. Mische anschließend dein Deck. Dein Zug endet."
+		de: "Wähle bis zu 3 Pokémon auf deiner Bank. Durchsuche für jedes jener Pokémon dein Deck nach 1 Basis-Energiekarte verschiedenen Typs und lege sie an jenes Pokémon an. Mische anschließend dein Deck. Dein Zug endet. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG26.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG26.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 3 Pokémon Básicos que no tengan un recuadro de regla y ponlos en tu Banca. Después, baraja las cartas de tu baraja. (Pokémon V, Pokémon-GX, etc. tienen recuadros de regla).",
 		it: "Cerca nel tuo mazzo fino a tre Pokémon Base che non hanno una regola speciale e mettili nella tua panchina. Poi rimischia le carte del tuo mazzo. I Pokémon-V, i Pokémon-GX, ecc. hanno regole speciali.",
 		pt: "Procure por até 3 Pokémon Básicos no seu baralho que não tenham uma Caixa de Regras e coloque-os no seu Banco. Em seguida, embaralhe o seu baralho (Pokémon V, Pokémon-GX, etc. têm Caixas de Regras).",
-		de: "Durchsuche dein Deck nach bis zu 3 Basis-Pokémon, die kein Regelfeld haben, und lege sie auf deine Bank. Mische anschließend dein Deck. (Pokémon-V, Pokémon-GX, usw. haben Regelfelder.)"
+		de: "Durchsuche dein Deck nach bis zu 3 Basis-Pokémon, die kein Regelfeld haben und lege sie auf deine Bank. Mische anschließend dein Deck. (Pokémon-V, Pokémon-GX usw. haben Regelfelder.) Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG27.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG27.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "$$$CARD.RULES.MISSING.TOKEN$$$",
 		it: "$$$CARD.RULES.MISSING.TOKEN$$$",
 		pt: "$$$CARD.RULES.MISSING.TOKEN$$$",
-		de: "$$$CARD.RULES.MISSING.TOKEN$$$"
+		de: "Du kannst diese Karte nur spielen, wenn es die letzte Karte auf deiner Hand ist. Lege 1 Fließender-Angriff-Pokémon aus deinem Ablagestapel auf deine Bank. Wenn du das machst, ziehe 5 Karten. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG28.ts
+++ b/data/Sword & Shield/Brilliant Stars Trainer Gallery/TG28.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "$$$CARD.RULES.MISSING.TOKEN$$$",
 		it: "$$$CARD.RULES.MISSING.TOKEN$$$",
 		pt: "$$$CARD.RULES.MISSING.TOKEN$$$",
-		de: "$$$CARD.RULES.MISSING.TOKEN$$$"
+		de: "Du kannst diese Karte nur spielen, wenn es die letzte Karte auf deiner Hand ist. Durchsuche dein Deck nach 1 Fokussierter-Angriff-Pokémon und lege es auf deine Bank. Mische anschließend dein Deck. Wenn du auf diese Weise dein Deck durchsucht hast, ziehe 5 Karten. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",


### PR DESCRIPTION
## Add missing German translations for swsh9tg

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
