### PR TITLE
Add missing German translations for swsh12

### DIFF
--- a/data/Sword & Shield/Silver Tempest/001.ts
+++ b/data/Sword & Shield/Silver Tempest/001.ts
@@ -48,6 +48,7 @@ const card: Card = {
 
 	description: {
 		en: "Lives in the shadows of tall trees where it eats bugs. It is attracted by light at night.",
+		de: "Dieses Pokémon lebt im Schatten großer Bäume. Es frisst Insekten und wird von Licht angezogen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/002.ts
+++ b/data/Sword & Shield/Silver Tempest/002.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "The wings are covered with dustlike scales. Every time it flaps its wings, it looses highly toxic dust.",
+		de: "Seine Flügel sind mit staubähnlichen Schuppen überzogen. Mit jedem Flügelschlag verliert es hochgiftigen Staub."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/003.ts
+++ b/data/Sword & Shield/Silver Tempest/003.ts
@@ -48,6 +48,7 @@ const card: Card = {
 
 	description: {
 		en: "Although the poison from its fangs isn't that strong, it's potent enough to weaken prey that gets caught in its web.",
+		de: "Das Gift an seinen Mundwerkzeugen ist nicht sonderlich stark, jedoch ausreichend, um Beute zu schwächen, die ihm ins Netz gegangen ist."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/004.ts
+++ b/data/Sword & Shield/Silver Tempest/004.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			es: "Los ataques de los Pokémon V-ASTRO de tu rival cuestan Colorless más. No puedes aplicar más de 1 habilidad Hilos Ocultos a la vez.",
 			it: "Il costo degli attacchi dei Pokémon-V ASTRO del tuo avversario aumenta di Colorless. Non puoi applicare più di un'abilità Tela Occulta alla volta.",
 			pt: "Os ataques dos Pokémon V-ASTRO do seu oponente custam Colorless a mais. Você não pode usar mais de 1 Habilidade Fios Ocultos por vez.",
-			de: "Die Kosten der Attacken von Pokémon-VSTAR deines Gegners erhöhen sich um Colorless. Du kannst immer nur jeweils 1 Fähigkeit Verborgene Fäden einsetzen."
+			de: "Die Kosten der Attacken von Pokémon-VSTAR deines Gegners erhöhen sich um {C}. Du kannst immer nur jeweils 1 Fähigkeit Verborgene Fäden einsetzen."
 		}
 	}],
 
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It spews threads from its mouth to catch its prey. When night falls, it leaves its web to go hunt aggressively.",
+		de: "Seine Beute ergreift es mit einem Seidenfaden. Bei Anbruch der Nacht verlässt es sein Netz und macht sich auf die Jagd."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/005.ts
+++ b/data/Sword & Shield/Silver Tempest/005.ts
@@ -48,6 +48,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives by drinking only dewdrops from under the leaves of plants. It is said that it eats nothing else.",
+		de: "Es ernährt sich ausschließlich von den Tautropfen, die von den Blättern über ihm hinabfallen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/006.ts
+++ b/data/Sword & Shield/Silver Tempest/006.ts
@@ -67,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "It gets energy from warm sunlight and is known for its habit of moving in pursuit of it.",
+		de: "Warmes Sonnenlicht gibt ihm Energie. Daher wandert es stets dem Sonnenlicht hinterher."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/009.ts
+++ b/data/Sword & Shield/Silver Tempest/009.ts
@@ -61,6 +61,7 @@ const card: Card = {
 
 	description: {
 		en: "The leaves on its head are highly valued for medicinal purposes. Dry the leaves in the sun, boil them, and then drink the bitter decoction for remarkably effective relief from fatigue.",
+		de: "Ein Aufguss aus den sonnengetrockneten Blättern seines Hauptes schmeckt zwar bitter, ist jedoch als wirksames Mittel gegen Müdigkeit sehr geschätzt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/010.ts
+++ b/data/Sword & Shield/Silver Tempest/010.ts
@@ -47,7 +47,7 @@ const card: Card = {
 			es: "Busca en tu baraja hasta 2 cartas de Energía Grass y únelas a tus Pokémon en Banca de la manera que desees. Después, baraja las cartas de tu baraja.",
 			it: "Cerca nel tuo mazzo fino a due carte Energia Grass e assegnale ai tuoi Pokémon in panchina nel modo che preferisci. Poi rimischia le carte del tuo mazzo.",
 			pt: "Procure por até 2 cartas de Energia Grass no seu baralho e ligue-as aos seus Pokémon no Banco como desejar. Em seguida, embaralhe o seu baralho.",
-			de: "Durchsuche dein Deck nach bis zu 2 Grass-Energiekarten und lege sie beliebig an die Pokémon auf deiner Bank an. Mische anschließend dein Deck."
+			de: "Durchsuche dein Deck nach bis zu 2 {G}-Energiekarten und lege sie beliebig an die Pokémon auf deiner Bank an. Mische anschließend dein Deck."
 		}
 	}, {
 		cost: ["Colorless", "Colorless"],
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "I suspect that its well-developed legs are the result of a life spent on mountains covered in deep snow. The scent it exudes from its flower crown heartens those in proximity.",
+		de: "Die starke Beinmuskulatur verdankt es wohl dem Leben auf schneebedeckten Bergen. Über seine Blumenkrone verströmt es stimulierende Düfte."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/011.ts
+++ b/data/Sword & Shield/Silver Tempest/011.ts
@@ -48,6 +48,7 @@ const card: Card = {
 
 	description: {
 		en: "No one knows what the Poké Ball–like pattern on Foongus means or why Foongus has it.",
+		de: "Bis heute kann niemand genau sagen, wieso Tarnpignon ein Pokéball-Muster aufweisen und welchen Zweck dies erfüllt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/012.ts
+++ b/data/Sword & Shield/Silver Tempest/012.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon puffs poisonous spores at its foes. If the spores aren't washed off quickly, they'll grow into mushrooms wherever they land.",
+		de: "Hutsassa versprüht Giftsporen. Wäscht man diese nicht sofort ab, wachsen dort, wo sie gelandet sind, Pilze."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/013.ts
+++ b/data/Sword & Shield/Silver Tempest/013.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "They lay their eggs deep inside their nests. When attacked by Heatmor, they retaliate using their massive mandibles.",
+		de: "Es legt seine Eier im hintersten Winkel des Nests. Wenn es von Furnifraß bedroht wird, wehrt es sich mit seinen kräftigen Kiefern."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/014.ts
+++ b/data/Sword & Shield/Silver Tempest/014.ts
@@ -79,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "A legend tells of this Pokémon working together with Cobalion and Terrakion to protect the Pokémon of the Unova region.",
+		de: "Eine Legende berichtet davon, wie Viridium einst mit Kobalium und Terrakium unermüdlich die Pokémon Einalls vor den Menschen beschützte."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/016.ts
+++ b/data/Sword & Shield/Silver Tempest/016.ts
@@ -79,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "This feared Pokémon has long, slender legs and a cruel heart. It shows no mercy as it stomps on its opponents.",
+		de: "Seine langen Beine und sein grausames Herz werden gefürchtet. Es tritt ohne Gnade auf seine Gegner ein."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/017.ts
+++ b/data/Sword & Shield/Silver Tempest/017.ts
@@ -57,6 +57,7 @@ const card: Card = {
 
 	description: {
 		en: "While young, it has six gorgeous tails. When it grows, several new tails are sprouted.",
+		de: "In seiner Jugend hat es sechs hinreißende Schweife. Während es wächst, kommen noch weitere neue Schweife hinzu."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/018.ts
+++ b/data/Sword & Shield/Silver Tempest/018.ts
@@ -87,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said to live 1,000 years, and each of its tails is loaded with supernatural powers.",
+		de: "Man sagt, es lebe 1 000 Jahre und jedem seiner Schweife wohnen übernatürliche Kräfte inne."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/019.ts
+++ b/data/Sword & Shield/Silver Tempest/019.ts
@@ -61,6 +61,7 @@ const card: Card = {
 
 	description: {
 		en: "It has a brave and trustworthy nature. It fearlessly stands up to bigger and stronger foes.",
+		de: "Es ist von Natur aus tapfer und vertrauenswürdig und scheut auch vor Gegnern nicht zurück, die größer und stärker sind als es selbst."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/020.ts
+++ b/data/Sword & Shield/Silver Tempest/020.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			es: "Une 1 carta de Energía Fire de tu pila de descartes a este Pokémon.",
 			it: "Assegna a questo Pokémon una carta Energia Fire dalla tua pila degli scarti.",
 			pt: "Ligue 1 carta de Energia Fire da sua pilha de descarte a este Pokémon.",
-			de: "Lege 1 Fire-Energiekarte aus deinem Ablagestapel an dieses Pokémon an."
+			de: "Lege 1 {R}-Energiekarte aus deinem Ablagestapel an dieses Pokémon an."
 		},
 
 		damage: 30
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "The sight of it running over 6,200 miles in a single day and night has captivated many people.",
+		de: "Viele Trainer sind davon fasziniert, dass dieses Pokémon innerhalb eines Tages 10 000 km zurücklegen kann."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/021.ts
+++ b/data/Sword & Shield/Silver Tempest/021.ts
@@ -57,6 +57,7 @@ const card: Card = {
 
 	description: {
 		en: "It can't run properly when it's newly born. As it races around with others of its kind, its legs grow stronger.",
+		de: "Nach der Geburt fällt ihm das Laufen schwer. Die Wettrennen, die es sich mit seinen Freunden liefert, stärken jedoch seine Beinmuskulatur."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/022.ts
+++ b/data/Sword & Shield/Silver Tempest/022.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			es: "Una vez durante tu turno, puedes descartar 1 carta de Energía Fire de tu mano para poder usar esta habilidad. Durante este turno, los ataques de tus Pokémon Fire hacen 30 puntos de daño más al Pokémon Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
 			it: "Una sola volta durante il tuo turno, puoi scartare una carta Energia Fire che hai in mano per usare questa abilità. Durante questo turno, gli attacchi dei tuoi Pokémon Fire infliggono 30 danni in più al Pokémon attivo del tuo avversario, prima di aver applicato debolezza e resistenza.",
 			pt: "Uma vez durante o seu turno, você poderá descartar 1 carta de Energia Fire da sua mão para usar esta Habilidade. Durante este turno, os ataques dos seus Pokémon Fire causarão 30 pontos de dano a mais ao Pokémon Ativo do seu oponente (antes de aplicar Fraqueza e Resistência).",
-			de: "Einmal während deines Zuges kannst du 1 Fire-Energiekarte aus deiner Hand auf deinen Ablagestapel legen, um diese Fähigkeit einzusetzen. Während dieses Zuges fügen die Attacken deiner Fire-Pokémon dem Aktiven Pokémon deines Gegners 30 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
+			de: "Einmal während deines Zuges kannst du 1 {R}-Energiekarte aus deiner Hand auf deinen Ablagestapel legen, um diese Fähigkeit einzusetzen. Während dieses Zuges fügen die Attacken deiner {R}-Pokémon dem Aktiven Pokémon deines Gegners 30 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
 		}
 	}],
 
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon can be seen galloping through fields at speeds of up to 150 mph, its fiery mane fluttering in the wind.",
+		de: "Die lodernde Mähne dieses Pokémon flattert im Wind, wenn es mit einer Geschwindigkeit von 240 km/h über Felder und Wiesen galoppiert."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/023.ts
+++ b/data/Sword & Shield/Silver Tempest/023.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			es: "Une hasta 2 cartas de Energía Fire de tu pila de descartes a tus Pokémon de la manera que desees.",
 			it: "Assegna ai tuoi Pokémon fino a due carte Energia Fire dalla tua pila degli scarti nel modo che preferisci.",
 			pt: "Ligue até 2 cartas de Energia Fire da sua pilha de descarte aos seus Pokémon como desejar.",
-			de: "Lege bis zu 2 Fire-Energiekarten aus deinem Ablagestapel beliebig an deine Pokémon an."
+			de: "Lege bis zu 2 {R}-Energiekarten aus deinem Ablagestapel beliebig an deine Pokémon an."
 		},
 
 		damage: 20
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "When it shares the infinite energy it creates, that being's entire body will be overflowing with power.",
+		de: "Jeder, dem Victini seine grenzenlose Energie zuteilwerden lässt, strotzt nur so vor Kraft."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/025.ts
+++ b/data/Sword & Shield/Silver Tempest/025.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "As it walks, it munches on a twig in place of a snack. It intimidates opponents by puffing hot air out of its ears.",
+		de: "Anstelle eines Snacks kaut es unterwegs auf einem Zweig herum. Es schreckt Gegner ab, indem es über seine Ohren heiße Luft ausstößt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/026.ts
+++ b/data/Sword & Shield/Silver Tempest/026.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "When the twig is plucked from its tail, friction sets the twig alight. The flame is used to send signals to its allies.",
+		de: "Sein Zweig entzündet sich durch die Reibung, die beim Herausziehen aus seinem Schweif entsteht. Mit der Flamme sendet es Signale an Kameraden."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/027.ts
+++ b/data/Sword & Shield/Silver Tempest/027.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "Using psychic power, it generates a fiery vortex of 5,400 degrees Fahrenheit, incinerating foes swept into this whirl of flame.",
+		de: "Mit seinen übernatürlichen Kräften kontrolliert es einen 3 000 °C heißen Flammenwirbel, mit dem es seine Gegner umhüllt und sie verbrennt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/028.ts
+++ b/data/Sword & Shield/Silver Tempest/028.ts
@@ -58,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "Fletchinder launches embers into the den of its prey. When the prey comes leaping out, Fletchinder's sharp talons finish it off.",
+		de: "Es speit Funken in Nisthöhlen und erlegt die erschrocken daraus hervorkommende Beute mit seinen scharfen Krallen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/029.ts
+++ b/data/Sword & Shield/Silver Tempest/029.ts
@@ -87,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "Talonflame mainly preys upon other bird Pokémon. To intimidate opponents, it sends embers spewing from gaps between its feathers.",
+		de: "Fiaro ernährt sich vor allem von Vogel-Pokémon. Aus den Zwischenräumen seines Gefieders sprüht es Funken, um seine Gegner einzuschüchtern."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/030.ts
+++ b/data/Sword & Shield/Silver Tempest/030.ts
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "Its coat regrows twice a year. When the time comes, Litten sets its own body on fire and burns away the old fur.",
+		de: "Es erneuert sein Fell zweimal pro Jahr. Wenn es mal wieder soweit ist, steckt es seinen Körper in Brand, um sein altes Haarkleid loszuwerden."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/031.ts
+++ b/data/Sword & Shield/Silver Tempest/031.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "When its mane is standing on end, you can tell it's feeling good. When it isn't feeling well, its fur will lie down flat.",
+		de: "Hat es seine Mähne aufgestellt, bedeutet dies, dass es guter Dinge ist. Geht es ihm jedoch schlecht, hängt sie schlaff nach hinten herab."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/032.ts
+++ b/data/Sword & Shield/Silver Tempest/032.ts
@@ -87,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "When its fighting spirit is set alight, the flames around its waist become especially intense.",
+		de: "Entbrennt sein Kampfeswille, lodern die Flammen um seine Hüfte noch heftiger auf."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/035.ts
+++ b/data/Sword & Shield/Silver Tempest/035.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			es: "Busca en tu baraja hasta 2 Pokémon que evolucionen de una carta de Objeto que tenga \"Fósil\" en su nombre y ponlos en tu Banca. Después, baraja las cartas de tu baraja.",
 			it: "Cerca nel tuo mazzo fino a due Pokémon che si evolvono da una carta Strumento che ha \"Fossile\" nel nome e mettili nella tua panchina. Poi rimischia le carte del tuo mazzo.",
 			pt: "Procure por até 2 Pokémon no seu baralho que evoluam de uma carta de Item que tenha \"Fóssil\" em seu nome e coloque-os no seu Banco. Em seguida, embaralhe o seu baralho.",
-			de: "Durchsuche dein Deck nach bis zu 2 Pokémon, die sich aus einer Itemkarte entwickeln, bei der \"Fossil\" zum Namen gehört, und lege sie auf deine Bank. Mische anschließend dein Deck."
+			de: "Durchsuche dein Deck nach bis zu 2 Pokémon, die sich aus einer Itemkarte entwickeln, bei der „Fossil“ zum Namen gehört, und lege sie auf deine Bank. Mische anschließend dein Deck."
 		}
 	}, {
 		cost: ["Water", "Colorless", "Colorless"],

--- a/data/Sword & Shield/Silver Tempest/036.ts
+++ b/data/Sword & Shield/Silver Tempest/036.ts
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "It's said that this Pokémon's beautiful blue wings are made of ice. Articuno flies over snowy mountains, its long tail fluttering along behind it.",
+		de: "Seine wunderschönen blauen Flügel sollen aus Eis bestehen. Es fliegt über schneebedeckte Berge, während sein langer Schweif hinter ihm flattert."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/037.ts
+++ b/data/Sword & Shield/Silver Tempest/037.ts
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "It shows off by spraying jets of seawater from the nostrils above its eyes. It eats a solid ton of Wishiwashi every day.",
+		de: "Es prustet Meerwasser aus den Nasenlöchern, die über seinen Augen liegen. Außerdem frisst es täglich eine Tonne Lusardin."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/038.ts
+++ b/data/Sword & Shield/Silver Tempest/038.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It can sometimes knock out opponents with the shock created by breaching and crashing its big body onto the water.",
+		de: "Springt es mit seinem gewaltigen Körper von einer Welle ab, kann es Gegner allein mit der Wucht des Aufpralls besiegen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/039.ts
+++ b/data/Sword & Shield/Silver Tempest/039.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "Although unattractive and unpopular, this Pokémon's marvelous vitality has made it a subject of research.",
+		de: "Sein unvorteilhaftes Aussehen macht es zwar unbeliebt, doch seine erstaunliche Lebenskraft hat das Interesse der Forscher an ihm geweckt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/040.ts
+++ b/data/Sword & Shield/Silver Tempest/040.ts
@@ -87,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "Milotic has provided inspiration to many artists. It has even been referred to as the most beautiful Pokémon of all.",
+		de: "Milotic soll das schönste aller Pokémon sein. Es hat schon so manchem Künstler als Quelle der Inspiration gedient."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/041.ts
+++ b/data/Sword & Shield/Silver Tempest/041.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "It's said that if they are seen at midnight, they'll cause heavy snow. They eat snow and ice to survive.",
+		de: "Erscheint es mitten in der Nacht, so sagt man, steht starker Schneefall bevor. Es ernährt sich von Eis und Schnee."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/042.ts
+++ b/data/Sword & Shield/Silver Tempest/042.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It has a body of ice that won't melt, even with fire. It can instantly freeze moisture in the atmosphere.",
+		de: "Seinen Eiskörper bringt nichts zum Schmelzen, auch Feuer nicht. Es kann Feuchtigkeit in der Luft sofort in Eis verwandeln."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/043.ts
+++ b/data/Sword & Shield/Silver Tempest/043.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "After a woman met her end on a snowy mountain, her regrets lingered on. From them, this Pokémon was born. Its favorite food is frozen souls.",
+		de: "Es ist aus dem Gram einer Frau entstanden, die auf schneebedeckten Bergen umgekommen ist. Am liebsten isst es gefrorene Seelen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/044.ts
+++ b/data/Sword & Shield/Silver Tempest/044.ts
@@ -77,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "Rock-hard scales and oil-filled swim bladders allow this Pokémon to survive the intense water pressure of the deep sea.",
+		de: "Dank seiner steinharten Schuppen und mit Fett gefüllten Schwimmblasen kann es dem Wasserdruck der Tiefsee standhalten."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/045.ts
+++ b/data/Sword & Shield/Silver Tempest/045.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			es: "Busca en tu baraja hasta 3 Pokémon Water Básicos y ponlos en tu Banca. Después, baraja las cartas de tu baraja.",
 			it: "Cerca nel tuo mazzo fino a tre Pokémon Base Water e mettili nella tua panchina. Poi rimischia le carte del tuo mazzo.",
 			pt: "Procure por até 3 Pokémon Water Básicos no seu baralho e coloque-os no seu Banco. Em seguida, embaralhe o seu baralho.",
-			de: "Durchsuche dein Deck nach bis zu 3 Basis-Water-Pokémon und lege sie auf deine Bank. Mische anschließend dein Deck."
+			de: "Durchsuche dein Deck nach bis zu 3 Basis-{W}-Pokémon und lege sie auf deine Bank. Mische anschließend dein Deck."
 		}
 	}, {
 		cost: ["Water"],
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "It drifts in warm seas. It always returns to where it was born, no matter how far it may have drifted.",
+		de: "Lässt sich in warmen Meeren treiben, kehrt aber immer an den Platz seiner Geburt zurück."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/046.ts
+++ b/data/Sword & Shield/Silver Tempest/046.ts
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "When it is resolute, its body fills with power and it becomes swifter. Its jumps are then too fast to follow.",
+		de: "Ist es sich seiner Sache sicher, strotzt es vor Kraft und seine Sprünge werden zu schnell für die menschliche Wahrnehmung."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/047.ts
+++ b/data/Sword & Shield/Silver Tempest/047.ts
@@ -48,6 +48,7 @@ const card: Card = {
 
 	description: {
 		en: "It forms a water bubble at the rear of its body and then covers its head with it. Meeting another Dewpider means comparing water-bubble sizes.",
+		de: "Mit dem Hinterleib füllt es eine Wasserblase auf und hüllt seinen Kopf darin ein. Trifft es andere Araqua, vergleichen sie ihre Wasserblasengröße."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/048.ts
+++ b/data/Sword & Shield/Silver Tempest/048.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It launches water bubbles with its legs, drowning prey within the bubbles. This Pokémon can then take its time to savor its meal.",
+		de: "Mit seinen Beinen verschießt es Wasserblasen, um Beute darin einzuschließen und zu ertränken. Dann verspeist es sie in aller Ruhe."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/049.ts
+++ b/data/Sword & Shield/Silver Tempest/049.ts
@@ -57,6 +57,7 @@ const card: Card = {
 
 	description: {
 		en: "Pikachu that can generate powerful electricity have cheek sacs that are extra soft and super stretchy.",
+		de: "Je stärker die Elektrizität ist, die Pikachu produziert, desto weicher und elastischer sind seine Backentaschen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/050.ts
+++ b/data/Sword & Shield/Silver Tempest/050.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "Its long tail serves as a ground to protect itself from its own high-voltage power.",
+		de: "Sein langer Schweif dient ihm zur Erdung. So bleibt es von der lähmenden Wirkung von Hochspannung selbst verschont."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/051.ts
+++ b/data/Sword & Shield/Silver Tempest/051.ts
@@ -61,6 +61,7 @@ const card: Card = {
 
 	description: {
 		en: "Its antennae, which evolved from a fin, have both positive and negative charges flowing through them.",
+		de: "Seine Antennen haben sich aus Flossen entwickelt und sind sowohl positiv als auch negativ geladen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/052.ts
+++ b/data/Sword & Shield/Silver Tempest/052.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "The light it emits is so bright that it can illuminate the sea's surface from a depth of over three miles.",
+		de: "Sein Licht ist so hell, dass es selbst aus 5 000 m Tiefe an die Meeresoberfläche dringt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/053.ts
+++ b/data/Sword & Shield/Silver Tempest/053.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "One boy's invention led to the development of many different machines that take advantage of Rotom's unique capabilities.",
+		de: "Die Erfindung eines jungen Tüftlers hat zu der Herstellung verschiedener Geräte geführt, die das Potenzial von Rotom nutzen können."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/054.ts
+++ b/data/Sword & Shield/Silver Tempest/054.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "As Emolga flutters through the air, it crackles with electricity. This Pokémon is cute, but it can cause a lot of trouble.",
+		de: "Emolga fliegt anmutig durch die Lüfte und entlädt dabei Strom. Es ist zwar niedlich, kann aber auch für viel Ärger sorgen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/055.ts
+++ b/data/Sword & Shield/Silver Tempest/055.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "Thanks to bacteria that lived in the mud flats with it, this Pokémon developed the organs it uses to generate electricity.",
+		de: "Dieses Pokémon lebt im Morast. Dank der dortigen Bakterien hat es ein Organ entwickelt, mit dem es Strom erzeugen kann."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/056.ts
+++ b/data/Sword & Shield/Silver Tempest/056.ts
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "It approaches its enemies at the speed of lightning, then tears them limb from limb with its sharp claws.",
+		de: "Schnell wie der Blitz nähert es sich seinen Feinden, um sie dann mit seinen scharfen Klauen in Stücke zu reißen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/058.ts
+++ b/data/Sword & Shield/Silver Tempest/058.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			es: "Los ataques de tus Pokémon Lightning Básicos hacen 30 puntos de daño más al Pokémon Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
 			it: "Gli attacchi dei tuoi Pokémon Base Lightning infliggono 30 danni in più al Pokémon attivo del tuo avversario, prima di aver applicato debolezza e resistenza.",
 			pt: "Os ataques dos seus Pokémon Lightning Básicos causam 30 pontos de dano a mais ao Pokémon Ativo do seu oponente (antes de aplicar Fraqueza e Resistência).",
-			de: "Die Attacken deiner Basis-Lightning-Pokémon fügen dem Aktiven Pokémon deines Gegners 30 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
+			de: "Die Attacken deiner Basis-{L}-Pokémon fügen dem Aktiven Pokémon deines Gegners 30 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
 		}
 	}],
 

--- a/data/Sword & Shield/Silver Tempest/059.ts
+++ b/data/Sword & Shield/Silver Tempest/059.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "It has an incredibly high level of intelligence. Some say that Alakazam remembers everything that ever happens to it, from birth till death.",
+		de: "Es verfügt über extrem hohe Intelligenz und soll sich an alles erinnern können, was zwischen seiner Geburt und seinem Tod passiert."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/060.ts
+++ b/data/Sword & Shield/Silver Tempest/060.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "It puts its prey to sleep and devours their dreams. It seems that bad dreams taste sour, so Drowzee doesn't particularly like eating them.",
+		de: "Traumato versetzt seine Beute in den Schlaf und frisst ihre Träume. Alpträume mag es aufgrund ihres säuerlichen Geschmacks nicht so gern."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/061.ts
+++ b/data/Sword & Shield/Silver Tempest/061.ts
@@ -84,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "There are some Hypno that assist doctors with patients who can't sleep at night in hospitals.",
+		de: "Manchmal unterstützt es das medizinische Personal in Krankenhäusern, wenn Patienten an Schlaflosigkeit leiden."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/062.ts
+++ b/data/Sword & Shield/Silver Tempest/062.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "In certain parts of Galar, Jynx was once feared and worshiped as the Queen of Ice.",
+		de: "In einer bestimmten Gegend von Galar wurde Rossana einst als „Königin des Eises“ gleichermaßen gefürchtet wie verehrt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/063.ts
+++ b/data/Sword & Shield/Silver Tempest/063.ts
@@ -63,6 +63,7 @@ const card: Card = {
 
 	description: {
 		en: "What makes it happy is imitating the voices of weeping people and scaring everyone. It doesn't deal well with folks who aren't easily frightened.",
+		de: "Es genießt es, das Schluchzen eines Menschen nachzuahmen und andere damit zu erschrecken. Wen das kaltlässt, den kann es nicht leiden."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/064.ts
+++ b/data/Sword & Shield/Silver Tempest/064.ts
@@ -93,6 +93,7 @@ const card: Card = {
 
 	description: {
 		en: "Its muttered curses can cause awful headaches or terrifying visions that torment others.",
+		de: "Es verursacht schreckliche Qualen, indem es Flüche flüstert, die schlimme Kopfschmerzen und fürchterliche Halluzinationen auslösen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/066.ts
+++ b/data/Sword & Shield/Silver Tempest/066.ts
@@ -72,7 +72,7 @@ const card: Card = {
 			es: "Mientras este Pokémon esté en juego, obtiene una habilidad que tiene el siguiente efecto: \"La Debilidad de cada uno de los Pokémon en juego de tu rival pasa a ser Psychic. (La cantidad de Debilidad no cambia)\". (Nopuedes usar más de 1 Poder V-ASTRO en una partida).",
 			it: "Finché questo Pokémon rimane in gioco, possiede un'abilità che ha l'effetto: \"La debolezza di ciascun Pokémon in gioco del tuo avversario diventa Psychic. Quanto è debole non cambia\". Non puoi usare più di un Potere V ASTRO a partita.",
 			pt: "Até este Pokémon sair de jogo, ele ganhará uma Habilidade com o efeito \"A Fraqueza de cada um dos Pokémon do seu oponente em jogo será Psychic (a quantidade de Fraqueza não muda).\"(você não pode usar mais de 1 Poder V-ASTRO por partida).",
-			de: "Bis dieses Pokémon das Spiel verlässt, erhält es eine Fähigkeit mit dem Effekt \"Die Schwäche jedes Pokémon deines Gegners im Spiel ist jetzt Psychic. (Die Höhe der Schwäche ändert sich nicht.)\" (Du kannst pro Spiel nur 1 VSTAR-Power einsetzen.)"
+			de: "Bis dieses Pokémon das Spiel verlässt, erhält es eine Fähigkeit mit dem Effekt „Die Schwäche jedes Pokémon deines Gegners im Spiel ist jetzt {P}. (Die Höhe der Schwäche ändert sich nicht.)“ (Du kannst pro Spiel nur 1 VSTAR-Power einsetzen.)"
 		}
 	}],
 

--- a/data/Sword & Shield/Silver Tempest/067.ts
+++ b/data/Sword & Shield/Silver Tempest/067.ts
@@ -57,6 +57,7 @@ const card: Card = {
 
 	description: {
 		en: "It is highly attuned to the emotions of people and Pokémon. It hides if it senses hostility.",
+		de: "Es hat ein feines Gespür für die Gefühle der Menschen und Pokémon. Wenn es Feindseligkeit wahrnimmt, versteckt es sich."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/068.ts
+++ b/data/Sword & Shield/Silver Tempest/068.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "If its Trainer becomes happy, it overflows with energy, dancing joyously while spinning about.",
+		de: "Wenn sich sein Trainer freut, tanzt es in einem Schwall von Energie fröhlich kreisend umher."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/069.ts
+++ b/data/Sword & Shield/Silver Tempest/069.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It has the power to predict the future. Its power peaks when it is protecting its Trainer.",
+		de: "Es kann die Zukunft vorhersagen. Beschützt es seinen Trainer, erreicht seine Kraft ihren Höhepunkt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/072.ts
+++ b/data/Sword & Shield/Silver Tempest/072.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "It eats just one berry a day. By enduring hunger, its spirit is tempered and made sharper.",
+		de: "Es isst gerade mal eine Beere am Tag. Durch Hunger wird sein Geist ruhiger und schärfer."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/073.ts
+++ b/data/Sword & Shield/Silver Tempest/073.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			es: "Si tienes exactamente 4 cartas en tu mano, los ataques de este Pokémon cuestan ColorlessColorlessColorless menos.",
 			it: "Se hai esattamente quattro carte in mano, il costo degli attacchi di questo Pokémon è ridotto di ColorlessColorlessColorless.",
 			pt: "Se você tiver exatamente 4 cartas na sua mão, os ataques deste Pokémon custarão ColorlessColorlessColorless a menos.",
-			de: "Wenn du genau 4 Karten auf deiner Hand hast, verringern sich die Kosten der Attacken dieses Pokémon um ColorlessColorlessColorless."
+			de: "Wenn du genau 4 Karten auf deiner Hand hast, verringern sich die Kosten der Attacken dieses Pokémon um {C}{C}{C}."
 		}
 	}],
 
@@ -95,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "Through yoga training, it gained the psychic power to predict its foe's next move.",
+		de: "Mit Yoga-Training hat es seine Psycho-Kräfte geschärft und ahnt so die Attacken seiner Gegner voraus."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/074.ts
+++ b/data/Sword & Shield/Silver Tempest/074.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "Emitting ultrasonic cries, it floats on winds to travel great distances.",
+		de: "Es setzt Ultraschallwellen frei, während es sich vom Wind über große Distanzen tragen lässt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/075.ts
+++ b/data/Sword & Shield/Silver Tempest/075.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "Psychic power allows these Pokémon to fly. Some say they were the guardians of an ancient city. Others say they were the guardians' emissaries.",
+		de: "Es fliegt mithilfe seiner Psycho-Kräfte. Einige sagen, es war einst der Wächter einer Stadt aus uralten Zeiten. Andere sagen, es war sein Bote."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/076.ts
+++ b/data/Sword & Shield/Silver Tempest/076.ts
@@ -54,6 +54,7 @@ const card: Card = {
 
 	description: {
 		en: "It communicates with others telepathically. Its body is encapsulated in liquid, but if it takes a heavy blow, the liquid will leak out.",
+		de: "Monozyto kommunizieren untereinander mittels Telepathie. Erfährt es eine starke Erschütterung, läuft die Flüssigkeit, die es umgibt, aus."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/077.ts
+++ b/data/Sword & Shield/Silver Tempest/077.ts
@@ -73,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "Its psychic power can supposedly cover a range of more than half a mile—but only if its two brains can agree with each other.",
+		de: "Die gewaltigen Psycho-Kräfte, die entstehen, wenn seine zwei Denkapparate einer Meinung sind, sollen im Umkreis von 1 km zu spüren sein."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/078.ts
+++ b/data/Sword & Shield/Silver Tempest/078.ts
@@ -95,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "While it could use its psychic abilities in battle, this Pokémon prefers to swing its powerful arms around to beat opponents into submission.",
+		de: "Es ist stolz auf seine beiden Arme und greift bei Kämpfen lieber auf diese zurück, anstatt seine übernatürlichen Kräfte einzusetzen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/079.ts
+++ b/data/Sword & Shield/Silver Tempest/079.ts
@@ -54,6 +54,7 @@ const card: Card = {
 
 	description: {
 		en: "If this Pokémon stands near a TV, strange scenery will appear on the screen. That scenery is said to be from its home.",
+		de: "Wenn es in der Nähe ist, beginnen Fernseher zu flackern und fremdartige Landschaften zu zeigen. Diese stellen angeblich seine Heimat dar."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/080.ts
+++ b/data/Sword & Shield/Silver Tempest/080.ts
@@ -84,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "Whenever a Beheeyem visits a farm, a Dubwool mysteriously disappears.",
+		de: "Jedes Mal, wenn ein Megalon auf einer Farm auftaucht, verschwindet bald darauf ein Zwollock unter mysteriösen Umständen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/081.ts
+++ b/data/Sword & Shield/Silver Tempest/081.ts
@@ -67,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "Though Espurr's expression never changes, behind that blank stare is an intense struggle to contain its devastating psychic power.",
+		de: "Sein Gesicht ist stets ausdruckslos. Grund dafür ist die enorme Anstrengung, die es aufbringen muss, um seine Psycho-Kräfte zu kontrollieren."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/082.ts
+++ b/data/Sword & Shield/Silver Tempest/082.ts
@@ -86,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "Females are a bit more selfish and aggressive than males. If they don't get what they want, they will torment you with their psychic abilities.",
+		de: "Weibliche Psiaugon sind etwas aggressiver und eigensinniger als männliche. Wer ihnen die Laune verdirbt, bekommt ihre Psycho-Kräfte zu spüren."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/083.ts
+++ b/data/Sword & Shield/Silver Tempest/083.ts
@@ -61,6 +61,7 @@ const card: Card = {
 
 	description: {
 		en: "It eats its own weight in sugar every day. If it doesn't get enough sugar, it becomes incredibly grumpy.",
+		de: "Die Menge an Zucker, die es pro Tag verschlingt, entspricht seinem Körpergewicht. Bekommt es nicht genügend Zucker, wird es unausstehlich."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/084.ts
+++ b/data/Sword & Shield/Silver Tempest/084.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "By taking in a person's scent, it can sniff out their mental and physical condition. It's hoped that this skill will have many medical applications.",
+		de: "Es kann die körperliche und seelische Verfassung anderer anhand ihres Körpergeruchs erkennen. Dies versucht man für die Medizin zu nutzen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/085.ts
+++ b/data/Sword & Shield/Silver Tempest/085.ts
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "A Dedenne's whiskers pick up electrical waves other Dedenne send out. These Pokémon share locations of food or electricity with one another.",
+		de: "Mit den Schnurrhaaren empfangen sie elektrische Wellen von Artgenossen. So teilen sie einander mit, wo Futter und Elektrizität zu finden sind."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/086.ts
+++ b/data/Sword & Shield/Silver Tempest/086.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "These intelligent Pokémon touch horns with each other to share information between them.",
+		de: "Ein äußerst intelligentes Pokémon, das mit seinen Artgenossen kommuniziert, indem es die Hörner eines anderen Exemplars mit seinen berührt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/087.ts
+++ b/data/Sword & Shield/Silver Tempest/087.ts
@@ -63,6 +63,7 @@ const card: Card = {
 
 	description: {
 		en: "After being reborn as a ghost Pokémon, Dreepy wanders the areas it used to inhabit back when it was alive in prehistoric seas.",
+		de: "In der Urzeit lebte es im Meer. Nun ist es als Geister-Pokémon wiedererwacht und irrt rastlos durch seinen früheren Lebensraum."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/088.ts
+++ b/data/Sword & Shield/Silver Tempest/088.ts
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "It's capable of flying faster than 120 mph. It battles alongside Dreepy and dotes on them until they successfully evolve.",
+		de: "Beim Fliegen ist es bis zu 200 km/h schnell. Es kämpft gemeinsam mit Grolldra und kümmert sich bis zu dessen Entwicklung um es."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/089.ts
+++ b/data/Sword & Shield/Silver Tempest/089.ts
@@ -84,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "When it isn't battling, it keeps Dreepy in the holes on its horns. Once a fight starts, it launches the Dreepy like supersonic missiles.",
+		de: "Es transportiert Grolldra in den Löchern an seinen Hörnern. Kommt es zum Kampf, schießt es diese mit Mach-Geschwindigkeit ab."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/090.ts
+++ b/data/Sword & Shield/Silver Tempest/090.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			es: "Todas las veces que quieras durante tu turno, puedes mover 1 Energía Fighting de 1 de tus otros Pokémon a este Pokémon.",
 			it: "Durante il tuo turno, puoi spostare un'Energia Fighting da uno dei tuoi altri Pokémon a questo Pokémon tutte le volte che vuoi.",
 			pt: "Quantas vezes desejar durante o seu turno, você poderá mover 1 Energia Fighting de 1 dos seus outros Pokémon para este Pokémon.",
-			de: "Beliebig oft während deines Zuges kannst du 1 Fighting-Energie von 1 deiner anderen Pokémon auf dieses Pokémon verschieben."
+			de: "Beliebig oft während deines Zuges kannst du 1 {F}-Energie von 1 deiner anderen Pokémon auf dieses Pokémon verschieben."
 		}
 	}],
 
@@ -62,7 +62,7 @@ const card: Card = {
 			es: "Este ataque hace 30 puntos de daño más por cada Energía Fighting unida a este Pokémon.",
 			it: "Questo attacco infligge 30 danni in più per ogni Energia Fighting assegnata a questo Pokémon.",
 			pt: "Este ataque causa 30 pontos de dano a mais para cada Energia Fighting ligada a este Pokémon.",
-			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte Fighting-Energie 30 Schadenspunkte mehr zu."
+			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte {F}-Energie 30 Schadenspunkte mehr zu."
 		},
 
 		damage: "90+"

--- a/data/Sword & Shield/Silver Tempest/091.ts
+++ b/data/Sword & Shield/Silver Tempest/091.ts
@@ -57,6 +57,7 @@ const card: Card = {
 
 	description: {
 		en: "It is strong despite its compact size. It can easily pick up and carry an adult human on its back.",
+		de: "Trotz seiner geringen Größe ist es stark. Es kann einen Erwachsenen mühelos auf dem Rücken tragen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/092.ts
+++ b/data/Sword & Shield/Silver Tempest/092.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "The longer and bigger its tusks, the higher its rank in its herd. The tusks take long to grow.",
+		de: "Je größer und länger die Stoßzähne, desto höher ist ihr Rang in der Herde, doch das dauert lange."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/093.ts
+++ b/data/Sword & Shield/Silver Tempest/093.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "It moves while spinning around on its single foot. Some Baltoy have been seen spinning on their heads.",
+		de: "Es bewegt sich, indem es auf seinem Fuß kreiselt. Vereinzelt sieht man auch Puppance, die dies kopfüber tun."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/094.ts
+++ b/data/Sword & Shield/Silver Tempest/094.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			es: "Puedes usar esta habilidad solo si no tienes ninguna carta de Partidario en tu pila de descartes. Una vez durante tu turno, puedes unir 1 carta de Energía Fighting de tu pila de descartes a 1 de tus Pokémon.",
 			it: "Puoi usare questa abilità solo se non hai carte Aiuto nella tua pila degli scarti. Una sola volta durante il tuo turno, puoi assegnare a uno dei tuoi Pokémon una carta Energia Fighting dalla tua pila degli scarti.",
 			pt: "Você só pode usar esta Habilidade se não tiver cartas de Apoiador na sua pilha de descarte. Uma vez durante o seu turno, você poderá ligar 1 carta de Energia Fighting da sua pilha de descarte a 1 dos seus Pokémon.",
-			de: "Du kannst diese Fähigkeit nur einsetzen, wenn du keine Unterstützerkarten in deinem Ablagestapel hast. Einmal während deines Zuges kannst du 1 Fighting-Energiekarte aus deinem Ablagestapel an 1 deiner Pokémon anlegen."
+			de: "Du kannst diese Fähigkeit nur einsetzen, wenn du keine Unterstützerkarten in deinem Ablagestapel hast. Einmal während deines Zuges kannst du 1 {F}-Energiekarte aus deinem Ablagestapel an 1 deiner Pokémon anlegen."
 		}
 	}],
 
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "This mysterious Pokémon started life as an ancient clay figurine made over 20,000 years ago.",
+		de: "Dieses rätselhafte Pokémon ist aus einer Lehmpuppe entstanden, die vor 20 000 Jahren von einem uralten Volk angefertigt wurde."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/095.ts
+++ b/data/Sword & Shield/Silver Tempest/095.ts
@@ -67,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon was restored from a fossil. Anorith lived in the ocean about 100,000,000 years ago, hunting with its pair of claws.",
+		de: "Es wurde aus einem Fossil wiederbelebt. Vor circa 100 Millionen Jahren war es im Meer zu Hause, wo es mit seinen beiden Klauen auf Jagd ging."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/096.ts
+++ b/data/Sword & Shield/Silver Tempest/096.ts
@@ -78,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "After evolution, this Pokémon emerged onto land. Its lower body has become stronger, and blows from its tail are devastating.",
+		de: "Nach seiner Entwicklung ging es an Land, sodass sich sein Unterkörper verstärkte. Ein Hieb seines Schweifs besitzt gewaltige Zerstörungskraft."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/097.ts
+++ b/data/Sword & Shield/Silver Tempest/097.ts
@@ -57,6 +57,7 @@ const card: Card = {
 
 	description: {
 		en: "It has phenomenal power. It will mercilessly crush anyone or anything that bullies small Pokémon.",
+		de: "Terrakium verfügt über unvergleichliche Kräfte. Wer kleinere Pokémon bedroht oder schlecht behandelt, wird von ihm zur Strecke gebracht."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/098.ts
+++ b/data/Sword & Shield/Silver Tempest/098.ts
@@ -83,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "It drives its opponents to exhaustion with its agile maneuvers, then ends the fight with a flashy finishing move.",
+		de: "Durch flinke Angriffsmanöver raubt es seinen Gegnern ihre Kraft, um sie dann mit prachtvollen Spezialtechniken niederzuringen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/099.ts
+++ b/data/Sword & Shield/Silver Tempest/099.ts
@@ -57,6 +57,7 @@ const card: Card = {
 
 	description: {
 		en: "Grudges of the dead have possessed a mound of sand and become a Pokémon. Sandygast is fond of the shovel on its head.",
+		de: "Es entstand aus einem Sandhaufen, in den der Groll eines Verstorbenen fuhr. Die Schaufel auf Sankabuhs Kopf ist sein größter Schatz."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/100.ts
+++ b/data/Sword & Shield/Silver Tempest/100.ts
@@ -78,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "Palossand is known as the Beach Nightmare. It pulls its prey down into the sand by controlling the sand itself, and then it sucks out their souls.",
+		de: "Colossand wird auch als „Schrecken der Strände“ bezeichnet. Es manipuliert Sand, um seine Beute zu begraben und sich ihre Seele einzuverleiben."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/101.ts
+++ b/data/Sword & Shield/Silver Tempest/101.ts
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "It stands in grasslands, watching the sun's descent from zenith to horizon. This Pokémon has a talent for delivering dynamic kicks.",
+		de: "Es verweilt auf weitläufigen Wiesen und beobachtet den Lauf der Sonne. Dynamische Trittangriffe sind sein Spezialgebiet."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/103.ts
+++ b/data/Sword & Shield/Silver Tempest/103.ts
@@ -48,6 +48,7 @@ const card: Card = {
 
 	description: {
 		en: "It emits ultrasonic waves from its mouth to check its surroundings. Even in tight caves, Zubat flies around with skill.",
+		de: "Über den Mund stößt es Ultraschallwellen aus, um seine Umgebung zu erkunden. So kann es selbst in engen Höhlen geschickt umherfliegen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/104.ts
+++ b/data/Sword & Shield/Silver Tempest/104.ts
@@ -58,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "It loves to drink other creatures' blood. It's said that if it finds others of its kind going hungry, it sometimes shares the blood it's gathered.",
+		de: "Das Blut anderer Lebewesen ist seine Leibspeise. Man sagt, dass es das abgesaugte Blut manchmal mit hungrigen Artgenossen teilt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/105.ts
+++ b/data/Sword & Shield/Silver Tempest/105.ts
@@ -87,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "Both of its legs have turned into wings. Without a sound, Crobat flies swiftly toward its prey and sinks its fangs into the nape of its target's neck.",
+		de: "Seine zwei Beine wurden zu Flügeln. Es fliegt schnell und lautlos zu seiner Beute, um ihr dann die Zähne in den Nacken zu bohren."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/106.ts
+++ b/data/Sword & Shield/Silver Tempest/106.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "It searches for shiny things for its boss. Murkrow's presence is said to be unlucky, so many people detest it.",
+		de: "Für seinen Chef geht es auf die Jagd nach glitzernden Objekten. Von vielen Menschen wird es als Überbringer des Unheils verabscheut."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/107.ts
+++ b/data/Sword & Shield/Silver Tempest/107.ts
@@ -93,6 +93,7 @@ const card: Card = {
 
 	description: {
 		en: "Its goons take care of most of the fighting for it. The only time it dirties its own hands is in delivering a final blow to finish off an opponent.",
+		de: "Das Kämpfen überlässt es größtenteils seinen Untergebenen. Es macht sich nur die Flügel schmutzig, um dem Gegner den Rest zu geben."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/109.ts
+++ b/data/Sword & Shield/Silver Tempest/109.ts
@@ -48,6 +48,7 @@ const card: Card = {
 
 	description: {
 		en: "It makes frightening noises with its poison-filled cheek sacs. When opponents flinch, Croagunk hits them with a poison jab.",
+		de: "Es schüchtert Gegner mit Geräuschen ein, die es mit seinen Giftbeuteln erzeugt. Gelingt ihm dies, erledigt es sein Ziel mit einem Giftangriff."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/110.ts
+++ b/data/Sword & Shield/Silver Tempest/110.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It bounces toward opponents and gouges them with poisonous claws. No more than a scratch is needed to knock out its adversaries.",
+		de: "Es nähert sich springend seinem Gegner und bohrt seine giftigen Klauen in ihn hinein. Schon ein kleiner Kratzer lässt den Gegner K.O. gehen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/111.ts
+++ b/data/Sword & Shield/Silver Tempest/111.ts
@@ -48,6 +48,7 @@ const card: Card = {
 
 	description: {
 		en: "The desert gets cold at night, so when the sun sets, this Pokémon burrows deep into the sand and sleeps until sunrise.",
+		de: "Da die Wüste nachts abkühlt, vergräbt es sich tief im Sand und schläft dort, bis die Sonne wieder aufgeht."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/112.ts
+++ b/data/Sword & Shield/Silver Tempest/112.ts
@@ -67,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "Krokorok has specialized eyes that enable it to see in the dark. This ability lets Krokorok hunt in the dead of night without getting lost.",
+		de: "Da es dank seiner besonderen Augen selbst im Dunkeln gut sieht, kann es auch nachts auf die Jagd gehen, ohne sich zu verirren."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/113.ts
+++ b/data/Sword & Shield/Silver Tempest/113.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon is known as the Bully of the Sands. Krookodile's mighty jaws can bite through heavy plates of iron with almost no effort at all.",
+		de: "Es wird auch als „Tyrann der Wüste“ bezeichnet. Mit seinem mächtigen Kiefer durchbeißt es selbst dicke Eisenplatten mit Leichtigkeit."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/114.ts
+++ b/data/Sword & Shield/Silver Tempest/114.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "The first symptom of its sting is numbness. The next is an itching sensation so intense that it's impossible to resist the urge to claw at your skin.",
+		de: "Wird man von seinen Stacheln gestochen, setzt zunächst Taubheit ein, gefolgt von einem nahezu unerträglich starken Juckreiz."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/115.ts
+++ b/data/Sword & Shield/Silver Tempest/115.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "To survive in the cold waters of Galar, this Pokémon forms a dome with its legs, enclosing its body so it can capture its own body heat.",
+		de: "Um dem kalten Wasser der Galar-Region zu trotzen, bilden seine Beine eine Kuppel, deren Inneres es mittels Körperwärme aufheizt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/116.ts
+++ b/data/Sword & Shield/Silver Tempest/116.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "Intense hunger drives it to extremes of violence, and the electricity in its cheek sacs has converted into a Dark-type energy.",
+		de: "Es wandelt in seinen Backentaschen Elektrizität in Unlicht-Energie um. Wenn es der Hunger überkommt, wird es rasend vor Wut."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/117.ts
+++ b/data/Sword & Shield/Silver Tempest/117.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "From its rear, Beldum emits a magnetic force that rapidly pulls opponents in. They get skewered on Beldum's sharp claws.",
+		de: "Mit der Magnetkraft, die es an seinem Hinterteil erzeugt, zieht es Gegner ruckartig zu sich heran, um sie mit seinen scharfen Krallen aufzuspießen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/118.ts
+++ b/data/Sword & Shield/Silver Tempest/118.ts
@@ -73,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "Two Beldum have become stuck together via their own magnetic forces. With two brains, the resulting Metang has doubled psychic powers.",
+		de: "Durch Magnetismus verschmolzen zwei Tanhel miteinander. Da es nun zwei Gehirne besitzt, haben sich seine Psycho-Kräfte verdoppelt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/119.ts
+++ b/data/Sword & Shield/Silver Tempest/119.ts
@@ -95,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "Because the magnetic powers of these Pokémon get stronger in freezing temperatures, Metagross living on snowy mountains are full of energy.",
+		de: "Metagross, die auf verschneiten Bergen leben, sind besonders aktiv, da Temperaturen unter dem Gefrierpunkt ihren Magnetismus verstärken."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/120.ts
+++ b/data/Sword & Shield/Silver Tempest/120.ts
@@ -83,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said to have the ability to grant any wish for just one week every thousand years.",
+		de: "Man sagt, es kann alle 1 000 Jahre für eine Woche jeden Wunsch erfüllen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/121.ts
+++ b/data/Sword & Shield/Silver Tempest/121.ts
@@ -67,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "It defends itself by launching spikes, but its aim isn't very good at first. Only after a lot of practice will it improve.",
+		de: "Es schützt sich, indem es Dornen verschießt. Ein Kastadur muss jahrelang trainieren, um präzise zielen zu können."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/122.ts
+++ b/data/Sword & Shield/Silver Tempest/122.ts
@@ -77,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon scrapes its spikes across rocks, and then uses the tips of its feelers to absorb the nutrients it finds within the stone.",
+		de: "Es kratzt mit seinen Dornen Kerben in Felswände und extrahiert dann mit den Dornenspitzen an seinen Schlingen Nährstoffe aus dem Gestein."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/123.ts
+++ b/data/Sword & Shield/Silver Tempest/123.ts
@@ -61,6 +61,7 @@ const card: Card = {
 
 	description: {
 		en: "The two minigears that compose this Pokémon are closer than twins. They mesh well only with each other.",
+		de: "Seine zwei Teile stehen einander näher als Zwillinge. Eine andere Kombination würde nicht halb so gut ineinandergreifen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/124.ts
+++ b/data/Sword & Shield/Silver Tempest/124.ts
@@ -73,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "When Klang goes all out, the minigear links up perfectly with the outer part of the big gear, and this Pokémon's rotation speed increases sharply.",
+		de: "Macht es Ernst, greift das kleine äußere Rad in das große Rad, was die Drehgeschwindigkeit merklich erhöht."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/125.ts
+++ b/data/Sword & Shield/Silver Tempest/125.ts
@@ -86,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "From its spikes, it launches powerful blasts of electricity. Its red core contains an enormous amount of energy.",
+		de: "Die Stachelspitzen können starke Elektrizität abfeuern. Im roten Zentralbestandteil sind Unmengen von Energie gespeichert."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/126.ts
+++ b/data/Sword & Shield/Silver Tempest/126.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			es: "Los ataques de tus Pokémon Básicos hacen 30 puntos de daño más al Pokémon Darkness Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
 			it: "Gli attacchi dei tuoi Pokémon Base infliggono 30 danni in più al Pokémon attivo Darkness del tuo avversario, prima di aver applicato debolezza e resistenza.",
 			pt: "Os ataques dos seus Pokémon Básicos causam 30 pontos de dano a mais ao Pokémon Darkness Ativo do seu oponente (antes de aplicar Fraqueza e Resistência).",
-			de: "Die Attacken deiner Basis-Pokémon fügen dem Aktiven Darkness-Pokémon deines Gegners 30 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
+			de: "Die Attacken deiner Basis-Pokémon fügen dem Aktiven {D}-Pokémon deines Gegners 30 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
 		}
 	}],
 
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon appears in a legend alongside Terrakion and Virizion, fighting against humans in defense of the Unova region's Pokémon.",
+		de: "Legenden zufolge kämpfte es einst zusammen mit Terrakium und Viridium gegen die Menschen, um die Pokémon der Einall-Region zu beschützen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/127.ts
+++ b/data/Sword & Shield/Silver Tempest/127.ts
@@ -63,6 +63,7 @@ const card: Card = {
 
 	description: {
 		en: "With the long hairs on its back, this Pokémon takes in electricity from other electric Pokémon. It stores what it absorbs in an electric sac.",
+		de: "Der Schweif an seinem Rücken absorbiert Blitze und Angriffe von Elektro-Pokémon. Es speichert den so gewonnenen Strom in Elektrotaschen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/129.ts
+++ b/data/Sword & Shield/Silver Tempest/129.ts
@@ -51,6 +51,7 @@ const card: Card = {
 
 	description: {
 		en: "Dratini dwells near bodies of rapidly flowing water, such as the plunge pools of waterfalls. As it grows, Dratini will shed its skin many times.",
+		de: "Dratini lebt in der Nähe reißender Gewässer, wie etwa in tiefen Becken unter Wasserfällen. Es wächst, indem es sich immer wieder häutet."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/130.ts
+++ b/data/Sword & Shield/Silver Tempest/130.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon lives in pristine oceans and lakes. It can control the weather, and it uses this power to fly into the sky, riding on the wind.",
+		de: "Dragonir lebt in klaren Meeren und Seen. Mit seiner Gabe, das Wetter zu beeinflussen, schwingt es sich auf dem Wind in den Himmel."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/131.ts
+++ b/data/Sword & Shield/Silver Tempest/131.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "It's a kindhearted Pokémon. If it spots a drowning person or Pokémon, Dragonite simply must help them.",
+		de: "Erspäht dieses gutherzige Pokémon ertrinkende Menschen oder Pokémon, so kann es gar nicht anders, als sie zu retten."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/132.ts
+++ b/data/Sword & Shield/Silver Tempest/132.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "After nightfall, they emerge from the caves they nest in during the day. Using their ultrasonic waves, they go on the hunt for ripened fruit.",
+		de: "Bei Sonnenuntergang verlässt es seine Höhle und geht mithilfe von Ultraschallwellen auf die Suche nach reifem Obst."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/133.ts
+++ b/data/Sword & Shield/Silver Tempest/133.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Aggressive and cruel, this Pokémon will ruthlessly torment enemies that are helpless in the dark.",
+		de: "Ein heißblütiges und brutales Pokémon. Es fügt seinen in der Dunkelheit wehrlosen Gegnern gnadenlos Verletzungen zu."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/134.ts
+++ b/data/Sword & Shield/Silver Tempest/134.ts
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "Born when around 10% of Zygarde's cells have been gathered from all over, this form is skilled in close-range combat.",
+		de: "Diese Form nimmt es an, wenn 10 % seiner Zellen gesammelt wurden. Das Spezialgebiet von diesem Pokémon ist der Nahkampf."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/136.ts
+++ b/data/Sword & Shield/Silver Tempest/136.ts
@@ -50,7 +50,7 @@ const card: Card = {
 			es: "Elige 1 ataque de 1 de los Pokémon Dragon de tu pila de descartes y úsalo para este ataque.",
 			it: "Scegli un attacco di un Pokémon Dragon nella tua pila degli scarti e usalo al posto di questo attacco.",
 			pt: "Escolha um ataque de um Pokémon Dragon da sua pilha de descarte e use-o como este ataque.",
-			de: "Wähle 1 Attacke eines Dragon-Pokémon in deinem Ablagestapel und setze sie als diese Attacke ein."
+			de: "Wähle 1 Attacke eines {N}-Pokémon in deinem Ablagestapel und setze sie als diese Attacke ein."
 		}
 	}],
 

--- a/data/Sword & Shield/Silver Tempest/137.ts
+++ b/data/Sword & Shield/Silver Tempest/137.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "It draws symbols with the fluid that oozes from the tip of its tail. Depending on the symbol, Smeargle fanatics will pay big money for them.",
+		de: "Mit der Flüssigkeit, die aus seiner Schweifspitze austritt, hinterlässt es Markierungen. Die besten werden unter Fans zu hohen Preisen gehandelt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/139.ts
+++ b/data/Sword & Shield/Silver Tempest/139.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		es: "Lugia V",
 		it: "Lugia-V",
 		pt: "Lugia V",
-		de: "Lugia-V"
+		de: "Lugia VSTAR"
 	},
 
 	stage: "VSTAR",

--- a/data/Sword & Shield/Silver Tempest/141.ts
+++ b/data/Sword & Shield/Silver Tempest/141.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "Each Spinda's spot pattern is different. With its stumbling movements, it evades opponents' attacks brilliantly!",
+		de: "Jedes Pandir hat ein anderes Fleckenmuster. Mit seinem taumelnden Gang weicht es gegnerischen Angriffen souverän aus."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/142.ts
+++ b/data/Sword & Shield/Silver Tempest/142.ts
@@ -63,6 +63,7 @@ const card: Card = {
 
 	description: {
 		en: "Its cottony wings are full of air, making them light and fluffy to the touch. Swablu takes diligent care of its wings.",
+		de: "Seine watteartigen Flügel enthalten Luft und fühlen sich daher schön flauschig an. Wablu lässt keine Gelegenheit aus, sie zu pflegen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/143.ts
+++ b/data/Sword & Shield/Silver Tempest/143.ts
@@ -84,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "As it flies in a calm and relaxed manner, Altaria performs a humming song that would enrapture any audience.",
+		de: "Es schwebt gemächlich durch die Lüfte und lässt dabei ein wunderschönes Summen ertönen, das alle in seinen Bann zieht, die es hören."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/144.ts
+++ b/data/Sword & Shield/Silver Tempest/144.ts
@@ -57,6 +57,7 @@ const card: Card = {
 
 	description: {
 		en: "If both of Buneary's ears are rolled up, something is wrong with its body or mind. It's a sure sign the Pokémon is in need of care.",
+		de: "Sind seine beiden Ohren aufgerollt, deutet das darauf hin, dass es ihm körperlich oder psychisch nicht gut geht und es Zuwendung braucht."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/145.ts
+++ b/data/Sword & Shield/Silver Tempest/145.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "Lopunny is constantly monitoring its surroundings. If danger approaches, this Pokémon responds with superdestructive kicks.",
+		de: "Schlapor behält seine Umgebung stets im Auge. Wenn Gefahr im Verzug ist, setzt es sich mit vernichtenden Tritten zur Wehr."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/146.ts
+++ b/data/Sword & Shield/Silver Tempest/146.ts
@@ -77,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon was successfully restored from a fossil. As research suggested, Archen is unable to fly. But it's very good at jumping.",
+		de: "Es wurde aus einem Fossil zurückverwandelt. Wie von Forschern vermutet, kann Flapteryx zwar nicht fliegen, dafür aber umso besser springen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/147.ts
+++ b/data/Sword & Shield/Silver Tempest/147.ts
@@ -86,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "It needs a running start to take off. If Archeops wants to fly, it first needs to run nearly 25 mph, building speed over a course of about 2.5 miles.",
+		de: "Um abheben zu können, muss es circa 4 km Anlauf nehmen und dabei eine Geschwindigkeit von 40 km/h erreichen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/148.ts
+++ b/data/Sword & Shield/Silver Tempest/148.ts
@@ -63,6 +63,7 @@ const card: Card = {
 
 	description: {
 		en: "Its chick-like looks belie its hotheadedness. It challenges its parents at every opportunity, desperate to prove its strength.",
+		de: "Obwohl sein Aussehen dem eines Kükens gleicht, ist es sehr heißblütig und nutzt jede Gelegenheit zum Kräftemessen mit den Eltern, um seine Stärke unter Beweis zu stellen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/149.ts
+++ b/data/Sword & Shield/Silver Tempest/149.ts
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "Screaming a bloodcurdling battle cry, this huge and ferocious bird Pokémon goes out on the hunt. It blasts lakes with shock waves, then scoops up any prey that float to the water's surface.",
+		de: "Mit entsetzlichem Kampfgeschrei geht dieses erbarmungslose, riesige Vogel-Pokémon auf Jagd. Es erzeugt Stoßwellen über Seen, um sodann die emportreibende Beute zu ergreifen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/150.ts
+++ b/data/Sword & Shield/Silver Tempest/150.ts
@@ -54,6 +54,7 @@ const card: Card = {
 
 	description: {
 		en: "Its melodious cries are actually warnings. Fletchling will mercilessly peck at anything that enters its territory.",
+		de: "Sein wunderschönes Zwitschern ist in Wirklichkeit eine Warnung. Wer in sein Revier eindringt, wird gnadenlos von ihm gepickt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest/151.ts
+++ b/data/Sword & Shield/Silver Tempest/151.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Puedes usar esta carta solo cuando sea la última carta en tu mano.\nRoba 1 carta por cada Pokémon en Banca (tanto tuyos como de tu rival).",
 		it: "Puoi usare questa carta solo se è l'ultima carta che hai in mano.\nPesca una carta per ogni Pokémon in panchina, sia tuo che del tuo avversario.",
 		pt: "Você só pode usar esta carta se ela for a última carta na sua mão.\nCompre 1 carta para cada Pokémon no Banco\n(seus e do seu oponente).",
-		de: "Du kannst diese Karte nur verwenden, wenn es die letzte Karte auf deiner Hand ist.\nZiehe 1 Karte für jedes Pokémon auf der Bank (deiner und der deines Gegners)."
+		de: "Du kannst diese Karte nur verwenden, wenn es die letzte Karte auf deiner Hand ist. Ziehe 1 Karte für jedes Pokémon auf der Bank (deiner und der deines Gegners). Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest/152.ts
+++ b/data/Sword & Shield/Silver Tempest/152.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Mira las 7 primeras cartas de tu baraja. Puedes enseñar cualquier cantidad de cartas de Pokémon Water y de Energía Water que encuentres entre ellas y ponerlas en tu mano. Pon el resto de las cartas de nuevo en tu baraja y barájalas todas.",
 		it: "Guarda le prime sette carte del tuo mazzo. Puoi mostrare un numero qualsiasi di Pokémon Water e carte Energia Water presenti tra esse e aggiungerli alle carte che hai in mano. Poi rimischia le altre carte nel tuo mazzo.",
 		pt: "Olhe as 7 cartas de cima do seu baralho. Você pode revelar qualquer número de cartas de Pokémon Water e de Energia Water que encontrar lá e colocá-las na sua mão. Embaralhe as demais cartas de volta no seu baralho.",
-		de: "Schau dir die obersten 7 Karten deines Decks an. Du kannst beliebig viele Water-Pokémon und Water-Energiekarten, die du dort findest, deinem Gegner zeigen und auf deine Hand nehmen. Mische die anderen Karten zurück in dein Deck."
+		de: "Schau dir die obersten 7 Karten deines Decks an. Du kannst beliebig viele {W}-Pokémon und {W}-Energiekarten, die du dort findest, deinem Gegner zeigen und auf deine Hand nehmen. Mische die anderen Karten zurück in dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest/153.ts
+++ b/data/Sword & Shield/Silver Tempest/153.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Lanza 1 moneda. Si sale cara, busca en tu baraja 1 Pokémon Evolución, enséñalo y ponlo en tu mano. Si sale cruz, busca en tu baraja 1 Pokémon Básico, enséñalo y ponlo en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Lancia una moneta. Se esce testa, cerca nel tuo mazzo un Pokémon Evoluzione, mostralo e aggiungilo alle carte che hai in mano. Se esce croce, cerca nel tuo mazzo un Pokémon Base, mostralo e aggiungilo alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Jogue 1 moeda. Se sair cara, procure por 1 Pokémon de Evolução no seu baralho, revele-o e coloque-o na sua mão. Se sair coroa, procure por 1 Pokémon Básico no seu baralho, revele-o e coloque-o na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Wirf 1 Münze. Durchsuche bei Kopf dein Deck nach 1 Entwicklungs-Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Durchsuche bei Zahl dein Deck nach 1 Basis-Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck."
+		de: "Wirf 1 Münze. Durchsuche bei Kopf dein Deck nach 1 Entwicklungs-Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Durchsuche bei Zahl dein Deck nach 1 Basis-Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Silver Tempest/154.ts
+++ b/data/Sword & Shield/Silver Tempest/154.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "El Pokémon V al que esté unida esta carta puede usar el Poder V-ASTRO de esta carta. (Sigues necesitando las Energías necesarias para usar este ataque).",
 		it: "Il Pokémon-V a cui è assegnata questa carta può usare il Potere V ASTRO di questa carta. Devi comunque avere l'Energia necessaria per usare questo attacco.",
 		pt: "O Pokémon V ao qual esta carta está ligada pode usar o Poder V-ASTRO desta carta (você ainda precisa da Energia necessária para usar este ataque).",
-		de: "Das Pokémon-V, an das diese Karte angelegt ist, kann die VSTAR-Power auf dieser Karte einsetzen. (Du benötigst jedoch die für diese Attacke notwendige Energie.)"
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Das Pokémon-V, an das diese Karte angelegt ist, kann die VSTAR-Power auf dieser Karte einsetzen. (Du benötigst jedoch die für diese Attacke notwendige Energie.) Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sword & Shield/Silver Tempest/155.ts
+++ b/data/Sword & Shield/Silver Tempest/155.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Al final de cada turno, si al Pokémon al que está unida esta carta le quedan 30 PS o menos y tiene algún contador de daño sobre él, cúrale 120 puntos de daño. Si has curado algún punto de daño de esta manera, descarta esta carta.",
 		it: "Alla fine di ogni turno, se il Pokémon a cui è assegnata questa carta ha 30 PS o meno rimanenti e se ha dei segnalini danno, cura quel Pokémon da 120 danni. Se hai curato dei danni in questo modo, scarta questa carta.",
 		pt: "No final de cada turno, se o Pokémon ao qual esta carta está ligada tiver PS restante de 30 ou menos e tiver algum contador de dano nele, cure 120 pontos de dano dele. Se você curou qualquer dano desta forma, descarte esta carta.",
-		de: "Am Ende jedes Zuges, wenn das Pokémon, an das diese Karte angelegt ist, 30 oder weniger verbleibende KP hat und auf ihm mindestens 1 Schadensmarke liegt, heile 120 Schadenspunkte bei jenem Pokémon. Wenn du auf diese Weise Schaden geheilt hast, lege diese Karte auf deinen Ablagestapel."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Am Ende jedes Zuges, wenn das Pokémon, an das diese Karte angelegt ist, 30 oder weniger verbleibende KP hat und auf ihm mindestens 1 Schadensmarke liegt, heile 120 Schadenspunkte bei jenem Pokémon. Wenn du auf diese Weise Schaden geheilt hast, lege diese Karte auf deinen Ablagestapel. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sword & Shield/Silver Tempest/156.ts
+++ b/data/Sword & Shield/Silver Tempest/156.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "El Pokémon V al que esté unida esta carta puede usar el Poder V-ASTRO de esta carta.\nAstro Alquimia\nDurante tu turno, puedes buscar en tu baraja\n1 carta y ponerla en tu mano. Después, baraja las cartas de tu baraja. (No puedes usar más de 1 Poder V-ASTRO en una partida).",
 		it: "Il Pokémon-V a cui è assegnata questa carta può usare il Potere V ASTRO di questa carta.\nAstro Alchimia\nDurante il tuo turno, puoi cercare nel tuo mazzo una carta e aggiungerla a quelle che hai in mano. Poi rimischia le carte del tuo mazzo. Non puoi usare più di un Potere V ASTRO a partita.",
 		pt: "O Pokémon V ao qual esta carta está ligada pode usar o Poder V-ASTRO desta carta.\nAlquimia Astral\nDurante o seu turno, você poderá procurar por 1 carta no seu baralho e colocá-la na sua mão. Em seguida, embaralhe o seu baralho (você não pode usar mais de 1 Poder V-ASTRO por partida).",
-		de: "Das Pokémon-V, an das diese Karte angelegt ist, kann die VSTAR-Power auf dieser Karte einsetzen.\nSternenalchemie\nWährend deines Zuges kannst du dein Deck nach 1 Karte durchsuchen und sie auf deine Hand nehmen. Mische anschließend dein Deck. (Du kannst pro Spiel nur 1 VSTAR-Power einsetzen.)"
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Das Pokémon-V, an das diese Karte angelegt ist, kann die VSTAR-Power auf dieser Karte einsetzen. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sword & Shield/Silver Tempest/157.ts
+++ b/data/Sword & Shield/Silver Tempest/157.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Busca en tu baraja 1 Pokémon Básico y ponlo en tu Banca. Después, baraja las cartas de tu baraja. Puedes cambiar ese Pokémon por tu Pokémon Activo.",
 		it: "Cerca nel tuo mazzo un Pokémon Base e mettilo nella tua panchina. Poi rimischia le carte del tuo mazzo. Puoi scambiare quel Pokémon con il tuo Pokémon attivo.",
 		pt: "Procure por 1 Pokémon Básico no seu baralho e coloque-o no seu Banco. Em seguida, embaralhe o seu baralho. Você pode trocar aquele Pokémon pelo seu Pokémon Ativo.",
-		de: "Durchsuche dein Deck nach 1 Basis-Pokémon und lege es auf deine Bank. Mische anschließend dein Deck. Du kannst jenes Pokémon gegen dein Aktives Pokémon austauschen."
+		de: "Durchsuche dein Deck nach 1 Basis-Pokémon und lege es auf deine Bank. Mische anschließend dein Deck. Du kannst jenes Pokémon gegen dein Aktives Pokémon austauschen. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest/158.ts
+++ b/data/Sword & Shield/Silver Tempest/158.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Roba 2 cartas. Si alguno de tus Pokémon quedó Fuera de Combate durante el último turno de tu rival, roba 2 cartas más.",
 		it: "Pesca due carte. Se uno qualsiasi dei tuoi Pokémon è stato messo KO durante l'ultimo turno del tuo avversario, pesca altre due carte.",
 		pt: "Compre 2 cartas. Se algum dos seus Pokémon tiver sido Nocauteado durante o último turno do seu oponente, compre 2 cartas a mais.",
-		de: "Ziehe 2 Karten. Wenn mindestens 1 deiner Pokémon während des letzten Zuges deines Gegners kampfunfähig wurde, ziehe 2 Karten mehr."
+		de: "Ziehe 2 Karten. Wenn mindestens 1 deiner Pokémon während des letzten Zuges deines Gegners kampfunfähig wurde, ziehe 2 Karten mehr. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest/159.ts
+++ b/data/Sword & Shield/Silver Tempest/159.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 3 Pokémon Dragon, enséñalos y ponlos en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo fino a tre Pokémon Dragon, mostrali e aggiungili alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por até 3 Pokémon Dragon no seu baralho, revele-os e coloque-os na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach bis zu 3 Dragon-Pokémon, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Dursuche dein Deck nach bis zu 3 {N}-Pokémon, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest/160.ts
+++ b/data/Sword & Shield/Silver Tempest/160.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Cada vez que tu rival juegue 1 carta de Partidario de su mano, evita todos los efectos de esa carta infligidos al Pokémon V-ASTRO o al Pokémon VMAX al que esté unida esta carta.",
 		it: "Ogni volta che il tuo avversario gioca una carta Aiuto che ha in mano, previeni tutti gli effetti di quella carta sul Pokémon-V ASTRO o Pokémon-VMAX a cui è assegnata questa carta.",
 		pt: "Sempre que seu oponente jogar 1 carta de Apoiador da própria mão, previna todos os efeitos daquela carta causados ao Pokémon V-ASTRO ou Pokémon VMAX ao qual esta carta está ligada.",
-		de: "Verhindere jedes Mal, wenn dein Gegner 1 Unterstützerkarte aus seiner Hand spielt, alle Effekte jener Karte, die dem Pokémon-VSTAR oder Pokémon-VMAX, an das diese Karte angelegt ist, zugefügt werden."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Verhindere jedes Mal, wenn dein Gegner 1 Unterstützerkarte aus seiner Hand spielt, alle Effekte jener Karte, die dem Pokémon-VSTAR oder Pokémon-VMAX, an das diese Karte angelegt ist, zugefügt werden. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sword & Shield/Silver Tempest/161.ts
+++ b/data/Sword & Shield/Silver Tempest/161.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Una vez durante el turno de cada jugador, ese jugador puede mirar la primera carta de su baraja. Puede descartar esa carta.",
 		it: "Una sola volta durante il turno di ciascun giocatore, quel giocatore può guardare la prima carta del suo mazzo. Può scartare quella carta.",
 		pt: "Uma vez durante o turno de cada jogador, aquele jogador poderá olhar a carta de cima do próprio baralho. Ele(a) poderá descartar aquela carta.",
-		de: "Einmal während des Zuges jedes Spielers kann sich jener Spieler die oberste Karte seines Decks anschauen. Er kann jene Karte auf den Ablagestapel legen."
+		de: "Einmal während des Zuges jedes Spielers kann sich jener Spieler die oberste Karte seines Decks anschauen. Er kann jene Karte auf den Ablagestapel legen. Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 
 	trainerType: "Stadium",

--- a/data/Sword & Shield/Silver Tempest/162.ts
+++ b/data/Sword & Shield/Silver Tempest/162.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Pon hasta 3 Pokémon que tengan \"de Hisui\" en su nombre de tu pila de descartes en tu mano.",
 		it: "Prendi fino a tre Pokémon che hanno \"di Hisui\" nel nome dalla tua pila degli scarti e aggiungili alle carte che hai in mano.",
 		pt: "Coloque até 3 Pokémon que tenham \"de Hisui\" no seu nome da sua pilha de descarte na sua mão.",
-		de: "Nimm bis zu 3 Pokémon, bei denen \"Hisui\" zum Namen gehört, aus deinem Ablagestapel auf deine Hand."
+		de: "Nimm bis zu 3 Pokémon, bei denen „Hisui“ zum Namen gehört, aus deinem Ablagestapel auf deine Hand. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest/163.ts
+++ b/data/Sword & Shield/Silver Tempest/163.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Puedes usar 4 cartas de Piedra Cuádruple de una vez.\n• Si has usado 1 carta, cura 10 puntos de daño a tu Pokémon Activo.\n• Si has usado 4 cartas, cura todos los puntos de daño a cada uno de tus Pokémon. (Este efecto funciona una vez por 4 cartas).",
 		it: "Puoi usare quattro carte Tetrapietra alla volta.\n• Se hai usato una carta, cura il tuo Pokémon attivo da 10 danni.\n• Se hai usato quattro carte, cura ciascuno dei tuoi Pokémon da tutti i danni. Questo effetto si applica una volta ogni quattro carte.",
 		pt: "Você pode usar 4 cartas Pedra Quádrupla de uma vez.\n• Se você usou 1 carta, cure 10 pontos de dano do seu Pokémon Ativo.\n• Se você usou 4 cartas, cure todo o dano de cada um dos seus Pokémon\n(este efeito funciona uma vez para 4 cartas).",
-		de: "Du kannst 4 Quartettstein-Karten gleichzeitig verwenden.\n• Wenn du 1 Karte verwendet hast, heile 10 Schadenspunkte bei deinem Aktiven Pokémon.\n• Wenn du 4 Karten verwendet hast, heile allen Schaden bei jedem deiner Pokémon. (Dieser Effekt funktioniert einmal für 4 Karten.)"
+		de: "Du kannst 4 Quartettstein-Karten gleichzeitig verwenden. Wenn du 1 Karte verwendet hast, heile 10 Schadenspunkte bei deinem Aktiven Pokémon. Du kannst während deines Zuges beliebig viele Itemkarten spielen. Wenn du 4 Karten verwendet hast, heile allen Schaden bei jedem deiner Pokémon. (Dieser Effekt funktioniert einmal für 4 Karten.)"
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Silver Tempest/164.ts
+++ b/data/Sword & Shield/Silver Tempest/164.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Elige 1 opción:\n• Descarta hasta 3 cartas de tu mano. (Debes descartar por lo menos 1 carta). Si lo haces, roba cartas hasta que tengas 5 cartas en tu mano.\n• Cambia 1 de los Pokémon V en Banca de tu rival por su Pokémon Activo.",
 		it: "Scegli:\n• Scarta fino a tre carte che hai in mano.\nDevi scartare almeno una carta. Se lo fai, pesca fino ad avere cinque carte in mano.\n• Scambia uno dei Pokémon-V nella panchina del tuo avversario con il suo Pokémon attivo.",
 		pt: "Escolha 1:\n• Descarte até 3 cartas da sua mão\n(você deve descartar pelo menos 1 carta). Se fizer isto, compre cartas até ter 5 cartas na sua mão.\n• Troque 1 dos Pokémon V no Banco do seu oponente pelo Pokémon Ativo dele(a).",
-		de: "Wähle 1:\n• Lege bis zu 3 Karten aus deiner Hand auf deinen Ablagestapel. (Du musst mindestens 1 Karte auf deinen Ablagestapel legen.) Wenn du das machst, ziehe so lange Karten, bis du 5 Karten auf deiner Hand hast.\n• Tausche 1 Pokémon-V auf der Bank deines Gegners gegen sein Aktives Pokémon aus."
+		de: "Wähle 1: Lege bis zu 3 Karten aus deiner Hand auf deinen Ablagestapel. (Du musst mindestens 1 Karte auf deinen Ablagestapel legen.) Wenn du das machst, ziehe so lange Karten, bis du 5 Karten auf deiner Hand hast. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen. Tausche 1 Pokémon-V auf der Bank deines Gegners gegen sein Aktives Pokémon aus."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest/165.ts
+++ b/data/Sword & Shield/Silver Tempest/165.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Juega esta carta como si fuera un Pokémon Colorless Básico de 60 PS. En cualquier momento durante tu turno, puedes descartar esta carta del juego.\nEsta carta no puede retirarse.",
 		it: "Gioca questa carta come se fosse un Pokémon Base Colorless con 60 PS. Durante il tuo turno, in qualsiasi momento, puoi scartare questa carta dal gioco.\nQuesta carta non può ritirarsi.",
 		pt: "Jogue esta carta como se fosse um Pokémon Colorless Básico com PS 60. A qualquer momento, durante o seu turno, você poderá descartar esta carta do jogo.\nEsta carta não pode recuar.",
-		de: "Spiele diese Karte, als ob sie ein Basis-Colorless-Pokémon mit 60 KP wäre. Du kannst diese Karte jederzeit während deines Zuges aus dem Spiel nehmen und auf deinen Ablagestapel legen.\nDiese Karte kann sich nicht zurückziehen."
+		de: "Spiele diese Karte, als ob sie ein Basis-{C}-Pokémon mit 60 KP wäre. Du kannst diese Karte jederzeit während deines Zuges aus dem Spiel nehmen und auf deinen Ablagestapel legen. Diese Karte kann sich nicht zurückziehen. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Silver Tempest/166.ts
+++ b/data/Sword & Shield/Silver Tempest/166.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Roba 3 cartas. Tu rival puede robar 1 carta. Si lo hace, robas 1 carta más.",
 		it: "Pesca tre carte. Il tuo avversario può pescare una carta. Se lo fa, peschi un'altra carta.",
 		pt: "Compre 3 cartas. Seu oponente pode comprar 1 carta. Se ele(a) fizer isto, compre 1 carta a mais.",
-		de: "Ziehe 3 Karten. Dein Gegner kann 1 Karte ziehen. Wenn er das macht, ziehe 1 Karte mehr."
+		de: "Ziehe 3 Karten. Dein Gegner kann 1 Karte ziehen. Wenn er das macht, ziehe 1 Karte mehr. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest/167.ts
+++ b/data/Sword & Shield/Silver Tempest/167.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Roba 3 cartas. Descarta un Estadio en juego.",
 		it: "Pesca tre carte. Scarta una carta Stadio in gioco.",
 		pt: "Compre 3 cartas. Descarte 1 Estádio em jogo.",
-		de: "Ziehe 3 Karten. Lege 1 Stadionkarte im Spiel auf den Ablagestapel."
+		de: "Ziehe 3 Karten. Lege 1 Stadionkarte im Spiel auf den Ablagestapel. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest/168.ts
+++ b/data/Sword & Shield/Silver Tempest/168.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mientras esta carta esté unida a 1 Pokémon, proporciona 1 Energía Colorless.\nCada vez que juegues 1 Pokémon de tu mano para hacer evolucionar al Pokémon V al que esté unida esta carta, cura 100 puntos de daño a ese Pokémon.",
 		it: "Fintanto che questa carta è assegnata a un Pokémon, fornisce Energia Colorless.\nOgni volta che giochi un Pokémon dalla tua mano per far evolvere\nil Pokémon-V a cui è assegnata questa carta, cura quel Pokémon da 100 danni.",
 		pt: "Enquanto esta carta estiver ligada a um Pokémon, ela fornecerá Energia Colorless.\nSempre que você jogar um Pokémon da sua mão para evoluir o Pokémon V ao qual esta carta está ligada, cure 100 pontos de dano daquele Pokémon.",
-		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie Colorless-Energie.\nJedes Mal, wenn du ein Pokémon aus deiner Hand spielst, um das Pokémon-V, an das diese Karte angelegt ist, zu entwickeln, heile 100 Schadenspunkte bei jenem Pokémon."
+		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie {C}-Energie. Jedes Mal, wenn du ein Pokémon aus deiner Hand spielst, um das Pokémon-V, an das diese Karte angelegt ist, zu entwickeln, heile 100 Schadenspunkte bei jenem Pokémon."
 	},
 
 	energyType: "Special",

--- a/data/Sword & Shield/Silver Tempest/169.ts
+++ b/data/Sword & Shield/Silver Tempest/169.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mientras esta carta esté unida a 1 Pokémon, proporciona 1 Energía Colorless.\nLos ataques de los Pokémon V de tu rival hacen 30 puntos de daño menos al Pokémon al que esté unida esta carta (después de aplicar Debilidad y Resistencia). Este efecto no puede aplicarse más de una vez de forma simultánea al mismo Pokémon.",
 		it: "Fintanto che questa carta è assegnata a un Pokémon, fornisce Energia Colorless.\nIl Pokémon a cui è assegnata questa carta subisce 30 danni in meno dagli attacchi dei Pokémon-V del tuo avversario,\ndopo aver applicato debolezza e resistenza. Questo effetto non può essere applicato più di una volta contemporaneamente allo stesso Pokémon.",
 		pt: "Enquanto esta carta estiver ligada a um Pokémon, ela fornecerá Energia Colorless.\nO Pokémon ao qual esta carta está ligada recebe 30 pontos de dano a menos de ataques dos Pokémon V do seu oponente\n(depois de aplicar Fraqueza e Resistência). Este efeito não pode ser aplicado mais de uma vez ao mesmo Pokémon por vez.",
-		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie Colorless-Energie.\nDem Pokémon, an das diese Karte angelegt ist, werden durch Attacken von Pokémon-V deines Gegners 30 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden). Dieser Effekt kann nur jeweils einmal auf dasselbe Pokémon angewandt werden."
+		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie {C}-Energie. Dem Pokémon, an das diese Karte angelegt ist, werden durch Attacken von Pokémon-V deines Gegners 30 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden). Dieser Effekt kann nur jeweils einmal auf dasselbe Pokémon angewandt werden."
 	},
 
 	energyType: "Special",

--- a/data/Sword & Shield/Silver Tempest/174.ts
+++ b/data/Sword & Shield/Silver Tempest/174.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			es: "Busca en tu baraja hasta 2 Pokémon que evolucionen de una carta de Objeto que tenga \"Fósil\" en su nombre y ponlos en tu Banca. Después, baraja las cartas de tu baraja.",
 			it: "Cerca nel tuo mazzo fino a due Pokémon che si evolvono da una carta Strumento che ha \"Fossile\" nel nome e mettili nella tua panchina. Poi rimischia le carte del tuo mazzo.",
 			pt: "Procure por até 2 Pokémon no seu baralho que evoluam de uma carta de Item que tenha \"Fóssil\" em seu nome e coloque-os no seu Banco. Em seguida, embaralhe o seu baralho.",
-			de: "Durchsuche dein Deck nach bis zu 2 Pokémon, die sich aus einer Itemkarte entwickeln, bei der \"Fossil\" zum Namen gehört, und lege sie auf deine Bank. Mische anschließend dein Deck."
+			de: "Durchsuche dein Deck nach bis zu 2 Pokémon, die sich aus einer Itemkarte entwickeln, bei der „Fossil“ zum Namen gehört, und lege sie auf deine Bank. Mische anschließend dein Deck."
 		}
 	}, {
 		cost: ["Water", "Colorless", "Colorless"],

--- a/data/Sword & Shield/Silver Tempest/179.ts
+++ b/data/Sword & Shield/Silver Tempest/179.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			es: "Todas las veces que quieras durante tu turno, puedes mover 1 Energía Fighting de 1 de tus otros Pokémon a este Pokémon.",
 			it: "Durante il tuo turno, puoi spostare un'Energia Fighting da uno dei tuoi altri Pokémon a questo Pokémon tutte le volte che vuoi.",
 			pt: "Quantas vezes desejar durante o seu turno, você poderá mover 1 Energia Fighting de 1 dos seus outros Pokémon para este Pokémon.",
-			de: "Beliebig oft während deines Zuges kannst du 1 Fighting-Energie von 1 deiner anderen Pokémon auf dieses Pokémon verschieben."
+			de: "Beliebig oft während deines Zuges kannst du 1 {F}-Energie von 1 deiner anderen Pokémon auf dieses Pokémon verschieben."
 		}
 	}],
 
@@ -62,7 +62,7 @@ const card: Card = {
 			es: "Este ataque hace 30 puntos de daño más por cada Energía Fighting unida a este Pokémon.",
 			it: "Questo attacco infligge 30 danni in più per ogni Energia Fighting assegnata a questo Pokémon.",
 			pt: "Este ataque causa 30 pontos de dano a mais para cada Energia Fighting ligada a este Pokémon.",
-			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte Fighting-Energie 30 Schadenspunkte mehr zu."
+			de: "Diese Attacke fügt für jede an dieses Pokémon angelegte {F}-Energie 30 Schadenspunkte mehr zu."
 		},
 
 		damage: "90+"

--- a/data/Sword & Shield/Silver Tempest/188.ts
+++ b/data/Sword & Shield/Silver Tempest/188.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Puedes usar esta carta solo cuando sea la última carta en tu mano.\nRoba 1 carta por cada Pokémon en Banca (tanto tuyos como de tu rival).",
 		it: "Puoi usare questa carta solo se è l'ultima carta che hai in mano.\nPesca una carta per ogni Pokémon in panchina, sia tuo che del tuo avversario.",
 		pt: "Você só pode usar esta carta se ela for a última carta na sua mão.\nCompre 1 carta para cada Pokémon no Banco\n(seus e do seu oponente).",
-		de: "Du kannst diese Karte nur verwenden, wenn es die letzte Karte auf deiner Hand ist.\nZiehe 1 Karte für jedes Pokémon auf der Bank (deiner und der deines Gegners)."
+		de: "Du kannst diese Karte nur verwenden, wenn es die letzte Karte auf deiner Hand ist. Ziehe 1 Karte für jedes Pokémon auf der Bank (deiner und der deines Gegners). Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest/189.ts
+++ b/data/Sword & Shield/Silver Tempest/189.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Mira las 7 primeras cartas de tu baraja. Puedes enseñar cualquier cantidad de cartas de Pokémon Water y de Energía Water que encuentres entre ellas y ponerlas en tu mano. Pon el resto de las cartas de nuevo en tu baraja y barájalas todas.",
 		it: "Guarda le prime sette carte del tuo mazzo. Puoi mostrare un numero qualsiasi di Pokémon Water e carte Energia Water presenti tra esse e aggiungerli alle carte che hai in mano. Poi rimischia le altre carte nel tuo mazzo.",
 		pt: "Olhe as 7 cartas de cima do seu baralho. Você pode revelar qualquer número de cartas de Pokémon Water e de Energia Water que encontrar lá e colocá-las na sua mão. Embaralhe as demais cartas de volta no seu baralho.",
-		de: "Schau dir die obersten 7 Karten deines Decks an. Du kannst beliebig viele Water-Pokémon und Water-Energiekarten, die du dort findest, deinem Gegner zeigen und auf deine Hand nehmen. Mische die anderen Karten zurück in dein Deck."
+		de: "Schau dir die obersten 7 Karten deines Decks an. Du kannst beliebig viele {W}-Pokémon und {W}-Energiekarten, die du dort findest, deinem Gegner zeigen und auf deine Hand nehmen. Mische die anderen Karten zurück in dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest/190.ts
+++ b/data/Sword & Shield/Silver Tempest/190.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Busca en tu baraja 1 Pokémon Básico y ponlo en tu Banca. Después, baraja las cartas de tu baraja. Puedes cambiar ese Pokémon por tu Pokémon Activo.",
 		it: "Cerca nel tuo mazzo un Pokémon Base e mettilo nella tua panchina. Poi rimischia le carte del tuo mazzo. Puoi scambiare quel Pokémon con il tuo Pokémon attivo.",
 		pt: "Procure por 1 Pokémon Básico no seu baralho e coloque-o no seu Banco. Em seguida, embaralhe o seu baralho. Você pode trocar aquele Pokémon pelo seu Pokémon Ativo.",
-		de: "Durchsuche dein Deck nach 1 Basis-Pokémon und lege es auf deine Bank. Mische anschließend dein Deck. Du kannst jenes Pokémon gegen dein Aktives Pokémon austauschen."
+		de: "Durchsuche dein Deck nach 1 Basis-Pokémon und lege es auf deine Bank. Mische anschließend dein Deck. Du kannst jenes Pokémon gegen dein Aktives Pokémon austauschen. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest/191.ts
+++ b/data/Sword & Shield/Silver Tempest/191.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Roba 2 cartas. Si alguno de tus Pokémon quedó Fuera de Combate durante el último turno de tu rival, roba 2 cartas más.",
 		it: "Pesca due carte. Se uno qualsiasi dei tuoi Pokémon è stato messo KO durante l'ultimo turno del tuo avversario, pesca altre due carte.",
 		pt: "Compre 2 cartas. Se algum dos seus Pokémon tiver sido Nocauteado durante o último turno do seu oponente, compre 2 cartas a mais.",
-		de: "Ziehe 2 Karten. Wenn mindestens 1 deiner Pokémon während des letzten Zuges deines Gegners kampfunfähig wurde, ziehe 2 Karten mehr."
+		de: "Ziehe 2 Karten. Wenn mindestens 1 deiner Pokémon während des letzten Zuges deines Gegners kampfunfähig wurde, ziehe 2 Karten mehr. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest/192.ts
+++ b/data/Sword & Shield/Silver Tempest/192.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 3 Pokémon Dragon, enséñalos y ponlos en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo fino a tre Pokémon Dragon, mostrali e aggiungili alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por até 3 Pokémon Dragon no seu baralho, revele-os e coloque-os na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach bis zu 3 Dragon-Pokémon, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Dursuche dein Deck nach bis zu 3 {N}-Pokémon, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest/193.ts
+++ b/data/Sword & Shield/Silver Tempest/193.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Elige 1 opción:\n• Descarta hasta 3 cartas de tu mano. (Debes descartar por lo menos 1 carta). Si lo haces, roba cartas hasta que tengas 5 cartas en tu mano.\n• Cambia 1 de los Pokémon V en Banca de tu rival por su Pokémon Activo.",
 		it: "Scegli:\n• Scarta fino a tre carte che hai in mano.\nDevi scartare almeno una carta. Se lo fai, pesca fino ad avere cinque carte in mano.\n• Scambia uno dei Pokémon-V nella panchina del tuo avversario con il suo Pokémon attivo.",
 		pt: "Escolha 1:\n• Descarte até 3 cartas da sua mão\n(você deve descartar pelo menos 1 carta). Se fizer isto, compre cartas até ter 5 cartas na sua mão.\n• Troque 1 dos Pokémon V no Banco do seu oponente pelo Pokémon Ativo dele(a).",
-		de: "Wähle 1:\n• Lege bis zu 3 Karten aus deiner Hand auf deinen Ablagestapel. (Du musst mindestens 1 Karte auf deinen Ablagestapel legen.) Wenn du das machst, ziehe so lange Karten, bis du 5 Karten auf deiner Hand hast.\n• Tausche 1 Pokémon-V auf der Bank deines Gegners gegen sein Aktives Pokémon aus."
+		de: "Wähle 1: Lege bis zu 3 Karten aus deiner Hand auf deinen Ablagestapel. (Du musst mindestens 1 Karte auf deinen Ablagestapel legen.) Wenn du das machst, ziehe so lange Karten, bis du 5 Karten auf deiner Hand hast. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen. Tausche 1 Pokémon-V auf der Bank deines Gegners gegen sein Aktives Pokémon aus."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest/194.ts
+++ b/data/Sword & Shield/Silver Tempest/194.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Roba 3 cartas. Tu rival puede robar 1 carta. Si lo hace, robas 1 carta más.",
 		it: "Pesca tre carte. Il tuo avversario può pescare una carta. Se lo fa, peschi un'altra carta.",
 		pt: "Compre 3 cartas. Seu oponente pode comprar 1 carta. Se ele(a) fizer isto, compre 1 carta a mais.",
-		de: "Ziehe 3 Karten. Dein Gegner kann 1 Karte ziehen. Wenn er das macht, ziehe 1 Karte mehr."
+		de: "Ziehe 3 Karten. Dein Gegner kann 1 Karte ziehen. Wenn er das macht, ziehe 1 Karte mehr. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest/195.ts
+++ b/data/Sword & Shield/Silver Tempest/195.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Roba 3 cartas. Descarta un Estadio en juego.",
 		it: "Pesca tre carte. Scarta una carta Stadio in gioco.",
 		pt: "Compre 3 cartas. Descarte 1 Estádio em jogo.",
-		de: "Ziehe 3 Karten. Lege 1 Stadionkarte im Spiel auf den Ablagestapel."
+		de: "Ziehe 3 Karten. Lege 1 Stadionkarte im Spiel auf den Ablagestapel. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest/198.ts
+++ b/data/Sword & Shield/Silver Tempest/198.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			es: "Los ataques de tus Pokémon Lightning Básicos hacen 30 puntos de daño más al Pokémon Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
 			it: "Gli attacchi dei tuoi Pokémon Base Lightning infliggono 30 danni in più al Pokémon attivo del tuo avversario, prima di aver applicato debolezza e resistenza.",
 			pt: "Os ataques dos seus Pokémon Lightning Básicos causam 30 pontos de dano a mais ao Pokémon Ativo do seu oponente (antes de aplicar Fraqueza e Resistência).",
-			de: "Die Attacken deiner Basis-Lightning-Pokémon fügen dem Aktiven Pokémon deines Gegners 30 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
+			de: "Die Attacken deiner Basis-{L}-Pokémon fügen dem Aktiven Pokémon deines Gegners 30 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
 		}
 	}],
 

--- a/data/Sword & Shield/Silver Tempest/199.ts
+++ b/data/Sword & Shield/Silver Tempest/199.ts
@@ -72,7 +72,7 @@ const card: Card = {
 			es: "Mientras este Pokémon esté en juego, obtiene una habilidad que tiene el siguiente efecto: \"La Debilidad de cada uno de los Pokémon en juego de tu rival pasa a ser Psychic. (La cantidad de Debilidad no cambia)\". (Nopuedes usar más de 1 Poder V-ASTRO en una partida).",
 			it: "Finché questo Pokémon rimane in gioco, possiede un'abilità che ha l'effetto: \"La debolezza di ciascun Pokémon in gioco del tuo avversario diventa Psychic. Quanto è debole non cambia\". Non puoi usare più di un Potere V ASTRO a partita.",
 			pt: "Até este Pokémon sair de jogo, ele ganhará uma Habilidade com o efeito \"A Fraqueza de cada um dos Pokémon do seu oponente em jogo será Psychic (a quantidade de Fraqueza não muda).\"(você não pode usar mais de 1 Poder V-ASTRO por partida).",
-			de: "Bis dieses Pokémon das Spiel verlässt, erhält es eine Fähigkeit mit dem Effekt \"Die Schwäche jedes Pokémon deines Gegners im Spiel ist jetzt Psychic. (Die Höhe der Schwäche ändert sich nicht.)\" (Du kannst pro Spiel nur 1 VSTAR-Power einsetzen.)"
+			de: "Bis dieses Pokémon das Spiel verlässt, erhält es eine Fähigkeit mit dem Effekt „Die Schwäche jedes Pokémon deines Gegners im Spiel ist jetzt {P}. (Die Höhe der Schwäche ändert sich nicht.)“ (Du kannst pro Spiel nur 1 VSTAR-Power einsetzen.)"
 		}
 	}],
 

--- a/data/Sword & Shield/Silver Tempest/201.ts
+++ b/data/Sword & Shield/Silver Tempest/201.ts
@@ -50,7 +50,7 @@ const card: Card = {
 			es: "Elige 1 ataque de 1 de los Pokémon Dragon de tu pila de descartes y úsalo para este ataque.",
 			it: "Scegli un attacco di un Pokémon Dragon nella tua pila degli scarti e usalo al posto di questo attacco.",
 			pt: "Escolha um ataque de um Pokémon Dragon da sua pilha de descarte e use-o como este ataque.",
-			de: "Wähle 1 Attacke eines Dragon-Pokémon in deinem Ablagestapel und setze sie als diese Attacke ein."
+			de: "Wähle 1 Attacke eines {N}-Pokémon in deinem Ablagestapel und setze sie als diese Attacke ein."
 		}
 	}],
 

--- a/data/Sword & Shield/Silver Tempest/202.ts
+++ b/data/Sword & Shield/Silver Tempest/202.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		es: "Lugia V",
 		it: "Lugia-V",
 		pt: "Lugia V",
-		de: "Lugia-V"
+		de: "Lugia VSTAR"
 	},
 
 	stage: "VSTAR",

--- a/data/Sword & Shield/Silver Tempest/203.ts
+++ b/data/Sword & Shield/Silver Tempest/203.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Puedes usar esta carta solo cuando sea la última carta en tu mano.\nRoba 1 carta por cada Pokémon en Banca (tanto tuyos como de tu rival).",
 		it: "Puoi usare questa carta solo se è l'ultima carta che hai in mano.\nPesca una carta per ogni Pokémon in panchina, sia tuo che del tuo avversario.",
 		pt: "Você só pode usar esta carta se ela for a última carta na sua mão.\nCompre 1 carta para cada Pokémon no Banco\n(seus e do seu oponente).",
-		de: "Du kannst diese Karte nur verwenden, wenn es die letzte Karte auf deiner Hand ist.\nZiehe 1 Karte für jedes Pokémon auf der Bank (deiner und der deines Gegners)."
+		de: "Du kannst diese Karte nur verwenden, wenn es die letzte Karte auf deiner Hand ist. Ziehe 1 Karte für jedes Pokémon auf der Bank (deiner und der deines Gegners). Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest/204.ts
+++ b/data/Sword & Shield/Silver Tempest/204.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Mira las 7 primeras cartas de tu baraja. Puedes enseñar cualquier cantidad de cartas de Pokémon Water y de Energía Water que encuentres entre ellas y ponerlas en tu mano. Pon el resto de las cartas de nuevo en tu baraja y barájalas todas.",
 		it: "Guarda le prime sette carte del tuo mazzo. Puoi mostrare un numero qualsiasi di Pokémon Water e carte Energia Water presenti tra esse e aggiungerli alle carte che hai in mano. Poi rimischia le altre carte nel tuo mazzo.",
 		pt: "Olhe as 7 cartas de cima do seu baralho. Você pode revelar qualquer número de cartas de Pokémon Water e de Energia Water que encontrar lá e colocá-las na sua mão. Embaralhe as demais cartas de volta no seu baralho.",
-		de: "Schau dir die obersten 7 Karten deines Decks an. Du kannst beliebig viele Water-Pokémon und Water-Energiekarten, die du dort findest, deinem Gegner zeigen und auf deine Hand nehmen. Mische die anderen Karten zurück in dein Deck."
+		de: "Schau dir die obersten 7 Karten deines Decks an. Du kannst beliebig viele {W}-Pokémon und {W}-Energiekarten, die du dort findest, deinem Gegner zeigen und auf deine Hand nehmen. Mische die anderen Karten zurück in dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest/205.ts
+++ b/data/Sword & Shield/Silver Tempest/205.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Busca en tu baraja 1 Pokémon Básico y ponlo en tu Banca. Después, baraja las cartas de tu baraja. Puedes cambiar ese Pokémon por tu Pokémon Activo.",
 		it: "Cerca nel tuo mazzo un Pokémon Base e mettilo nella tua panchina. Poi rimischia le carte del tuo mazzo. Puoi scambiare quel Pokémon con il tuo Pokémon attivo.",
 		pt: "Procure por 1 Pokémon Básico no seu baralho e coloque-o no seu Banco. Em seguida, embaralhe o seu baralho. Você pode trocar aquele Pokémon pelo seu Pokémon Ativo.",
-		de: "Durchsuche dein Deck nach 1 Basis-Pokémon und lege es auf deine Bank. Mische anschließend dein Deck. Du kannst jenes Pokémon gegen dein Aktives Pokémon austauschen."
+		de: "Durchsuche dein Deck nach 1 Basis-Pokémon und lege es auf deine Bank. Mische anschließend dein Deck. Du kannst jenes Pokémon gegen dein Aktives Pokémon austauschen. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest/206.ts
+++ b/data/Sword & Shield/Silver Tempest/206.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 3 Pokémon Dragon, enséñalos y ponlos en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo fino a tre Pokémon Dragon, mostrali e aggiungili alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por até 3 Pokémon Dragon no seu baralho, revele-os e coloque-os na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach bis zu 3 Dragon-Pokémon, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Dursuche dein Deck nach bis zu 3 {N}-Pokémon, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest/207.ts
+++ b/data/Sword & Shield/Silver Tempest/207.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Elige 1 opción:\n• Descarta hasta 3 cartas de tu mano. (Debes descartar por lo menos 1 carta). Si lo haces, roba cartas hasta que tengas 5 cartas en tu mano.\n• Cambia 1 de los Pokémon V en Banca de tu rival por su Pokémon Activo.",
 		it: "Scegli:\n• Scarta fino a tre carte che hai in mano.\nDevi scartare almeno una carta. Se lo fai, pesca fino ad avere cinque carte in mano.\n• Scambia uno dei Pokémon-V nella panchina del tuo avversario con il suo Pokémon attivo.",
 		pt: "Escolha 1:\n• Descarte até 3 cartas da sua mão\n(você deve descartar pelo menos 1 carta). Se fizer isto, compre cartas até ter 5 cartas na sua mão.\n• Troque 1 dos Pokémon V no Banco do seu oponente pelo Pokémon Ativo dele(a).",
-		de: "Wähle 1:\n• Lege bis zu 3 Karten aus deiner Hand auf deinen Ablagestapel. (Du musst mindestens 1 Karte auf deinen Ablagestapel legen.) Wenn du das machst, ziehe so lange Karten, bis du 5 Karten auf deiner Hand hast.\n• Tausche 1 Pokémon-V auf der Bank deines Gegners gegen sein Aktives Pokémon aus."
+		de: "Wähle 1: Lege bis zu 3 Karten aus deiner Hand auf deinen Ablagestapel. (Du musst mindestens 1 Karte auf deinen Ablagestapel legen.) Wenn du das machst, ziehe so lange Karten, bis du 5 Karten auf deiner Hand hast. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen. Tausche 1 Pokémon-V auf der Bank deines Gegners gegen sein Aktives Pokémon aus."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest/208.ts
+++ b/data/Sword & Shield/Silver Tempest/208.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Roba 3 cartas. Tu rival puede robar 1 carta. Si lo hace, robas 1 carta más.",
 		it: "Pesca tre carte. Il tuo avversario può pescare una carta. Se lo fa, peschi un'altra carta.",
 		pt: "Compre 3 cartas. Seu oponente pode comprar 1 carta. Se ele(a) fizer isto, compre 1 carta a mais.",
-		de: "Ziehe 3 Karten. Dein Gegner kann 1 Karte ziehen. Wenn er das macht, ziehe 1 Karte mehr."
+		de: "Ziehe 3 Karten. Dein Gegner kann 1 Karte ziehen. Wenn er das macht, ziehe 1 Karte mehr. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest/209.ts
+++ b/data/Sword & Shield/Silver Tempest/209.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Roba 3 cartas. Descarta un Estadio en juego.",
 		it: "Pesca tre carte. Scarta una carta Stadio in gioco.",
 		pt: "Compre 3 cartas. Descarte 1 Estádio em jogo.",
-		de: "Ziehe 3 Karten. Lege 1 Stadionkarte im Spiel auf den Ablagestapel."
+		de: "Ziehe 3 Karten. Lege 1 Stadionkarte im Spiel auf den Ablagestapel. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest/211.ts
+++ b/data/Sword & Shield/Silver Tempest/211.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		es: "Lugia V",
 		it: "Lugia-V",
 		pt: "Lugia V",
-		de: "Lugia-V"
+		de: "Lugia VSTAR"
 	},
 
 	stage: "VSTAR",

--- a/data/Sword & Shield/Silver Tempest/212.ts
+++ b/data/Sword & Shield/Silver Tempest/212.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Mueve 1 Energía Básica de 1 de tus Pokémon a otro de tus Pokémon.",
 		it: "Sposta un'Energia base da uno dei tuoi Pokémon a un altro.",
 		pt: "Mova 1 Energia básica de 1 dos seus Pokémon para outro Pokémon seu.",
-		de: "Verschiebe 1 Basis-Energie von 1 deiner Pokémon auf 1 anderes deiner Pokémon."
+		de: "Verschiebe 1 Basis-Energie von 1 deiner Pokémon auf 1 anderes deiner Pokémon. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Silver Tempest/213.ts
+++ b/data/Sword & Shield/Silver Tempest/213.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Cada vez que algún jugador ponga 1 Pokémon Básico de su mano en su Banca, pon 2 contadores de daño en ese Pokémon.",
 		it: "Ogni volta che uno dei giocatori prende un Pokémon Base dalla propria mano e lo mette nella propria panchina, metti due segnalini danno su quel Pokémon.",
 		pt: "Sempre que qualquer um dos jogadores colocar um Pokémon Básico da própria mão no próprio Banco, coloque 2 contadores de dano naquele Pokémon.",
-		de: "Lege jedes Mal, wenn ein Spieler 1 Basis-Pokémon aus seiner Hand auf seine Bank legt, 2 Schadensmarken auf jenes Pokémon."
+		de: "Lege jedes Mal, wenn ein Spieler 1 Basis-Pokémon aus seiner Hand auf seine Bank legt, 2 Schadensmarken auf jenes Pokémon. Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 
 	trainerType: "Stadium",

--- a/data/Sword & Shield/Silver Tempest/214.ts
+++ b/data/Sword & Shield/Silver Tempest/214.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Cada vez que tu rival juegue 1 carta de Partidario de su mano, evita todos los efectos de esa carta infligidos al Pokémon V-ASTRO o al Pokémon VMAX al que esté unida esta carta.",
 		it: "Ogni volta che il tuo avversario gioca una carta Aiuto che ha in mano, previeni tutti gli effetti di quella carta sul Pokémon-V ASTRO o Pokémon-VMAX a cui è assegnata questa carta.",
 		pt: "Sempre que seu oponente jogar 1 carta de Apoiador da própria mão, previna todos os efeitos daquela carta causados ao Pokémon V-ASTRO ou Pokémon VMAX ao qual esta carta está ligada.",
-		de: "Verhindere jedes Mal, wenn dein Gegner 1 Unterstützerkarte aus seiner Hand spielt, alle Effekte jener Karte, die dem Pokémon-VSTAR oder Pokémon-VMAX, an das diese Karte angelegt ist, zugefügt werden."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Verhindere jedes Mal, wenn dein Gegner 1 Unterstützerkarte aus seiner Hand spielt, alle Effekte jener Karte, die dem Pokémon-VSTAR oder Pokémon-VMAX, an das diese Karte angelegt ist, zugefügt werden. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sword & Shield/Silver Tempest/215.ts
+++ b/data/Sword & Shield/Silver Tempest/215.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mientras esta carta esté unida a 1 Pokémon, proporciona 1 Energía Colorless.\nLos ataques de los Pokémon V de tu rival hacen 30 puntos de daño menos al Pokémon al que esté unida esta carta (después de aplicar Debilidad y Resistencia). Este efecto no puede aplicarse más de una vez de forma simultánea al mismo Pokémon.",
 		it: "Fintanto che questa carta è assegnata a un Pokémon, fornisce Energia Colorless.\nIl Pokémon a cui è assegnata questa carta subisce 30 danni in meno dagli attacchi dei Pokémon-V del tuo avversario,\ndopo aver applicato debolezza e resistenza. Questo effetto non può essere applicato più di una volta contemporaneamente allo stesso Pokémon.",
 		pt: "Enquanto esta carta estiver ligada a um Pokémon, ela fornecerá Energia Colorless.\nO Pokémon ao qual esta carta está ligada recebe 30 pontos de dano a menos de ataques dos Pokémon V do seu oponente\n(depois de aplicar Fraqueza e Resistência). Este efeito não pode ser aplicado mais de uma vez ao mesmo Pokémon por vez.",
-		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie Colorless-Energie.\nDem Pokémon, an das diese Karte angelegt ist, werden durch Attacken von Pokémon-V deines Gegners 30 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden). Dieser Effekt kann nur jeweils einmal auf dasselbe Pokémon angewandt werden."
+		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie {C}-Energie. Dem Pokémon, an das diese Karte angelegt ist, werden durch Attacken von Pokémon-V deines Gegners 30 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden). Dieser Effekt kann nur jeweils einmal auf dasselbe Pokémon angewandt werden."
 	},
 
 	energyType: "Special",


### PR DESCRIPTION
## Add missing German translations for swsh12

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
