### PR TITLE
Add missing German translations for 2023sv

### DIFF
--- a/data/McDonald's Collection/McDonald's Collection 2023/1.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2023/1.ts
@@ -41,6 +41,7 @@ const card: Card = {
 			cost: ["Grass", "Colorless"],
 			name: {
 				en: "Leafage",
+				de: "Blattwerk"
 			},
 			damage: 20,
 		},

--- a/data/McDonald's Collection/McDonald's Collection 2023/10.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2023/10.ts
@@ -38,6 +38,7 @@ const card: Card = {
 			cost: ["Fighting", "Fighting", "Colorless"],
 			name: {
 				en: "Skull Bash",
+				de: "Schädelwumme"
 			},
 			damage: 30,
 		},
@@ -45,9 +46,11 @@ const card: Card = {
 			cost: ["Fighting", "Fighting", "Fighting", "Colorless"],
 			name: {
 				en: "Sandstorm Spray",
+				de: "Sandsturmspray"
 			},
 			effect: {
 				en: "Discard 2 Energy from this Pokémon. If you discarded any Energy in this way, your opponent shuffles their Active Pokémon and all attached cards into their deck.",
+				de: "Lege 2 Energien von diesem Pokémon auf deinen Ablagestapel. Wenn du auf diese Weise mindestens 1 Energie auf deinen Ablagestapel gelegt hast, mischt dein Gegner sein Aktives Pokémon und alle angelegten Karten in sein Deck."
 			},
 		},
 	],

--- a/data/McDonald's Collection/McDonald's Collection 2023/11.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2023/11.ts
@@ -41,10 +41,12 @@ const card: Card = {
 			cost: ["Fighting", "Colorless", "Colorless"],
 			name: {
 				en: "Adrenaline Hammer",
+				de: "Adrenalinhammer"
 			},
 			damage: 130,
 			effect: {
 				en: "This Pokémon is now Confused.",
+				de: "Dieses Pokémon ist jetzt verwirrt."
 			},
 		},
 	],

--- a/data/McDonald's Collection/McDonald's Collection 2023/12.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2023/12.ts
@@ -37,10 +37,12 @@ const card: Card = {
 		{
 			type: "Ability",
 			name: {
-				en: "Busybody Nurse"
+				en: "Busybody Nurse",
+				de: "Emsige Pflege"
 			},
 			effect: {
-				en: "Once during your turn, you may use this Ability. Your Active Pokémon recovers from all Special Conditions."
+				en: "Once during your turn, you may use this Ability. Your Active Pokémon recovers from all Special Conditions.",
+				de: "Einmal während deines Zuges kannst du diese Fähigkeit einsetzen. Dein Aktives Pokémon erholt sich von allen Speziellen Zuständen."
 			}
 		}
 	],
@@ -50,9 +52,11 @@ const card: Card = {
 			cost: ["Colorless", "Colorless", "Colorless"],
 			name: {
 				en: "Happy Cyclone",
+				de: "Freudiger Wirbel"
 			},
 			effect: {
-				en: "Move all Energy from this Pokémon to 1 of your Benched Pokémon."
+				en: "Move all Energy from this Pokémon to 1 of your Benched Pokémon.",
+				de: "Verschiebe alle Energien von diesem Pokémon auf 1 Pokémon auf deiner Bank."
 			},
 			damage: 150,
 		},

--- a/data/McDonald's Collection/McDonald's Collection 2023/13.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2023/13.ts
@@ -29,9 +29,11 @@ const card: Card = {
 			cost: ["Colorless", "Colorless"],
 			name: {
 				en: "Double Hit",
+				de: "Doppelschlag"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 30 damage for each heads.",
+				de: "Wirf 2 Münzen. Diese Attacke fügt 30 Schadenspunkte pro Kopf zu."
 			},
 			damage: "30x"
 		},

--- a/data/McDonald's Collection/McDonald's Collection 2023/14.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2023/14.ts
@@ -29,9 +29,11 @@ const card: Card = {
 			cost: ["Colorless"],
 			name: {
 				en: "Touring",
+				de: "Spritztour"
 			},
 			effect: {
 				en: "Draw 2 cards.",
+				de: "Ziehe 2 Karten."
 			},
 		},
 		{

--- a/data/McDonald's Collection/McDonald's Collection 2023/15.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2023/15.ts
@@ -50,9 +50,11 @@ const card: Card = {
 			cost: ["Psychic"],
 			name: {
 				en: "Phychic",
+				de: "Psychokinese"
 			},
 			effect: {
-				en: "This attack does 20 more damage for each Energy attached to your opponent's Active Pokémon."
+				en: "This attack does 20 more damage for each Energy attached to your opponent's Active Pokémon.",
+				de: "Diese Attacke fügt für jede an das Aktive Pokémon deines Gegners angelegte Energie 20 Schadenspunkte mehr zu."
 			},
 			damage: 20,
 		}

--- a/data/McDonald's Collection/McDonald's Collection 2023/2.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2023/2.ts
@@ -41,6 +41,7 @@ const card: Card = {
 			cost: ["Fire", "Fire", "Colorless"],
 			name: {
 				en: "Combustion",
+				de: "Glühen"
 			},
 			damage: 50,
 		},

--- a/data/McDonald's Collection/McDonald's Collection 2023/3.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2023/3.ts
@@ -41,6 +41,7 @@ const card: Card = {
 			cost: ["Water", "Colorless"],
 			name: {
 				en: "Kick",
+				de: "Tritt"
 			},
 			damage: 20,
 		},

--- a/data/McDonald's Collection/McDonald's Collection 2023/4.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2023/4.ts
@@ -29,6 +29,7 @@ const card: Card = {
 			cost: ["Water"],
 			name: {
 				en: "Icicle",
+				de: "Eiszapfen"
 			},
 			damage: 10,
 		},
@@ -36,6 +37,7 @@ const card: Card = {
 			cost: ["Water", "Colorless", "Colorless"],
 			name: {
 				en: "Sharp Fin",
+				de: "Schneidige Flosse"
 			},
 			damage: 50,
 		},

--- a/data/McDonald's Collection/McDonald's Collection 2023/5.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2023/5.ts
@@ -38,6 +38,7 @@ const card: Card = {
 			cost: ["Colorless", "Colorless"],
 			name: {
 				en: "Hammer In",
+				de: "Einhämmern"
 			},
 			damage: 50,
 		},
@@ -45,10 +46,12 @@ const card: Card = {
 			cost: ["Water", "Colorless", "Colorless"],
 			name: {
 				en: "Sweeping Tackle",
+				de: "Fege-Tackle"
 			},
 			damage: "200-",
 			effect: {
 				en: "This attack does 20 less damage for each damage counter on this",
+				de: "Diese Attacke fügt für jede Schadensmarke auf diesem Pokémon 20 Schadenspunkte weniger zu."
 			},
 		},
 	],

--- a/data/McDonald's Collection/McDonald's Collection 2023/6.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2023/6.ts
@@ -29,15 +29,18 @@ const card: Card = {
 			cost: ["Colorless"],
 			name: {
 				en: "Growl",
+				de: "Heuler"
 			},
 			effect: {
-				en: "During your opponent's next turn, the Defending Pokémon's attacks do 20 less damage (before applying Weakness and Resistance)."
+				en: "During your opponent's next turn, the Defending Pokémon's attacks do 20 less damage (before applying Weakness and Resistance).",
+				de: "Während des nächsten Zuges deines Gegners fügen die Attacken des Verteidigenden Pokémon 20 Schadenspunkte weniger zu (bevor Schwäche und Resistenz verrechnet werden)."
 			}
 		},
 		{
 			cost: ["Lightning", "Colorless"],
 			name: {
 				en: "Pika Bolt",
+				de: "Pikaschuss"
 			},
 			damage: 30,
 		},

--- a/data/McDonald's Collection/McDonald's Collection 2023/7.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2023/7.ts
@@ -29,6 +29,7 @@ const card: Card = {
 			cost: ["Colorless"],
 			name: {
 				en: "Light Punch",
+				de: "Leichter Hieb"
 			},
 			damage: 10,
 		},

--- a/data/McDonald's Collection/McDonald's Collection 2023/8.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2023/8.ts
@@ -38,18 +38,22 @@ const card: Card = {
 			cost: ["Colorless", "Colorless"],
 			name: {
 				en: "Skill Dive",
+				de: "Geübter Sturzflug"
 			},
 			effect: {
 				en: "This attack does 50 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
+				de: "Diese Attacke fügt 1 Pokémon deines Gegners 50 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 		},
 		{
 			cost: ["Lightning", "Colorless", "Colorless"],
 			name: {
 				en: "Thunder Blast",
+				de: "Donnerkeil"
 			},
 			effect: {
 				en: "Discard a Lightning Energy from this Pokémon",
+				de: "Lege 1 {L}-Energie von diesem Pokémon auf deinen Ablagestapel."
 			},
 			damage: 140,
 		},

--- a/data/McDonald's Collection/McDonald's Collection 2023/9.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2023/9.ts
@@ -29,6 +29,7 @@ const card: Card = {
 			cost: ["Psychic"],
 			name: {
 				en: "Ram",
+				de: "Ramme"
 			},
 			damage: 10,
 		},


### PR DESCRIPTION
## Add missing German translations for 2023sv

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
