### PR TITLE
Add missing German translations for A2b

### DIFF
--- a/data/Pokémon TCG Pocket/Shining Revelry/001.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/001.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "On trouve souvent ce Pokémon dans les forêts\net les hautes herbes. L'aiguillon de 5 cm\nsur sa tête contient un venin très toxique.",
 		es: "Suele habitar bosques y praderas.\nTiene un afilado y venenoso aguijón\nde unos 5 cm encima de la cabeza.",
 		it: "Vive soprattutto nei boschi e nei prati. Sul capo\nha un affilato e velenoso pungiglione lungo 5 cm.",
-		de: "Es lebt bevorzugt in Wäldern und in hohem Gras.\nAuf dem Kopf trägt es einen circa 5 cm langen,\nspitzen, giftigen Stachel.",
+		de: "Es lebt bevorzugt in Wäldern und in hohem Gras. Auf dem Kopf trägt es einen circa 5 cm langen, spitzen, giftigen Stachel.",
 		'pt-br': "Encontrado frequentemente em florestas e\npradarias. Possui uma farpa afiada e tóxica\nde cerca de 5 cm em cima da cabeça.",
 		ko: "숲이나 풀밭에 많이 서식한다.\n머리끝에 5cm 정도의\n작고 날카로운 독침을 지니고 있다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/002.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/002.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Weedle",
-		fr: "Aspicot"
+		fr: "Aspicot",
+		de: "Hornliu"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Incapable de se déplacer de lui-même,\nil se défend en durcissant sa carapace.",
 		es: "Casi incapaz de moverse, este Pokémon solo\npuede endurecer su caparazón para protegerse.",
 		it: "Quasi incapace di muoversi, questo Pokémon può\nsolo indurire il proprio guscio per proteggersi.",
-		de: "Dieses Pokémon kann sich kaum bewegen.\nBei drohender Gefahr verhärtet es seinen Panzer.",
+		de: "Dieses Pokémon kann sich kaum bewegen. Bei drohender Gefahr verhärtet es seinen Panzer.",
 		'pt-br': "Quase incapaz de se mover, esse Pokémon\npode apenas endurecer sua carapaça para\nse proteger quando está em perigo.",
 		ko: "스스로는 거의 움직일 수 없지만\n위험할 때는 단단해져서\n몸을 보호하고 있는 것 같다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/003.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/003.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Kakuna",
-		fr: "Coconfort"
+		fr: "Coconfort",
+		de: "Kokuna"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Shining Revelry/004.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/004.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Ses cornes déterminent son rang au sein\ndu groupe. Plus elles sont imposantes, plus\nles membres du sexe opposé l'apprécient.",
 		es: "Los Pinsir se juzgan entre ellos por la robustez\nde la cornamenta. Cuanto más imponente sea,\nmás agradará a sus congéneres del sexo opuesto.",
 		it: "I Pinsir si giudicano a vicenda in base alle corna.\nQuelli con corna grosse e imponenti hanno\npiù successo con gli esemplari dell'altro sesso.",
-		de: "Der Status eines Pinsirs hängt von seinen Hörnern\nab. Je dicker und stattlicher diese sind, desto\nbeliebter ist es beim anderen Geschlecht.",
+		de: "Der Status eines Pinsirs hängt von seinen Hörnern ab. Je dicker und stattlicher diese sind, desto beliebter ist es beim anderen Geschlecht.",
 		'pt-br': "Estes Pokémon se julgam de acordo com\nsuas pinças. As pinças mais grossas e notáveis\nsão mais populares com o gênero oposto.",
 		ko: "뿔로 서로의 등급을 매긴다.\n굵고 훌륭한 뿔을 가진\n쁘사이저일수록 이성에게 인기다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/005.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/005.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Ce Pokémon lave assidûment son visage pour\néviter qu'il ne s'assèche. La composition de son\npelage soyeux est proche de celle des plantes.",
 		es: "Su sedoso pelaje se asemeja en composición a las plantas.\nSe lava la cara con diligencia para que no se le seque.",
 		it: "Il suo pelo vellutato ha una composizione simile a quella delle\npiante. Si lava il muso di frequente per evitare che si disidrati.",
-		de: "Die Zusammensetzung seines weichen Fells ähnelt\nder von Pflanzen. Es reinigt penibel sein Gesicht,\num zu verhindern, dass dieses austrocknet.",
+		de: "Die Zusammensetzung seines weichen Fells ähnelt der von Pflanzen. Es reinigt penibel sein Gesicht, um zu verhindern, dass dieses austrocknet.",
 		'pt-br': "A composição de seu pelo fofinho é semelhante\nà das plantas. Este Pokémon lava o rosto frequentemente\npara evitar que fique ressecado.",
 		ko: "복슬복슬한 털은 식물에 가까운 성분으로\n이루어져 있다. 수시로 세수를 하면서\n건조해지는 것을 방지한다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/006.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/006.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Sprigatito",
-		fr: "Poussacha"
+		fr: "Poussacha",
+		de: "Felori"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il manie avec habileté la liane dissimulée\nsous ses longs poils et frappe ses adversaires\navec le bourgeon dur situé à son extrémité.",
 		es: "Maneja diestramente la vid oculta bajo su largo pelaje y propina\nlatigazos al enemigo con el capullo endurecido de la punta.",
 		it: "Muove con agilità la liana nascosta\nsotto il lungo pelo e sferza il nemico\ncon il duro bocciolo sulla punta.",
-		de: "Es lenkt geschickt die Ranke, die es unter\nseinem langen Fell verbirgt, und schleudert\ndie harte Knospe an ihrem Ende auf Gegner.",
+		de: "Es lenkt geschickt die Ranke, die es unter seinem langen Fell verbirgt, und schleudert die harte Knospe an ihrem Ende auf Gegner.",
 		'pt-br': "Floragato empunha com maestria o cipó escondido\nentre seus pelos longos. Golpeia seus oponentes\ncom o botão de flor rígido.",
 		ko: "긴 털 아래 숨긴 덩굴을\n능숙하게 다뤄서\n단단한 꽃봉오리로 상대를 가격한다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/007.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/007.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Floragato",
-		fr: "Matourgeon"
+		fr: "Matourgeon",
+		de: "Feliospa"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il se sert de la réverbération de la lumière sur\nla fourrure de sa cape pour camoufler sa tige,\nce qui donne l'illusion que sa fleur flotte dans les airs.",
 		es: "Se sirve de la luz que reflejan los tricomas de\nsu manto de hojas para camuflar la vid y crear\nla ilusión óptica de que la flor flota en el aire.",
 		it: "I riflessi del pelo all'interno del mantello\ncamuffano lo stelo del suo fiore, che\ncosì sembra fluttuare nell'aria.",
-		de: "Es erweckt den Eindruck, als würde seine Blume\nschweben, indem es ihren Stiel mit der Reflexion\ndes Fells an der Innenseite seines Mantels tarnt.",
+		de: "Es erweckt den Eindruck, als würde seine Blume schweben, indem es ihren Stiel mit der Reflexion des Fells an der Innenseite seines Mantels tarnt.",
 		'pt-br': "Este Pokémon usa a pelugem reflexiva da sua capa\npara camuflar o caule da sua flor, criando a ilusão\nde que a flor está flutuando.",
 		ko: "꽃이 떠 있는 것처럼 보이는 것은\n망토 뒷면의 털이 빛을 반사해서\n줄기를 보이지 않게 하기 때문이다."
 	},
@@ -58,7 +59,7 @@ const card: Card = {
 			fr: "Si le Pokémon Actif de votre adversaire est un Pokémon-{ex}, cette attaque inflige 70 dégâts supplémentaires.",
 			es: "Si el Pokémon Activo de tu rival es un Pokémon {ex}, este ataque hace 70 puntos de daño más.",
 			it: "Se il Pokémon attivo del tuo avversario è un Pokémon-{ex}, questo attacco infligge 70 danni in più.",
-			de: "Wenn das Aktive Pokémon deines Gegners ein Pokémon-{ex} ist, fügt diese Attacke 70 Schadenspunkte mehr zu.",
+			de: "Wenn das Aktive Pokémon deines Gegners ein Pokémon-ex ist, fügt diese Attacke 70 Schadenspunkte mehr zu.",
 			'pt-br': "Se o Pokémon Ativo do seu oponente for um Pokémon {ex}, este ataque causará 70 pontos de dano a mais.",
 			ko: "상대의 배틀 포켓몬이 「포켓몬 {ex}」라면 70데미지를 추가한다."
 		}

--- a/data/Pokémon TCG Pocket/Shining Revelry/008.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/008.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il préfère ce qui est chaud. En cas de pluie,\nde la vapeur se forme autour de sa queue.",
 		es: "Prefiere las cosas calientes. Dicen que cuando\nllueve le sale vapor de la punta de la cola.",
 		it: "Ama le cose calde. Si dice che quando piove\ngli esca vapore dalla punta della coda.",
-		de: "Dieses Pokémon bevorzugt heiße Dinge.\nBei Regen soll seine Schwanzspitze dampfen.",
+		de: "Dieses Pokémon bevorzugt heiße Dinge. Bei Regen soll seine Schwanzspitze dampfen.",
 		'pt-br': "Prefere coisas quentes. Quando chove, dizem\nque solta vapor pela ponta de sua cauda.",
 		ko: "뜨거운 것을 좋아하는 성격이다.\n비에 젖으면 꼬리 끝에서\n연기가 난다고 한다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/009.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/009.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Charmander",
-		fr: "Salamèche"
+		fr: "Salamèche",
+		de: "Glumanda"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il est très brutal. En combat, il se sert de ses griffes acérées\net de sa queue enflammée pour mettre en pièces ses adversaires.",
 		es: "Este Pokémon de naturaleza agresiva\nataca en combate con su cola llameante\ny hace trizas al rival con sus afiladas garras.",
 		it: "Ha un'indole feroce. Usa la coda fiammeggiante come\nuna frusta e lacera l'avversario con gli artigli affilati.",
-		de: "Es ist brutal veranlagt. Im Kampf schlägt es mit\nseinem brennenden Schweif um sich und schlitzt\nGegner mit seinen scharfen Klauen auf.",
+		de: "Es ist brutal veranlagt. Im Kampf schlägt es mit seinem brennenden Schweif um sich und schlitzt Gegner mit seinen scharfen Klauen auf.",
 		'pt-br': "Possui uma natureza bárbara. Em batalha, chicoteia\ncom sua cauda de fogo e corta com suas garras afiadas.",
 		ko: "불타는 꼬리를 휘두르며\n날카로운 발톱으로 상대를\n베어 가르는 몹시 거친 성격이다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/010.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/010.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Charmeleon",
-		fr: "Reptincel"
+		fr: "Reptincel",
+		de: "Glutexo"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Shining Revelry/011.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/011.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il achève ses proies avec ses flammes, mais\nil lui arrive de les calciner accidentellement,\nà son plus grand regret.",
 		es: "Abate a sus presas con las llamas\nque genera y con frecuencia acaba\nreduciéndolas a carbonilla por accidente.",
 		it: "Abbatte le sue prede con le fiamme, ma\nfinisce per carbonizzarle accidentalmente,\ncon suo grande rammarico.",
-		de: "Magmar erlegt seine Beute mit Feuer. Manchmal\nröstet es diese zu seinem Bedauern so stark,\ndass sie versehentlich verkohlt.",
+		de: "Magmar erlegt seine Beute mit Feuer. Manchmal röstet es diese zu seinem Bedauern so stark, dass sie versehentlich verkohlt.",
 		'pt-br': "Magmar incendeia suas presas, mas sempre se\narrepende ao perceber que as reduziu a cinzas.",
 		ko: "불꽃으로 먹이를 꼼짝 못 하게 한다.\n무의식중에 너무 오래 익혀서\n까맣게 태우고는 후회한다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/012.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/012.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Magmar",
-		fr: "Magmar"
+		fr: "Magmar",
+		de: "Magmar"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Quand il inspire profondément, les flammes dans son\nventre gagnent en intensité et atteignent les 2 000 °C.",
 		es: "Al respirar profundamente, el fuego del interior de su\nvientre gana intensidad y puede alcanzar los 2000 °C.",
 		it: "Quando respira profondamente, le fiamme all'interno del\nsuo ventre aumentano d'intensità, raggiungendo i 2.000 ºC.",
-		de: "Holt es tief Luft, werden die Flammen in seinem Bauch\nstärker und erreichen eine Temperatur von 2000 ºC.",
+		de: "Holt es tief Luft, werden die Flammen in seinem Bauch stärker und erreichen eine Temperatur von 2000 ºC.",
 		'pt-br': "Quando Magmortar respira fundo, o fogo na sua barriga\nse intensifica, chegando a atingir temperaturas superiores\na 2.000 ºC.",
 		ko: "크게 숨을 들이쉬면 배 안의\n불꽃이 더욱 거세어져서\n섭씨 2000도에 달하게 된다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/013.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/013.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Ses cornes atteignent les 1 000 °C lorsqu'elles\nsont chauffées par énergie incandescente.\nElles infligent blessures et brûlures à ses adversaires.",
 		es: "Sus cuernos alcanzan los 1000 °C cuando los\ncalienta con energía ígnea. Quienes reciben una\nde sus cornadas sufren heridas y quemaduras.",
 		it: "Le corna arroventate dalla sua energia\nFuoco raggiungono i 1.000 ºC e causano\nal nemico trafitto sia ferite che ustioni.",
-		de: "Seine Hörner erreichen mithilfe von Feuer-Energie\n1000 ºC. Spießt es damit Gegner auf, so erleiden\ndiese Verletzungen und Verbrennungen.",
+		de: "Seine Hörner erreichen mithilfe von Feuer-Energie 1000 ℃. Spießt es damit Gegner auf, so erleiden diese Verletzungen und Verbrennungen.",
 		'pt-br': "Quando aquecido por energia de fogo, seus chifres podem\nchegar a mais de 980 ºC. Aqueles que forem atacados\npor eles sofrerão com feridas e queimaduras.",
 		ko: "불꽃 에너지로 가열된 뿔은\n섭씨 1000도에 달하며, 뿔에 찔린 상대는\n상처와 화상에 고통받게 된다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/014.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/014.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Peu doué pour la natation, ce Pokémon\nse contente de flotter à la surface des eaux\npeu profondes pour chasser ses proies.",
 		es: "Sus facultades natatorias son más bien escasas,\npor lo que se limita a flotar a la deriva en\naguas poco profundas en busca de alimento.",
 		it: "Non essendo molto abile a nuotare, va in cerca\ndi prede fluttuando in acque poco profonde.",
-		de: "Da Tentacha kein besonders guter Schwimmer ist,\ntreibt es in seichten Gewässern an der\nWasseroberfläche und sucht nach Beute.",
+		de: "Da Tentacha kein besonders guter Schwimmer ist, treibt es in seichten Gewässern an der Wasseroberfläche und sucht nach Beute.",
 		'pt-br': "Tentacool não nada particularmente bem.\nFlutua pela superfície de águas rasas\nenquanto procura por sua presa.",
 		ko: "헤엄치는 힘은 강하지 않다.\n얕은 바다 수면을 떠다니면서\n먹이를 찾는다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/015.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/015.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Tentacool",
-		fr: "Tentacool"
+		fr: "Tentacool",
+		de: "Tentacha"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il faut faire attention lorsque les globes rouges\nsur sa tête se mettent à briller intensément,\ncar c'est qu'il s'apprête à émettre des ultrasons.",
 		es: "Si las esferas rojas que tiene a ambos lados\nde la cabeza brillan con intensidad, indica que\nestá a punto de lanzar ondas ultrasónicas.",
 		it: "Meglio fare attenzione quando le sfere rosse\nche ha sulla testa brillano intensamente, perché\nvuol dire che sta per emettere ultrasuoni.",
-		de: "Leuchten die roten Kugeln auf seinem Kopf stark\nauf, ist Vorsicht geboten, da es kurz danach\nUltraschallwellen ausstoßen wird.",
+		de: "Leuchten die roten Kugeln auf seinem Kopf stark auf, ist Vorsicht geboten, da es kurz danach Ultraschallwellen ausstoßen wird.",
 		'pt-br': "Quando o orbe vermelho na cabeça de Tantacruel\nbrilha intensamente, cuidado: este Pokémon está\nprestes a disparar uma rajada de ondas ultrassônicas.",
 		ko: "머리의 빨간 구슬이\n밝게 빛나면 주의가 필요하다.\n초음파를 발산하려는 전조다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/016.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/016.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "La bouée autour de son cou lui permet de\ngarder la tête hors de l'eau. Ainsi, il peut scruter\nles mouvements de ses proies sur la terre ferme.",
 		es: "La vejiga natatoria alrededor del cuello le permite flotar\nen el agua con la cabeza fuera para divisar a sus presas.",
 		it: "Gonfia il suo collare galleggiante e\nrimane con la testa fuori dall'acqua\nin cerca di prede sulla terraferma.",
-		de: "Füllt es die Schwimmblase um seinen Hals mit Luft,\nragt sein Kopf aus dem Wasser und es kann die\nBewegungen von Beute an Land beobachten.",
+		de: "Füllt es die Schwimmblase um seinen Hals mit Luft, ragt sein Kopf aus dem Wasser und es kann die Bewegungen von Beute an Land beobachten.",
 		'pt-br': "Infla sua bolsa de flutuação e mantém o rosto acima\nda água para procurar o movimento de presas.",
 		ko: "목의 부낭을 부풀려\n수면에 얼굴을 내밀고 지상에 있는\n먹이의 움직임을 살핀다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/017.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/017.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Buizel",
-		fr: "Mustébouée"
+		fr: "Mustébouée",
+		de: "Bamelin"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il gonfle sa bouée pour permettre aux gens de\nmonter sur son dos et il la dégonfle pour plonger.",
 		es: "Con la vejiga natatoria inflada, puede llevar a personas\nsobre su espalda. Antes de bucear, la desinfla.",
 		it: "Col galleggiante gonfio, può trasportare delle\npersone sul dorso. Per immergersi lo sgonfia.",
-		de: "Mit gefüllter Schwimmblase kann es Menschen\nauf seinem Rücken tragen. Lässt es Luft aus ihr\nheraus, taucht es unter.",
+		de: "Mit gefüllter Schwimmblase kann es Menschen auf seinem Rücken tragen. Lässt es Luft aus ihr heraus, taucht es unter.",
 		'pt-br': "Com sua bolsa de flutuação inflada, pode transportar\npessoas nas costas. Esvazia a bolsa antes de mergulhar.",
 		ko: "부낭을 부풀리면 사람을\n등에 태울 수 있다.\n부낭을 오그라들게 하여 잠수한다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/018.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/018.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il détecte l'odeur de Délestin à plus de vingt mètres,\nce qui lui donne le temps de s'enfouir dans le sable.",
 		es: "Puede percibir el olor de los Veluza a 20 m de distancia,\nlo que le permite ocultarse bajo la arena a tiempo.",
 		it: "Fiuta l'odore di un Veluza da 20 metri\ndi distanza e si nasconde nella sabbia.",
-		de: "Es kann den Geruch eines Agiluza auf 20 m Entfernung\nwahrnehmen und versteckt sich daraufhin flugs im Sand.",
+		de: "Es kann den Geruch eines Agiluza auf 20 m Entfernung wahrnehmen und versteckt sich daraufhin flugs im Sand.",
 		'pt-br': "Este Pokémon é capaz de sentir o cheiro de Veluza\na mais de 20 metros de distância e se esconderá na areia.",
 		ko: "20m 떨어진 가비루사에게서 나는\n냄새도 맡을 수 있어서\n모래 속에 몸을 숨긴다."
 	},
@@ -52,7 +52,7 @@ const card: Card = {
 			fr: "Un des Pokémon de votre adversaire est choisi au hasard. Il subit 30 dégâts.",
 			es: "Se elige a un Pokémon aleatorio de tu rival. Hazle 30 puntos de daño.",
 			it: "Viene scelto un Pokémon avversario a caso. Quel Pokémon subisce 30 danni.",
-			de: "1 Pokémon des Gegners wird zufällig ausgewählt.\nFüge diesem Pokémon 30 Schadenspunkte zu.",
+			de: "1 Pokémon des Gegners wird zufällig ausgewählt. Füge diesem Pokémon 30 Schadenspunkte zu.",
 			'pt-br': "Um dos Pokémon do seu oponente é escolhido aleatoriamente. Cause 30 pontos de dano a ele.",
 			ko: "상대의 포켓몬이 랜덤으로 1번 선택되어 선택된 포켓몬에게 30데미지를 준다."
 		}

--- a/data/Pokémon TCG Pocket/Shining Revelry/019.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/019.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Wiglett",
-		fr: "Taupikeau"
+		fr: "Taupikeau",
+		de: "Schligda"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Shining Revelry/020.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/020.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Comme il n'est pas très doué pour attraper ses proies,\nce Pokémon vorace fait équipe avec Nigirigon pour chasser.",
 		es: "Le gusta mucho comer, pero no se le da bien cazar, por lo\nque aúna fuerzas con Tatsugiri con el fin de capturar presas.",
 		it: "È un Pokémon vorace, ma non è molto abile\nnel procacciarsi il cibo. Cattura le sue prede\ncollaborando con il Tatsugiri che è con lui.",
-		de: "Es ist zwar ein Vielfraß, doch die Jagd liegt\nihm nicht. Deshalb schließt es sich mit\nNigiragi zusammen, um Beute zu fangen.",
+		de: "Es ist zwar ein Vielfraß, doch die Jagd liegt ihm nicht. Deshalb schließt es sich mit Nigiragi zusammen, um Beute zu fangen.",
 		'pt-br': "Este Pokémon é guloso, mas não é nada\nbom em conseguir comida. Alia-se a\nTatsugiri para pegar suas presas.",
 		ko: "대식가지만 먹이를 잡는 것이 서툴다.\n싸리용과 콤비를 이뤄\n먹이를 사냥한다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/021.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/021.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Ce petit Pokémon Dragon vit dans la gueule\nd'Oyacata, à l'abri de ses adversaires.",
 		es: "Pokémon dragón de pequeño tamaño. Vive en la boca de un\nDondozo para protegerse de los ataques de los depredadores.",
 		it: "Un Pokémon di tipo Drago di piccole\ndimensioni. Vive all'interno della bocca di\nDondozo, protetto dagli attacchi dei nemici.",
-		de: "Dieses kleine Drachen-Pokémon lebt im Maul von\nHeerashai, wodurch es vor Feinden geschützt ist.",
+		de: "Dieses kleine Drachen-Pokémon lebt im Maul von Heerashai, wodurch es vor Feinden geschützt ist.",
 		'pt-br': "Este é um pequeno Pokémon dragão. Mora dentro da\nboca de Dondozo para proteger-se\nde inimigos do mundo externo.",
 		ko: "작은 몸집의 드래곤포켓몬.\n어써러셔의 입안에 살며\n외부의 적으로부터 몸을 지킨다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/023.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/023.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il se déplace en roulant. Si le sol est cabossé,\nles chocs le font exploser.",
 		es: "Se mueve rodando. Si el terreno es\nirregular, una chispa provocada por\nalgún bache lo hará explotar.",
 		it: "Rotola per spostarsi. Se il terreno è\nirregolare, può esplodere all'improvviso\na causa dell'urto contro un dosso.",
-		de: "Es bewegt sich rollend fort. Rollt es über\nunebenen Boden, kann es plötzlich explodieren.",
+		de: "Es bewegt sich rollend fort. Rollt es über unebenen Boden, kann es plötzlich explodieren.",
 		'pt-br': "Ele rola para se mover. Quando o solo está\ndesnivelado, um solavanco repentino após\num baque pode fazê-lo explodir.",
 		ko: "굴러서 이동하기 때문에\n땅이 울퉁불퉁하면\n충격으로 폭발해 버린다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/024.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/024.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Voltorb",
-		fr: "Voltorbe"
+		fr: "Voltorbe",
+		de: "Voltobal"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Plus il accumule de l'énergie de type Électrik, plus il est rapide.\nMais il a aussi davantage de chances d'exploser.",
 		es: "Cuanta más energía almacena, mayor\nvelocidad alcanza, aunque aumenta\ntambién el riesgo de que explote.",
 		it: "L'energia Elettro che immagazzina\nlo fa andare sempre più veloce, ma\nlo fa anche esplodere più facilmente.",
-		de: "Je mehr elektrische Energie es speichert, desto\nschneller ist es. Allerdings steigt dabei auch das\nRisiko, dass es explodiert.",
+		de: "Je mehr elektrische Energie es speichert, desto schneller ist es. Allerdings steigt dabei auch das Risiko, dass es explodiert.",
 		'pt-br': "Quanto mais energia carrega, mais\nvelocidade ganha. Mas também aumenta\na sua probabilidade de explodir.",
 		ko: "전기 에너지를 모을수록\n고속으로 이동할 수 있게 되나\n그만큼 폭발하기도 쉬워진다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/025.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/025.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		fr: "Pachirisu fait partie des Pokémon aux joues électriques.\nIl libère l'énergie qu'il accumule par la queue.",
 		es: "Forma parte del grupo de Pokémon que\nposee bolsas de electricidad en las mejillas.\nDescarga por la cola la electricidad que acumula.",
 		it: "Appartiene alla tipologia di Pokémon\nmuniti di sacche elettriche sulle guance.\nRilascia dalla coda l'elettricità accumulata.",
-		de: "Pachirisu ist eines der Pokémon, die mit ihren\nBackentaschen Elektrizität erzeugen. Den so\ngesammelten Strom gibt es über den Schweif ab.",
+		de: "Pachirisu ist eines der Pokémon, die mit ihren Backentaschen Elektrizität erzeugen. Den so gesammelten Strom gibt es über den Schweif ab.",
 		ko: "볼에 전기 주머니를 가진 포켓몬의 일종.\n꼬리에 모인 전기를 방출한다.",
 		'pt-br': "É um dos tipos de Pokémon com bolsas elétricas\nnas bochechas. Ele dispara cargas de sua cauda."
 	},
@@ -45,7 +45,7 @@ const card: Card = {
 			fr: "Prenez une Énergie {L} de votre zone Énergie et attachez-la à l'un de vos Pokémon de Banc.",
 			es: "Une 1 Energía {L} de tu área de Energía a 1 de tus Pokémon en Banca.",
 			it: "Prendi un'Energia {L} dalla tua Zona Energia e assegnala a uno dei tuoi Pokémon in panchina.",
-			de: "Lege 1 {L}-Energie aus deinem Energiebereich an 1 Pokémon auf deiner Bank an.",
+			de: "Lege 1 {L}-Energie aus deinem Energiebereich an 1 {L}-Pokémon auf deiner Bank an.",
 			ko: "자신의 에너지존에서 {L}에너지를 1개 내보내 벤치 포켓몬에게 붙인다.",
 			'pt-br': "Pegue uma Energia {L} da sua Zona de Energia e ligue-a 1 dos seus Pokémon no Banco."
 		}

--- a/data/Pokémon TCG Pocket/Shining Revelry/026.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/026.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Les poches sur ses joues sont peu développées.\nElles ne produisent de l'électricité que\nlorsqu'il les frotte avec ses coussinets.",
 		es: "Como las bolsas de sus mejillas están poco desarrolladas, genera\nelectricidad frotándolas con las almohadillas de sus patas delanteras.",
 		it: "Le sacche elettriche sulle sue guance non si sono\nsviluppate del tutto e per generare energia deve\nsfregarle vigorosamente con le zampe anteriori.",
-		de: "Seine elektrischen Backentaschen sind nicht ganz\nausgebildet. Um Strom zu erzeugen, muss es mit\nden Ballen der Vorderpfoten kräftig daran reiben.",
+		de: "Seine elektrischen Backentaschen sind nicht ganz ausgebildet. Um Strom zu erzeugen, muss es mit den Ballen der Vorderpfoten kräftig daran reiben.",
 		'pt-br': "Possui bolsas de eletricidade subdesenvolvidas em suas\nbochechas. Elas só produzem eletricidade se Pawmi esfregá-las\nfuriosamente com as almofadas de suas patas dianteiras.",
 		ko: "볼의 전기 주머니가 아직 발달하지 않았다.\n앞발의 볼록살을 열심히 비벼야\n겨우 전기가 만들어진다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/027.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/027.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pawmi",
-		fr: "Pohm"
+		fr: "Pohm",
+		de: "Pamo"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Quand on attaque son groupe, ce Pokémon\nest le premier à riposter. Il défait ses adversaires\navec un art martial qui repose sur l'électricité.",
 		es: "Cuando su manada se ve amenazada, atacan a la\nvanguardia usando un arte marcial caracterizado\npor el empleo de descargas eléctricas.",
 		it: "Quando il branco viene attaccato, lotta in prima\nfila contro il nemico per atterrarlo con tecniche\nmarziali che rilasciano scariche elettriche.",
-		de: "Wird seine Kolonie angegriffen, stürzt es sich\nsofort in den Kampf und besiegt den Feind mit\nKampftechniken, die auf Elektroschocks setzen.",
+		de: "Wird seine Kolonie angegriffen, stürzt es sich sofort in den Kampf und besiegt den Feind mit Kampftechniken, die auf Elektroschocks setzen.",
 		'pt-br': "Quando seu grupo é atacado, Pawmo é o primeiro a\nentrar na batalha, derrotando os inimigos com uma\ntécnica de combate que utiliza choques elétricos.",
 		ko: "무리가 공격을 받으면\n전격을 날리는 격투기로\n먼저 싸움을 걸고 적을 쓰러뜨린다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/028.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/028.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Pawmo",
-		fr: "Pohmotte"
+		fr: "Pohmotte",
+		de: "Pamamo"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "D'ordinaire, ce Pokémon est plutôt calme,\nmais lorsqu'il se bat, il élimine ses adversaires\navec des mouvements rapides comme l'éclair.",
 		es: "Este Pokémon es normalmente bastante calmado,\npero, una vez en combate, derriba a sus rivales\ncon movimientos de una velocidad vertiginosa.",
 		it: "Di solito è piuttosto flemmatico, ma\nquando si trova a lottare atterra il\nnemico con movimenti fulminei.",
-		de: "Dieses Pokémon ist für gewöhnlich sehr gelassen,\ndoch sobald ein Kampf beginnt, streckt es den Gegner\nmit blitzschnellen Bewegungen zu Boden.",
+		de: "Dieses Pokémon ist für gewöhnlich sehr gelassen, doch sobald ein Kampf beginnt, streckt es den Gegner mit blitzschnellen Bewegungen zu Boden.",
 		'pt-br': "Este Pokémon costuma demorar para reagir, mas quando\nentra na batalha, derrota seus oponentes\ncom golpes na velocidade da luz.",
 		ko: "평소에는 느긋하지만\n싸움이 시작되면 전광석화와도 같은\n몸놀림으로 적을 때려눕힌다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/029.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/029.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Le contenu de ses rêves influe sur les pouvoirs\npsychiques qu'il utilise dans son sommeil.",
 		es: "Es capaz de usar sus poderes psíquicos aun\nestando dormido. Al parecer, el contenido\ndel sueño influye en sus facultades.",
 		it: "Il contenuto dei suoi sogni influisce sui suoi poteri\npsichici, che può utilizzare anche mentre dorme.",
-		de: "Es setzt seine Psycho-Kräfte selbst im\nSchlaf ein. Der Inhalt seiner Träume hat\nEinfluss auf die Kräfte, die es verwendet.",
+		de: "Es setzt seine Psycho-Kräfte selbst im Schlaf ein. Der Inhalt seiner Träume hat Einfluss auf die Kräfte, die es verwendet.",
 		'pt-br': "Usa seus poderes psíquicos enquanto dorme.\nO conteúdo dos sonhos de Abra afeta os\npoderes que este Pokémon possui.",
 		ko: "자면서 초능력을 구사한다.\n꿈의 내용이\n사용하는 힘에 영향을 준다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/030.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/030.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Abra",
-		fr: "Abra"
+		fr: "Abra",
+		de: "Abra"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Ses pouvoirs psychiques lui permettent de léviter en dormant.\nIl utilise alors sa queue très souple comme un oreiller.",
 		es: "Duerme suspendido en el aire gracias a sus\npoderes psíquicos. La cola, de una flexibilidad\nextraordinaria, hace las veces de almohada.",
 		it: "I suoi poteri psichici gli permettono di\nlevitare mentre dorme. Come cuscino usa\nla sua coda straordinariamente elastica.",
-		de: "Kadabras Psycho-Kräfte ermöglichen es ihm,\nschwebend zu schlafen. Seinen äußerst\nelastischen Schweif nutzt es dabei als Kissen.",
+		de: "Kadabras Psycho-Kräfte ermöglichen es ihm, schwebend zu schlafen. Seinen äußerst elastischen Schweif nutzt es dabei als Kissen.",
 		'pt-br': "Usando seu poder psíquico, Kadabra levita\nenquanto dorme. Usa sua cauda elástica\ncomo um travesseiro.",
 		ko: "사이코 파워로 공중에 떠서 잠든다.\n탄력이 뛰어난 꼬리를\n베개 대신으로 사용한다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/031.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/031.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Kadabra",
-		fr: "Kadabra"
+		fr: "Kadabra",
+		de: "Kadabra"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Doué d'une intelligence hors du commun,\nce Pokémon serait capable de conserver tous\nses souvenirs, de sa naissance jusqu'à sa mort.",
 		es: "Posee una capacidad intelectual fuera de\nlo común que le permite recordar todo lo\nsucedido desde el instante de su nacimiento.",
 		it: "Possiede un intelletto estremamente elevato\ne si dice sia in grado di ricordare ogni evento\ndella sua vita, dalla nascita alla morte.",
-		de: "Es verfügt über extrem hohe Intelligenz und soll\nsich an alles erinnern können, was zwischen seiner\nGeburt und seinem Tod passiert.",
+		de: "Es verfügt über extrem hohe Intelligenz und soll sich an alles erinnern können, was zwischen seiner Geburt und seinem Tod passiert.",
 		'pt-br': "Tem um nível de inteligência incrivelmente alto.\nAlguns dizem que Alakazam se lembra de tudo\nque acontece na sua vida, do nascimento até a morte.",
 		ko: "매우 높은 지능을 지녔다.\n태어나서 죽을 때까지 일어나는 일을\n모두 기억한다고 한다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/032.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/032.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "De nombreux savants pensent que ses mains\nse sont développées pour faire de la pantomime.",
 		es: "Muchos estudiosos sostienen que el\ndesarrollo de sus enormes manos se debe\na su afán por practicar la pantomima.",
 		it: "Molti studiosi ritengono che abbia sviluppato mani\ncosì grandi perché gli sono utili per la mimica.",
-		de: "Viele Forscher glauben, seine Hände hätten nur\ndeshalb so eine beachtliche Größe angenommen,\ndamit es Pantomime praktizieren kann.",
+		de: "Viele Forscher glauben, seine Hände hätten nur deshalb so eine beachtliche Größe angenommen, damit es Pantomime praktizieren kann.",
 		'pt-br': "Suas mãos talvez não sejam grandes\npor acaso: muitos cientistas acreditam que\nas palmas se alargaram para fazer mímica.",
 		ko: "커다란 손바닥은 팬터마임을\n하기 위해 발달했다고\n생각하는 학자도 많다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/033.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/033.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "On dit que les jeunes enfants qui agrippent Baudrive après\nl'avoir pris pour un ballon disparaissent sans laisser de traces.",
 		es: "Se dice que a veces desaparecen niños que\nagarran un Drifloon pensando que es un globo.",
 		it: "Si dice che i bambini piccoli possano scomparire nel nulla\nse tengono un Drifloon scambiandolo per un palloncino.",
-		de: "So manches kleine Kind soll schon verschwunden\nsein, weil es ein Driftlon festhielt, das es mit\neinem Ballon verwechselt hatte.",
+		de: "So manches kleine Kind soll schon verschwunden sein, weil es ein Driftlon festhielt, das es mit einem Ballon verwechselt hatte.",
 		'pt-br': "Diz-se por aí que se uma criança confundir Drifloon\ncom um balão e o segurar, poderá acabar desaparecendo.",
 		ko: "풍선으로 착각해 흔들풍손을\n가지고 있었던 어린아이가\n사라지는 경우가 있다고 한다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/034.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/034.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Drifloon",
-		fr: "Baudrive"
+		fr: "Baudrive",
+		de: "Driftlon"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il contrôle son altitude en produisant des gaz\nà l'intérieur de son corps puis en les expulsant.",
 		es: "Crea en su interior gases y los expulsa. De esta\nforma es capaz de volar y controlar su altura.",
 		it: "Può regolare l'altitudine di volo grazie\nalla capacità di produrre gas all'interno\ndel proprio corpo e di espellerli.",
-		de: "Indem es Gas in seinem Körper erzeugt und\nwieder ausstößt, reguliert es seine Flughöhe.",
+		de: "Indem es Gas in seinem Körper erzeugt und wieder ausstößt, reguliert es seine Flughöhe.",
 		'pt-br': "Ele pode gerar e soltar gases dentro do seu corpo.\nÉ assim que ele pode controlar a altitude da sua flutuação.",
 		ko: "몸 안에서 가스를\n만들거나 토해 내며\n하늘을 나는 높이를 조절한다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/036.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/036.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Ce Pokémon est né dans un coffre au trésor,\nil y a environ 1 500 ans. Il absorbe l'énergie\nvitale des voyous qui osent voler son magot.",
 		es: "El cofre en el que nació data de hace 1500 años\naproximadamente. Absorbe la energía vital de los\ngranujas que intentan hacerse con su tesoro.",
 		it: "Nacque all'interno di un forziere circa 1.500\nanni fa. Assorbe l'energia vitale dei furfanti\nche provano a rubare il suo tesoro.",
-		de: "Es entstand vor etwa 1500 Jahren in einer Schatztruhe.\nWenn Diebe versuchen, den Schatz zu stehlen, saugt es\nihnen die Lebensenergie aus.",
+		de: "Es entstand vor etwa 1500 Jahren in einer Schatztruhe. Wenn Diebe versuchen, den Schatz zu stehlen, saugt es ihnen die Lebensenergie aus.",
 		'pt-br': "Este Pokémon nasceu em um baú do tesouro cerca\nde 1.500 anos atrás. Suga a força vital de\nfanfarrões que tentam roubar o tesouro.",
 		ko: "약 1500년 전의 보물 상자 안에서 태어났다.\n보물을 훔치려 드는\n괘씸한 자의 생기를 흡수한다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/037.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/037.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Son corps est essentiellement composé de muscles.\nMême s'il fait la taille d'un petit enfant,\nil peut soulever 100 adultes avec ses bras.",
 		es: "Es una masa de músculos y, pese a su\npequeño tamaño, tiene fuerza de sobra\npara levantar en brazos a 100 personas.",
 		it: "Il suo corpo è formato interamente da\nmuscoli. Non è più alto di un bambino,\nma può sollevare e lanciare 100 adulti.",
-		de: "Sein ganzer Körper besteht aus Muskeln. Auch\nwenn es nur so groß wie ein Menschenkind ist,\nkann es 100 Erwachsene jonglieren.",
+		de: "Sein ganzer Körper besteht aus Muskeln. Auch wenn es nur so groß wie ein Menschenkind ist, kann es 100 Erwachsene jonglieren.",
 		'pt-br': "Seu corpo é inteiramente composto por músculos.\nApesar de ter o tamanho de uma criança humana,\nconsegue arremessar 100 adultos.",
 		ko: "몸집은 어린아이만 하지만\n온몸이 근육으로 되어 있어서\n어른 100명은 날려 버릴 수 있다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/038.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/038.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Machop",
-		fr: "Machoc"
+		fr: "Machoc",
+		de: "Machollo"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Son corps est si puissant qu'il lui faut\nune ceinture pour maîtriser sa force.",
 		es: "Su musculoso cuerpo es tan fuerte que usa un\ncinto antifuerza para controlar sus movimientos.",
 		it: "Il suo corpo muscoloso è così forte che usa\nuna cintura per contenere la sua potenza.",
-		de: "Dieses Pokémon ist superstark. Es kann sich nur\nmit einem kraftregulierenden Gürtel bewegen.",
+		de: "Dieses Pokémon ist superstark. Es kann sich nur mit einem kraftregulierenden Gürtel bewegen.",
 		'pt-br': "Sua massa muscular é tão poderosa que ele\nprecisa usar um cinto de economia de energia\npara controlar seus movimentos.",
 		ko: "엄청나게 강한 육체를 지녔기 때문에\n파워 세이브 벨트를 차서\n힘을 제어하고 있다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/039.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/039.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Machoke",
-		fr: "Machopeur"
+		fr: "Machopeur",
+		de: "Maschock"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il peut bouger ses quatre bras à grande vitesse\net frapper du poing ou du tranchant de la main\ndans toutes les directions sans se fatiguer.",
 		es: "Mueve rápidamente sus cuatro brazos\npara asestar incesantes golpes y\npuñetazos desde todos los ángulos.",
 		it: "Agita velocemente le quattro braccia tempestando\ngli avversari di pugni e colpi da ogni direzione.",
-		de: "Es verwendet seine vier Arme, um seine\nGegner unermüdlich mit schnellen Schlägen\naus allen Winkeln einzudecken.",
+		de: "Es verwendet seine vier Arme, um seine Gegner unermüdlich mit schnellen Schlägen aus allen Winkeln einzudecken.",
 		'pt-br': "Ele balança velozmente seus quatro braços para\natingir seus oponentes com socos e pancadas\nincessantes de todos os ângulos.",
 		ko: "4개의 팔을 재빠르게 움직여서\n모든 각도에서 쉬지 않고\n펀치와 당수를 날린다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/040.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/040.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il possède un fantastique sens de l'équilibre, et peut donner\ndes rafales de coups de pied dans toutes les positions.",
 		es: "Este Pokémon tiene un sentido del equilibrio\nincreíble. Puede dar patadas desde cualquier posición.",
 		it: "Questo straordinario Pokémon ha\nun grande equilibrio. Può tirare\nraffiche di calci da qualsiasi posizione.",
-		de: "Dieses Pokémon besitzt einen formidablen\nGleichgewichtssinn. Es kann in jeder Position\npausenlos zutreten.",
+		de: "Dieses Pokémon besitzt einen formidablen Gleichgewichtssinn. Es kann in jeder Position pausenlos zutreten.",
 		'pt-br': "Este incrível Pokémon possui um ótimo equilíbrio.\nConsegue chutar repetidamente de qualquer posição.",
 		ko: "훌륭한 밸런스 감각으로\n어떤 자세라도 연속\n킥을 날리는 대단한 녀석이다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/041.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/041.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Ses poings fendent l'air. Ils sont si rapides\nqu'un simple frôlement peut causer une brûlure.",
 		es: "Sus puñetazos cortan el aire. Son tan veloces que\nel mínimo roce podría causar una quemadura.",
 		it: "I suoi pugni fendono l'aria a una tale velocità che\nbasta venire sfiorati per riportare una scottatura.",
-		de: "Seine Fäuste zerschneiden regelrecht die Luft.\nSie sind so schnell, dass selbst die geringste\nBerührung Verbrennungen verursacht.",
+		de: "Seine Fäuste zerschneiden regelrecht die Luft. Sie sind so schnell, dass selbst die geringste Berührung Verbrennungen verursacht.",
 		'pt-br': "Seus murros cortam o ar. São tão\nvelozes que um simples toque pode\ncausar uma queimadura.",
 		ko: "주변의 공기를 가르는 펀치.\n스치기만 해도 화상을 입을 정도로\n펀치 스피드가 매우 빠르다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/042.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/042.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Les Riolu communiquent entre eux à l'aide de\nleur aura. Ils sont capables de courir toute la nuit.",
 		es: "Se comunica con los suyos emitiendo ondas.\nPuede pasarse toda una noche corriendo.",
 		it: "Comunica con i suoi simili tramite l'aura.\nPuò correre un'intera notte senza stancarsi.",
-		de: "Dieses Pokémon nutzt seine Aura, um mit seinen\nArtgenossen zu kommunizieren. Es kann eine\nganze Nacht lang laufen.",
+		de: "Dieses Pokémon nutzt seine Aura, um mit seinen Artgenossen zu kommunizieren. Es kann eine ganze Nacht lang laufen.",
 		'pt-br': "Eles comunicam-se uns com os outros usando suas auras.\nSão capazes de correr a noite inteira.",
 		ko: "파동을 내서\n동료끼리 의사소통을 한다.\n밤새도록 계속 달릴 수 있다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/043.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/043.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Riolu",
-		fr: "Riolu"
+		fr: "Riolu",
+		de: "Riolu"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Shining Revelry/044.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/044.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "On pense qu'il fait un nœud à la base de son cou\nafin d'empêcher l'énergie qu'il accumule\ndans son ventre de s'échapper par son bec.",
 		es: "Al parecer, se anudan la base del cuello para\nimpedir que la energía que tienen almacenada\nen el estómago escape por el pico.",
 		it: "Sembra che il nodo che fa alla base del collo\nserva a evitare che l'energia accumulata\nnel suo stomaco fuoriesca dal becco.",
-		de: "Dieses Pokémon verknotet offenbar seinen Hals\nam Ansatz, damit die im Bauch gespeicherte Energie\nnicht über den Schnabel entweicht.",
+		de: "Dieses Pokémon verknotet offenbar seinen Hals am Ansatz, damit die im Bauch gespeicherte Energie nicht über den Schnabel entweicht.",
 		'pt-br': "Pelo visto, este Pokémon amarra a base de seu pescoço\nem um nó para que a energia armazenada\nem sua barriga não escape pelo bico.",
 		ko: "배에 비축해 둔 에너지가\n부리를 통해 새어 나오지 않게 하기 위해\n목 아래쪽을 꼬아 놓은 듯하다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/045.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/045.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il peut se déboîter la mâchoire pour avaler tout rond des proies\nplus grosses que lui. Il se replie ensuite sur lui-même pour digérer.",
 		es: "Es capaz de desencajar la mandíbula para\nengullir presas enteras mayores que él mismo,\ntras lo cual se enrosca para descansar.",
 		it: "Può sganciare la mandibola per ingoiare\nintere prede più grosse di lui. Dopo il pasto,\nsi arrotola su se stesso per riposarsi.",
-		de: "Es hängt seinen Kiefer aus und verschlingt so\nselbst größere Beute am Stück. Danach rollt\nes sich zusammen und ruht sich aus.",
+		de: "Es hängt seinen Kiefer aus und verschlingt so selbst größere Beute am Stück. Danach rollt es sich zusammen und ruht sich aus.",
 		'pt-br': "Desloca a própria mandíbula para engolir presas\nmaiores que si mesmo. Depois de uma refeição,\nse enrosca e descansa.",
 		ko: "턱을 빼 자신보다\n큰 먹이를 통째로 삼킨다.\n식후에는 몸을 둥글게 하고 쉰다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/046.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/046.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Ekans",
-		fr: "Abo"
+		fr: "Abo",
+		de: "Rettan"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il intimide sa proie grâce au motif situé sur\nle devant de son capuchon, puis l'enserre\njusqu'à ce que son cœur cesse de battre.",
 		es: "Tras confundir a su presa con el motivo de su cuerpo, se enrosca\na su alrededor y la aferra, a la espera de que su pulso se detenga.",
 		it: "Spiazza l'avversario con il disegno sul ventre,\npoi gli si avvinghia rapidamente e aspetta\nche il suo battito cardiaco si fermi.",
-		de: "Es schüchtert seinen Gegner mit dem Muster auf seinem\nBauch ein und nimmt ihn dann in den Würgegriff, bis es\nkeinen Widerstand mehr spürt.",
+		de: "Es schüchtert seinen Gegner mit dem Muster auf seinem Bauch ein und nimmt ihn dann in den Würgegriff, bis es keinen Widerstand mehr spürt.",
 		'pt-br': "Após atordoar os seus oponentes com as marcas\nem seu estômago, enrola-os rapidamente contra seu\ncorpo e espera eles pararem de se mover.",
 		ko: "배의 무늬로 풀이 죽게 한 뒤\n재빠르게 몸으로 조여서\n상대의 고동이 멈추기를 기다린다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/047.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/047.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Depuis qu'une dispute territoriale l'a contraint\nà vivre sur la terre ferme, il protège son corps\nen le recouvrant d'un fluide toxique.",
 		es: "Tras perder una disputa territorial, se vio forzado\na vivir en tierra firme y desarrolló una membrana\nmucosa tóxica con la que proteger su cuerpo.",
 		it: "Vive sulla terraferma da quando perse una\nlotta territoriale. Per proteggere il corpo ha\nsviluppato una membrana mucosa tossica.",
-		de: "Ein verlorener Revierkampf zwang es, an Land\nzu leben. Um sich zu schützen, entwickelte es\neine giftige Schleimschicht auf seinem Körper.",
+		de: "Ein verlorener Revierkampf zwang es, an Land zu leben. Um sich zu schützen, entwickelte es eine giftige Schleimschicht auf seinem Körper.",
 		'pt-br': "Após perder uma disputa por território, Wooper passou a\nviver em terra firme. Seu corpo mudou ao longo do tempo,\ndesenvolvendo uma camada venenosa para protegê-lo.",
 		ko: "영역 다툼에서 밀려 육지에 살게 되면서\n독성을 띠는 점막으로\n몸을 보호하도록 변화했다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/048.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/048.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Paldean Wooper",
-		fr: "Axoloto de Paldea"
+		fr: "Axoloto de Paldea",
+		de: "Paldea-Felino"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Shining Revelry/049.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/049.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Son mauvais comportement lui a valu d'être enchaîné\nà une Clé de Voûte par un mystérieux sortilège.",
 		es: "Por sus constantes fechorías se le acabó uniendo\na una Piedra Espíritu con un misterioso hechizo.",
 		it: "A causa del suo comportamento molesto\nè stato imprigionato in una Roccianima\ncon un misterioso incantesimo.",
-		de: "Aufgrund seiner ständigen Untaten wurde es mit\nmysteriösen Künsten an einen Spiritkern gebunden.",
+		de: "Aufgrund seiner ständigen Untaten wurde es mit mysteriösen Künsten an einen Spiritkern gebunden.",
 		'pt-br': "Sua constante malvadeza e seus delitos causaram\nsua ligação a uma pedra por um feitiço misterioso.",
 		ko: "항상 나쁜 짓만 하고 있었기에\n신비한 술법에 의해 본모습을\n쐐기돌에 속박당했다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/050.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/050.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Ce Pokémon est d'un naturel doux, mais lorsqu'il\nse met en colère, il mord à l'aide de ses incisives\nacérées et imprégnées de venin paralysant.",
 		es: "Es manso, pero muerde y paraliza a quien lo enfada\ncon sus afilados incisivos impregnados de toxinas.",
 		it: "È di natura mite, ma se qualcuno lo\nfa arrabbiare lo morde con gli incisivi\nimpregnati di un veleno paralizzante.",
-		de: "Wer dieses friedfertige Pokémon verärgert,\nwird durch einen Biss mit seinen scharfen,\ngiftgetränkten Schneidezähnen gelähmt.",
+		de: "Wer dieses friedfertige Pokémon verärgert, wird durch einen Biss mit seinen scharfen, giftgetränkten Schneidezähnen gelähmt.",
 		'pt-br': "Apesar de normalmente ser manso, este Pokémon finca\nseus dentes frontais afiados e venenosos em\nqualquer um que o irritar, causando paralisia.",
 		ko: "온화하지만 화가 나게 하면\n독이 밴 날카로운 앞니로 물어서\n상대를 마비시킨다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/051.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/051.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Shroodle",
-		fr: "Gribouraigne"
+		fr: "Gribouraigne",
+		de: "Sproxi"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Sa salive toxique change de couleur selon\nson alimentation. Il en enduit ses doigts pour\ndessiner des motifs sur les arbres de la forêt.",
 		es: "El color de su saliva venenosa varía según su\nalimentación. Se embadurna los dedos con ella\npara pintar motivos en los árboles del bosque.",
 		it: "Traccia dei motivi sugli alberi della foresta\ncon le dita imbrattate di saliva velenosa, il\ncui colore cambia in base all'alimentazione.",
-		de: "Es beschmiert seine Finger mit giftigem Speichel,\nder je nach Futter anders gefärbt ist, und malt\ndamit Muster auf die Bäume im Wald.",
+		de: "Es beschmiert seine Finger mit giftigem Speichel, der je nach Futter anders gefärbt ist, und malt damit Muster auf die Bäume im Wald.",
 		'pt-br': "A cor da saliva venenosa deste Pokémon depende\nda sua dieta. Grafaiai cobre seus dedos com saliva\ne desenha em árvores da floresta.",
 		ko: "먹이에 따라 색이 변하는\n독성의 침을 손가락에 묻혀서\n숲의 나무들에 무늬를 그린다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/052.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/052.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Il se défend en brandissant un marteau qu'il a créé\nlui-même, mais les Pokémon qui se nourrissent\nde métaux ont tendance à le lui voler.",
 		es: "Agita su martillo forjado a mano para ahuyentar\na posibles amenazas, pero los Pokémon que se\nalimentan a base de metal suelen robárselo.",
 		it: "Si difende adoperando un martello che ha\nforgiato personalmente, anche se spesso\ni Pokémon ghiotti di metallo glielo rubano.",
-		de: "Es schwingt seinen handgeschmiedeten Hammer,\num sich zu schützen. Dieser wird ihm allerdings oft\nvon Pokémon gestohlen, die Metall fressen.",
+		de: "Es schwingt seinen handgeschmiedeten Hammer, um sich zu schützen. Dieser wird ihm allerdings oft von Pokémon gestohlen, die Metall fressen.",
 		'pt-br': "Balança seu martelo feito à mão para se proteger,\nmas o martelo é roubado com frequência\npor Pokémon que comem metal.",
 		ko: "손수 만든 해머를 휘둘러\n몸을 지키려 하나\n금속을 먹는 포켓몬에게 자주 빼앗기고 만다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/053.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/053.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Tinkatink",
-		fr: "Forgerette"
+		fr: "Forgerette",
+		de: "Forgita"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Ce Pokémon attaque des cohortes de Scalpion\net de Scalproie pour rassembler le métal nécessaire\nà la confection d'un grand marteau robuste.",
 		es: "Asalta el séquito entero de un Bisharp para reunir\nmetal con el que forjar su enorme y robusto martillo.",
 		it: "Assalta i branchi capeggiati da Bisharp\nper procurarsi il metallo necessario a\nrealizzare il suo martello grande e resistente.",
-		de: "Es überfällt Gruppen von Gladiantri und Caesurio,\num Metall zu sammeln, das es zum Herstellen seines\ngroßen, robusten Hammers benötigt.",
+		de: "Es überfällt Gruppen von Gladiantri und Caesurio, um Metall zu sammeln, das es zum Herstellen seines großen, robusten Hammers benötigt.",
 		'pt-br': "Este Pokémon ataca grupos de Pawniard e Bisharp com\no intuito de coletar metal deles e\ncriar um martelo grande e resistente.",
 		ko: "크고 튼튼한 해머를 만들기 위해\n절각참 무리를 습격해서\n금속을 모은다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/054.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/054.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Tinkatuff",
-		fr: "Forgella"
+		fr: "Forgella",
+		de: "Tafforgita"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Shining Revelry/055.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/055.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "On raconte qu'il est né lorsqu'un mystérieux Pokémon Poison\na pris possession d'un moteur laissé à l'abandon dans une casse.",
 		es: "Se dice que surgió cuando un misterioso Pokémon venenoso\ntomó posesión de un motor abandonado en un desguace.",
 		it: "Pare sia nato quando un misterioso Pokémon\ndi tipo Veleno prese possesso di un motore\nabbandonato in un deposito di rottami.",
-		de: "Es soll entstanden sein, als ein unbekanntes\nGift-Pokémon von einem Motor Besitz ergriff,\nder in einer Schrottfabrik zurückgelassen wurde.",
+		de: "Es soll entstanden sein, als ein unbekanntes Gift-Pokémon von einem Motor Besitz ergriff, der in einer Schrottfabrik zurückgelassen wurde.",
 		'pt-br': "Acredita-se que este Pokémon nasceu quando um\nPokémon venenoso desconhecido possuiu um motor\nabandonado em uma fábrica que processa ferro-velho.",
 		ko: "고철 처리장에 방치된 엔진에\n정체불명의 독포켓몬이 들어가\n탄생한 것으로 전해지고 있다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/056.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/056.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Varoom",
-		fr: "Vrombi"
+		fr: "Vrombi",
+		de: "Knattox"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il produit de l'énergie en faisant exploser dans\nses huit cylindres un mélange gazeux qui\ncontient une substance toxique et des minéraux.",
 		es: "Posee ocho cilindros, con los que genera energía\nhaciendo estallar el gas que produce al mezclar\nlos minerales de las rocas con su veneno.",
 		it: "Produce energia facendo esplodere\nnei suoi otto cilindri un gas che forma\nmescolando tossine e minerali delle rocce.",
-		de: "Mit seinen nunmehr acht Zylindern lässt es ein\nGasgemisch aus Gift und Gesteinsmineralien\nexplodieren, um daraus Energie zu gewinnen.",
+		de: "Mit seinen nunmehr acht Zylindern lässt es ein Gasgemisch aus Gift und Gesteinsmineralien explodieren, um daraus Energie zu gewinnen.",
 		'pt-br': "Cria um gás a partir de veneno e minerais de pedras.\nEntão, detona o gás em seus cilindros,\nque agora são oito, para gerar energia.",
 		ko: "독소와 바위 성분이 섞인 가스를\n8개로 늘어난 실린더에서 폭발시켜\n에너지를 만들어 낸다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/057.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/057.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Gimmighoul",
-		fr: "Mordudor"
+		fr: "Mordudor",
+		de: "Gierspenst"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Son corps serait composé de 1 000 pièces. Sociable,\nil peut se lier d'amitié très rapidement avec n'importe qui.",
 		es: "Se dice que su cuerpo está formado por 1000\nmonedas. Es capaz de hacer buenas migas con\ncualquiera rápidamente por su sociabilidad.",
 		it: "Pare che il suo corpo sia formato da\n1.000 monete. È molto socievole e\nfa subito amicizia con chiunque.",
-		de: "Sein Körper soll aus 1000 Münzen bestehen.\nEs ist sehr umgänglich und schließt mit jedem\nrasch Freundschaft.",
+		de: "Sein Körper soll aus 1000 Münzen bestehen. Es ist sehr umgänglich und schließt mit jedem rasch Freundschaft.",
 		'pt-br': "Seu corpo parece ser feito de 1.000 moedas.\nEste Pokémon se dá bem com os outros\ne faz amizades com qualquer um rapidamente.",
 		ko: "몸은 1000개의 코인으로\n이뤄져 있다고 한다. 붙임성이 좋아서\n누구와도 금방 친해진다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/058.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/058.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Ses incisives poussent tout au long de sa vie.\nSi elles dépassent une certaine longueur,\nil ne peut plus s'alimenter et meurt de faim.",
 		es: "Sus incisivos crecen durante toda su vida.\nSi aumentan demasiado de tamaño, no\npuede alimentarse y muere de inanición.",
 		it: "I suoi incisivi continuano a crescere per\ntutta la vita. Se si allungano troppo, non\nriesce più a nutrirsi e muore di fame.",
-		de: "Seine Nagezähne wachsen sein ganzes Leben\nüber. Werden sie allzu lang, kann es damit nicht\nmehr fressen und verhungert.",
+		de: "Seine Nagezähne wachsen sein ganzes Leben über. Werden sie allzu lang, kann es damit nicht mehr fressen und verhungert.",
 		'pt-br': "Seus incisivos crescem continuamente durante toda\na sua vida, mas se ficarem longos demais, este Pokémon\nnão conseguirá comer e morrerá de fome.",
 		ko: "평생 앞니가 계속 자란다.\n너무 많이 자라면 먹이를\n먹을 수 없어 굶어 죽는다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/059.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/059.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Rattata",
-		fr: "Rattata"
+		fr: "Rattata",
+		de: "Rattfratz"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Les petites palmes de ses pattes postérieures\nlui permettraient de se rendre d'île en île\nà la nage afin d'échapper à ses prédateurs.",
 		es: "Las pequeñas membranas que tiene en las\npatas traseras le permiten nadar entre las islas\nde Alola y escapar así de sus depredadores.",
 		it: "Si dice che sia sfuggito ai nemici nuotando\nda un'isola all'altra grazie alle minuscole\nmembrane tra le dita delle zampe posteriori.",
-		de: "Auf der Flucht vor seinen Feinden nutzt es die\nSchwimmhäute an seinen Hinterläufen, um von\nInsel zu Insel zu schwimmen.",
+		de: "Auf der Flucht vor seinen Feinden nutzt es die Schwimmhäute an seinen Hinterläufen, um von Insel zu Insel zu schwimmen.",
 		'pt-br': "Dizem que fugiu dos seus inimigos\nusando seus pés palmados para nadar\nde ilha em ilha em Alola.",
 		ko: "뒷발의 작은 물갈퀴로\n바다를 헤엄쳐 섬을 건너\n적을 피해 도망쳤다고 한다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/060.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/060.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Ce Pokémon aime inspirer profondément\net chanter une mélodie mystérieuse qui endort\nimmédiatement tous ceux qui l'entendent.",
 		es: "Hincha su vientre considerablemente y entona una melodía\nmisteriosa que duerme en el acto a todo aquel que la oye.",
 		it: "Gonfia la pancia per cantare una melodia\nmisteriosa che fa addormentare chiunque l'ascolti.",
-		de: "Es kann tief einatmen und seinen Bauch mit Luft\nfüllen, um ein sonderbares Lied anzustimmen.\nWer dieses hört, schläft auf der Stelle ein.",
+		de: "Es kann tief einatmen und seinen Bauch mit Luft füllen, um ein sonderbares Lied anzustimmen. Wer dieses hört, schläft auf der Stelle ein.",
 		'pt-br': "Infla seu estômago e canta uma melodia misteriosa.\nSe você ouvir esta melodia,\nacabará dormindo na mesma hora.",
 		ko: "배를 크게 부풀려서\n신비한 멜로디를 노래한다.\n들으면 바로 졸음이 쏟아진다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/061.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/061.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Jigglypuff",
-		fr: "Rondoudou"
+		fr: "Rondoudou",
+		de: "Pummeluff"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il a une très belle fourrure. Mieux vaut éviter de le mettre\nen colère, ou il gonflera avant d'attaquer de tout son corps.",
 		es: "Tiene un pelaje muy fino. Se recomienda no enfadarlo,\no se inflará y golpeará con todo su cuerpo.",
 		it: "Ha un pelo molto fino. Attenzione a non farlo adirare,\nperché può gonfiarsi e caricare con tutto il suo peso.",
-		de: "Es hat sehr feines Fell. Doch Vorsicht: Verärgert\nman Knuddeluff, bläst es sich stark auf und stürzt\nsich mit seinem ganzen Körper auf einen.",
+		de: "Es hat sehr feines Fell. Doch Vorsicht: Verärgert man Knuddeluff, bläst es sich stark auf und stürzt sich mit seinem ganzen Körper auf einen.",
 		'pt-br': "Ele tem a pele muito fina. Tome cuidado para\nnão zangá-lo ou ele pode inflar permanentemente\ne golpear com uma pancada de corpo.",
 		ko: "얇고 고운 털을 지니고 있다.\n화나게 하면 몸을 점점 부풀리며\n덮쳐 오기 때문에 주의가 필요하다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/062.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/062.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Si sa salive gluante entre en contact avec la peau\net qu'on ne l'essuie pas bien, elle provoque de\nterribles démangeaisons qui ne s'arrêtent jamais.",
 		es: "Si sus lametones no se tratan a tiempo,\nsu saliva pegajosa y urticante puede\nprovocar picores persistentes.",
 		it: "La sua saliva appiccicosa provoca\nun prurito terribile che non dà tregua\nse le parti leccate non vengono ripulite.",
-		de: "Wäscht man sich nach der Berührung mit seinem\nklebrigen Speichel nicht, setzt bald ein starker\nJuckreiz ein, der nicht mehr zu stoppen ist.",
+		de: "Wäscht man sich nach der Berührung mit seinem klebrigen Speichel nicht, setzt bald ein starker Juckreiz ein, der nicht mehr zu stoppen ist.",
 		'pt-br': "Se você entrar em contato com a saliva grudenta\ndeste Pokémon e não se limpar, sentirá uma\ncoceira intensa. E a coceira não parará.",
 		ko: "끈적끈적한 타액에 접촉한 후\n그대로 방치하면 굉장히 가렵고\n급기야 멈출 수 없게 된다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/063.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/063.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Lickitung",
-		fr: "Excelangue"
+		fr: "Excelangue",
+		de: "Schlurp"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Sa langue a l'incroyable faculté de s'allonger et\nd'atteindre plusieurs fois la taille de son corps.\nCe mystère de la nature reste entier.",
 		es: "Su lengua es un misterio sin resolver: no se sabe\ncómo puede extenderla hasta alcanzar longitudes\nque superan varias veces la de su propio cuerpo.",
 		it: "La sua lingua può misteriosamente allungarsi\nfino a molte volte la lunghezza del corpo.\nAncora non si è capito come faccia.",
-		de: "Seine sonderbare Zunge kann sich bis auf ein\nVielfaches seiner Körpergröße ausdehnen.\nNiemand weiß, wie das möglich ist.",
+		de: "Seine sonderbare Zunge kann sich bis auf ein Vielfaches seiner Körpergröße ausdehnen. Niemand weiß, wie das möglich ist.",
 		'pt-br': "A língua estranha de Lickilicky pode esticar e ficar\nmais longa do que seu corpo. Ninguém jamais descobriu\ncomo a língua deste Pokémon pode esticar tanto.",
 		ko: "몸의 몇 배의 길이로 늘어나는\n신비한 혀를 가졌다.\n그 비밀은 아직 밝혀지지 않았다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/064.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/064.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Rien ne peut perturber ses nerfs d'acier.\nIl est plus agile et énergique qu'il n'y paraît.",
 		es: "Tiene nervios de acero y nada puede perturbarlo.\nEs más ágil y activo de lo que aparenta.",
 		it: "Ha i nervi d'acciaio e niente può turbarlo.\nÈ più agile e attivo di quanto sembri.",
-		de: "Es hat Nerven wie Drahtseile, nichts kann es erschüttern.\nEs ist agiler und aktiver, als es scheint.",
+		de: "Es hat Nerven wie Drahtseile, nichts kann es erschüttern. Es ist agiler und aktiver, als es scheint.",
 		'pt-br': "Com nervos de aço, nada pode perturbá-lo.\nÉ mais ágil e ativo do que parece.",
 		ko: "어떤 것에도 동요하지 않는\n대담한 신경의 소유자다.\n보기보다는 기민하게 활동한다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/065.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/065.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Bidoof",
-		fr: "Keunotor"
+		fr: "Keunotor",
+		de: "Bidiza"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Shining Revelry/066.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/066.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Quand ses deux oreilles sont repliées, c'est\nsigne qu'il ne se sent pas bien physiquement\nou mentalement et qu'il a besoin de soins.",
 		es: "Cuando enrolla ambas orejas, es señal de que tiene algún\ntipo de malestar físico o emocional y necesita cuidados.",
 		it: "Se arrotola entrambe le orecchie significa che\nè afflitto da qualche disturbo fisico o emotivo.\nÈ segno che bisogna prendersi cura di lui.",
-		de: "Sind seine beiden Ohren aufgerollt, deutet das\ndarauf hin, dass es ihm körperlich oder psychisch\nnicht gut geht und es Zuwendung braucht.",
+		de: "Sind seine beiden Ohren aufgerollt, deutet das darauf hin, dass es ihm körperlich oder psychisch nicht gut geht und es Zuwendung braucht.",
 		'pt-br': "Se as duas orelhas de Buneary estão enroladas, algo está\nerrado com seu corpo ou mente. É um sinal claro\nde que o Pokémon precisa de cuidados.",
 		ko: "양쪽 귀를 말고 있을 때는\n몸이나 마음이 좋지 않다는 뜻이므로\n관리가 필요하다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/067.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/067.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Buneary",
-		fr: "Laporeille"
+		fr: "Laporeille",
+		de: "Haspiror"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Constamment sur le qui-vive, il donne des coups de pied\nparticulièrement dévastateurs si une menace approche.",
 		es: "Está siempre atento a lo que ocurre a su\nalrededor. Si advierte peligro, se defenderá\ncon patadas de potencia devastadora.",
 		it: "Presta sempre attenzione all'ambiente\ncircostante e in caso di pericolo sfodera\ncalci di straordinaria potenza distruttiva.",
-		de: "Schlapor behält seine Umgebung stets im Auge.\nWenn Gefahr im Verzug ist, setzt es sich mit\nvernichtenden Tritten zur Wehr.",
+		de: "Schlapor behält seine Umgebung stets im Auge. Wenn Gefahr im Verzug ist, setzt es sich mit vernichtenden Tritten zur Wehr.",
 		'pt-br': "Lopunny está constantemente monitorando seus\narredores. Se o perigo se aproxima, este Pokémon\nresponde com chutes superdestrutivos.",
 		ko: "주위 상황을 항상 신경 쓰고 있으며\n위험이 닥치면 무시무시한 파괴력을\n가진 킥을 날린다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/068.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/068.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Des fresques vieilles de 10 000 ans laissent penser\nque ce Pokémon transporte des êtres humains\nsur son dos depuis les temps anciens.",
 		es: "Según parece, ha permitido que los humanos\nmonten en él desde tiempos remotos. Aparece\nen pinturas rupestres de hace diez mil años.",
 		it: "Sembra che trasportasse esseri umani sul\ndorso già nell'antichità. È rappresentato in\npitture rupestri risalenti a 10.000 anni fa.",
-		de: "Seit uralten Zeiten soll es Menschen auf seinem\nRücken reiten lassen. Darstellungen davon finden\nsich auf 10 000 Jahre alten Wandmalereien.",
+		de: "Seit uralten Zeiten soll es Menschen auf seinem Rücken reiten lassen. Darstellungen davon finden sich auf 10 000 Jahre alten Wandmalereien.",
 		'pt-br': "Aparentemente, Cyclizar permite que as pessoas o\nmontem desde os tempos antigos. Representações deste\nato foram encontradas em murais com mais de 10.000 anos.",
 		ko: "먼 옛날부터 인간을\n등에 태우고 다녔다고 한다.\n1만 년 전 벽화에도 그 모습이 그려져 있다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/071.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/071.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		fr: "Pendant ce tour, les attaques de vos Pokémon infligent + 20 dégâts au Pokémon-{ex} Actif de votre adversaire.",
 		es: "Durante este turno, los ataques de tus Pokémon hacen +20 puntos de daño al Pokémon {ex} Activo de tu rival.",
 		it: "Durante questo turno, gli attacchi usati dai tuoi Pokémon infliggono +20 danni al Pokémon-{ex} attivo del tuo avversario.",
-		de: "Während dieses Zuges fügen die Attacken deiner Pokémon dem Aktiven Pokémon-{ex} deines Gegners + 20 Schadenspunkte zu.",
+		de: "Während dieses Zuges fügen die Attacken deiner Pokémon dem Aktiven Pokémon-ex deines Gegners + 20 Schadenspunkte zu. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen.",
 		'pt-br': "Durante este turno, os ataques usados pelos seus Pokémon causam +20 pontos de dano ao Pokémon {ex} Ativo do seu oponente.",
 		ko: "이 차례에 자신의 포켓몬이 사용하는 기술이 상대 배틀필드의 「포켓몬 {ex}」에게 주는 데미지를 +20한다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/072.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/072.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		fr: "Lancez une pièce jusqu'à ce que vous obteniez pile. Pour chaque côté face, défaussez au hasard une Énergie du Pokémon Actif de votre adversaire.",
 		es: "Lanza 1 moneda hasta que salga cruz. Por cada cara, descarta 1 Energía aleatoria del Pokémon Activo de tu rival.",
 		it: "Lancia una moneta finché non esce croce. Ogni volta che esce testa, scarta un'Energia a caso dal Pokémon attivo del tuo avversario.",
-		de: "Wirf so lange 1 Münze, bis sie Zahl zeigt. Lege pro Kopf 1 zufällige Energie vom Aktiven Pokémon deines Gegners ab.",
+		de: "Wirf so lange 1 Münze, bis sie Zahl zeigt. Lege pro Kopf 1 zufällige Energie vom Aktiven Pokémon deines Gegners ab. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen.",
 		'pt-br': "Jogue uma moeda até sair coroa. Para cada cara, descarte uma Energia aleatória do Pokémon Ativo do seu oponente.",
 		ko: "뒷면이 나올 때까지 동전을 던져서 앞면이 나온 수만큼 상대의 배틀 포켓몬에서 에너지를 랜덤으로 트래쉬한다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/073.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/073.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Floragato",
-		fr: "Matourgeon"
+		fr: "Matourgeon",
+		de: "Feliospa"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il se sert de la réverbération de la lumière sur\nla fourrure de sa cape pour camoufler sa tige,\nce qui donne l'illusion que sa fleur flotte dans les airs.",
 		es: "Se sirve de la luz que reflejan los tricomas de\nsu manto de hojas para camuflar la vid y crear\nla ilusión óptica de que la flor flota en el aire.",
 		it: "I riflessi del pelo all'interno del mantello\ncamuffano lo stelo del suo fiore, che\ncosì sembra fluttuare nell'aria.",
-		de: "Es erweckt den Eindruck, als würde seine Blume\nschweben, indem es ihren Stiel mit der Reflexion\ndes Fells an der Innenseite seines Mantels tarnt.",
+		de: "Es erweckt den Eindruck, als würde seine Blume schweben, indem es ihren Stiel mit der Reflexion des Fells an der Innenseite seines Mantels tarnt.",
 		'pt-br': "Este Pokémon usa a pelugem reflexiva da sua capa\npara camuflar o caule da sua flor, criando a ilusão\nde que a flor está flutuando.",
 		ko: "꽃이 떠 있는 것처럼 보이는 것은\n망토 뒷면의 털이 빛을 반사해서\n줄기를 보이지 않게 하기 때문이다."
 	},
@@ -58,7 +59,7 @@ const card: Card = {
 			fr: "Si le Pokémon Actif de votre adversaire est un Pokémon-{ex}, cette attaque inflige 70 dégâts supplémentaires.",
 			es: "Si el Pokémon Activo de tu rival es un Pokémon {ex}, este ataque hace 70 puntos de daño más.",
 			it: "Se il Pokémon attivo del tuo avversario è un Pokémon-{ex}, questo attacco infligge 70 danni in più.",
-			de: "Wenn das Aktive Pokémon deines Gegners ein Pokémon-{ex} ist, fügt diese Attacke 70 Schadenspunkte mehr zu.",
+			de: "Wenn das Aktive Pokémon deines Gegners ein Pokémon-ex ist, fügt diese Attacke 70 Schadenspunkte mehr zu.",
 			'pt-br': "Se o Pokémon Ativo do seu oponente for um Pokémon {ex}, este ataque causará 70 pontos de dano a mais.",
 			ko: "상대의 배틀 포켓몬이 「포켓몬 {ex}」라면 70데미지를 추가한다."
 		}

--- a/data/Pokémon TCG Pocket/Shining Revelry/074.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/074.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "La bouée autour de son cou lui permet de\ngarder la tête hors de l'eau. Ainsi, il peut scruter\nles mouvements de ses proies sur la terre ferme.",
 		es: "La vejiga natatoria alrededor del cuello le permite flotar\nen el agua con la cabeza fuera para divisar a sus presas.",
 		it: "Gonfia il suo collare galleggiante e\nrimane con la testa fuori dall'acqua\nin cerca di prede sulla terraferma.",
-		de: "Füllt es die Schwimmblase um seinen Hals mit Luft,\nragt sein Kopf aus dem Wasser und es kann die\nBewegungen von Beute an Land beobachten.",
+		de: "Füllt es die Schwimmblase um seinen Hals mit Luft, ragt sein Kopf aus dem Wasser und es kann die Bewegungen von Beute an Land beobachten.",
 		'pt-br': "Infla sua bolsa de flutuação e mantém o rosto acima\nda água para procurar o movimento de presas.",
 		ko: "목의 부낭을 부풀려\n수면에 얼굴을 내밀고 지상에 있는\n먹이의 움직임을 살핀다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/075.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/075.ts
@@ -27,7 +27,7 @@ const card: Card = {
 		fr: "Ce petit Pokémon Dragon vit dans la gueule\nd'Oyacata, à l'abri de ses adversaires.",
 		es: "Pokémon dragón de pequeño tamaño. Vive en la boca de un\nDondozo para protegerse de los ataques de los depredadores.",
 		it: "Un Pokémon di tipo Drago di piccole\ndimensioni. Vive all'interno della bocca di\nDondozo, protetto dagli attacchi dei nemici.",
-		de: "Dieses kleine Drachen-Pokémon lebt im Maul von\nHeerashai, wodurch es vor Feinden geschützt ist.",
+		de: "Dieses kleine Drachen-Pokémon lebt im Maul von Heerashai, wodurch es vor Feinden geschützt ist.",
 		'pt-br': "Este é um pequeno Pokémon dragão. Mora dentro da\nboca de Dondozo para proteger-se\nde inimigos do mundo externo.",
 		ko: "작은 몸집의 드래곤포켓몬.\n어써러셔의 입안에 살며\n외부의 적으로부터 몸을 지킨다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/076.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/076.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Shroodle",
-		fr: "Gribouraigne"
+		fr: "Gribouraigne",
+		de: "Sproxi"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Sa salive toxique change de couleur selon\nson alimentation. Il en enduit ses doigts pour\ndessiner des motifs sur les arbres de la forêt.",
 		es: "El color de su saliva venenosa varía según su\nalimentación. Se embadurna los dedos con ella\npara pintar motivos en los árboles del bosque.",
 		it: "Traccia dei motivi sugli alberi della foresta\ncon le dita imbrattate di saliva velenosa, il\ncui colore cambia in base all'alimentazione.",
-		de: "Es beschmiert seine Finger mit giftigem Speichel,\nder je nach Futter anders gefärbt ist, und malt\ndamit Muster auf die Bäume im Wald.",
+		de: "Es beschmiert seine Finger mit giftigem Speichel, der je nach Futter anders gefärbt ist, und malt damit Muster auf die Bäume im Wald.",
 		'pt-br': "A cor da saliva venenosa deste Pokémon depende\nda sua dieta. Grafaiai cobre seus dedos com saliva\ne desenha em árvores da floresta.",
 		ko: "먹이에 따라 색이 변하는\n독성의 침을 손가락에 묻혀서\n숲의 나무들에 무늬를 그린다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/077.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/077.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Gimmighoul",
-		fr: "Mordudor"
+		fr: "Mordudor",
+		de: "Gierspenst"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Son corps serait composé de 1 000 pièces. Sociable,\nil peut se lier d'amitié très rapidement avec n'importe qui.",
 		es: "Se dice que su cuerpo está formado por 1000\nmonedas. Es capaz de hacer buenas migas con\ncualquiera rápidamente por su sociabilidad.",
 		it: "Pare che il suo corpo sia formato da\n1.000 monete. È molto socievole e\nfa subito amicizia con chiunque.",
-		de: "Sein Körper soll aus 1000 Münzen bestehen.\nEs ist sehr umgänglich und schließt mit jedem\nrasch Freundschaft.",
+		de: "Sein Körper soll aus 1000 Münzen bestehen. Es ist sehr umgänglich und schließt mit jedem rasch Freundschaft.",
 		'pt-br': "Seu corpo parece ser feito de 1.000 moedas.\nEste Pokémon se dá bem com os outros\ne faz amizades com qualquer um rapidamente.",
 		ko: "몸은 1000개의 코인으로\n이뤄져 있다고 한다. 붙임성이 좋아서\n누구와도 금방 친해진다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/078.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/078.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Jigglypuff",
-		fr: "Rondoudou"
+		fr: "Rondoudou",
+		de: "Pummeluff"
 	},
 
 	description: {
@@ -32,7 +33,7 @@ const card: Card = {
 		fr: "Il a une très belle fourrure. Mieux vaut éviter de le mettre\nen colère, ou il gonflera avant d'attaquer de tout son corps.",
 		es: "Tiene un pelaje muy fino. Se recomienda no enfadarlo,\no se inflará y golpeará con todo su cuerpo.",
 		it: "Ha un pelo molto fino. Attenzione a non farlo adirare,\nperché può gonfiarsi e caricare con tutto il suo peso.",
-		de: "Es hat sehr feines Fell. Doch Vorsicht: Verärgert\nman Knuddeluff, bläst es sich stark auf und stürzt\nsich mit seinem ganzen Körper auf einen.",
+		de: "Es hat sehr feines Fell. Doch Vorsicht: Verärgert man Knuddeluff, bläst es sich stark auf und stürzt sich mit seinem ganzen Körper auf einen.",
 		'pt-br': "Ele tem a pele muito fina. Tome cuidado para\nnão zangá-lo ou ele pode inflar permanentemente\ne golpear com uma pancada de corpo.",
 		ko: "얇고 고운 털을 지니고 있다.\n화나게 하면 몸을 점점 부풀리며\n덮쳐 오기 때문에 주의가 필요하다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/079.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/079.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Kakuna",
-		fr: "Coconfort"
+		fr: "Coconfort",
+		de: "Kokuna"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Shining Revelry/080.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/080.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Charmeleon",
-		fr: "Reptincel"
+		fr: "Reptincel",
+		de: "Glutexo"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Shining Revelry/081.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/081.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Wiglett",
-		fr: "Taupikeau"
+		fr: "Taupikeau",
+		de: "Schligda"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Shining Revelry/084.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/084.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Riolu",
-		fr: "Riolu"
+		fr: "Riolu",
+		de: "Riolu"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Shining Revelry/085.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/085.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Paldean Wooper",
-		fr: "Axoloto de Paldea"
+		fr: "Axoloto de Paldea",
+		de: "Paldea-Felino"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Shining Revelry/086.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/086.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Tinkatuff",
-		fr: "Forgella"
+		fr: "Forgella",
+		de: "Tafforgita"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Shining Revelry/087.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/087.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Bidoof",
-		fr: "Keunotor"
+		fr: "Keunotor",
+		de: "Bidiza"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Shining Revelry/091.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/091.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		fr: "Lancez une pièce jusqu'à ce que vous obteniez pile. Pour chaque côté face, défaussez au hasard une Énergie du Pokémon Actif de votre adversaire.",
 		es: "Lanza 1 moneda hasta que salga cruz. Por cada cara, descarta 1 Energía aleatoria del Pokémon Activo de tu rival.",
 		it: "Lancia una moneta finché non esce croce. Ogni volta che esce testa, scarta un'Energia a caso dal Pokémon attivo del tuo avversario.",
-		de: "Wirf so lange 1 Münze, bis sie Zahl zeigt. Lege pro Kopf 1 zufällige Energie vom Aktiven Pokémon deines Gegners ab.",
+		de: "Wirf so lange 1 Münze, bis sie Zahl zeigt. Lege pro Kopf 1 zufällige Energie vom Aktiven Pokémon deines Gegners ab. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen.",
 		'pt-br': "Jogue uma moeda até sair coroa. Para cada cara, descarte uma Energia aleatória do Pokémon Ativo do seu oponente.",
 		ko: "뒷면이 나올 때까지 동전을 던져서 앞면이 나온 수만큼 상대의 배틀 포켓몬에서 에너지를 랜덤으로 트래쉬한다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/093.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/093.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Paldean Wooper",
-		fr: "Axoloto de Paldea"
+		fr: "Axoloto de Paldea",
+		de: "Paldea-Felino"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Shining Revelry/094.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/094.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Tinkatuff",
-		fr: "Forgella"
+		fr: "Forgella",
+		de: "Tafforgita"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Shining Revelry/095.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/095.ts
@@ -24,7 +24,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Bidoof",
-		fr: "Keunotor"
+		fr: "Keunotor",
+		de: "Bidiza"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Shining Revelry/097.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/097.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "On trouve souvent ce Pokémon dans les forêts\net les hautes herbes. L'aiguillon de 5 cm\nsur sa tête contient un venin très toxique.",
 		es: "Suele habitar bosques y praderas.\nTiene un afilado y venenoso aguijón\nde unos 5 cm encima de la cabeza.",
 		it: "Vive soprattutto nei boschi e nei prati. Sul capo\nha un affilato e velenoso pungiglione lungo 5 cm.",
-		de: "Es lebt bevorzugt in Wäldern und in hohem Gras.\nAuf dem Kopf trägt es einen circa 5 cm langen,\nspitzen, giftigen Stachel.",
+		de: "Es lebt bevorzugt in Wäldern und in hohem Gras. Auf dem Kopf trägt es einen circa 5 cm langen, spitzen, giftigen Stachel.",
 		'pt-br': "Encontrado frequentemente em florestas e\npradarias. Possui uma farpa afiada e tóxica\nde cerca de 5 cm em cima da cabeça.",
 		ko: "숲이나 풀밭에 많이 서식한다.\n머리끝에 5cm 정도의\n작고 날카로운 독침을 지니고 있다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/098.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/098.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Weedle",
-		fr: "Aspicot"
+		fr: "Aspicot",
+		de: "Hornliu"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "Incapable de se déplacer de lui-même,\nil se défend en durcissant sa carapace.",
 		es: "Casi incapaz de moverse, este Pokémon solo\npuede endurecer su caparazón para protegerse.",
 		it: "Quasi incapace di muoversi, questo Pokémon può\nsolo indurire il proprio guscio per proteggersi.",
-		de: "Dieses Pokémon kann sich kaum bewegen.\nBei drohender Gefahr verhärtet es seinen Panzer.",
+		de: "Dieses Pokémon kann sich kaum bewegen. Bei drohender Gefahr verhärtet es seinen Panzer.",
 		'pt-br': "Quase incapaz de se mover, esse Pokémon\npode apenas endurecer sua carapaça para\nse proteger quando está em perigo.",
 		ko: "스스로는 거의 움직일 수 없지만\n위험할 때는 단단해져서\n몸을 보호하고 있는 것 같다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/099.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/099.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Il préfère ce qui est chaud. En cas de pluie,\nde la vapeur se forme autour de sa queue.",
 		es: "Prefiere las cosas calientes. Dicen que cuando\nllueve le sale vapor de la punta de la cola.",
 		it: "Ama le cose calde. Si dice che quando piove\ngli esca vapore dalla punta della coda.",
-		de: "Dieses Pokémon bevorzugt heiße Dinge.\nBei Regen soll seine Schwanzspitze dampfen.",
+		de: "Dieses Pokémon bevorzugt heiße Dinge. Bei Regen soll seine Schwanzspitze dampfen.",
 		'pt-br': "Prefere coisas quentes. Quando chove, dizem\nque solta vapor pela ponta de sua cauda.",
 		ko: "뜨거운 것을 좋아하는 성격이다.\n비에 젖으면 꼬리 끝에서\n연기가 난다고 한다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/100.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/100.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Charmander",
-		fr: "Salamèche"
+		fr: "Salamèche",
+		de: "Glumanda"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "Il est très brutal. En combat, il se sert de ses griffes acérées\net de sa queue enflammée pour mettre en pièces ses adversaires.",
 		es: "Este Pokémon de naturaleza agresiva\nataca en combate con su cola llameante\ny hace trizas al rival con sus afiladas garras.",
 		it: "Ha un'indole feroce. Usa la coda fiammeggiante come\nuna frusta e lacera l'avversario con gli artigli affilati.",
-		de: "Es ist brutal veranlagt. Im Kampf schlägt es mit\nseinem brennenden Schweif um sich und schlitzt\nGegner mit seinen scharfen Klauen auf.",
+		de: "Es ist brutal veranlagt. Im Kampf schlägt es mit seinem brennenden Schweif um sich und schlitzt Gegner mit seinen scharfen Klauen auf.",
 		'pt-br': "Possui uma natureza bárbara. Em batalha, chicoteia\ncom sua cauda de fogo e corta com suas garras afiadas.",
 		ko: "불타는 꼬리를 휘두르며\n날카로운 발톱으로 상대를\n베어 가르는 몹시 거친 성격이다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/101.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/101.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Il détecte l'odeur de Délestin à plus de vingt mètres,\nce qui lui donne le temps de s'enfouir dans le sable.",
 		es: "Puede percibir el olor de los Veluza a 20 m de distancia,\nlo que le permite ocultarse bajo la arena a tiempo.",
 		it: "Fiuta l'odore di un Veluza da 20 metri\ndi distanza e si nasconde nella sabbia.",
-		de: "Es kann den Geruch eines Agiluza auf 20 m Entfernung\nwahrnehmen und versteckt sich daraufhin flugs im Sand.",
+		de: "Es kann den Geruch eines Agiluza auf 20 m Entfernung wahrnehmen und versteckt sich daraufhin flugs im Sand.",
 		'pt-br': "Este Pokémon é capaz de sentir o cheiro de Veluza\na mais de 20 metros de distância e se esconderá na areia.",
 		ko: "20m 떨어진 가비루사에게서 나는\n냄새도 맡을 수 있어서\n모래 속에 몸을 숨긴다."
 	},
@@ -51,7 +51,7 @@ const card: Card = {
 			fr: "Un des Pokémon de votre adversaire est choisi au hasard. Il subit 30 dégâts.",
 			es: "Se elige a un Pokémon aleatorio de tu rival. Hazle 30 puntos de daño.",
 			it: "Viene scelto un Pokémon avversario a caso. Quel Pokémon subisce 30 danni.",
-			de: "1 Pokémon des Gegners wird zufällig ausgewählt.\nFüge diesem Pokémon 30 Schadenspunkte zu.",
+			de: "1 Pokémon des Gegners wird zufällig ausgewählt. Füge diesem Pokémon 30 Schadenspunkte zu.",
 			'pt-br': "Um dos Pokémon do seu oponente é escolhido aleatoriamente. Cause 30 pontos de dano a ele.",
 			ko: "상대의 포켓몬이 랜덤으로 1번 선택되어 선택된 포켓몬에게 30데미지를 준다."
 		}

--- a/data/Pokémon TCG Pocket/Shining Revelry/102.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/102.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Comme il n'est pas très doué pour attraper ses proies,\nce Pokémon vorace fait équipe avec Nigirigon pour chasser.",
 		es: "Le gusta mucho comer, pero no se le da bien cazar, por lo\nque aúna fuerzas con Tatsugiri con el fin de capturar presas.",
 		it: "È un Pokémon vorace, ma non è molto abile\nnel procacciarsi il cibo. Cattura le sue prede\ncollaborando con il Tatsugiri che è con lui.",
-		de: "Es ist zwar ein Vielfraß, doch die Jagd liegt\nihm nicht. Deshalb schließt es sich mit\nNigiragi zusammen, um Beute zu fangen.",
+		de: "Es ist zwar ein Vielfraß, doch die Jagd liegt ihm nicht. Deshalb schließt es sich mit Nigiragi zusammen, um Beute zu fangen.",
 		'pt-br': "Este Pokémon é guloso, mas não é nada\nbom em conseguir comida. Alia-se a\nTatsugiri para pegar suas presas.",
 		ko: "대식가지만 먹이를 잡는 것이 서툴다.\n싸리용과 콤비를 이뤄\n먹이를 사냥한다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/103.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/103.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		fr: "Pachirisu fait partie des Pokémon aux joues électriques.\nIl libère l'énergie qu'il accumule par la queue.",
 		es: "Forma parte del grupo de Pokémon que\nposee bolsas de electricidad en las mejillas.\nDescarga por la cola la electricidad que acumula.",
 		it: "Appartiene alla tipologia di Pokémon\nmuniti di sacche elettriche sulle guance.\nRilascia dalla coda l'elettricità accumulata.",
-		de: "Pachirisu ist eines der Pokémon, die mit ihren\nBackentaschen Elektrizität erzeugen. Den so\ngesammelten Strom gibt es über den Schweif ab.",
+		de: "Pachirisu ist eines der Pokémon, die mit ihren Backentaschen Elektrizität erzeugen. Den so gesammelten Strom gibt es über den Schweif ab.",
 		ko: "볼에 전기 주머니를 가진 포켓몬의 일종.\n꼬리에 모인 전기를 방출한다.",
 		'pt-br': "É um dos tipos de Pokémon com bolsas elétricas\nnas bochechas. Ele dispara cargas de sua cauda."
 	},
@@ -44,7 +44,7 @@ const card: Card = {
 			fr: "Prenez une Énergie {L} de votre zone Énergie et attachez-la à l'un de vos Pokémon de Banc.",
 			es: "Une 1 Energía {L} de tu área de Energía a 1 de tus Pokémon en Banca.",
 			it: "Prendi un'Energia {L} dalla tua Zona Energia e assegnala a uno dei tuoi Pokémon in panchina.",
-			de: "Lege 1 {L}-Energie aus deinem Energiebereich an 1 Pokémon auf deiner Bank an.",
+			de: "Lege 1 {L}-Energie aus deinem Energiebereich an 1 {L}-Pokémon auf deiner Bank an.",
 			ko: "자신의 에너지존에서 {L}에너지를 1개 내보내 벤치 포켓몬에게 붙인다.",
 			'pt-br': "Pegue uma Energia {L} da sua Zona de Energia e ligue-a 1 dos seus Pokémon no Banco."
 		}

--- a/data/Pokémon TCG Pocket/Shining Revelry/104.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/104.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "Les Riolu communiquent entre eux à l'aide de\nleur aura. Ils sont capables de courir toute la nuit.",
 		es: "Se comunica con los suyos emitiendo ondas.\nPuede pasarse toda una noche corriendo.",
 		it: "Comunica con i suoi simili tramite l'aura.\nPuò correre un'intera notte senza stancarsi.",
-		de: "Dieses Pokémon nutzt seine Aura, um mit seinen\nArtgenossen zu kommunizieren. Es kann eine\nganze Nacht lang laufen.",
+		de: "Dieses Pokémon nutzt seine Aura, um mit seinen Artgenossen zu kommunizieren. Es kann eine ganze Nacht lang laufen.",
 		'pt-br': "Eles comunicam-se uns com os outros usando suas auras.\nSão capazes de correr a noite inteira.",
 		ko: "파동을 내서\n동료끼리 의사소통을 한다.\n밤새도록 계속 달릴 수 있다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/105.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/105.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		fr: "On raconte qu'il est né lorsqu'un mystérieux Pokémon Poison\na pris possession d'un moteur laissé à l'abandon dans une casse.",
 		es: "Se dice que surgió cuando un misterioso Pokémon venenoso\ntomó posesión de un motor abandonado en un desguace.",
 		it: "Pare sia nato quando un misterioso Pokémon\ndi tipo Veleno prese possesso di un motore\nabbandonato in un deposito di rottami.",
-		de: "Es soll entstanden sein, als ein unbekanntes\nGift-Pokémon von einem Motor Besitz ergriff,\nder in einer Schrottfabrik zurückgelassen wurde.",
+		de: "Es soll entstanden sein, als ein unbekanntes Gift-Pokémon von einem Motor Besitz ergriff, der in einer Schrottfabrik zurückgelassen wurde.",
 		'pt-br': "Acredita-se que este Pokémon nasceu quando um\nPokémon venenoso desconhecido possuiu um motor\nabandonado em uma fábrica que processa ferro-velho.",
 		ko: "고철 처리장에 방치된 엔진에\n정체불명의 독포켓몬이 들어가\n탄생한 것으로 전해지고 있다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/106.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/106.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Varoom",
-		fr: "Vrombi"
+		fr: "Vrombi",
+		de: "Knattox"
 	},
 
 	description: {
@@ -31,7 +32,7 @@ const card: Card = {
 		fr: "Il produit de l'énergie en faisant exploser dans\nses huit cylindres un mélange gazeux qui\ncontient une substance toxique et des minéraux.",
 		es: "Posee ocho cilindros, con los que genera energía\nhaciendo estallar el gas que produce al mezclar\nlos minerales de las rocas con su veneno.",
 		it: "Produce energia facendo esplodere\nnei suoi otto cilindri un gas che forma\nmescolando tossine e minerali delle rocce.",
-		de: "Mit seinen nunmehr acht Zylindern lässt es ein\nGasgemisch aus Gift und Gesteinsmineralien\nexplodieren, um daraus Energie zu gewinnen.",
+		de: "Mit seinen nunmehr acht Zylindern lässt es ein Gasgemisch aus Gift und Gesteinsmineralien explodieren, um daraus Energie zu gewinnen.",
 		'pt-br': "Cria um gás a partir de veneno e minerais de pedras.\nEntão, detona o gás em seus cilindros,\nque agora são oito, para gerar energia.",
 		ko: "독소와 바위 성분이 섞인 가스를\n8개로 늘어난 실린더에서 폭발시켜\n에너지를 만들어 낸다."
 	},

--- a/data/Pokémon TCG Pocket/Shining Revelry/107.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/107.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Kakuna",
-		fr: "Coconfort"
+		fr: "Coconfort",
+		de: "Kokuna"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Shining Revelry/108.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/108.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Charmeleon",
-		fr: "Reptincel"
+		fr: "Reptincel",
+		de: "Glutexo"
 	},
 
 	stage: "Stage2",

--- a/data/Pokémon TCG Pocket/Shining Revelry/109.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/109.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Wiglett",
-		fr: "Taupikeau"
+		fr: "Taupikeau",
+		de: "Schligda"
 	},
 
 	stage: "Stage1",

--- a/data/Pokémon TCG Pocket/Shining Revelry/110.ts
+++ b/data/Pokémon TCG Pocket/Shining Revelry/110.ts
@@ -23,7 +23,8 @@ const card: Card = {
 
 	evolveFrom: {
 		en: "Riolu",
-		fr: "Riolu"
+		fr: "Riolu",
+		de: "Riolu"
 	},
 
 	stage: "Stage1",


### PR DESCRIPTION
## Add missing German translations for A2b

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
