### PR TITLE
Add missing German translations for swsh11tg

### DIFF
--- a/data/Sword & Shield/Lost Origin Trainer Gallery/TG15.ts
+++ b/data/Sword & Shield/Lost Origin Trainer Gallery/TG15.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			es: "Este ataque hace 40 puntos de daño más por cada Energía Fire unida a este Pokémon. Si has infligido daño con este ataque, puedes unir 1 carta de Energía Fire de tu pila de descartes a este Pokémon.",
 			it: "Questo attacco infligge 40 danni in più per ogni Energia Fire assegnata a questo Pokémon. Sei hai inflitto dei danni con questo attacco, puoi assegnare a questo Pokémon una carta Energia Fire dalla tua pila degli scarti.",
 			pt: "Este ataque causa 40 pontos de dano a mais para cada Energia Fire ligada a este Pokémon. Se tiver causado qualquer dano com este ataque, você poderá ligar 1 carta de Energia Fire da sua pilha de descarte a este Pokémon.",
-			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte Fire-Energie 40 Schadenspunkte mehr zu. Wenn du mit dieser Attacke Schaden zugefügt hast, kannst du 1 Fire-Energiekarte aus deinem Ablagestapel an dieses Pokémon anlegen."
+			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte {R}-Energie 40 Schadenspunkte mehr zu. Wenn du mit dieser Attacke Schaden zugefügt hast, kannst du 1 {R}-Energiekarte aus deinem Ablagestapel an dieses Pokémon anlegen."
 		},
 
 		damage: "40+"

--- a/data/Sword & Shield/Lost Origin Trainer Gallery/TG16.ts
+++ b/data/Sword & Shield/Lost Origin Trainer Gallery/TG16.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			es: "Busca en tu baraja hasta 2 cartas de Energía Lightning y únelas a este Pokémon. Después, baraja las cartas de tu baraja.",
 			it: "Cerca nel tuo mazzo fino a due carte Energia Lightning e assegnale a questo Pokémon. Poi rimischia le carte del tuo mazzo.",
 			pt: "Procure por até 2 cartas de Energia Lightning no seu baralho e ligue-as a este Pokémon. Em seguida, embaralhe o seu baralho.",
-			de: "Durchsuche dein Deck nach bis zu 2 Lightning-Energiekarten und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
+			de: "Durchsuche dein Deck nach bis zu 2 {L}-Energiekarten und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
 		}
 	}, {
 		cost: ["Lightning", "Lightning", "Colorless"],

--- a/data/Sword & Shield/Lost Origin Trainer Gallery/TG18.ts
+++ b/data/Sword & Shield/Lost Origin Trainer Gallery/TG18.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			es: "Evita todos los efectos de las habilidades de los Pokémon de tu rival infligidos a cada uno de tus Pokémon que tenga alguna Energía Psychic unida a él, excepto a los Enamorus V.",
 			it: "Previeni tutti gli effetti delle abilità dei Pokémon del tuo avversario inflitti ai tuoi Pokémon che hanno delle Energie Psychic assegnate, a eccezione di qualsiasi Enamorus-V.",
 			pt: "Previna todos os efeitos das Habilidades dos Pokémon do seu oponente causados a cada um dos seus Pokémon que tiver alguma Energia Psychic ligada a ele, exceto por quaisquer Enamorus V.",
-			de: "Verhindere alle Effekte von Fähigkeiten der Pokémon deines Gegners, die jedem deiner Pokémon, an das mindestens 1 Psychic-Energie angelegt ist, außer Cupidos-V, zugefügt werden."
+			de: "Verhindere alle Effekte von Fähigkeiten der Pokémon deines Gegners, die jedem deiner Pokémon, an das mindestens 1 {P}-Energie angelegt ist, außer Cupidos-V, zugefügt werden."
 		}
 	}],
 

--- a/data/Sword & Shield/Lost Origin Trainer Gallery/TG21.ts
+++ b/data/Sword & Shield/Lost Origin Trainer Gallery/TG21.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			es: "Puedes unir 1 carta de Energía Darkness de tu mano a 1 de tus Pokémon en Banca.",
 			it: "Puoi assegnare a uno dei tuoi Pokémon in panchina una carta Energia Darkness dalla tua mano.",
 			pt: "Você pode ligar 1 carta de Energia Darkness da sua mão a 1 dos seus Pokémon no Banco.",
-			de: "Du kannst 1 Darkness-Energiekarte aus deiner Hand an 1 Pokémon auf deiner Bank anlegen."
+			de: "Du kannst 1 {D}-Energiekarte aus deiner Hand an 1 Pokémon auf deiner Bank anlegen."
 		},
 
 		damage: 30

--- a/data/Sword & Shield/Lost Origin Trainer Gallery/TG22.ts
+++ b/data/Sword & Shield/Lost Origin Trainer Gallery/TG22.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			es: "Si todos tus Pokémon en juego son de tipo Darkness, puedes tener hasta 8 Pokémon en tu Banca y no puedes poner Pokémon no Darkness en juego. (Si esta habilidad deja de funcionar, descarta Pokémon de tu Banca hasta que tengas 5).",
 			it: "Se tutti i tuoi Pokémon in gioco sono di tipo Darkness, puoi avere fino a otto Pokémon nella tua panchina e non puoi mettere in gioco Pokémon che non siano di tipo Darkness. Se questa abilità smette di funzionare, scarta i Pokémon dalla tua panchina fino ad averne cinque.",
 			pt: "Se todos os seus Pokémon em jogo forem de tipo Darkness, você poderá ter até 8 Pokémon no seu Banco e não poderá colocar Pokémon que não sejam de tipo Darkness em jogo (se esta Habilidade parar de funcionar, descarte Pokémon até ter 5 no seu Banco).",
-			de: "Wenn alle deine Pokémon im Spiel vom Typ Darkness sind, kannst du bis zu 8 Pokémon auf deiner Bank haben und Pokémon, die keine Darkness-Pokémon sind, nicht ins Spiel bringen. (Wenn diese Fähigkeit nicht mehr aktiv ist, lege so lange Pokémon von deiner Bank auf deinen Ablagestapel, bis du  5 hast.)"
+			de: "Wenn alle deine Pokémon im Spiel vom Typ {D} sind, kannst du bis zu 8 Pokémon auf deiner Bank haben und Pokémon, die keine {D}-Pokémon sind, nicht ins Spiel bringen. (Wenn diese Fähigkeit nicht mehr aktiv ist, lege so lange Pokémon von deiner Bank auf deinen Ablagestapel, bis du  5 hast.)"
 		}
 	}],
 
@@ -71,7 +71,7 @@ const card: Card = {
 			es: "Este ataque hace 30 puntos de daño por cada uno de tus Pokémon Darkness en juego.",
 			it: "Questo attacco infligge 30 danni per ogni tuo Pokémon Darkness in gioco.",
 			pt: "Este ataque causa 30 pontos de dano para cada um dos seus Pokémon Darkness em jogo.",
-			de: "Diese Attacke fügt für jedes deiner Darkness-Pokémon im Spiel 30 Schadenspunkte zu."
+			de: "Diese Attacke fügt für jedes deiner {D}-Pokémon im Spiel 30 Schadenspunkte zu."
 		},
 
 		damage: "30×"

--- a/data/Sword & Shield/Lost Origin Trainer Gallery/TG23.ts
+++ b/data/Sword & Shield/Lost Origin Trainer Gallery/TG23.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 3 Pokémon V, enséñalos y ponlos en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo fino a tre Pokémon-V, mostrali e aggiungili alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por até 3 Pokémon V no seu baralho, revele-os e coloque-os na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach bis zu 3 Pokémon-V, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach bis zu 3 Pokémon-V, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Lost Origin Trainer Gallery/TG24.ts
+++ b/data/Sword & Shield/Lost Origin Trainer Gallery/TG24.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Cambia 1 de los Pokémon en Banca de tu rival por su Pokémon Activo.",
 		it: "Scambia uno dei Pokémon nella panchina del tuo avversario con il suo Pokémon attivo.",
 		pt: "Troque 1 dos Pokémon no Banco do seu oponente pelo Pokémon Ativo dele(a).",
-		de: "Tausche 1 Pokémon auf der Bank deines Gegners gegen sein Aktives Pokémon aus."
+		de: "Tausche 1 Pokémon auf der Bank deines Gegners gegen sein Aktives Pokémon aus. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Lost Origin Trainer Gallery/TG25.ts
+++ b/data/Sword & Shield/Lost Origin Trainer Gallery/TG25.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Cura 70 puntos de daño a tu Pokémon Activo.",
 		it: "Cura il tuo Pokémon attivo da 70 danni.",
 		pt: "Cure 70 pontos de dano do seu Pokémon Ativo.",
-		de: "Heile 70 Schadenspunkte bei deinem Aktiven Pokémon."
+		de: "Heile 70 Schadenspunkte bei deinem Aktiven Pokémon. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Lost Origin Trainer Gallery/TG26.ts
+++ b/data/Sword & Shield/Lost Origin Trainer Gallery/TG26.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Pon las cartas de tu mano en tu baraja y barájalas todas. Después, roba 4 cartas. Si tu Pokémon Activo es tu único Pokémon en juego, roba 8 cartas en vez de 4.",
 		it: "Rimischia le carte che hai in mano nel tuo mazzo. Poi pesca quattro carte. Se il tuo Pokémon attivo è il tuo unico Pokémon in gioco, invece pescane otto.",
 		pt: "Embaralhe a sua mão no seu baralho. Em seguida, compre 4 cartas. Se o seu Pokémon Ativo for o seu único Pokémon em jogo, compre 8 cartas ao invés de 4.",
-		de: "Mische deine Handkarten in dein Deck. Ziehe anschließend 4 Karten. Wenn dein Aktives Pokémon dein einziges Pokémon im Spiel ist, ziehe stattdessen 8 Karten."
+		de: "Mische deine Handkarten in dein Deck. Ziehe anschließend 4 Karten. Wenn dein Aktives Pokémon dein einziges Pokémon im Spiel ist, ziehe stattdessen 8 Karten. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Lost Origin Trainer Gallery/TG27.ts
+++ b/data/Sword & Shield/Lost Origin Trainer Gallery/TG27.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Pon hasta 4 cartas de Pokémon Water y de Energía Water, en cualquier combinación, de tu pila de descartes en tu mano.",
 		it: "Prendi fino a quattro Pokémon Water e carte Energia Water in qualsiasi combinazione dalla tua pila degli scarti e aggiungili alle carte che hai in mano.",
 		pt: "Coloque até 4 cartas de Pokémon Water e de Energia Water da sua pilha de descarte na sua mão em qualquer combinação.",
-		de: "Nimm eine beliebige Kombination aus bis zu 4 Water-Pokémon und Water-Energiekarten aus deinem Ablagestapel auf deine Hand."
+		de: "Nimm eine beliebige Kombination aus bis zu 4 {W}-Pokémon und {W}-Energiekarten aus deinem Ablagestapel auf deine Hand. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Lost Origin Trainer Gallery/TG30.ts
+++ b/data/Sword & Shield/Lost Origin Trainer Gallery/TG30.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		es: "Mew V",
 		it: "Mew-V",
 		pt: "Mew V",
-		de: "Mew-V"
+		de: "Mew VMAX"
 	},
 
 	stage: "VMAX",


### PR DESCRIPTION
## Add missing German translations for swsh11tg

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
