### PR TITLE
Add missing German translations for swsh12tg

### DIFF
--- a/data/Sword & Shield/Silver Tempest Trainer Gallery/TG01.ts
+++ b/data/Sword & Shield/Silver Tempest Trainer Gallery/TG01.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "When the twig is plucked from its tail, friction sets the twig alight. The flame is used to send signals to its allies.",
+		de: "Sein Zweig entzündet sich durch die Reibung, die beim Herausziehen aus seinem Schweif entsteht. Mit der Flamme sendet es Signale an Kameraden."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest Trainer Gallery/TG02.ts
+++ b/data/Sword & Shield/Silver Tempest Trainer Gallery/TG02.ts
@@ -87,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "Milotic has provided inspiration to many artists. It has even been referred to as the most beautiful Pokémon of all.",
+		de: "Milotic soll das schönste aller Pokémon sein. Es hat schon so manchem Künstler als Quelle der Inspiration gedient."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest Trainer Gallery/TG03.ts
+++ b/data/Sword & Shield/Silver Tempest Trainer Gallery/TG03.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			es: "Una vez durante tu turno (antes de tu ataque), puedes unir una carta de Energía Lightning de tu pila de descartes a 1 de tus Pokémon en Banca.",
 			it: "Una sola volta durante il tuo turno, prima di attaccare, puoi assegnare a uno dei tuoi Pokémon in panchina una carta Energia Lightning dalla tua pila degli scarti.",
 			pt: "Uma vez na sua vez de jogar (antes de atacar), você poderá ligar um card de Energia Lightning da sua pilha de descarte a 1 dos seus Pokémon no Banco.",
-			de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 Lightning-Energiekarte von deinem Ablagestapel an 1 Pokémon auf deiner Bank anlegen."
+			de: "Einmal während deines Zuges kannst du 1 {L}-Energiekarte aus deinem Ablagestapel an 1 Pokémon auf deiner Bank anlegen."
 		}
 	}],
 
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It stores electricity in its fluffy fleece. If it stores up too much, it will start to go bald in those patches.",
+		de: "Sein flauschiges Fell speichert Elektrizität. Zu große Mengen bewirkten aber stellenweise einen Haarausfall, wo nun glatte Haut freiliegt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest Trainer Gallery/TG04.ts
+++ b/data/Sword & Shield/Silver Tempest Trainer Gallery/TG04.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "In certain parts of Galar, Jynx was once feared and worshiped as the Queen of Ice.",
+		de: "In einer bestimmten Gegend von Galar wurde Rossana einst als „Königin des Eises“ gleichermaßen gefürchtet wie verehrt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest Trainer Gallery/TG05.ts
+++ b/data/Sword & Shield/Silver Tempest Trainer Gallery/TG05.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It has the power to predict the future. Its power peaks when it is protecting its Trainer.",
+		de: "Es kann die Zukunft vorhersagen. Beschützt es seinen Trainer, erreicht seine Kraft ihren Höhepunkt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest Trainer Gallery/TG06.ts
+++ b/data/Sword & Shield/Silver Tempest Trainer Gallery/TG06.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			es: "Enseña cualquier cantidad de cartas de Golpe Fluido de tu mano. Este ataque hace 40 puntos de daño por cada carta que hayas enseñado de esta manera. Después, pon esas cartas en tu baraja y barájalas todas.",
 			it: "Mostra un numero qualsiasi di carte Colpo Rapido che hai in mano. Questo attacco infligge 40 danni per ogni carta che hai mostrato in questo modo. Poi rimischia quelle carte nel tuo mazzo.",
 			pt: "Revele qualquer número de cartas Golpe Fluido da sua mão. Este ataque causa 40 pontos de dano para cada carta revelada desta forma. Em seguida, embaralhe aquelas cartas no seu baralho.",
-			de: "Zeige deinem Gegner beliebig viele Fließender-Angriff-Karten auf deiner Hand. Diese Attacke fügt für jede auf diese Weise gezeigte Karte 40 Schadenspunkte zu. Mische jene Karten anschließend in dein Deck."
+			de: "Zeige deinem Gegner beliebig viele Fließender-Angriff-Karten aus deiner Hand. Diese Attacke fügt für jede auf diese Weise gezeigte Karte 40 Schadenspunkte zu. Mische jene Karten anschließend in dein Deck."
 		},
 
 		damage: "40×"
@@ -73,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "It's said that Malamar's hypnotic powers played a role in certain history-changing events.",
+		de: "Man erzählt sich, dass die hypnotischen Kräfte dieses Pokémon mit einigen geschichtsträchtigen Ereignissen in Verbindung stehen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest Trainer Gallery/TG07.ts
+++ b/data/Sword & Shield/Silver Tempest Trainer Gallery/TG07.ts
@@ -57,6 +57,7 @@ const card: Card = {
 
 	description: {
 		en: "When it rubs the rocks on its neck against you, that's proof of its love for you. However, the rocks are sharp, so the gesture is quite painful!",
+		de: "Reibt es seinen steinernen Fellkragen an einem Trainer, ist das ein Zeichen seiner Zuneigung. Da er jedoch scharf ist, besteht Verletzungsgefahr."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest Trainer Gallery/TG08.ts
+++ b/data/Sword & Shield/Silver Tempest Trainer Gallery/TG08.ts
@@ -77,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "Passimian live in groups of about 20, with each member performing an assigned role. Through cooperation, the group survives.",
+		de: "Sie bilden Gruppen von 20 Exemplaren. Durch klare Aufgabenteilung haben sie den Gefahren der Natur getrotzt und bis heute überlebt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest Trainer Gallery/TG09.ts
+++ b/data/Sword & Shield/Silver Tempest Trainer Gallery/TG09.ts
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "Druddigon are vicious and cunning. They take up residence in nests dug out by other Pokémon, treating the stolen nests as their own lairs.",
+		de: "Shardrago ist grausam und gerissen. Es nimmt die selbstgegrabenen Höhlen anderer Pokémon ein, um sie zu seinem Unterschlupf zu machen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest Trainer Gallery/TG10.ts
+++ b/data/Sword & Shield/Silver Tempest Trainer Gallery/TG10.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "It draws symbols with the fluid that oozes from the tip of its tail. Depending on the symbol, Smeargle fanatics will pay big money for them.",
+		de: "Mit der Flüssigkeit, die aus seiner Schweifspitze austritt, hinterlässt es Markierungen. Die besten werden unter Fans zu hohen Preisen gehandelt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest Trainer Gallery/TG11.ts
+++ b/data/Sword & Shield/Silver Tempest Trainer Gallery/TG11.ts
@@ -84,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "As it flies in a calm and relaxed manner, Altaria performs a humming song that would enrapture any audience.",
+		de: "Es schwebt gemächlich durch die Lüfte und lässt dabei ein wunderschönes Summen ertönen, das alle in seinen Bann zieht, die es hören."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Silver Tempest Trainer Gallery/TG20.ts
+++ b/data/Sword & Shield/Silver Tempest Trainer Gallery/TG20.ts
@@ -71,7 +71,7 @@ const card: Card = {
 			es: "Puedes descartar cualquier cantidad de Energías Fire Básicas o cualquier cantidad de Energías Lightning Básicas de este Pokémon. Este ataque hace 80 puntos de daño más por cada carta que hayas descartado de esta manera.",
 			it: "Puoi scartare tutte le Energie base Fire o tutte le Energie base Lightning che vuoi da questo Pokémon. Questo attacco infligge 80 danni in più per ogni carta che hai scartato in questo modo.",
 			pt: "Você pode descartar qualquer quantidade de Energia Fire básica ou qualquer quantidade de Energia Lightning básica deste Pokémon. Este ataque causa 80 pontos de dano a mais para cada carta descartada desta forma.",
-			de: "Du kannst beliebig viele Basis-Fire-Energien oder beliebig viele Basis-Lightning-Energien von diesem Pokémon auf deinen Ablagestapel legen. Diese Attacke fügt für jede auf diese Weise abgelegte Karte 80 Schadenspunkte mehr zu."
+			de: "Du kannst beliebig viele Basis-{R}-Energien oder beliebig viele Basis-{L}-Energien von diesem Pokémon auf deinen Ablagestapel legen. Diese Attacke fügt für jede auf diese Weise abgelegte Karte 80 Schadenspunkte mehr zu."
 		},
 
 		damage: "20+"

--- a/data/Sword & Shield/Silver Tempest Trainer Gallery/TG22.ts
+++ b/data/Sword & Shield/Silver Tempest Trainer Gallery/TG22.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			es: "Cada vez que unas 1 carta de Energía de tu mano a este Pokémon, elimina todas sus Condiciones Especiales.",
 			it: "Ogni volta che assegni una carta Energia a questo Pokémon dalla tua mano, rimuovi tutte le condizioni speciali che lo influenzano.",
 			pt: "Sempre que ligar 1 carta de Energia da sua mão a este Pokémon, remova todas as Condições Especiais dele.",
-			de: "Jedes Mal, wenn du 1 Energiekarte aus deiner Hand an dieses Pokémon anlegst, verlieren alle Speziellen Zustände auf diesem Pokémon ihre Wirkung."
+			de: "Jedes Mal, wenn du 1 Energiekarte aus deiner Hand an dieses Pokémon anlegst, erholt es sich von allen Speziellen Zuständen."
 		}
 	}],
 

--- a/data/Sword & Shield/Silver Tempest Trainer Gallery/TG23.ts
+++ b/data/Sword & Shield/Silver Tempest Trainer Gallery/TG23.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Roba 3 cartas.",
 		it: "Pesca tre carte.",
 		pt: "Compre 3 cartas.",
-		de: "Ziehe 3 Karten."
+		de: "Ziehe 3 Karten. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest Trainer Gallery/TG24.ts
+++ b/data/Sword & Shield/Silver Tempest Trainer Gallery/TG24.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Mira las 7 primeras cartas de tu baraja. Puedes enseñar cualquier cantidad de cartas de Energía que encuentres entre ellas y ponerlas en tu mano. Pon el resto de las cartas de nuevo en tu baraja y barájalas todas.",
 		it: "Guarda le prime sette carte del tuo mazzo. Puoi mostrare un numero qualsiasi di carte Energia presenti tra esse e aggiungerle alle carte che hai in mano. Poi rimischia le altre carte nel tuo mazzo.",
 		pt: "Olhe as 7 cartas de cima do seu baralho. Você poderá revelar qualquer número de cartas de Energia que encontrar lá e colocá-las na sua mão. Embaralhe as demais cartas de volta no seu baralho.",
-		de: "Schau dir die obersten 7 Karten deines Decks an. Du kannst beliebig viele Energiekarten, die du dort findest, deinem Gegner zeigen und auf deine Hand nehmen. Mische die anderen Karten zurück in dein Deck."
+		de: "Schau dir die obersten 7 Karten deines Decks an. Du kannst beliebig viele Energiekarten, die du dort findest, deinem Gegner zeigen und auf deine Hand nehmen. Mische die anderen Karten zurück in dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest Trainer Gallery/TG26.ts
+++ b/data/Sword & Shield/Silver Tempest Trainer Gallery/TG26.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 2 cartas y descártalas. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo fino a due carte e scartale. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por até 2 cartas no seu baralho e descarte-as. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach bis zu 2 Karten und lege sie auf deinen Ablagestapel. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach bis zu 2 Karten und lege sie auf deinen Ablagestapel. Mische anschließend dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest Trainer Gallery/TG27.ts
+++ b/data/Sword & Shield/Silver Tempest Trainer Gallery/TG27.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Puedes jugar esta carta solo si alguno de tus Pokémon quedó Fuera de Combate durante el último turno de tu rival.\nUne 1 carta de Energía Básica de tu pila de descartes a 1 de tus Pokémon. Si lo haces, busca en tu baraja 1 carta y ponla en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Puoi giocare questa carta solo se uno dei tuoi Pokémon è stato messo KO durante l'ultimo turno del tuo avversario.\nAssegna a uno dei tuoi Pokémon una carta Energia base dalla tua pila degli scarti. Se lo fai, cerca nel tuo mazzo una carta e aggiungila a quelle che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Você só pode jogar esta carta se algum dos seus Pokémon tiver sido Nocauteado durante o último turno do seu oponente.\nLigue 1 carta de Energia básica da sua pilha de descarte a 1 dos seus Pokémon. Se fizer isto, procure por 1 carta no seu baralho e coloque-a na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Du kannst diese Karte nur spielen, wenn mindestens 1 deiner Pokémon während des letzten Zuges deines Gegners kampfunfähig wurde.\nLege 1 Basis-Energiekarte aus deinem Ablagestapel an 1 deiner Pokémon an. Wenn du das machst, durchsuche dein Deck nach 1 Karte und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Du kannst diese Karte nur spielen, wenn mindestens 1 deiner Pokémon während des letzten Zuges deines Gegners kampfunfähig wurde. Lege 1 Basis-Energiekarte aus deinem Ablagestapel an 1 deiner Pokémon an. Wenn du das machst, durchsuche dein Deck nach 1 Karte und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest Trainer Gallery/TG28.ts
+++ b/data/Sword & Shield/Silver Tempest Trainer Gallery/TG28.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Elige 1 carta de Entrenador de tu pila de descartes. Después, pregúntale a tu rival si puedes ponerla en tu mano. Si contesta que sí, pon esa carta en tu mano. Si contesta que no, roba 3 cartas.",
 		it: "Scegli una carta Allenatore dalla tua pila degli scarti. Poi chiedi al tuo avversario se puoi aggiungerla a quelle che hai in mano. Se dice di sì, aggiungila alle carte che hai in mano. Se dice di no, pesca tre carte.",
 		pt: "Escolha uma carta de Treinador da sua pilha de descarte. Em seguida, pergunte ao seu oponente se você pode colocá-la na sua mão. Se sim, coloque a carta na sua mão. Se não, compre 3 cartas.",
-		de: "Wähle 1 Trainerkarte aus deinem Ablagestapel. Frage anschließend deinen Gegner, ob du sie auf deine Hand nehmen darfst. Wenn ja, nimm sie auf deine Hand. Wenn nein, ziehe 3 Karten."
+		de: "Wähle 1 Trainerkarte aus deinem Ablagestapel. Frage anschließend deinen Gegner, ob du sie auf deine Hand nehmen darfst. Wenn ja, nimm sie auf deine Hand. Wenn nein, ziehe 3 Karten. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Silver Tempest Trainer Gallery/TG29.ts
+++ b/data/Sword & Shield/Silver Tempest Trainer Gallery/TG29.ts
@@ -71,7 +71,7 @@ const card: Card = {
 			es: "Puedes descartar cualquier cantidad de Energías Fire Básicas o cualquier cantidad de Energías Lightning Básicas de este Pokémon. Este ataque hace 80 puntos de daño más por cada carta que hayas descartado de esta manera.",
 			it: "Puoi scartare tutte le Energie base Fire o tutte le Energie base Lightning che vuoi da questo Pokémon. Questo attacco infligge 80 danni in più per ogni carta che hai scartato in questo modo.",
 			pt: "Você pode descartar qualquer quantidade de Energia Fire básica ou qualquer quantidade de Energia Lightning básica deste Pokémon. Este ataque causa 80 pontos de dano a mais para cada carta descartada desta forma.",
-			de: "Du kannst beliebig viele Basis-Fire-Energien oder beliebig viele Basis-Lightning-Energien von diesem Pokémon auf deinen Ablagestapel legen. Diese Attacke fügt für jede auf diese Weise abgelegte Karte 80 Schadenspunkte mehr zu."
+			de: "Du kannst beliebig viele Basis-{R}-Energien oder beliebig viele Basis-{L}-Energien von diesem Pokémon auf deinen Ablagestapel legen. Diese Attacke fügt für jede auf diese Weise abgelegte Karte 80 Schadenspunkte mehr zu."
 		},
 
 		damage: "20+"


### PR DESCRIPTION
## Add missing German translations for swsh12tg

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
