### PR TITLE
Add missing German translations for sv03

### DIFF
--- a/data/Scarlet & Violet/Obsidian Flames/001.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/001.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "During the day, it stays in the cold underground to avoid the sun. It grows by bathing in moonlight.",
+		de: "Tagsüber versteckt es sich in der kalten Erde, um die Sonne zu meiden. Es wächst im Mondschein."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/002.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/002.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "What appears to be drool is actually sweet honey. It is very sticky and clings stubbornly if touched.",
+		de: "Was wie Speichel aussieht, ist eigentlich Honig. Er ist sehr klebrig und wenn man ihn berührt, bekommt man ihn nicht mehr ab."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/003.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/003.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "Bellossom gather at times and appear to dance. They say that the dance is a ritual to summon the sun.",
+		de: "Von Zeit zu Zeit kommen Blubella zusammen, um zu tanzen. Man sagt, ihr Tanz sei ein Ritual, um die Sonne herbeizurufen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/004.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/004.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "It slashes through grass with its sharp scythes, moving too fast for the human eye to track.",
+		de: "Es bahnt sich mit seinen scharfen Sicheln so schnell einen Weg durch das Gras, dass es dabei für das menschliche Auge unsichtbar ist."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/005.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/005.ts
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "The berries stored in its vaselike shell eventually become a thick, pulpy juice.",
+		de: "In seinem vasenförmigen Panzer gelagerte Beeren verwandeln sich mit der Zeit zu einem dickflüssigen Saft."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/006.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/006.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "They usually live on ponds, but after an evening shower, they may appear on puddles in towns.",
+		de: "Normalerweise leben sie in Teichen, aber nach einem Schauer am Abend kann man sie auch in Pfützen in den Städten finden."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/007.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/007.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "It flaps its four wings to hover and fly freely in any direction—to and fro and sideways.",
+		de: "Dank seiner vier Flügel kann es frei in alle Richtungen fliegen, sogar seitwärts und rückwärts."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/008.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/008.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "At night, Combee sleep in a group of about a hundred, packed closely together in a lump.",
+		de: "Des Nachts schmiegen sich bis zu 100 Wadribie aneinander und formieren sich so zum Schlafen zu einem großen Gebilde."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/009.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/009.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "There is a theory that the developer of the modern-day Poké Ball really liked Foongus, but this has not been confirmed.",
+		de: "Einer Theorie zufolge fand der Entwickler des Pokéballs Gefallen an Tarnpignon. Jedoch konnte dies bisher nicht bestätigt werden."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/010.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/010.ts
@@ -63,6 +63,7 @@ const card: Card = {
 
 	description: {
 		en: "Be wary of the poisonous spores it releases. Mushrooms resembling Amoonguss's caps will grow out of anywhere the spores touch.",
+		de: "Vorsicht vor den Giftsporen, die Hutsassa versprüht! Wo auch immer diese landen, wachsen Pilze, die seinen Hüten ähneln."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/011.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/011.ts
@@ -46,6 +46,7 @@ const card: Card = {
 
 	description: {
 		en: "With a voice like a human child's, it cries out to lure adults deep into the forest, getting them lost among the trees.",
+		de: "Es imitiert das Schluchzen eines Menschenkindes, um Erwachsene tief in den Wald zu locken und dafür zu sorgen, dass diese sich verlaufen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/012.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/012.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "Small roots that extend from the tips of this Pokémon's feet can tie into the trees of the forest and give Trevenant control over them.",
+		de: "Es streckt die dünnen Wurzeln an seinen Beinen aus, um sich so mit den Bäumen im Wald zu verbinden und sie nach Belieben zu kontrollieren."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/013.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/013.ts
@@ -46,6 +46,7 @@ const card: Card = {
 
 	description: {
 		en: "It feels relaxed in tight, dark places and has been known to use its Trainer's pocket or bag as a nest.",
+		de: "An engen, dunklen Orten fühlt es sich wohl. Manchmal zweckentfremdet es die Brusttasche oder den Beutel seines Trainers als Nest."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/014.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/014.ts
@@ -63,6 +63,7 @@ const card: Card = {
 
 	description: {
 		en: "Supremely sensitive to the presence of others, it can detect opponents standing behind it, flinging its sharp feathers to take them out.",
+		de: "Es merkt sofort, wenn jemand in der Nähe ist. Spürt es hinter sich die Präsenz eines Gegners, eliminiert es ihn, indem es scharfe Federn wirft."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/016.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/016.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "Its sweat is sweet, like syrup made from boiled-down fruit. Because of this, Bounsweet was highly valued in the past, when sweeteners were scarce.",
+		de: "Sein Schweiß schmeckt so süß wie eingekochtes Obst und wurde daher früher, als es nur wenige Süßungsmittel gab, sehr geschätzt."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/017.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/017.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "Steenee spreads a sweet scent that makes others feel invigorated. This same scent is popular for antiperspirants.",
+		de: "Es verströmt ein süßes Aroma, das für gute Laune sorgt und auch als Duftnote für Deodorants sehr beliebt ist."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/018.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/018.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon is proud and aggressive. However, it is said that a Tsareena will instantly become calm if someone touches the crown on its calyx.",
+		de: "Zwar ist es stolz und aggressiv, aber wenn man seine Krone berührt, soll es sich augenblicklich beruhigen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/019.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/019.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "It protects itself from enemies by emitting oil from the fruit on its head. This oil is bitter and astringent enough to make someone flinch.",
+		de: "Um sich vor Feinden zu schützen, sondert es aus der Frucht auf seinem Kopf Öl ab. Dieses ist so bitter, dass es einen zusammenzucken lässt."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/020.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/020.ts
@@ -63,6 +63,7 @@ const card: Card = {
 
 	description: {
 		en: "Dolliv shares its tasty, fresh-scented oil with others. This species has coexisted with humans since times long gone.",
+		de: "Bereitwillig teilt dieses Pokémon sein köstliches, frisch duftendes Öl mit anderen. Seit langer Zeit schon lebt es Seite an Seite mit den Menschen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/021.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/021.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "This calm Pokémon is very compassionate. It will share its delicious, nutrient-rich oil with weakened Pokémon.",
+		de: "Dieses Pokémon ist sehr friedlich und gütig. Es teilt sein leckeres, nährstoffreiches Öl mit geschwächten Pokémon."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/023.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/023.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "The more sunlight this Pokémon bathes in, the more spicy chemicals are produced by its body, and thus the spicier its moves become.",
+		de: "Je länger es Sonnenlicht tankt, desto intensiver werden die Scharfstoffe in seinem Körper und umso pikanter fallen seine Attacken aus."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/024.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/024.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "The more sunlight this Pokémon bathes in, the more spicy chemicals are produced by its body, and thus the spicier its moves become.",
+		de: "Je länger es Sonnenlicht tankt, desto intensiver werden die Scharfstoffe in seinem Körper und umso pikanter fallen seine Attacken aus."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/025.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/025.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "The red head converts spicy chemicals into fire energy and blasts the surrounding area with a super spicy stream of flame.",
+		de: "Sein roter Kopf wandelt Scharfstoffe in Feuer-Energie um und kann so feurig scharfe Flammen von sich geben."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/026.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/026.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "From the time it is born, a flame burns at the tip of its tail. Its life would end if the flame were to go out.",
+		de: "Von Geburt an brennt die Flamme auf seiner Schwanzspitze. Sobald sie verglimmt, erlischt auch sein Lebenslicht."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/027.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/027.ts
@@ -63,6 +63,7 @@ const card: Card = {
 
 	description: {
 		en: "If it becomes agitated during battle, it spouts intense flames, incinerating its surroundings.",
+		de: "Steigert es sich in einen Kampf hinein, spuckt es Flammen, die alles in seiner Umgebung niederbrennen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/028.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/028.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "As each tail grows, its fur becomes more lustrous. When held, it feels slightly warm.",
+		de: "Sein Fell wird geschmeidiger, wenn seine sechs Schweife wachsen. Wenn man das Fell berührt, fühlt es sich leicht warm an."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/029.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/029.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "Very smart and very vengeful. Grabbing one of its many tails could result in a 1,000-year curse.",
+		de: "Dieses Pokémon ist intelligent, aber rachsüchtig. Wer zum Spaß einen seiner Schweife ergreift, kann sich einen tausendjährigen Fluch einhandeln."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/030.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/030.ts
@@ -77,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said that when it roars, a volcano erupts somewhere around the globe.",
+		de: "Man sagt, wenn es brüllt, bricht irgendwo in der Welt ein Vulkan aus."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/031.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/031.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "Magma of almost 2,200 degrees Fahrenheit courses through its body. When it grows cold, the magma hardens and slows it.",
+		de: "Durch seinen Körper fließt bis zu 1200 ℃ heißes Magma. Wird es kalt, verfestigt sich das Magma und macht das Pokémon träge."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/032.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/032.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives in the crater of a volcano. It is well known that the humps on its back erupt every 10 years.",
+		de: "Es lebt in Vulkankratern und ist bekannt dafür, dass die Höcker auf seinem Rücken alle zehn Jahre heftig ausbrechen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/034.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/034.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "This popular symbol of good fortune will never fall over in its sleep, no matter how it's pushed or pulled.",
+		de: "Während es schläft, lässt es sich nicht mal mit Gewalt umstoßen. Aus diesem Grund ist es ein beliebtes Motiv für Glücksbringer."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/035.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/035.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon's power level rises along with the temperature of its fire, which can reach 2,500 degrees Fahrenheit.",
+		de: "Je heißer das Feuer in ihm brennt, desto mehr Kraft steht ihm zur Verfügung. Seine innere Temperatur erreicht mitunter mehr als 1 400 ºC."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/036.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/036.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "The younger the life this Pokémon absorbs, the brighter and eerier the flame on its head burns.",
+		de: "Je jünger das Opfer, dem es die Lebensenergie entzieht, desto höher und unheimlicher brennt die Flamme auf seinem Kopf."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/037.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/037.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "It lurks in cities, pretending to be a lamp. Once it finds someone whose death is near, it will trail quietly after them.",
+		de: "Es gibt sich als Lampe aus und lungert in Städten herum. Entdeckt es einen Menschen, dessen Todesstunde naht, folgt es ihm leise."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/038.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/038.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "In homes illuminated by Chandelure instead of lights, funerals were a constant occurrence—or so it's said.",
+		de: "Angeblich soll früher in Häusern, wo Skelabra zur Beleuchtung verwendet wurden, eine Beerdigung auf die andere gefolgt sein."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/039.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/039.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "A flame serves as its tongue, melting through the hard shell of Durant so that Heatmor can devour their insides.",
+		de: "Es nutzt eine Flamme als Zunge. Damit bringt es die Panzer von Fermicula zum Schmelzen und verspeist im Anschluss ihr Inneres."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/040.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/040.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon was called the Larva That Stole the Sun. The fire Larvesta spouts from its horns can cut right through a sheet of iron.",
+		de: "Man nannte es die „Larve, welche die Sonne stahl“. Die Flammen, die es aus seinen Hörnern feuert, können selbst Eisenplatten zerteilen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/041.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/041.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "Its burning body causes it to be unpopular in hot parts of the world, but in cold ones, Volcarona is revered as an embodiment of the sun.",
+		de: "In heißen Gebieten ist sein brennender Körper unbeliebt, aber in kalten Gegenden wird es als Verkörperung der Sonne verehrt."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/043.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/043.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "Burnt charcoal came to life and became a Pokémon. Possessing a fiery fighting spirit, Charcadet will battle even tough opponents.",
+		de: "Ein verbranntes Stück Holzkohle ist als Pokémon zum Leben erwacht. Es fordert selbst starke Gegner heraus und hat einen feurigen Kampfgeist."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/044.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/044.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "Armarouge evolved through the use of a set of armor that belonged to a distinguished warrior. This Pokémon is incredibly loyal.",
+		de: "Es entwickelte sich durch die Rüstung eines heldenhaften Kriegers zu dieser Form. Crimanzo besitzt einen ausgeprägten Sinn für Loyalität."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/045.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/045.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "Crossing icy seas is no issue for this cold-resistant Pokémon. Its smooth skin is a little cool to the touch.",
+		de: "Es kommt gut mit Kälte zurecht und kann auch in eisigen Meeren problemlos schwimmen. Seine Haut fühlt sich glatt und kühl an."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/046.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/046.ts
@@ -46,6 +46,7 @@ const card: Card = {
 
 	description: {
 		en: "These Pokémon have sharp fangs and powerful jaws. Sailors avoid Carvanha dens at all costs.",
+		de: "Es verfügt über äußerst spitze Zähne und kräftige Kiefer. Seefahrer meiden die Lebensräume von Kanivanha um jeden Preis."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/047.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/047.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon is known as the Bully of the Sea. Any ship entering the waters Sharpedo calls home will be attacked—no exceptions.",
+		de: "Tohaido trägt den Spitznamen „Tyrann des Meeres“. Schiffe, die in sein Revier eindringen, greift es ausnahmslos an."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/048.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/048.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "It spins its two tails like a screw to propel itself through water. The tails also slice clinging seaweed.",
+		de: "Es lässt seine Ruten wie eine Schiffsschraube rotieren, um sich im Wasser fortzubewegen und Algen zu zerschneiden, die an ihm haften."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/049.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/049.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "With its flotation sac inflated, it can carry people on its back. It deflates the sac before it dives.",
+		de: "Mit gefüllter Schwimmblase kann es Menschen auf seinem Rücken tragen. Lässt es Luft aus ihr heraus, taucht es unter."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/050.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/050.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "It uses sound waves to communicate with others of its kind. People and other Pokémon species can't hear its cries of warning.",
+		de: "Es kommuniziert mit seinen Artgenossen über Schallwellen. Seine Warnrufe sind für Menschen und andere Pokémon nicht hörbar."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/051.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/051.ts
@@ -54,6 +54,7 @@ const card: Card = {
 
 	description: {
 		en: "On occasion, their cries are sublimely pleasing to the ear. Palpitoad with larger lumps on their bodies can sing with a wider range of sounds.",
+		de: "Gelegentlich singt es sehr schön. Je größer die Fortsätze an seinem Körper ausgebildet sind, desto ausgeprägter fällt sein Stimmumfang aus."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/052.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/052.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon is popular among the elderly, who say the vibrations of its lumps are great for massages.",
+		de: "Es erfreut sich großer Beliebtheit bei Senioren, seit bekannt wurde, dass sich seine vibrierenden Beulen zur Massagetherapie einsetzen lassen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/053.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/053.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "Many of this species can be found along the shorelines of cold regions. If a Cubchoo lacks dangling snot, there's a chance it is sick.",
+		de: "Sie kommen verstärkt an den Küsten kalter Gebiete vor. Wenn einem Petznief kein Schleim aus der Nase hängt, ist es womöglich krank."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/054.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/054.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "It is a ferocious, carnivorous Pokémon. Once it captures its prey, it will breathe cold air onto the prey to freeze and preserve it.",
+		de: "Dieses grimmige, fleischfressende Pokémon bläst eisigen Atem auf gefangene Beute, um sie einzufrieren und so zu konservieren."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/055.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/055.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "Cryogonal appear during cold seasons. It is said that people and Pokémon who die on snowy mountains are reborn into these Pokémon.",
+		de: "Sie erscheinen in der kalten Jahreszeit. Man sagt, sie seien Reinkarnationen von Pokémon und Menschen, die auf verschneiten Bergen starben."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/056.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/056.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "It protects its skin by covering its body in delicate bubbles. Beneath its happy-go-lucky air, it keeps a watchful eye on its surroundings.",
+		de: "Es schützt seine Haut mit feinen Blasen, die seinen Körper umhüllen. Es mag unbekümmert aussehen, behält die Umgebung aber immer aufmerksam im Auge."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/057.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/057.ts
@@ -63,6 +63,7 @@ const card: Card = {
 
 	description: {
 		en: "Its swiftness is unparalleled. It can scale a tower of more than 600 metres in a minute's time.",
+		de: "Seine Flinkheit sucht ihresgleichen. Es kann einen 600 m hohen Turm in weniger als einer Minute erklimmen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/058.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/058.ts
@@ -46,6 +46,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon can pick up the scent of a Veluza just over 65 feet away and will hide itself in the sand.",
+		de: "Es kann den Geruch eines Agiluza auf 20 m Entfernung wahrnehmen und versteckt sich daraufhin flugs im Sand."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/059.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/059.ts
@@ -63,6 +63,7 @@ const card: Card = {
 
 	description: {
 		en: "It has a vicious temperament, contrary to what its appearance may suggest. It wraps its long bodies around prey, then drags the prey into its den.",
+		de: "Entgegen seinem Äußeren ist es von grober Natur. Mit seinen langen Körpern nimmt es Beute in die Mangel und zieht sie in sein Nest."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/060.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/060.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "It likes playing with others of its kind using the water ring on its tail. It uses ultrasonic waves to sense the emotions of other living creatures.",
+		de: "Mit dem Wasserring an der Schwanzflosse spielt es gerne mit Artgenossen. Über Ultraschallwellen kann es die Gefühle anderer Lebewesen erfassen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/061.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/061.ts
@@ -46,6 +46,7 @@ const card: Card = {
 
 	description: {
 		en: "It likes playing with others of its kind using the water ring on its tail. It uses ultrasonic waves to sense the emotions of other living creatures.",
+		de: "Mit dem Wasserring an der Schwanzflosse spielt es gerne mit Artgenossen. Über Ultraschallwellen kann es die Gefühle anderer Lebewesen erfassen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/062.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/062.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon's ancient genes have awakened. It is now so extraordinarily strong that it can easily lift a cruise ship with one fin.",
+		de: "Die uralten Gene dieses Pokémon sind erwacht. Es ist so übernatürlich stark, dass es mühelos mit einer Flosse ein Kreuzfahrtschiff anheben kann."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/063.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/063.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "The electromagnetic waves emitted by the units at the sides of its head expel antigravity, which allows it to float.",
+		de: "Die seitlichen Module halten es in der Luft, indem sie mit elektromagnetischen Wellen die Schwerkraft überlisten."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/064.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/064.ts
@@ -67,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "Three Magnemite are linked by a strong magnetic force. Earaches will occur if you get too close.",
+		de: "Drei Magnetilo sind durch ein starkes Magnetfeld verbunden. In seiner Nähe bekommt man Ohrensausen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/065.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/065.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "As it zooms through the sky, this Pokémon seems to be receiving signals of unknown origin while transmitting signals of unknown purpose.",
+		de: "Es heißt, dass es beim Herumfliegen mysteriöse Funkwellen aussende und unbekannte Wellen empfange."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/067.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/067.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "While one alone doesn't have much power, a chain of many Tynamo can be as powerful as lightning.",
+		de: "Allein erzeugt es nur wenig Strom, doch wenn sich viele Zapplardin miteinander verbinden, gleicht ihre Kraft der eines Blitzes."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/068.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/068.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "They coil around foes and shock them with electricity-generating organs that seem simply to be circular patterns.",
+		de: "Die runden Flecken sind Organe, die Strom erzeugen. Es schlingt sich um seinen Gegner, presst sie gegen ihn und aktiviert sie."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/069.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/069.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "They crawl out of the ocean using their arms. They will attack prey on shore and immediately drag it into the ocean.",
+		de: "Es kriecht mithilfe seiner Arme an Land, stürzt sich auf seine Beute und zerrt sie augenblicklich ins Meer."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/070.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/070.ts
@@ -77,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "As it flies around, it shoots lightning all over the place and causes forest fires. It is therefore disliked.",
+		de: "Es ist bei den Leuten verhasst, weil es auf seinen Rundflügen immer wieder Blitze erzeugt, die Waldbrände verursachen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/071.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/071.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "It has no problem drinking dirty water. An organ inside Toxel's body filters such water into a poisonous liquid that is harmless to Toxel.",
+		de: "Es kann problemlos Schmutzwasser trinken. Ein Organ in seinem Körper filtert dieses zu einer giftigen Flüssigkeit, die ihm nichts anhaben kann."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/072.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/072.ts
@@ -83,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "Many youths admire the way this Pokémon listlessly picks fights and keeps its cool no matter what opponent it faces.",
+		de: "Kein Gegner kann es aus der Fassung bringen. Dies und die Lässigkeit, mit der es Streit sucht, erklären wohl, warum die Jugend es so schätzt."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/074.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/074.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "Tadbulb shakes its tail to generate electricity. If it senses danger, it will make its head blink on and off to alert its allies.",
+		de: "Es erzeugt Strom, indem es mit seinem Schwanz wedelt. Bei Gefahr warnt es seine Artgenossen, indem es seinen Kopf aufblinken lässt."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/075.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/075.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "Tadbulb shakes its tail to generate electricity. If it senses danger, it will make its head blink on and off to alert its allies.",
+		de: "Es erzeugt Strom, indem es mit seinem Schwanz wedelt. Bei Gefahr warnt es seine Artgenossen, indem es seinen Kopf aufblinken lässt."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/076.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/076.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "Tadbulb shakes its tail to generate electricity. If it senses danger, it will make its head blink on and off to alert its allies.",
+		de: "Es erzeugt Strom, indem es mit seinem Schwanz wedelt. Bei Gefahr warnt es seine Artgenossen, indem es seinen Kopf aufblinken lässt."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/077.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/077.ts
@@ -63,6 +63,7 @@ const card: Card = {
 
 	description: {
 		en: "When this Pokémon expands and contracts its wobbly body, the belly-button dynamo in its stomach produces a huge amount of electricity.",
+		de: "Dehnt und kontrahiert es seinen elastischen Körper, erzeugt der Nabeldynamo in seinem Bauch große Mengen an Elektrizität."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/078.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/078.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "When this Pokémon expands and contracts its wobbly body, the belly-button dynamo in its stomach produces a huge amount of electricity.",
+		de: "Dehnt und kontrahiert es seinen elastischen Körper, erzeugt der Nabeldynamo in seinem Bauch große Mengen an Elektrizität."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/080.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/080.ts
@@ -51,6 +51,7 @@ const card: Card = {
 
 	description: {
 		en: "Because of its unusual, starlike silhouette, people believe that it came here on a meteor.",
+		de: "Aufgrund seiner ungewöhnlichen Sternform sagt man, es sei auf einem Meteor hierhergereist."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/081.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/081.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "Its adorable behavior and cry make it highly popular. However, this cute Pokémon is rarely found.",
+		de: "Aufgrund seines reizenden Wesens und seines Rufes erfreut sich dieses Pokémon großer Beliebtheit. Leider ist es auch sehr selten."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/083.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/083.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "It is considered to be a symbol of good luck. Its shell is said to be filled with happiness.",
+		de: "Es gilt als Glücksbringer. Man sagt, seine Schale sei voll von purer Freude."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/084.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/084.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "It grows dispirited if it is not with kind people. It can float in midair without moving its wings.",
+		de: "Es kann, ohne mit den Flügeln zu schlagen, in der Luft schweben. Ein Mangel an gutherzigen Menschen in seiner Nähe schlägt ihm aufs Gemüt."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/085.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/085.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "Known as a bringer of blessings, it's been depicted on good-luck charms since ancient times.",
+		de: "Man sagt, es verteile Wohltaten. Aus diesem Grund wird sein Abbild seit Urzeiten für Glücksbringer verwendet."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/086.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/086.ts
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "The tip of its forked tail quivers when it is predicting its opponent's next move.",
+		de: "Die Spitze seines geteilten Schweifs bebt, wenn es die nächste Attacke seines Feindes voraussagt."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/087.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/087.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "In contrast to its appearance, it's quite timid. When playing with other puppy Pokémon, it sometimes gets bullied.",
+		de: "Man sieht es ihm zwar nicht an, aber es ist recht feige. Lässt man es mit anderen kleinen Hunde-Pokémon spielen, wird es oft gehänselt."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/088.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/088.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "Although it's popular with young people, Granbull is timid and sensitive, so it's totally incompetent as a watchdog.",
+		de: "Es ist bei jungen Leuten sehr beliebt. Aufgrund seines feigen und sensiblen Charakters ist es als Wache allerdings völlig ungeeignet."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/089.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/089.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "It chomps with its gaping mouth. Its huge jaws are actually steel horns that have been transformed.",
+		de: "Sein riesiger Kiefer hat sich aus stählernen Hörnern entwickelt. Mit ihm beißt es seine Gegner."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/090.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/090.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "Spoink will die if it stops bouncing. The pearl on its head amplifies its psychic powers.",
+		de: "Hört es je auf umherzuspringen, stirbt es. Die Perle auf seinem Kopf verstärkt seine Psycho-Kräfte."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/091.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/091.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It can perform odd dance steps to influence foes. Its style of dancing became hugely popular overseas.",
+		de: "Die seltsamen Tanzschritte, mit denen es seine Gegner kontrolliert, erfreuten sich einst in anderen Regionen großer Beliebtheit."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/092.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/092.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "It was discovered at the site of a meteor strike 40 years ago. Its stare can lull its foes to sleep.",
+		de: "Es wurde erstmals vor 40 Jahren bei einem Meteoritenkrater entdeckt. Gegner versetzt es allein mit seinem Blick in Schlaf."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/093.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/093.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "Solar energy is the source of its power, so it is strong during the daytime. When it spins, its body shines.",
+		de: "Da es seine Energie aus Sonnenlicht gewinnt, ist es tagsüber am stärksten. Wenn es sich dreht, leuchtet es."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/094.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/094.ts
@@ -61,6 +61,7 @@ const card: Card = {
 
 	description: {
 		en: "It was discovered in ancient ruins. While moving, it constantly spins. It stands on one foot even when asleep.",
+		de: "Es wurde in antiken Ruinen entdeckt. Wenn es sich bewegt, dreht es sich. Auch im Schlaf steht es auf einem Bein."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/095.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/095.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It appears to have been born from clay dolls made by ancient people. It uses telekinesis to float and move.",
+		de: "Es scheint, sein Ursprung geht auf altertümliche Lehmpuppen zurück. Durch Telekinese kann es schweben und sich bewegen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/097.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/097.ts
@@ -61,6 +61,7 @@ const card: Card = {
 
 	description: {
 		en: "The soul of someone who died alone possessed some leftover tea. This Pokémon appears in hotels and houses.",
+		de: "Die Seele eines einsam Verstorbenen hat von halb ausgetrunkenem Schwarztee Besitz ergriffen. Fatalitee zeigt sich in Hotels und Wohnhäusern."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/098.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/098.ts
@@ -87,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "The tea that composes Polteageist's body has a distinct and enjoyable flavor. Drinking too much, however, can be fatal.",
+		de: "Sein aus Schwarztee bestehender Körper hat ein markantes, doch angenehmes Aroma. Übermäßiger Genuss kann aber zum Tod führen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/099.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/099.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said that a dog Pokémon that died in the wild without ever interacting with a human was reborn as this Pokémon.",
+		de: "Es soll die Wiedergeburt eines streunenden Hunde-Pokémon sein, das starb, ohne je in Berührung mit Menschen gekommen zu sein."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/100.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/100.ts
@@ -61,6 +61,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said that a dog Pokémon that died in the wild without ever interacting with a human was reborn as this Pokémon.",
+		de: "Es soll die Wiedergeburt eines streunenden Hunde-Pokémon sein, das starb, ohne je in Berührung mit Menschen gekommen zu sein."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/101.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/101.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "Houndstone spends most of its time sleeping in graveyards. Among all the dog Pokémon, this one is most loyal to its master.",
+		de: "Man findet es meist schlafend auf Friedhöfen. Friedwuff ist das loyalste aller Hunde-Pokémon."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/103.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/103.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives about one yard underground, where it feeds on plant roots. It sometimes appears aboveground.",
+		de: "Dieses Pokémon lebt 1 m unter der Erde. Es frisst Wurzeln und kommt hin und wieder an die Oberfläche."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/104.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/104.ts
@@ -63,6 +63,7 @@ const card: Card = {
 
 	description: {
 		en: "Its three heads bob separately up and down to loosen the soil nearby, making it easier for it to burrow.",
+		de: "Seine drei Köpfe bewegen sich abwechselnd hinauf und hinunter, um das Erdreich um sich herum zu lockern und leichter graben zu können."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/105.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/105.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "Born deep underground, this Pokémon becomes a pupa after eating enough dirt to make a mountain.",
+		de: "Es wird tief im Erdreich geboren. Hat es einen Berg Erde gefressen, verpuppt sich dieses Pokémon."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/106.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/106.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "This pupa flies around wildly by venting with great force the gas pressurized inside its body.",
+		de: "Diese Puppe katapultiert sich in die Luft, indem sie Gas ausstößt, das sich in ihrem Körper angestaut hat, und sorgt so für Unruhe."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/107.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/107.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "It hunts without twitching a muscle by pulling in its prey with powerful magnetism. But sometimes it pulls natural enemies in close.",
+		de: "Es jagt bewegungslos, indem es Beute mit seinem starken Magnetfeld zu sich heranzieht. Manchmal sind jedoch auch Fressfeinde dabei."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/108.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/108.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "Its two whiskers provide a sensitive radar. Even in muddy waters, it can detect its prey's location.",
+		de: "Seine zwei Barteln dienen ihm als empfindliches Radarsystem. Selbst in schlammigem Wasser kann es so die Position seiner Beute ausmachen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/109.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/109.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "It is extremely protective of its territory. If any foe approaches, it attacks using vicious tremors.",
+		de: "Es hat ein ausgeprägtes Revierverhalten. Nähert sich ein Feind, greift es diesen an, indem es die Erde heftig beben lässt."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/110.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/110.ts
@@ -53,6 +53,7 @@ const card: Card = {
 
 	description: {
 		en: "In order to adjust the level of fluids in its body, it exudes water from its eyes. This makes it appear to be crying.",
+		de: "Es reguliert seinen Wasserhaushalt, indem es überschüssige Flüssigkeit durch die Augen ableitet. Es wirkt nur so, als würde es weinen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/111.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/111.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "It's a digger, using its claws to burrow through the ground. It causes damage to vegetable crops, so many farmers have little love for it.",
+		de: "Ein Pokémon, das sich bei Landwirten mäßiger Beliebtheit erfreut, da es beim Graben durchs Erdreich gelegentlich ihre Ernten ruiniert."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/112.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/112.ts
@@ -77,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "For some reason, this Pokémon smiles slightly when it emits a strong electric current from the yellow markings on its body.",
+		de: "Es verteilt über das gelbe Muster auf seinem Körper starke Stromstöße. Immer wenn es Strom absondert, grinst es. Niemand weiß, wieso."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/113.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/113.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "The fur on its belly retains heat exceptionally well. People used to make heavy winter clothing from fur shed by this Pokémon.",
+		de: "Das Fell an seinem Bauch hält es schön warm. Früher haben die Menschen daraus Kleidung gefertigt, die sie vor Kälte schützte."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/114.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/114.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon punches trees and eats the berries that drop down, training itself and getting food at the same time.",
+		de: "Dieses Pokémon boxt Bäume und frisst dann die Beeren, die von ihnen herabfallen. So gelangt es an Nahrung und kann gleichzeitig trainieren."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/115.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/115.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "The detached pincers of these Pokémon are delicious. Some Trainers bring Lechonk into the mountains just to search for them.",
+		de: "Krawells abgeworfene Scheren sind köstlich. Manche Trainer suchen sogar gezielt mit Ferkuli in den Bergen danach."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/116.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/116.ts
@@ -46,6 +46,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon is very friendly when it's young. Its disposition becomes vicious once it matures, but it never forgets the kindness of its master.",
+		de: "Wuffels ist sehr zutraulich, solange es jung ist. Mit dem Alter wird es zunehmend wilder, doch es bleibt seinem Trainer auf ewig verbunden."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/117.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/117.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon uses its rocky mane to slash any who approach. It will even disobey its Trainer if it dislikes the orders it was given.",
+		de: "Mit seiner steinernen Mähne schaltet es jeden aus, der sich ihm nähert. Den Anweisungen seines Trainers folgt es nur, wenn diese ihm zusagen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/118.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/118.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "Toedscool lives in muggy forests. The flaps that fall from its body are chewy and very delicious.",
+		de: "Es lebt in feuchten Wäldern. Die Falten, die sich von seinem Körper lösen, sind gummiartig und sehr schmackhaft."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/119.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/119.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "These Pokémon gather into groups and form colonies deep within forests. They absolutely hate it when strangers approach.",
+		de: "Diese Pokémon gründen Kolonien, die tief im Wald leben. Sie können es nicht ausstehen, wenn ihnen Fremde zu nahe kommen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/121.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/121.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "It absorbs nutrients from cave walls. The petals it wears are made of crystallized poison.",
+		de: "Es absorbiert Nährstoffe von Höhlenwänden und bedeckt seinen Körper mit Blütenblättern, die aus kristallisiertem Gift bestehen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/122.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/122.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "It absorbs nutrients from cave walls. The petals it wears are made of crystallized poison.",
+		de: "Es absorbiert Nährstoffe von Höhlenwänden und bedeckt seinen Körper mit Blütenblättern, die aus kristallisiertem Gift bestehen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/126.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/126.ts
@@ -53,6 +53,7 @@ const card: Card = {
 
 	description: {
 		en: "After losing a territorial struggle, Wooper began living on land. The Pokémon changed over time, developing a poisonous film to protect its body.",
+		de: "Ein verlorener Revierkampf zwang es, an Land zu leben. Um sich zu schützen, entwickelte es eine giftige Schleimschicht auf seinem Körper."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/127.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/127.ts
@@ -46,6 +46,7 @@ const card: Card = {
 
 	description: {
 		en: "After losing a territorial struggle, Wooper began living on land. The Pokémon changed over time, developing a poisonous film to protect its body.",
+		de: "Ein verlorener Revierkampf zwang es, an Land zu leben. Um sich zu schützen, entwickelte es eine giftige Schleimschicht auf seinem Körper."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/128.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/128.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "When attacked, this Pokémon will retaliate by sticking thick spines out from its body. It's a risky move that puts everything on the line.",
+		de: "Wird Suelord angegriffen, wehrt es sich, indem es dicke Stacheln ausfährt. Setzt es diese riskante Attacke ein, ist es bereit, aufs Ganze zu gehen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/129.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/129.ts
@@ -83,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "When attacked, this Pokémon will retaliate by sticking thick spines out from its body. It's a risky move that puts everything on the line.",
+		de: "Wird Suelord angegriffen, wehrt es sich, indem es dicke Stacheln ausfährt. Setzt es diese riskante Attacke ein, ist es bereit, aufs Ganze zu gehen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/130.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/130.ts
@@ -83,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "When exposed to the moon's aura, the rings on its body glow faintly and it gains a mysterious power.",
+		de: "Wird es der Aura des Mondes ausgesetzt, glühen die ringförmigen Muster auf seinem Körper leicht und es erhält eine mysteriöse Kraft."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/131.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/131.ts
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "It is smart enough to hunt in packs. It uses a variety of cries for communicating with others.",
+		de: "Es ist intelligent genug, um bei der Jagd über eine ganze Reihe von Rufen mit seinem Rudel zu kommunizieren."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/132.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/132.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "It is smart enough to hunt in packs. It uses a variety of cries for communicating with others.",
+		de: "Es ist intelligent genug, um bei der Jagd über eine ganze Reihe von Rufen mit seinem Rudel zu kommunizieren."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/133.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/133.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "If you are burned by the flames it shoots from its mouth, the pain will never go away.",
+		de: "Wird man von den Flammen getroffen, die es aus seinem Maul schießt, so erleidet man eine Brandwunde, deren Schmerz nie nachlässt."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/136.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/136.ts
@@ -77,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "It can lull people to sleep and make them dream. It is active during nights of the new moon.",
+		de: "Es kann andere in Schlaf versetzen und ihnen Träume geben. Es ist nur bei Neumond aktiv."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/137.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/137.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "By exposing foes to the blinking of its luminescent spots, Inkay demoralizes them, and then it seizes the chance to flee.",
+		de: "Es lässt die Punkte auf seinem Körper blinken, um Gegnern den Kampfeswillen zu rauben. Diesen Moment nutzt es dann, um zu fliehen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/138.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/138.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "It's said that Malamar's hypnotic powers played a role in certain history-changing events.",
+		de: "Man erzählt sich, dass die hypnotischen Kräfte dieses Pokémon mit einigen geschichtsträchtigen Ereignissen in Verbindung stehen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/139.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/139.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "It taunts its prey and lures them into narrow, rocky areas where it then sprays them with toxic gas to make them dizzy and take them down.",
+		de: "Es provoziert seine Beute und lockt sie in enge Felsspalten, wo es sie dann mit Giftgas ins Taumeln bringt und erlegt."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/140.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/140.ts
@@ -67,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "Salazzle makes its opponents light-headed with poisonous gas, then captivates them with alluring movements to turn them into loyal servants.",
+		de: "Zuerst benebelt es Gegner mit Giftgas, um sie danach mit fesselnden Körperbewegungen zu betören und zu ergebenen Dienern zu machen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/141.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/141.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon's pincers, which contain steel, can crush any hard object they get ahold of into bits.",
+		de: "Scherox’ Scheren bestehen zum Teil aus Stahl, wodurch es mit ihnen jedes noch so harte Objekt zerkleinern kann, das es zu fassen bekommt."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/142.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/142.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "People fashion swords from Skarmory's shed feathers, so this Pokémon is a popular element in heraldic designs.",
+		de: "Es wird gern als Vorlage für Wappenmotive genutzt, da aus den Federn, die ihm ausfallen, Schwerter hergestellt werden."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/143.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/143.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "It chomps with its gaping mouth. Its huge jaws are actually steel horns that have been transformed.",
+		de: "Sein riesiger Kiefer hat sich aus stählernen Hörnern entwickelt. Mit ihm beißt es seine Gegner."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/144.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/144.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "Ancient people believed that the pattern on Bronzor's back contained a mysterious power.",
+		de: "Früher glaubten die Menschen, dem Muster auf seinem Rücken wohne eine mysteriöse Kraft inne."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/145.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/145.ts
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "In ages past, this Pokémon was revered as a bringer of rain. It was found buried in the ground.",
+		de: "Vor Urzeiten wurden sie als Regenmacher verehrt. Manchmal findet man eines von ihnen im Boden vergraben."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/146.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/146.ts
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "It uses three small units to catch prey and battle enemies. The main body mostly just gives orders.",
+		de: "Sein Körper selbst befehligt meist nur die drei kleinen Einheiten, die an seiner Stelle kämpfen und für die Nahrungssuche zuständig sind."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/147.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/147.ts
@@ -60,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "Known as the Drill King, this Pokémon can tunnel through the terrain at speeds of over 90 mph.",
+		de: "Es wird auch der „Bohrkönig“ genannt. Bei seinen Bohrmanövern im Erdreich erreicht es eine Spitzengeschwindigkeit von 150 km/h."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/148.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/148.ts
@@ -61,6 +61,7 @@ const card: Card = {
 
 	description: {
 		en: "Pawniard will fearlessly challenge even powerful foes. In a pinch, it will cling to opponents and pierce them with the blades all over its body.",
+		de: "Furchtlos stellt es sich selbst starken Gegnern. Im Ernstfall hält es sich an ihnen fest und sticht mit den vielen Klingen an seinem Körper zu."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/149.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/149.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon commands a group of several Pawniard. Groups that are defeated in territorial disputes are absorbed by the winning side.",
+		de: "Es dient als Anführer einer Schar Gladiantri. Nach Revierkämpfen werden die Verlierer in die Gewinnerschar assimiliert."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/150.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/150.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "Only a Bisharp that stands above all others in its vast army can evolve into Kingambit.",
+		de: "Allein das Caesurio an der Spitze seiner riesigen Armee kann sich zu Gladimperio entwickeln."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/151.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/151.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "When it's in trouble, it curls up into a ball, makes its fur spikes stand on end, and then discharges electricity indiscriminately.",
+		de: "Bei Gefahr rollt es sich zusammen, stellt seine Rückenstacheln auf und schießt willkürlich mit Elektrizität um sich."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/152.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/152.ts
@@ -52,6 +52,7 @@ const card: Card = {
 
 	description: {
 		en: "They live as a group, but when the time comes, one strong Meltan will absorb all the others and evolve.",
+		de: "Sie leben in Gruppen. Doch wenn die Zeit reif ist, nimmt ein starkes Meltan seine Artgenossen in sich auf und entwickelt sich."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/154.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/154.ts
@@ -61,6 +61,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said that this Pokémon was born when an unknown poison Pokémon entered and inspirited an engine left at a scrap-processing factory.",
+		de: "Es soll entstanden sein, als ein unbekanntes Gift-Pokémon von einem Motor Besitz ergriff, der in einer Schrottfabrik zurückgelassen wurde."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/155.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/155.ts
@@ -52,6 +52,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said that this Pokémon was born when an unknown poison Pokémon entered and inspirited an engine left at a scrap-processing factory.",
+		de: "Es soll entstanden sein, als ein unbekanntes Gift-Pokémon von einem Motor Besitz ergriff, der in einer Schrottfabrik zurückgelassen wurde."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/157.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/157.ts
@@ -40,6 +40,7 @@ const card: Card = {
 
 	description: {
 		en: "It sheds many layers of skin as it grows larger. During this process, it is protected by a rapid waterfall.",
+		de: "Es häutet sich, um zu wachsen. Dabei wird es von einem tosenden Wasserfall beschützt."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/158.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/158.ts
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "They say that if it emits an aura from its whole body, the weather will begin to change instantly.",
+		de: "Man sagt, wenn sein ganzer Körper eine Aura ausstrahle, ändere sich augenblicklich das Wetter in seiner Umgebung."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/160.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/160.ts
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "If it bonds with a person, it will gently envelop the friend with its soft wings, then hum.",
+		de: "Spürt es eine enge Verbindung zu jemandem, umschließt es ihn mit seinen schönen, weichen Flügeln und summt dabei."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/161.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/161.ts
@@ -49,6 +49,7 @@ const card: Card = {
 
 	description: {
 		en: "Drampa is a kind and friendly Pokémon—up until it's angered. When that happens, it stirs up a gale and flattens everything around.",
+		de: "Ein zutrauliches und gutmütiges Pokémon. Wird es jedoch wütend, beschwört es heftige Stürme herauf, die alles und jeden davonfegen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/162.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/162.ts
@@ -52,6 +52,7 @@ const card: Card = {
 
 	description: {
 		en: "It is docile and prefers to avoid conflict. If disturbed, however, it can ferociously strike back.",
+		de: "Reizt man dieses an sich gutmütige Pokémon, wehrt es sich wütend."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/163.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/163.ts
@@ -60,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "Very protective of its sprawling territorial area, this Pokémon will fiercely peck at any intruder.",
+		de: "Dieses Pokémon verteidigt sein abgegrenztes Areal sorgsam gegen alle Eindringlinge."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/165.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/165.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "There are records of a lost human child being raised by a childless Kangaskhan.",
+		de: "Es liegen Berichte vor, laut denen Kangama ohne eigenen Nachwuchs stattdessen Menschenkinder in Not aufgezogen haben."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/166.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/166.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "Its ability to evolve into many forms allows it to adapt smoothly and perfectly to any environment.",
+		de: "Um sich jeder Umgebung perfekt anpassen zu können, ist es in der Lage, sich zu verschiedenen Pokémon zu entwickeln."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/167.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/167.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon with abundant curiosity. It shows an interest in everything, so it always zigzags.",
+		de: "Ein sehr neugieriges Pokémon. Es zeigt an allem Interesse, daher läuft es zickzack."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/168.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/168.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "It uses its explosive speed and razor-sharp claws to bring down prey. Running along winding paths is not its strong suit.",
+		de: "Es erlegt seine Beute mit schnellen Bewegungen und scharfen Klauen. Kurven zu nehmen bereitet ihm aber große Schwierigkeiten."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/169.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/169.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "It constantly grooms its cotton-like wings. It takes a shower to clean itself if it becomes dirty.",
+		de: "Ständig pflegt es seine watteartigen Flügel. Falls es schmutzig wird, badet es und putzt sich sauber."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/170.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/170.ts
@@ -46,6 +46,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon is far brighter than the average child, and Lillipup won't forget the love it receives or any abuse it suffers.",
+		de: "Yorkleff ist deutlich intelligenter als die meisten Kinder und vergisst nie, wenn man ihm Zuneigung entgegenbringt oder es schlecht behandelt."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/171.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/171.ts
@@ -67,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "The black fur that covers this Pokémon's body is dense and springy. Even sharp fangs bounce right off.",
+		de: "Das dunkle Fell, das seinen Körper bedeckt, ist sehr dicht und federnd. Selbst Angriffe mit scharfen Fangzähnen prallen davon ab."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/172.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/172.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "Stoutland is immensely proud of its impressive moustache. It's said that moustache length is what determines social standing among this species.",
+		de: "Seinen üppigen Schnauzbart trägt es mit Stolz. Angeblich entscheidet dessen Länge über die Rangordnung innerhalb dieser Pokémon-Art."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/173.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/173.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon has a kind heart. By touching with its feelers, Audino can gauge other creatures' feelings and physical conditions.",
+		de: "Berührt dieses herzensgute Pokémon jemanden mit seinen Fühlern, kann es dessen körperliche Verfassung und Gemütszustand ertasten."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/174.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/174.ts
@@ -77,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "These Pokémon live in herds of about 20 individuals. Bouffalant that betray the herd will lose the hair on their heads for some reason.",
+		de: "Es lebt in Gruppen von circa 20 Artgenossen. Verrät ein Bisofank seine Herde, fällt ihm aus unbekannten Gründen das Fell am Kopf aus."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/175.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/175.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "It's very sensitive to danger. The sound of Corviknight's flapping will have Bunnelby digging a hole to hide underground in moments.",
+		de: "Es ist permanent in Alarmbereitschaft. Sobald es die Flügel eines Krarmors rascheln hört, gräbt es ein Loch und verschwindet im Boden."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/176.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/176.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "Its stomach fills most of its torso. It wanders the same path every day, searching for fresh food.",
+		de: "Sein Magen füllt beinahe seinen ganzen Körper aus. Auf der Suche nach frischem Futter schlägt es täglich denselben Pfad ein."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/177.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/177.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "Once it finds signs of prey, it will patiently stake out the location, waiting until the sun goes down.",
+		de: "Findet Manguspektor Spuren potenzieller Beute, legt es sich geduldig auf die Lauer und verharrt bis Sonnenuntergang am selben Ort."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/178.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/178.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "It stores berries in its cheeks. When there are no berries to be found, Skwovet will stuff pebbles into its cheeks to stave off its cravings.",
+		de: "Es hortet Beeren in seinen Backentaschen. Falls es einmal keine findet, stopft es stattdessen Kiesel hinein, um Heißhungerattacken zu überwinden."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/180.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/180.ts
@@ -46,6 +46,7 @@ const card: Card = {
 
 	description: {
 		en: "It searches for food all day. It possesses a keen sense of smell but doesn't use it for anything other than foraging.",
+		de: "Es verfügt über einen fantastischen Geruchssinn, nutzt diesen aber ausschließlich zur Futtersuche, der es sich den lieben langen Tag widmet."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/181.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/181.ts
@@ -55,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "It searches for food all day. It possesses a keen sense of smell but doesn't use it for anything other than foraging.",
+		de: "Es verfügt über einen fantastischen Geruchssinn, nutzt diesen aber ausschließlich zur Futtersuche, der es sich den lieben langen Tag widmet."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/182.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/182.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "It searches for food all day. It possesses a keen sense of smell but doesn't use it for anything other than foraging.",
+		de: "Es verfügt über einen fantastischen Geruchssinn, nutzt diesen aber ausschließlich zur Futtersuche, der es sich den lieben langen Tag widmet."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/183.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/183.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "Oinkologne is proud of its fine, glossy skin. It emits a concentrated scent from the tip of its tail.",
+		de: "Seine glatte, glänzende Haut ist sein ganzer Stolz. Über die Spitze seines Schwanzes setzt es einen konzentrierten Duft frei."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/184.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/184.ts
@@ -83,6 +83,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon sends a flowerlike scent wafting about. Well-developed muscles in its legs allow it to leap more than 16 feet with no trouble at all.",
+		de: "Es verbreitet ein blumiges Aroma. Mit seinen gut ausgebildeten Beinmuskeln kann es leicht über 5 m weit springen."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/185.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/185.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon apparently ties the base of its neck into a knot so that the energy stored in its belly does not escape from its beak.",
+		de: "Dieses Pokémon verknotet offenbar seinen Hals am Ansatz, damit die im Bauch gespeicherte Energie nicht über den Schnabel entweicht."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/186.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/186.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja 1 carta de Objeto y 1 carta de Herramienta Pokémon, enséñalas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo una carta Strumento e una carta Oggetto Pokémon, mostrale e aggiungile alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por uma carta de Item e uma carta de Ferramenta Pokémon no seu baralho, revele-as e coloque-as na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach 1 Itemkarte und 1 Pokémon-Ausrüstung, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach 1 Itemkarte und 1 Pokémon-Ausrüstung, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Scarlet & Violet/Obsidian Flames/187.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/187.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cuenta las cartas de tu mano, pon esas cartas en tu baraja y barájalas todas. Después, roba esa misma cantidad de cartas más 1.",
 		it: "Conta le carte che hai in mano, rimischiale nel tuo mazzo e poi pesca lo stesso numero di carte più una.",
 		pt: "Conte as cartas na sua mão, embaralhe aquelas cartas no seu baralho e, em seguida, compre aquele mesmo número de cartas mais 1.",
-		de: "Zähle die Karten auf deiner Hand, mische jene Karten in dein Deck und ziehe anschließend genauso viele Karten plus 1."
+		de: "Zähle die Karten auf deiner Hand, mische jene Karten in dein Deck und ziehe anschließend genauso viele Karten plus 1. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Scarlet & Violet/Obsidian Flames/188.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/188.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 2 cartas de Energía Básica y únelas a uno de tus Pokémon. Después, baraja las cartas de tu baraja. Durante este turno, tus Pokémon no pueden atacar. (Esto incluye Pokémon que entran en juego en este turno).",
 		it: "Cerca nel tuo mazzo fino a due carte Energia base e assegnale a uno dei tuoi Pokémon. Poi rimischia le carte del tuo mazzo. Durante questo turno, i tuoi Pokémon non possono attaccare. Questo include i Pokémon entrati in gioco durante questo turno.",
 		pt: "Procure por até 2 cartas de Energia Básica no seu baralho e ligue-as a 1 dos seus Pokémon. Em seguida, embaralhe o seu baralho. Durante este turno, seus Pokémon não poderão atacar. (Isto inclui Pokémon que entrarem em jogo durante este turno.)",
-		de: "Durchsuche dein Deck nach bis zu 2 Basis-Energiekarten und lege sie an 1 deiner Pokémon an. Mische anschließend dein Deck. Während dieses Zuges können deine Pokémon nicht angreifen. (Dies schließt Pokémon ein, die während dieses Zuges ins Spiel gebracht werden.)"
+		de: "Durchsuche dein Deck nach bis zu 2 Basis-Energiekarten und lege sie an 1 deiner Pokémon an. Mische anschließend dein Deck. Während dieses Zuges können deine Pokémon nicht angreifen. (Dies schließt Pokémon ein, die während dieses Zuges ins Spiel gebracht werden.) Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Scarlet & Violet/Obsidian Flames/189.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/189.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Puedes usar esta carta solo si alguno de tus Pokémon quedó Fuera de Combate durante el último turno de tu rival.\nBusca en tu baraja hasta 3 cartas de Energía Básica, enséñalas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Puoi usare questa carta solo se uno dei tuoi Pokémon è stato messo KO durante l'ultimo turno del tuo avversario.\nCerca nel tuo mazzo fino a tre carte Energia base, mostrale e aggiungile alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Você só pode usar esta carta se algum dos seus Pokémon tiver sido Nocauteado durante o último turno do seu oponente.\nProcure por até 3 cartas de Energia Básica no seu baralho, revele-as e coloque-as na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Du kannst diese Karte nur einsetzen, wenn mindestens 1 deiner Pokémon während des letzten Zuges deines Gegners kampfunfähig wurde.\nDurchsuche dein Deck nach bis zu 3 Basis-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Du kannst diese Karte nur einsetzen, wenn mindestens 1 deiner Pokémon während des letzten Zuges deines Gegners kampfunfähig wurde. Durchsuche dein Deck nach bis zu 3 Basis-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Scarlet & Violet/Obsidian Flames/190.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/190.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Tu rival enseña las cartas de su mano. Elige 1 carta que encuentres entre ellas y ponla en la parte inferior de su baraja. Si has puesto una carta en la parte inferior de la baraja de tu rival de esta manera, tu rival puede robar 1 carta.",
 		it: "Il tuo avversario mostra le carte che ha in mano. Scegline una e mettila in fondo al suo mazzo. Se hai messo una carta in fondo al mazzo del tuo avversario in questo modo, il tuo avversario può pescare una carta.",
 		pt: "Seu oponente revela a mão dele, e você escolhe uma carta que encontrar lá e a coloca como a carta de baixo do baralho dele. Se você colocou uma carta como a carta de baixo do baralho do seu oponente desta forma, seu oponente poderá comprar uma carta.",
-		de: "Dein Gegner zeigt dir seine Handkarten und du wählst 1 Karte, die du dort findest, und legst sie unter sein Deck. Wenn du auf diese Weise 1 Karte unter das Deck deines Gegners gelegt hast, kann dein Gegner 1 Karte ziehen."
+		de: "Dein Gegner zeigt dir seine Handkarten und du wählst 1 Karte, die du dort findest, und legst sie unter sein Deck. Wenn du auf diese Weise 1 Karte unter das Deck deines Gegners gelegt hast, kann dein Gegner 1 Karte ziehen. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Scarlet & Violet/Obsidian Flames/191.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/191.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mientras el Pokémon al que esté unida esta carta esté en el Puesto Activo, las cartas de tu baraja no se pueden descartar por los efectos de los ataques, habilidades, cartas de Objeto, cartas de Herramienta Pokémon o cartas de Partidario de tu rival.",
 		it: "Fintanto che il Pokémon a cui è assegnata questa carta è in posizione attiva, le carte del tuo mazzo non possono essere scartate per effetto degli attacchi, delle abilità, delle carte Strumento, delle carte Oggetto Pokémon o delle carte Aiuto del tuo avversario.",
 		pt: "Enquanto o Pokémon ao qual esta carta está ligada estiver no Campo Ativo, cartas no seu baralho não poderão ser descartadas por efeitos de ataques, Habilidades, cartas de Item, cartas de Ferramenta Pokémon ou cartas de Apoiador do seu oponente.",
-		de: "Solange das Pokémon, an das diese Karte angelegt ist, in der Aktiven Position ist, können Karten in deinem Deck nicht durch Effekte von Attacken, Fähigkeiten, Itemkarten, Pokémon-Ausrüstungen oder Unterstützerkarten deines Gegners auf deinen Ablagestapel gelegt werden."
+		de: "Solange das Pokémon, an das diese Karte angelegt ist, in der Aktiven Position ist, können Karten in deinem Deck nicht durch Effekte von Attacken, Fähigkeiten, Itemkarten, Pokémon-Ausrüstungen oder Unterstützerkarten deines Gegners auf deinen Ablagestapel gelegt werden. Du kannst während deines Zuges beliebig viele Pokémon-Ausrüstungen an deine Pokémon anlegen. Du kannst an jedes Pokémon nur 1 Pokémon-Ausrüstung anlegen, und sie bleibt angelegt."
 	},
 
 	trainerType: "Tool",

--- a/data/Scarlet & Violet/Obsidian Flames/192.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/192.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Los ataques usados por cada Pokémon Básico en juego (tanto tuyos como de tu rival) cuestan {C} más.",
 		it: "Il costo degli attacchi usati da ciascun Pokémon Base in gioco, sia tuo che del tuo avversario, aumenta di {C}.",
 		pt: "Os ataques usados por cada Pokémon Básico em jogo (seus e do seu oponente) custam {C} a mais.",
-		de: "Die Kosten der von allen Basis-Pokémon im Spiel (deinen und denen deines Gegners) eingesetzten Attacken erhöhen sich um {C}."
+		de: "Die Kosten der von allen Basis-Pokémon im Spiel (deinen und denen deines Gegners) eingesetzten Attacken erhöhen sich um {C}. Du kannst während deines Zuges nur 1 Stadionkarte spielen. Lege sie neben die Aktive Position, und lege sie auf den Ablagestapel, wenn eine andere Stadionkarte ins Spiel gebracht wird. Eine Stadionkarte mit demselben Namen kann nicht gespielt werden."
 	},
 
 	trainerType: "Stadium",

--- a/data/Scarlet & Violet/Obsidian Flames/193.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/193.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mueve hasta 2 Energías de uno de tus Pokémon a otro de tus Pokémon.",
 		it: "Sposta fino a due Energie da uno dei tuoi Pokémon a un altro.",
 		pt: "Mova até 2 Energias de 1 dos seus Pokémon para outro Pokémon seu.",
-		de: "Verschiebe bis zu 2 Energien von 1 deiner Pokémon auf 1 anderes deiner Pokémon."
+		de: "Verschiebe bis zu 2 Energien von 1 deiner Pokémon auf 1 anderes deiner Pokémon. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Scarlet & Violet/Obsidian Flames/194.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/194.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba 3 cartas. Mueve el Pokémon Activo de tu rival a la Banca. (Tu rival elige el nuevo Pokémon Activo).",
 		it: "Pesca tre carte. Sposta il Pokémon attivo del tuo avversario nella sua panchina. Il tuo avversario sceglie il nuovo Pokémon attivo.",
 		pt: "Compre 3 cartas. Mande o Pokémon Ativo do seu oponente para o Banco. (O seu oponente escolhe o novo Pokémon Ativo.)",
-		de: "Ziehe 3 Karten. Wechsle das Aktive Pokémon deines Gegners auf seine Bank aus. (Dein Gegner wählt das neue Aktive Pokémon.)"
+		de: "Ziehe 3 Karten. Wechsle das Aktive Pokémon deines Gegners auf seine Bank aus. (Dein Gegner wählt das neue Aktive Pokémon.) Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Scarlet & Violet/Obsidian Flames/195.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/195.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon 1 Energía unida al Pokémon Activo de tu rival en la parte superior de su baraja.",
 		it: "Prendi un'Energia assegnata al Pokémon attivo del tuo avversario e mettila in cima al suo mazzo.",
 		pt: "Coloque uma Energia ligada ao Pokémon Ativo do seu oponente como a carta de cima do baralho dele.",
-		de: "Lege 1 an das Aktive Pokémon deines Gegners angelegte Energie auf sein Deck."
+		de: "Lege 1 an das Aktive Pokémon deines Gegners angelegte Energie auf sein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Scarlet & Violet/Obsidian Flames/196.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/196.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Una vez durante el turno de cada jugador, ese jugador puede buscar en su baraja 1 carta de Herramienta Pokémon, enseñarla y ponerla en su mano. Después, ese jugador baraja las cartas de su baraja.",
 		it: "Una sola volta durante il turno di ciascun giocatore, quel giocatore può cercare nel suo mazzo una carta Oggetto Pokémon, mostrarla e aggiungerla alle carte che ha in mano. Poi quel giocatore rimischia le carte del suo mazzo.",
 		pt: "Uma vez durante o turno de cada jogador, aquele jogador poderá procurar no próprio baralho por uma carta de Ferramenta Pokémon, revelá-la e colocá-la na própria mão. Em seguida, aquele jogador embaralha o próprio baralho.",
-		de: "Einmal während des Zuges jedes Spielers kann jener Spieler sein Deck nach 1 Pokémon-Ausrüstung durchsuchen, sie seinem Gegner zeigen und auf seine Hand nehmen. Anschließend mischt jener Spieler sein Deck."
+		de: "Einmal während des Zuges jedes Spielers kann jener Spieler sein Deck nach 1 Pokémon-Ausrüstung durchsuchen, sie seinem Gegner zeigen und auf seine Hand nehmen. Anschließend mischt jener Spieler sein Deck. Du kannst während deines Zuges nur 1 Stadionkarte spielen. Lege sie neben die Aktive Position, und lege sie auf den Ablagestapel, wenn eine andere Stadionkarte ins Spiel gebracht wird. Eine Stadionkarte mit demselben Namen kann nicht gespielt werden."
 	},
 
 	trainerType: "Stadium",

--- a/data/Scarlet & Violet/Obsidian Flames/197.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/197.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Si el Pokémon al que está unida esta carta queda Fuera de Combate por el daño de un ataque de los Pokémon de tu rival, pon 4 contadores de daño en el Pokémon Atacante.",
 		it: "Se il Pokémon a cui è assegnata questa carta viene messo KO dai danni inflitti da un attacco di un Pokémon del tuo avversario, metti quattro segnalini danno sul Pokémon attaccante.",
 		pt: "Se o Pokémon ao qual esta carta está ligada for Nocauteado pelo dano de um ataque dos Pokémon do seu oponente, coloque 4 contadores de dano no Pokémon Atacante.",
-		de: "Wenn das Pokémon, an das diese Karte angelegt ist, durch Schaden einer Attacke von Pokémon deines Gegners kampfunfähig wird, lege 4 Schadensmarken auf das Angreifende Pokémon."
+		de: "Wenn das Pokémon, an das diese Karte angelegt ist, durch Schaden einer Attacke von Pokémon deines Gegners kampfunfähig wird, lege 4 Schadensmarken auf das Angreifende Pokémon. Du kannst während deines Zuges beliebig viele Pokémon-Ausrüstungen an deine Pokémon anlegen. Du kannst an jedes Pokémon nur 1 Pokémon-Ausrüstung anlegen, und sie bleibt angelegt."
 	},
 
 	trainerType: "Tool",

--- a/data/Scarlet & Violet/Obsidian Flames/198.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/198.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "What appears to be drool is actually sweet honey. It is very sticky and clings stubbornly if touched.",
+		de: "Was wie Speichel aussieht, ist eigentlich Honig. Er ist sehr klebrig und wenn man ihn berührt, bekommt man ihn nicht mehr ab."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/199.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/199.ts
@@ -74,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "Very smart and very vengeful. Grabbing one of its many tails could result in a 1,000-year curse.",
+		de: "Dieses Pokémon ist intelligent, aber rachsüchtig. Wer zum Spaß einen seiner Schweife ergreift, kann sich einen tausendjährigen Fluch einhandeln."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/200.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/200.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon's ancient genes have awakened. It is now so extraordinarily strong that it can easily lift a cruise ship with one fin.",
+		de: "Die uralten Gene dieses Pokémon sind erwacht. Es ist so übernatürlich stark, dass es mühelos mit einer Flosse ein Kreuzfahrtschiff anheben kann."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/201.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/201.ts
@@ -85,6 +85,7 @@ const card: Card = {
 
 	description: {
 		en: "When this Pokémon expands and contracts its wobbly body, the belly-button dynamo in its stomach produces a huge amount of electricity.",
+		de: "Dehnt und kontrahiert es seinen elastischen Körper, erzeugt der Nabeldynamo in seinem Bauch große Mengen an Elektrizität."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/202.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/202.ts
@@ -51,6 +51,7 @@ const card: Card = {
 
 	description: {
 		en: "Because of its unusual, starlike silhouette, people believe that it came here on a meteor.",
+		de: "Aufgrund seiner ungewöhnlichen Sternform sagt man, es sei auf einem Meteor hierhergereist."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/203.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/203.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "Born deep underground, this Pokémon becomes a pupa after eating enough dirt to make a mountain.",
+		de: "Es wird tief im Erdreich geboren. Hat es einen Berg Erde gefressen, verpuppt sich dieses Pokémon."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/204.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/204.ts
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "It is smart enough to hunt in packs. It uses a variety of cries for communicating with others.",
+		de: "Es ist intelligent genug, um bei der Jagd über eine ganze Reihe von Rufen mit seinem Rudel zu kommunizieren."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/205.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/205.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon's pincers, which contain steel, can crush any hard object they get ahold of into bits.",
+		de: "Scherox’ Scheren bestehen zum Teil aus Stahl, wodurch es mit ihnen jedes noch so harte Objekt zerkleinern kann, das es zu fassen bekommt."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/206.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/206.ts
@@ -61,6 +61,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said that this Pokémon was born when an unknown poison Pokémon entered and inspirited an engine left at a scrap-processing factory.",
+		de: "Es soll entstanden sein, als ein unbekanntes Gift-Pokémon von einem Motor Besitz ergriff, der in einer Schrottfabrik zurückgelassen wurde."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/207.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/207.ts
@@ -52,6 +52,7 @@ const card: Card = {
 
 	description: {
 		en: "It is docile and prefers to avoid conflict. If disturbed, however, it can ferociously strike back.",
+		de: "Reizt man dieses an sich gutmütige Pokémon, wehrt es sich wütend."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/208.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/208.ts
@@ -60,6 +60,7 @@ const card: Card = {
 
 	description: {
 		en: "Very protective of its sprawling territorial area, this Pokémon will fiercely peck at any intruder.",
+		de: "Dieses Pokémon verteidigt sein abgegrenztes Areal sorgsam gegen alle Eindringlinge."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/209.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/209.ts
@@ -46,6 +46,7 @@ const card: Card = {
 
 	description: {
 		en: "It searches for food all day. It possesses a keen sense of smell but doesn't use it for anything other than foraging.",
+		de: "Es verfügt über einen fantastischen Geruchssinn, nutzt diesen aber ausschließlich zur Futtersuche, der es sich den lieben langen Tag widmet."
 	},
 
 	variants: [

--- a/data/Scarlet & Violet/Obsidian Flames/218.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/218.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 2 cartas de Energía Básica y únelas a uno de tus Pokémon. Después, baraja las cartas de tu baraja. Durante este turno, tus Pokémon no pueden atacar. (Esto incluye Pokémon que entran en juego en este turno).",
 		it: "Cerca nel tuo mazzo fino a due carte Energia base e assegnale a uno dei tuoi Pokémon. Poi rimischia le carte del tuo mazzo. Durante questo turno, i tuoi Pokémon non possono attaccare. Questo include i Pokémon entrati in gioco durante questo turno.",
 		pt: "Procure por até 2 cartas de Energia Básica no seu baralho e ligue-as a 1 dos seus Pokémon. Em seguida, embaralhe o seu baralho. Durante este turno, seus Pokémon não poderão atacar. (Isto inclui Pokémon que entrarem em jogo durante este turno.)",
-		de: "Durchsuche dein Deck nach bis zu 2 Basis-Energiekarten und lege sie an 1 deiner Pokémon an. Mische anschließend dein Deck. Während dieses Zuges können deine Pokémon nicht angreifen. (Dies schließt Pokémon ein, die während dieses Zuges ins Spiel gebracht werden.)"
+		de: "Durchsuche dein Deck nach bis zu 2 Basis-Energiekarten und lege sie an 1 deiner Pokémon an. Mische anschließend dein Deck. Während dieses Zuges können deine Pokémon nicht angreifen. (Dies schließt Pokémon ein, die während dieses Zuges ins Spiel gebracht werden.) Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Scarlet & Violet/Obsidian Flames/219.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/219.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Tu rival enseña las cartas de su mano. Elige 1 carta que encuentres entre ellas y ponla en la parte inferior de su baraja. Si has puesto una carta en la parte inferior de la baraja de tu rival de esta manera, tu rival puede robar 1 carta.",
 		it: "Il tuo avversario mostra le carte che ha in mano. Scegline una e mettila in fondo al suo mazzo. Se hai messo una carta in fondo al mazzo del tuo avversario in questo modo, il tuo avversario può pescare una carta.",
 		pt: "Seu oponente revela a mão dele, e você escolhe uma carta que encontrar lá e a coloca como a carta de baixo do baralho dele. Se você colocou uma carta como a carta de baixo do baralho do seu oponente desta forma, seu oponente poderá comprar uma carta.",
-		de: "Dein Gegner zeigt dir seine Handkarten und du wählst 1 Karte, die du dort findest, und legst sie unter sein Deck. Wenn du auf diese Weise 1 Karte unter das Deck deines Gegners gelegt hast, kann dein Gegner 1 Karte ziehen."
+		de: "Dein Gegner zeigt dir seine Handkarten und du wählst 1 Karte, die du dort findest, und legst sie unter sein Deck. Wenn du auf diese Weise 1 Karte unter das Deck deines Gegners gelegt hast, kann dein Gegner 1 Karte ziehen. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Scarlet & Violet/Obsidian Flames/220.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/220.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mueve hasta 2 Energías de uno de tus Pokémon a otro de tus Pokémon.",
 		it: "Sposta fino a due Energie da uno dei tuoi Pokémon a un altro.",
 		pt: "Mova até 2 Energias de 1 dos seus Pokémon para outro Pokémon seu.",
-		de: "Verschiebe bis zu 2 Energien von 1 deiner Pokémon auf 1 anderes deiner Pokémon."
+		de: "Verschiebe bis zu 2 Energien von 1 deiner Pokémon auf 1 anderes deiner Pokémon. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Scarlet & Violet/Obsidian Flames/221.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/221.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba 3 cartas. Mueve el Pokémon Activo de tu rival a la Banca. (Tu rival elige el nuevo Pokémon Activo).",
 		it: "Pesca tre carte. Sposta il Pokémon attivo del tuo avversario nella sua panchina. Il tuo avversario sceglie il nuovo Pokémon attivo.",
 		pt: "Compre 3 cartas. Mande o Pokémon Ativo do seu oponente para o Banco. (O seu oponente escolhe o novo Pokémon Ativo.)",
-		de: "Ziehe 3 Karten. Wechsle das Aktive Pokémon deines Gegners auf seine Bank aus. (Dein Gegner wählt das neue Aktive Pokémon.)"
+		de: "Ziehe 3 Karten. Wechsle das Aktive Pokémon deines Gegners auf seine Bank aus. (Dein Gegner wählt das neue Aktive Pokémon.) Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Scarlet & Violet/Obsidian Flames/226.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/226.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 2 cartas de Energía Básica y únelas a uno de tus Pokémon. Después, baraja las cartas de tu baraja. Durante este turno, tus Pokémon no pueden atacar. (Esto incluye Pokémon que entran en juego en este turno).",
 		it: "Cerca nel tuo mazzo fino a due carte Energia base e assegnale a uno dei tuoi Pokémon. Poi rimischia le carte del tuo mazzo. Durante questo turno, i tuoi Pokémon non possono attaccare. Questo include i Pokémon entrati in gioco durante questo turno.",
 		pt: "Procure por até 2 cartas de Energia Básica no seu baralho e ligue-as a 1 dos seus Pokémon. Em seguida, embaralhe o seu baralho. Durante este turno, seus Pokémon não poderão atacar. (Isto inclui Pokémon que entrarem em jogo durante este turno.)",
-		de: "Durchsuche dein Deck nach bis zu 2 Basis-Energiekarten und lege sie an 1 deiner Pokémon an. Mische anschließend dein Deck. Während dieses Zuges können deine Pokémon nicht angreifen. (Dies schließt Pokémon ein, die während dieses Zuges ins Spiel gebracht werden.)"
+		de: "Durchsuche dein Deck nach bis zu 2 Basis-Energiekarten und lege sie an 1 deiner Pokémon an. Mische anschließend dein Deck. Während dieses Zuges können deine Pokémon nicht angreifen. (Dies schließt Pokémon ein, die während dieses Zuges ins Spiel gebracht werden.) Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Scarlet & Violet/Obsidian Flames/227.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/227.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mueve hasta 2 Energías de uno de tus Pokémon a otro de tus Pokémon.",
 		it: "Sposta fino a due Energie da uno dei tuoi Pokémon a un altro.",
 		pt: "Mova até 2 Energias de 1 dos seus Pokémon para outro Pokémon seu.",
-		de: "Verschiebe bis zu 2 Energien von 1 deiner Pokémon auf 1 anderes deiner Pokémon."
+		de: "Verschiebe bis zu 2 Energien von 1 deiner Pokémon auf 1 anderes deiner Pokémon. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Scarlet & Violet/Obsidian Flames/229.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/229.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Una vez durante el turno de cada jugador, ese jugador puede buscar en su baraja 1 Pokémon Básico que no tenga un recuadro de regla y ponerlo en su Banca. Después, ese jugador baraja las cartas de su baraja. (Pokémon ex, Pokémon V, etc. tienen recuadros de regla).",
 		it: "Una sola volta durante il turno di ciascun giocatore, quel giocatore può cercare nel suo mazzo un Pokémon Base che non ha una regola speciale e metterlo nella sua panchina. Poi quel giocatore rimischia le carte del suo mazzo. I Pokémon-ex, i Pokémon-V, ecc. hanno regole speciali.",
 		pt: "Uma vez durante o turno de cada jogador, aquele jogador poderá procurar no próprio baralho por um Pokémon Básico que não tiver uma Caixa de Regras e colocá-lo no próprio Banco. Em seguida, aquele jogador embaralha o próprio baralho. (Pokémon ex, Pokémon V, etc. têm Caixas de Regras.)",
-		de: "Einmal während des Zuges jedes Spielers kann jener Spieler sein Deck nach 1 Basis-Pokémon, das kein Regelfeld hat, durchsuchen und es auf seine Bank legen. Anschließend mischt jener Spieler sein Deck. (Pokémon-ex, Pokémon-V usw. haben Regelfelder.)"
+		de: "Einmal während des Zuges jedes Spielers kann jener Spieler sein Deck nach 1 Basis-Pokémon, das kein Regelfeld hat, durchsuchen und es auf seine Bank legen. Anschließend mischt jener Spieler sein Deck. (Pokémon-ex, Pokémon-V usw. haben Regelfelder.) Du kannst während deines Zuges nur 1 Stadionkarte spielen. Lege sie neben die Aktive Position, und lege sie auf den Ablagestapel, wenn eine andere Stadionkarte ins Spiel gebracht wird. Eine Stadionkarte mit demselben Namen kann nicht gespielt werden."
 	},
 
 	trainerType: "Stadium",


### PR DESCRIPTION
## Add missing German translations for sv03

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
