### PR TITLE
Add missing German translations for P-A

### DIFF
--- a/data/Pokémon TCG Pocket/Promos-A/009.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/009.ts
@@ -44,7 +44,7 @@ const card: Card = {
 		fr: "Quand il s'énerve, il libère instantanément\nl'énergie emmagasinée dans les poches de\nses joues.",
 		es: "Cuando se enfada, este Pokémon\ndescarga la energía que almacena en\nel interior de las bolsas de las mejillas.",
 		it: "Quando s'arrabbia, libera subito l'energia\naccumulata nelle sacche sulle guance.",
-		de: "Ist es wütend, entlädt sich augenblicklich die\nElektrizität, die es in seinen Backentaschen\ngespeichert hat.",
+		de: "Ist es wütend, entlädt sich augenblicklich die Elektrizität, die es in seinen Backentaschen gespeichert hat.",
 		'pt-br': "Quando está com raiva, descarrega\nimediatamente a energia armazenada\nnas bolsas em suas bochechas.",
 		ko: "양 볼에는 전기를 저장하는 주머니가 있다.\n화가 나면 저장한 전기를 단숨에 방출한다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/010.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/010.ts
@@ -54,7 +54,7 @@ const card: Card = {
 		fr: "Il est le fruit de nombreuses expériences\ngénétiques horribles et malsaines.",
 		es: "Fue creado por un científico tras años de\nhorribles experimentos de ingeniería genética.",
 		it: "Creato da uno scienziato dopo anni di\norribili esperimenti di ingegneria genetica.",
-		de: "Dieses Pokémon ist das Resultat eines jahrelangen\nund skrupellosen Experimentes.",
+		de: "Dieses Pokémon ist das Resultat eines jahrelangen und skrupellosen Experimentes.",
 		'pt-br': "Foi criado por cientistas através de anos\nde experimentos genéticos terríveis com\nmanipulação de DNA.",
 		ko: "한 과학자가 몇 년에 걸쳐\n무서운 유전자의 연구를\n계속한 결과 탄생했다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/011.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/011.ts
@@ -44,7 +44,7 @@ const card: Card = {
 		fr: "Ce Pokémon très serviable distribue ses œufs hautement\nnutritifs aux êtres humains et aux Pokémon blessés.",
 		es: "Un generoso Pokémon que pone huevos muy\nnutritivos y se los da a personas o Pokémon heridos.",
 		it: "Un Pokémon altruista che depone\nuova molto nutrienti e le condivide\ncon persone o Pokémon feriti.",
-		de: "Ein freundliches Pokémon, das nahrhafte Eier\nlegt, um diese mit verletzten Pokémon und\nMenschen zu teilen.",
+		de: "Ein freundliches Pokémon, das nahrhafte Eier legt, um diese mit verletzten Pokémon und Menschen zu teilen.",
 		'pt-br': "Este Pokémon gentil bota ovos bastante nutritivos\ne os compartilha com pessoas ou Pokémon feridos.",
 		ko: "상처 입은 포켓몬이나 사람이 있으면\n영양 만점의 알을 낳아\n나눠 주는 상냥한 포켓몬이다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/012.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/012.ts
@@ -54,7 +54,7 @@ const card: Card = {
 		fr: "Il passe ses journées à dormir. La nuit venue,\nil patrouille sur son territoire, les yeux brillants.",
 		es: "Durante el día, se dedica a dormir.\nDe noche, vigila su territorio con un brillo en los ojos.",
 		it: "Di giorno non fa che dormire, mentre la notte\nperlustra il suo territorio con gli occhi luccicanti.",
-		de: "Es schläft den ganzen Tag. Nachts patrouilliert es\nsein Revier mit glühenden Augen.",
+		de: "Es schläft den ganzen Tag. Nachts patrouilliert es sein Revier mit glühenden Augen.",
 		'pt-br': "Tudo o que este Pokémon faz é dormir\ndurante o dia. À noite, patrulha seu\nterritório com seus olhos brilhantes.",
 		ko: "낮에는 거의 잠만 잔다.\n밤이 되면 눈을 반짝이며\n영역을 돌아다닌다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/013.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/013.ts
@@ -65,7 +65,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Metapod",
-		fr: "Chrysacier"
+		fr: "Chrysacier",
+		de: "Safcon"
 	},
 
 	description: {
@@ -73,7 +74,7 @@ const card: Card = {
 		fr: "En combat, il bat des ailes très rapidement pour\nprojeter de la poudre toxique sur ses ennemis.",
 		es: "Aletea a gran velocidad para lanzar al aire\nsus escamas extremadamente tóxicas.",
 		it: "Sbatte le ali a gran velocità per liberare\nle sue polveri tossiche nell'aria.",
-		de: "Wenn es sehr schnell mit den Flügeln schlägt,\nsetzt es hochgiftigen Flügelstaub frei.",
+		de: "Wenn es sehr schnell mit den Flügeln schlägt, setzt es hochgiftigen Flügelstaub frei.",
 		'pt-br': "Durante as batalhas, bate as asas muito rápido\npara liberar uma poeira altamente tóxica no ar.",
 		ko: "매우 빠르게 날갯짓하면\n맹독성의 인분이\n바람을 타고 날아간다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/015.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/015.ts
@@ -44,7 +44,7 @@ const card: Card = {
 		fr: "Quand il s'énerve, il libère instantanément\nl'énergie emmagasinée dans les poches de\nses joues.",
 		es: "Cuando se enfada, este Pokémon\ndescarga la energía que almacena en\nel interior de las bolsas de las mejillas.",
 		it: "Quando s'arrabbia, libera subito l'energia\naccumulata nelle sacche sulle guance.",
-		de: "Ist es wütend, entlädt sich augenblicklich die\nElektrizität, die es in seinen Backentaschen\ngespeichert hat.",
+		de: "Ist es wütend, entlädt sich augenblicklich die Elektrizität, die es in seinen Backentaschen gespeichert hat.",
 		'pt-br': "Quando está com raiva, descarrega\nimediatamente a energia armazenada\nnas bolsas em suas bochechas.",
 		ko: "양 볼에는 전기를 저장하는 주머니가 있다.\n화가 나면 저장한 전기를 단숨에 방출한다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/016.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/016.ts
@@ -44,7 +44,7 @@ const card: Card = {
 		fr: "On dit que ceux qui voient danser un groupe de Mélofée\nsous la pleine lune connaîtront un grand bonheur.",
 		es: "Se dice que la felicidad llegará\na quien vea un grupo de Clefairy\nbailando a la luz de la luna llena.",
 		it: "Si dice che vedere un gruppo di Clefairy ballare\ncon la luna piena sia di ottimo auspicio.",
-		de: "Eine Ansammlung von Piepi bei Vollmond tanzen\nzu sehen, soll ein glückliches Leben verheißen.",
+		de: "Eine Ansammlung von Piepi bei Vollmond tanzen zu sehen, soll ein glückliches Leben verheißen.",
 		'pt-br': "Acredita-se que a felicidade virá para aqueles\nque virem um grupo de Clefairy dançando sob\na lua cheia.",
 		ko: "보름달 밤에 삐삐가 모여\n춤을 추는 모습을 보면\n행복해진다고 전해진다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/017.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/017.ts
@@ -54,7 +54,7 @@ const card: Card = {
 		fr: "Il vit en groupe au sommet des arbres. S'il perd\nses congénères de vue, la solitude le rend furieux.",
 		es: "Vive en grupos en las copas de\nlos árboles. Si pierde de vista a su\nmanada, se siente solo y se enfada.",
 		it: "Vivono in branchi in cima agli alberi. Se perdono\nil contatto con il gruppo s'infuriano per la solitudine.",
-		de: "Es lebt mit Artgenossen in Baumkronen.\nVerliert es sie aus den Augen, wird es\nvor Einsamkeit sofort zornig.",
+		de: "Es lebt mit Artgenossen in Baumkronen. Verliert es sie aus den Augen, wird es vor Einsamkeit sofort zornig.",
 		'pt-br': "Vive em grupo no topo de árvores.\nSe perde seu grupo de vista, a solidão\ndeixa este Pokémon furioso.",
 		ko: "나무 위에 무리 지어 산다.\n무리에서 떨어진 망키는\n외로운 나머지 금방 화를 낸다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/018.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/018.ts
@@ -51,7 +51,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Ivysaur",
-		fr: "Herbizarre"
+		fr: "Herbizarre",
+		de: "Bisaknosp"
 	},
 
 	description: {
@@ -59,7 +60,7 @@ const card: Card = {
 		fr: "Sa plante donne une grosse fleur quand\nelle absorbe les rayons du soleil. Il est toujours\nà la recherche des endroits les plus ensoleillés.",
 		es: "La planta florece cuando absorbe energía solar,\nlo cual le obliga a buscar siempre la luz del sol.",
 		it: "Il fiore sboccia assorbendo energia solare.\nSi muove continuamente in cerca di luce.",
-		de: "Es nutzt Solarenergie als Nahrung und\nbringt so seine große Blume zum Blühen.\nEs geht dorthin, wo die Sonne scheint.",
+		de: "Es nutzt Solarenergie als Nahrung und bringt so seine große Blume zum Blühen. Es geht dorthin, wo die Sonne scheint.",
 		'pt-br': "Sua planta floresce ao absorver energia solar,\npor isso este Pokémon vive em busca da luz do sol.",
 		ko: "태양에너지를 양분으로\n큰 꽃을 피운다. 양지를 향해\n이끌려가듯이 이동한다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/019.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/019.ts
@@ -65,7 +65,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Frogadier",
-		fr: "Croâporal"
+		fr: "Croâporal",
+		de: "Amphizel"
 	},
 
 	description: {
@@ -73,7 +74,7 @@ const card: Card = {
 		fr: "Il transforme des jets d'eau sous pression en redoutables\nshuriken. Une fois lancés, ils tournent si vite qu'ils peuvent\nmême couper le métal.",
 		es: "Comprime el agua y crea estrellas ninja con\nlas que ataca al enemigo. Cuando las hace girar\na gran velocidad, cortan en dos hasta el metal.",
 		it: "Crea lame d'acqua micidiali che ruotano ad alta\nvelocità e, se lanciate, possono perforare il metallo.",
-		de: "Es stellt Wurfsterne aus komprimiertem Wasser\nher, die durch ihre hohe Drehgeschwindigkeit\nbeim Werfen sogar Metall durchtrennen.",
+		de: "Es stellt Wurfsterne aus komprimiertem Wasser her, die durch ihre hohe Drehgeschwindigkeit beim Werfen sogar Metall durchtrennen.",
 		'pt-br': "Cria estrelas ninja de água comprimida.\nAo girá-las e atirá-las em alta velocidade,\nas estrelas podem dividir metais ao meio.",
 		ko: "물을 압축시켜 수리검을\n만들어 낸다. 고속으로 회전시키며\n던지면 금속도 두 동강이 난다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/020.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/020.ts
@@ -51,7 +51,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Gastly",
-		fr: "Fantominus"
+		fr: "Fantominus",
+		de: "Nebulak"
 	},
 
 	description: {
@@ -59,7 +60,7 @@ const card: Card = {
 		fr: "Il adore se tapir dans l'ombre et faire frissonner\nses proies pour l'éternité en leur touchant l'épaule.",
 		es: "Le gusta acechar en la oscuridad y tocarles el\nhombro a sus víctimas con su mano gaseosa.\nEstas se quedan temblando para siempre.",
 		it: "Adora stare in agguato nei luoghi bui e toccare\nle spalle delle vittime con le sue mani gassose.\nIl suo tocco causa brividi incontenibili.",
-		de: "Es lauert gern im Dunkeln und tippt Leuten mit\nseiner gasförmigen Hand auf die Schulter.\nSeine Berührung erzeugt endloses Schaudern.",
+		de: "Es lauert gern im Dunkeln und tippt Leuten mit seiner gasförmigen Hand auf die Schulter. Seine Berührung erzeugt endloses Schaudern.",
 		'pt-br': "Gosta de se esconder no escuro e bater nos\nombros dos outros com sua mão gasosa.\nSeu toque causa arrepios que não acabam mais.",
 		ko: "어둠을 틈타 가스로 된 손을 뻗쳐\n사람의 어깨를 두드리기 좋아한다.\n그 손에 닿으면 떨림이 멈추지 않는다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/021.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/021.ts
@@ -44,7 +44,7 @@ const card: Card = {
 		fr: "Il absorbe des éléments solides en creusant le sol,\nce qui le rend plus robuste.",
 		es: "Al abrirse paso bajo tierra, va absorbiendo todo lo que\nencuentra. Eso hace que su cuerpo sea así de sólido.",
 		it: "Scava nel terreno assorbendo gli oggetti\npiù duri per irrobustire il suo corpo.",
-		de: "Wenn es sich durch die Erde gräbt,\nnimmt es viele harte Gegenstände auf,\ndie seinen Körper erhärten.",
+		de: "Wenn es sich durch die Erde gräbt, nimmt es viele harte Gegenstände auf, die seinen Körper erhärten.",
 		'pt-br': "Ao cavar o chão, absorve vários objetos rígidos,\ntornando o seu corpo extremamente sólido.",
 		ko: "땅속을 파고들면서 여러 가지\n단단한 것들을 집어삼켜서\n튼튼한 몸을 만든다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/022.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/022.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			fr: "Le Pokémon Actif de votre adversaire est maintenant Endormi.",
 			es: "El Pokémon Activo de tu rival pasa a estar Dormido.",
 			it: "Il Pokémon attivo del tuo avversario viene addormentato.",
-			de: "Das Aktive Pokémon deines Gegners ist jetzt schläft.",
+			de: "Das Aktive Pokémon deines Gegners schläft jetzt.",
 			
 			ko: "상대의 배틀 포켓몬을 잠듦으로 만든다.",
 			'pt-br': "O Pokémon Ativo do seu oponente agora está Adormecido."
@@ -54,7 +54,7 @@ const card: Card = {
 		fr: "Quand ses grands yeux luisent, il chante\nune berceuse mystérieuse et agréable\nqui pousse ses ennemis à s'endormir.",
 		es: "Cuando le tiemblan sus redondos y adorables\nojos, entona una melodía agradable y misteriosa\ncon la que duerme a sus enemigos.",
 		it: "Quando i suoi occhioni rotondi tremolano, canta\nuna misteriosa melodia che fa addormentare.",
-		de: "Wenn seine Kulleraugen zu flackern beginnen,\nsingt es ein mysteriöses, wohlklingendes Lied,\ndas Zuhörer in Schlaf versetzt.",
+		de: "Wenn seine Kulleraugen zu flackern beginnen, singt es ein mysteriöses, wohlklingendes Lied, das Zuhörer in Schlaf versetzt.",
 		'pt-br': "Quando seus enormes olhos ficam pesados,\ncanta uma melodia misteriosa e relaxante,\nfazendo com que os inimigos adormeçam.",
 		ko: "초롱초롱한 눈동자가 흔들릴 때\n졸음이 쏟아지게 하는 이상하고\n기분 좋은 노래를 부른다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/023.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/023.ts
@@ -44,7 +44,7 @@ const card: Card = {
 		fr: "Il y a une graine sur son dos depuis sa naissance.\nElle grossit un peu chaque jour.",
 		es: "Este Pokémon nace con una semilla en el\nlomo, que brota con el paso del tiempo.",
 		it: "Fin dalla nascita questo Pokémon ha sulla\nschiena un seme che cresce lentamente.",
-		de: "Dieses Pokémon trägt von Geburt an einen\nSamen auf dem Rücken, der im Laufe der Zeit\nkeimt und wächst.",
+		de: "Dieses Pokémon trägt von Geburt an einen Samen auf dem Rücken, der im Laufe der Zeit keimt und wächst.",
 		'pt-br': "Este Pokémon já nasce com uma semente\nnas costas. Aos poucos, a semente cresce.",
 		ko: "태어났을 때부터 등에\n식물의 씨앗이 있으며\n조금씩 크게 자란다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/024.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/024.ts
@@ -44,7 +44,7 @@ const card: Card = {
 		fr: "Les ondes électromagnétiques émises par ses extrémités\nlui permettent de défier les lois de la gravité et de flotter.",
 		es: "Las unidades laterales crean ondas\nelectromagnéticas que contrarrestan\nla gravedad y le permiten flotar.",
 		it: "Le onde elettromagnetiche generate dagli\nelementi laterali neutralizzano la gravità\npermettendogli di levitare a mezz'aria.",
-		de: "Die seitlichen Module halten es in der Luft,\nindem sie mit elektromagnetischen Wellen\ndie Schwerkraft überlisten.",
+		de: "Die seitlichen Module halten es in der Luft, indem sie mit elektromagnetischen Wellen die Schwerkraft überlisten.",
 		'pt-br': "As ondas eletromagnéticas emitidas pelas\nunidades nas laterais de sua cabeça geram\nantigravidade, o que faz com que ele possa flutuar.",
 		ko: "좌우에 있는 유닛에서 나오는\n전자파를 이용해\n중력을 거슬러 하늘에 떠 있다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/026.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/026.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Quand il s'énerve, il libère instantanément\nl'énergie emmagasinée dans les poches de\nses joues.",
 		es: "Cuando se enfada, este Pokémon\ndescarga la energía que almacena en\nel interior de las bolsas de las mejillas.",
 		it: "Quando s'arrabbia, libera subito l'energia\naccumulata nelle sacche sulle guance.",
-		de: "Ist es wütend, entlädt sich augenblicklich die\nElektrizität, die es in seinen Backentaschen\ngespeichert hat.",
+		de: "Ist es wütend, entlädt sich augenblicklich die Elektrizität, die es in seinen Backentaschen gespeichert hat.",
 		'pt-br': "Quando está com raiva, descarrega\nimediatamente a energia armazenada\nnas bolsas em suas bochechas.",
 		ko: "양 볼에는 전기를 저장하는 주머니가 있다.\n화가 나면 저장한 전기를 단숨에 방출한다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/027.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/027.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "La lumière du soleil augmente fortement son agilité.\nSes lianes sont plus habiles que ses mains.",
 		es: "Cuando recibe los rayos de sol, se mueve\nmucho más rápido que de costumbre.\nUsa mejor sus lianas que sus manos.",
 		it: "Quando è esposto alla luce solare può muoversi più\nvelocemente. Usa le sue liane meglio dei suoi stessi arti.",
-		de: "Im Sonnenlicht erhöht sich das Tempo\nseiner Bewegungen. Es ist mit seinen\nSchlingen geschickter als mit den Händen.",
+		de: "Im Sonnenlicht erhöht sich das Tempo seiner Bewegungen. Es ist mit seinen Schlingen geschickter als mit den Händen.",
 		'pt-br': "Quando exposto à luz solar, seus movimentos tornam-se mais\nrápidos. Ele usa as trepadeiras com mais destreza que suas mãos.",
 		ko: "태양의 빛을 받으면\n평소보다 빨리 움직일 수 있다.\n손보다 덩굴을 잘 사용한다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/028.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/028.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Larvesta",
-		fr: "Pyronille"
+		fr: "Pyronille",
+		de: "Ignivor"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Son corps brûlant le rend impopulaire dans les\nrégions chaudes. Toutefois, on le vénère comme\nl'incarnation du soleil dans les régions froides.",
 		es: "El calor que irradia le granjea pocas simpatías en\ntierras cálidas. Por el contrario, en las regiones\nmás frías lo veneran como encarnación del sol.",
 		it: "Chi vive in regioni calde odia il suo corpo\ninfuocato, ma nelle terre più fredde viene\nvenerato come l'incarnazione stessa del sole.",
-		de: "In heißen Gebieten ist sein brennender Körper\nunbeliebt, aber in kalten Gegenden wird es als\nVerkörperung der Sonne verehrt.",
+		de: "In heißen Gebieten ist sein brennender Körper unbeliebt, aber in kalten Gegenden wird es als Verkörperung der Sonne verehrt.",
 		'pt-br': "Seu corpo em chamas faz com que seja impopular em partes quentes\ndo mundo. Mas, em lugares frios, Volcarona é reverenciado como\numa personificação do sol.",
 		ko: "더운 곳에서는 타오르는 몸 때문에\n미움을 받지만, 추운 곳에서는\n태양의 화신이라며 받들어진다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/029.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/029.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Wartortle",
-		fr: "Carabaffe"
+		fr: "Carabaffe",
+		de: "Schillok"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "Il écrase ses adversaires de tout son poids\npour leur faire perdre connaissance.\nIl rentre dans sa carapace s'il se sent en danger.",
 		es: "Para acabar con su enemigo, lo aplasta\ncon el peso de su cuerpo. En momentos\nde apuro, se esconde en el caparazón.",
 		it: "Mette KO gli avversari schiacciandoli sotto il corpo\npossente. Se è in difficoltà, può ritrarsi nella corazza.",
-		de: "Es begräbt seine Gegner mit seinem enormen\nKörpergewicht. Wenn es in einer aussichtslosen\nLage steckt, zieht es sich in seinen Panzer zurück.",
+		de: "Es begräbt seine Gegner mit seinem enormen Körpergewicht. Wenn es in einer aussichtslosen Lage steckt, zieht es sich in seinen Panzer zurück.",
 		ko: "무거운 몸으로 상대를\n덮쳐서 기절시킨다.\n위기에 처하면 등껍질에 숨는다.",
 		'pt-br': "Esmaga seus inimigos com seu corpo pesado\naté que desmaiem. Quando está em apuros,\nse esconde dentro do seu casco."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/030.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/030.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Ses multiples évolutions lui permettent\nde s'adapter à tout type de milieu naturel.",
 		es: "Es capaz de evolucionar de muchas maneras\npara adaptarse sin problemas a cualquier medio.",
 		it: "La capacità di evolversi in diverse specie gli permette\ndi adattarsi perfettamente a qualsiasi tipo di ambiente.",
-		de: "Um sich jeder Umgebung perfekt anpassen zu\nkönnen, ist es in der Lage, sich zu verschiedenen\nPokémon zu entwickeln.",
+		de: "Um sich jeder Umgebung perfekt anpassen zu können, ist es in der Lage, sich zu verschiedenen Pokémon zu entwickeln.",
 		'pt-br': "Sua capacidade de evoluir para muitas formas\npermite que se adapte fácil e perfeitamente\na qualquer ambiente.",
 		ko: "환경 변화에 곧바로 적응할 수 있도록\n여러 형태로 진화할 수 있는\n가능성을 가지고 있다."
 	},
@@ -52,7 +52,7 @@ const card: Card = {
 			fr: "Pendant le prochain tour de votre adversaire, les attaques utilisées par le Pokémon Défenseur infligent − 20 dégâts.",
 			es: "Durante el próximo turno de tu rival, los ataques del Pokémon Defensor hacen -20 puntos de daño.",
 			it: "Durante il prossimo turno del tuo avversario, gli attacchi usati dal Pokémon difensore infliggono -20 danni.",
-			de: "Während des nächsten Zuges deines Gegners fügen die Attacken des Verteidigenden Pokémon − 20 Schadenspunkte zu.",
+			de: "Während des nächsten Zuges deines Gegners fügen die Attacken des Verteidigenden Pokémon - 20 Schadenspunkte zu.",
 			'pt-br': "Durante o próximo turno do seu oponente, os ataques usados pelo Pokémon Defensor causarão −20 pontos de dano.",
 			ko: "상대의 다음 차례에 이 기술을 받은 포켓몬이 사용하는 기술의 데미지를 -20한다."
 		}

--- a/data/Pokémon TCG Pocket/Promos-A/031.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/031.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Minccino",
-		fr: "Chinchidou"
+		fr: "Chinchidou",
+		de: "Picochilla"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il ne supporte pas de voir le moindre grain de poussière.\nIl utilise l'huile qu'il sécrète pour recouvrir son nid\nd'un revêtement protecteur.",
 		es: "Es tan sumamente pulcro que no puede ver\nni una mota de polvo. La grasa que exuda\npor el cuerpo le sirve de película protectora.",
 		it: "È un maniaco della pulizia e non sopporta la\nvista neanche di un granello di polvere. Riveste\nla tana del grasso che trasuda dal suo corpo.",
-		de: "Es ist sehr reinlich und duldet nicht mal das\nkleinste Staubkorn. Es beschichtet sein Nest\nmit dem Öl, das sein Körper absondert.",
+		de: "Es ist sehr reinlich und duldet nicht mal das kleinste Staubkorn. Es beschichtet sein Nest mit dem Öl, das sein Körper absondert.",
 		'pt-br': "Seu corpo secreta um óleo que este Pokémon\nespalha sobre seu ninho para protegê-lo de poeira.\nCinccino não suporta nem um grãozinho de sujeira.",
 		ko: "먼지 한 톨도 용납하지 않는 결벽증.\n몸에서 나오는 기름을\n둥지에 발라서 코팅한다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/032.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/032.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Il préfère ce qui est chaud. En cas de pluie,\nde la vapeur se forme autour de sa queue.",
 		es: "Prefiere las cosas calientes. Dicen que cuando\nllueve le sale vapor de la punta de la cola.",
 		it: "Ama le cose calde. Si dice che quando piove\ngli esca vapore dalla punta della coda.",
-		de: "Dieses Pokémon bevorzugt heiße Dinge.\nBei Regen soll seine Schwanzspitze dampfen.",
+		de: "Dieses Pokémon bevorzugt heiße Dinge. Bei Regen soll seine Schwanzspitze dampfen.",
 		ko: "뜨거운 것을 좋아하는 성격이다.\n비에 젖으면 꼬리 끝에서\n연기가 난다고 한다.",
 		'pt-br': "Prefere coisas quentes. Quando chove, dizem\nque solta vapor pela ponta de sua cauda."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/033.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/033.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Quand il rentre son cou dans sa carapace,\nil peut projeter de l'eau à haute pression.",
 		es: "Cuando retrae su largo cuello en el caparazón,\ndispara agua a una presión increíble.",
 		it: "Quando ritrae il lungo collo dentro la\ncorazza sputa un vigoroso getto d'acqua.",
-		de: "Zieht es seinen langen Hals in seinen Panzer\nzurück, verspritzt es Wasser mit unbändiger Kraft.",
+		de: "Zieht es seinen langen Hals in seinen Panzer zurück, verspritzt es Wasser mit unbändiger Kraft.",
 		'pt-br': "Ao retrair o pescoço longo para dentro\ndo seu casco, lança um jato de água\nmuito poderoso.",
 		ko: "기다란 목을 등껍질 속에\n감춘 다음 기세 좋게\n물대포를 발사한다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/034.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/034.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Ce Pokémon est difficile à entraîner car il est très\ndésobéissant et déteste qu'on lui rende service.",
 		es: "No le gusta que lo cuiden. Como no aprecia el apoyo\nde su Entrenador, le cuesta coger confianza con él.",
 		it: "Molto orgoglioso. Difficile farci amicizia\nperché non ascolta mai i consigli dell'Allenatore.",
-		de: "Einmischung kann es gar nicht leiden. Es ist bockig\nund fasst nur schwer Zutrauen zu seinem Trainer.",
+		de: "Einmischung kann es gar nicht leiden. Es ist bockig und fasst nur schwer Zutrauen zu seinem Trainer.",
 		'pt-br': "Estes Pokémon não gostam que tomem conta deles.\nÉ muito difícil criar laços com eles,\npois não costumam obedecer aos seus Treinadores.",
 		ko: "신세를 지는 것을 싫어한다.\n트레이너의 지시를 듣지 않아\n친해지기 어렵다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/035.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/035.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il s'expose à la lumière du soleil pour que\nson corps l'assimile par photosynthèse.\nSa carapace est composée de terre durcie.",
 		es: "Al bañarlo los rayos de sol, realiza la fotosíntesis con todo\nel cuerpo. Su caparazón está formado por tierra endurecida.",
 		it: "Si espone ai raggi solari ed esegue la fotosintesi con\ntutto il corpo. La sua corazza è fatta di terra rassodata.",
-		de: "Es badet im Sonnenlicht und betreibt dabei mit\ndem ganzen Körper Fotosynthese. Sein Panzer\nbesteht aus hartem Lehm.",
+		de: "Es badet im Sonnenlicht und betreibt dabei mit dem ganzen Körper Fotosynthese. Sein Panzer besteht aus hartem Lehm.",
 		'pt-br': "Usa o corpo todo para fazer fotossíntese ao se expor\nà luz do sol. Seu casco é feito de solo endurecido.",
 		ko: "태양의 빛을 쬐어\n전신으로 광합성을 한다.\n등껍질은 흙이 딱딱해진 것이다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/036.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/036.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Electabuzz",
-		fr: "Élektek"
+		fr: "Élektek",
+		de: "Elektek"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "La quantité d'électricité qu'il génère est\nproportionnelle à son pouls. Quand il livre\nun combat, son voltage augmente aussitôt.",
 		es: "La cantidad de electricidad que genera es\nproporcional a su pulso. Al enzarzarse en\ncombate, su voltaje aumenta drásticamente.",
 		it: "Produce una quantità di elettricità direttamente\nproporzionale alla sua frequenza cardiaca.\nDurante la lotta il voltaggio si alza all'istante.",
-		de: "Wie viel Strom es erzeugt, ist abhängig von\nseinem Puls. Im Kampf steigt Elevolteks\nelektrische Spannung schlagartig an.",
+		de: "Wie viel Strom es erzeugt, ist abhängig von seinem Puls. Im Kampf steigt Elevolteks elektrische Spannung schlagartig an.",
 		ko: "발전량은 심박 수에 비례한다.\n싸움이 시작되면\n단숨에 전압이 올라간다.",
 		'pt-br': "A quantidade de energia elétrica que este Pokémon\nproduz é proporcional à sua pulsação. A voltagem\naumenta drasticamente quando Electivire está batalhando."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/038.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/038.ts
@@ -28,7 +28,7 @@ const card: Card = {
 		fr: "Il fait peur aux gens en pleine nuit et se nourrit de leur frayeur.",
 		es: "Sorprende a la gente en mitad de la noche\ny acumula su miedo como energía.",
 		it: "Un Pokémon che terrorizza la gente nel cuore della\nnotte. Assorbe la paura per usarla come energia.",
-		de: "Ein Pokémon, das Menschen mitten in der Nacht\nerschreckt. Es sammelt die Angst als seine Energie.",
+		de: "Ein Pokémon, das Menschen mitten in der Nacht erschreckt. Es sammelt die Angst als seine Energie.",
 		'pt-br': "Este Pokémon assusta pessoas no meio da noite.\nAcumula o medo para usar como energia.",
 		ko: "한밤중에 사람을 놀라게 하고\n무서워하는 마음을 모아 자신의\n에너지로 만드는 포켓몬이다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/039.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/039.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Ce Pokémon orne souvent les blasons, car les plumes\nqu'il perd sont utilisées pour forger des épées.",
 		es: "Aparece a menudo en escudos heráldicos, pues se\npueden forjar espadas a partir de las plumas que pierde.",
 		it: "Le piume perse da Skarmory sono utilizzate\nper produrre spade. Per questo è molto\napprezzato come motivo degli stemmi nobiliari.",
-		de: "Es wird gern als Vorlage für Wappenmotive\ngenutzt, da aus den Federn, die ihm ausfallen,\nSchwerter hergestellt werden.",
+		de: "Es wird gern als Vorlage für Wappenmotive genutzt, da aus den Federn, die ihm ausfallen, Schwerter hergestellt werden.",
 		'pt-br': "As pessoas forjam espadas com as penas que caíram\nde Skarmory, por isso, a imagem deste Pokémon é\num elemento popular em brasões.",
 		ko: "빠진 깃털로 검을\n만들 수 있어서 문장\n도안으로 인기가 많다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/040.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/040.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "La flamme de sa queue est alimentée par un gaz de\nson estomac. Même la pluie ne saurait l'éteindre.",
 		es: "El gas de su panza alimenta el fuego de su\nparte trasera, que ni la lluvia puede extinguir.",
 		it: "Le fiamme sulla coda, alimentate dai gas della\npancia, non si spengono neppure quando piove.",
-		de: "Das Feuer an seinem Hinterteil wird durch Gase\nim Bauch genährt. Selbst Regen löscht es nicht.",
+		de: "Das Feuer an seinem Hinterteil wird durch Gase im Bauch genährt. Selbst Regen löscht es nicht.",
 		'pt-br': "Sua cauda flamejante é alimentada pelos gases\ngerados em seu estômago.\nNem mesmo a chuva consegue apagar o fogo.",
 		ko: "엉덩이의 불꽃은 배에서\n만들어진 가스가 연료다.\n비에 젖어도 꺼지지 않는다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/041.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/041.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Sa coquille est remplie de joie.\nOn dit que s'il est bien traité, il porte chance.",
 		es: "El cascarón parece estar lleno de alegría.\nDicen que trae buena suerte si se le trata con cariño.",
 		it: "Sembra che il suo guscio sia ricolmo di felicità.\nSi dice che porti fortuna se lo si tratta bene.",
-		de: "Seine Schale ist voll von Freude. Es heißt,\nwenn man es freundlich und gut behandelt,\nteile es sein Glück.",
+		de: "Seine Schale ist voll von Freude. Es heißt, wenn man es freundlich und gut behandelt, teile es sein Glück.",
 		'pt-br': "Sua casca parece ser cheia de alegria e dizem que\ncompartilha a boa sorte quando é tratado com carinho.",
 		ko: "껍질 안에 행복이 가득 차 있어서\n상냥하게 대해준 사람에게\n행운을 나누어 준다고 한다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/043.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/043.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Cherubi",
-		fr: "Ceribou"
+		fr: "Ceribou",
+		de: "Kikugi"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il prend cette forme lorsqu'il a fait le plein de soleil.\nIl déborde alors d'énergie et reste très actif jusqu'au crépuscule.",
 		es: "Adopta esta forma cuando lo bañan los rayos del sol. Siempre\nestá rebosante de energía y se mantiene activo hasta el ocaso.",
 		it: "Assume questa forma dopo essersi esposto\nalla luce solare e aver fatto il pieno di energia.\nResta vivace fino al crepuscolo.",
-		de: "Diese Form nimmt Kinoso an, wenn es viel Sonne\ngetankt und dadurch seine Energie aufgefüllt hat.\nEs bleibt bis zum Sonnenuntergang aktiv.",
+		de: "Diese Form nimmt Kinoso an, wenn es viel Sonne getankt und dadurch seine Energie aufgefüllt hat. Es bleibt bis zum Sonnenuntergang aktiv.",
 		'pt-br': "Após absorver uma grande quantidade de luz solar,\nCherrim assume esta forma. Enquanto estiver assim, fica\ncheio de energia, e seu vigor permanece até o cair do sol.",
 		ko: "태양의 빛을 받아\n기운이 넘치는 모습.\n해가 지기 전까지는 활발하다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/044.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/044.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pikachu",
-		fr: "Pikachu"
+		fr: "Pikachu",
+		de: "Pikachu"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il se protège des décharges grâce à sa queue,\nqui dissipe l'électricité dans le sol.",
 		es: "Su cola actúa como toma de tierra\ny descarga electricidad al suelo, lo\nque le protege de los calambrazos.",
 		it: "La sua coda scarica elettricità a terra,\nproteggendolo dalle scosse elettriche.",
-		de: "Mithilfe seines Schweifs entlädt es Elektrizität\nin den Boden, um sich auf diese Weise vor\nelektrischen Schlägen zu schützen.",
+		de: "Mithilfe seines Schweifs entlädt es Elektrizität in den Boden, um sich auf diese Weise vor elektrischen Schlägen zu schützen.",
 		'pt-br': "Sua cauda descarrega a eletricidade\nno solo, protegendo-o contra choques.",
 		ko: "꼬리가 어스 역할을 하여\n전기를 지면으로 흘려보내므로\n자신은 감전되거나 하지 않는다."
 	},
@@ -57,7 +58,7 @@ const card: Card = {
 			fr: "Si vous avez Arceus ou Arceus-ex en jeu, ce Pokémon subit − 30 dégâts provenant des attaques.",
 			es: "Si tienes a Arceus o Arceus ex en juego, los ataques hacen -30 puntos de daño a este Pokémon.",
 			it: "Se hai in gioco Arceus o Arceus-ex, questo Pokémon subisce -30 danni dagli attacchi.",
-			de: "Wenn du Arceus oder Arceus-ex im Spiel hast, werden diesem Pokémon durch Attacken − 30 Schadenspunkte zugefügt.",
+			de: "Wenn du Arceus oder Arceus-ex im Spiel hast, werden diesem Pokémon durch Attacken - 30 Schadenspunkte zugefügt.",
 			'pt-br': "Se você tiver Arceus ou Arceus ex em jogo, este Pokémon receberá −30 pontos de dano de ataques.",
 			ko: "자신의 필드에 「아르세우스」 또는 「아르세우스 ex」 있다면 이 포켓몬이 받는 기술의 데미지를 -30한다."
 		}

--- a/data/Pokémon TCG Pocket/Promos-A/045.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/045.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il ne se déplace que d'un centimètre\npar an, mais s'il se sent menacé, il virevolte\net s'enfonce dans le sol en un instant.",
 		es: "Solo se desplaza un centímetro al año, pero,\nsi se siente amenazado, gira sobre sí mismo\ny se hunde bajo tierra en un abrir y cerrar de ojos.",
 		it: "Si sposta di 1 cm all'anno, ma quando si trova in difficoltà\nruota su se stesso e in un attimo si nasconde sottoterra.",
-		de: "Es bewegt sich nur 1 cm pro Jahr, aber in\nNotlagen bohrt es sich mit seinem Körper\nblitzschnell in den Boden.",
+		de: "Es bewegt sich nur 1 cm pro Jahr, aber in Notlagen bohrt es sich mit seinem Körper blitzschnell in den Boden.",
 		'pt-br': "Este Pokémon move-se 3 centímetros por ano,\nmas quando está em uma enrascada, gira e perfura o solo\nem questão de segundos.",
 		ko: "1년에 1cm밖에 움직이지 않지만\n위기에 처하면 회전하여\n순식간에 땅속으로 파고든다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/046.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/046.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il attend qu'une proie passe pour bondir hors de son trou\net la croquer. Dans son élan, il se casse parfois les dents.",
 		es: "Permanece oculto en cuevas y, cuando pasa una\npresa, se abalanza sobre ella y la muerde con\ntanta fuerza que hasta se le rompen los dientes.",
 		it: "Aspetta nemici e prede in agguato nella sua\ntana. Quando gli arrivano a tiro, li addenta\ncon tale forza che a volte si spezza i denti.",
-		de: "Es verbirgt sich in kleinen Höhlen, aus denen es\nherausspringt und vorbeilaufende Gegner oder\nBeute beißt. Manchmal bricht dabei ein Zahn ab.",
+		de: "Es verbirgt sich in kleinen Höhlen, aus denen es herausspringt und vorbeilaufende Gegner oder Beute beißt. Manchmal bricht dabei ein Zahn ab.",
 		'pt-br': "Esconde-se em cavernas e quando presas ou inimigos\npassam, sai e os devora. A força do seu ataque às vezes\nquebra seus dentes.",
 		ko: "구멍에 숨어서 먹이나 적이\n지나가면 뛰쳐나가 문다.\n기세가 대단해 이가 빠질 때도 있다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/047.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/047.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Staravia",
-		fr: "Étourvol"
+		fr: "Étourvol",
+		de: "Staravia"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "Quand Étourvol évolue en Étouraptor, il quitte son groupe\npour vivre seul. Ses ailes sont très souples et puissantes.",
 		es: "Al evolucionar a Staraptor, deja su bandada y\npasa a vivir en soledad. Sus alas son inmensas.",
 		it: "Non appena si evolve, lascia lo stormo e affronta la\nvita da solo. Le sue ali sono estremamente robuste.",
-		de: "Entwickelt sich Staravia zu Staraptor, verlässt es\nden Schwarm und lebt allein. Die Spannweite\nseiner Flügel ist gigantisch.",
+		de: "Entwickelt sich Staravia zu Staraptor, verlässt es den Schwarm und lebt allein. Die Spannweite seiner Flügel ist gigantisch.",
 		ko: "찌르호크가 되면 무리에서\n떨어져 혼자서 살아간다.\n강인한 날개를 가지고 있다.",
 		'pt-br': "Quando um Staravia evolui para Staraptor,\ndeixa o bando para viver sozinho. Têm asas robustas."
 	},
@@ -75,7 +76,7 @@ const card: Card = {
 			fr: "Ce Pokémon subit − 30 dégâts provenant des attaques des Pokémon {F}.",
 			es: "Los ataques de Pokémon {F} hacen -30 puntos de daño a este Pokémon.",
 			it: "Questo Pokémon subisce -30 danni dagli attacchi dei Pokémon {F}.",
-			de: "Diesem Pokémon werden durch Attacken von {F}-Pokémon − 30 Schadenspunkte zugefügt.",
+			de: "Diesem Pokémon werden durch Attacken von {F}-Pokémon - 30 Schadenspunkte zugefügt.",
 			ko: "이 포켓몬이 {F}포켓몬으로부터 받는 기술의 데미지를 -30한다.",
 			'pt-br': "Este Pokémon recebe −30 pontos de dano de ataques de Pokémon {F}."
 		}

--- a/data/Pokémon TCG Pocket/Promos-A/048.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/048.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il est né avec le pouvoir incroyable de créer\ndes liens avec n'importe quel Pokémon.",
 		es: "Nace con un maravilloso poder que le permite\nestablecer vínculos con cualquier tipo de Pokémon.",
 		it: "Dispone di un potere innato che lo fa\nlegare con qualsiasi specie di Pokémon.",
-		de: "Es wird mit einer wundersamen Kraft geboren,\ndie eine Bindung zu jedem anderen Pokémon\nmöglich macht.",
+		de: "Es wird mit einer wundersamen Kraft geboren, die eine Bindung zu jedem anderen Pokémon möglich macht.",
 		'pt-br': "Ele nasce com um poder extraordinário\nque o permite se ligar a qualquer tipo de Pokémon.",
 		ko: "태어났을 때부터 가지고 있는\n이상한 힘을 쓰면 어떤 포켓몬과도\n마음이 서로 통하게 된다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/049.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/049.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Ronflex n'est pas satisfait tant qu'il n'a pas avalé\nses 400 kg de nourriture quotidienne. Dès qu'il\na fini, il commence une sieste pour digérer.",
 		es: "No se encuentra satisfecho hasta haber\ningerido 400 kg de comida cada día.\nCuando acaba de comer, se queda dormido.",
 		it: "Dopo aver trangugiato i suoi immancabili 400 kg\ndi cibo quotidiani, cade in un sonno profondo.",
-		de: "Es muss über 400 kg Nahrung am Tag fressen,\num satt zu werden. Ist es mit dem Essen fertig,\nschläft es sofort ein.",
+		de: "Es muss über 400 kg Nahrung am Tag fressen, um satt zu werden. Ist es mit dem Essen fertig, schläft es sofort ein.",
 		'pt-br': "Não se satisfaz a menos que coma mais de\n400 kg de alimentos todos os dias. Quando\ntermina de comer, dorme imediatamente.",
 		ko: "하루에 400kg의 음식을\n먹지 않으면 성에 차지 않는다.\n다 먹으면 잠이 들어 버린다."
 	},
@@ -53,7 +53,7 @@ const card: Card = {
 			fr: "Ce Pokémon est maintenant Endormi.",
 			es: "Este Pokémon pasa a estar Dormido.",
 			it: "Questo Pokémon viene addormentato.",
-			de: "Dieses Pokémon ist jetzt schläft.",
+			de: "Dieses Pokémon schläft jetzt.",
 			
 			ko: "이 포켓몬을 잠듦으로 만든다.",
 			'pt-br': "Este Pokémon agora está Adormecido."

--- a/data/Pokémon TCG Pocket/Promos-A/051.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/051.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Des fresques vieilles de 10 000 ans laissent penser\nque ce Pokémon transporte des êtres humains\nsur son dos depuis les temps anciens.",
 		es: "Según parece, ha permitido que los humanos\nmonten en él desde tiempos remotos. Aparece\nen pinturas rupestres de hace diez mil años.",
 		it: "Sembra che trasportasse esseri umani sul\ndorso già nell'antichità. È rappresentato in\npitture rupestri risalenti a 10.000 anni fa.",
-		de: "Seit uralten Zeiten soll es Menschen auf seinem\nRücken reiten lassen. Darstellungen davon finden\nsich auf 10 000 Jahre alten Wandmalereien.",
+		de: "Seit uralten Zeiten soll es Menschen auf seinem Rücken reiten lassen. Darstellungen davon finden sich auf 10 000 Jahre alten Wandmalereien.",
 		'pt-br': "Aparentemente, Cyclizar permite que as pessoas o\nmontem desde os tempos antigos. Representações deste\nato foram encontradas em murais com mais de 10.000 anos.",
 		ko: "먼 옛날부터 인간을\n등에 태우고 다녔다고 한다.\n1만 년 전 벽화에도 그 모습이 그려져 있다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/052.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/052.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Ce Pokémon lave assidûment son visage pour\néviter qu'il ne s'assèche. La composition de son\npelage soyeux est proche de celle des plantes.",
 		es: "Su sedoso pelaje se asemeja en composición a las plantas.\nSe lava la cara con diligencia para que no se le seque.",
 		it: "Il suo pelo vellutato ha una composizione simile a quella delle\npiante. Si lava il muso di frequente per evitare che si disidrati.",
-		de: "Die Zusammensetzung seines weichen Fells ähnelt\nder von Pflanzen. Es reinigt penibel sein Gesicht,\num zu verhindern, dass dieses austrocknet.",
+		de: "Die Zusammensetzung seines weichen Fells ähnelt der von Pflanzen. Es reinigt penibel sein Gesicht, um zu verhindern, dass dieses austrocknet.",
 		'pt-br': "A composição de seu pelo fofinho é semelhante\nà das plantas. Este Pokémon lava o rosto frequentemente\npara evitar que fique ressecado.",
 		ko: "복슬복슬한 털은 식물에 가까운 성분으로\n이루어져 있다. 수시로 세수를 하면서\n건조해지는 것을 방지한다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/053.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/053.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il gonfle sa bouée pour permettre aux gens de\nmonter sur son dos et il la dégonfle pour plonger.",
 		es: "Con la vejiga natatoria inflada, puede llevar a personas\nsobre su espalda. Antes de bucear, la desinfla.",
 		it: "Col galleggiante gonfio, può trasportare delle\npersone sul dorso. Per immergersi lo sgonfia.",
-		de: "Mit gefüllter Schwimmblase kann es Menschen\nauf seinem Rücken tragen. Lässt es Luft aus ihr\nheraus, taucht es unter.",
+		de: "Mit gefüllter Schwimmblase kann es Menschen auf seinem Rücken tragen. Lässt es Luft aus ihr heraus, taucht es unter.",
 		'pt-br': "Com sua bolsa de flutuação inflada, pode transportar\npessoas nas costas. Esvazia a bolsa antes de mergulhar.",
 		ko: "부낭을 부풀리면 사람을\n등에 태울 수 있다.\n부낭을 오그라들게 하여 잠수한다."
 	},
@@ -36,7 +36,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Buizel",
-		fr: "Mustébouée"
+		fr: "Mustébouée",
+		de: "Bamelin"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Promos-A/054.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/054.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "D'ordinaire, ce Pokémon est plutôt calme,\nmais lorsqu'il se bat, il élimine ses adversaires\navec des mouvements rapides comme l'éclair.",
 		es: "Este Pokémon es normalmente bastante calmado,\npero, una vez en combate, derriba a sus rivales\ncon movimientos de una velocidad vertiginosa.",
 		it: "Di solito è piuttosto flemmatico, ma\nquando si trova a lottare atterra il\nnemico con movimenti fulminei.",
-		de: "Dieses Pokémon ist für gewöhnlich sehr gelassen,\ndoch sobald ein Kampf beginnt, streckt es den Gegner\nmit blitzschnellen Bewegungen zu Boden.",
+		de: "Dieses Pokémon ist für gewöhnlich sehr gelassen, doch sobald ein Kampf beginnt, streckt es den Gegner mit blitzschnellen Bewegungen zu Boden.",
 		'pt-br': "Este Pokémon costuma demorar para reagir, mas quando\nentra na batalha, derrota seus oponentes\ncom golpes na velocidade da luz.",
 		ko: "평소에는 느긋하지만\n싸움이 시작되면 전광석화와도 같은\n몸놀림으로 적을 때려눕힌다."
 	},
@@ -36,7 +36,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pawmo",
-		fr: "Pohmotte"
+		fr: "Pohmotte",
+		de: "Pamamo"
 	},
 
 	weaknesses: [{

--- a/data/Pokémon TCG Pocket/Promos-A/055.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/055.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il peut bouger ses quatre bras à grande vitesse\net frapper du poing ou du tranchant de la main\ndans toutes les directions sans se fatiguer.",
 		es: "Mueve rápidamente sus cuatro brazos\npara asestar incesantes golpes y\npuñetazos desde todos los ángulos.",
 		it: "Agita velocemente le quattro braccia tempestando\ngli avversari di pugni e colpi da ogni direzione.",
-		de: "Es verwendet seine vier Arme, um seine\nGegner unermüdlich mit schnellen Schlägen\naus allen Winkeln einzudecken.",
+		de: "Es verwendet seine vier Arme, um seine Gegner unermüdlich mit schnellen Schlägen aus allen Winkeln einzudecken.",
 		'pt-br': "Ele balança velozmente seus quatro braços para\natingir seus oponentes com socos e pancadas\nincessantes de todos os ângulos.",
 		ko: "4개의 팔을 재빠르게 움직여서\n모든 각도에서 쉬지 않고\n펀치와 당수를 날린다."
 	},
@@ -36,7 +36,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Machoke",
-		fr: "Machopeur"
+		fr: "Machopeur",
+		de: "Maschock"
 	},
 
 	attacks: [{

--- a/data/Pokémon TCG Pocket/Promos-A/056.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/056.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il peut se déboîter la mâchoire pour avaler tout rond des proies\nplus grosses que lui. Il se replie ensuite sur lui-même pour digérer.",
 		es: "Es capaz de desencajar la mandíbula para\nengullir presas enteras mayores que él mismo,\ntras lo cual se enrosca para descansar.",
 		it: "Può sganciare la mandibola per ingoiare\nintere prede più grosse di lui. Dopo il pasto,\nsi arrotola su se stesso per riposarsi.",
-		de: "Es hängt seinen Kiefer aus und verschlingt so\nselbst größere Beute am Stück. Danach rollt\nes sich zusammen und ruht sich aus.",
+		de: "Es hängt seinen Kiefer aus und verschlingt so selbst größere Beute am Stück. Danach rollt es sich zusammen und ruht sich aus.",
 		'pt-br': "Desloca a própria mandíbula para engolir presas\nmaiores que si mesmo. Depois de uma refeição,\nse enrosca e descansa.",
 		ko: "턱을 빼 자신보다\n큰 먹이를 통째로 삼킨다.\n식후에는 몸을 둥글게 하고 쉰다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/057.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/057.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Rien ne peut perturber ses nerfs d'acier.\nIl est plus agile et énergique qu'il n'y paraît.",
 		es: "Tiene nervios de acero y nada puede perturbarlo.\nEs más ágil y activo de lo que aparenta.",
 		it: "Ha i nervi d'acciaio e niente può turbarlo.\nÈ più agile e attivo di quanto sembri.",
-		de: "Es hat Nerven wie Drahtseile, nichts kann es erschüttern.\nEs ist agiler und aktiver, als es scheint.",
+		de: "Es hat Nerven wie Drahtseile, nichts kann es erschüttern. Es ist agiler und aktiver, als es scheint.",
 		'pt-br': "Com nervos de aço, nada pode perturbá-lo.\nÉ mais ágil e ativo do que parece.",
 		ko: "어떤 것에도 동요하지 않는\n대담한 신경의 소유자다.\n보기보다는 기민하게 활동한다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/058.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/058.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Pachirisu fait partie des Pokémon aux joues électriques.\nIl libère l'énergie qu'il accumule par la queue.",
 		es: "Forma parte del grupo de Pokémon que\nposee bolsas de electricidad en las mejillas.\nDescarga por la cola la electricidad que acumula.",
 		it: "Appartiene alla tipologia di Pokémon\nmuniti di sacche elettriche sulle guance.\nRilascia dalla coda l'elettricità accumulata.",
-		de: "Pachirisu ist eines der Pokémon, die mit ihren\nBackentaschen Elektrizität erzeugen. Den so\ngesammelten Strom gibt es über den Schweif ab.",
+		de: "Pachirisu ist eines der Pokémon, die mit ihren Backentaschen Elektrizität erzeugen. Den so gesammelten Strom gibt es über den Schweif ab.",
 		'pt-br': "É um dos tipos de Pokémon com bolsas elétricas\nnas bochechas. Ele dispara cargas de sua cauda.",
 		ko: "볼에 전기 주머니를 가진 포켓몬의 일종.\n꼬리에 모인 전기를 방출한다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/059.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/059.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Les Riolu communiquent entre eux à l'aide de\nleur aura. Ils sont capables de courir toute la nuit.",
 		es: "Se comunica con los suyos emitiendo ondas.\nPuede pasarse toda una noche corriendo.",
 		it: "Comunica con i suoi simili tramite l'aura.\nPuò correre un'intera notte senza stancarsi.",
-		de: "Dieses Pokémon nutzt seine Aura, um mit seinen\nArtgenossen zu kommunizieren. Es kann eine\nganze Nacht lang laufen.",
+		de: "Dieses Pokémon nutzt seine Aura, um mit seinen Artgenossen zu kommunizieren. Es kann eine ganze Nacht lang laufen.",
 		'pt-br': "Eles comunicam-se uns com os outros usando suas auras.\nSão capazes de correr a noite inteira.",
 		ko: "파동을 내서\n동료끼리 의사소통을 한다.\n밤새도록 계속 달릴 수 있다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/060.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/060.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Même s'il ressemble à un tas d'œufs,\nil s'agit bien d'un Pokémon. Il paraît qu'ils\ncommuniquent entre eux par télépathie.",
 		es: "Pese a su aspecto de mera piña de huevos,\nse trata de un Pokémon. Al parecer, sus\ncabezas se comunican entre sí por telepatía.",
 		it: "Somiglia a un mucchio di uova, ma è\nun Pokémon a tutti gli effetti. Pare che\ncomunichi con i suoi simili telepaticamente.",
-		de: "Owei mag zwar Eiern ähneln, ist aber ein echtes\nPokémon, das aus sechs Individuen besteht, die\nwohl telepathisch miteinander kommunizieren.",
+		de: "Owei mag zwar Eiern ähneln, ist aber ein echtes Pokémon, das aus sechs Individuen besteht, die wohl telepathisch miteinander kommunizieren.",
 		ko: "알처럼 보이지만 엄연한\n포켓몬이다. 텔레파시로\n동료와 교신하는 듯하다.",
 		'pt-br': "Apesar de parecer só um monte de ovos, é um Pokémon\nde verdade. Exeggcute se comunica com outros de sua\nespécie por meio de telepatia."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/061.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/061.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Sa poitrine et son dos sécrètent une mousse\nqui lui permet de subir moins de dégâts en\namortissant le choc des attaques.",
 		es: "Secreta burbujas tanto por la espalda como\npor el pecho. Gracias a la elasticidad de estas,\npuede parar ataques y reducir el daño recibido.",
 		it: "Dal petto e dalla schiena secerne una schiuma che gli\npermette di attutire i danni causati dagli attacchi nemici.",
-		de: "Es stößt aus Brust und Rücken elastische Blasen aus,\nmit denen es gegnerische Angriffe abfängt und so\nden erlittenen Schaden verringert.",
+		de: "Es stößt aus Brust und Rücken elastische Blasen aus, mit denen es gegnerische Angriffe abfängt und so den erlittenen Schaden verringert.",
 		'pt-br': "Liberam bolhas flexíveis do peito e das costas.\nAs bolhas reduzem os danos que sofreriam\nao serem atacados.",
 		ko: "가슴과 등에서 거품을 내뿜는다.\n탄력 있는 거품으로 공격을\n막아내고 데미지를 줄인다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/062.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/062.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il tranche ses adversaires avec sa tige, qu'il manie comme\nune épée. Quand la situation l'exige, il s'en nourrit.",
 		es: "Blande el puerro que sujeta con un ala como si\nse tratase de una espada para rebanar a su rival.\nEn caso de necesidad, se lo come para nutrirse.",
 		it: "Colpisce gli avversari con un gambo, che\nbrandisce con l'ala come se fosse una spada.\nIn caso di necessità, può anche mangiarselo.",
-		de: "Unter seinem Flügel trägt es eine Lauchstange,\ndie es wie ein Schwert gegen Feinde einsetzt und\nwelche ihm im Bedarfsfall auch als Nahrung dient.",
+		de: "Unter seinem Flügel trägt es eine Lauchstange, die es wie ein Schwert gegen Feinde einsetzt und welche ihm im Bedarfsfall auch als Nahrung dient.",
 		'pt-br': "O caule que este Pokémon carrega em suas asas\nserve como uma espada para cortar seus oponentes.\nEm situações difíceis, ele também pode servir como alimento.",
 		ko: "날개로 쥐고 있는 파 줄기를\n칼처럼 휘둘러 상대를 베어버린다.\n몹시 허기질 때는 먹기도 한다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/063.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/063.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il vit dans la couche d'ozone, au-dessus\ndes nuages. Il est invisible depuis le sol.",
 		es: "Vive en la capa de ozono sobre las nubes\ny no puede ser visto desde el suelo.",
 		it: "Vive nello strato di ozono oltre le nuvole\ne non può essere avvistato da terra.",
-		de: "Es lebt in der Ozonschicht hoch über den Wolken\nund kann vom Boden aus nicht gesehen werden.",
+		de: "Es lebt in der Ozonschicht hoch über den Wolken und kann vom Boden aus nicht gesehen werden.",
 		'pt-br': "Ele vive na camada de ozônio muito acima das nuvens\ne não pode ser visto do solo.",
 		ko: "구름보다 아득히 먼 위의 오존층에\n서식하고 있기 때문에 지상에서\n모습을 볼 수 없다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/067.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/067.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Son corps est composé d'un gaz très instable.\nIl se fait emporter par la moindre brise, mais\nn'a pas l'air de s'en soucier pour autant.",
 		es: "Hasta la brisa más leve es capaz de arrastrar\nsu cuerpo, compuesto de una materia gaseosa\ninestable, pero no parece que eso le moleste.",
 		it: "Il suo corpo è formato da un gas instabile. Potrebbe volare via\nal minimo soffio di vento, ma non sembra preoccuparsene.",
-		de: "Da sein Körper aus Gas besteht, kann es schon\nvon einem leichten Luftzug weggeweht werden.\nAber das scheint ihm nichts auszumachen.",
+		de: "Da sein Körper aus Gas besteht, kann es schon von einem leichten Luftzug weggeweht werden. Aber das scheint ihm nichts auszumachen.",
 		'pt-br': "Seu corpo indefeso e gasoso pode ser carregado por\nbrisas leves, mas Cosmog não parece se importar muito.",
 		ko: "의지할 곳 없는 가스 상태의 몸은\n약한 바람에도 휩쓸리지만,\n전혀 신경 쓰지 않는 듯하다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/068.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/068.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Rockruff",
-		fr: "Rocabot"
+		fr: "Rocabot",
+		de: "Wuffels"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il attaque ses proies à l'aide de ses griffes\net de ses crocs acérés. Il obéira toujours\nà son Dresseur s'il lui fait confiance.",
 		es: "Ataca a sus presas con sus afilados colmillos y\ngarras. Solo obedece las órdenes de aquellos\nEntrenadores que logran ganarse su confianza.",
 		it: "Caccia la sua preda usando le zanne e gli artigli affilatissimi.\nAscolta fedelmente le indicazioni degli Allenatori di cui si fida.",
-		de: "Es greift seine Beute mit scharfen Fangzähnen\nund Krallen an. Vertraut es einem Trainer,\nbefolgt es treu dessen Anweisungen.",
+		de: "Es greift seine Beute mit scharfen Fangzähnen und Krallen an. Vertraut es einem Trainer, befolgt es treu dessen Anweisungen.",
 		'pt-br': "Lycanroc ataca suas presas com seus caninos\ne garras afiadas. Obedece lealmente às instruções\nde um Treinador em quem confia.",
 		ko: "날카로운 발톱과 이빨로 먹이를 공격한다.\n신뢰하는 트레이너의 지시에는\n충실히 따른다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/069.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/069.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Exeggcute",
-		fr: "Noeunoeuf"
+		fr: "Noeunoeuf",
+		de: "Owei"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "L'exposition aux rayons éblouissants du soleil a\nrévélé sa véritable apparence et son potentiel réel.",
 		es: "Los intensos rayos solares que bañan su hábitat le han conferido\nun poder y aspecto que muchos consideran su forma original.",
 		it: "L'esposizione a intensi raggi solari ha risvegliato\nl'aspetto e il potere originari di questo Pokémon.",
-		de: "Durch starke Sonneneinstrahlung wurden seine\neigentlichen Kräfte und seine wahre Gestalt freigesetzt.",
+		de: "Durch starke Sonneneinstrahlung wurden seine eigentlichen Kräfte und seine wahre Gestalt freigesetzt.",
 		'pt-br': "A luz solar escaldante revelou a verdadeira forma\ne os poderes deste Pokémon.",
 		ko: "쨍쨍 내리쬐는 태양 빛을\n받은 결과 본래의\n모습과 능력이 각성되었다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/070.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/070.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Alolan Vulpix",
-		fr: "Goupix d’Alola"
+		fr: "Goupix d’Alola",
+		de: "Alola-Vulpix"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Parce qu'il vivait dans une montagne enneigée\nqui abritait une divinité, on le considérait jadis\ncomme un avatar de cette dernière.",
 		es: "Antaño lo veneraban como la encarnación de una deidad\nque se creía que moraba en las montañas nevadas.",
 		it: "In passato viveva su un impenetrabile monte innevato,\ndimora di una divinità di cui era considerato l'incarnazione.",
-		de: "Einst lebte es auf einem schneebedeckten Berg,\nder auch die Heimat einer Gottheit war, weshalb\nes als deren Verkörperung verehrt wurde.",
+		de: "Einst lebte es auf einem schneebedeckten Berg, der auch die Heimat einer Gottheit war, weshalb es als deren Verkörperung verehrt wurde.",
 		'pt-br': "Uma divindade vive nas montanhas nevadas que são o lar\ndeste Pokémon. Em tempos antigos, foi venerado como\na encarnação dessa divindade.",
 		ko: "눈으로 폐쇄된 신이 사는\n산에 살았기 때문에 과거에는\n신의 화신으로 숭상받아왔다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/071.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/071.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il boxe les arbres et mange les Baies qui\nen tombent, ce qui lui permet de s'entraîner\net de se nourrir en même temps.",
 		es: "Propina puñetazos a los árboles y devora las\nbayas que caen al suelo tras el impacto. Esto le\npermite entrenar y alimentarse al mismo tiempo.",
 		it: "Prende a pugni gli alberi, per poi cibarsi delle\nbacche che cadono dai rami. In questo modo,\nsi allena e si procaccia il cibo simultaneamente.",
-		de: "Dieses Pokémon boxt Bäume und frisst dann die Beeren,\ndie von ihnen herabfallen. So gelangt es an Nahrung und\nkann gleichzeitig trainieren.",
+		de: "Dieses Pokémon boxt Bäume und frisst dann die Beeren, die von ihnen herabfallen. So gelangt es an Nahrung und kann gleichzeitig trainieren.",
 		'pt-br': "Este Pokémon esmurra árvores e come as frutas que\ncaem, treinando e conseguindo comida ao mesmo tempo.",
 		ko: "나무를 때려서 떨어진 나무열매를 먹는다.\n트레이닝도 되고 먹이도 구해져서\n그야말로 일석이조다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/072.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/072.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Dans les décharges d'Alola, une centaine d'entre\neux dévorent les immondices avec diligence.",
 		es: "En los vertederos de Alola habitan unos 100\nejemplares que devoran la basura con diligencia.",
 		it: "Negli impianti di smaltimento rifiuti di Alola ne vivono circa\n100 esemplari che lavorano sodo mangiando rifiuti in quantità.",
-		de: "Die Müllanlagen Alolas beherbergen rund hundert\nExemplare dieses Pokémon. Sie sind fleißig dabei,\nriesige Mengen an Müll zu vertilgen.",
+		de: "Die Müllanlagen Alolas beherbergen rund hundert Exemplare dieses Pokémon. Sie sind fleißig dabei, riesige Mengen an Müll zu vertilgen.",
 		'pt-br': "Há cerca de cem deles vivendo no lixão de Alola.\nEles todos trabalham duro e comem muito lixo.",
 		ko: "알로라의 쓰레기 처리장에서는\n약 100마리가 살고 있다. 모두\n쓰레기를 많이 먹는 유능한 일꾼이다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/073.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/073.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Trumbeak",
-		fr: "Piclairon"
+		fr: "Piclairon",
+		de: "Trompeck"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Ils communiquent entre eux en se frappant\nmutuellement sur le bec. La force et la cadence\ndes coups en disent long sur leur état d'esprit.",
 		es: "Se comunican con sus compañeros chocando los\npicos. El número de veces y la fuerza con la que\nlo hacen transmiten sus distintos sentimientos.",
 		it: "I Toucannon comunicano tra di loro sbattendo i becchi. La forza\ne il numero dei colpi indicano i sentimenti che vogliono esprimere.",
-		de: "Sie kommunizieren miteinander, indem sie ihre\nSchnäbel gegeneinanderschlagen. Stärke und\nAnzahl der Schläge übermitteln ihre Gefühle.",
+		de: "Sie kommunizieren miteinander, indem sie ihre Schnäbel gegeneinanderschlagen. Stärke und Anzahl der Schläge übermitteln ihre Gefühle.",
 		'pt-br': "Batem os bicos com outros de sua espécie\npara se comunicar. A quantidade e a força das bicadas\ndemonstram como estão se sentindo.",
 		ko: "동료와 부리를 부딪히며\n커뮤니케이션한다. 부딪히는 강도나\n횟수로 기분을 전달한다."
 	},

--- a/data/Pokémon TCG Pocket/Promos-A/075.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/075.ts
@@ -6,7 +6,8 @@ const card: Card = {
 
 	name: {
 		en: "Kartana",
-		es: "Kartana"
+		es: "Kartana",
+		de: "Katagami"
 	},
 
 	illustrator: "Hasuno",
@@ -20,6 +21,7 @@ const card: Card = {
 	description: {
 		en: "This Ultra Beast's body, which is as thin\nas paper, is like a sharpened sword.",
 		es: "El cuerpo de este Ultraente es fino como el papel\ny tan cortante como una espada recién afilada",
+		de: "Der Körper dieser Ultrabestie ist dünn wie Papier und so scharfkantig wie eine geschliffene Klinge."
 	},
 
 	stage: "Basic",
@@ -27,7 +29,8 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Thrash Metal",
-			es: "Thrash Metal"
+			es: "Thrash Metal",
+			de: "Thrash Metal"
 		},
 
 		damage: 40,

--- a/data/Pokémon TCG Pocket/Promos-A/076.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/076.ts
@@ -6,7 +6,8 @@ const card: Card = {
 
 	name: {
 		en: "Blacephalon",
-		es: "Blacephalon"
+		es: "Blacephalon",
+		de: "Kopplosio"
 	},
 
 	illustrator: "Hasuno",
@@ -20,6 +21,7 @@ const card: Card = {
 	description: {
 		en: "It slithers toward people. Then, without warning, it triggers the\nexplosion of its own head. It's apparently one kind of Ultra Beast.",
 		es: "Parece ser uno de los temibles Ultraentes. Se acerca a la gente\ncontoneándose y hace explotar su propia cabeza súbitamente",
+		de: "Dieses Wesen ist vermutlich eine Ultrabestie. Es nähert sich Menschen tänzelnd, nur um dann plötzlich seinen Kopf explodieren zu lassen."
 
 	},
 
@@ -28,7 +30,8 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Beat Punk",
-			es: "Beat Punk"
+			es: "Beat Punk",
+			de: "Beat Punk"
 		},
 
 		damage: 130,
@@ -36,7 +39,8 @@ const card: Card = {
 
 		effect: {
 			en: "This Pokémon also does 70 damage to itself.",
-			es: "Este Pokémon también se hace 70 puntos de daño a si mismo"
+			es: "Este Pokémon también se hace 70 puntos de daño a si mismo",
+			de: "Dieses Pokémon fügt auch sich selbst 70 Schadenspunkte zu."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Promos-A/077.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/077.ts
@@ -6,7 +6,8 @@ const card: Card = {
 
 	name: {
 		en: "Xurkitree",
-		es: "Xurkitree"
+		es: "Xurkitree",
+		de: "Voltriant"
 	},
 
 	illustrator: "Shin Nagasawa",
@@ -19,7 +20,8 @@ const card: Card = {
 
 	description: {
 		en: "Although it's alien to this world and a danger here, it's apparently\na common organism in the world where it normally lives.",
-		es: "Para los seres de este mundo resulta extraño y peligroso, pero\nen el mundo del que procede es una criatura muy común."
+		es: "Para los seres de este mundo resulta extraño y peligroso, pero\nen el mundo del que procede es una criatura muy común.",
+		de: "In dieser Welt wirkt sein Aussehen gefährlich und fremdartig, doch in seiner ursprünglichen Welt ist es ein ganz gewöhnliches Lebewesen."
 	},
 
 	stage: "Basic",
@@ -27,7 +29,8 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Electronica",
-			es: "Electrónica"
+			es: "Electrónica",
+			de: "Electronica"
 		},
 
 		damage: 60,
@@ -35,7 +38,8 @@ const card: Card = {
 
 		effect: {
 			en: "Your opponent's Active Pokémon is now Confused.",
-			es: "El Pokémon Activo de tu rival pasa a estar Confundido"
+			es: "El Pokémon Activo de tu rival pasa a estar Confundido",
+			de: "Das Aktive Pokémon deines Gegners ist jetzt verwirrt."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Promos-A/078.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/078.ts
@@ -6,7 +6,8 @@ const card: Card = {
 
 	name: {
 		en: "Dawn Wings Necrozma",
-		es: "Necrozma Alas del Alba"
+		es: "Necrozma Alas del Alba",
+		de: "Morgenschwingen-Necrozma"
 	},
 
 	illustrator: "nagimiso",
@@ -19,7 +20,8 @@ const card: Card = {
 
 	description: {
 		en: "Lunala no longer has a will of its own. Now under the\ncontrol of Necrozma, it continuously expels all of its energy.",
-		es: "En esta forma, Lunala no goza de voluntad propia. Necrozma\ntiene control absoluto y absorbe su energía poco a poco."
+		es: "En esta forma, Lunala no goza de voluntad propia. Necrozma\ntiene control absoluto y absorbe su energía poco a poco.",
+		de: "In dieser Form unterliegt Lunala gänzlich Necrozmas Kontrolle, es hat keinen eigenen Willen mehr. Seine Energie fließt ungehindert aus."
 	},
 
 	stage: "Basic",
@@ -27,7 +29,8 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Psychobilly",
-			es: "Psychobilly"
+			es: "Psychobilly",
+			de: "Psychobilly"
 		},
 
 		damage: 100,
@@ -35,7 +38,8 @@ const card: Card = {
 
 		effect: {
 			en: "This Pokémon also does 30 damage to itself.",
-			es: "Este Pokémon también se hace 30 puntos de daño a sí mismo."
+			es: "Este Pokémon también se hace 30 puntos de daño a sí mismo.",
+			de: "Dieses Pokémon fügt auch sich selbst 30 Schadenspunkte zu."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Promos-A/079.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/079.ts
@@ -6,7 +6,8 @@ const card: Card = {
 
 	name: {
 		en: "Dusk Mane Necrozma",
-		es: "Necrozma Melena Crepuscular"
+		es: "Necrozma Melena Crepuscular",
+		de: "Abendmähne-Necrozma"
 	},
 
 	illustrator: "nagimiso",
@@ -19,7 +20,8 @@ const card: Card = {
 
 	description: {
 		en: "This is its form while it is devouring the light of\nSolgaleo. It pounces on foes and then slashes\nthem with the claws on its four limbs and back.",
-		es: "Forma que adopta tras alimentarse de la luz de Solgaleo.\nSe lanza sobre su oponente y lo desgarra sin piedad."
+		es: "Forma que adopta tras alimentarse de la luz de Solgaleo.\nSe lanza sobre su oponente y lo desgarra sin piedad.",
+		de: "Necrozma nimmt diese Form an, wenn es das Licht von Solgaleo verschlingt. Es schlitzt Gegner mit seinen vielen scharfen Krallen auf."
 	},
 
 	stage: "Basic",
@@ -27,7 +29,8 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Black Metal",
-			es: "Black Metal"
+			es: "Black Metal",
+			de: "Black Metal"
 		},
 
 		damage: 100,
@@ -35,7 +38,8 @@ const card: Card = {
 
 		effect: {
 			en: "Discard a {M} Energy from this Pokémon.",
-			es: "Descarta 1 Energía {M} de este Pokémon."
+			es: "Descarta 1 Energía {M} de este Pokémon.",
+			de: "Lege 1 {M}-Energie von diesem Pokémon ab."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Promos-A/080.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/080.ts
@@ -6,7 +6,8 @@ const card: Card = {
 
 	name: {
 		en: "Stakataka",
-		es: "Stakataka"
+		es: "Stakataka",
+		de: "Muramura"
 	},
 
 	illustrator: "Shin Nagasawa",
@@ -19,7 +20,8 @@ const card: Card = {
 
 	description: {
 		en: "It appeared from an Ultra Wormhole. Each one\nappears to be made up of many life-forms\nstacked one on top of each other.",
-		es: "Surgió de un Ultraumbral. Parece estar compuesto de varias\n criaturas que se han combinado para formar un solo ser."
+		es: "Surgió de un Ultraumbral. Parece estar compuesto de varias\n criaturas que se han combinado para formar un solo ser.",
+		de: "Diese Kreatur kam durch eine Ultrapforte. Sie besteht anscheinend aus mehreren aufeinandergestapelten Wesen."
 	},
 
 	stage: "Basic",
@@ -27,7 +29,8 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Brass Rock",
-			es: "Brass Rock"
+			es: "Brass Rock",
+			de: "Brass Rock"
 		},
 
 		damage: 40,
@@ -35,7 +38,8 @@ const card: Card = {
 
 		effect: {
 			en: "During your opponent's next turn, this Pokémon takes −20 damage from attacks.",
-			es: "Durante el próximo turno de tu rival, los ataques hacen -20 puntos de daño a este Pokémon."
+			es: "Durante el próximo turno de tu rival, los ataques hacen -20 puntos de daño a este Pokémon.",
+			de: "Während des nächsten Zuges deines Gegners werden diesem Pokémon durch Attacken - 20 Schadenspunkte zugefügt."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Promos-A/081.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/081.ts
@@ -6,7 +6,8 @@ const card: Card = {
 
 	name: {
 		en: "Ultra Necrozma ex",
-		es: "Ultra-Necrozma ex"
+		es: "Ultra-Necrozma ex",
+		de: "Ultra-Necrozma-ex"
 	},
 
 	illustrator: "PLANETA Tsuji",
@@ -22,7 +23,8 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Photon Claw",
-			es: "Garra Fotónica"
+			es: "Garra Fotónica",
+			de: "Photonenklaue"
 		},
 
 		damage: 60,
@@ -31,7 +33,8 @@ const card: Card = {
 	{
 		name: {
 			en: "Shoegaze",
-			es: "Shoegaze"
+			es: "Shoegaze",
+			de: "Shoegaze"
 		},
 
 		damage: 120,
@@ -39,7 +42,8 @@ const card: Card = {
 
 		effect: {
 			en: "Discard the top 5 cards of each player's deck.",
-			es: "Descarta las 5 primeras cartas de la baraja de cada jugador."
+			es: "Descarta las 5 primeras cartas de la baraja de cada jugador.",
+			de: "Lege die obersten 5 Karten des Decks jedes Spielers ab."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Promos-A/082.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/082.ts
@@ -6,7 +6,8 @@ const card: Card = {
 
 	name: {
 		en: "Poipole",
-		es: "Poipole"
+		es: "Poipole",
+		de: "Venicro"
 	},
 
 	illustrator: "Megumi Mizutani",
@@ -19,7 +20,8 @@ const card: Card = {
 
 	description: {
 		en: "This Ultra Beast is well enough liked to be\nchosen as a first partner in its own world.",
-		es: "En su mundo, este Ultraente se considera tan entrañable\ncomo para ser elegido compañero de viaje."
+		es: "En su mundo, este Ultraente se considera tan entrañable\ncomo para ser elegido compañero de viaje.",
+		de: "Diese Ultrabestie wird in der Welt, aus der sie kommt, so gemocht, dass sie oft als Partner für Reisen gewählt wird."
 	},
 
 	stage: "Basic",
@@ -27,7 +29,8 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "2-Step",
-			es: "2-Step"
+			es: "2-Step",
+			de: "2-Step"
 		},
 
 		damage: 20,
@@ -35,7 +38,8 @@ const card: Card = {
 
 		effect: {
 			en: "Flip 2 coins. This attack does 20 damage for each heads.",
-			es: "Lanza 2 monedas. Este ataque hace 20 puntos de daño por cada cara."
+			es: "Lanza 2 monedas. Este ataque hace 20 puntos de daño por cada cara.",
+			de: "Wirf 2 Münzen. Diese Attacke fügt 20 Schadenspunkte pro Kopf zu."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Promos-A/083.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/083.ts
@@ -6,7 +6,8 @@ const card: Card = {
 
 	name: {
 		en: "Stufful",
-		es: "Stufful"
+		es: "Stufful",
+		de: "Velursi"
 	},
 
 	illustrator: "Kanako Eo",
@@ -19,7 +20,8 @@ const card: Card = {
 
 	description: {
 		en: "Its fluffy fur is a delight to pet, but carelessly reaching out\nto touch this Pokémon could result in painful retaliation.",
-		es: "Su suave pelaje invita a acariciarlo, pero quien cometa\nsemejante temeridad recibirá un severo escarmiento."
+		es: "Su suave pelaje invita a acariciarlo, pero quien cometa\nsemejante temeridad recibirá un severo escarmiento.",
+		de: "Sein Pelz ist wunderbar flauschig. Wagt man es jedoch, diesen zu berühren, setzt es sich ohne Rücksicht auf Verluste zur Wehr."
 	},
 
 	stage: "Basic",
@@ -27,7 +29,8 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Ram",
-			es: "Apisonar"
+			es: "Apisonar",
+			de: "Ramme"
 		},
 
 		damage: 40,

--- a/data/Pokémon TCG Pocket/Promos-A/084.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/084.ts
@@ -6,7 +6,8 @@ const card: Card = {
 
 	name: {
 		en: "Tapu Koko ex",
-		es: "Tapu Koko ex"
+		es: "Tapu Koko ex",
+		de: "Kapu-Riki-ex"
 	},
 
 	illustrator: "PLANETA Tsuji",
@@ -22,7 +23,8 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Plasma Hurricane",
-			es: "Huracán Plasma"
+			es: "Huracán Plasma",
+			de: "Plasmaorkan"
 		},
 
 		damage: 20,
@@ -30,13 +32,15 @@ const card: Card = {
 
 		effect: {
 			en: "Take a {L} Energy from your Energy Zone and attach it to this Pokémon.",
-			es: "Une 1 Energía {L} de tu área de Energía a este Pokémon."
+			es: "Une 1 Energía {L} de tu área de Energía a este Pokémon.",
+			de: "Lege 1 {L}-Energie aus deinem Energiebereich an dieses Pokémon an."
 		}
 	},
 	{
 		name: {
 			en: "Mach Bolt",
-			es: "Rayo Mach"
+			es: "Rayo Mach",
+			de: "Flotter Sprung"
 		},
 
 		damage: 90,

--- a/data/Pokémon TCG Pocket/Promos-A/085.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/085.ts
@@ -6,7 +6,8 @@ const card: Card = {
 
 	name: {
 		en: "Vanillite",
-		es: "Vanillite"
+		es: "Vanillite",
+		de: "Gelatini"
 	},
 
 	illustrator: "OOYAMA",
@@ -19,7 +20,8 @@ const card: Card = {
 
 	description: {
 		en: "Unable to survive in hot areas, it makes itself\ncomfortable by breathing out air cold enough to\ncause snow. It burrows into the snow to sleep.",
-		es: "No puede vivir en lugares muy cálidos. Provoca\nnevadas exhalando un vaho gélido y luego se\nacurruca en la nieve acumulada para dormir."
+		es: "No puede vivir en lugares muy cálidos. Provoca\nnevadas exhalando un vaho gélido y luego se\nacurruca en la nieve acumulada para dormir.",
+		de: "Gelatini kann nicht an warmen Orten leben. Es erzeugt Schnee, indem es kalte Luft ausatmet, und vergräbt sich dann darin, um zu schlafen."
 	},
 
 	stage: "Basic",
@@ -27,7 +29,8 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Sweets Relay",
-			es: "Relevo Dulce"
+			es: "Relevo Dulce",
+			de: "Süße Staffel"
 		},
 
 		damage: 10,
@@ -35,7 +38,8 @@ const card: Card = {
 
 		effect: {
 			en: "If 1 of your Pokémon used Sweets Relay during your last turn, this attack does 20 more damage.",
-			es: "Si 1 de tus Pokémon usó Relevo Dulce durante tu último turno, este ataque hace 20 puntos de daño más."
+			es: "Si 1 de tus Pokémon usó Relevo Dulce durante tu último turno, este ataque hace 20 puntos de daño más.",
+			de: "Wenn 1 deiner Pokémon während deines letzten Zuges Süße Staffel eingesetzt hat, fügt diese Attacke 20 Schadenspunkte mehr zu."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Promos-A/086.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/086.ts
@@ -6,7 +6,8 @@ const card: Card = {
 
 	name: {
 		en: "Jolteon",
-		es: "Jolteon"
+		es: "Jolteon",
+		de: "Blitza"
 	},
 
 	illustrator: "Mizue",
@@ -19,12 +20,14 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Eevee",
-		es: "Eevee"
+		es: "Eevee",
+		de: "Evoli"
 	},
 
 	description: {
 		en: "It concentrates the weak electric charges emitted\nby its cells and launches wicked lightning bolts.",
-		es: "Concentra la débil actividad eléctrica de\nsus células para lanzar dañinas descargas."
+		es: "Concentra la débil actividad eléctrica de\nsus células para lanzar dañinas descargas.",
+		de: "Es sammelt die schwache elektrische Energie, die von seinen Zellen ausgeht, und feuert starke Blitze ab."
 	},
 
 	stage: "Stage1",
@@ -32,7 +35,8 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Beginning Bolt",
-			es: "Descarga de Arranque"
+			es: "Descarga de Arranque",
+			de: "Startspannung"
 		},
 
 		damage: 40,
@@ -40,7 +44,8 @@ const card: Card = {
 
 		effect: {
 			en: "If this Pokémon evolved during this turn, this attack does 20 more damage.",
-			es: "Si este Pokémon ha evolucionado durante este turno, este ataque hace 20 puntos de daño más."
+			es: "Si este Pokémon ha evolucionado durante este turno, este ataque hace 20 puntos de daño más.",
+			de: "Wenn sich dieses Pokémon während dieses Zuges entwickelt hat, fügt diese Attacke 20 Schadenspunkte mehr zu."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Promos-A/087.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/087.ts
@@ -6,7 +6,8 @@ const card: Card = {
 
 	name: {
 		en: "Alcremie",
-		es: "Alcremie"
+		es: "Alcremie",
+		de: "Pokusan"
 	},
 
 	illustrator: "Tika Matsuno",
@@ -19,12 +20,14 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Milcery",
-		es: "Milcery"
+		es: "Milcery",
+		de: "Hokumil"
 	},
 
 	description: {
 		en: "When it trusts a Trainer, it will treat them\nto berries it's decorated with cream.",
-		es: "Obsequia bayas decoradas con nata a\naquellos Entrenadores en los que confía."
+		es: "Obsequia bayas decoradas con nata a\naquellos Entrenadores en los que confía.",
+		de: "Es macht einem Trainer, dem es vertraut, mit Beeren samt Sahnedekoration eine Freude."
 	},
 
 	stage: "Stage1",
@@ -32,7 +35,8 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Sweets Overload",
-			es: "Dulzor Extremo"
+			es: "Dulzor Extremo",
+			de: "Süßer Überfluss"
 		},
 
 		damage: 40,
@@ -40,7 +44,8 @@ const card: Card = {
 
 		effect: {
 			en: "This attack does 40 damage for each time your Pokémon used Sweets Relay during this game.",
-			es: "Este ataque hace 40 puntos de daño por cada vez que tus Pokémon hayan usado Relevo Dulce durante esta partida."
+			es: "Este ataque hace 40 puntos de daño por cada vez que tus Pokémon hayan usado Relevo Dulce durante esta partida.",
+			de: "Diese Attacke fügt für jedes Mal, wenn deine Pokémon in diesem Spiel Süße Staffel eingesetzt haben, 40 Schadenspunkte zu."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Promos-A/088.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/088.ts
@@ -6,7 +6,8 @@ const card: Card = {
 
 	name: {
 		en: "Dragonair",
-		es: "Dragonair"
+		es: "Dragonair",
+		de: "Dragonir"
 	},
 
 	illustrator: "Shinya Komatsu",
@@ -19,12 +20,14 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Dratini",
-		es: "Dratini"
+		es: "Dratini",
+		de: "Dratini"
 	},
 
 	description: {
 		en: "They say that if it emits an aura from its whole\nbody, the weather will begin to change instantly.",
-		es: "Dicen que, cuando su cuerpo desprende un aura,\nel tiempo empieza a cambiar inmediatamente."
+		es: "Dicen que, cuando su cuerpo desprende un aura,\nel tiempo empieza a cambiar inmediatamente.",
+		de: "Man sagt, wenn sein ganzer Körper eine Aura ausstrahle, ändere sich augenblicklich das Wetter in seiner Umgebung."
 	},
 
 	stage: "Stage1",
@@ -32,14 +35,16 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Shed Skin",
-			es: "Mudar"
+			es: "Mudar",
+			de: "Expidermis"
 		},
 
 		cost: ["Colorless"],
 
 		effect: {
 			en: "Heal 30 damage from this Pokémon.",
-			es: "Cura 30 puntos de daño a este Pokémon."
+			es: "Cura 30 puntos de daño a este Pokémon.",
+			de: "Heile 30 Schadenspunkte bei diesem Pokémon."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Promos-A/089.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/089.ts
@@ -6,7 +6,8 @@ const card: Card = {
 
 	name: {
 		en: "Audino",
-		es: "Audino"
+		es: "Audino",
+		de: "Ohrdoch"
 	},
 
 	illustrator: "MAHOU",
@@ -19,7 +20,8 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon has a kind heart. By touching with its feelers,\nAudino can gauge other creatures' feelings and physical conditions.",
-		es: "Un Pokémon gentil que es capaz de comprender\nlos sentimientos y averiguar el estado de salud\nde todo aquel que toque con sus antenas."
+		es: "Un Pokémon gentil que es capaz de comprender\nlos sentimientos y averiguar el estado de salud\nde todo aquel que toque con sus antenas.",
+		de: "Berührt dieses herzensgute Pokémon jemanden mit seinen Fühlern, kann es dessen körperliche Verfassung und Gemütszustand ertasten."
 	},
 
 	stage: "Basic",
@@ -27,7 +29,8 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Drain Slap",
-			es: "Absorbebofetón"
+			es: "Absorbebofetón",
+			de: "Watschensauger"
 		},
 
 		damage: 40,
@@ -35,7 +38,8 @@ const card: Card = {
 
 		effect: {
 			en: "Heal 10 damage from this Pokémon.",
-			es: "Cura 10 puntos de daño a este Pokémon."
+			es: "Cura 10 puntos de daño a este Pokémon.",
+			de: "Heile 10 Schadenspunkte bei diesem Pokémon."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Promos-A/090.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/090.ts
@@ -6,7 +6,8 @@ const card: Card = {
 
 	name: {
 		en: "Togedemaru",
-		es: "Togedemaru"
+		es: "Togedemaru",
+		de: "Togedemaru"
 	},
 
 	illustrator: "sowsow",
@@ -19,7 +20,8 @@ const card: Card = {
 
 	description: {
 		en: "With the long hairs on its back, this Pokémon\ntakes in electricity from other electric Pokémon.\nIt stores what it absorbs in an electric sac.",
-		es: "Utiliza el apéndice de la cabeza para absorber los raoys o los\nataques de los Pokémon de tipo Eléctrico para recargar su bolsa."
+		es: "Utiliza el apéndice de la cabeza para absorber los raoys o los\nataques de los Pokémon de tipo Eléctrico para recargar su bolsa.",
+		de: "Der Schweif an seinem Rücken absorbiert Blitze und Angriffe von Elektro-Pokémon. Es speichert den so gewonnenen Strom in Elektrotaschen."
 	},
 
 	stage: "Basic",
@@ -27,7 +29,8 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Bristling Spikes",
-			es: "Púas Erizadas"
+			es: "Púas Erizadas",
+			de: "Aufgestellte Stacheln"
 		},
 
 		damage: 30,
@@ -35,7 +38,8 @@ const card: Card = {
 
 		effect: {
 			en: "During your opponent's next turn, if this Pokémon is damaged by an attack, do 30 damage to the Attacking Pokémon.",
-			es: "Durante el próximo turno de tu rival, si este Pokémon resulta dañado por un ataque, el Pokémon Atacante sufre 30 puntos de daño."
+			es: "Durante el próximo turno de tu rival, si este Pokémon resulta dañado por un ataque, el Pokémon Atacante sufre 30 puntos de daño.",
+			de: "Wenn diesem Pokémon während des nächsten Zuges deines Gegners durch eine Attacke Schaden zugefügt wird, füge dem Angreifenden Pokémon 30 Schadenspunkte zu."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Promos-A/091.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/091.ts
@@ -6,7 +6,8 @@ const card: Card = {
 
 	name: {
 		en: "Greedent",
-		es: "Greedent"
+		es: "Greedent",
+		de: "Schlaraffel"
 	},
 
 	illustrator: "HYOGONOSUKE",
@@ -19,12 +20,14 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Skwovet",
-		es: "Skwovet"
+		es: "Skwovet",
+		de: "Raffel"
 	},
 
 	description: {
 		en: "This Pokémon makes off with heaps of fallen berries by wrapping\nthem in its tail, which is roughly twice the length of its body.",
-		es: "Su cola es el doble de larga que su cuerpo.\nEnvuelve con ella las bayas que tira de los\nárboles para llevárselas consigo."
+		es: "Su cola es el doble de larga que su cuerpo.\nEnvuelve con ella las bayas que tira de los\nárboles para llevárselas consigo.",
+		de: "Sein Schweif ist etwa doppelt so lang wie sein Körper. Es umwickelt damit von Bäumen gefallene Beeren und trägt sie mit sich fort."
 	},
 
 	stage: "Stage1",
@@ -32,7 +35,8 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Enhanced Fang",
-			es: "Incisivos Mejorados"
+			es: "Incisivos Mejorados",
+			de: "Spezial-Zahn"
 		},
 
 		damage: 50,
@@ -40,7 +44,8 @@ const card: Card = {
 
 		effect: {
 			en: "If this Pokémon has a Pokémon Tool attached, this attack does 50 more damage.",
-			es: "Si este Pokémon tiene 1 Herramienta Pokémon unida a él, este ataque hace 50 puntos de daño más."
+			es: "Si este Pokémon tiene 1 Herramienta Pokémon unida a él, este ataque hace 50 puntos de daño más.",
+			de: "Wenn an dieses Pokémon 1 Pokémon-Ausrüstung angelegt ist, fügt diese Attacke 50 Schadenspunkte mehr zu."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Promos-A/092.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/092.ts
@@ -6,7 +6,8 @@ const card: Card = {
 
 	name: {
 		en: "Eevee",
-		es: "Eevee"
+		es: "Eevee",
+		de: "Evoli"
 	},
 
 	illustrator: "nisimono",
@@ -19,7 +20,8 @@ const card: Card = {
 
 	description: {
 		en: "Its ability to evolve into many forms allows it to\nadapt smoothly and perfectly to any environment.",
-		es: "Es capaz de evolucionar de muchas maneras\npara adaptarse sin problemas a cualquier medio."
+		es: "Es capaz de evolucionar de muchas maneras\npara adaptarse sin problemas a cualquier medio.",
+		de: "Um sich jeder Umgebung perfekt anpassen zu können, ist es in der Lage, sich zu verschiedenen Pokémon zu entwickeln."
 	},
 
 	stage: "Basic",
@@ -27,7 +29,8 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Tackle",
-			es: "Placaje"
+			es: "Placaje",
+			de: "Tackle"
 		},
 
 		damage: 20,

--- a/data/Pokémon TCG Pocket/Promos-A/093.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/093.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Cleffa"
+		en: "Cleffa",
+		de: "Pii"
 	},
 
 	illustrator: "Tika Matsuno",
@@ -17,18 +18,21 @@ const card: Card = {
 	types: ["Psychic"],
 
 	description: {
-		en: "According to local rumors, Cleffa are often seen\nin places where shooting stars have fallen."
+		en: "According to local rumors, Cleffa are often seen\nin places where shooting stars have fallen.",
+		de: "Man erzählt sich, dass überall dort besonders häufig Pii anzutreffen seien, wo einst eine Sternschnuppe eingeschlagen ist."
 	},
 
 	stage: "Basic",
 
 	attacks: [{
 		name: {
-			en: "Twinkly Call"
+			en: "Twinkly Call",
+			de: "Funkelruf"
 		},
 
 		effect: {
-			en: "Put a random Pokémon from your deck into your hand."
+			en: "Put a random Pokémon from your deck into your hand.",
+			de: "Nimm 1 zufälliges Pokémon aus deinem Deck auf deine Hand."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Promos-A/094.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/094.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Horsea"
+		en: "Horsea",
+		de: "Seeper"
 	},
 
 	illustrator: "Taira Akitsu",
@@ -17,20 +18,23 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		en: "Horsea makes its home in oceans with gentle\ncurrents. If this Pokémon is under attack, it spits\nout pitch-black ink and escapes."
+		en: "Horsea makes its home in oceans with gentle\ncurrents. If this Pokémon is under attack, it spits\nout pitch-black ink and escapes.",
+		de: "Es lebt in Meeren mit ruhigem Gezeitenstrom. Wird es angegriffen, versprüht es tiefschwarze Tinte und ergreift daraufhin die Flucht."
 	},
 
 	stage: "Basic",
 
 	attacks: [{
 		name: {
-			en: "Water Arrow"
+			en: "Water Arrow",
+			de: "Wasserpfeil"
 		},
 
 		cost: ["Water"],
 
 		effect: {
-			en: "This attack does 10 damage to 1 of your opponent's Pokémon."
+			en: "This attack does 10 damage to 1 of your opponent's Pokémon.",
+			de: "Diese Attacke fügt 1 Pokémon deines Gegners 10 Schadenspunkte zu."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Promos-A/095.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/095.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Chinchou"
+		en: "Chinchou",
+		de: "Lampi"
 	},
 
 	illustrator: "Aya Kusube",
@@ -17,20 +18,23 @@ const card: Card = {
 	types: ["Lightning"],
 
 	description: {
-		en: "Its antennae, which evolved from a fin, have both\npositive and negative charges flowing through them."
+		en: "Its antennae, which evolved from a fin, have both\npositive and negative charges flowing through them.",
+		de: "Seine Antennen haben sich aus Flossen entwickelt und sind sowohl positiv als auch negativ geladen."
 	},
 
 	stage: "Basic",
 
 	attacks: [{
 		name: {
-			en: "Luring Glow"
+			en: "Luring Glow",
+			de: "Lockendes Glühen"
 		},
 
 		cost: ["Lightning"],
 
 		effect: {
-			en: "Flip a coin. If heads, switch in 1 of your opponent's Benched Pokémon to the Active Spot."
+			en: "Flip a coin. If heads, switch in 1 of your opponent's Benched Pokémon to the Active Spot.",
+			de: "Wirf 1 Münze. Wechsle bei Kopf 1 Pokémon von der Bank deines Gegners in die Aktive Position ein."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Promos-A/096.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/096.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Houndoom"
+		en: "Houndoom",
+		de: "Hundemon"
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -17,25 +18,29 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Houndour"
+		en: "Houndour",
+		de: "Hunduster"
 	},
 
 	description: {
-		en: "If you are burned by the flames it shoots from its\nmouth, the pain will never go away."
+		en: "If you are burned by the flames it shoots from its\nmouth, the pain will never go away.",
+		de: "Wird man von den Flammen getroffen, die es aus seinem Maul schießt, so erleidet man eine Brandwunde, deren Schmerz nie nachlässt."
 	},
 
 	stage: "Stage1",
 
 	attacks: [{
 		name: {
-			en: "Diving Swipe"
+			en: "Diving Swipe",
+			de: "Sturzklau"
 		},
 
 		damage: 70,
 		cost: ["Darkness", "Darkness", "Darkness"],
 
 		effect: {
-			en: "Discard a random card from your opponent's hand."
+			en: "Discard a random card from your opponent's hand.",
+			de: "Lege 1 zufällige Karte aus der Hand deines Gegners auf seinen Ablagestapel."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Promos-A/097.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/097.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Kangaskhan"
+		en: "Kangaskhan",
+		de: "Kangama"
 	},
 
 	illustrator: "Kouki Saitou",
@@ -17,21 +18,24 @@ const card: Card = {
 	types: ["Colorless"],
 
 	description: {
-		en: "Although it's carrying its baby in a pouch on\nits belly, Kangaskhan is swift on its feet. It\nintimidates its opponents with quick jabs."
+		en: "Although it's carrying its baby in a pouch on\nits belly, Kangaskhan is swift on its feet. It\nintimidates its opponents with quick jabs.",
+		de: "Obwohl es sein Junges im Beutel trägt, bewegt sich dieses Pokémon äußerst leichtfüßig. Gegner schreckt Kangama mit blitzschnellen Schlägen ab."
 	},
 
 	stage: "Basic",
 
 	attacks: [{
 		name: {
-			en: "Cross-Cut"
+			en: "Cross-Cut",
+			de: "Überkreuzzerschneider"
 		},
 
 		damage: 20,
 		cost: ["Colorless"],
 
 		effect: {
-			en: "If your opponent's Active Pokémon is an Evolution Pokémon, this attack does 40 more damage."
+			en: "If your opponent's Active Pokémon is an Evolution Pokémon, this attack does 40 more damage.",
+			de: "Wenn das Aktive Pokémon deines Gegners ein Entwicklungs-Pokémon ist, fügt diese Attacke 40 Schadenspunkte mehr zu."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Promos-A/098.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/098.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Blissey ex"
+		en: "Blissey ex",
+		de: "Heiteira-ex"
 	},
 
 	illustrator: "PLANETA CG Works",
@@ -17,7 +18,8 @@ const card: Card = {
 	types: ["Colorless"],
 
 	evolveFrom: {
-		en: "Chansey"
+		en: "Chansey",
+		de: "Chaneira"
 	},
 
 	stage: "Stage1",
@@ -25,14 +27,16 @@ const card: Card = {
 
 	attacks: [{
 		name: {
-			en: "Happy Punch"
+			en: "Happy Punch",
+			de: "Freudenschlag"
 		},
 
 		damage: 100,
 		cost: ["Colorless", "Colorless", "Colorless", "Colorless"],
 
 		effect: {
-			en: "Flip a coin. If heads, heal 60 damage from this Pokémon."
+			en: "Flip a coin. If heads, heal 60 damage from this Pokémon.",
+			de: "Wirf 1 Münze. Heile bei Kopf 60 Schadenspunkte bei diesem Pokémon."
 		}
 	}],
 

--- a/data/Pokémon TCG Pocket/Promos-A/099.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/099.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Marill"
+		en: "Marill",
+		de: "Marill"
 	},
 
 	illustrator: "Shibuzoh.",
@@ -17,14 +18,16 @@ const card: Card = {
 	types: ["Water"],
 
 	description: {
-		en: "The fur on its body naturally repels water. It can\nstay dry even when it plays in the water."
+		en: "The fur on its body naturally repels water. It can\nstay dry even when it plays in the water.",
+		de: "Sein Fell ist von Natur aus wasserabweisend. Es bleibt trocken, auch wenn es im Wasser spielt."
 	},
 
 	stage: "Basic",
 
 	attacks: [{
 		name: {
-			en: "Tackle"
+			en: "Tackle",
+			de: "Tackle"
 		},
 
 		damage: 10,

--- a/data/Pokémon TCG Pocket/Promos-A/100.ts
+++ b/data/Pokémon TCG Pocket/Promos-A/100.ts
@@ -5,7 +5,8 @@ const card: Card = {
 	set: Set,
 
 	name: {
-		en: "Weavile"
+		en: "Weavile",
+		de: "Snibunna"
 	},
 
 	illustrator: "Satoshi Shirai",
@@ -17,18 +18,21 @@ const card: Card = {
 	types: ["Darkness"],
 
 	evolveFrom: {
-		en: "Sneasel"
+		en: "Sneasel",
+		de: "Sniebel"
 	},
 
 	description: {
-		en: "Evolution made it even more devious.\nIt communicates by clawing signs in boulders."
+		en: "Evolution made it even more devious.\nIt communicates by clawing signs in boulders.",
+		de: "Snibunna wurde durch seine Entwicklung noch verschlagener. Es kommuniziert durch in Felsen gekratzte Zeichen."
 	},
 
 	stage: "Stage1",
 
 	attacks: [{
 		name: {
-			en: "Slash"
+			en: "Slash",
+			de: "Schlitzer"
 		},
 
 		damage: 50,


### PR DESCRIPTION
## Add missing German translations for P-A

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
