### PR TITLE
Add missing German translations for A1a

### DIFF
--- a/data/Pokémon TCG Pocket/Mythical Island/001.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/001.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Même s'il ressemble à un tas d'œufs,\nil s'agit bien d'un Pokémon. Il paraît qu'ils\ncommuniquent entre eux par télépathie.",
 		es: "Pese a su aspecto de mera piña de huevos,\nse trata de un Pokémon. Al parecer, sus\ncabezas se comunican entre sí por telepatía.",
 		it: "Somiglia a un mucchio di uova, ma è\nun Pokémon a tutti gli effetti. Pare che\ncomunichi con i suoi simili telepaticamente.",
-		de: "Owei mag zwar Eiern ähneln, ist aber ein echtes\nPokémon, das aus sechs Individuen besteht, die\nwohl telepathisch miteinander kommunizieren.",
+		de: "Owei mag zwar Eiern ähneln, ist aber ein echtes Pokémon, das aus sechs Individuen besteht, die wohl telepathisch miteinander kommunizieren.",
 		'pt-br': "Apesar de parecer só um monte de ovos, é um Pokémon\nde verdade. Exeggcute se comunica com outros de sua\nespécie por meio de telepatia.",
 		ko: "알처럼 보이지만 엄연한\n포켓몬이다. 텔레파시로\n동료와 교신하는 듯하다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/002.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/002.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Exeggcute",
-		fr: "Noeunoeuf"
+		fr: "Noeunoeuf",
+		de: "Owei"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "Chacune de ses trois têtes pense de manière autonome.\nElles ne semblent s'intéresser qu'à elles-mêmes.",
 		es: "Cada una de las tres cabezas piensa\nde forma independiente y apenas\nmuestra interés por el resto.",
 		it: "Le sue tre teste ragionano in\nmodo indipendente. Sembra\nche ciascuna pensi solo a sé.",
-		de: "Jeder der drei Köpfe hat einen\neigenen Willen und scheint sich\nnur für sich selbst zu interessieren.",
+		de: "Jeder der drei Köpfe hat einen eigenen Willen und scheint sich nur für sich selbst zu interessieren.",
 		'pt-br': "Cada uma das três cabeças de Exeggutor está\npensando em coisas diferentes. Elas não parecem\nse interessar umas pelas outras.",
 		ko: "3개의 머리는 서로 다른\n생각을 하고 있다. 자신 외에는\n별로 흥미가 없는 듯하다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/004.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/004.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "La lumière du soleil augmente fortement son agilité.\nSes lianes sont plus habiles que ses mains.",
 		es: "Cuando recibe los rayos de sol, se mueve\nmucho más rápido que de costumbre.\nUsa mejor sus lianas que sus manos.",
 		it: "Quando è esposto alla luce solare può muoversi più\nvelocemente. Usa le sue liane meglio dei suoi stessi arti.",
-		de: "Im Sonnenlicht erhöht sich das Tempo\nseiner Bewegungen. Es ist mit seinen\nSchlingen geschickter als mit den Händen.",
+		de: "Im Sonnenlicht erhöht sich das Tempo seiner Bewegungen. Es ist mit seinen Schlingen geschickter als mit den Händen.",
 		'pt-br': "Quando exposto à luz solar, seus movimentos tornam-se mais\nrápidos. Ele usa as trepadeiras com mais destreza que suas mãos.",
 		ko: "태양의 빛을 받으면\n평소보다 빨리 움직일 수 있다.\n손보다 덩굴을 잘 사용한다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/005.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/005.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Snivy",
-		fr: "Vipélierre"
+		fr: "Vipélierre",
+		de: "Serpifeu"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "Il court comme s'il glissait sur le sol. Il déroute l'ennemi\npar ses mouvements et l'assomme d'un coup de liane.",
 		es: "Parece que se desliza al correr. Engaña a sus rivales\ncon su velocidad y los fustiga con su látigo.",
 		it: "Corre quasi scivolando sulle superfici. Confonde il nemico\ncon i rapidi movimenti, per poi attaccarlo con una frustata.",
-		de: "Huscht beinahe gleitend über den Boden\nund täuscht Gegner mit agilen Manövern,\nbis es mithilfe seiner Efeurute obsiegt.",
+		de: "Huscht beinahe gleitend über den Boden und täuscht Gegner mit agilen Manövern, bis es mithilfe seiner Efeurute obsiegt.",
 		'pt-br': "Move-se pelo chão como se estivesse deslizando.\nAtordoa seus inimigos com movimentos rápidos\ne os ataca com um chicote de vinha.",
 		ko: "땅을 미끄러지듯 달린다.\n빠른 움직임으로 상대를 혼란시키고\n덩굴채찍으로 꼼짝 못하게 한다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/006.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/006.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Servine",
-		fr: "Lianaja"
+		fr: "Lianaja",
+		de: "Efoserp"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "Il ne donnera tout son potentiel que contre un ennemi\npuissant indifférent à son regard écrasant de noblesse.",
 		es: "Tan solo muestra su verdadero poder\na quienes no se amedrentan ante su\nnoble pero inquisitoria mirada.",
 		it: "Dà il meglio di sé solo contro chi non\nresta intimidito dal suo nobile sguardo.",
-		de: "Im Kampf zeigt es nur Gegnern, die seinem\nedlen Blick standhalten, seine wahre Kraft.",
+		de: "Im Kampf zeigt es nur Gegnern, die seinem edlen Blick standhalten, seine wahre Kraft.",
 		'pt-br': "Dá o máximo de si somente contra oponentes fortes\nque não são perturbados pelo brilho intenso dos olhos\nnobres de Serperior.",
 		ko: "샤로다의 고상한 눈동자로\n쏘아보아도 태연할 정도로 강한\n상대에게만 진정한 실력을 발휘한다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/007.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/007.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Ses chapeaux sont délicieux, et les Pokémon\nde la forêt s'en délectent. Heureusement pour lui,\nses couvre-chefs repoussent en une nuit.",
 		es: "Sus sombrerillos tienen un sabor delicioso.\nAunque los Pokémon del bosque se los\ncoman, les vuelven a crecer al día siguiente.",
 		it: "I cappelli sul suo capo sono molto gustosi e i\nPokémon che vivono nei boschi se ne cibano.\nPer fortuna, ricrescono nel giro di una notte.",
-		de: "Sein Pilzhut ist sehr schmackhaft. Er wird zwar\nhäufig von den Pokémon des Waldes verspeist,\nwächst aber über Nacht wieder nach.",
+		de: "Sein Pilzhut ist sehr schmackhaft. Er wird zwar häufig von den Pokémon des Waldes verspeist, wächst aber über Nacht wieder nach.",
 		'pt-br': "Os Pokémon que vivem nas florestas se alimentam dos chapéus na\ncabeça de Morelull. Os chapéus crescem novamente durante a noite.",
 		ko: "머리의 갓은 매우 맛있다.\n숲속의 포켓몬들에게 먹히지만\n하룻밤 만에 재생한다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/008.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/008.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Morelull",
-		fr: "Spododo"
+		fr: "Spododo",
+		de: "Bubungus"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "Il attire ses proies et les endort grâce au\nclignotement de ses spores. Il aspire ensuite\nleur énergie vitale du bout de ses doigts.",
 		es: "Atrae y duerme a su presa con la luz parpadeante\nde sus esporas y luego le absorbe la energía vital\ncon la punta de los dedos.",
 		it: "Attira a sé la preda con la luce intermittente\ndelle sue spore e l'addormenta. Poi ne succhia\nl'energia vitale con le estremità delle dita.",
-		de: "Mit blinkenden Sporen lullt es seine Beute\nin den Schlaf und saugt ihr dann über seine\nFingerspitzen die Lebenskraft aus.",
+		de: "Mit blinkenden Sporen lullt es seine Beute in den Schlaf und saugt ihr dann über seine Fingerspitzen die Lebenskraft aus.",
 		'pt-br': "Os seus esporos tremeluzentes atraem as presas e as deixam adormecidas.\nAssim que este Pokémon coloca a sua presa para dormir, drena a vitalidade\ndela com as pontas dos seus dedos.",
 		ko: "깜빡이는 포자의 빛으로\n먹이를 유인해서 잠들게 한다.\n손끝으로 생기를 흡수한다."
 	},
@@ -57,7 +58,7 @@ const card: Card = {
 			fr: "Le Pokémon Actif de votre adversaire est maintenant Endormi.",
 			es: "El Pokémon Activo de tu rival pasa a estar Dormido.",
 			it: "Il Pokémon attivo del tuo avversario viene addormentato.",
-			de: "Das Aktive Pokémon deines Gegners ist jetzt schläft.",
+			de: "Das Aktive Pokémon deines Gegners schläft jetzt.",
 			
 			ko: "상대의 배틀 포켓몬을 잠듦으로 만든다.",
 			'pt-br': "O Pokémon Ativo do seu oponente agora está Adormecido."

--- a/data/Pokémon TCG Pocket/Mythical Island/009.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/009.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Ce Pokémon Spectre naît lorsque les algues\ndérivant au fond de l'océan se fixent sur\ndes morceaux d'épaves de navire.",
 		es: "Este Pokémon de tipo Fantasma no es sino la\nreencarnación de las algas que flotan a la deriva\ny arrastran consigo vestigios de barcos hundidos.",
 		it: "Alcune alghe, impigliandosi a dei pezzi di\nrelitti sul fondo del mare, si sono tramutate\nin questo Pokémon di tipo Spettro.",
-		de: "Dieses Geister-Pokémon entstand, als sich\nvom Meeresgrund stammendes Seegras auf\nBruchstücken eines Schiffswracks ablagerte.",
+		de: "Dieses Geister-Pokémon entstand, als sich vom Meeresgrund stammendes Seegras auf Bruchstücken eines Schiffswracks ablagerte.",
 		'pt-br': "Depois que um pedaço de alga marinha se fundiu\na destroços de um navio naufragado, renasceu como\neste Pokémon fantasma.",
 		ko: "해저를 떠도는 해초가\n침몰선의 부품을 거두어들여서\n고스트포켓몬으로 다시 태어났다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/010.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/010.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "À la naissance, il ne court pas très vite. C'est en faisant\nla course avec ses camarades qu'il se muscle les jambes.",
 		es: "Al nacer es un poco lento, pero va\nfortaleciendo las patas paulatinamente\nal disputar carreras con sus congéneres.",
 		it: "Appena nato non è un buon corridore, ma col tempo\nirrobustisce le sue zampe rincorrendo i suoi simili.",
-		de: "Nach der Geburt fällt ihm das Laufen schwer.\nDie Wettrennen, die es sich mit seinen Freunden\nliefert, stärken jedoch seine Beinmuskulatur.",
+		de: "Nach der Geburt fällt ihm das Laufen schwer. Die Wettrennen, die es sich mit seinen Freunden liefert, stärken jedoch seine Beinmuskulatur.",
 		'pt-br': "Nasce sem saber correr muito bem, mas, à medida\nque corre com outros da sua espécie, suas pernas\nvão ficando mais fortes.",
 		ko: "갓 태어났을 때는 달리는 것이 서툴다.\n동료와 달리기 경주를 하는 사이에\n하반신이 튼튼하게 성장한다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/011.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/011.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Ponyta",
-		fr: "Ponyta"
+		fr: "Ponyta",
+		de: "Ponita"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "Ce Pokémon traverse les plaines à plus de 240 km/h,\nsa crinière flamboyante flottant au vent.",
 		es: "Su ardiente crin ondea al viento mientras atraviesa\nextensas praderas a una velocidad de 240 km/h.",
 		it: "Sfreccia nelle praterie a una velocità di 240 km/h,\nfacendo sventolare la sua criniera ardente.",
-		de: "Die lodernde Mähne dieses Pokémon flattert im\nWind, wenn es mit einer Geschwindigkeit von\n240 km/h über Felder und Wiesen galoppiert.",
+		de: "Die lodernde Mähne dieses Pokémon flattert im Wind, wenn es mit einer Geschwindigkeit von 240 km/h über Felder und Wiesen galoppiert.",
 		'pt-br': "Este Pokémon pode ser encontrado galopando\nnas pradarias, com sua crina de fogo ao vento,\na velocidades de até 240 km/h.",
 		ko: "불타는 갈기를 휘날리며\n시속 240km의 속도로\n넓은 초원을 달려나간다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/012.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/012.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Il achève ses proies avec ses flammes, mais\nil lui arrive de les calciner accidentellement,\nà son plus grand regret.",
 		es: "Abate a sus presas con las llamas\nque genera y con frecuencia acaba\nreduciéndolas a carbonilla por accidente.",
 		it: "Abbatte le sue prede con le fiamme, ma\nfinisce per carbonizzarle accidentalmente,\ncon suo grande rammarico.",
-		de: "Magmar erlegt seine Beute mit Feuer. Manchmal\nröstet es diese zu seinem Bedauern so stark,\ndass sie versehentlich verkohlt.",
+		de: "Magmar erlegt seine Beute mit Feuer. Manchmal röstet es diese zu seinem Bedauern so stark, dass sie versehentlich verkohlt.",
 		'pt-br': "Magmar incendeia suas presas, mas sempre se\narrepende ao perceber que as reduziu a cinzas.",
 		ko: "불꽃으로 먹이를 꼼짝 못 하게 한다.\n무의식중에 너무 오래 익혀서\n까맣게 태우고는 후회한다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/013.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/013.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "On l'appelait autrefois \" la larve qui a dérobé\nle soleil \". Les flammes qui jaillissent de ses\ncornes peuvent découper une plaque de fer.",
 		es: "Antaño lo llamaron la Larva que Hurtó el Sol.\nLas llamas que brotan de sus cuernos pueden\nfundir sin problema una plancha de acero.",
 		it: "Veniva chiamato la \"larva che ha rubato\nil sole\". Con le fiamme che lancia dalle\ncorna può tagliare anche lastre di ferro.",
-		de: "Man nannte es die \"Larve, welche die Sonne\nstahl\". Die Flammen, die es aus seinen Hörnern\nfeuert, können selbst Eisenplatten zerteilen.",
+		de: "Man nannte es die „Larve, welche die Sonne stahl“. Die Flammen, die es aus seinen Hörnern feuert, können selbst Eisenplatten zerteilen.",
 		'pt-br': "Este Pokémon era chamado de \"Larva que Roubou o Sol\". O fogo\nque Larvesta expele de seus chifres pode cortar uma placa de ferro.",
 		ko: "태양을 훔친 유충이라 불렸었다.\n뿔을 통해 분출하는 불꽃은\n철판도 끊어 버릴 수 있다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/014.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/014.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Larvesta",
-		fr: "Pyronille"
+		fr: "Pyronille",
+		de: "Ignivor"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "Son corps brûlant le rend impopulaire dans les\nrégions chaudes. Toutefois, on le vénère comme\nl'incarnation du soleil dans les régions froides.",
 		es: "El calor que irradia le granjea pocas simpatías en\ntierras cálidas. Por el contrario, en las regiones\nmás frías lo veneran como encarnación del sol.",
 		it: "Chi vive in regioni calde odia il suo corpo\ninfuocato, ma nelle terre più fredde viene\nvenerato come l'incarnazione stessa del sole.",
-		de: "In heißen Gebieten ist sein brennender Körper\nunbeliebt, aber in kalten Gegenden wird es als\nVerkörperung der Sonne verehrt.",
+		de: "In heißen Gebieten ist sein brennender Körper unbeliebt, aber in kalten Gegenden wird es als Verkörperung der Sonne verehrt.",
 		'pt-br': "Seu corpo em chamas faz com que seja impopular em partes quentes\ndo mundo. Mas, em lugares frios, Volcarona é reverenciado como\numa personificação do sol.",
 		ko: "더운 곳에서는 타오르는 몸 때문에\n미움을 받지만, 추운 곳에서는\n태양의 화신이라며 받들어진다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/015.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/015.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Il provoque ses proies afin de les attirer dans\nd'étroites zones rocheuses, puis il les étourdit\navec son gaz toxique avant de les achever.",
 		es: "Provoca a sus presas para conducirlas a zonas\nrocosas y estrechas, donde las aturde con un\ngas venenoso antes de acabar con ellas.",
 		it: "Provoca le sue prede e le attira in stretti luoghi rocciosi,\nper poi stordirle con il suo gas velenoso e abbatterle.",
-		de: "Es provoziert seine Beute und lockt sie\nin enge Felsspalten, wo es sie dann mit\nGiftgas ins Taumeln bringt und erlegt.",
+		de: "Es provoziert seine Beute und lockt sie in enge Felsspalten, wo es sie dann mit Giftgas ins Taumeln bringt und erlegt.",
 		'pt-br': "Provoca suas presas e as atrai para áreas estreitas\ne rochosas. Em seguida, espirra sobre elas um gás\ntóxico para deixá-las atordoadas e dar o bote.",
 		ko: "먹잇감을 도발해서\n좁은 암석 지대로 유인한 뒤\n어지러워지는 독가스를 뿜어서 마무리한다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/016.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/016.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Salandit",
-		fr: "Tritox"
+		fr: "Tritox",
+		de: "Molunk"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "Il étourdit ses adversaires avec son gaz toxique,\npuis il les asservit en exécutant une danse envoûtante.",
 		es: "Convierte a sus rivales en devotos súbditos\ntras marearlos con su gas venenoso y seducirlos\ncon los cautivadores movimientos de su cuerpo.",
 		it: "Trasforma gli avversari in seguaci stordendoli con del\ngas tossico per poi sedurli con movenze ammalianti.",
-		de: "Zuerst benebelt es Gegner mit Giftgas, um sie\ndanach mit fesselnden Körperbewegungen zu\nbetören und zu ergebenen Dienern zu machen.",
+		de: "Zuerst benebelt es Gegner mit Giftgas, um sie danach mit fesselnden Körperbewegungen zu betören und zu ergebenen Dienern zu machen.",
 		'pt-br': "Salazzle deixa os oponentes zonzos com seu\ngás venenoso, depois os cativa com movimentos\nfascinantes para transformá-los em servos leais.",
 		ko: "독가스에 어질어질해진 상대를\n요염한 몸놀림으로 유혹해서\n충실한 부하로 만들어 버린다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/017.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/017.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Un Pokémon tout à fait pathétique. En de très\nrares occasions, il est capable de sauter haut,\nmais jamais à plus de deux mètres.",
 		es: "Un Pokémon desvalido y patético. A veces es\ncapaz de saltar alto, pero rara vez más de 2 m.",
 		it: "Un Pokémon debole e patetico. Nelle rare\noccasioni in cui spicca alti salti, non riesce\ncomunque a raggiungere i due metri.",
-		de: "Ein schwaches und jämmerliches Pokémon.\nManchmal gelingen ihm hohe Sprünge,\naber über 2 m kommt es selten hinaus.",
+		de: "Ein schwaches und jämmerliches Pokémon. Manchmal gelingen ihm hohe Sprünge, aber über 2 m kommt es selten hinaus.",
 		'pt-br': "Este Pokémon é patético e nem um pouco\npoderoso. Às vezes, até pula bem alto,\nmas nunca mais de dois metros.",
 		ko: "힘없는 한심한 포켓몬이다.\n가끔 높이 뛰어오르지만\n2m를 겨우 넘기는 게 고작이다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/018.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/018.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Magikarp",
-		fr: "Magicarpe"
+		fr: "Magicarpe",
+		de: "Karpador"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Mythical Island/019.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/019.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Eevee",
-		fr: "Évoli"
+		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "Il vit au bord de l'eau. Sa queue semblable à celle\nd'un poisson lui donne l'apparence d'une sirène.",
 		es: "Vive cerca del agua. Su cola termina en una\naleta parecida a la de un pez, por lo que hay\ngente que lo confunde con una sirena.",
 		it: "Vive vicino all'acqua. Sulla punta della coda ha una\npinna, per questo alcuni lo scambiano per una sirena.",
-		de: "Dieses Pokémon lebt nahe an Gewässern.\nWegen seiner fischähnlichen Schwanzflosse wird\nes manchmal für eine Meerjungfrau gehalten.",
+		de: "Dieses Pokémon lebt nahe an Gewässern. Wegen seiner fischähnlichen Schwanzflosse wird es manchmal für eine Meerjungfrau gehalten.",
 		'pt-br': "Este Pokémon vive perto da água. A sua longa\ncauda é coberta por uma barbatana e muitas\nvezes é confundida com a de uma sereia.",
 		ko: "물가에 살지만 꼬리에\n물고기처럼 지느러미가 남아 있어서\n인어로 착각하는 사람도 있다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/020.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/020.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "La ligne qui fait le tour de son corps emmagasine\nl'énergie solaire et brille intensément la nuit.",
 		es: "La línea que le recorre el costado puede almacenar\nluz solar. Brilla con mucha fuerza por la noche.",
 		it: "La linea che contorna il suo corpo immagazzina la luce\nsolare. Di notte si illumina di una luce splendente.",
-		de: "Die Linie an seiner Seite kann Sonnenlicht\nspeichern. Nachts leuchtet es sehr intensiv.",
+		de: "Die Linie an seiner Seite kann Sonnenlicht speichern. Nachts leuchtet es sehr intensiv.",
 		'pt-br': "A linha na lateral de seu corpo armazena luz solar\ne brilha intensamente à noite.",
 		ko: "몸 옆쪽에 있는 줄에\n태양 빛을 모아 둘 수 있다.\n밤이 되면 아름답게 빛난다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/021.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/021.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Finneon",
-		fr: "Écayon"
+		fr: "Écayon",
+		de: "Finneon"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "La lumière qu'il émet pour attirer ses\nproies attire également ses prédateurs,\ndes Pokémon poissons féroces.",
 		es: "Atrae a sus presas con el destello que emite,\naunque eso también llama la atención de sus\nferoces depredadores marinos.",
 		it: "Con la sua luce attira le prede, ma anche i feroci\nPokémon acquatici che sono suoi predatori naturali.",
-		de: "Mit seinem Licht lockt es Beute an. Leider\nwerden dadurch auch grausame Fisch-Pokémon\nangezogen – seine natürlichen Fressfeinde.",
+		de: "Mit seinem Licht lockt es Beute an. Leider werden dadurch auch grausame Fisch-Pokémon angezogen – seine natürlichen Fressfeinde.",
 		'pt-br': "Ao brilhar intensamente, atrai as presas para perto. Porém,\na luz também chega a atrair Pokémon peixe ferozes, seus\npredadores naturais.",
 		ko: "빛으로 먹이를 유인하지만\n천적인 사나운 물고기포켓몬까지\n다가온다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/022.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/022.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Son incisive continue à pousser.\nLorsqu'elle le démange, il joue avec un\nde ses congénères et lui mord la corne.",
 		es: "Su gran incisivo no le ha terminado de salir.\nCuando le molesta, juguetea con uno de sus\ncompañeros mordisqueándole el cuerno.",
 		it: "Il suo grande incisivo sta ancora crescendo\ne, quando gli causa prurito, questo Pokémon\ngioca a mordicchiare il corno dei suoi simili.",
-		de: "Juckt sein noch im Wachstum befindlicher großer\nVorderzahn, schnappt es nach dem Horn eines\nArtgenossen und tobt mit diesem herum.",
+		de: "Juckt sein noch im Wachstum befindlicher großer Vorderzahn, schnappt es nach dem Horn eines Artgenossen und tobt mit diesem herum.",
 		'pt-br': "Seu grande incisivo ainda está em crescimento.\nQuando o dente coça, este Pokémon morde o chifre\nde outro Chewtle e os dois entram em uma briga danada.",
 		ko: "커다란 앞니는 난 지 얼마 되지 않았다.\n이빨이 가려울 때는 동료의 뿔을\n덥석 물면서 장난을 친다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/023.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/023.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Chewtle",
-		fr: "Khélocrok"
+		fr: "Khélocrok",
+		de: "Kamehaps"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "Ce Pokémon très agressif peut\nfacilement broyer des rochers grâce à\nson énorme mâchoire en dents de scie.",
 		es: "Con sus fuertes mandíbulas serradas es capaz\nde destrozar rocas de un mordisco. Tiene un\ntemperamento extremadamente violento.",
 		it: "Con la sua grande mascella frastagliata riesce\na frantumare una roccia con un morso. Ha un\ntemperamento estremamente aggressivo.",
-		de: "Ein Biss mit seinem riesigen, gezackten Maul\nreicht aus, um einen Felsbrocken zu zermalmen.\nEs besitzt ein äußerst aggressives Temperament.",
+		de: "Ein Biss mit seinem riesigen, gezackten Maul reicht aus, um einen Felsbrocken zu zermalmen. Es besitzt ein äußerst aggressives Temperament.",
 		'pt-br': "O seu gigantesco dente afiado pode destruir um rochedo\ncom apenas uma mordida. Este Pokémon tem tendências\nextremamente violentas.",
 		ko: "매우 크고 뾰족뾰족한 입은\n한 번 물기만 해도 암석을 부술 정도다.\n성질이 매우 흉포하다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/024.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/024.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Il est assez puissant pour terrasser un\nennemi d'un seul coup, mais il est tellement\nnigaud qu'il oublie contre qui il se bat.",
 		es: "Su colosal potencia le permite machacar al rival\nde un solo golpe, aunque su carácter despistado\nlo lleva a olvidarse de su presencia.",
 		it: "È così potente che può sconfiggere l'avversario\nin un colpo solo, ma è talmente smemorato\nche si dimentica perfino con chi stava lottando.",
-		de: "Es ist so stark, dass es seine Gegner mit einem\nAngriff vernichten könnte, aber zerstreut wie es\nist, vergisst es öfters, wen es gerade bekämpft.",
+		de: "Es ist so stark, dass es seine Gegner mit einem Angriff vernichten könnte, aber zerstreut wie es ist, vergisst es öfters, wen es gerade bekämpft.",
 		'pt-br': "É tão forte que consegue derrubar alguns oponentes com um único golpe,\nmas às vezes se esquece de que está batalhando bem no meio da luta.",
 		ko: "상대를 일격에 쓰러뜨릴 정도로\n파워풀하지만 건망증이 심해서\n싸우고 있는 상대를 잊어버린다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/025.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/025.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Quand il s'énerve, il libère instantanément\nl'énergie emmagasinée dans les poches de\nses joues.",
 		es: "Cuando se enfada, este Pokémon\ndescarga la energía que almacena en\nel interior de las bolsas de las mejillas.",
 		it: "Quando s'arrabbia, libera subito l'energia\naccumulata nelle sacche sulle guance.",
-		de: "Ist es wütend, entlädt sich augenblicklich die\nElektrizität, die es in seinen Backentaschen\ngespeichert hat.",
+		de: "Ist es wütend, entlädt sich augenblicklich die Elektrizität, die es in seinen Backentaschen gespeichert hat.",
 		'pt-br': "Quando está com raiva, descarrega\nimediatamente a energia armazenada\nnas bolsas em suas bochechas.",
 		ko: "양 볼에는 전기를 저장하는 주머니가 있다.\n화가 나면 저장한 전기를 단숨에 방출한다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/026.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/026.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pikachu",
-		fr: "Pikachu"
+		fr: "Pikachu",
+		de: "Pikachu"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "Il se protège des décharges grâce à sa queue,\nqui dissipe l'électricité dans le sol.",
 		es: "Su cola actúa como toma de tierra\ny descarga electricidad al suelo, lo\nque le protege de los calambrazos.",
 		it: "La sua coda scarica elettricità a terra,\nproteggendolo dalle scosse elettriche.",
-		de: "Mithilfe seines Schweifs entlädt es Elektrizität\nin den Boden, um sich auf diese Weise vor\nelektrischen Schlägen zu schützen.",
+		de: "Mithilfe seines Schweifs entlädt es Elektrizität in den Boden, um sich auf diese Weise vor elektrischen Schlägen zu schützen.",
 		'pt-br': "Sua cauda descarrega a eletricidade\nno solo, protegendo-o contra choques.",
 		ko: "꼬리가 어스 역할을 하여\n전기를 지면으로 흘려보내므로\n자신은 감전되거나 하지 않는다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/027.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/027.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "De nombreuses centrales électriques gardent\ndes Pokémon Sol à proximité afin d'empêcher\nles Élektek de leur voler de l'électricité.",
 		es: "Es habitual que las centrales eléctricas cuenten\ncon Pokémon de tipo Tierra para hacer frente\na los Electabuzz ávidos de electricidad.",
 		it: "Molte centrali elettriche utilizzano\nPokémon di tipo Terra per difendersi\ndagli Electabuzz a caccia di elettricità.",
-		de: "In vielen Elektrizitätswerken werden Pokémon\nvom Typ Boden eingesetzt, um Elektek davon\nabzuhalten, den dortigen Strom anzuzapfen.",
+		de: "In vielen Elektrizitätswerken werden Pokémon vom Typ Boden eingesetzt, um Elektek davon abzuhalten, den dortigen Strom anzuzapfen.",
 		'pt-br': "Muitas usinas mantêm Pokémon de tipo Terrestre\npor perto. Fazem isso para protegê-las de Electabuzz\nque aparecem em busca de eletricidade.",
 		ko: "전기를 노리는 에레브를\n퇴치하고자 땅포켓몬을 두는\n발전소도 많다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/029.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/029.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Joltik",
-		fr: "Statitik"
+		fr: "Statitik",
+		de: "Wattzapf"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "Il attaque en projetant les poils de son abdomen\nchargés en électricité. La victime reste alors\nparalysée pendant trois jours et trois nuits.",
 		es: "Ataca lanzando hilos electrificados por el\nabdomen, que inmovilizan por completo al\nenemigo durante tres días y tres noches.",
 		it: "Attacca lanciando peli carichi di elettricità dall'addome.\nChi viene colpito rimane paralizzato per tre giorni interi.",
-		de: "Es schießt elektrisch geladene Haare von seinem\nAbdomen. Wer getroffen wird, ist drei Tage und\nNächte am ganzen Körper gelähmt.",
+		de: "Es schießt elektrisch geladene Haare von seinem Abdomen. Wer getroffen wird, ist drei Tage und Nächte am ganzen Körper gelähmt.",
 		'pt-br': "Para atacar, lança pelos eletrificados do abdômen. Os oponentes que forem\natingidos por estes pelos poderão enfrentar três dias e três noites de paralisia.",
 		ko: "전기를 띤 배의 털을 날려서\n공격한다. 털에 찔리면\n삼 일 밤낮으로 전신이 마비된다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/030.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/030.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Son corps étant petit et son organe générateur\nd'électricité peu développé, il se recharge en\naspirant l'électricité des maisons avec sa queue.",
 		es: "Como es menudo y su órgano electrógeno está\npoco desarrollado, absorbe electricidad de las\ncasas con la cola para recargar sus reservas.",
 		it: "A causa del corpo piccolo, l'organo che genera\nelettricità non è molto sviluppato. Si ricarica\nassorbendo l'elettricità dalle case con la coda.",
-		de: "Da es klein ist und sein elektrisches Organ nicht\nstark ausgebildet ist, zapft es mit seinem Schwanz\nin Häusern Strom ab, um sich aufzuladen.",
+		de: "Da es klein ist und sein elektrisches Organ nicht stark ausgebildet ist, zapft es sich mit seinem Schwanz in Häusern Strom ab, um sich aufzuladen.",
 		'pt-br': "Este Pokémon é pequeno, e seu órgão gerador de eletricidade ainda não se desenvolveu.\nAbastece a si mesmo usando sua cauda, com a qual absorve energia das casas das pessoas.",
 		ko: "몸집이 작고 발전 기관이 미숙하기 때문에\n사람이 사는 집의 전기를\n꼬리를 통해 흡수해서 충전한다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/031.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/031.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Nombre de scientifiques voient en lui l'ancêtre des Pokémon\ncar il maîtrise toutes leurs capacités.",
 		es: "Varios científicos lo consideran el antecesor de los\nPokémon porque usa todo tipo de movimientos.",
 		it: "Poiché sa usare qualsiasi mossa,\nmolti scienziati ritengono che Mew\nsia l'antenato di tutti i Pokémon.",
-		de: "Es beherrscht alle möglichen Attacken, daher sieht\nman in ihm den Vorfahren aller Pokémon.",
+		de: "Es beherrscht alle möglichen Attacken, daher sieht man in ihm den Vorfahren aller Pokémon.",
 		'pt-br': "Como pode usar todos os tipos de movimentos,\nmuitos cientistas acreditam que Mew seja\no ancestral dos Pokémon.",
 		ko: "모든 기술을 사용하기 때문에\n포켓몬의 조상이라고 생각하는\n학자가 많다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/033.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/033.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Il vole grâce à ses pouvoirs psychiques. Certains disent qu'il était\nle dieu protecteur d'une ville antique, d'autres, son messager.",
 		es: "Vuela gracias a sus poderes psíquicos. Dicen que\nhabía sido la deidad protectora de una antigua\nciudad, si bien otros creen que era su mensajero.",
 		it: "Vola grazie ai suoi poteri psichici. Si dice che fosse lo\nspirito custode di un'antica città o il suo messaggero.",
-		de: "Es fliegt mithilfe seiner Psycho-Kräfte. Einige\nsagen, es war einst der Wächter einer Stadt aus\nuralten Zeiten. Andere sagen, es war sein Bote.",
+		de: "Es fliegt mithilfe seiner Psycho-Kräfte. Einige sagen, es war einst der Wächter einer Stadt aus uralten Zeiten. Andere sagen, es war sein Bote.",
 		'pt-br': "O poder psíquico destes Pokémon permite que voem. Há quem diga que eles\neram os guardiões de uma cidade antiga. Outros dizem que, na verdade, eram\nos emissários dos guardiões.",
 		ko: "사이코 파워로 하늘을 난다.\n고대 도시의 수호신 또는\n수호신의 사자로 일컬어진다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/034.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/034.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "S'il se tient près d'une télé, d'étranges panoramas\napparaissent à l'écran. On raconte qu'il s'agirait\nde paysages venus des terres natales de Lewsor.",
 		es: "Cuando se halla junto a un televisor, la pantalla\nmuestra imágenes de extraños paisajes. Se cree\nque corresponden a su lugar de origen.",
 		it: "Quando si trova vicino a un televisore, sullo\nschermo appaiono paesaggi singolari. Si dice\nche siano vedute del luogo da cui proviene.",
-		de: "Wenn es in der Nähe ist, beginnen Fernseher zu\nflackern und fremdartige Landschaften zu zeigen.\nDiese stellen angeblich seine Heimat dar.",
+		de: "Wenn es in der Nähe ist, beginnen Fernseher zu flackern und fremdartige Landschaften zu zeigen. Diese stellen angeblich seine Heimat dar.",
 		'pt-br': "Se este Pokémon estiver próximo a uma televisão,\npaisagens estranhas aparecerão na tela. Dizem que essas\nimagens são do seu lar.",
 		ko: "TV 근처에 있으면 모니터에\n기묘한 풍경이 비친다.\n리그레의 고향이라 여겨지고 있다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/035.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/035.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Elgyem",
-		fr: "Lewsor"
+		fr: "Lewsor",
+		de: "Pygraulon"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "À chaque fois que Neitram se matérialise dans une pâture,\nun Moumouflon disparaît dans des circonstances mystérieuses.",
 		es: "Por algún extraño motivo, siempre que se avista un\nBeheeyem en una granja desaparece un Dubwool.",
 		it: "Per qualche strano motivo, nelle fattorie in cui\ncompare un Beheeyem sparisce sempre un Dubwool.",
-		de: "Jedes Mal, wenn ein Megalon auf einer Farm\nauftaucht, verschwindet bald darauf ein\nZwollock unter mysteriösen Umständen.",
+		de: "Jedes Mal, wenn ein Megalon auf einer Farm auftaucht, verschwindet bald darauf ein Zwollock unter mysteriösen Umständen.",
 		'pt-br': "Sempre que um Beheeyem visita uma fazenda,\num Dubwool desaparece misteriosamente.",
 		ko: "벰크가 나타난 목장에서는\n배우르 1마리가\n어느샌가 모습을 감춘다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/036.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/036.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Ce Pokémon parvient à extraire l'énergie\ncachée des fleurs sauvages. Il aime\nparticulièrement les fleurs rouges.",
 		es: "Posee el don de extraer el poder oculto de\nlas flores silvestres. Siente una predilección\nespecial por las flores rojas.",
 		it: "Possiede il dono di estrarre la forza\nnascosta dei fiori che sbocciano nei campi.\nAma in particolar modo i fiori rossi.",
-		de: "Dieses Pokémon ist in der Lage, Wildblumen\nihre geheimen Kräfte zu entlocken. Rote\nBlumen haben es ihm besonders angetan.",
+		de: "Dieses Pokémon ist in der Lage, Wildblumen ihre geheimen Kräfte zu entlocken. Rote Blumen haben es ihm besonders angetan.",
 		'pt-br': "Este Pokémon é capaz de trazer à tona o poder escondido\nno florescer das flores silvestres. Gosta especialmente de flores vermelhas.",
 		ko: "들판에 핀 꽃에 숨겨진 힘을\n끌어내는 능력을 가지고 있다.\n특히 빨간 꽃을 좋아한다."
 	},
@@ -51,7 +51,7 @@ const card: Card = {
 			fr: "Le Pokémon Actif de votre adversaire est maintenant Endormi.",
 			es: "El Pokémon Activo de tu rival pasa a estar Dormido.",
 			it: "Il Pokémon attivo del tuo avversario viene addormentato.",
-			de: "Das Aktive Pokémon deines Gegners ist jetzt schläft.",
+			de: "Das Aktive Pokémon deines Gegners schläft jetzt.",
 			
 			ko: "상대의 배틀 포켓몬을 잠듦으로 만든다.",
 			'pt-br': "O Pokémon Ativo do seu oponente agora está Adormecido."

--- a/data/Pokémon TCG Pocket/Mythical Island/037.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/037.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Flabébé",
-		fr: "Flabébé"
+		fr: "Flabébé",
+		de: "Flabébé"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "Ce Pokémon parvient à canaliser le peu d'énergie\nencore présent dans les fleurs fanées pour leur\nredonner du tonus. Il tient une fleur rouge.",
 		es: "Puede extraer la fuerza que les resta\na las flores marchitas para reanimarlas.\nLleva consigo una flor de color rojo.",
 		it: "Riesce a tirare fuori l'energia rimasta\nnei fiori ormai secchi, rivitalizzandoli.\nQuesto Floette stringe un fiore rosso.",
-		de: "Es entlockt verwelkten Blumen ihre letzte Kraft\nund nutzt diese, um sie wieder aufzupäppeln.\nDieses Exemplar trägt eine rote Blume.",
+		de: "Es entlockt verwelkten Blumen ihre letzte Kraft und nutzt diese, um sie wieder aufzupäppeln. Dieses Exemplar trägt eine rote Blume.",
 		'pt-br': "Este Pokémon revitaliza o resquício de força\nem flores murchas para torná-las saudáveis de novo.\nEle segura uma flor vermelha.",
 		ko: "시든 꽃의 남은 힘을\n끌어내어 건강해지게 한다.\n빨간 꽃을 들고 있는 플라엣테."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/038.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/038.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Floette",
-		fr: "Floette"
+		fr: "Floette",
+		de: "Floette"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "Ce Pokémon transforme son territoire en\nmagnifique jardin fleuri. Il tire sa puissance\ndes fleurs rouges qui ornent son cou.",
 		es: "Hace de su territorio un jardín esplendoroso.\nExtrae su poder de las flores rojas que lleva\nen torno al cuello.",
 		it: "Questo Pokémon trasforma il proprio territorio\nin uno splendido giardino fiorito. I suoi poteri\nderivano dai fiori rossi che ha attorno al collo.",
-		de: "In seinem Revier legt Florges einen prächtigen\nBlumengarten an. Es schöpft seine Kraft aus\nden roten Blumen um seinen Hals.",
+		de: "In seinem Revier legt Florges einen prächtigen Blumengarten an. Es schöpft seine Kraft aus den roten Blumen um seinen Hals.",
 		'pt-br': "Este Pokémon cria um jardim de flores impressionante em seu território.\nTraz consigo o poder das flores vermelhas ao redor do seu pescoço.",
 		ko: "자신의 영역에 멋진 화원을 만든다.\n목을 감싸고 있는\n빨간 꽃의 파워를 끌어낸다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/039.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/039.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Il mange son propre poids en sucre chaque\njour. S'il n'a pas sa dose de sucreries,\nil devient horriblement grognon.",
 		es: "Ingiere diariamente una cantidad de azúcar\nequivalente a su peso corporal. De lo contrario,\nse pone de muy mal humor.",
 		it: "Mangia ogni giorno una quantità di zucchero\npari al peso del suo corpo. Quando il suo livello\ndi glucosio cala troppo, diventa di cattivo umore.",
-		de: "Die Menge an Zucker, die es pro Tag verschlingt,\nentspricht seinem Körpergewicht. Bekommt es\nnicht genügend Zucker, wird es unausstehlich.",
+		de: "Die Menge an Zucker, die es pro Tag verschlingt, entspricht seinem Körpergewicht. Bekommt es nicht genügend Zucker, wird es unausstehlich.",
 		'pt-br': "Come o equivalente ao seu próprio peso em açúcar todos os dias.\nSe não consumir açúcar suficiente, ficará absurdamente mal-humorado.",
 		ko: "하루에 자신의 체중만큼의\n설탕을 먹는다. 당분이\n부족하면 매우 기분이 나빠진다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/040.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/040.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Swirlix",
-		fr: "Sucroquin"
+		fr: "Sucroquin",
+		de: "Flauschling"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "Il peut diagnostiquer l'état de santé mentale et\nphysique de quelqu'un rien qu'à l'odorat. Un tel\ndon pourrait avoir des applications en médecine.",
 		es: "Puede percibir el estado físico y mental de\nalguien solo con olerlo, lo que podría tener\naplicaciones útiles en el campo de la medicina.",
 		it: "È in grado di comprendere lo stato fisico e\nmentale altrui dall'odore. Questa capacità\npotrebbe essere molto utile in campo medico.",
-		de: "Es kann die körperliche und seelische Verfassung\nanderer anhand ihres Körpergeruchs erkennen.\nDies versucht man für die Medizin zu nutzen.",
+		de: "Es kann die körperliche und seelische Verfassung anderer anhand ihres Körpergeruchs erkennen. Dies versucht man für die Medizin zu nutzen.",
 		'pt-br': "Pelo aroma de uma pessoa, consegue detectar sua condição física e mental.\nEspera-se que um dia esta técnica tenha muitas aplicações na medicina.",
 		ko: "체취로 몸과 마음의 상태를\n알아낸다. 의료계에서 응용될\n것으로 기대되고 있다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/041.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/041.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Il vit en groupe au sommet des arbres. S'il perd\nses congénères de vue, la solitude le rend furieux.",
 		es: "Vive en grupos en las copas de\nlos árboles. Si pierde de vista a su\nmanada, se siente solo y se enfada.",
 		it: "Vivono in branchi in cima agli alberi. Se perdono\nil contatto con il gruppo s'infuriano per la solitudine.",
-		de: "Es lebt mit Artgenossen in Baumkronen.\nVerliert es sie aus den Augen, wird es\nvor Einsamkeit sofort zornig.",
+		de: "Es lebt mit Artgenossen in Baumkronen. Verliert es sie aus den Augen, wird es vor Einsamkeit sofort zornig.",
 		'pt-br': "Vive em grupo no topo de árvores.\nSe perde seu grupo de vista, a solidão\ndeixa este Pokémon furioso.",
 		ko: "나무 위에 무리 지어 산다.\n무리에서 떨어진 망키는\n외로운 나머지 금방 화를 낸다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/042.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/042.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Mankey",
-		fr: "Férosinge"
+		fr: "Férosinge",
+		de: "Menki"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "Il devient fou furieux s'il se sent observé\net pourchasse tout être qui croise son regard.",
 		es: "Se pone furioso si nota que alguien lo\nestá mirando. Persigue a cualquiera\nque establezca contacto visual con él.",
 		it: "Diventa furioso se si sente osservato.\nInsegue chiunque incontri il suo sguardo.",
-		de: "Spürt Rasaff, dass jemand es anblickt, wird es\nrasend vor Wut. Es verfolgt jeden, der es wagt,\nseinen Blick zu erwidern.",
+		de: "Spürt Rasaff, dass jemand es anblickt, wird es rasend vor Wut. Es verfolgt jeden, der es wagt, seinen Blick zu erwidern.",
 		'pt-br': "Fica incrivelmente furioso se perceber que\nestá sendo observado. Persegue qualquer\num que o encarar.",
 		ko: "누군가의 시선을 느끼기만 해도\n대단히 화를 낸다. 그리고\n눈이 마주친 상대를 쫓아다닌다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/043.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/043.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Les aspérités de Racaillou s'adoucissent au fil\ndes années, tout comme sa personnalité.\nIl devient tout lisse, tout rond, et tout calme.",
 		es: "Con la edad, su temperamento se amansa\ny su cuerpo se va alisando hasta adquirir\nuna forma completamente redonda.",
 		it: "Col passare degli anni le asperità del suo corpo\nvengono levigate, rendendolo perfettamente\nrotondo, e il suo carattere si fa più tranquillo.",
-		de: "Mit dem Alter verliert es zunehmend seine\nKantigkeit, bis es vollkommen rund und auch\ncharakterlich immer ausgeglichener wird.",
+		de: "Mit dem Alter verliert es zunehmend seine Kantigkeit, bis es vollkommen rund und auch charakterlich immer ausgeglichener wird.",
 		'pt-br': "Geodude que já viveram muito são completamente\nredondos, porque todas as irregularidades foram polidas\npelo tempo. Sua natureza também se torna calma e tranquila.",
 		ko: "오래 산 꼬마돌은 모가 없이\n동그랗다. 성격도 매우\n차분하고 온화하다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/044.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/044.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Geodude",
-		fr: "Racaillou"
+		fr: "Racaillou",
+		de: "Kleinstein"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "Il escalade les falaises pour en atteindre\nles sommets. Une fois tout en haut, il se\nlaisse rouler par le chemin d'où il est arrivé.",
 		es: "Escala los riscos de las montañas\ny, una vez alcanzada la cima,\ndesciende rodando por los senderos.",
 		it: "Scala le pareti scoscese delle montagne e, una volta\nraggiunta la vetta, rotola giù lungo lo stesso percorso.",
-		de: "Es klettert Berghänge bis zum Gipfel empor.\nEinmal oben angekommen, rollt es über den\nBergpfad sogleich wieder hinunter.",
+		de: "Es klettert Berghänge bis zum Gipfel empor. Einmal oben angekommen, rollt es über den Bergpfad sogleich wieder hinunter.",
 		'pt-br': "Escala penhascos em direção ao cume\nda montanha. Assim que atinge o topo,\nrola para baixo pelo mesmo caminho que veio.",
 		ko: "정상을 목표로 절벽을 오른다.\n정상에 도착하면 곧바로\n올라온 산길을 굴러 내려간다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/045.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/045.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Graveler",
-		fr: "Gravalanch"
+		fr: "Gravalanch",
+		de: "Georok"
 	},
 
 	description: {

--- a/data/Pokémon TCG Pocket/Mythical Island/046.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/046.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Old Amber",
-		fr: "Vieil Ambre"
+		fr: "Vieil Ambre",
+		de: "Altbernstein"
 	},
 
 	suffix: "EX",

--- a/data/Pokémon TCG Pocket/Mythical Island/048.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/048.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Les éléments rocheux qui constituent son corps\ncorrespondent à ceux qu'on trouve dans le sol\nd'une zone très éloignée de son habitat actuel.",
 		es: "Los elementos que componen las rocas de\nsu cuerpo se han encontrado en lechos de\nroca muy alejados de su hábitat.",
 		it: "La composizione delle pietre che formano il suo corpo coincide\ncon quella di basamenti rocciosi molto distanti dal suo habitat.",
-		de: "Sein Körper setzt sich aus Steinen zusammen,\ndie mit dem Grundgestein einer weit von seinem\nLebensraum entfernten Gegend identisch sind.",
+		de: "Sein Körper setzt sich aus Steinen zusammen, die mit dem Grundgestein einer weit von seinem Lebensraum entfernten Gegend identisch sind.",
 		'pt-br': "A composição elementar das pedras que formam seu corpo é a mesma\nencontrada em leitos rochosos em terras distantes do habitat deste Pokémon.",
 		ko: "몸의 암석 성분이\n서식지에서 멀리 떨어진 땅의\n암반과 일치했다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/049.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/049.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Son corps est gonflé de gaz toxique. Il se rend dans les décharges,\nattiré par l'odeur des déchets alimentaires en décomposition.",
 		es: "Su cuerpo está lleno a rebosar de gas venenoso.\nAcude a los vertederos atraído por el putrefacto\nolor que emana de los desperdicios.",
 		it: "Il suo corpo è gonfio di gas velenosi. Va nelle\ndiscariche attratto dall'odore di rifiuti putrescenti.",
-		de: "Sein Körper ist zum Bersten voll mit Giftgas.\nAngelockt vom fauligen Geruch verrottender\nAbfälle, lungert es auf Müllhalden herum.",
+		de: "Sein Körper ist zum Bersten voll mit Giftgas. Angelockt vom fauligen Geruch verottender Abfälle, lungert es auf Müllhalden herum.",
 		'pt-br': "Seu corpo é cheio de gás venenoso. Flutua\npara lixões à procura dos gases exalados\npor lixo apodrecido.",
 		ko: "독가스로 몸 안이 가득 차 있다.\n음식물 쓰레기의 악취에\n이끌려 쓰레기장을 찾아간다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/050.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/050.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Koffing",
-		fr: "Smogo"
+		fr: "Smogo",
+		de: "Smogon"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "Si l'un des deux Smogo se gonfle, l'autre se dégonfle.\nIls mélangent leurs gaz en permanence.",
 		es: "Si uno de los gemelos Koffing se\ninfla, el otro se desinfla. Mezclan\nconstantemente sus venenosos gases.",
 		it: "Se un gemello Koffing si sgonfia, l'altro si gonfia.\nI gas velenosi dei due si mischiano continuamente.",
-		de: "Pumpt sich eines der zwei Smogon auf, lässt das\nandere Luft ab. So findet ein Giftgasaustausch statt.",
+		de: "Pumpt sich eines der zwei Smogon auf, lässt das andere Luft ab. So findet ein Giftgasaustausch statt.",
 		'pt-br': "Se um dos gêmeos Koffing inflar, o outro\nesvazia, misturando constantemente\nseus gases venenosos.",
 		ko: "한쪽이 부풀어 오르면 다른 한쪽은\n오그라드는 쌍둥이 또가스. 항상\n체내의 독가스를 섞고 있다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/051.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/051.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Il vole les biens des personnes rien que pour voir leur\nvisage désemparé. Son plus grand rival est Goupilou.",
 		es: "Sustrae las pertenencias de las personas solo para\nverlas pasar apuros. Es un rival encarnizado de Nickit.",
 		it: "Ruba le cose alle persone per vederle\nin difficoltà. Nickit è il suo rivale.",
-		de: "Es bestiehlt liebend gerne Leute, um sich an ihrer\nFrustration zu erfreuen. Mit Kleptifux verbindet\nes eine tiefe Rivalität.",
+		de: "Es bestiehlt liebend gerne Leute, um sich an ihrer Frustration zu erfreuen. Mit Kleptifux verbindet es eine tiefe Rivalität.",
 		'pt-br': "Furta as pessoas só para se divertir com a frustração delas.\nExiste uma rivalidade entre este Pokémon e Nickit.",
 		ko: "곤란해하는 모습을 보기 위해\n사람의 물건을 훔친다.\n훔처우와는 라이벌 관계다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/052.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/052.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Purrloin",
-		fr: "Chacripan"
+		fr: "Chacripan",
+		de: "Felilou"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "On se laisse facilement éblouir par son pelage\nmagnifique et son allure élégante, mais gare\nà son caractère imprévisible et agressif.",
 		es: "Bajo su hermoso pelaje y cautivador estilo,\nque puede llevar fácilmente a engaño, se\noculta un carácter imprevisible y agresivo.",
 		it: "Pokémon dalla magnifica pelliccia e dalle linee aggraziate,\ndietro cui si nasconde un carattere volubile e feroce.",
-		de: "Man wird schnell von seinem schönen Fell und\nseiner Anmut verleitet, aber es ist ein sehr\nlaunisches und gewalttätiges Pokémon.",
+		de: "Man wird schnell von seinem schönen Fell und seiner Anmut verleitet, aber es ist ein sehr launisches und gewalttätiges Pokémon.",
 		'pt-br': "Não se deixe enganar pela sua pelugem fantástica e figura\nelegante. Este Pokémon é instável e perverso.",
 		ko: "아름다운 털과 스타일에\n쉽게 매료되지만 변덕스럽고\n흉포한 포켓몬이다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/053.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/053.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Bien qu'appartenant à des espèces similaires,\nles Venipatte et les Grillepattes se livrent\nà des conflits violents lorsqu'ils se croisent.",
 		es: "Aunque se trata de una especie emparentada\ncon los Sizzlipede, si se encuentran ejemplares\nde ambas, entablarán una lucha encarnizada.",
 		it: "Appartiene a una specie simile a quella di Sizzlipede, ma\nse le loro strade si incrociano si scatena il finimondo.",
-		de: "Es ist zwar artverwandt mit Thermopod, aber\njedes Mal, wenn sich die beiden über den Weg\nkrabbeln, streiten sie erbittert miteinander.",
+		de: "Es ist zwar artverwandt mit Thermopod, aber jedes Mal, wenn sich die beiden über den Weg krabbeln, streiten sie erbittert miteinander.",
 		'pt-br': "Venipede e Sizzlipede são espécies similares, mas,\nquando se encontram, travam uma briga daquelas.",
 		ko: "태우지네와는 종류가 다른\n동료지만 서로 만나면\n큰 싸움이 된다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/054.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/054.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Venipede",
-		fr: "Venipatte"
+		fr: "Venipatte",
+		de: "Toxiped"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "Il se propulse sur ses ennemis en tournant\ntrès vite sur lui-même. Il peut ainsi atteindre\nune vitesse d'environ 100 km/h.",
 		es: "Gira a gran velocidad y carga contra sus\nrivales. Puede alcanzar los 100 km/h.",
 		it: "Attacca l'avversario turbinando rapidamente su se\nstesso. Può raggiungere una velocità di circa 100 km/h.",
-		de: "Rollum dreht sich mit hoher Geschwindigkeit\nund rammt seine Gegner. Dabei erreicht es\nGeschwindigkeiten von bis zu 100 km/h.",
+		de: "Rollum dreht sich mit hoher Geschwindigkeit und rammt seine Gegner. Dabei erreicht es Geschwindigkeiten von bis zu 100 km/h.",
 		'pt-br': "Este Pokémon gira o corpo rapidamente e ataca seus oponentes.\nSua velocidade máxima é de pouco mais de 100 km/h.",
 		ko: "고속으로 회전해 상대에게\n돌격한다. 최고 시속은\n약 100km에 달한다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/055.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/055.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Whirlipede",
-		fr: "Scobolide"
+		fr: "Scobolide",
+		de: "Rollum"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "Après avoir saisi sa proie à l'aide des\ngriffes de son cou, il la plaque au sol puis la\ntransperce avec ses épines empoisonnées.",
 		es: "Usa las garras que le sobresalen del cuello para\natrapar a su presa, golpearla contra el suelo y\nrematarla inoculando un potente veneno.",
 		it: "Sbatte a terra la preda afferrandola con gli artigli\ndel collo per poi infilzarla con le punte velenose.",
-		de: "Kriegt es seine Beute mit den Krallen an seinem\nHals zu fassen, wirft es sie zu Boden und rammt\ndie giftigen Spitzen der Krallen in sie hinein.",
+		de: "Kriegt es seine Beute mit den Krallen an seinem Hals zu fassen, wirft es sie zu Boden und rammt die giftigen Spitzen der Krallen in sie hinein.",
 		'pt-br': "Scolipede fixa-se à sua presa com as garras em seu pescoço. Em seguida,\nlança-a ao chão e a espeta com os espinhos tóxicos de suas garras.",
 		ko: "목의 가시로 먹이를 잡은 채\n그대로 땅으로 내동댕이쳐서\n독가시를 꽂는다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/056.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/056.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Il vit sous terre, mais il doit impérativement\ns'exposer au soleil, car il devient incapable\nde bouger lorsque son corps se refroidit.",
 		es: "Habita en túneles. Pierde la movilidad si baja su\ntemperatura corporal, por lo que aprovecha la\nmenor oportunidad para tomar el sol.",
 		it: "Vive in cavità sotterranee, ma poiché non\nriesce più a muoversi se il suo corpo si\nraffredda, non può fare a meno dei bagni di sole.",
-		de: "Shardrago lebt in Grotten. Kühlt sein Körper ab,\nerstarrt es, weshalb es regelmäßig Sonnenbäder\nnehmen muss.",
+		de: "Shardrago lebt in Grotten. Kühlt sein Körper ab, erstarrt es, weshalb es regelmäßig Sonnenbäder nehmen muss.",
 		'pt-br': "Druddigon habita cavernas, mas nunca deixa de tomar um banho de sol.\nEle não é capaz de mover seu corpo se ficar com muito frio.",
 		ko: "토굴에 산다. 몸이 차가워지면\n움직이지 못하기 때문에\n일광욕을 거르지 않는다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/057.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/057.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "On l'aperçoit souvent dans les forêts. Avec ses ailes,\nil brasse l'air près du sol pour projeter du sable.",
 		es: "Muy común en bosques y selvas.\nAletea al nivel del suelo para levantar la gravilla.",
 		it: "Molto comune in boschi e foreste, sbatte le ali\na livello del suolo per sollevare sabbia accecante.",
-		de: "Ein vorwiegend in Wäldern lebendes Pokémon,\ndas zur Verteidigung mit den Flügeln Sand aufwirbelt.",
+		de: "Ein vorwiegend in Wäldern lebendes Pokémon, das zur Verteidigung mit den Flügeln Sand aufwirbelt.",
 		'pt-br': "Uma visão comum nas florestas. Ele agita suas\nasas no chão para levantar uma areia cegante.",
 		ko: "숲이나 수풀에 많이 분포해 있다.\n땅에서도 격렬한 날갯짓으로\n모래를 뿌리기도 한다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/058.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/058.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pidgey",
-		fr: "Roucool"
+		fr: "Roucool",
+		de: "Taubsi"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "Grâce à ses griffes très puissantes, il est capable de transporter\ndes Noeunoeuf vers un nid éloigné de plus de 100 km.",
 		es: "Tiene unas garras desarrolladas. Puede\natrapar un Exeggcute y transportarlo\ndesde una distancia de casi 100 km.",
 		it: "Grazie ai potenti artigli può trasportare una preda\ndelle dimensioni di un Exeggcute per oltre 100 km.",
-		de: "Die Krallen an seinen Füßen sind sehr ausgeprägt.\nEs kann sogar ein Owei zu seinem Nest\nin 100 km Entfernung tragen.",
+		de: "Die Krallen an seinen Füßen sind sehr ausgeprägt. Es kann sogar ein Owei zu seinem Nest in 100 km Entfernung tragen.",
 		'pt-br': "As garras nos seus pés são bem desenvolvidas.\nEle pode levar presas como Exeggcute para seu\nninho a mais de 100 km de distância.",
 		ko: "발톱이 발달해 있다.\n먹이인 아라리를 잡아\n100km 떨어져 있는 둥지까지 나른다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/059.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/059.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pidgeotto",
-		fr: "Roucoups"
+		fr: "Roucoups",
+		de: "Tauboga"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Mythical Island/060.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/060.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Il faut prendre garde quand un Tauros fouette\nson corps avec ses queues. Cela signifie qu'il\ns'apprête à charger à une vitesse démentielle.",
 		es: "Conviene tener cuidado si empieza a\nfustigarse con las colas, pues es señal\nde que va a cargar a máxima velocidad.",
 		it: "Quando comincia a frustarsi con le sue stesse\ncode è pericoloso, in quanto è segno che sta\nper partire alla carica a tutta velocità.",
-		de: "Peitscht es seinen Körper mit seinen Schweifen\naus, ist Vorsicht geboten, denn es steht kurz\ndavor, mit Karacho auf sein Ziel loszustürmen.",
+		de: "Peitscht es seinen Körper mit seinen Schweifen aus, ist Vorsicht geboten, denn es steht kurz davor, mit Karacho auf sein Ziel loszustürmen.",
 		'pt-br': "Quando Tauros começa a chicotear a si mesmo\ncom suas caudas, é um aviso de que está prestes\na atacar com velocidade surpreendente.",
 		ko: "꼬리로 자신의 몸을\n때리기 시작하면 위험하다.\n맹렬한 스피드로 덤벼든다."
 	},
@@ -52,7 +52,7 @@ const card: Card = {
 			fr: "Si le Pokémon Actif de votre adversaire est un Pokémon-{ex}, cette attaque inflige 80 dégâts supplémentaires.",
 			es: "Si el Pokémon Activo de tu rival es un Pokémon {ex}, este ataque hace 80 puntos de daño más.",
 			it: "Se il Pokémon attivo del tuo avversario è un Pokémon-{ex}, questo attacco infligge 80 danni in più.",
-			de: "Wenn das Aktive Pokémon deines Gegners ein Pokémon-{ex} ist, fügt diese Attacke 80 Schadenspunkte mehr zu.",
+			de: "Wenn das Aktive Pokémon deines Gegners ein Pokémon-ex ist, fügt diese Attacke 80 Schadenspunkte mehr zu.",
 			'pt-br': "Se o Pokémon Ativo do seu oponente for um Pokémon {ex}, este ataque causará 80 pontos de dano a mais.",
 			ko: "상대의 배틀 포켓몬이 「포켓몬 {ex}」라면 80데미지를 추가한다."
 		}

--- a/data/Pokémon TCG Pocket/Mythical Island/061.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/061.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Ses multiples évolutions lui permettent\nde s'adapter à tout type de milieu naturel.",
 		es: "Es capaz de evolucionar de muchas maneras\npara adaptarse sin problemas a cualquier medio.",
 		it: "La capacità di evolversi in diverse specie gli permette\ndi adattarsi perfettamente a qualsiasi tipo di ambiente.",
-		de: "Um sich jeder Umgebung perfekt anpassen zu\nkönnen, ist es in der Lage, sich zu verschiedenen\nPokémon zu entwickeln.",
+		de: "Um sich in jeder Umgebung perfekt anpassen zu können, ist es in der Lage, sich zu verschiedenen Pokémon zu entwickeln.",
 		'pt-br': "Sua capacidade de evoluir para muitas formas\npermite que se adapte fácil e perfeitamente\na qualquer ambiente.",
 		ko: "환경 변화에 곧바로 적응할 수 있도록\n여러 형태로 진화할 수 있는\n가능성을 가지고 있다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/065.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/065.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		fr: "Regardez la carte du dessus de votre deck. Si cette carte est un Pokémon {P}, ajoutez-la à votre main. Si ce n'est pas un Pokémon {P}, placez-la en dessous de votre deck.",
 		es: "Mira la primera carta de tu baraja. Si es un Pokémon {P}, ponla en tu mano. Si no es un Pokémon {P}, ponla en la parte inferior de tu baraja.",
 		it: "Guarda la prima carta del tuo mazzo. Se quella carta è un Pokémon {P}, aggiungila alle carte che hai in mano. Se non è un Pokémon {P}, mettila in fondo al tuo mazzo.",
-		de: "Schau dir die oberste Karte deines Decks an. Ist die Karte ein {P}-Pokémon, nimm sie auf die Hand. Ist die Karte kein {P}-Pokémon, lege sie unter dein Deck.",
+		de: "Schau dir die oberste Karte deines Decks an. Ist die Karte ein {P}-Pokémon, nimm sie auf die Hand. Ist die Karte kein {P}-Pokémon, lege sie unter dein Deck. Du kannst während deines Zuges beliebig viele Itemkarten spielen.",
 		'pt-br': "Olhe a carta de cima do seu baralho. Se aquela carta for um Pokémon {P}, coloque-a na sua mão. Se não for um Pokémon {P}, coloque-a como a carta de baixo do seu baralho.",
 		ko: "자신의 덱을 위에서부터 1장 보고 그 카드가 {P}포켓몬이라면 패로 가져온다. {P}포켓몬이 아니라면 덱의 아래로 되돌린다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/066.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/066.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		fr: "Ajoutez votre Mew-ex sur le Poste Actif à votre main.",
 		es: "Pon a tu Mew ex que esté en el Puesto Activo en tu mano.",
 		it: "Riprendi in mano il tuo Mew-ex in posizione attiva.",
-		de: "Nimm dein Mew-ex in der Aktiven Position auf deine Hand.",
+		de: "Nimm dein Mew-ex in der Aktiven Position auf deine Hand. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen.",
 		'pt-br': "Coloque seu Mew ex do Campo Ativo na sua mão.",
 		ko: "자신의 배틀필드의 「뮤 ex」 패로 되돌린다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/067.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/067.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		fr: "Pendant le prochain tour de votre adversaire, tous vos Pokémon subissent − 10 dégâts provenant des attaques des Pokémon de votre adversaire.",
 		es: "Durante el próximo turno de tu rival, los ataques de los Pokémon de tu rival hacen -10 puntos de daño a todos tus Pokémon.",
 		it: "Durante il prossimo turno del tuo avversario, tutti i tuoi Pokémon subiscono -10 danni dagli attacchi dei Pokémon avversari.",
-		de: "Während des nächsten Zuges deines Gegners werden allen deinen Pokémon durch Attacken von Pokémon deines Gegners − 10 Schadenspunkte zugefügt.",
+		de: "Während des nächsten Zuges deines Gegners werden allen deinen Pokémon durch Attacken von Pokémon deines Gegners − 10 Schadenspunkte zugefügt. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen.",
 		'pt-br': "Durante o próximo turno do seu oponente, todos os seus Pokémon receberão −10 pontos de dano de ataques dos Pokémon do seu oponente.",
 		ko: "상대의 다음 차례에 자신의 포켓몬 전원이 상대의 포켓몬으로부터 받는 기술의 데미지를 -10한다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/068.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/068.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		fr: "Pendant ce tour, le Coût de Retraite de votre Pokémon Actif est diminué de 2 Énergies.",
 		es: "Durante este turno, el Coste de Retirada de tu Pokémon Activo es de 2 menos.",
 		it: "Durante questo turno, il costo di ritirata del tuo Pokémon attivo è ridotto di 2.",
-		de: "Während dieses Zuges verringern sich die Rückzugskosten deines Aktiven Pokémon um 2.",
+		de: "Während dieses Zuges verringern sich die Rückzugskosten deines Aktiven Pokémon um 2. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen.",
 		'pt-br': "Durante este turno, o custo de Recuo do seu Pokémon Ativo é 2 a menos.",
 		ko: "이 차례에 자신의 배틀 포켓몬의 후퇴에 필요한 에너지를 2개 적게 만든다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/069.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/069.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Exeggcute",
-		fr: "Noeunoeuf"
+		fr: "Noeunoeuf",
+		de: "Owei"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "Chacune de ses trois têtes pense de manière autonome.\nElles ne semblent s'intéresser qu'à elles-mêmes.",
 		es: "Cada una de las tres cabezas piensa\nde forma independiente y apenas\nmuestra interés por el resto.",
 		it: "Le sue tre teste ragionano in\nmodo indipendente. Sembra\nche ciascuna pensi solo a sé.",
-		de: "Jeder der drei Köpfe hat einen\neigenen Willen und scheint sich\nnur für sich selbst zu interessieren.",
+		de: "Jeder der drei Köpfe hat einen eigenen Willen und scheint sich nur für sich selbst zu interessieren.",
 		'pt-br': "Cada uma das três cabeças de Exeggutor está\npensando em coisas diferentes. Elas não parecem\nse interessar umas pelas outras.",
 		ko: "3개의 머리는 서로 다른\n생각을 하고 있다. 자신 외에는\n별로 흥미가 없는 듯하다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/070.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/070.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Servine",
-		fr: "Lianaja"
+		fr: "Lianaja",
+		de: "Efoserp"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "Il ne donnera tout son potentiel que contre un ennemi\npuissant indifférent à son regard écrasant de noblesse.",
 		es: "Tan solo muestra su verdadero poder\na quienes no se amedrentan ante su\nnoble pero inquisitoria mirada.",
 		it: "Dà il meglio di sé solo contro chi non\nresta intimidito dal suo nobile sguardo.",
-		de: "Im Kampf zeigt es nur Gegnern, die seinem\nedlen Blick standhalten, seine wahre Kraft.",
+		de: "Im Kampf zeigt es nur Gegnern, die seinem edlen Blick standhalten, seine wahre Kraft.",
 		'pt-br': "Dá o máximo de si somente contra oponentes fortes\nque não são perturbados pelo brilho intenso dos olhos\nnobres de Serperior.",
 		ko: "샤로다의 고상한 눈동자로\n쏘아보아도 태연할 정도로 강한\n상대에게만 진정한 실력을 발휘한다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/071.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/071.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Il provoque ses proies afin de les attirer dans\nd'étroites zones rocheuses, puis il les étourdit\navec son gaz toxique avant de les achever.",
 		es: "Provoca a sus presas para conducirlas a zonas\nrocosas y estrechas, donde las aturde con un\ngas venenoso antes de acabar con ellas.",
 		it: "Provoca le sue prede e le attira in stretti luoghi rocciosi,\nper poi stordirle con il suo gas velenoso e abbatterle.",
-		de: "Es provoziert seine Beute und lockt sie\nin enge Felsspalten, wo es sie dann mit\nGiftgas ins Taumeln bringt und erlegt.",
+		de: "Es provoziert seine Beute und lockt sie in enge Felsspalten, wo es sie dann mit Giftgas ins Taumeln bringt und erlegt.",
 		'pt-br': "Provoca suas presas e as atrai para áreas estreitas\ne rochosas. Em seguida, espirra sobre elas um gás\ntóxico para deixá-las atordoadas e dar o bote.",
 		ko: "먹잇감을 도발해서\n좁은 암석 지대로 유인한 뒤\n어지러워지는 독가스를 뿜어서 마무리한다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/072.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/072.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Eevee",
-		fr: "Évoli"
+		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "Il vit au bord de l'eau. Sa queue semblable à celle\nd'un poisson lui donne l'apparence d'une sirène.",
 		es: "Vive cerca del agua. Su cola termina en una\naleta parecida a la de un pez, por lo que hay\ngente que lo confunde con una sirena.",
 		it: "Vive vicino all'acqua. Sulla punta della coda ha una\npinna, per questo alcuni lo scambiano per una sirena.",
-		de: "Dieses Pokémon lebt nahe an Gewässern.\nWegen seiner fischähnlichen Schwanzflosse wird\nes manchmal für eine Meerjungfrau gehalten.",
+		de: "Dieses Pokémon lebt nahe an Gewässern. Wegen seiner fischähnlichen Schwanzflosse wird es manchmal für eine Meerjungfrau gehalten.",
 		'pt-br': "Este Pokémon vive perto da água. A sua longa\ncauda é coberta por uma barbatana e muitas\nvezes é confundida com a de uma sereia.",
 		ko: "물가에 살지만 꼬리에\n물고기처럼 지느러미가 남아 있어서\n인어로 착각하는 사람도 있다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/073.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/073.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Son corps étant petit et son organe générateur\nd'électricité peu développé, il se recharge en\naspirant l'électricité des maisons avec sa queue.",
 		es: "Como es menudo y su órgano electrógeno está\npoco desarrollado, absorbe electricidad de las\ncasas con la cola para recargar sus reservas.",
 		it: "A causa del corpo piccolo, l'organo che genera\nelettricità non è molto sviluppato. Si ricarica\nassorbendo l'elettricità dalle case con la coda.",
-		de: "Da es klein ist und sein elektrisches Organ nicht\nstark ausgebildet ist, zapft es mit seinem Schwanz\nin Häusern Strom ab, um sich aufzuladen.",
+		de: "Da es klein ist und sein elektrisches Organ nicht stark ausgebildet ist, zapft es mit seinem Schwanz in Häusern Strom ab, um sich aufzuladen.",
 		'pt-br': "Este Pokémon é pequeno, e seu órgão gerador de eletricidade ainda não se desenvolveu.\nAbastece a si mesmo usando sua cauda, com a qual absorve energia das casas das pessoas.",
 		ko: "몸집이 작고 발전 기관이 미숙하기 때문에\n사람이 사는 집의 전기를\n꼬리를 통해 흡수해서 충전한다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/076.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/076.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Magikarp",
-		fr: "Magicarpe"
+		fr: "Magicarpe",
+		de: "Karpador"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Mythical Island/078.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/078.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Old Amber",
-		fr: "Vieil Ambre"
+		fr: "Vieil Ambre",
+		de: "Altbernstein"
 	},
 	
 	suffix: "EX",

--- a/data/Pokémon TCG Pocket/Mythical Island/079.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/079.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pidgeotto",
-		fr: "Roucoups"
+		fr: "Roucoups",
+		de: "Tauboga"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Mythical Island/080.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/080.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		fr: "Ajoutez votre Mew-ex sur le Poste Actif à votre main.",
 		es: "Pon a tu Mew ex que esté en el Puesto Activo en tu mano.",
 		it: "Riprendi in mano il tuo Mew-ex in posizione attiva.",
-		de: "Nimm dein Mew-ex in der Aktiven Position auf deine Hand.",
+		de: "Nimm dein Mew-ex in der Aktiven Position auf deine Hand. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen.",
 		'pt-br': "Coloque seu Mew ex do Campo Ativo na sua mão.",
 		ko: "자신의 배틀필드의 「뮤 ex」 패로 되돌린다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/081.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/081.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		fr: "Pendant le prochain tour de votre adversaire, tous vos Pokémon subissent − 10 dégâts provenant des attaques des Pokémon de votre adversaire.",
 		es: "Durante el próximo turno de tu rival, los ataques de los Pokémon de tu rival hacen -10 puntos de daño a todos tus Pokémon.",
 		it: "Durante il prossimo turno del tuo avversario, tutti i tuoi Pokémon subiscono -10 danni dagli attacchi dei Pokémon avversari.",
-		de: "Während des nächsten Zuges deines Gegners werden allen deinen Pokémon durch Attacken von Pokémon deines Gegners − 10 Schadenspunkte zugefügt.",
+		de: "Während des nächsten Zuges deines Gegners werden allen deinen Pokémon durch Attacken von Pokémon deines Gegners − 10 Schadenspunkte zugefügt. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen.",
 		'pt-br': "Durante o próximo turno do seu oponente, todos os seus Pokémon receberão −10 pontos de dano de ataques dos Pokémon do seu oponente.",
 		ko: "상대의 다음 차례에 자신의 포켓몬 전원이 상대의 포켓몬으로부터 받는 기술의 데미지를 -10한다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/082.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/082.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		fr: "Pendant ce tour, le Coût de Retraite de votre Pokémon Actif est diminué de 2 Énergies.",
 		es: "Durante este turno, el Coste de Retirada de tu Pokémon Activo es de 2 menos.",
 		it: "Durante questo turno, il costo di ritirata del tuo Pokémon attivo è ridotto di 2.",
-		de: "Während dieses Zuges verringern sich die Rückzugskosten deines Aktiven Pokémon um 2.",
+		de: "Während dieses Zuges verringern sich die Rückzugskosten deines Aktiven Pokémon um 2. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen.",
 		'pt-br': "Durante este turno, o custo de Recuo do seu Pokémon Ativo é 2 a menos.",
 		ko: "이 차례에 자신의 배틀 포켓몬의 후퇴에 필요한 에너지를 2개 적게 만든다."
 	},

--- a/data/Pokémon TCG Pocket/Mythical Island/084.ts
+++ b/data/Pokémon TCG Pocket/Mythical Island/084.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Old Amber",
-		fr: "Vieil Ambre"
+		fr: "Vieil Ambre",
+		de: "Altbernstein"
 	},
 	
 	suffix: "EX",


### PR DESCRIPTION
## Add missing German translations for A1a

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
