### PR TITLE
Add missing German translations for A2a

### DIFF
--- a/data/Pokémon TCG Pocket/Triumphant Light/001.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/001.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il aime tellement la sève qu'il la défend\njalousement : à l'aide de son imposante corne,\nil projette quiconque s'en approche dans les airs.",
 		es: "Le encanta la savia dulce y usa su cuerno para lanzar\npor los aires a cualquiera que se acerque a ella.",
 		it: "È ghiotto della dolce linfa degli alberi e\nper non farsela rubare scaglia lontano\ni nemici con il suo possente corno.",
-		de: "Es liebt süßen Baumsaft. Mit seinem Horn, auf\ndas es sehr stolz ist, schleudert es Rivalen hinfort,\num allen Baumsaft für sich zu beanspruchen.",
+		de: "Es liebt süßen Baumsaft. Mit seinem Horn, auf das es sehr stolz ist, schleudert es Rivalen hinfort, um allen Baumsaft für sich zu beanspruchen.",
 		'pt-br': "Este Pokémon adora néctar doce. Para ficar com todo\no néctar para si mesmo, arremessa os rivais para longe\ncom seu chifre precioso.",
 		ko: "달콤한 꿀을 아주 좋아해서\n혼자 독차지하기 위해\n자랑스런 뿔을 써서 상대를 내동댕이친다."
 	},
@@ -53,7 +53,7 @@ const card: Card = {
 			fr: "Lancez 2 pièces. Si toutes sont côté face, cette attaque inflige 70 dégâts de plus.",
 			es: "Lanza 2 monedas. Si en las dos sale cara, este ataque hace 70 puntos de daño más.",
 			it: "Lancia 2 volte una moneta. Se esce testa entrambe le volte, questo attacco infligge 70 danni in più.",
-			de: "Wirf 2 Münzen. [Gr:Count p=\"Zeigen alle Münzen Kopf,\" one=\"Bei Kopf\" two=\"Zeigen beide Münzen Kopf,\" ] fügt diese Attacke 70 Schadenspunkte mehr zu.",
+			de: "Wirf 2 Münzen. Zeigen beide Münzen Kopf, fügt diese Attacke 70 Schadenspunkte mehr zu.",
 			'pt-br': "Jogue 2 moedas. Se as duas saírem cara, este ataque causará 70 pontos de dano a mais.",
 			ko: "동전을 2번 던져서 모두 앞면이 나오면 70데미지를 추가한다."
 		}

--- a/data/Pokémon TCG Pocket/Triumphant Light/002.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/002.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Pour se protéger des vents glacés de l'hiver,\nil s'est tissé une cape de feuilles et de brindilles.",
 		es: "Para protegerse de los vientos fríos invernales,\nse cubre con un caparazón de ramas y hojas.",
 		it: "Per ripararsi dal freddo e dai venti invernali\nsi copre con un manto fatto di rami e foglie.",
-		de: "Um sich vor dem eisigen Winterwind zu schützen,\nlegt es sich unter einen Umhang aus Ästen und Laub.",
+		de: "Um sich vor dem eisigen Winterwind zu schützen, legt es sich unter einen Umhang aus Ästen und Laub.",
 		'pt-br': "Para se proteger dos ventos gelados do inverno, cobre-se\ncom um manto feito de galhos e folhas.",
 		ko: "차가운 초겨울 바람을 막으려고\n작은 가지나 낙엽을 재료로\n도롱이를 만들어 몸을 감싼다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/003.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/003.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Burmy",
-		fr: "Cheniti"
+		fr: "Cheniti",
+		de: "Burmy"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il aime le nectar des fleurs et n'hésite\npas à voler celui que récupère Apitrini.",
 		es: "Le encanta la miel de las flores y roba la que recoge Combee.",
 		it: "Ama il nettare dei fiori. Ruba e mangia\nil nettare raccolto da Combee.",
-		de: "Es liebt Honig und stiehlt den Honig,\nder von Wadribie gesammelt wurde.",
+		de: "Es liebt Honig und stiehlt den Honig, der von Wadribie gesammelt wurde.",
 		'pt-br': "Adora o néctar das flores e rouba mel\ncoletado por Combee.",
 		ko: "꽃의 꿀을 매우 좋아한다.\n세꿀버리가 모아둔 꿀을\n가로채어 먹어 버린다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/004.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/004.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "À la nuit tombée, les Apitrini s'agglutinent\npar grappes de cent pour dormir.",
 		es: "Cuando llega la noche, se juntan unos cien\nCombee y duermen formando una gran colmena.",
 		it: "Scesa la notte, formano dei grandi alveari di\ncirca 100 esemplari e dormono raggruppati.",
-		de: "Des Nachts schmiegen sich bis zu 100 Wadribie\naneinander und formieren sich so zum Schlafen\nzu einem großen Gebilde.",
+		de: "Des Nachts schmiegen sich bis zu 100 Wadribie aneinander und formieren sich so zum Schlafen zu einem großen Gebilde.",
 		'pt-br': "À noite, Combee dormem amontados\nem grupos de aproximadamente cem indivíduos.",
 		ko: "밤이 되면 100마리 정도의\n세꿀버리가 모여\n커다란 덩어리가 되어 잠잔다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/005.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/005.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Combee",
-		fr: "Apitrini"
+		fr: "Apitrini",
+		de: "Wadribie"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Son abdomen abrite ses petits, qu'il\ncontrôle grâce à des phéromones.",
 		es: "Cría larvas en los panales de su cuerpo y\nsegrega diversas feromonas para controlarlas.",
 		it: "Nell'addome ospita la sua progenie, sulla quale esercita\nun controllo assoluto tramite i feromoni che rilascia.",
-		de: "Sein Rumpf fungiert als Wabe für die Larven,\ndie es mithilfe verschiedener Pheromone frei\nherumkommandieren kann.",
+		de: "Sein Rumpf fungiert als Wabe für die Larven, die es mithilfe verschiedener Pheromone frei herumkommandieren kann.",
 		'pt-br': "Guarda sua colônia em células do seu corpo\ne libera vários feromônios para que as larvas\ncumpram suas exigências.",
 		ko: "몸통은 새끼들의 둥지다.\n여러 페로몬을 내뿜어\n새끼들을 자유롭게 조종한다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/006.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/006.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il s'enfuit à la vue des Pokémon oiseaux, dont le mets\nfavori est sa petite boule remplie de nutriments.",
 		es: "Se ve obligado a huir constantemente de\nlos Pokémon pájaro, pues su pequeña esfera\nrepleta de nutrientes es su manjar predilecto.",
 		it: "Fugge dai Pokémon alati, ghiotti della\nsua pallina ricca di sostanze nutritive.",
-		de: "Sein nährstoffreiches Bällchen erfreut sich bei\nVogel-Pokémon großer Beliebtheit. Es ist ständig\nauf der Flucht, damit es nicht gefressen wird.",
+		de: "Sein nährstoffreiches Bällchen erfreut sich bei Vogel-Pokémon großer Beliebtheit. Es ist ständig auf der Flucht, damit es nicht gefressen wird.",
 		'pt-br': "Corre agilmente para evitar ser bicado por Pokémon\npássaro que adorariam fugir com sua bolinha\nde armazenamento rica em nutrientes.",
 		ko: "영양이 듬뿍 담긴 구슬을\n새포켓몬들이 아주 좋아한다.\n쪼이지 않기 위해 도망 다닌다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/007.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/007.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Cherubi",
-		fr: "Ceribou"
+		fr: "Ceribou",
+		de: "Kikugi"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Pendant sa période de bourgeonnement, il reste\npresque totalement immobile et attend que le soleil se lève.",
 		es: "Permanece casi inmóvil cerrado en un capullo\na la espera de que lo bañen los rayos del sol.",
 		it: "Quando è un bocciolo rimane pressoché\nimmobile in attesa che spunti il sole.",
-		de: "Als Knospe verhält es sich ruhig und bewegt sich kaum,\nwährend es geduldig auf Sonnenschein wartet.",
+		de: "Als Knospe verhält es sich ruhig und bewegt sich kaum, während es geduldig auf Sonnenschein wartet.",
 		'pt-br': "Como um botão, quase não se move. Fica parado,\nesperando tranquilamente a luz do sol aparecer.",
 		ko: "봉오리일 때는 얌전하고\n거의 움직이지 않는다. 햇빛이\n들기를 가만히 기다리고 있다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/008.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/008.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Cherubi",
-		fr: "Ceribou"
+		fr: "Ceribou",
+		de: "Kikugi"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il prend cette forme lorsqu'il a fait le plein de soleil.\nIl déborde alors d'énergie et reste très actif jusqu'au crépuscule.",
 		es: "Adopta esta forma cuando lo bañan los rayos del sol. Siempre\nestá rebosante de energía y se mantiene activo hasta el ocaso.",
 		it: "Assume questa forma dopo essersi esposto\nalla luce solare e aver fatto il pieno di energia.\nResta vivace fino al crepuscolo.",
-		de: "Diese Form nimmt Kinoso an, wenn es viel Sonne\ngetankt und dadurch seine Energie aufgefüllt hat.\nEs bleibt bis zum Sonnenuntergang aktiv.",
+		de: "Diese Form nimmt Kinoso an, wenn es viel Sonne getankt und dadurch seine Energie aufgefüllt hat. Es bleibt bis zum Sonnenuntergang aktiv.",
 		'pt-br': "Após absorver uma grande quantidade de luz solar,\nCherrim assume esta forma. Enquanto estiver assim, fica\ncheio de energia, e seu vigor permanece até o cair do sol.",
 		ko: "태양의 빛을 받아\n기운이 넘치는 모습.\n해가 지기 전까지는 활발하다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/009.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/009.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il attire sa proie avec sa salive odorante avant\nde la croquer. Il lui faut une journée pour l'avaler.",
 		es: "Atrae a sus presas con saliva de olor dulce y\nlas mastica. Tarda todo un día en comérselas.",
 		it: "Attira le prede con il dolce aroma della saliva e poi\nle ingoia. Impiega un giorno per mangiare una preda.",
-		de: "Sein süßlich riechender Speichel zieht Beute an,\ndie es frisst. Es braucht einen Tag, sie zu fressen.",
+		de: "Sein süßlich riechender Speichel zieht Beute an, die es frisst. Es braucht einen Tag, sie zu fressen.",
 		'pt-br': "Atrai presas com sua saliva doce e depois as mastiga.\nLeva um dia inteiro para comer uma presa.",
 		ko: "달콤한 냄새의 타액으로 먹이를\n끌어들여 큰 턱으로 꿀꺽한다.\n하루에 걸쳐 먹이를 먹는다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/010.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/010.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Eevee",
-		fr: "Évoli"
+		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Triumphant Light/011.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/011.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Ce Pokémon est rusé. Il chasse en meute en communiquant\navec les siens grâce à une variété de cris.",
 		es: "Tiene suficiente inteligencia para cazar en manada.\nSe comunica con los demás a través de diversos aullidos.",
 		it: "È abbastanza intelligente da cacciare in\nbranco, utilizzando una varietà di versi\nper comunicare con i compagni.",
-		de: "Es ist intelligent genug, um bei der Jagd über eine ganze\nReihe von Rufen mit seinem Rudel zu kommunizieren.",
+		de: "Es ist intelligent genug, um bei der Jagd über eine ganze Reihe von Rufen mit seinem Rudel zu kommunizieren.",
 		'pt-br': "É inteligente o suficiente para caçar em bandos.\nEle usa uma variedade de choros para se comunicar\ncom os outros.",
 		ko: "수많은 울음소리를 가려 써서\n동료들과 의사소통을 하며\n사냥을 하는 지능을 가지고 있다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/012.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/012.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Houndour",
-		fr: "Malosse"
+		fr: "Malosse",
+		de: "Hunduster"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Les blessures provoquées par son souffle enflammé\nsont permanentes, et la douleur ne disparaît jamais.",
 		es: "Si alguien se quema con las llamas que lanza\npor la boca, el dolor no desaparecerá nunca.",
 		it: "Se si viene ustionati dalle fiamme che sputa\ndalla bocca, il dolore rimarrà per sempre.",
-		de: "Wird man von den Flammen getroffen, die es\naus seinem Maul schießt, so erleidet man eine\nBrandwunde, deren Schmerz nie nachlässt.",
+		de: "Wird man von den Flammen getroffen, die es aus seinem Maul schießt, so erleidet man eine Brandwunde, deren Schmerz nie nachlässt.",
 		'pt-br': "Se você for queimado pelas chamas disparadas\nde sua boca, a dor nunca passará.",
 		ko: "입에서 뿜어내는 불꽃에 의해\n화상을 입으면 시간이 아무리 지나도\n상처 난 자리가 욱신거린다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/014.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/014.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Sa fourrure est imperméable, si bien qu'il\nreste sec même quand il joue dans l'eau.",
 		es: "Tiene un pelaje que repele el agua, por lo\nque está seco incluso después de bañarse.",
 		it: "La pelliccia è idrorepellente. Così, rimane\nasciutto anche giocando nell'acqua.",
-		de: "Sein Fell ist von Natur aus wasserabweisend.\nEs bleibt trocken, auch wenn es im Wasser spielt.",
+		de: "Sein Fell ist von Natur aus wasserabweisend. Es bleibt trocken, auch wenn es im Wasser spielt.",
 		'pt-br': "A sua pelagem repele água naturalmente.\nPode brincar na água por horas sem se molhar.",
 		ko: "전신의 털은\n물을 튕겨 내는 성질을 지녀\n물을 끼얹어도 말라 있다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/015.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/015.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Marill",
-		fr: "Marill"
+		fr: "Marill",
+		de: "Marill"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Ses longues oreilles lui permettent d'entendre tout\nce qui se passe sous l'eau de manière très distincte.",
 		es: "Sus largas orejas son unos sensores excepcionales que le\npermiten diferenciar e identificar lo que oye dentro del agua.",
 		it: "Le sue lunghe orecchie sono ricettori sensibilissimi.\nRiesce a distinguere e identificare ogni minimo\nrumore perfino sott'acqua.",
-		de: "Seine langen Ohren sind hervorragende\nSensoren, mit denen es Geräusche unter\nWasser unterscheiden und zuordnen kann.",
+		de: "Seine langen Ohren sind hervorragende Sensoren, mit denen es Geräusche unter Wasser unterscheiden und zuordnen kann.",
 		'pt-br': "Suas orelhas longas são sensores soberbos.\nEle é capaz de diferenciar os movimentos\ndos objetos nas águas e dizer o que eles são.",
 		ko: "긴 귀는 뛰어난 센서.\n물속의 소리를 구별하여\n무엇이 움직이는지 알 수 있다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/016.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/016.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il se sert de ses barbillons comme d'un radar\nultrasophistiqué. Ils lui permettent de détecter\nses proies même dans l'eau boueuse.",
 		es: "Sus bigotes son muy sensibles y le sirven de\nradar. Puede detectar la posición de su presa\nincluso en el agua turbia de los lodazales.",
 		it: "I suoi baffi sono un radar sensibilissimo in grado di\nindividuare la preda persino nelle acque più torbide.",
-		de: "Seine zwei Barteln dienen ihm als empfindliches\nRadarsystem. Selbst in schlammigem Wasser kann\nes so die Position seiner Beute ausmachen.",
+		de: "Seine zwei Barteln dienen ihm als empfindliches Radarsystem. Selbst in schlammigem Wasser kann es so die Position seiner Beute ausmachen.",
 		'pt-br': "Seus dois bigodes fornecem um radar sensível.\nPode localizar as suas presas até mesmo\nem águas lamacentas.",
 		ko: "2개의 수염은 민감한 레이더이다.\n진흙으로 탁해진 물속에서도\n먹이의 위치를 감지한다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/017.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/017.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Barboach",
-		fr: "Barloche"
+		fr: "Barloche",
+		de: "Schmerbe"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il est très protecteur vis-à-vis de son territoire.\nSi des ennemis approchent, il le défend\nen déclenchant des secousses terribles.",
 		es: "Protege su territorio por encima de todo. Si se acerca\nun enemigo, lo ataca con violentos temblores de tierra.",
 		it: "È molto protettivo del suo territorio e, se\nun nemico si avvicina, reagisce facendo\ntremare violentemente la terra.",
-		de: "Es hat ein ausgeprägtes Revierverhalten.\nNähert sich ein Feind, greift es diesen an,\nindem es die Erde heftig beben lässt.",
+		de: "Es hat ein ausgeprägtes Revierverhalten. Nähert sich ein Feind, greift es diesen an, indem es die Erde heftig beben lässt.",
 		'pt-br': "Protege seu território com muito afinco. Se algum\ninimigo se aproxima, ataca-o usando tremores perversos.",
 		ko: "영역 의식이 매우 강하여\n외부의 적이 다가오면 격렬하게\n지면을 울리며 덤벼든다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/018.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/018.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "On dit qu'ils vivent en groupe et\nen harmonie sous des feuilles gigantesques.",
 		es: "Se dice que se reúnen en grupos bajo hojas\ngigantescas y viven allí en total armonía.",
 		it: "Si dice che vivano in armonia riunendosi\nin gruppi all'ombra di enormi foglie.",
-		de: "Gerüchten zufolge versammeln sich Schneppke unter\nriesigen Blättern und leben dort friedlich zusammen.",
+		de: "Gerüchten zufolge versammeln sich Schneppke unter riesigen Blättern und leben dort friedlich zusammen.",
 		'pt-br': "Dizem que vários Snorunt se juntam\nsob folhas gigantes e vivem em harmonia.",
 		ko: "커다란 잎사귀 아래서\n여러 마리의 눈꼬마가 모여\n사이좋게 살고 있다고 한다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/019.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/019.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Snorunt",
-		fr: "Stalgamin"
+		fr: "Stalgamin",
+		de: "Schneppke"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il congèle les êtres humains et les Pokémon\nqui lui plaisent. Il les emmène ensuite\ndans sa tanière pour les admirer à loisir.",
 		es: "Con su gélido aliento congela a todo Pokémon\no humano que le llame la atención y se lo lleva\na su guarida para usarlo como objeto decorativo.",
 		it: "Con il suo alito glaciale congela gli esseri\numani e i Pokémon che gli piacciono\ne li usa per decorare la sua tana.",
-		de: "Menschen und Pokémon, die ihm gefallen,\nfriert es mit eisiger Luft ein. Dann nimmt es\nsie mit in seinen Bau und stellt sie dort aus.",
+		de: "Menschen und Pokémon, die ihm gefallen, friert es mit eisiger Luft ein. Dann nimmt es sie mit in seinen Bau und stellt sie dort aus.",
 		'pt-br': "Quando encontra humanos ou Pokémon de que gosta,\ncongela-os e os leva para seu covil gelado,\nonde são transformados em decoração.",
 		ko: "마음에 든 인간과 포켓몬을\n냉기로 얼린 다음\n보금자리에 가져가서 장식한다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/020.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/020.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il s'aventure jusqu'au pied des montagnes en hiver,\nmais se réfugie sur les pics neigeux au printemps.",
 		es: "En las estaciones frías baja al pie de la montaña,\npero regresa a las cimas nevadas en primavera.",
 		it: "In inverno scende fino ai piedi delle\nmontagne, ma in primavera se ne torna\nsulle cime montuose dove c'è ancora neve.",
-		de: "In der kalten Jahreszeit steigt es bis zum Fuß\nder Berge hinab. Im Frühjahr kehrt es auf die\nGipfel zurück, wo noch Schnee liegt.",
+		de: "In der kalten Jahreszeit steigt es bis zum Fuß der Berge hinab. Im Frühjahr kehrt es auf die Gipfel zurück, wo noch Schnee liegt.",
 		'pt-br': "Durante as temporadas frias, migra para as partes baixas\nda montanha. Na primavera, retorna para o cume nevado.",
 		ko: "추운 계절에는 산기슭까지\n내려오지만 봄이 되면\n눈이 남아 있는 산 정상으로 돌아간다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/021.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/021.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Snover",
-		fr: "Blizzi"
+		fr: "Blizzi",
+		de: "Shnebedeck"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il vit paisiblement dans les massifs où s'amoncellent les neiges\néternelles, et il déclenche des blizzards pour se cacher.",
 		es: "Vive en paz en cordilleras de nieves eternas.\nGenera ventiscas para ocultarse.",
 		it: "Vive nella pace delle cime montuose tra le nevi\nperenni. Si nasconde scatenando bufere di neve.",
-		de: "Es führt ein ruhiges Leben im Gebirge, wo\newiger Schnee liegt, und löst Blizzards aus,\num sich zu verstecken.",
+		de: "Es führt ein ruhiges Leben im Gebirge, wo ewiger Schnee liegt, und löst Blizzards aus, um sich zu verstecken.",
 		'pt-br': "Leva uma vida tranquila em montanhas que estão\npermanentemente cobertas de neve. Ele se esconde\nprovocando nevascas.",
 		ko: "만년설이 쌓인 산맥에서 조용히 지낸다.\n블리자드를 발생시켜 모습을 감춘다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/022.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/022.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Eevee",
-		fr: "Évoli"
+		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Triumphant Light/023.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/023.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Cette forme qui sillonne les cieux me fait penser\nau créateur de toutes choses. Je pense qu'épouser cette\napparence prodigue à Palkia les pouvoirs du créateur.",
 		es: "Esta forma que surca el cielo me hace pensar\nen el creador de todo lo existente. Quizá adopte\ndicha forma para hacerse con su poder.",
 		it: "Vederlo solcare i cieli mi riporta alla mente l'entità\ncreatrice. Che, imitandone la forma, stia forse\ncercando di impadronirsi del suo potere?",
-		de: "Dem Schöpfer aller Dinge gleich gleitet es über das\nHimmelszelt. Womöglich gebärdet es sich auf diese Weise,\num sich die Macht der Schöpfergottheit zu eigen zu machen.",
+		de: "Dem Schöpfer aller Dinge gleich gleitet es über das Himmelszelt. Womöglich gebärdet es sich auf diese Weise, um sich die Macht der Schöpfergottheit zu eigen zu machen.",
 		'pt-br': "Dispara pelos céus com uma forma que se assemelha\nmuito ao criador de todas as coisas. Pode ser que essa\nimitação de aparência de Palkia seja uma estratégia\npara conquistar os poderes de Arceus.",
 		ko: "하늘을 나는 모습은 만물의 창조주를 연상케한다.\n창조주의 모습을 흉내 냄으로써\n그 힘을 자신의 것으로 만들었다고 추측된다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/024.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/024.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il gonfle la bouée de sa tête et se laisse flotter\nà la surface quand la mer se réchauffe.",
 		es: "Si sube la temperatura del mar, infla el flotador\nde su cabeza y flota en grupo en la superficie.",
 		it: "Quando la temperatura del mare si alza, gonfia\nil galleggiante che ha in testa e fluttua in gruppo.",
-		de: "Steigt die Meerestemperatur, bläst es seinen\nSchwimmbeutel auf und treibt in Schwärmen\nauf dem Wasser.",
+		de: "Steigt die Meerestemperatur, bläst es seinen Schwimmbeutel auf und treibt in Schwärmen auf dem Wasser.",
 		'pt-br': "Em águas mornas, inflam as boias de suas cabeças\ne, em bando, flutuam lentamente no mar.",
 		ko: "바다 온도가 높아지면\n머리의 부낭을 부풀려서\n해수면을 집단으로 떠돈다."
 	},
@@ -53,7 +53,7 @@ const card: Card = {
 			fr: "Le Pokémon Actif de votre adversaire est maintenant Endormi.",
 			es: "El Pokémon Activo de tu rival pasa a estar Dormido.",
 			it: "Il Pokémon attivo del tuo avversario viene addormentato.",
-			de: "Das Aktive Pokémon deines Gegners ist jetzt schläft.",
+			de: "Das Aktive Pokémon deines Gegners schläft jetzt.",
 			
 			ko: "상대의 배틀 포켓몬을 잠듦으로 만든다.",
 			'pt-br': "O Pokémon Ativo do seu oponente agora está Adormecido."

--- a/data/Pokémon TCG Pocket/Triumphant Light/025.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/025.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Quand il s'énerve, il libère instantanément\nl'énergie emmagasinée dans les poches de\nses joues.",
 		es: "Cuando se enfada, este Pokémon\ndescarga la energía que almacena en\nel interior de las bolsas de las mejillas.",
 		it: "Quando s'arrabbia, libera subito l'energia\naccumulata nelle sacche sulle guance.",
-		de: "Ist es wütend, entlädt sich augenblicklich die\nElektrizität, die es in seinen Backentaschen\ngespeichert hat.",
+		de: "Ist es wütend, entlädt sich augenblicklich die Elektrizität, die es in seinen Backentaschen gespeichert hat.",
 		'pt-br': "Quando está com raiva, descarrega\nimediatamente a energia armazenada\nnas bolsas em suas bochechas.",
 		ko: "양 볼에는 전기를 저장하는 주머니가 있다.\n화가 나면 저장한 전기를 단숨에 방출한다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/026.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/026.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pikachu",
-		fr: "Pikachu"
+		fr: "Pikachu",
+		de: "Pikachu"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il se protège des décharges grâce à sa queue,\nqui dissipe l'électricité dans le sol.",
 		es: "Su cola actúa como toma de tierra\ny descarga electricidad al suelo, lo\nque le protege de los calambrazos.",
 		it: "La sua coda scarica elettricità a terra,\nproteggendolo dalle scosse elettriche.",
-		de: "Mithilfe seines Schweifs entlädt es Elektrizität\nin den Boden, um sich auf diese Weise vor\nelektrischen Schlägen zu schützen.",
+		de: "Mithilfe seines Schweifs entlädt es Elektrizität in den Boden, um sich auf diese Weise vor elektrischen Schlägen zu schützen.",
 		'pt-br': "Sua cauda descarrega a eletricidade\nno solo, protegendo-o contra choques.",
 		ko: "꼬리가 어스 역할을 하여\n전기를 지면으로 흘려보내므로\n자신은 감전되거나 하지 않는다."
 	},
@@ -57,7 +58,7 @@ const card: Card = {
 			fr: "Si vous avez Arceus ou Arceus-ex en jeu, ce Pokémon subit − 30 dégâts provenant des attaques.",
 			es: "Si tienes a Arceus o Arceus ex en juego, los ataques hacen -30 puntos de daño a este Pokémon.",
 			it: "Se hai in gioco Arceus o Arceus-ex, questo Pokémon subisce -30 danni dagli attacchi.",
-			de: "Wenn du Arceus oder Arceus-ex im Spiel hast, werden diesem Pokémon durch Attacken − 30 Schadenspunkte zugefügt.",
+			de: "Wenn du Arceus oder Arceus-ex im Spiel hast, werden diesem Pokémon durch Attacken - 30 Schadenspunkte zugefügt.",
 			'pt-br': "Se você tiver Arceus ou Arceus ex em jogo, este Pokémon receberá −30 pontos de dano de ataques.",
 			ko: "자신의 필드에 「아르세우스」 또는 「아르세우스 ex」 있다면 이 포켓몬이 받는 기술의 데미지를 -30한다."
 		}

--- a/data/Pokémon TCG Pocket/Triumphant Light/027.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/027.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il émet des décharges à partir de l'électricité\nstatique accumulée dans sa fourrure. Il produit\ndes étincelles lorsque le temps devient orageux.",
 		es: "Acumula electricidad estática en el pelaje para lanzar descargas.\nCuando va a haber tormenta, suelta chispas por todo el cuerpo.",
 		it: "Accumula elettricità statica nella pelliccia e poi la rilascia.\nSe si avvicina una tempesta, emette scintille.",
-		de: "In seinem Fell speichert es statische Elektrizität\nfür spätere Entladungen. Braut sich ein Sturm\nzusammen, entlädt es Funken.",
+		de: "In seinem Fell speichert es statische Elektrizität für spätere Entladungen. Braut sich ein Sturm zusammen, entlädt es Funken.",
 		'pt-br': "Ele armazena eletricidade estática no pelo\npara depois descarregá-la.\nQuando uma tempestade se aproxima, solta fagulhas.",
 		ko: "정전기를 털에 비축하여\n방전한다. 폭풍이 가까이 오면\n온몸에서 불꽃을 튀긴다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/028.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/028.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Electrike",
-		fr: "Dynavolt"
+		fr: "Dynavolt",
+		de: "Frizelbliz"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il diffuse de l'électricité dans ses membres\npour augmenter sa vitesse. C'est également\nainsi qu'il apaise ses douleurs musculaires.",
 		es: "La electricidad estimula su musculatura para\nque pueda moverse a gran velocidad y le ayuda\na recuperarse del dolor muscular rápidamente.",
 		it: "L'elettricità gli stimola i muscoli rendendolo più\nveloce e inoltre allevia i suoi dolori muscolari\nfacendolo tornare rapidamente in forma.",
-		de: "Da es seine Muskeln mit Elektrizität stimuliert,\nkann es sich sehr schnell bewegen.\nAuch Muskelkater heilt es sofort mit Strom.",
+		de: "Da es seine Muskeln mit Elektrizität stimuliert, kann es sich sehr schnell bewegen. Auch Muskelkater heilt es sofort mit Strom.",
 		'pt-br': "Estimula eletricamente os próprios músculos para\nmover-se mais rapidamente. Alivia também as suas dores\ncom eletricidade, para se recuperar mais rápido.",
 		ko: "전기로 근육을 자극해서\n재빠르게 움직일 수 있다. 근육통도\n전기로 풀기 때문에 금방 낫는다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/029.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/029.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "On dit que ceux qui voient danser un groupe de Mélofée\nsous la pleine lune connaîtront un grand bonheur.",
 		es: "Se dice que la felicidad llegará\na quien vea un grupo de Clefairy\nbailando a la luz de la luna llena.",
 		it: "Si dice che vedere un gruppo di Clefairy ballare\ncon la luna piena sia di ottimo auspicio.",
-		de: "Eine Ansammlung von Piepi bei Vollmond tanzen\nzu sehen, soll ein glückliches Leben verheißen.",
+		de: "Eine Ansammlung von Piepi bei Vollmond tanzen zu sehen, soll ein glückliches Leben verheißen.",
 		'pt-br': "Acredita-se que a felicidade virá para aqueles\nque virem um grupo de Clefairy dançando sob\na lua cheia.",
 		ko: "보름달 밤에 삐삐가 모여\n춤을 추는 모습을 보면\n행복해진다고 전해진다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/030.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/030.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Clefairy",
-		fr: "Mélofée"
+		fr: "Mélofée",
+		de: "Piepi"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Ce Pokémon s'apparente à une petite fée\nqui n'apparaît que rarement devant les humains.\nIl court se cacher dès qu'il ressent une présence.",
 		es: "Este Pokémon de aspecto feérico, raramente\nvisto por los humanos, corre a esconderse\nen cuanto detecta que hay alguien cerca.",
 		it: "Timido Pokémon Fata, molto raro a\nvedersi. Scappa e si nasconde non\nappena avverte la presenza delle persone.",
-		de: "Ein feenhaftes und scheues Pokémon,\ndas sofort die Flucht ergreift, wenn es\nMenschen wahrnimmt.",
+		de: "Ein feenhaftes und scheues Pokémon, das sofort die Flucht ergreift, wenn es Menschen wahrnimmt.",
 		'pt-br': "Um tímido Pokémon fada raramente visto,\ncorre e esconde-se assim que percebe\na presença de pessoas.",
 		ko: "요정의 동료로 좀처럼\n사람 앞에 나타나지 않는다. 기척을\n느끼면 바로 도망가는 듯하다."
 	},
@@ -58,7 +59,7 @@ const card: Card = {
 			fr: "Pendant le prochain tour de votre adversaire, les attaques utilisées par le Pokémon Défenseur infligent − 30 dégâts.",
 			es: "Durante el próximo turno de tu rival, los ataques del Pokémon Defensor hacen -30 puntos de daño.",
 			it: "Durante il prossimo turno del tuo avversario, gli attacchi usati dal Pokémon difensore infliggono -30 danni.",
-			de: "Während des nächsten Zuges deines Gegners fügen die Attacken des Verteidigenden Pokémon − 30 Schadenspunkte zu.",
+			de: "Während des nächsten Zuges deines Gegners fügen die Attacken des Verteidigenden Pokémon - 30 Schadenspunkte zu.",
 			'pt-br': "Durante o próximo turno do seu oponente, os ataques usados pelo Pokémon Defensor causarão −30 pontos de dano.",
 			ko: "상대의 다음 차례에 이 기술을 받은 포켓몬이 사용하는 기술의 데미지를 -30한다."
 		}

--- a/data/Pokémon TCG Pocket/Triumphant Light/031.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/031.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il enveloppe ses proies dans le nuage de gaz\nque forme son corps et les empoisonne à travers\nleur peau afin de les affaiblir petit à petit.",
 		es: "Su estrategia consiste en envolver al rival con su\ncuerpo gaseoso y envenenarlo a través de la piel.",
 		it: "Avvolge le prede nel corpo gassoso\ne le indebolisce lentamente facendo\npenetrare il veleno nella loro pelle.",
-		de: "Es hüllt seine Beute in seinen Gaskörper ein\nund schwächt sie, indem es sie nach und nach\nüber die Haut vergiftet.",
+		de: "Es hüllt seine Beute in seinen Gaskörper ein und schwächt sie, indem es sie nach und nach über die Haut vergiftet.",
 		'pt-br': "Envolve o oponente em seu corpo gasoso,\nenfraquecendo sua presa lentamente\ne a envenenando pela pele.",
 		ko: "가스로 된 몸으로 휘감은 다음\n먹이의 피부를 통해 조금씩\n독을 흘려보내어 약하게 만든다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/032.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/032.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Gastly",
-		fr: "Fantominus"
+		fr: "Fantominus",
+		de: "Nebulak"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il adore se tapir dans l'ombre et faire frissonner\nses proies pour l'éternité en leur touchant l'épaule.",
 		es: "Le gusta acechar en la oscuridad y tocarles el\nhombro a sus víctimas con su mano gaseosa.\nEstas se quedan temblando para siempre.",
 		it: "Adora stare in agguato nei luoghi bui e toccare\nle spalle delle vittime con le sue mani gassose.\nIl suo tocco causa brividi incontenibili.",
-		de: "Es lauert gern im Dunkeln und tippt Leuten mit\nseiner gasförmigen Hand auf die Schulter.\nSeine Berührung erzeugt endloses Schaudern.",
+		de: "Es lauert gern im Dunkeln und tippt Leuten mit seiner gasförmigen Hand auf die Schulter. Seine Berührung erzeugt endloses Schaudern.",
 		'pt-br': "Gosta de se esconder no escuro e bater nos\nombros dos outros com sua mão gasosa.\nSeu toque causa arrepios que não acabam mais.",
 		ko: "어둠을 틈타 가스로 된 손을 뻗쳐\n사람의 어깨를 두드리기 좋아한다.\n그 손에 닿으면 떨림이 멈추지 않는다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/033.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/033.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Haunter",
-		fr: "Spectrum"
+		fr: "Spectrum",
+		de: "Alpollo"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il se cache dans l'ombre de sa victime et attend\npatiemment le bon moment pour lui voler sa vie.",
 		es: "Para quitarle la vida a su presa, se desliza en su\nsombra y espera su oportunidad en silencio.",
 		it: "Per sottrarre energia alla vittima si\nnasconde nella sua ombra e attende\nin silenzio il momento opportuno.",
-		de: "Um Beute zu erlegen, versteckt es sich\nin deren Schatten und wartet still auf\neine günstige Gelegenheit.",
+		de: "Um Beute zu erlegen, versteckt es sich in deren Schatten und wartet still auf eine günstige Gelegenheit.",
 		'pt-br': "Este Pokémon aguarda pela oportunidade\nperfeita para se esconder na sombra de sua\npresa e roubar a vida dela.",
 		ko: "생명을 빼앗기로 정한 먹잇감의\n그림자에 숨어들어\n꼼짝하지 않고 기회를 노린다."
 	},
@@ -58,7 +59,7 @@ const card: Card = {
 			fr: "Le Pokémon Actif de votre adversaire est maintenant Endormi.",
 			es: "El Pokémon Activo de tu rival pasa a estar Dormido.",
 			it: "Il Pokémon attivo del tuo avversario viene addormentato.",
-			de: "Das Aktive Pokémon deines Gegners ist jetzt schläft.",
+			de: "Das Aktive Pokémon deines Gegners schläft jetzt.",
 			
 			ko: "상대의 배틀 포켓몬을 잠듦으로 만든다.",
 			'pt-br': "O Pokémon Ativo do seu oponente agora está Adormecido."

--- a/data/Pokémon TCG Pocket/Triumphant Light/034.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/034.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Son corps plat et fin est toujours collé aux murs.\nOn pense que sa forme a une signification.",
 		es: "Su cuerpo fino y plano aparece siempre en los\nmuros. Su forma parece tener algún significado.",
 		it: "Il corpo piatto e sottile sta sempre attaccato ai muri.\nPare che la forma abbia un preciso significato.",
-		de: "Sein flacher, dünner Körper hängt immer an Wänden.\nSeine Form scheint eine Bedeutung zu haben.",
+		de: "Sein flacher, dünner Körper hängt immer an Wänden. Seine Form scheint eine Bedeutung zu haben.",
 		'pt-br': "Seu corpo delgado e plano fica sempre colado\nnas paredes. Sua forma parece ter algum propósito.",
 		ko: "몸 자체는 굉장히 얇고\n항상 벽에 들러붙어 있다.\n모습에는 뭔가 의미가 있는 듯하다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/035.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/035.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Son corps semblable à de l'électricité lui permet\nde prendre le contrôle de certains appareils\nménagers pour jouer des tours aux autres.",
 		es: "Con su cuerpo eléctrico puede infiltrarse en algunos\naparatos para controlarlos y hacer travesuras.",
 		it: "Il suo corpo simile all'elettricità può introdursi in alcuni\napparecchi, di cui prende il controllo per combinare guai.",
-		de: "Sein Körper ähnelt Elektrizität und erlaubt es ihm,\nin einige Geräte einzudringen, um dann damit für\nChaos zu sorgen.",
+		de: "Sein Körper ähnelt Elektrizität und erlaubt es ihm, in einige Geräte einzudringen, um dann damit für Chaos zu sorgen.",
 		'pt-br': "Seu corpo elétrico pode penetrar em alguns tipos\nde máquinas e assumir o controle para fazer malvadezas.",
 		ko: "전기 같은 몸은\n일부 기계에 들어갈 수 있다.\n그리고 그 몸으로 장난을 친다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/036.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/036.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Bien qu'il fasse semblant d'être un arbre, par sa composition,\nil semble plus proche d'un minéral que d'un végétal.",
 		es: "Aunque pretende ser un árbol, en su composición\nse parece más a una roca que a una planta.",
 		it: "Sebbene finga di essere un albero, il suo corpo\nha una composizione più simile a quella di una\nroccia che a quella di un vegetale.",
-		de: "Obwohl es vorgibt, ein Baum zu sein, kommt seine\nZusammensetzung einem Stein näher als einer Pflanze.",
+		de: "Obwohl es vorgibt, ein Baum zu sein, kommt seine Zusammensetzung einem Stein näher als einer Pflanze.",
 		'pt-br': "Apesar de sempre fingir ser uma árvore, sua composição\ntem mais semelhanças com pedras do que com vegetação.",
 		ko: "항상 나무인 척하고 있다.\n몸의 구조는 식물보다\n돌이나 바위에 가까운 듯하다."
 	},
@@ -53,7 +53,7 @@ const card: Card = {
 			fr: "Si le Pokémon Actif de votre adversaire est un Pokémon-{ex}, cette attaque inflige 30 dégâts supplémentaires.",
 			es: "Si el Pokémon Activo de tu rival es un Pokémon {ex}, este ataque hace 30 puntos de daño más.",
 			it: "Se il Pokémon attivo del tuo avversario è un Pokémon-{ex}, questo attacco infligge 30 danni in più.",
-			de: "Wenn das Aktive Pokémon deines Gegners ein Pokémon-{ex} ist, fügt diese Attacke 30 Schadenspunkte mehr zu.",
+			de: "Wenn das Aktive Pokémon deines Gegners ein Pokémon-ex ist, fügt diese Attacke 30 Schadenspunkte mehr zu.",
 			'pt-br': "Se o Pokémon Ativo do seu oponente for um Pokémon {ex}, este ataque causará 30 pontos de dano a mais.",
 			ko: "상대의 배틀 포켓몬이 「포켓몬 {ex}」라면 30데미지를 추가한다."
 		}

--- a/data/Pokémon TCG Pocket/Triumphant Light/037.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/037.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Les Phanpy vivent dans les trous qu'ils creusent,\nprès des rivières. Après avoir joué dans la boue,\nils ont besoin de faire leur toilette pour se calmer.",
 		es: "Vive en hoyos que cava en la ribera de los ríos. Tras retozar en el\nlodo, no se queda tranquilo hasta haberse lavado bien el cuerpo.",
 		it: "Vive in tane che costruisce in riva ai fiumi.\nDopo aver giocato nel fango, non riesce\na star tranquillo finché non si è lavato.",
-		de: "Es lebt in Nestern, die es an Flussufern baut.\nNach dem Spielen im Schlamm muss es sich\nerst waschen, um sich wohlzufühlen.",
+		de: "Es lebt in Nestern, die es an Flussufern baut. Nach dem Spielen im Schlamm muss es sich erst waschen, um sich wohlzufühlen.",
 		'pt-br': "Este Pokémon vive e constrói seu ninho nas margens\ndos rios. Depois de brincar na lama, não sossega\naté se lavar direito.",
 		ko: "냇가에 굴을 파고 산다.\n흙장난을 한 뒤에 몸을 씻지 못하면\n안절부절못하기 때문이다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/038.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/038.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Phanpy",
-		fr: "Phanpy"
+		fr: "Phanpy",
+		de: "Phanpy"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Sa peau est si dure qu'une collision avec\nune voiture le laisserait indifférent. En revanche,\nil est extrêmement sensible à la pluie.",
 		es: "Su dura piel podría resistir el choque contra un coche sin\nsufrir un rasguño. La lluvia, sin embargo, es su punto débil.",
 		it: "La sua pelle è così dura che anche se sbatte\ncontro una macchina non si fa un graffio.\nLa pioggia è il suo punto debole.",
-		de: "Seine Haut ist so hart, dass ihm nicht einmal der\nZusammenprall mit einem Auto etwas anhaben kann.\nRegen setzt ihm jedoch stark zu.",
+		de: "Seine Haut ist so hart, dass ihm nicht einmal der Zusammenprall mit einem Auto etwas anhaben kann. Regen setzt ihm jedoch stark zu.",
 		'pt-br': "Donphan é recoberto por uma couraça resistente\ne não se abala nem quando é atingido por um carro.\nNo entanto, é extremamente vulnerável a chuva.",
 		ko: "튼튼한 피부로 둘러싸여 있기 때문에\n차에 부딪혀도 끄떡없다.\n그러나 비에는 매우 약하다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/039.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/039.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il naît dans les profondeurs terrestres. Après\navoir englouti une quantité de terre équivalente\nà une montagne, il se transforme en chrysalide.",
 		es: "Nacido en las profundidades subterráneas,\neste Pokémon se convierte en pupa al comer\nla cantidad de tierra equivalente a una montaña.",
 		it: "Nasce nel profondo sottosuolo e dopo\naver mangiato una montagna di terra\nsi trasforma in una crisalide.",
-		de: "Es wird tief im Erdreich geboren. Hat es einen Berg\nErde gefressen, verpuppt sich dieses Pokémon.",
+		de: "Es wird tief im Erdreich geboren. Hat es einen Berg Erde gefressen, verpuppt sich dieses Pokémon.",
 		'pt-br': "Este Pokémon nasce no subsolo e se torna uma pupa\napós comer terra o suficiente para fazer uma montanha.",
 		ko: "땅속 깊은 곳에서 태어나\n산을 이룰 정도의 흙을 먹고 나면\n몸을 만들기 위해 번데기가 된다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/040.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/040.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Larvitar",
-		fr: "Embrylex"
+		fr: "Embrylex",
+		de: "Larvitar"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il est très fort, et sa carapace est aussi\ndure que la pierre. Lorsqu'il est furieux,\nses coups peuvent raser une montagne.",
 		es: "Su caparazón es duro como una piedra y muy\nresistente. Sus golpes pueden derribar montañas.",
 		it: "Il suo corpo è ricoperto da un guscio duro come\nla roccia ed è molto forte. Quando si infuria, è\ncapace di abbattere persino una montagna.",
-		de: "Es ist sehr stark und hat einen steinharten Panzer.\nGerät es außer Kontrolle, kann es Berge dem\nErdboden gleichmachen.",
+		de: "Es ist sehr stark und hat einen steinharten Panzer. Gerät es außer Kontrolle, kann es Berge dem Erdboden gleichmachen.",
 		'pt-br': "Seu casco é duro como rocha e muito forte.\nSuas pancadas podem derrubar uma montanha.",
 		ko: "암반 같은 단단한 껍질로\n둘러싸여 있지만 힘이 강해서\n난동을 부리면 산도 무너져 버린다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/041.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/041.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pupitar",
-		fr: "Ymphect"
+		fr: "Ymphect",
+		de: "Pupitar"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Ce Pokémon est si fort qu'il est capable\nde modifier la topographie d'un lieu.\nIl ne se préoccupe pas des autres.",
 		es: "Tiene tanta fuerza que puede cambiar el paisaje.\nSu naturaleza insolente le hace ser muy egoísta.",
 		it: "Con la sua forza smisurata riesce a trasformare\nil paesaggio con estrema facilità. La sua indole\ninsolente lo rende indifferente al mondo.",
-		de: "Dieses kaltblütige und rücksichtslose Pokémon ist\nso stark, dass es mit Leichtigkeit das Aussehen\nganzer Landstriche verändern kann.",
+		de: "Dieses kaltblütige und rücksichtslose Pokémon ist so stark, dass es mit Leichtigkeit das Aussehen ganzer Landstriche verändern kann.",
 		'pt-br': "Extremamente forte, pode modificar a paisagem.\nÉ tão insolente que não se preocupa com os outros.",
 		ko: "주변 지형을 바꾸는 정도쯤은\n쉽게 해낼 정도의 힘을 가지고 있다.\n주위를 신경 쓰지 않는 대담한 성격."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/042.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/042.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il ne se déplace que d'un centimètre\npar an, mais s'il se sent menacé, il virevolte\net s'enfonce dans le sol en un instant.",
 		es: "Solo se desplaza un centímetro al año, pero,\nsi se siente amenazado, gira sobre sí mismo\ny se hunde bajo tierra en un abrir y cerrar de ojos.",
 		it: "Si sposta di 1 cm all'anno, ma quando si trova in difficoltà\nruota su se stesso e in un attimo si nasconde sottoterra.",
-		de: "Es bewegt sich nur 1 cm pro Jahr, aber in\nNotlagen bohrt es sich mit seinem Körper\nblitzschnell in den Boden.",
+		de: "Es bewegt sich nur 1 cm pro Jahr, aber in Notlagen bohrt es sich mit seinem Körper blitzschnell in den Boden.",
 		'pt-br': "Este Pokémon move-se 3 centímetros por ano,\nmas quando está em uma enrascada, gira e perfura o solo\nem questão de segundos.",
 		ko: "1년에 1cm밖에 움직이지 않지만\n위기에 처하면 회전하여\n순식간에 땅속으로 파고든다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/043.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/043.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Méditikka ne rate jamais une séance\nde yoga. Il augmente sa force\nintérieure par la méditation.",
 		es: "Practica yoga a diario y no se pierde ni una sesión.\nMediante la meditación, aumenta su fuerza interior.",
 		it: "Non rinuncia mai alla sua ora di yoga\nquotidiana. La meditazione gli permette\ndi aumentare la sua forza interiore.",
-		de: "Es vergisst nie sein tägliches Yogatraining.\nDurch Meditation erhöht es seine innere Stärke.",
+		de: "Es vergisst nie sein tägliches Yogatraining. Durch Meditation erhöht es seine innere Stärke.",
 		'pt-br': "Nunca perde um dia de ioga.\nAumenta sua força interior com meditação.",
 		ko: "매일 요가 수행을 거르지 않는다.\n명상을 통해서 정신력을 높인다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/044.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/044.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Meditite",
-		fr: "Méditikka"
+		fr: "Méditikka",
+		de: "Meditie"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Ses pouvoirs psychiques, renforcés\npar la pratique du yoga, lui permettent\nde prédire les mouvements de ses adversaires.",
 		es: "Puede prever los movimientos de su rival usando\nsus poderes psíquicos, fortalecidos por el yoga.",
 		it: "È in grado di conoscere in anticipo le mosse\ndel nemico grazie ai poteri di preveggenza\nottenuti con le pratiche yoga.",
-		de: "Mit Yogaübungen hat es seine Psycho-Kräfte geschärft\nund ahnt so die Attacken seiner Gegner voraus.",
+		de: "Mit Yogaübungen hat es seine Psycho-Kräfte geschärft und ahnt so die Attacken seiner Gegner voraus.",
 		'pt-br': "Através do treinamento de ioga, ganhou o poder psíquico\nde prever o movimento seguinte do oponente.",
 		ko: "요가 수행으로 단련된\n사이코 파워로 상대의 움직임을\n예상할 수 있다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/045.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/045.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il attend qu'une proie passe pour bondir hors de son trou\net la croquer. Dans son élan, il se casse parfois les dents.",
 		es: "Permanece oculto en cuevas y, cuando pasa una\npresa, se abalanza sobre ella y la muerde con\ntanta fuerza que hasta se le rompen los dientes.",
 		it: "Aspetta nemici e prede in agguato nella sua\ntana. Quando gli arrivano a tiro, li addenta\ncon tale forza che a volte si spezza i denti.",
-		de: "Es verbirgt sich in kleinen Höhlen, aus denen es\nherausspringt und vorbeilaufende Gegner oder\nBeute beißt. Manchmal bricht dabei ein Zahn ab.",
+		de: "Es verbirgt sich in kleinen Höhlen, aus denen es herausspringt und vorbeilaufende Gegner oder Beute beißt. Manchmal bricht dabei ein Zahn ab.",
 		'pt-br': "Esconde-se em cavernas e quando presas ou inimigos\npassam, sai e os devora. A força do seu ataque às vezes\nquebra seus dentes.",
 		ko: "구멍에 숨어서 먹이나 적이\n지나가면 뛰쳐나가 문다.\n기세가 대단해 이가 빠질 때도 있다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/046.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/046.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Gible",
-		fr: "Griknot"
+		fr: "Griknot",
+		de: "Kaumalat"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Lorsqu'il mue, il perd parfois ses écailles. Les remèdes\nconcoctés à partir de celles-ci sont de puissants toniques.",
 		es: "Muy ocasionalmente puede mudar la piel y\nperder las escamas. Las medicinas que las usan\ncomo ingrediente son muy reconstituyentes.",
 		it: "Fa la muta molto di rado. Con le scaglie perse\nin questo modo si possono preparare tonici che\nalleviano la stanchezza e ripristinano le energie.",
-		de: "Ab und zu häutet es sich und verliert Schuppen.\nMedizin, die solche Schuppen enthält, macht\nmüde Körper munter.",
+		de: "Ab und zu häutet es sich und verliert Schuppen. Medizin, die solche Schuppen enthält, macht müde Körper munter.",
 		'pt-br': "Troca de pele raramente e deixa suas escamas para trás.\nRemédios feitos com suas escamas farão um adoecido\nsentir-se revigorado.",
 		ko: "드물게 탈피해서 비늘이 벗겨진다.\n그 성분이 들어 있는 약은\n피곤한 몸을 회복시켜 준다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/047.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/047.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Gabite",
-		fr: "Carmache"
+		fr: "Carmache",
+		de: "Knarksel"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Triumphant Light/048.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/048.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il sonde les environs en émettant des ultrasons\navec sa bouche, et peut ainsi se frayer un chemin\nmême dans les grottes les plus étroites.",
 		es: "Emite ondas ultrasónicas por la boca\npara escrutar el entorno, lo que le permite\nvolar con pericia por cuevas angostas.",
 		it: "Sonda l'ambiente circostante emettendo\nultrasuoni dalla bocca. In questo modo riesce\na volteggiare agilmente anche in caverne strette.",
-		de: "Über den Mund stößt es Ultraschallwellen aus,\num seine Umgebung zu erkunden. So kann es\nselbst in engen Höhlen geschickt umherfliegen.",
+		de: "Über den Mund stößt es Ultraschallwellen aus, um seine Umgebung zu erkunden. So kann es selbst in engen Höhlen geschickt umherfliegen.",
 		'pt-br': "Emite ondas ultrassônicas de sua boca para\nverificar os arredores. Zubat voa com certa\ndestreza mesmo em cavernas apertadas.",
 		ko: "입에서 내보내는 초음파로\n주위의 상황을 살핀다. 좁은\n동굴에서도 능숙하게 날아다닌다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/049.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/049.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Zubat",
-		fr: "Nosferapti"
+		fr: "Nosferapti",
+		de: "Zubat"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Le sang des êtres vivants est son péché mignon.\nOn dit qu'il partage parfois ce précieux breuvage\navec ses congénères affamés.",
 		es: "Le encanta chuparles la sangre a los seres\nvivos. En ocasiones comparte la preciada\ncolecta con otros congéneres hambrientos.",
 		it: "Va matto per il sangue di altre creature. Si dice\nche a volte lo condivida con i compagni affamati.",
-		de: "Das Blut anderer Lebewesen ist seine Leibspeise.\nMan sagt, dass es das abgesaugte Blut manchmal\nmit hungrigen Artgenossen teilt.",
+		de: "Das Blut anderer Lebewesen ist seine Leibspeise. Man sagt, dass es das abgesaugte Blut manchmal mit hungrigen Artgenossen teilt.",
 		'pt-br': "Ama beber o sangue de outras criaturas. Dizem que,\nse encontra outros de sua espécie passando fome,\nàs vezes compartilha o sangue que recolheu.",
 		ko: "살아 있는 생물의 혈액을 좋아한다.\n굶주린 동료에게 빨아들인 피를\n나눠주기도 한다고 한다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/050.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/050.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Golbat",
-		fr: "Nosferalto"
+		fr: "Nosferalto",
+		de: "Golbat"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Ses pattes sont devenues des ailes.\nIl fond sur sa proie furtivement puis\nplante ses crocs dans sa nuque.",
 		es: "Sus patas se han convertido en alas. Se lanza\nsobre su presa en un vuelo silencioso a alta\nvelocidad y le clava los colmillos en la nuca.",
 		it: "Le due zampe si sono mutate in ali. Vola verso\nla preda ad alta velocità senza fare alcun\nrumore e le affonda le zanne nella nuca.",
-		de: "Seine zwei Beine wurden zu Flügeln. Es fliegt\nschnell und lautlos zu seiner Beute, um ihr dann\ndie Zähne in den Nacken zu bohren.",
+		de: "Seine zwei Beine wurden zu Flügeln. Es fliegt schnell und lautlos zu seiner Beute, um ihr dann die Zähne in den Nacken zu bohren.",
 		'pt-br': "Suas duas pernas se transformaram em asas.\nSilenciosamente, Crobat voa de forma ágil em direção\nà sua presa e afunda seus dentes na nuca de seu alvo.",
 		ko: "양발이 날개로 변화했다.\n소리를 내지 않고 고속으로 날아\n먹이의 목덜미에 이빨을 꽂는다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/051.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/051.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il fait gonfler ses glandes venimeuses tout en émettant un son\neffrayant, ce qui lui permet d'empoisonner ses proies pétrifiées.",
 		es: "Infla sus bolsas venenosas para emitir un sonido macabro\na su alrededor y envenena al rival en cuanto se amedrenta.",
 		it: "Gonfia le sue sacche di veleno emettendo un verso\nsinistro che fa impietrire l'avversario, poi lo avvelena.",
-		de: "Bläst es seine Giftbeutel auf, ertönt ein\nunheimliches Geräusch. Wenn Gegner\ndadurch zurückschrecken, vergiftet es sie.",
+		de: "Bläst es seine Giftbeutel auf, ertönt ein unheimliches Geräusch. Wenn Gegner dadurch zurückschrecken, vergiftet es sie.",
 		'pt-br': "Ao inflar suas bolsas de veneno, preenche a área\ncom um som peculiar e acerta os oponentes assustados\ncom um soco venenoso.",
 		ko: "독주머니를 부풀리며 울어서\n주변에 으스스한 소리를 퍼트린 후\n상대가 풀죽으면 독찌르기를 한다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/052.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/052.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Croagunk",
-		fr: "Cradopaud"
+		fr: "Cradopaud",
+		de: "Glibunkel"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il esquive avec souplesse les attaques de ses\nadversaires tout en bondissant dans leur direction,\npuis il riposte de ses griffes empoisonnées.",
 		es: "Esquiva ágilmente los ataques de sus\nenemigos mientras va acortando distancias\npara contraatacar con sus garras venenosas.",
 		it: "Con il suo corpo flessibile schiva l'attacco del\nnemico e lo trafigge al volo con spine velenose.",
-		de: "Mit seinem geschmeidigen Körper weicht es\nAttacken aus und durchbricht die Deckung des\nGegners, um mit seinen Giftklauen zuzustechen.",
+		de: "Mit seinem geschmeidigen Körper weicht es Attacken aus und durchbricht die Deckung des Gegners, um mit seinen Giftklauen zuzustechen.",
 		'pt-br': "Balançando e desviando dos ataques dos inimigos,\neste Pokémon usa seu corpo flexível para se aproximar\ne, em seguida, atacar com suas garras venenosas.",
 		ko: "유연한 몸으로 상대의 공격을 피하며\n깊숙이 뛰어들어 독가시를 꿰찌른다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/053.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/053.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Les ondes électromagnétiques émises par ses extrémités\nlui permettent de défier les lois de la gravité et de flotter.",
 		es: "Las unidades laterales crean ondas\nelectromagnéticas que contrarrestan\nla gravedad y le permiten flotar.",
 		it: "Le onde elettromagnetiche generate dagli\nelementi laterali neutralizzano la gravità\npermettendogli di levitare a mezz'aria.",
-		de: "Die seitlichen Module halten es in der Luft,\nindem sie mit elektromagnetischen Wellen\ndie Schwerkraft überlisten.",
+		de: "Die seitlichen Module halten es in der Luft, indem sie mit elektromagnetischen Wellen die Schwerkraft überlisten.",
 		'pt-br': "As ondas eletromagnéticas emitidas pelas\nunidades nas laterais de sua cabeça geram\nantigravidade, o que faz com que ele possa flutuar.",
 		ko: "좌우에 있는 유닛에서 나오는\n전자파를 이용해\n중력을 거슬러 하늘에 떠 있다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/054.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/054.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Magnemite",
-		fr: "Magnéti"
+		fr: "Magnéti",
+		de: "Magnetilo"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Le lien magnétique qui rattache ces trois Magnéti est si puissant\nqu'il fait mal aux oreilles si on s'en approche trop.",
 		es: "Tres Magnemite se enlazan mediante una\nintensa fuerza magnética. Provoca un fuerte\npitido en los oídos a quien se le acerque.",
 		it: "Tre Magnemite sono uniti da una\npotente forza magnetica. Se ci si\navvicina troppo, le orecchie fischiano.",
-		de: "Drei Magnetilo sind durch ein starkes\nMagnetfeld verbunden. In seiner Nähe\nbekommt man Ohrensausen.",
+		de: "Drei Magnetilo sind durch ein starkes Magnetfeld verbunden. In seiner Nähe bekommt man Ohrensausen.",
 		'pt-br': "Três Magnemite estão vinculados por uma força\nmagnética muito poderosa. Se você chegar\nmuito perto, ficará com dor de ouvido.",
 		ko: "3개의 코일은 강한 자력으로\n연결되어 있다. 가까이 다가가면\n강한 귀울림에 시달리게 된다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/055.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/055.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Magneton",
-		fr: "Magnéton"
+		fr: "Magnéton",
+		de: "Magneton"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il parcourt le ciel en émettant et en\nrecevant des ondes bien mystérieuses.",
 		es: "Se dice que mientras vuela emite unas ondas eléctricas\nmisteriosas, a la vez que recibe otras ondas desconocidas.",
 		it: "Vola per il cielo inviando misteriose onde\nelettromagnetiche e ricevendo onde sconosciute.",
-		de: "Es heißt, dass es beim Herumfliegen mysteriöse Funkwellen\naussende und unbekannte Wellen empfange.",
+		de: "Es heißt, dass es beim Herumfliegen mysteriöse Funkwellen aussende und unbekannte Wellen empfange.",
 		'pt-br': "Dizem que enquanto voa pelo céu, emite ondas\neletromagnéticas misteriosas enquanto recebe\nondas desconhecidas.",
 		ko: "괴전파를 발신하며 하늘을 날면서\n미지의 전파를 수신한다고 한다."
 	},
@@ -57,7 +58,7 @@ const card: Card = {
 			fr: "Si vous avez Arceus ou Arceus-ex en jeu, ce Pokémon subit − 30 dégâts provenant des attaques.",
 			es: "Si tienes a Arceus o Arceus ex en juego, los ataques hacen -30 puntos de daño a este Pokémon.",
 			it: "Se hai in gioco Arceus o Arceus-ex, questo Pokémon subisce -30 danni dagli attacchi.",
-			de: "Wenn du Arceus oder Arceus-ex im Spiel hast, werden diesem Pokémon durch Attacken − 30 Schadenspunkte zugefügt.",
+			de: "Wenn du Arceus oder Arceus-ex im Spiel hast, werden diesem Pokémon durch Attacken - 30 Schadenspunkte zugefügt.",
 			'pt-br': "Se você tiver Arceus ou Arceus ex em jogo, este Pokémon receberá −30 pontos de dano de ataques.",
 			ko: "자신의 필드에 「아르세우스」 또는 「아르세우스 ex」 있다면 이 포켓몬이 받는 기술의 데미지를 -30한다."
 		}

--- a/data/Pokémon TCG Pocket/Triumphant Light/056.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/056.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Trompés par son visage innocent, ses ennemis se font happer\npar ses énormes mâchoires et ne peuvent plus s'échapper.",
 		es: "Con su cara inocente hace que el rival se confíe\ny, al bajar la guardia, le da un mordisco con sus\nenormes fauces del que no se puede liberar.",
 		it: "Distrae i nemici con la sua faccia innocente,\nper poi azzannarli con le sue possenti mascelle.\nNon molla la presa a nessun costo.",
-		de: "Mit seinem friedlichen Gesicht wiegt es Gegner\nin Sicherheit und beißt dann mit seinem riesigen\nKiefer zu. Danach gibt es kein Entkommen mehr.",
+		de: "Mit seinem friedlichen Gesicht wiegt es Gegner in Sicherheit und beißt dann mit seinem riesigen Kiefer zu. Danach gibt es kein Entkommen mehr.",
 		'pt-br': "Usa seu rosto dócil para fazer seus inimigos\ncomplacentes e então os morde com suas\nmandíbulas enormes sem dar trégua.",
 		ko: "얌전한 얼굴로 상대를 방심하게\n만들고 큰 턱으로 덥석 문다.\n한번 물면 절대로 놓지 않는다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/057.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/057.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Nosepass",
-		fr: "Tarinor"
+		fr: "Tarinor",
+		de: "Nasgnet"
 	},
 
 	stage: "Stage1",
@@ -49,7 +50,7 @@ const card: Card = {
 			fr: "Pendant le prochain tour de votre adversaire, ce Pokémon subit − 20 dégâts provenant des attaques.",
 			es: "Durante el próximo turno de tu rival, los ataques hacen -20 puntos de daño a este Pokémon.",
 			it: "Durante il prossimo turno del tuo avversario, questo Pokémon subisce -20 danni dagli attacchi.",
-			de: "Während des nächsten Zuges deines Gegners werden diesem Pokémon durch Attacken − 20 Schadenspunkte zugefügt.",
+			de: "Während des nächsten Zuges deines Gegners werden diesem Pokémon durch Attacken - 20 Schadenspunkte zugefügt.",
 			'pt-br': "Durante o próximo turno do seu oponente, este Pokémon receberá −20 pontos de dano de ataques.",
 			ko: "상대의 다음 차례에 이 포켓몬이 받는 기술의 데미지를 -20한다."
 		}

--- a/data/Pokémon TCG Pocket/Triumphant Light/058.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/058.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "On croyait autrefois que les motifs qui ornent\nson dos renfermaient une puissance mystique.",
 		es: "Antaño se creía que en el dibujo de su parte\nposterior residía una fuerza misteriosa.",
 		it: "Nell'antichità si credeva che una forza misteriosa\ndimorasse nei disegni sul dorso di Bronzor.",
-		de: "Früher glaubten die Menschen, dem Muster auf\nseinem Rücken wohne eine mysteriöse Kraft inne.",
+		de: "Früher glaubten die Menschen, dem Muster auf seinem Rücken wohne eine mysteriöse Kraft inne.",
 		'pt-br': "Os povos antigos acreditavam que o padrão nas costas\nde Bronzor continha um poder misterioso.",
 		ko: "옛날 사람들은 동미러의\n등 무늬에 신비한 힘이\n깃들어 있다고 믿었다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/059.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/059.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Bronzor",
-		fr: "Archéomire"
+		fr: "Archéomire",
+		de: "Bronzel"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il a longtemps été vénéré pour avoir apporté\nla pluie. On le trouve parfois enterré dans le sol.",
 		es: "Antaño se adoraba a este Pokémon para\nque propiciara lluvias abundantes. A veces,\npuede encontrarse enterrado bajo tierra.",
 		it: "È stato venerato per secoli come Pokémon che\nporta la pioggia. A volte lo si trova sepolto nel terreno.",
-		de: "Vor Urzeiten wurden sie als Regenmacher verehrt.\nManchmal findet man eines von ihnen im Boden vergraben.",
+		de: "Vor Urzeiten wurden sie als Regenmacher verehrt. Manchmal findet man eines von ihnen im Boden vergraben.",
 		'pt-br': "Nas idades antigas, este Pokémon era reverenciado\ncomo aquele que fazia chover. Ele foi descoberto\nenterrado no chão.",
 		ko: "비구름을 부르는 포켓몬으로\n아주 옛날부터 떠받들어졌다.\n가끔 땅에 묻혀 있다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/060.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/060.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "La lumière lui a donné cette forme semblable à celle du créateur\nde toutes choses. La force qu'il déploie est telle que je ne peux\nm'empêcher de penser qu'il est sous sa forme véritable.",
 		es: "La luz desencadena el cambio a esta forma, que recuerda\nal creador de todo lo existente. La colosal fuerza de la que\nhace gala nos sugiere que se trata de su verdadera forma.",
 		it: "La luce ha cagionato in lui un cambio di forma radicale,\nrendendolo un simulacro della divinità creatrice sì potente\nche fatico a non ritenere questa la sua forma veritiera.",
-		de: "Licht lässt es eine Form annehmen, die der Schöpfergottheit\nzu gleichen scheint. Die gewaltige Stärke nährt den Verdacht,\ndass es sich bei dieser Gestalt um sein wahres Antlitz handelt.",
+		de: "Licht lässt es eine Form annehmen, die der Schöpfergottheit zu gleichen scheint. Die gewaltige Stärke nährt den Verdacht, dass es sich bei dieser Gestalt um sein wahres Antlitz handelt.",
 		'pt-br': "Uma luz radiante fez com que Dialga assumisse uma\nforma semelhante ao Pokémon criador. Sua força é tão\ncolossal que acreditam ser essa a sua verdadeira forma.",
 		ko: "밝은 빛이 폼체인지의 방아쇠가 되었다.\n창조신과 흡사한 이 모습이야말로 진정한 모습임에\n의심할 여지가 없을 정도로 강력한 힘을 발휘한다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/061.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/061.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il vit dans le Monde Distorsion,\nun monde à l'opposé du nôtre\nqui échappe au sens commun.",
 		es: "Vive en el Mundo Distorsión, un mundo opuesto\nal nuestro y cuyas leyes desafían el sentido común.",
 		it: "Vive nel Mondo Distorto che, sfidando l'ordine\ncosmico, si trova sul lato opposto al nostro.",
-		de: "Es lebt in einer Zerrwelt, die auf der Kehrseite\nder unseren liegt und die sich aller Logik entzieht.",
+		de: "Es lebt in einer Zerrwelt, die auf der Kehrseite der unseren liegt und die sich aller Logik entzieht.",
 		'pt-br': "Dizem que este Pokémon vive em um mundo reverso\nao nosso, onde o senso comum é distorcido e estranho.",
 		ko: "상식이 통하지 않는\n이 세상의 이면에 있다고 불리는\n깨어진 세계에 서식한다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/062.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/062.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Ses multiples évolutions lui permettent\nde s'adapter à tout type de milieu naturel.",
 		es: "Es capaz de evolucionar de muchas maneras\npara adaptarse sin problemas a cualquier medio.",
 		it: "La capacità di evolversi in diverse specie gli permette\ndi adattarsi perfettamente a qualsiasi tipo di ambiente.",
-		de: "Um sich jeder Umgebung perfekt anpassen zu\nkönnen, ist es in der Lage, sich zu verschiedenen\nPokémon zu entwickeln.",
+		de: "Um sich jeder Umgebung perfekt anpassen zu können, ist es in der Lage, sich zu verschiedenen Pokémon zu entwickeln.",
 		'pt-br': "Sua capacidade de evoluir para muitas formas\npermite que se adapte fácil e perfeitamente\na qualquer ambiente.",
 		ko: "환경 변화에 곧바로 적응할 수 있도록\n여러 형태로 진화할 수 있는\n가능성을 가지고 있다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/063.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/063.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Ronflex n'est pas satisfait tant qu'il n'a pas avalé\nses 400 kg de nourriture quotidienne. Dès qu'il\na fini, il commence une sieste pour digérer.",
 		es: "No se encuentra satisfecho hasta haber\ningerido 400 kg de comida cada día.\nCuando acaba de comer, se queda dormido.",
 		it: "Dopo aver trangugiato i suoi immancabili 400 kg\ndi cibo quotidiani, cade in un sonno profondo.",
-		de: "Es muss über 400 kg Nahrung am Tag fressen,\num satt zu werden. Ist es mit dem Essen fertig,\nschläft es sofort ein.",
+		de: "Es muss über 400 kg Nahrung am Tag fressen, um satt zu werden. Ist es mit dem Essen fertig, schläft es sofort ein.",
 		'pt-br': "Não se satisfaz a menos que coma mais de\n400 kg de alimentos todos os dias. Quando\ntermina de comer, dorme imediatamente.",
 		ko: "하루에 400kg의 음식을\n먹지 않으면 성에 차지 않는다.\n다 먹으면 잠이 들어 버린다."
 	},
@@ -53,7 +53,7 @@ const card: Card = {
 			fr: "Ce Pokémon est maintenant Endormi.",
 			es: "Este Pokémon pasa a estar Dormido.",
 			it: "Questo Pokémon viene addormentato.",
-			de: "Dieses Pokémon ist jetzt schläft.",
+			de: "Dieses Pokémon schläft jetzt.",
 			
 			ko: "이 포켓몬을 잠듦으로 만든다.",
 			'pt-br': "Este Pokémon agora está Adormecido."

--- a/data/Pokémon TCG Pocket/Triumphant Light/064.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/064.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il se tient toujours sur un pied.\nIl en change si vite qu'on peut\nà peine distinguer ce mouvement.",
 		es: "Se apoya en una sola pata y, cuando cambia de una\na otra, se mueve tan rápido que apenas se percibe.",
 		it: "Sta sempre su una zampa sola. Cambia\nzampa così rapidamente che è quasi\nimpossibile seguirne i movimenti.",
-		de: "Es steht immer auf einem Bein. Es wechselt sein\nStandbein so schnell, dass man es kaum sieht.",
+		de: "Es steht immer auf einem Bein. Es wechselt sein Standbein so schnell, dass man es kaum sieht.",
 		'pt-br': "Sempre fica sobre um pé e troca de pé tão rápido\nque o movimento raramente é percebido.",
 		ko: "항상 한 발로 서 있다.\n발을 교체하는 순간이\n빨라서 좀처럼 볼 수 없다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/065.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/065.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Hoothoot",
-		fr: "Hoothoot"
+		fr: "Hoothoot",
+		de: "Hoothoot"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Ses yeux à la structure particulière\nsont capables de voir comme en plein\njour même quand il fait très sombre.",
 		es: "Tiene los ojos muy desarrollados y puede ver con\nincreíble claridad en la oscuridad más absoluta.",
 		it: "Grazie alla speciale struttura dei suoi occhi,\ngli basta la luce più fioca per vedere anche\nnell'oscurità come fosse pieno giorno.",
-		de: "Seine Augen sind so gut entwickelt, dass es selbst in fast\nkompletter Dunkelheit so klar sehen kann, als wäre es Tag.",
+		de: "Seine Augen sind so gut entwickelt, dass es selbst in fast kompletter Dunkelheit so klar sehen kann, als wäre es Tag.",
 		'pt-br': "Seus olhos são especialmente desenvolvidos\npara permitir que ele enxergue na mais sombria\nescuridão e com o mínimo de luz.",
 		ko: "특수한 구조의 두 눈은\n약간의 빛만 있으면\n어둠 속에서도 낮처럼 볼 수 있다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/066.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/066.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Ils cherchent des Pokémon Insecte par monts et par\nvaux en grandes volées. Leur chant est très bruyant.",
 		es: "Sobrevuela los campos en bandada buscando Pokémon\nde tipo Bicho. Chilla de forma muy estridente.",
 		it: "Sorvola i campi in grandi stormi a caccia di Pokémon\nColeottero. Il suo canto è alquanto fastidioso.",
-		de: "Auf der Suche nach Käfer-Pokémon fliegen Schwärme\nvon ihnen durchs Land. Ihr Ruf erzeugt großen Lärm.",
+		de: "Auf der Suche nach Käfer-Pokémon fliegen Schwärme von ihnen durchs Land. Ihr Ruf erzeugt großen Lärm.",
 		'pt-br': "Juntam-se ao redor de montanhas e campos,\ncaçando Pokémon inseto. Seu canto é barulhento\ne irritante.",
 		ko: "벌레포켓몬을 노리고 산과 들을\n많은 무리로 날아다닌다.\n울음소리가 무척 시끄럽다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/067.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/067.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Starly",
-		fr: "Étourmi"
+		fr: "Étourmi",
+		de: "Staralili"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Conscient de sa faiblesse, il vit toujours en groupe.\nQuand il se retrouve seul, il se met à piailler bruyamment.",
 		es: "Son conscientes de su debilidad, así que siempre viven\nen grupo. Si se encuentran solos, lloran a gritos.",
 		it: "Conscio della propria debolezza, forma grandi\ngruppi con i propri simili. Quando si ritrova\nsolo, canta con voce insistente e fastidiosa.",
-		de: "Da sie sich ihrer eigenen Schwäche bewusst sind,\nleben Staravia stets in Schwärmen. Sind sie allein,\nstoßen sie laute Rufe aus.",
+		de: "Da sie sich ihrer eigenen Schwäche bewusst sind, leben Staravia stets in Schwärmen. Sind sie allein, stoßen sie laute Rufe aus.",
 		'pt-br': "Reconhecendo suas próprias fraquezas, eles sempre vivem\nem grupo. Quando sozinho, um Staravia chora\nde forma ruidosa.",
 		ko: "자신의 약함을 잘 알고 있기에\n항상 무리를 지어 살고 있다.\n혼자가 되면 요란하게 운다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/068.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/068.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Staravia",
-		fr: "Étourvol"
+		fr: "Étourvol",
+		de: "Staravia"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Quand Étourvol évolue en Étouraptor, il quitte son groupe\npour vivre seul. Ses ailes sont très souples et puissantes.",
 		es: "Al evolucionar a Staraptor, deja su bandada y\npasa a vivir en soledad. Sus alas son inmensas.",
 		it: "Non appena si evolve, lascia lo stormo e affronta la\nvita da solo. Le sue ali sono estremamente robuste.",
-		de: "Entwickelt sich Staravia zu Staraptor, verlässt es\nden Schwarm und lebt allein. Die Spannweite\nseiner Flügel ist gigantisch.",
+		de: "Entwickelt sich Staravia zu Staraptor, verlässt es den Schwarm und lebt allein. Die Spannweite seiner Flügel ist gigantisch.",
 		'pt-br': "Quando um Staravia evolui para Staraptor,\ndeixa o bando para viver sozinho. Têm asas robustas.",
 		ko: "찌르호크가 되면 무리에서\n떨어져 혼자서 살아간다.\n강인한 날개를 가지고 있다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/069.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/069.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il peut dissoudre les toxines dans l'air pour transformer\nun désert en un champ de fleurs luxuriantes.",
 		es: "Puede disolver las toxinas del aire para\ntransformar tierra yerma en campos de flores.",
 		it: "Può dissolvere le tossine nell'aria per mutare\nall'istante una terra arida in un rigoglioso campo fiorito.",
-		de: "Es kann die Luft von Giften reinigen und Ödland\nin ein üppig blühendes Blumenfeld verwandeln.",
+		de: "Es kann die Luft von Giften reinigen und Ödland in ein üppig blühendes Blumenfeld verwandeln.",
 		'pt-br': "Pode dissolver toxinas no ar para instantaneamente\ntransformar terras arruinadas em campos\nde flores deslumbrantes.",
 		ko: "대기의 독소를 분해해서\n거칠어진 대지를 일순간에\n꽃밭으로 만드는 힘을 가지고 있다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/070.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/070.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "La mythologie de Sinnoh veut\nqu'il soit apparu sous forme\nd'Œuf et ait créé le monde.",
 		es: "Según la mitología de Sinnoh, Arceus surgió\nde un huevo y después creó todo el mundo.",
 		it: "Secondo la mitologia di Sinnoh, Arceus è\nnato da un uovo e poi ha creato il mondo.",
-		de: "In den Legenden Sinnohs heißt es, es sei aus einem Ei\ngeschlüpft und hätte die gesamte Welt geschaffen.",
+		de: "In den Legenden Sinnohs heißt es, es sei aus einem Ei geschlüpft und hätte die gesamte Welt geschaffen.",
 		'pt-br': "De acordo com lendas de Sinnoh, este Pokémon surgiu\nde um ovo e construiu tudo o que há neste mundo.",
 		ko: "알에서 모습을 나타내\n모든 세계를 창조했다고\n신오신화에서 묘사된다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/073.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/073.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		fr: "Ajoutez au hasard à votre main un Pokémon de base de votre pile de défausse.",
 		es: "Pon 1 Pokémon Básico aleatorio de tu pila de descartes en tu mano.",
 		it: "Prendi un Pokémon Base a caso dalla tua pila degli scarti e aggiungilo alle carte che hai in mano.",
-		de: "Nimm 1 zufälliges Basis-Pokémon aus deinem Ablagestapel auf deine Hand.",
+		de: "Nimm 1 zufälliges Basis-Pokémon aus deinem Ablagestapel auf deine Hand. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen.",
 		'pt-br': "Coloque 1 Pokémon Básico aleatório da sua pilha de descarte na sua mão.",
 		ko: "자신의 트래쉬에서 기본 포켓몬eul_reul 랜덤으로 1장 패로 가져온다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/076.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/076.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Houndour",
-		fr: "Malosse"
+		fr: "Malosse",
+		de: "Hunduster"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Les blessures provoquées par son souffle enflammé\nsont permanentes, et la douleur ne disparaît jamais.",
 		es: "Si alguien se quema con las llamas que lanza\npor la boca, el dolor no desaparecerá nunca.",
 		it: "Se si viene ustionati dalle fiamme che sputa\ndalla bocca, il dolore rimarrà per sempre.",
-		de: "Wird man von den Flammen getroffen, die es\naus seinem Maul schießt, so erleidet man eine\nBrandwunde, deren Schmerz nie nachlässt.",
+		de: "Wird man von den Flammen getroffen, die es aus seinem Maul schießt, so erleidet man eine Brandwunde, deren Schmerz nie nachlässt.",
 		'pt-br': "Se você for queimado pelas chamas disparadas\nde sua boca, a dor nunca passará.",
 		ko: "입에서 뿜어내는 불꽃에 의해\n화상을 입으면 시간이 아무리 지나도\n상처 난 자리가 욱신거린다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/077.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/077.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Sa fourrure est imperméable, si bien qu'il\nreste sec même quand il joue dans l'eau.",
 		es: "Tiene un pelaje que repele el agua, por lo\nque está seco incluso después de bañarse.",
 		it: "La pelliccia è idrorepellente. Così, rimane\nasciutto anche giocando nell'acqua.",
-		de: "Sein Fell ist von Natur aus wasserabweisend.\nEs bleibt trocken, auch wenn es im Wasser spielt.",
+		de: "Sein Fell ist von Natur aus wasserabweisend. Es bleibt trocken, auch wenn es im Wasser spielt.",
 		'pt-br': "A sua pelagem repele água naturalmente.\nPode brincar na água por horas sem se molhar.",
 		ko: "전신의 털은\n물을 튕겨 내는 성질을 지녀\n물을 끼얹어도 말라 있다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/078.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/078.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Son corps plat et fin est toujours collé aux murs.\nOn pense que sa forme a une signification.",
 		es: "Su cuerpo fino y plano aparece siempre en los\nmuros. Su forma parece tener algún significado.",
 		it: "Il corpo piatto e sottile sta sempre attaccato ai muri.\nPare che la forma abbia un preciso significato.",
-		de: "Sein flacher, dünner Körper hängt immer an Wänden.\nSeine Form scheint eine Bedeutung zu haben.",
+		de: "Sein flacher, dünner Körper hängt immer an Wänden. Seine Form scheint eine Bedeutung zu haben.",
 		'pt-br': "Seu corpo delgado e plano fica sempre colado\nnas paredes. Sua forma parece ter algum propósito.",
 		ko: "몸 자체는 굉장히 얇고\n항상 벽에 들러붙어 있다.\n모습에는 뭔가 의미가 있는 듯하다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/079.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/079.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Bien qu'il fasse semblant d'être un arbre, par sa composition,\nil semble plus proche d'un minéral que d'un végétal.",
 		es: "Aunque pretende ser un árbol, en su composición\nse parece más a una roca que a una planta.",
 		it: "Sebbene finga di essere un albero, il suo corpo\nha una composizione più simile a quella di una\nroccia che a quella di un vegetale.",
-		de: "Obwohl es vorgibt, ein Baum zu sein, kommt seine\nZusammensetzung einem Stein näher als einer Pflanze.",
+		de: "Obwohl es vorgibt, ein Baum zu sein, kommt seine Zusammensetzung einem Stein näher als einer Pflanze.",
 		'pt-br': "Apesar de sempre fingir ser uma árvore, sua composição\ntem mais semelhanças com pedras do que com vegetação.",
 		ko: "항상 나무인 척하고 있다.\n몸의 구조는 식물보다\n돌이나 바위에 가까운 듯하다."
 	},
@@ -53,7 +53,7 @@ const card: Card = {
 			fr: "Si le Pokémon Actif de votre adversaire est un Pokémon-{ex}, cette attaque inflige 30 dégâts supplémentaires.",
 			es: "Si el Pokémon Activo de tu rival es un Pokémon {ex}, este ataque hace 30 puntos de daño más.",
 			it: "Se il Pokémon attivo del tuo avversario è un Pokémon-{ex}, questo attacco infligge 30 danni in più.",
-			de: "Wenn das Aktive Pokémon deines Gegners ein Pokémon-{ex} ist, fügt diese Attacke 30 Schadenspunkte mehr zu.",
+			de: "Wenn das Aktive Pokémon deines Gegners ein Pokémon-ex ist, fügt diese Attacke 30 Schadenspunkte mehr zu.",
 			'pt-br': "Se o Pokémon Ativo do seu oponente for um Pokémon {ex}, este ataque causará 30 pontos de dano a mais.",
 			ko: "상대의 배틀 포켓몬이 「포켓몬 {ex}」라면 30데미지를 추가한다."
 		}

--- a/data/Pokémon TCG Pocket/Triumphant Light/080.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/080.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Les ondes électromagnétiques émises par ses extrémités\nlui permettent de défier les lois de la gravité et de flotter.",
 		es: "Las unidades laterales crean ondas\nelectromagnéticas que contrarrestan\nla gravedad y le permiten flotar.",
 		it: "Le onde elettromagnetiche generate dagli\nelementi laterali neutralizzano la gravità\npermettendogli di levitare a mezz'aria.",
-		de: "Die seitlichen Module halten es in der Luft,\nindem sie mit elektromagnetischen Wellen\ndie Schwerkraft überlisten.",
+		de: "Die seitlichen Module halten es in der Luft, indem sie mit elektromagnetischen Wellen die Schwerkraft überlisten.",
 		'pt-br': "As ondas eletromagnéticas emitidas pelas\nunidades nas laterais de sua cabeça geram\nantigravidade, o que faz com que ele possa flutuar.",
 		ko: "좌우에 있는 유닛에서 나오는\n전자파를 이용해\n중력을 거슬러 하늘에 떠 있다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/081.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/081.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il peut dissoudre les toxines dans l'air pour transformer\nun désert en un champ de fleurs luxuriantes.",
 		es: "Puede disolver las toxinas del aire para\ntransformar tierra yerma en campos de flores.",
 		it: "Può dissolvere le tossine nell'aria per mutare\nall'istante una terra arida in un rigoglioso campo fiorito.",
-		de: "Es kann die Luft von Giften reinigen und Ödland\nin ein üppig blühendes Blumenfeld verwandeln.",
+		de: "Es kann die Luft von Giften reinigen und Ödland in ein üppig blühendes Blumenfeld verwandeln.",
 		'pt-br': "Pode dissolver toxinas no ar para instantaneamente\ntransformar terras arruinadas em campos\nde flores deslumbrantes.",
 		ko: "대기의 독소를 분해해서\n거칠어진 대지를 일순간에\n꽃밭으로 만드는 힘을 가지고 있다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/082.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/082.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Eevee",
-		fr: "Évoli"
+		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Triumphant Light/083.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/083.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Eevee",
-		fr: "Évoli"
+		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Triumphant Light/084.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/084.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Gabite",
-		fr: "Carmache"
+		fr: "Carmache",
+		de: "Knarksel"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Triumphant Light/085.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/085.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Nosepass",
-		fr: "Tarinor"
+		fr: "Tarinor",
+		de: "Nasgnet"
 	},
 
 	stage: "Stage1",
@@ -49,7 +50,7 @@ const card: Card = {
 			fr: "Pendant le prochain tour de votre adversaire, ce Pokémon subit − 20 dégâts provenant des attaques.",
 			es: "Durante el próximo turno de tu rival, los ataques hacen -20 puntos de daño a este Pokémon.",
 			it: "Durante il prossimo turno del tuo avversario, questo Pokémon subisce -20 danni dagli attacchi.",
-			de: "Während des nächsten Zuges deines Gegners werden diesem Pokémon durch Attacken − 20 Schadenspunkte zugefügt.",
+			de: "Während des nächsten Zuges deines Gegners werden diesem Pokémon durch Attacken - 20 Schadenspunkte zugefügt.",
 			'pt-br': "Durante o próximo turno do seu oponente, este Pokémon receberá −20 pontos de dano de ataques.",
 			ko: "상대의 다음 차례에 이 포켓몬이 받는 기술의 데미지를 -20한다."
 		}

--- a/data/Pokémon TCG Pocket/Triumphant Light/088.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/088.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		fr: "Ajoutez au hasard à votre main un Pokémon de base de votre pile de défausse.",
 		es: "Pon 1 Pokémon Básico aleatorio de tu pila de descartes en tu mano.",
 		it: "Prendi un Pokémon Base a caso dalla tua pila degli scarti e aggiungilo alle carte che hai in mano.",
-		de: "Nimm 1 zufälliges Basis-Pokémon aus deinem Ablagestapel auf deine Hand.",
+		de: "Nimm 1 zufälliges Basis-Pokémon aus deinem Ablagestapel auf deine Hand. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen.",
 		'pt-br': "Coloque 1 Pokémon Básico aleatório da sua pilha de descarte na sua mão.",
 		ko: "자신의 트래쉬에서 기본 포켓몬eul_reul 랜덤으로 1장 패로 가져온다."
 	},

--- a/data/Pokémon TCG Pocket/Triumphant Light/091.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/091.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Eevee",
-		fr: "Évoli"
+		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Triumphant Light/092.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/092.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Eevee",
-		fr: "Évoli"
+		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Triumphant Light/093.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/093.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Gabite",
-		fr: "Carmache"
+		fr: "Carmache",
+		de: "Knarksel"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Triumphant Light/094.ts
+++ b/data/Pokémon TCG Pocket/Triumphant Light/094.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Nosepass",
-		fr: "Tarinor"
+		fr: "Tarinor",
+		de: "Nasgnet"
 	},
 
 	stage: "Stage1",
@@ -49,7 +50,7 @@ const card: Card = {
 			fr: "Pendant le prochain tour de votre adversaire, ce Pokémon subit − 20 dégâts provenant des attaques.",
 			es: "Durante el próximo turno de tu rival, los ataques hacen -20 puntos de daño a este Pokémon.",
 			it: "Durante il prossimo turno del tuo avversario, questo Pokémon subisce -20 danni dagli attacchi.",
-			de: "Während des nächsten Zuges deines Gegners werden diesem Pokémon durch Attacken − 20 Schadenspunkte zugefügt.",
+			de: "Während des nächsten Zuges deines Gegners werden diesem Pokémon durch Attacken - 20 Schadenspunkte zugefügt.",
 			'pt-br': "Durante o próximo turno do seu oponente, este Pokémon receberá −20 pontos de dano de ataques.",
 			ko: "상대의 다음 차례에 이 포켓몬이 받는 기술의 데미지를 -20한다."
 		}


### PR DESCRIPTION
## Add missing German translations for A2a

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
