### PR TITLE
Add missing German translations for dp6

### DIFF
--- a/data/Diamond & Pearl/Legends Awakened/1.ts
+++ b/data/Diamond & Pearl/Legends Awakened/1.ts
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "An alien virus that fell to earth on a meteor underwent a DNA mutation to become this Pokémon.",
-		fr: "Il vient d'un virus extraterrestre arrivé avec une météorite et ayant subi une mutation génétique."
+		fr: "Il vient d'un virus extraterrestre arrivé avec une météorite et ayant subi une mutation génétique.",
+		de: "Ein außerirdischer Virus kam mit einem Meteor auf die Erde. Seine DNA mutierte. So entstand DEOXYS."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/10.ts
+++ b/data/Diamond & Pearl/Legends Awakened/10.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Metang",
 		fr: "Métang",
+		de: "Metang"
 	},
 
 	stage: "Stage2",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may flip a coin. If heads, switch 1 of your opponent's Benched Pokémon with 1 of the Defending Pokémon. This power can't be used if Metagross is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez lancer une pièce. Si c'est face, échangez 1 des Pokémon de Banc de votre adversaire avec 1 des Pokémon Défenseurs. Ce pouvoir ne peut pas être utilisé si Metalosse est affecté par un État Spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 Münze werfen. Bei \"Kopf\" tausche 1 Verteidigendes Pokémon gegen 1 Pokémon auf der Bank deines Gegners aus. Diese Poké-Power kann nicht benutzt werden, wenn Metagross von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 Münze werfen. Bei „Kopf“ tausche 1 Verteidigendes Pokémon gegen 1 Pokémon auf der Bank deines Gegners aus. Diese Poké-Power kann nicht benutzt werden, wenn Metagross von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -86,7 +87,8 @@ const card: Card = {
 
 	description: {
 		en: "Metang combined to form it. With four brains, it has the intelligence of a supercomputer.",
-		fr: "Il est né de la fusion de plusieurs Métang. Ses quatre cerveaux en font l'égal d'un superordinateur."
+		fr: "Il est né de la fusion de plusieurs Métang. Ses quatre cerveaux en font l'égal d'un superordinateur.",
+		de: "Mehrere METANG bilden dieses PKMN. Mit seinen 4 Gehirnen besitzt es die Intelligenz eines Supercomputers."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/100.ts
+++ b/data/Diamond & Pearl/Legends Awakened/100.ts
@@ -72,7 +72,8 @@ const card: Card = {
 
 	description: {
 		en: "Its legs can stretch double. First-time foes are startled by its extensible reach.",
-		fr: "Ses pattes élastiques s'allongent, ce qui ne manque jamais de surprendre au premier combat."
+		fr: "Ses pattes élastiques s'allongent, ce qui ne manque jamais de surprendre au premier combat.",
+		de: "Seine Beine können die doppelte Länge annehmen. Gegner, die das nicht wissen, erschrecken."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/101.ts
+++ b/data/Diamond & Pearl/Legends Awakened/101.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20x",
 
@@ -76,7 +76,8 @@ const card: Card = {
 
 	description: {
 		en: "It fights while spinning like a top. The centrifugal force boosts its destructive power by ten.",
-		fr: "Il combat en tournoyant comme une toupie. La force centrifuge décuple sa puissance destructrice."
+		fr: "Il combat en tournoyant comme une toupie. La force centrifuge décuple sa puissance destructrice.",
+		de: "Es kämpft, während es sich wie ein Kreisel dreht. Die Zentrifugalkraft erhöht die Kampfkraft um 10."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/102.ts
+++ b/data/Diamond & Pearl/Legends Awakened/102.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "If the Defending Pokémon tries to attack during your opponent's next turn, your opponent flips a coin. If tails, that attack does nothing.",
 				fr: "Si le Pokémon Défenseur essaye d'attaquer lors du prochain tour de votre adversaire, celui-ci lance une pièce. Si c'est pile, cette attaque est sans effet.",
-				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen."
+				de: "Falls das Verteidigende Pokémon während des nächsten Zuges deines Gegners angreift, wirft dein Gegner 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen."
 			},
 
 		},
@@ -72,7 +72,8 @@ const card: Card = {
 
 	description: {
 		en: "It makes its nest in the shade of corals. If it senses danger, it spits murky ink and flees.",
-		fr: "Il niche à l'ombre du corail. Quand il se sent menacé, il disparaît dans un nuage d'encre opaque."
+		fr: "Il niche à l'ombre du corail. Quand il se sent menacé, il disparaît dans un nuage d'encre opaque.",
+		de: "Im Schatten von Korallen legt es sein Nest an. Bei Gefahr versprüht es Tinte und flieht."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/103.ts
+++ b/data/Diamond & Pearl/Legends Awakened/103.ts
@@ -75,7 +75,8 @@ const card: Card = {
 
 	description: {
 		en: "It conveys its feelings using different cries. It works in a pack to cleverly take down prey.",
-		fr: "Il exprime ses émotions en modulant son cri. Ce Pokémon rusé chasse en meute pour abattre ses proies."
+		fr: "Il exprime ses émotions en modulant son cri. Ce Pokémon rusé chasse en meute pour abattre ses proies.",
+		de: "Durch unterschiedliche Schreie drückt es seine Gefühle aus. Diese PKMN jagen im Verbund nach Beute."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/104.ts
+++ b/data/Diamond & Pearl/Legends Awakened/104.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt verwirrt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 
 		},
@@ -80,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "It is so timid, it can't move if it isn't with a swarm of others. It conveys its feelings with scent.",
-		fr: "Il est si timide qu'il ne se déplace qu'au milieu d'un essaim. Il exprime ses émotions par l'odeur."
+		fr: "Il est si timide qu'il ne se déplace qu'au milieu d'un essaim. Il exprime ses émotions par l'odeur.",
+		de: "Es ist so scheu, dass es sich nur bewegt, wenn es sich in einem Schwarm befindet."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/105.ts
+++ b/data/Diamond & Pearl/Legends Awakened/105.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Root Fossil",
 		fr: "Wurzelfossil",
+		de: "Wurzelfossil"
 	},
 
 	stage: "Stage1",
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "It lived on the seafloor 100 million years ago and was reanimated scientifically.",
-		fr: "Il vivait au fond de la mer il y a 100 millions d'années. La science a permis de le ressusciter."
+		fr: "Il vivait au fond de la mer il y a 100 millions d'années. La science a permis de le ressusciter.",
+		de: "Vor 100 Millionen Jahren lebte dieses PKMN auf dem Meeresgrund. Die Wissenschaft belebte es neu."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/106.ts
+++ b/data/Diamond & Pearl/Legends Awakened/106.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, draw a card.",
 				fr: "Lancez une pièce. Si c'est face, piochez une carte.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ziehe 1 Karte."
+				de: "Wirf 1 Münze. Bei „Kopf“ ziehe 1 Karte."
 			},
 			damage: 10,
 
@@ -56,7 +56,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 3 coins. This attack does 10 damage times the number of heads.",
 				fr: "Lancez 3 pièces. Cette attaque inflige 10 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 3 Münzen.Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 3 Münzen. Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10x",
 
@@ -74,7 +74,8 @@ const card: Card = {
 
 	description: {
 		en: "It is nocturnal in nature. If it spots something shiny, its eyes glitter brightly.",
-		fr: "Son regard s'anime à la vue d'un objet brillant. C'est un Pokémon nocturne."
+		fr: "Son regard s'anime à la vue d'un objet brillant. C'est un Pokémon nocturne.",
+		de: "Ein nachtaktives Pokémon. Sieht es etwas Schimmerndes, fangen seine Augen an zu glänzen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/107.ts
+++ b/data/Diamond & Pearl/Legends Awakened/107.ts
@@ -77,7 +77,8 @@ const card: Card = {
 
 	description: {
 		en: "It loves to sneak up on people late at night, then startle them with its shrieklike cry.",
-		fr: "Il adore se faufiler derrière les gens la nuit pour les effrayer avec son cri strident."
+		fr: "Il adore se faufiler derrière les gens la nuit pour les effrayer avec son cri strident.",
+		de: "Es liebt es, sich nachts an andere heranzuschleichen und sie mit einem schrillen Schrei zu erschrecken."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/108.ts
+++ b/data/Diamond & Pearl/Legends Awakened/108.ts
@@ -68,7 +68,8 @@ const card: Card = {
 
 	description: {
 		en: "It grows underground, sensing its surroundings using antennae instead of its virtually blind eyes.",
-		fr: "Il grandit sous terre et se repère grâce à ses antennes car ses yeux sont quasiment aveugles."
+		fr: "Il grandit sous terre et se repère grâce à ses antennes car ses yeux sont quasiment aveugles.",
+		de: "Es wächst unterirdisch heran und nimmt seine Umgebung mit Antennen wahr, da es nahezu blind ist."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/109.ts
+++ b/data/Diamond & Pearl/Legends Awakened/109.ts
@@ -70,7 +70,8 @@ const card: Card = {
 
 	description: {
 		en: "Its nose is a magnet. As a result, this Pokémon always keeps its face pointing north.",
-		fr: "Son nez est un aimant, c'est pourquoi ce Pokémon fait toujours face au nord."
+		fr: "Son nez est un aimant, c'est pourquoi ce Pokémon fait toujours face au nord.",
+		de: "Seine Nase ist ein Magnet. Daher sieht das PKMN immer nach Norden."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/11.ts
+++ b/data/Diamond & Pearl/Legends Awakened/11.ts
@@ -75,7 +75,8 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon created by recombining Mew's genes. It's said to have the most savage heart among Pokémon.",
-		fr: "Un Pokémon conçu en réorganisant les gènes de Mew. On raconte qu'il s'agit du Pokémon le plus féroce."
+		fr: "Un Pokémon conçu en réorganisant les gènes de Mew. On raconte qu'il s'agit du Pokémon le plus féroce.",
+		de: "Die Gene von MEW wurden neu angeordnet, wodurch dieses PKMN entstand. Es hat ein wildes Herz."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/110.ts
+++ b/data/Diamond & Pearl/Legends Awakened/110.ts
@@ -53,7 +53,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Burned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Brûlé.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt verbrannt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verbrannt."
 			},
 			damage: 30,
 
@@ -71,7 +71,8 @@ const card: Card = {
 
 	description: {
 		en: "Its humped back stores intensely hot magma. In rain, the magma cools, slowing its movement.",
-		fr: "Son dos bosse renferme une lave bouillonnante. Elle refroidit par temps de pluie, ce qui le ralentit."
+		fr: "Son dos bosse renferme une lave bouillonnante. Elle refroidit par temps de pluie, ce qui le ralentit.",
+		de: "In seinem Rücken speichert es sehr heißes Magma. Regnet es, kühlt das Magma ab und es wird langsamer."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/111.ts
+++ b/data/Diamond & Pearl/Legends Awakened/111.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 
 		},
@@ -72,7 +72,8 @@ const card: Card = {
 
 	description: {
 		en: "It often plants its root feet in the ground during the day and sows seeds as it walks about at night.",
-		fr: "En journée, il plante ses piedsracines dans le sol. La nuit, il se promène en semant des graines."
+		fr: "En journée, il plante ses piedsracines dans le sol. La nuit, il se promène en semant des graines.",
+		de: "Tagsüber verankert es sich mit seinen Wurzelfüßen im Boden. Nachts wandert es und verteilt Samen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/112.ts
+++ b/data/Diamond & Pearl/Legends Awakened/112.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Empoisonné.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt vergiftet."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet."
 			},
 
 		},
@@ -69,7 +69,8 @@ const card: Card = {
 
 	description: {
 		en: "It often plants its root feet in the ground during the day and sows seeds as it walks about at night.",
-		fr: "En journée, il plante ses piedsracines dans le sol. La nuit, il se promène en semant des graines."
+		fr: "En journée, il plante ses piedsracines dans le sol. La nuit, il se promène en semant des graines.",
+		de: "Tagsüber verankert es sich mit seinen Wurzelfüßen im Boden. Nachts wandert es und verteilt Samen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/113.ts
+++ b/data/Diamond & Pearl/Legends Awakened/113.ts
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "It looks just like a pinecone. Its shell protects it from bird Pokémon that peck it by mistake.",
+		de: "Es sieht aus wie ein Tannenzapfen. Seine Schale schützt es vor Vogel-Pokémon, die an ihm picken wollen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/114.ts
+++ b/data/Diamond & Pearl/Legends Awakened/114.ts
@@ -51,7 +51,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused. If tails, the Defending Pokémon is now Asleep.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus. Si c'est pile, le Pokémon Défenseur est maintenant Endormi.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt verwirrt. Bei \"Zahl\" schläft das Verteidigende Pokémon jetzt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt. Bei „Zahl“ schläft das Verteidigende Pokémon jetzt."
 			},
 
 		},
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "Its skin is so thin, its internal organs are visible. It has trouble walking on its newly grown feet.",
+		de: "Seine Haut ist so dünn, dass man die inneren Organe sehen kann. Es hat Schwierigkeiten beim Laufen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/115.ts
+++ b/data/Diamond & Pearl/Legends Awakened/115.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Poliwag",
 		fr: "Quapsel",
+		de: "Quapsel"
 	},
 
 	stage: "Stage1",
@@ -59,7 +60,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 40,
 
@@ -77,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "The spiral pattern on its belly subtly undulates. Staring at it gradually causes drowsiness.",
+		de: "Das Spiralmuster auf seinem Bauch dreht sich langsam. Starrt man darauf, wird einem schwindelig."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/116.ts
+++ b/data/Diamond & Pearl/Legends Awakened/116.ts
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon with a persistent nature, it chases its chosen prey until the prey becomes exhausted.",
+		de: "Ein beharrliches PKMN, das seine Beute jagt, bis diese erschöpft ist."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/117.ts
+++ b/data/Diamond & Pearl/Legends Awakened/117.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "The aura that emanates from its body intensifies to alert others if it is afraid or sad.",
+		de: "Die Aura, die dieses PKMN umgibt, verstärkt sich, wenn es zeigen will, dass es ängstlich oder traurig ist."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/118.ts
+++ b/data/Diamond & Pearl/Legends Awakened/118.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Search your deck for a Lightning Energy card and attach it to Shinx. Shuffle your deck afterward.",
 				fr: "Choisissez dans votre deck une carte Énergie Lightning et attachez-la à Lixy. Ensuite, mélangez votre deck.",
-				de: "Durchsuche dein Deck nach 1 -Energiekarte und lege sie an Sheinux an. Mische dein Deck danach."
+				de: "Durchsuche dein Deck nach 1 {L}-Energiekarte und lege sie an Sheinux an. Mische dein Deck danach."
 			},
 
 		},
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20x",
 
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "All of its fur dazzles if danger is sensed. It flees while the foe is momentarily blinded.",
+		de: "In Gefahr blendet es seinen Gegner mit seinem Fell und flieht, während der Gegner einen Moment blind ist."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/119.ts
+++ b/data/Diamond & Pearl/Legends Awakened/119.ts
@@ -68,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "It can't stop itself from chasing moving things, and it runs in a circle, chasing its own tail.",
+		de: "Es muss Dinge, die sich bewegen, einfach jagen. Es rennt oft im Kreis und jagt seinen eigenen Schweif."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/12.ts
+++ b/data/Diamond & Pearl/Legends Awakened/12.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Poliwhirl",
 		fr: "Quaputzi",
+		de: "Quaputzi"
 	},
 
 	stage: "Stage2",
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 40 damage plus 40 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 40 dégâts plus 40 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 40 Schadenspunkte plus 40 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 40 Schadenspunkte plus 40 weitere Schadenspunkte zu."
 			},
 			damage: "40+",
 
@@ -78,7 +79,8 @@ const card: Card = {
 
 	description: {
 		en: "It gathers groups of others as their leader. Its cries make Poliwag obey.",
-		fr: "Il rassemble ses pairs pour les commander. Il utilise son cri pour diriger Ptitard."
+		fr: "Il rassemble ses pairs pour les commander. Il utilise son cri pour diriger Ptitard.",
+		de: "Es versammelt andere PKMN um sich herum und führt sie an. QUAPSEL gehorchen seinem Ruf."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/120.ts
+++ b/data/Diamond & Pearl/Legends Awakened/120.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "It feeds on eggs stolen from nests. Its sharply hooked claws rip vulnerable spots on prey.",
+		de: "Es ernährt sich von Eiern, die es aus Nestern stiehlt. Beute greift es mit seinen scharfen Krallen an."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/121.ts
+++ b/data/Diamond & Pearl/Legends Awakened/121.ts
@@ -73,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "It bounces constantly, using its tail like a spring. The shock of bouncing keeps its heart beating.",
+		de: "Es hüpft beständig umher, wobei es seinen Schweif als Feder verwendet. Nur so bleibt sein Herz aktiv."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/122.ts
+++ b/data/Diamond & Pearl/Legends Awakened/122.ts
@@ -69,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "Its body is virtually composed of water. It shoots strange beams from its crystal-like eyes.",
+		de: "Wird sein Körper verletzt, kann es sich regenerieren, sofern der rote Kern intakt ist."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/123.ts
+++ b/data/Diamond & Pearl/Legends Awakened/123.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, put any 1 card from your discard pile into your hand.",
 				fr: "Lancez une pièce. Si c'est face, placez n'importe quelle carte de votre pile de défausse dans votre main.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" wähle 1 Karte aus deinem Ablagestapel und nimm sie auf deine Hand."
+				de: "Wirf 1 Münze. Bei „Kopf“ wähle 1 Karte aus deinem Ablagestapel und nimm sie auf deine Hand."
 			},
 
 		},
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "It loves eating mushrooms that grow under dead grass. It also finds hot springs while foraging.",
+		de: "Es liebt Pilze, die unter totem Gras wachsen. Auf der Suche nach Nahrung findet es heiße Quellen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/124.ts
+++ b/data/Diamond & Pearl/Legends Awakened/124.ts
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "It has a gutsy spirit that makes it bravely take on tough foes. It flies in search of warm climates.",
+		de: "Es ist sehr mutig und stellt sich auch starken Gegnern. Es sucht ständig nach warmen Regionen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/125.ts
+++ b/data/Diamond & Pearl/Legends Awakened/125.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Tentacool during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, prévenez tous les effets d'une attaque, dégâts inclus, infligés à Tentacool lors du prochain tour de votre adversaire.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" verhindere während des nächsten Zuges deines Gegners alle Effekte eines Angriffs, einschließlich Schaden, die Tentacha zugefügt würden."
+				de: "Wirf 1 Münze. Bei „Kopf“ verhindere während des nächsten Zuges deines Gegners alle Effekte eines Angriffs, einschließlich Schaden, die Tentacha zugefügt würden."
 			},
 
 		},
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy card attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, défaussez une carte Énergie attachée au Pokémon Défenseur.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" lege 1 Energiekarte, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
+				de: "Wirf 1 Münze. Bei „Kopf“ lege 1 Energiekarte, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
 			},
 
 		},
@@ -71,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "Its body is virtually composed of water. It shoots strange beams from its crystal-like eyes.",
+		de: "Sein Körper besteht aus Wasser. Aus seinen kristallartigen Augen verschießt es eigenartige Strahlen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/126.ts
+++ b/data/Diamond & Pearl/Legends Awakened/126.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "It is famous for its eagerness to fight and always nurses injuries from challenging larger foes.",
+		de: "Es ist bekannt für seine Kampfbegierde. Es erholt sich ständig von Verletzungen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/127.ts
+++ b/data/Diamond & Pearl/Legends Awakened/127.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Bellsprout",
 		fr: "Knofensa",
+		de: "Knofensa"
 	},
 
 	stage: "Stage1",
@@ -75,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon that appears to be a plant. It captures unwary prey by dousing them with a toxic powder.",
+		de: "Ein Pokémon, das wie eine Pflanze aussieht. Es fängt Beute, indem es giftigen Puder darüber verteilt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/128.ts
+++ b/data/Diamond & Pearl/Legends Awakened/128.ts
@@ -56,7 +56,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Yanma during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, prévenez tous les effets d'une attaque, dégâts inclus, infligés à Yanma lors du prochain tour de votre adversaire.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" verhindere während des nächsten Zuges deines Gegners alle Effekte eines Angriffs, einschließlich Schaden, die Yanma zugefügt würden."
+				de: "Wirf 1 Münze. Bei „Kopf“ verhindere während des nächsten Zuges deines Gegners alle Effekte eines Angriffs, einschließlich Schaden, die Yanma zugefügt würden."
 			},
 			damage: 20,
 
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "Its eyes can see 360 degrees without moving its head. It won't miss prey—even those behind it.",
+		de: "Mit seinen Augen hat es einen Blickwinkel von 360 Grad. Es sieht sogar Beute, die sich hinter ihm befindet."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/129.ts
+++ b/data/Diamond & Pearl/Legends Awakened/129.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Attach Bubble Coat to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card. As long as Bubble Coat is attached to a Pokémon, that Pokémon has no Weakness. If that Pokémon is damaged by an opponent's attack, discard this card at the end of the turn.",
 		fr: "Attachez Manteau bulle à 1 de vos Pokémon qui ne possède pas déjà d'Outil Pokémon. Si ce Pokémon est mis K.O, défaussez-la.",
-		de: "Solange Blubberschutz an ein Pokémon angelegt ist, hat dieses Pokémon keine Schwäche. Wenn dieses Pokémon durch einen gegnerischen Angriff Schaden erhält, lege Blubberschutz am Ende des Zuges auf deinen Ablagestapel."
+		de: "Lege Blubberschutz an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn dieses Pokémon kampfunfähig wird, lege Blubberschutz auf den Ablagestapel. Solange Blubberschutz an ein Pokémon angelegt ist, hat dieses Pokémon keine Schwäche. Wenn dieses Pokémon durch einen gegnerischen Angriff Schaden erhält, lege Blubberschutz am Ende des Zuges auf den Ablagestapel."
 	},
 
 	trainerType: "Tool",

--- a/data/Diamond & Pearl/Legends Awakened/13.ts
+++ b/data/Diamond & Pearl/Legends Awakened/13.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Nosepass",
 		fr: "Nasgnet",
+		de: "Nasgnet"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Any damage done to Probopass by your opponent's attacks is reduced by 10 for each Metal Energy attached to Probopass (after applying Weakness and Resistance). You can't reduce more than 20 damage in this way.",
 				fr: "Tous dégâts infligés à Tarinorme par des attaques de votre adversaire sont réduits de 10 pour chaque Énergie Metal attachée à Tarinorme (après application de la Faiblesse et de la Résistance). Vous ne pouvez réduire de plus de 20 dégâts de cette façon.",
-				de: "Schaden, der Voluminas durch gegnerische Angriffe zugefügt wird, wird für jede an Voluminas angelegte -Energie um 10 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden). Der Schaden kann auf diese Weise nicht um mehr als 20 Schadenspunkte reduziert werden."
+				de: "Schaden, der Voluminas durch gegnerische Angriffe zugefügt wird, wird für jede an Voluminas angelegte {M}-Energie um 10 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden). Der Schaden kann auf diese Weise nicht um mehr als 20 Schadenspunkte reduziert werden."
 			},
 		},
 	],
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Choose a number of your opponent's Benched Pokémon up to the amount of Metal Energy attached to Probopass. This attack does 20 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Vous pouvez choisir autant de Pokémon de Banc de votre adversaire qu'il y a d'Énergie Metal attachée à Tarinorme. Cette attaque inflige 20 dégâts à chacun de ces Pokémon. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Wähle eine Anzahl gegnerischer Pokémon, die höchstens der Anzahl der an Voluminas angelegten -Energien entspricht. Dieser Angriff fügt jedem gewählten Pokémon 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Wähle eine Anzahl gegnerischer Pokémon, die höchstens der Anzahl der an Voluminas angelegten {M}-Energien entspricht. Dieser Angriff fügt jedem gewählten Pokémon 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 60,
 
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "It exudes strong magnetism from all over. It controls three small units call Mini-Noses.",
-		fr: "Son corps libère une puissante force magnétique. Il dirige trois petites unités appelées Mini-nez."
+		fr: "Son corps libère une puissante force magnétique. Il dirige trois petites unités appelées Mini-nez.",
+		de: "Es gibt starken Magnetismus ab. Es steuert drei kleine Einheiten, die sich Mininasen nennen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/130.ts
+++ b/data/Diamond & Pearl/Legends Awakened/130.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Draw 2 cards. As long as Buck's Training is next to your Active Pokémon, each of your Active Pokémon's attacks does 10 more damage to the Active Pokémon (before applying Weakness and Resistance).",
 		fr: "Piochez 2 cartes. Tant que l'entrainement de Cornil se trouve à côté de votre Pokémon Actif, les attaques de chacun de vos Pokémon Actifs infligent 10 dégâts supplémentaires au Pokémon Actif (avant application de la Faiblesse et de la Résistance).",
-		de: "Ziehe 2 Karten. Solange Avenaros Training neben deinem Aktiven Pokémon den Aktiven Pokémon liegt, fügen alle Angriffe deiner Aktiven Pokémon 10 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden).",
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Ziehe 2 Karten. Solange Avenaros Training neben deinem Aktiven Pokémon liegt, fügen alle Angriffe deiner Aktiven Pokémon den Aktiven Pokémon 10 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden).",
 	},
 
 	trainerType: "Supporter",

--- a/data/Diamond & Pearl/Legends Awakened/131.ts
+++ b/data/Diamond & Pearl/Legends Awakened/131.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "You can play only one Supporter card each turn. When you play this card, put it next to your Active Pokémon. When your turn ends, discard this card. Shuffle your hand into your deck. Then, draw 4 cards. If any of your Pokémon were Knocked Out during your opponent's last turn, draw 4 more cards.",
 		fr: "Mélangez votre main à votre deck. Ensuite, piochez 4 cartes. Si n'importe lequel de vos Pokémon a été mis K.O lors du tour précédent de votre adversaire, piochez 4 cartes supplémentaires.",
-		de: "Mische deine Handkarten in dein Deck. Ziehe danach 4 Karten. Wenn mindestens 1 deiner Pokémon im letzten Zug deines Gegners kampfunfähig wurde, ziehe 4 weitere Karten.",
+		de: "Du kannst in jedem Zug nur eine Unterstützerkarte spielen. Wenn du diese Karte ausspielst, lege sie neben dein Aktives Pokémon. Lege diese Karte am Ende deines Zuges auf deinen Ablagestapel. Mische deine Handkarten in dein Deck. Ziehe danach 4 Karten. Wenn mindestens 1 deiner Pokémon im letzten Zug deines Gegners kampfunfähig wurde, ziehe 4 weitere Karten.",
 	},
 
 	trainerType: "Supporter",

--- a/data/Diamond & Pearl/Legends Awakened/132.ts
+++ b/data/Diamond & Pearl/Legends Awakened/132.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "Flip a coin. If heads, search your discard pile for a basic Energy card and attach it to 1 of your Pokémon.",
 		fr: "Lancez une pièce. Si c'est face, choisissez dans votre pile de défausse une carte Énergie de base et attachez-la à 1 de vos Pokémon.",
-		de: "Wirf 1 Münze. Bei \"Kopf\" durchsuche deinen Ablagestapel nach 1 Basis-Energiekarte und lege sie an 1 deiner Pokémon an."
+		de: "Wirf 1 Münze. Bei „Kopf“ durchsuche deinen Ablagestapel nach 1 Basis-Energiekarte und lege sie an 1 deiner Pokémon an."
 	},
 
 	trainerType: "Item",

--- a/data/Diamond & Pearl/Legends Awakened/134.ts
+++ b/data/Diamond & Pearl/Legends Awakened/134.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card. Each Pokémon that isn't an Evolved Pokémon in play (both yours and your opponent's) gets +20 HP.",
 		fr: "Chaque Pokémon en jeu qui n'est pas un Pokémon Évolué (parmi les vôtres et ceux de votre adversaire) obtient + 20 PV.",
-		de: "Jedes Pokémon im Spiel (deine und die deines Gegners), das kein entwickeltes Pokémon ist, erhält +20 KP.",
+		de: "Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadion-Karte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen. Jedes Pokémon im Spiel (deine und die deines Gegners), das kein entwickeltes Pokémon ist, erhält +20 KP.",
 	},
 
 	trainerType: "Stadium",

--- a/data/Diamond & Pearl/Legends Awakened/135.ts
+++ b/data/Diamond & Pearl/Legends Awakened/135.ts
@@ -16,7 +16,7 @@ const card: Card = {
 	effect: {
 		en: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card. Once during each player's turn, that player may choose a Fire or Fighting Energy attached to 1 of his or her Pokémon and move that Energy to 1 of his or her Pokémon.",
 		fr: "Une seule fois lors du tour de chaque joueur, ce joueur peut choisir une Énergie Feu ou Combat attachée à 1 de ses Pokémon et déplacer cette Énergie sur 1 de ses Pokémon Feu ou Combat.",
-		de: "Einmal während seines Zuges kann jeder Spieler 1 - oder -Energie, die an 1 seiner Pokémon angelegt ist, entfernen und an 1 seiner - oder -Pokémon anlegen.",
+		de: "Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadion-Karte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen. Einmal während seines Zuges kann jeder Spieler 1 {R}- oder {F}-Energie, die an 1 seiner Pokémon angelegt ist, entfernen und an 1 seiner {R}- oder {F}-Pokémon anlegen.",
 	},
 
 	trainerType: "Stadium",

--- a/data/Diamond & Pearl/Legends Awakened/138.ts
+++ b/data/Diamond & Pearl/Legends Awakened/138.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "Play Claw Fossil as if it were a Colorless Basic Pokémon. (Claw Fossil counts as a Trainer card as well, but if Claw Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Claw Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Claw Fossil from play. (This doesn't count as a Knocked Out Pokémon.)",
 		fr: "Jouez Fossile griffe comme si c'était un Pokémon de base Colorless. (Fossile griffe compte aussi comme une carte Dresseur mais si Fossile griffe est mise K.O, elle compte comme un Pokémon K.O.) Fossile griffe ne peut pas être affectée par des États Spéciaux et ne peut pas battre en retraite. N'importe quand lors de votre tour, avant votre attaque, vous pouvez défausser Fossile griffe. (Cela ne compte pas comme un Pokémon K.O.)",
-		de: "Spiele Klauenfossil wie ein -Basis-Pokémon. (Klauenfossil zählt gleichzeitig als Trainerkarte, aber wenn Klauenfossil kampfunfähig wird, zählt es als kampfunfähiges Pokémon.) Klauenfossil kann nicht von Speziellen Zuständen betroffen werden und sich nicht zurückziehen. In deinem Zug (vor deinem Angriff) kannst du Klauenfossil auf deinen Ablagestapel legen. (Dies zählt nicht als kampfunfähig gemachtes Pokémon.)"
+		de: "Spiele Klauenfossil wie ein {C}-Basis-Pokémon. (Klauenfossil zählt gleichzeitig als Trainerkarte, aber wenn Klauenfossil kampfunfähig wird, zählt es als kampfunfähiges Pokémon.) Klauenfossil kann nicht von Speziellen Zuständen betroffen werden und sich nicht zurückziehen. In deinem Zug (vor deinem Angriff) kannst du Klauenfossil auf deinen Ablagestapel legen. (Dies zählt nicht als kampfunfähig gemachtes Pokémon.)"
 	},
 
 	trainerType: "Item",

--- a/data/Diamond & Pearl/Legends Awakened/139.ts
+++ b/data/Diamond & Pearl/Legends Awakened/139.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	effect: {
 		en: "Play Root Fossil as if it were a Colorless Basic Pokémon. (Root Fossil counts as a Trainer card as well, but if Root Fossil is Knocked Out, this counts as a Knocked Out Pokémon.) Root Fossil can't be affected by any Special Conditions and can't retreat. At any time during your turn before your attack, you may discard Root Fossil from play. (This doesn't count as a Knocked Out Pokémon.)",
 		fr: "Jouez Fossile racine comme si c'était un Pokémon de base Colorless. (Fossile racine compte aussi comme une carte Dresseur mais si Fossile racine est mise K.O, elle compte comme un Pokémon K.O.) Fossile racine ne peut pas être affectée par des États Spéciaux et ne peut pas battre en retraite. N'importe quand lors de votre tour, avant votre attaque, vous pouvez défausser Fossile racine. (Cela ne compte pas comme un Pokémon K.O.)",
-		de: "Spiele Wurzelfossil wie ein -Basis-Pokémon. (Wurzelfossil zählt gleichzeitig als Trainerkarte, aber wenn Klauenfossil kampfunfähig wird, zählt es als kampfunfähiges Pokémon.) Wurzelfossil kann nicht von Speziellen Zuständen betroffen werden und sich nicht zurückziehen. In deinem Zug (vor deinem Angriff) kannst du Wurzelfossil auf deinen Ablagestapel legen. (Dies zählt nicht als kampfunfähig gemachtes Pokémon.)"
+		de: "Spiele Wurzelfossil wie ein {C}-Basis-Pokémon. (Wurzelfossil zählt gleichzeitig als Trainerkarte, aber wenn Wurzelfossil kampfunfähig wird, zählt es als kampfunfähiges Pokémon.) Wurzelfossil kann nicht von Speziellen Zuständen betroffen werden und sich nicht zurückziehen. In deinem Zug (vor deinem Angriff) kannst du Wurzelfossil auf deinen Ablagestapel legen. (Dies zählt nicht als kampfunfähig gemachtes Pokémon.)"
 	},
 
 	trainerType: "Item",

--- a/data/Diamond & Pearl/Legends Awakened/14.ts
+++ b/data/Diamond & Pearl/Legends Awakened/14.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may flip a coin until you get tails. For each heads, search your discard pile for a basic Fire Energy card or a basic Lightning Energy card and attach it to Rayquaza. This power can't be used if Rayquaza is affected by a Special Condition or if you have another Rayquaza in play.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez lancer une pièce jusqu'à ce que vous obteniez pile. Pour chaque face, cherchez dans votre pile de défausse une carte Énergie de base Fire ou une carte Énergie de base Lightning et attachez-la à Rayquaza. Ce pouvoir ne peut pas être utilisé si Rayquaza est affecté par un État Spécial ou si vous possédez un autre Rayquaza en jeu.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du so lange 1 Münze werfen, bis zum ersten Mal das Ergebnis \"Zahl\" kommt. Durchsuche pro \"Kopf\" deinen Ablagestapel nach einer - oder -Basis-Energiekarte und lege sie an Rayquaza an. Diese Poké-Power kann nicht benutzt werden, wenn Rayquaza von einem Speziellen Zustand betroffen ist oder du mehr als 1 Rayquaza im Spiel hast."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du so lange 1 Münze werfen, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Durchsuche pro „Kopf“ deinen Ablagestapel nach einer {R}- oder {L}-Basis-Energiekarte und lege sie an Rayquaza an. Diese Poké-Power kann nicht benutzt werden, wenn Rayquaza von einem Speziellen Zustand betroffen ist oder du mehr als 1 Rayquaza im Spiel hast."
 			},
 		},
 	],
@@ -82,7 +82,8 @@ const card: Card = {
 
 	description: {
 		en: "It lives in the ozone layer far above the clouds and cannot be seen from the ground.",
-		fr: "Il vit dans la couche d'ozone, au-dessus des nuages. Il est invisible depuis le sol."
+		fr: "Il vit dans la couche d'ozone, au-dessus des nuages. Il est invisible depuis le sol.",
+		de: "Es lebt in der Ozonschicht hoch über den Wolken und kann vom Boden aus nicht gesehen werden."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/140.ts
+++ b/data/Diamond & Pearl/Legends Awakened/140.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Each of your Psychic Pokémon has no Weakness.",
 				fr: "Chacun de vos Pokémon Psychic ne possède pas de Faiblesse.",
-				de: "Jedes deiner -Pokémon hat keine Schwäche mehr."
+				de: "Jedes deiner {P}-Pokémon hat keine Schwäche mehr."
 			},
 		},
 	],

--- a/data/Diamond & Pearl/Legends Awakened/142.ts
+++ b/data/Diamond & Pearl/Legends Awakened/142.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "As often as you like during your turn (before your attack), you may move a Lightning or Metal Energy attached to 1 of your Pokémon to another of your Pokémon. This power can't be used if Magnezone is affected by a Special Condition.",
 				fr: "Autant de fois que vous le voulez lors de votre tour (avant votre attaque), vous pouvez déplacer une Énergie Lightning ou Metal attachée à 1 de vos Pokémon sur un autre de vos Pokémon. Ce pouvoir ne peut pas être utilisé si Magnézone est affecté par un État Spécial.",
-				de: "Beliebig oft während deines Zuges (vor deinem Angriff) kannst du 1 - oder -Energie, die an 1 deiner Pokémon angelegt ist, an ein anderes deiner Pokémon anlegen. Diese Poké-Power kann nicht benutzt werden, wenn Magnezone von einem Speziellen Zustand betroffen ist."
+				de: "Beliebig oft während deines Zuges (vor deinem Angriff) kannst du 1 {L}- oder {M}-Energie, die an 1 deiner Pokémon angelegt ist, an ein anderes deiner Pokémon anlegen. Diese Poké-Power kann nicht benutzt werden, wenn Magnezone von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Discard a Lightning Energy and a Metal Energy attached to Magnezone. The Defending Pokémon is now Paralyzed.",
 				fr: "Défaussez une Énergie Lightning et une Énergie Metal attachée à Magnézone. Le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Lege 1 -Energie und 1 -Energie, die an Magnezone angelegt sind, auf deinen Ablagestapel. Das Verteidigende Pokémon ist jetzt gelähmt."
+				de: "Lege 1 {L}-Energie und 1 {M}-Energie, die an Magnezone angelegt sind, auf deinen Ablagestapel. Das Verteidigende Pokémon ist jetzt gelähmt."
 			},
 			damage: 80,
 

--- a/data/Diamond & Pearl/Legends Awakened/145.ts
+++ b/data/Diamond & Pearl/Legends Awakened/145.ts
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Search your discard pile for all Fighting Energy cards, show them to your opponent, and shuffle them into your deck.",
 				fr: "Cherchez dans votre pile de défausse toutes les cartes Énergie Fighting, montrez-les à votre adversaire et mélangez-les à votre deck.",
-				de: "Durchsuche deinen Ablagestapel nach allen -Energiekarten, zeige sie deinem Gegner und mische sie in dein Deck."
+				de: "Durchsuche deinen Ablagestapel nach allen {F}-Energiekarten, zeige sie deinem Gegner und mische sie in dein Deck."
 			},
 			damage: 60,
 

--- a/data/Diamond & Pearl/Legends Awakened/15.ts
+++ b/data/Diamond & Pearl/Legends Awakened/15.ts
@@ -75,7 +75,8 @@ const card: Card = {
 
 	description: {
 		en: "There is an enduring legend that states this Pokémon towed continents with ropes.",
-		fr: "Une légende tenace veut que ce Pokémon ait traîné les continents en les attachant à des cordes."
+		fr: "Une légende tenace veut que ce Pokémon ait traîné les continents en les attachant à des cordes.",
+		de: "Es gibt eine Legende, wonach dieses PKMN die Kontinente mit einem Seil gezogen hat."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/16.ts
+++ b/data/Diamond & Pearl/Legends Awakened/16.ts
@@ -71,7 +71,8 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon that was formed by 108 spirits. It is bound to a fissure in an odd keystone.",
-		fr: "Un Pokémon composé de 108 esprits. Il provient d'une fissure dans une clé de voûte étrange."
+		fr: "Un Pokémon composé de 108 esprits. Il provient d'une fissure dans une clé de voûte étrange.",
+		de: "Ein PKMN, das aus 108 Geistern besteht. Es ist an einen Spalt in einem mysteriösen Stein gebunden."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/17.ts
+++ b/data/Diamond & Pearl/Legends Awakened/17.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Yanma",
 		fr: "Yanma",
+		de: "Yanma"
 	},
 
 	stage: "Stage1",
@@ -84,7 +85,8 @@ const card: Card = {
 
 	description: {
 		en: "By churning its wings, it creates shock waves that inflict critical internal injuries to foes.",
-		fr: "Les ondes de choc qu'il génère en battant des ailes infligent de graves blessures internes."
+		fr: "Les ondes de choc qu'il génère en battant des ailes infligent de graves blessures internes.",
+		de: "Durch die Bewegung seiner Flügel entstehen Schockwellen, die dem Gegner innere Verletzungen zufügen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/18.ts
+++ b/data/Diamond & Pearl/Legends Awakened/18.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Anorith",
 		fr: "Anorith",
+		de: "Anorith"
 	},
 
 	stage: "Stage2",
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "It went ashore after evolving. Its entire body is clad in a sturdy armor.",
-		fr: "Il a gagné la côte après son évolution. Une armure robuste recouvre son corps."
+		fr: "Il a gagné la côte après son évolution. Une armure robuste recouvre son corps.",
+		de: "Nach seiner Entwicklung ging es an Land. Sein Körper ist von einer robusten Rüstung umgeben."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/19.ts
+++ b/data/Diamond & Pearl/Legends Awakened/19.ts
@@ -72,7 +72,8 @@ const card: Card = {
 
 	description: {
 		en: "Known as \"The Being of Willpower.\" It sleeps at the bottom of a lake to keep the world in balance.",
-		fr: "On l'appelle \"être de la volonté\". Il dort au fond d'un lac pour maintenir l'équilibre du monde."
+		fr: "On l'appelle \"être de la volonté\". Il dort au fond d'un lac pour maintenir l'équilibre du monde.",
+		de: "\"Das starke Wesen\". Es schläft auf dem Grund eines Sees und hält so die Welt in Balance."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/2.ts
+++ b/data/Diamond & Pearl/Legends Awakened/2.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Dragonair",
 		fr: "Dragonir",
+		de: "Dragonir"
 	},
 
 	stage: "Stage2",
@@ -45,7 +46,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy card attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, défaussez une carte Énergie attachée au Pokémon Défenseur.",
-				de: "Wirf 1 Münze. Bei 'Kopf' lege 1 Energiekarte, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
+				de: "Wirf 1 Münze. Bei „Kopf“ lege 1 Energiekarte, die am Verteidigenden Pokémon angelegt ist, auf den Ablagestapel deines Gegners."
 			},
 			damage: 40,
 
@@ -65,7 +66,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin for each of your opponent's Pokémon. If that coin flip is heads, this attack does 50 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Lancez une pièce pour chaque Pokémon que possède votre adversaire. Si c'est une face, cette attaque inflige 50 dégâts au Pokémon correspondant. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc).",
-				de: "Wirf für jedes Pokémon deines Gegners jeweils 1 Münze. Dieser Angriff fügt jedem Pokémon, für das auf diese Weise 'Kopf' geworfen wurde, 50 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Wirf für jedes Pokémon deines Gegners jeweils 1 Münze. Dieser Angriff fügt jedem Pokémon, für das auf diese Weise „Kopf“ geworfen wurde, 50 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -89,7 +90,8 @@ const card: Card = {
 
 	description: {
 		en: "It is said to make its home somewhere in the sea. It guides crews of shipwrecks to shore.",
-		fr: "On raconte qu'il vit quelque part en mer. Il guide les équipages naufragés jusqu'à la terre ferme."
+		fr: "On raconte qu'il vit quelque part en mer. Il guide les équipages naufragés jusqu'à la terre ferme.",
+		de: "Man sagt, es lebe in den Meeren. Es bringt Schiffbrüchige sicher an Land."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/20.ts
+++ b/data/Diamond & Pearl/Legends Awakened/20.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gloom",
 		fr: "Duflor",
+		de: "Duflor"
 	},
 
 	stage: "Stage2",
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Does 40 damage plus 20 more damage for each Vileplume and each Bellossom you have in play. Flip a coin. If heads, the Defending Pokémon is now Burned.",
 				fr: "Inflige 40 dégâts plus 20 dégâts supplémentaires pour chaque Rafflesia et chaque Joliflor que vous avez en jeu. Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Brûlé.",
-				de: "Dieser Angriff fügt 40 Schadenspunkte plus 20 weitere Schadenspunkte für jedes Giflor und jedes Blubella, das du im Spiel hast, zu. Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt verbrannt."
+				de: "Dieser Angriff fügt 40 Schadenspunkte plus 20 weitere Schadenspunkte für jedes Giflor und jedes Blubella, das du im Spiel hast, zu. Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verbrannt."
 			},
 			damage: "40+",
 
@@ -86,7 +87,8 @@ const card: Card = {
 
 	description: {
 		en: "When the heavy rainfall season ends, it is drawn out by warm sunlight to dance in the open.",
-		fr: "À la fin de la saison des pluies, il sort danser en plein air, attiré par la chaleur du soleil."
+		fr: "À la fin de la saison des pluies, il sort danser en plein air, attiré par la chaleur du soleil.",
+		de: "Sobald die Regenzeit vorbei ist, wird es von der warmen Sonne nach draußen gezogen, wo es tanzt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/21.ts
+++ b/data/Diamond & Pearl/Legends Awakened/21.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Lileep",
 		fr: "Liliep",
+		de: "Liliep"
 	},
 
 	stage: "Stage2",
@@ -80,7 +81,8 @@ const card: Card = {
 
 	description: {
 		en: "It lives in the shallows of warm seas. When the tide goes out, it digs up prey from beaches.",
-		fr: "Il vit dans les hauts-fonds des mers chaudes. Il déterre sa proie du sable quand la marée se retire."
+		fr: "Il vit dans les hauts-fonds des mers chaudes. Il déterre sa proie du sable quand la marée se retire.",
+		de: "Es lebt in seichten Stellen warmer Meere. Bei Ebbe sucht es im Sand nach Beute."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/22.ts
+++ b/data/Diamond & Pearl/Legends Awakened/22.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Corphish",
 		fr: "Krebscorps",
+		de: "Krebscorps"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, your opponent returns the Defending Pokémon and all cards attached to it to his or her hand.",
 				fr: "Lancez une pièce. Si c'est face, votre adversaire reprend dans sa main le Pokémon Défenseur ainsi que toutes les cartes qui lui sont attachées.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" nimmt dein Gegner das Verteidigende Pokémon und alle daran angelegten Karten auf seine Hand zurück."
+				de: "Wirf 1 Münze. Bei „Kopf“ nimmt dein Gegner das Verteidigende Pokémon und alle daran angelegten Karten auf seine Hand zurück."
 			},
 
 		},
@@ -87,7 +88,8 @@ const card: Card = {
 
 	description: {
 		en: "It is a ruffian that uses its pincers to pick up and toss out other Pokémon from its pond.",
-		fr: "C'est un voyou qui utilise ses pinces pour chasser les autres Pokémon hors de sa mare."
+		fr: "C'est un voyou qui utilise ses pinces pour chasser les autres Pokémon hors de sa mare.",
+		de: "Dieser Grobian ergreift andere PKMN mit seinen Scheren und wirft sie aus seinem Teich."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/23.ts
+++ b/data/Diamond & Pearl/Legends Awakened/23.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Skitty",
 		fr: "Eneco",
+		de: "Eneco"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "If Delcatty is your Active Pokémon and is damaged by an opponent's attack (even if Delcatty is Knocked Out), flip a coin. If heads, the Attacking Pokémon is now Confused.",
 				fr: "Si Delcatty est votre Pokémon Actif et qu'une attaque de votre adversaire lui inflige des dégâts (même si Delcatty est mis K.O), lancez une pièce. Si c'est face, le Pokémon Attaquant est maintenant Confus.",
-				de: "Wenn Enekoro dein Aktives Pokémon ist und durch einen gegnerischen Angriff Schaden erhält (auch wenn Enekoro dadurch kampfunfähig wird), wirf 1 Münze. Bei \"Kopf\" ist das Angreifende Pokémon jetzt verwirrt."
+				de: "Wenn Enekoro dein Aktives Pokémon ist und durch einen gegnerischen Angriff Schaden erhält (auch wenn Enekoro dadurch kampfunfähig wird), wirf 1 Münze. Bei „Kopf“ ist das Angreifende Pokémon jetzt verwirrt."
 			},
 		},
 	],
@@ -77,7 +78,8 @@ const card: Card = {
 
 	description: {
 		en: "It is highly popular among female Trainers for its sublime fur. It does not keep a nest.",
-		fr: "Les femmes Dresseurs raffolent de sa sublime fourrure. Il ne possède pas de nid."
+		fr: "Les femmes Dresseurs raffolent de sa sublime fourrure. Il ne possède pas de nid.",
+		de: "Dieses PKMN ist bei weiblichen Trainern aufgrund seines Fells beliebt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/24.ts
+++ b/data/Diamond & Pearl/Legends Awakened/24.ts
@@ -74,7 +74,8 @@ const card: Card = {
 
 	description: {
 		en: "An alien virus that fell to earth on a meteor underwent a DNA mutation to become this Pokémon.",
-		fr: "Il vient d'un virus extraterrestre arrivé avec une météorite et ayant subi une mutation génétique."
+		fr: "Il vient d'un virus extraterrestre arrivé avec une météorite et ayant subi une mutation génétique.",
+		de: "Ein außerirdischer Virus kam mit einem Meteor auf die Erde. Seine DNA mutierte. So entstand DEOXYS."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/25.ts
+++ b/data/Diamond & Pearl/Legends Awakened/25.ts
@@ -74,7 +74,8 @@ const card: Card = {
 
 	description: {
 		en: "An alien virus that fell to earth on a meteor underwent a DNA mutation to become this Pokémon.",
-		fr: "Il vient d'un virus extraterrestre arrivé avec une météorite et ayant subi une mutation génétique."
+		fr: "Il vient d'un virus extraterrestre arrivé avec une météorite et ayant subi une mutation génétique.",
+		de: "Ein außerirdischer Virus kam mit einem Meteor auf die Erde. Seine DNA mutierte. So entstand DEOXYS."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/26.ts
+++ b/data/Diamond & Pearl/Legends Awakened/26.ts
@@ -70,7 +70,8 @@ const card: Card = {
 
 	description: {
 		en: "An alien virus that fell to earth on a meteor underwent a DNA mutation to become this Pokémon.",
-		fr: "Il vient d'un virus extraterrestre arrivé avec une météorite et ayant subi une mutation génétique."
+		fr: "Il vient d'un virus extraterrestre arrivé avec une météorite et ayant subi une mutation génétique.",
+		de: "Ein außerirdischer Virus kam mit einem Meteor auf die Erde. Seine DNA mutierte. So entstand DEOXYS."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/27.ts
+++ b/data/Diamond & Pearl/Legends Awakened/27.ts
@@ -52,7 +52,8 @@ const card: Card = {
 
 	description: {
 		en: "It has the ability to reconstitute its entire cellular structure to transform into whatever it sees.",
-		fr: "Il a la capacité de modifier sa structure cellulaire pour prendre l'apparence de ce qu'il voit."
+		fr: "Il a la capacité de modifier sa structure cellulaire pour prendre l'apparence de ce qu'il voit.",
+		de: "Es kann seine Zellstruktur so verändern, dass es sich in alles verwandeln kann, was es sieht."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/28.ts
+++ b/data/Diamond & Pearl/Legends Awakened/28.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pineco",
 		fr: "Tannza",
+		de: "Tannza"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Whenever you attach a basic Energy card from your hand to Forretress (excluding effects of attacks), you may flip a coin. If tails, put 2 damage counters on each Pokémon (both yours and your opponent's) (excluding any Forretress).",
 				fr: "Dès que vous attachez une carte Énergie de base de votre main à Forretress (effets d'attaques exclus), lancez une pièce. Si c'est pile, placez 2 marqueurs de dégât sur chaque Pokémon (les vôtres et ceux de votre adversaire) (n'importe quel Forretress exclus).",
-				de: "Jedes Mal, wenn du 1 Basis-Energiekarte von deiner Hand an Forstellka anlegst (ausgenommen durch Effekte von Angriffen), kannst du 1 Münze werfen. Bei \"Zahl\" lege 2 Schadensmarken auf jedes Pokémon (deine und die deines Gegners), außer allen Forstellka."
+				de: "Jedes Mal, wenn du 1 Basis-Energiekarte von deiner Hand an Forstellka anlegst (ausgenommen durch Effekte von Angriffen), kannst du 1 Münze werfen. Bei „Zahl“ lege 2 Schadensmarken auf jedes Pokémon (deine und die deines Gegners), außer allen Forstellka."
 			},
 		},
 	],
@@ -87,7 +88,8 @@ const card: Card = {
 
 	description: {
 		en: "It is encased in a steel shell. Its peering eyes are all that can be seen of its mysterious innards.",
-		fr: "Il est prisonnier d'une coquille d'acier. Ses yeux vigilants sont la seule partie visible de son corps."
+		fr: "Il est prisonnier d'une coquille d'acier. Ses yeux vigilants sont la seule partie visible de son corps.",
+		de: "Dieses PKMN ist von einer Stahlhülle umgeben. Seine stechenden Augen sind alles, was man von ihm sieht."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/29.ts
+++ b/data/Diamond & Pearl/Legends Awakened/29.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Choose up to 2 basic Fighting Energy cards from your hand and attach them to 1 of your Pokémon.",
 				fr: "Choisissez jusqu'à 2 cartes Énergie de base Fighting de votre main et attachez-les à 1 de vos Pokémon.",
-				de: "Wähle bis zu 2 -Basis-Energiekarten von deiner Hand und lege sie an 1 deiner Pokémon an."
+				de: "Wähle bis zu 2 {F}-Basis-Energiekarten von deiner Hand und lege sie an 1 deiner Pokémon an."
 			},
 
 		},
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "Discard 2 Fighting Energy attached to Groudon and this attack does 10 damage to each of your Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Défaussez 2 Énergies Fighting attachées à Groudon et cette attaque inflige 10 dégâts à chacun de vos Pokémon de Banc. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Lege 2 an Groudon angelegte -Energien auf deinen Ablagestapel und dieser Angriff fügt jedem Pokémon auf deiner Bank 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Lege 2 an Groudon angelegte {F}-Energien auf deinen Ablagestapel und dieser Angriff fügt jedem Pokémon auf deiner Bank 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 100,
 
@@ -79,7 +79,8 @@ const card: Card = {
 
 	description: {
 		en: "It had been asleep in underground magma ever since it fiercely fought Kyogre long ago.",
-		fr: "Il dormait dans le magma souterrain depuis sa lutte féroce contre Kyogre, il a longtemps de cela."
+		fr: "Il dormait dans le magma souterrain depuis sa lutte féroce contre Kyogre, il a longtemps de cela.",
+		de: "Es hat seit dem Kampf gegen KYOGRE in Magma unter dem Erdboden geschlafen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/3.ts
+++ b/data/Diamond & Pearl/Legends Awakened/3.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Snorunt",
 		fr: "Schneppke",
+		de: "Schneppke"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Discard a Psychic Energy attached to Froslass. During your opponent's next turn, if Froslass would be Knocked Out by damage from an attack, the Attacking Pokémon is Knocked Out.",
 				fr: "Défaussez une Énergie Psychic attachée à Momartik. Lors du prochain tour de votre adversaire, si Momartik est mis K.O par des dégâts d'une attaque, le Pokémon Attaquant est mis K.O.",
-				de: "Lege 1 an Frosdedje angelegte -Energie auf deinen Ablagestapel. Wenn Frosdedje im nächsten Zug deines Gegners durch Schaden eines Angriffs kampfunfähig würde, wird das Angreifende Pokémon kampfunfähig."
+				de: "Lege 1 an Frosdedje angelegte {P}-Energie auf deinen Ablagestapel. Wenn Frosdedje im nächsten Zug deines Gegners durch Schaden eines Angriffs kampfunfähig würde, wird das Angreifende Pokémon kampfunfähig."
 			},
 
 		},
@@ -78,7 +79,8 @@ const card: Card = {
 
 	description: {
 		en: "It freezes foes with an icy breath nearly -60 degrees F. What seems to be its body is actually hollow.",
-		fr: "Momartik gèle ses ennemis grâce à son souffle à -50°C. Ça ne se voit pas, mais son corps est creux."
+		fr: "Momartik gèle ses ennemis grâce à son souffle à -50°C. Ça ne se voit pas, mais son corps est creux.",
+		de: "Sein eisiger Atem mit minus 50 Grad friert Gegner ein. Was aussieht wie sein Körper ist tatsächlich hohl."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/30.ts
+++ b/data/Diamond & Pearl/Legends Awakened/30.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may move a Metal Energy attached to 1 of your Pokémon to Heatran. This power can't be used if Heatran is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez déplacer sur Heatran une Énergie Metal attachée à 1 de vos Pokémon. Ce pouvoir ne peut pas être utilisé si Heatran est affecté par un État Spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 -Energie, die an 1 deiner Pokémon angelegt ist, an Heatran anlegen. Diese Poké-Power kann nicht benutzt werden, wenn Heatran von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 {M}-Energie, die an 1 deiner Pokémon angelegt ist, an Heatran anlegen. Diese Poké-Power kann nicht benutzt werden, wenn Heatran von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -56,7 +56,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin for each Metal Energy attached to Heatran. This attack does 40 damage plus 20 more damage for each heads.",
 				fr: "Lancez une pièce pour chaque Énergie Metal attachée à Heatran. Cette attaque inflige 40 dégâts plus 20 dégâts supplémentaires pour chaque face.",
-				de: "Wirf 1 Münze für jede an Heatran angelegte -Energie. Dieser Angriff fügt 40 Schadenspunkte plus 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 1 Münze für jede an Heatran angelegte {M}-Energie. Dieser Angriff fügt 40 Schadenspunkte plus 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "40+",
 
@@ -74,7 +74,8 @@ const card: Card = {
 
 	description: {
 		en: "It dwells in volcanic caves. It digs in with its cross-shaped feet to crawl on ceilings and walls.",
-		fr: "Il hante les grottes volcaniques. Il rampe au mut et au plafond grâce à ses pieds en forme de croix."
+		fr: "Il hante les grottes volcaniques. Il rampe au mut et au plafond grâce à ses pieds en forme de croix.",
+		de: "Es lebt in vulkanischen Höhlen. Mit seinen kreuzförmigen Klauen kann es sogar an der Decke laufen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/31.ts
+++ b/data/Diamond & Pearl/Legends Awakened/31.ts
@@ -77,7 +77,8 @@ const card: Card = {
 
 	description: {
 		en: "It is said to have the ability to grant any wish for just one week every thousand years.",
-		fr: "On raconte qu'une fois tous les mille ans, il a la capacité d'exaucer tous les vœux durant une semaine."
+		fr: "On raconte qu'une fois tous les mille ans, il a la capacité d'exaucer tous les vœux durant une semaine.",
+		de: "Man sagt, es kann alle tausend Jahre für eine Woche jeden Wunsch erfüllen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/32.ts
+++ b/data/Diamond & Pearl/Legends Awakened/32.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Choose up to 2 basic Water Energy cards from your hand and attach them to 1 of your Pokémon.",
 				fr: "Choisissez jusqu'à 2 cartes Énergie de base Water de votre main et attachez-les à 1 de vos Pokémon.",
-				de: "Wähle bis zu 2 -Basis-Energiekarten von deiner Hand und lege sie an 1 deiner Pokémon an."
+				de: "Wähle bis zu 2 {W}-Basis-Energiekarten von deiner Hand und lege sie an 1 deiner Pokémon an."
 			},
 
 		},
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "Discard 2 Water Energy attached to Kyogre. This attack does 20 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Défaussez 2 Énergies Water attachées à Kyogre. Cette attaque inflige 20 dégâts à chacun des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Lege 2 an Kyogre angelegte -Energien auf deinen Ablagestapel. Dieser Angriff fügt jedem Pokémon auf der Bank deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Lege 2 an Kyogre angelegte {W}-Energien auf deinen Ablagestapel. Dieser Angriff fügt jedem Pokémon auf der Bank deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 60,
 
@@ -72,7 +72,8 @@ const card: Card = {
 
 	description: {
 		en: "It is said to have widened the seas by causing downpours. It had been asleep in a marine trench.",
-		fr: "On dit qu'il a fait monter les eaux en causant des pluies diluviennes. Il somnolait dans une fosse marine."
+		fr: "On dit qu'il a fait monter les eaux en causant des pluies diluviennes. Il somnolait dans une fosse marine.",
+		de: "Man sagt, es habe die Meere vergrößert, indem es es regnen ließ. Es schlief in einem Meeresgraben."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/33.ts
+++ b/data/Diamond & Pearl/Legends Awakened/33.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Buneary",
 		fr: "Haspiror",
+		de: "Haspiror"
 	},
 
 	stage: "Stage1",
@@ -92,7 +93,8 @@ const card: Card = {
 
 	description: {
 		en: "An extremely cautious Pokémon. It cloaks its body with its fluffy ear fur when it senses danger.",
-		fr: "Un Pokémon extrêmement prudent. Il couvre son corps de ses oreilles pelucheuses en cas de danger."
+		fr: "Un Pokémon extrêmement prudent. Il couvre son corps de ses oreilles pelucheuses en cas de danger.",
+		de: "Ein sehr vorsichtiges PKMN. Nimmt es Gefahr wahr, schützt es seinen Körper mit seinen weichen Ohren."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/34.ts
+++ b/data/Diamond & Pearl/Legends Awakened/34.ts
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "Known as \"The Being of Emotion.\" It taught humans the nobility of sorrow, pain, and joy.",
-		fr: "On l'appelle \"être de l'émotion\". Il enseigne aux hommes la beauté de la tristesse, la douleur de la joie."
+		fr: "On l'appelle \"être de l'émotion\". Il enseigne aux hommes la beauté de la tristesse, la douleur de la joie.",
+		de: "“Das fühlende Wesen”. Es lehrt die Menschen die Ideale von Trauer, Schmerz und Freude."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/35.ts
+++ b/data/Diamond & Pearl/Legends Awakened/35.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Poliwhirl",
 		fr: "Quaputzi",
+		de: "Quaputzi"
 	},
 
 	stage: "Stage2",
@@ -80,7 +81,8 @@ const card: Card = {
 
 	description: {
 		en: "With extremely tough muscles, it can keep swimming in the Pacific Ocean without resting.",
-		fr: "Il possède de sacrés biscoteaux. Il peut parcourir sans relâche l'Océan Pacifique."
+		fr: "Il possède de sacrés biscoteaux. Il peut parcourir sans relâche l'Océan Pacifique.",
+		de: "Es hat extrem starke Muskeln und kann durch den Ozean schwimmen, ohne sich ausruhen zu müssen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/36.ts
+++ b/data/Diamond & Pearl/Legends Awakened/36.ts
@@ -74,7 +74,8 @@ const card: Card = {
 
 	description: {
 		en: "Its body is made of ice from the ice age. It controls frigid air of -328 degrees Fahrenheit.",
-		fr: "Son corps est fait de glace datant de l'ère glaciaire. Il contrôle un air gelé de -200 °C."
+		fr: "Son corps est fait de glace datant de l'ère glaciaire. Il contrôle un air gelé de -200 °C.",
+		de: "Sein Körper besteht aus Eis aus der Eiszeit. Es kontrolliert gefrorene Luft, die minus 200 Grad kalt ist."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/37.ts
+++ b/data/Diamond & Pearl/Legends Awakened/37.ts
@@ -56,7 +56,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 60 damage plus 20 more damage and does 20 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 60 dégâts plus 20 dégâts supplémentaires et inflige 20 dégâts à 1 des Pokémon de Banc de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 60 Schadenspunkte plus 20 weitere Schadenspunkte zu und fügt 1 Pokémon auf der Bank deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 60 Schadenspunkte plus 20 weitere Schadenspunkte zu und fügt 1 Pokémon auf der Bank deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: "60+",
 
@@ -74,7 +74,8 @@ const card: Card = {
 
 	description: {
 		en: "There is an enduring legend that states this Pokémon towed continents with ropes.",
-		fr: "Une légende tenace veut que ce Pokémon ait traîné les continents en les attachant à des cordes."
+		fr: "Une légende tenace veut que ce Pokémon ait traîné les continents en les attachant à des cordes.",
+		de: "Es gibt eine Legende, wonach dieses PKMN die Kontinente mit einem Seil gezogen hat."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/38.ts
+++ b/data/Diamond & Pearl/Legends Awakened/38.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), if you have a Fighting Energy card in your discard pile, you may discard 2 cards from your hand. Then, attach a Fighting Energy card from your discard pile to Regirock. This power can't be used if Regirock is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), si vous possédez une carte Énergie Fighting dans votre pile de défausse, vous pouvez défausser 2 cartes de votre main. Ensuite, attachez une carte Énergie Fighting de votre pile de défausse sur Regirock. Ce pouvoir ne peut pas être utilisé si Regirock est affecté par un État Spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, falls mindestens 1 -Energiekarte in deinem Ablagestapel liegt, 2 Karten von deiner Hand auf deinen Ablagestapel legen. Danach wähle 1 -Energiekarte in deinem Ablagestapel und lege sie an Regirock an. Diese Poké-Power kann nicht benutzt werden, wenn Regirock von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, falls mindestens 1 {F}-Energiekarte in deinem Ablagestapel liegt, 2 Karten von deiner Hand auf deinen Ablagestapel legen. Danach wähle 1 {F}-Energiekarte in deinem Ablagestapel und lege sie an Regirock an. Diese Poké-Power kann nicht benutzt werden, wenn Regirock von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -56,7 +56,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 40 damage plus 30 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 40 dégâts plus 30 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 40 Schadenspunkte plus 30 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 40 Schadenspunkte plus 30 weitere Schadenspunkte zu."
 			},
 			damage: "40+",
 
@@ -74,7 +74,8 @@ const card: Card = {
 
 	description: {
 		en: "Its entire body is made of rock. If any part chips off in battle, it attaches rocks to repair itself.",
-		fr: "Tout son corps est fait de roche. S'il s'ébrèche au combat, il utilise des pierres pour le réparer."
+		fr: "Tout son corps est fait de roche. S'il s'ébrèche au combat, il utilise des pierres pour le réparer.",
+		de: "Sein Körper besteht aus Stein. Bricht im Kampf etwas heraus, wird es durch Stein wieder ersetzt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/39.ts
+++ b/data/Diamond & Pearl/Legends Awakened/39.ts
@@ -81,7 +81,8 @@ const card: Card = {
 
 	description: {
 		en: "Tempered by pressure underground over tens of thousands of years, its body cannot be scratched.",
-		fr: "Son corps invulnérable fut forgé par la pression souterraine durant des dizaines de milliers d'années."
+		fr: "Son corps invulnérable fut forgé par la pression souterraine durant des dizaines de milliers d'années.",
+		de: "Im Laufe der Jahrtausende, die es unterirdisch lebte, wurde sein Körper durch Druck u. Wärme hart."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/4.ts
+++ b/data/Diamond & Pearl/Legends Awakened/4.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			effect: {
 				en: "Choose 1 of your opponent's Benched Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Flip a coin. If heads, prevent all effects of an attack, including damage, done to Giratina during your opponent's next turn.",
 				fr: "Choisissez 1 des Pokémon de Banc de votre adversaire. Cette attaque lui inflige 20 dégâts. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.) Lancez une pièce. Si c'est face, prévenez tous les effets d'une attaque, dégâts inclus, infligés à Giratina lors du prochain tour de votre adversaire.",
-				de: "Wähle 1 Pokémon auf der Bank deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.) Wirf 1 Münze. Bei \"Kopf\" verhindere während des nächsten Zuges deines Gegners alle Effekte eines Angriffs, einschließlich Schaden, die Giratina zugefügt würden."
+				de: "Wähle 1 Pokémon auf der Bank deines Gegners. Dieser Angriff fügt dem gewählten Pokémon 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.) Wirf 1 Münze. Bei „Kopf“ verhindere während des nächsten Zuges deines Gegners alle Effekte eines Angriffs, einschließlich Schaden, die Giratina zugefügt würden."
 			},
 
 		},
@@ -83,7 +83,8 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon that is said to live in a world on the reverse side of ours. It appears in an ancient cemetery.",
-		fr: "Un Pokémon censé vivre dans un monde à l'opposé du nôtre. Il apparaît dans un cimetière ancien."
+		fr: "Un Pokémon censé vivre dans un monde à l'opposé du nôtre. Il apparaît dans un cimetière ancien.",
+		de: "Ein PKMN, von dem man sagt, es lebe in der Spiegelwelt unserer Welt. Es erscheint auf alten Friedhöfen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/40.ts
+++ b/data/Diamond & Pearl/Legends Awakened/40.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Nincada",
 		fr: "Ningale",
+		de: "Nincada"
 	},
 
 	stage: "Stage1",
@@ -67,7 +68,8 @@ const card: Card = {
 
 	description: {
 		en: "A discarded bug shell that came to life. Peering into the crack on its back is said to steal one's spirit.",
-		fr: "Une carapace d'insecte laissée à l'abandon. On dit qu'il vole l'âme de celui qui regarde à l'intérieur."
+		fr: "Une carapace d'insecte laissée à l'abandon. On dit qu'il vole l'âme de celui qui regarde à l'intérieur.",
+		de: "Ein weggeworfener Käferpanzer, der zum Leben erwachte. Schaut man hinein, stiehlt es einem die Seele."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/41.ts
+++ b/data/Diamond & Pearl/Legends Awakened/41.ts
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Burned and Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Brûlé et Paralysé.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt verbrannt und gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verbrannt und gelähmt."
 			},
 			damage: 30,
 
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "It burns coal inside its shell for energy. It blows out black soot if it is endangered.",
-		fr: "Il tire son énergie du charbon qu'il brûle dans sa carapace et crache de la suie noire en cas de danger."
+		fr: "Il tire son énergie du charbon qu'il brûle dans sa carapace et crache de la suie noire en cas de danger.",
+		de: "In seinem Panzer verbrennt es Kohle und gewinnt daraus Energie. Bei Gefahr sondert es Ruß ab."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/42.ts
+++ b/data/Diamond & Pearl/Legends Awakened/42.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn, when you put Unown ! from your hand onto your Bench, you may flip a coin. If heads, put 2 damage counters on 1 of your opponent's Pokémon. If tails, put 2 damage counters on 1 of your Pokémon.",
 				fr: "Une seule fois lors de votre tour, lorsque vous placez Zarbi ! de votre main sur votre Banc, vous pouvez lancer une pièce. Si c'est face, placez 2 marqueurs de dégât sur 1 des Pokémon de votre adversaire. Si c'est pile, placez 2 marqueurs de dégât sur 1 de vos Pokémon.",
-				de: "Einmal während deines Zuges kannst du, wenn du Icognito ! von deiner Hand auf deine Bank legst, 1 Münze werfen. Bei \"Kopf\" lege 2 Schadensmarken auf 1 Pokémon deines Gegners. Bei \"Zahl\" lege 2 Schadensmarken auf 1 deiner Pokémon."
+				de: "Einmal während deines Zuges kannst du, wenn du Icognito ! von deiner Hand auf deine Bank legst, 1 Münze werfen. Bei „Kopf“ lege 2 Schadensmarken auf 1 Pokémon deines Gegners. Bei „Zahl“ lege 2 Schadensmarken auf 1 deiner Pokémon."
 			},
 		},
 	],
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 10 more damage. If tails, Unown ! does 10 damage to itself, and this attack's damage isn't affected by Weakness or Resistance.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires. Si c'est pile, Zarbi ! s'inflige 10 dégâts et les dégâts de cette attaque ne sont pas affectés par la Faiblesse ou la Résistance.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu. Bei \"Zahl\" fügt sich Icognito ! selbst 10 Schadenspunkte zu und der Schaden dieses Angriffs wird durch Schwäche und Resistenz nicht verändert."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu. Bei „Zahl“ fügt sich Icognito ! selbst 10 Schadenspunkte zu und der Schaden dieses Angriffs wird durch Schwäche und Resistenz nicht verändert."
 			},
 			damage: "10+",
 
@@ -72,7 +72,8 @@ const card: Card = {
 
 	description: {
 		en: "Shaped like an ancient writing, it is a huge mystery whether language or Unown came first.",
-		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou de ZARBI est apparu en premier."
+		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou de ZARBI est apparu en premier.",
+		de: "Seine Form sieht aus wie antike Schrift. Was war zuerst da? Die Sprache oder ICOGNITO?"
 	},
 
 	variants: [

--- a/data/Diamond & Pearl/Legends Awakened/43.ts
+++ b/data/Diamond & Pearl/Legends Awakened/43.ts
@@ -72,7 +72,8 @@ const card: Card = {
 
 	description: {
 		en: "Known as \"The Being of Knowledge.\" It is said that it can wipe out the memory of those who see its eyes.",
-		fr: "On l'appelle \"être du savoir\". On raconte que son regard a le pouvoir d'effacer la mémoire."
+		fr: "On l'appelle \"être du savoir\". On raconte que son regard a le pouvoir d'effacer la mémoire.",
+		de: "\"Das wissende Wesen\". Es soll die Erinnerungen derer löschen, die ihm in die Augen sehen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/44.ts
+++ b/data/Diamond & Pearl/Legends Awakened/44.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Weepinbell",
 		fr: "Ultrigaria",
+		de: "Ultrigaria"
 	},
 
 	stage: "Stage2",
@@ -77,7 +78,8 @@ const card: Card = {
 
 	description: {
 		en: "It pools in its mouth a fluid with a honeylike scent, which is really an acid that dissolves anything.",
-		fr: "Sa bouche sécrète un fluide à l'odeur du miel, qui s'avère être un acide extrêmement corrosif."
+		fr: "Sa bouche sécrète un fluide à l'odeur du miel, qui s'avère être un acide extrêmement corrosif.",
+		de: "In seinem Maul sammelt sich eine Flüssigkeit, die nach Honig riecht, in Wahrheit aber ätzend ist."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/45.ts
+++ b/data/Diamond & Pearl/Legends Awakened/45.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gloom",
 		fr: "Duflor",
+		de: "Duflor"
 	},
 
 	stage: "Stage2",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Energy Reaction",
 				fr: "Réaction Énergie",
-				de: "Energie-Alllergie"
+				de: "Energie-Allergie"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), when you attach a Grass or Psychic Energy card from your hand to Vileplume (excluding effects of attacks or Poké-Powers), you may use this power. If you attach a Grass Energy card, the Defending Pokémon is now Asleep. If you attach a Psychic Energy card, the Defending Pokémon is now Poisoned. This power can't be used if Vileplume is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), lorsque vous attachez une carte Énergie Grass ou Psychic de votre main à Rafflesia (les effets d'attaques ou des Poké-Powers exclus), vous pouvez utiliser ce pouvoir. Si vous attachez une carte Énergie Grass, le Pokémon Défenseur est maintenant Endormi. Si vous attachez une carte Énergie Psychic, le Pokémon Défenseur est maintenant Empoisonné. Ce pouvoir ne peut pas être utilisé si Rafflesia est affecté par un État Spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff), wenn du 1 - oder -Energiekarte von deiner Hand an Giflor anlegst (ausgenommen durch Effekte von Angriffen oder Poké-Power), kannst du diese Poké-Power benutzen. Wenn du 1 Pflanze-Energiekarte angelegt hast, schläft das Verteidigende Pokémon jetzt. Wenn du 1 Psycho-Energiekarte angelegt hast, ist das Verteidigende Pokémon jetzt vergiftet. Diese Poké-Power kann nicht benutzt werden, wenn Giflor von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff), wenn du 1 {G}- oder {P}-Energiekarte von deiner Hand an Giflor anlegst (ausgenommen durch Effekte von Angriffen oder Poké-Power), kannst du diese Poké-Power benutzen. Wenn du 1 {G}-Energiekarte angelegt hast, schläft das Verteidigende Pokémon jetzt. Wenn du 1 {P}-Energiekarte angelegt hast, ist das Verteidigende Pokémon jetzt vergiftet. Diese Poké-Power kann nicht benutzt werden, wenn Giflor von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, your opponent can't play any Trainer, Supporter, or Stadium cards from his or her hand during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, votre adversaire ne peut pas jouer de cartes Dresseur, Supporter ou Stade de sa main lors du prochain tour de votre adversaire.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" kann dein Gegner in seinem nächsten Zug keine Trainer-, Unterstützer- und Stadion-Karten von seiner Hand spielen."
+				de: "Wirf 1 Münze. Bei „Kopf“ kann dein Gegner in seinem nächsten Zug keine Trainer-, Unterstützer- und Stadion-Karten von seiner Hand spielen."
 			},
 			damage: 60,
 
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "Its petals are the largest in the world. As it walks, it scatters extremely allergenic pollen.",
-		fr: "Ses pétales sont les plus grands du monde. Il marche en répandant un pollen extrêmement allergène."
+		fr: "Ses pétales sont les plus grands du monde. Il marche en répandant un pollen extrêmement allergène.",
+		de: "Es besitzt die größten Blätter der Welt. Es verteilt beim Gehen Pollen, die schreckliche Allergien auslösen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/46.ts
+++ b/data/Diamond & Pearl/Legends Awakened/46.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Claw Fossil",
 		fr: "Klauenfossil",
+		de: "Klauenfossil"
 	},
 
 	stage: "Stage1",
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 damage plus 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts plus 20 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 30 Schadenspunkte plus 20 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "30+",
 
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon ancestor that was reanimated from a fossil. It lived in the sea and hunted with claws.",
-		fr: "Un ancêtre Pokémon réanimé à partir d'un fossile. Il vivait en mer et chassait avec ses pinces."
+		fr: "Un ancêtre Pokémon réanimé à partir d'un fossile. Il vivait en mer et chassait avec ses pinces.",
+		de: "Ein Vorfahre der PKMN, der aus einem Fossil neu belebt wurde. Es lebte im Meer und jagte mit Klauen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/47.ts
+++ b/data/Diamond & Pearl/Legends Awakened/47.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Numel",
 		fr: "Camaub",
+		de: "Camaub"
 	},
 
 	stage: "Stage1",
@@ -81,7 +82,8 @@ const card: Card = {
 
 	description: {
 		en: "It has volcanoes on its back. If magma builds up in its body, it shudders, then erupts violently.",
-		fr: "Il porte des volcans sur son dos. Quand le magma remonte, il frissonne et entre en éruption."
+		fr: "Il porte des volcans sur son dos. Quand le magma remonte, il frissonne et entre en éruption.",
+		de: "Auf seinem Rücken befinden sich Vulkane. Magma bildet sich in seinem Körper, die irgendwann ausbricht."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/48.ts
+++ b/data/Diamond & Pearl/Legends Awakened/48.ts
@@ -50,7 +50,7 @@ const card: Card = {
 			name: {
 				en: "Weather Ball",
 				fr: "Ball'météo",
-				de: "Meterologe"
+				de: "Metereologe"
 			},
 			effect: {
 				en: "If you have a Stadium card in play, remove 3 damage counters from Castform. If your opponent has a Stadium card in play, this attack does 30 damage plus 30 more damage.",
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "Its appearance changes with the weather. Recently, its molecules were found to be just like water.",
-		fr: "Son aspect change avec la météo. On a récemment découvert que ses molécules étaient pareilles à l'eau."
+		fr: "Son aspect change avec la météo. On a récemment découvert que ses molécules étaient pareilles à l'eau.",
+		de: "Seine Gestalt ändert sich mit dem Wetter. Vor kurzem entdeckte man, dass seine Moleküle wie Wasser sind."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/49.ts
+++ b/data/Diamond & Pearl/Legends Awakened/49.ts
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "Its appearance changes with the weather. Recently, its molecules were found to be just like water.",
-		fr: "Son aspect change avec la météo. On a récemment découvert que ses molécules étaient pareilles à l'eau."
+		fr: "Son aspect change avec la météo. On a récemment découvert que ses molécules étaient pareilles à l'eau.",
+		de: "Seine Gestalt ändert sich mit dem Wetter. Vor kurzem entdeckte man, dass seine Moleküle wie Wasser sind."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/5.ts
+++ b/data/Diamond & Pearl/Legends Awakened/5.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gligar",
 		fr: "Skorgla",
+		de: "Skorgla"
 	},
 
 	stage: "Stage1",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Choose either Burned or Poisoned. The Defending Pokémon is now affected by that Special Condition. You may return Gliscor and all cards attached to it to your hand.",
 				fr: "Choisissez entre Brûlé et Empoisonné. Le Pokémon Défenseur est maintenant affecté par cet État Spécial. Vous pouvez reprendre Scorvol dans votre main ainsi que toutes les cartes qui lui sont attachées.",
-				de: "Wähle \"verbrannt\" oder \"vergiftet\". Das Verteidigende Pokémon ist jetzt vom gewählten Speziellen Zustand betroffen. Du kannst Skorgro und alle daran angelegten Karten auf deine Hand zurücknehmen."
+				de: "Wähle „verbrannt“ oder „vergiftet“. Das Verteidigende Pokémon ist jetzt vom gewählten Speziellen Zustand betroffen. Du kannst Skorgro und alle daran angelegten Karten auf deine Hand zurücknehmen."
 			},
 
 		},
@@ -83,7 +84,8 @@ const card: Card = {
 
 	description: {
 		en: "It observes prey while hanging inverted from branches. When the chance presents itself, it swoops!",
-		fr: "Il guette sa proie pendu à une branche la tête en bas, et s'en saisit à la première occasion."
+		fr: "Il guette sa proie pendu à une branche la tête en bas, et s'en saisit à la première occasion.",
+		de: "Es hängt kopfüber von einem Ast und beobachtet seine Beute. Bei Gelegenheit stürzt es sich auf sie."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/50.ts
+++ b/data/Diamond & Pearl/Legends Awakened/50.ts
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "Its appearance changes with the weather. Recently, its molecules were found to be just like water.",
-		fr: "Son aspect change avec la météo. On a récemment découvert que ses molécules étaient pareilles à l'eau."
+		fr: "Son aspect change avec la météo. On a récemment découvert que ses molécules étaient pareilles à l'eau.",
+		de: "Seine Gestalt ändert sich mit dem Wetter. Vor kurzem entdeckte man, dass seine Moleküle wie Wasser sind."
 	},
 
 	variants: [

--- a/data/Diamond & Pearl/Legends Awakened/51.ts
+++ b/data/Diamond & Pearl/Legends Awakened/51.ts
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Discard a Fire Energy attached to Castform Sunny Form.",
 				fr: "Défaussez une Énergie Fire attachée à Morpheo Soleil.",
-				de: "Lege 1 an Formeo Sonnenform angelegte -Energie auf deinen Ablagestapel."
+				de: "Lege 1 an Formeo Sonnenform angelegte {R}-Energie auf deinen Ablagestapel."
 			},
 			damage: 40,
 
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "Its appearance changes with the weather. Recently, its molecules were found to be just like water.",
-		fr: "Son aspect change avec la météo. On a récemment découvert que ses molécules étaient pareilles à l'eau."
+		fr: "Son aspect change avec la météo. On a récemment découvert que ses molécules étaient pareilles à l'eau.",
+		de: "Seine Gestalt ändert sich mit dem Wetter. Vor kurzem entdeckte man, dass seine Moleküle wie Wasser sind."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/52.ts
+++ b/data/Diamond & Pearl/Legends Awakened/52.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Dratini",
 		fr: "Minidraco",
+		de: "Dratini"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -63,7 +64,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 damage plus 20 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts plus 20 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 30 Schadenspunkte plus 20 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 Schadenspunkte plus 20 weitere Schadenspunkte zu."
 			},
 			damage: "30+",
 
@@ -81,7 +82,8 @@ const card: Card = {
 
 	description: {
 		en: "If its body takes on an aura, the weather changes instantly. It is said to live in seas and lakes.",
-		fr: "La météo change brusquement lorsqu'il est entouré d'une aura. On dit qu'il peuple les mers et les lacs."
+		fr: "La météo change brusquement lorsqu'il est entouré d'une aura. On dit qu'il peuple les mers et les lacs.",
+		de: "Erscheint um seinen Körper eine Aura, gibt es einen Wetterwechsel. Es soll in Seen und Meeren leben."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/53.ts
+++ b/data/Diamond & Pearl/Legends Awakened/53.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Drifloon",
 		fr: "Baudrive",
+		de: "Driftlon"
 	},
 
 	stage: "Stage1",
@@ -85,7 +86,8 @@ const card: Card = {
 
 	description: {
 		en: "It's drowzy in daytime, but flies off in the evening in big groups. No one knows where they go.",
-		fr: "Il somnole la journée et s'envole en grands groupes le soir venu. Nul ne sait où ils vont."
+		fr: "Il somnole la journée et s'envole en grands groupes le soir venu. Nul ne sait où ils vont.",
+		de: "Tagsüber treibt es faul vor sich hin, nachts fliegt es mit anderen umher. Niemand weiß wohin."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/54.ts
+++ b/data/Diamond & Pearl/Legends Awakened/54.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Exeggcute",
 		fr: "Owei",
+		de: "Owei"
 	},
 
 	stage: "Stage1",
@@ -57,7 +58,7 @@ const card: Card = {
 			effect: {
 				en: "Discard as many Energy cards as you like attached to your Pokémon. For each Energy card you discarded, flip a coin. This attack does 50 damage times the number of heads.",
 				fr: "Défaussez autant de cartes Énergie attachées à votre Pokémon que vous le voulez. Pour chaque carte Énergie défaussée, lancez une pièce. Cette attaque inflige 50 dégâts multipliés par le nombre de faces.",
-				de: "Du kannst beliebig viele Energiekarten von deinen Pokémon entfernen und auf deinen Ablagestapel legen. Wirf für jede auf diese Weise auf den Ablagestapel gelegte Energiekarte 1 Münze. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Du kannst beliebig viele Energiekarten von deinen Pokémon entfernen und auf deinen Ablagestapel legen. Wirf für jede auf diese Weise auf den Ablagestapel gelegte Energiekarte 1 Münze. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "50x",
 
@@ -75,7 +76,8 @@ const card: Card = {
 
 	description: {
 		en: "It is called \"The Walking Jungle.\" If a head grows too big, it falls off and becomes an Exeggcute.",
-		fr: "On l'appelle \"jungle sur pattes\". Si une tête devient trop grosse, elle tombe et produit un NOEUNOEUF."
+		fr: "On l'appelle \"jungle sur pattes\". Si une tête devient trop grosse, elle tombe et produit un NOEUNOEUF.",
+		de: "Man nennt es den “Laufenden Dschungel”. Wird ein Kopf zu groß, fällt er ab und wird zu einem OWEI."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/55.ts
+++ b/data/Diamond & Pearl/Legends Awakened/55.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gligar",
 		fr: "Skorgla",
+		de: "Skorgla"
 	},
 
 	stage: "Stage1",
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 30 damage plus 40 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 30 dégâts plus 40 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 30 Schadenspunkte plus 40 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 30 Schadenspunkte plus 40 weitere Schadenspunkte zu."
 			},
 			damage: "30+",
 
@@ -86,7 +87,8 @@ const card: Card = {
 
 	description: {
 		en: "It observes prey while hanging inverted from branches. When the chance presents itself, it swoops!",
-		fr: "Il guette sa proie, pendu à une branche la tête en bas, et s'en saisit à la première occasion."
+		fr: "Il guette sa proie, pendu à une branche la tête en bas, et s'en saisit à la première occasion.",
+		de: "Es hängt kopfüber von einem Ast und beobachtet seine Beute. Bei Gelegenheit stürzt es sich auf sie."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/56.ts
+++ b/data/Diamond & Pearl/Legends Awakened/56.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Spoink",
 		fr: "Spoink",
+		de: "Spoink"
 	},
 
 	stage: "Stage1",
@@ -36,12 +37,12 @@ const card: Card = {
 			name: {
 				en: "Magical Step",
 				fr: "Pas magique",
-				de: "Zauberschnitt"
+				de: "Zauberschritt"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Confused. Put 6 damage counters instead of 3 on the Confused Pokémon.",
 				fr: "Le Pokémon Défenseur est maintenant Confus. Placez sur le Pokémon Confus 6 marqueurs de dégât au lieu de 3.",
-				de: "Das Verteidigende Pokémon ist jetzt verwirrt. Wenn wegen des Speziellen Zustands \"verwirrt\" 3 Schadensmarken auf das Verteidigende Pokémon gelegt werden sollen, lege stattdessen 6 Schadensmarken darauf."
+				de: "Das Verteidigende Pokémon ist jetzt verwirrt. Wenn wegen des Speziellen Zustands „verwirrt“ 3 Schadensmarken auf das Verteidigende Pokémon gelegt werden sollen, lege stattdessen 6 Schadensmarken darauf."
 			},
 
 		},
@@ -58,7 +59,7 @@ const card: Card = {
 			effect: {
 				en: "Does 20 damage times the amount of Energy attached to Grumpig.",
 				fr: "Inflige 20 dégâts multipliés par le nombre d'Énergies attachées à Groret.",
-				de: "Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl der an Groink angelegten Energien zu,"
+				de: "Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl der an Groink angelegten Energien zu."
 			},
 			damage: "20x",
 
@@ -76,7 +77,8 @@ const card: Card = {
 
 	description: {
 		en: "It uses black pearls to amplify its psycho-power. It does an odd dance to gain control over foes.",
-		fr: "Les perles noires amplifient ses pouvoirs psy. Sa danse étrange lui permet de contrôler ses ennemis."
+		fr: "Les perles noires amplifient ses pouvoirs psy. Sa danse étrange lui permet de contrôler ses ennemis.",
+		de: "Mit schwarzen Perlen verstärkt es seine Psycho-Kräfte. Mit einem Tanz kontrolliert es seine Gegner."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/57.ts
+++ b/data/Diamond & Pearl/Legends Awakened/57.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Houndour",
 		fr: "Hunduster",
+		de: "Hunduster"
 	},
 
 	stage: "Stage1",
@@ -77,7 +78,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, discard 2 Fire Energy attached to Houndoom.",
 				fr: "Lancez une pièce. Si c'est pile, défaussez 2 Énergies Fire attachées à Demolosse.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" entferne 2 -Energien, die an Hundemon angelegt sind, und lege sie auf deinen Ablagestapel."
+				de: "Wirf 1 Münze. Bei „Zahl“ entferne 2 {R}-Energien, die an Hundemon angelegt sind, und lege sie auf deinen Ablagestapel."
 			},
 			damage: 60,
 
@@ -95,7 +96,8 @@ const card: Card = {
 
 	description: {
 		en: "Long ago, people imagined its eerie howls to be the call of the grim reaper.",
-		fr: "Jadis, les gens prenaient son étrange hurlement pour l'appel de la Faucheuse."
+		fr: "Jadis, les gens prenaient son étrange hurlement pour l'appel de la Faucheuse.",
+		de: "In alten Zeiten glaubte man, das Heulen dieses PKMN sei der Ruf des Todes."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/58.ts
+++ b/data/Diamond & Pearl/Legends Awakened/58.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Chinchou",
 		fr: "Lampi",
+		de: "Lampi"
 	},
 
 	stage: "Stage1",
@@ -80,7 +81,8 @@ const card: Card = {
 
 	description: {
 		en: "Lanturn's light can shine up from great depths. It is nicknamed \"The Deep-Sea Star.\"",
-		fr: "La lumière de LANTURN surgit des profondeurs. On le surnomme \"étoile des profondeurs\"."
+		fr: "La lumière de LANTURN surgit des profondeurs. On le surnomme \"étoile des profondeurs\".",
+		de: "LANTURNs Licht kann aus großen Tiefen heraufscheinen. Man nennt es auch “Tiefseestern”."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/59.ts
+++ b/data/Diamond & Pearl/Legends Awakened/59.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Chinchou",
 		fr: "Lampi",
+		de: "Lampi"
 	},
 
 	stage: "Stage1",
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Does 60 damage plus 10 more damage for each Water Energy attached to Lanturn.",
 				fr: "Inflige 60 dégâts plus 10 dégâts supplémentaires pour chaque Énergie Water attachée à Lanturn.",
-				de: "Dieser Angriff fügt 60 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Lanturn angelegte -Energie zu."
+				de: "Dieser Angriff fügt 60 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Lanturn angelegte {W}-Energie zu."
 			},
 			damage: "60+",
 
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "Lanturn's light can shine up from great depths. It is nicknamed \"The Deep-Sea Star.\"",
-		fr: "La lumière de LANTURN surgit des profondeurs. On le surnomme \"étoile des profondeurs\"."
+		fr: "La lumière de LANTURN surgit des profondeurs. On le surnomme \"étoile des profondeurs\".",
+		de: "LANTURNs Licht kann aus großen Tiefen heraufscheinen. Man nennt es auch “Tiefseestern”."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/6.ts
+++ b/data/Diamond & Pearl/Legends Awakened/6.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), you may move a Fire Energy attached to 1 of your Pokémon to Heatran. This power can't be used if Heatran is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez déplacer sur Heatran une Énergie Fire attachée à 1 de vos Pokémon. Ce pouvoir ne peut pas être utilisé si Heatran est affecté par un État Spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 -Energie, die an 1 deiner Pokémon angelegt ist, an Heatran anlegen. Diese Poké-Power kann nicht benutzt werden, wenn Heatran von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du 1 {R}-Energie, die an 1 deiner Pokémon angelegt ist, an Heatran anlegen. Diese Poké-Power kann nicht benutzt werden, wenn Heatran von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -75,7 +75,8 @@ const card: Card = {
 
 	description: {
 		en: "It dwells in volcanic caves. It digs in with its cross-shaped feet to crawl on ceilings and walls.",
-		fr: "Il hante les grottes volcaniques. Il rampe au mur et au plafond grâce à ses pieds en formes de croix."
+		fr: "Il hante les grottes volcaniques. Il rampe au mur et au plafond grâce à ses pieds en formes de croix.",
+		de: "Es lebt in vulkanischen Höhlen. Mit seinen kreuzförmigen Klauen kann es sogar an der Decke laufen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/60.ts
+++ b/data/Diamond & Pearl/Legends Awakened/60.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Ledyba",
 		fr: "Coxy",
+		de: "Ledyba"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 4 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 4 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 4 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 4 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20x",
 
@@ -86,7 +87,8 @@ const card: Card = {
 
 	description: {
 		en: "It uses starlight as energy. When more stars appear at night, the patterns on its back grow larger.",
-		fr: "Il tire sa force de la lumière des étoiles. Plus il y en a et plus ses motifs dorsaux sont grands."
+		fr: "Il tire sa force de la lumière des étoiles. Plus il y en a et plus ses motifs dorsaux sont grands.",
+		de: "Es zieht Energie aus dem Licht der Sterne. Je mehr Sterne zu sehen sind, desto größer ist sein Muster."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/61.ts
+++ b/data/Diamond & Pearl/Legends Awakened/61.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Riolu",
 		fr: "Riolu",
+		de: "Riolu"
 	},
 
 	stage: "Stage1",
@@ -79,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "It has the ability to sense the auras of all things. It understands human speech.",
-		fr: "Il ressent toutes les auras. Il comprend le langage humain."
+		fr: "Il ressent toutes les auras. Il comprend le langage humain.",
+		de: "Es besitzt die Fähigkeit, die Aura aller Dinge zu spüren. Es versteht die menschliche Sprache."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/62.ts
+++ b/data/Diamond & Pearl/Legends Awakened/62.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Shinx",
 		fr: "Sheinux",
+		de: "Sheinux"
 	},
 
 	stage: "Stage1",
@@ -63,7 +64,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, discard all Lightning Energy attached to Luxio.",
 				fr: "Lancez une pièce. Si c'est pile, défaussez toutes les Énergies Lightning attachées à Luxio.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" entferne alle -Energien, die an Luxio angelegt sind, und lege sie auf deinen Ablagestapel."
+				de: "Wirf 1 Münze. Bei „Zahl“ entferne alle {L}-Energien, die an Luxio angelegt sind, und lege sie auf deinen Ablagestapel."
 			},
 			damage: 70,
 
@@ -88,7 +89,8 @@ const card: Card = {
 
 	description: {
 		en: "Its claws loose electricity with enough amperage to cause fainting. They live in small groups.",
-		fr: "L'électricité libérée par ses griffes peut assommer l'ennemi. Il vit en petits groupes."
+		fr: "L'électricité libérée par ses griffes peut assommer l'ennemi. Il vit en petits groupes.",
+		de: "Seine Krallen geben Elektrizität ab, die stark genug ist, jemanden bewusstlos zu machen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/63.ts
+++ b/data/Diamond & Pearl/Legends Awakened/63.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cubone",
 		fr: "Tragosso",
+		de: "Tragosso"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, Marowak can't use Heavy Bone during your next turn.",
 				fr: "Lancez une pièce. Si c'est pile, Ossatueur ne peut pas utiliser Os lourd lors de votre prochain tour.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" kann Knogga Riesenknochen in deinem nächsten Zug nicht einsetzen."
+				de: "Wirf 1 Münze. Bei „Zahl“ kann Knogga Riesenknochen in deinem nächsten Zug nicht einsetzen."
 			},
 			damage: 40,
 
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin until you get tails. This attack does 50 damage times the number of heads.",
 				fr: "Lancez une pièce jusqu'à ce que vous obteniez pile. Cette attaque inflige 50 dégâts multipliés par le nombre de faces.",
-				de: "Wirf so lange 1 Münze, bis zum ersten Mal das Ergebnis \"Zahl\" kommt. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf so lange 1 Münze, bis zum ersten Mal das Ergebnis „Zahl“ kommt. Dieser Angriff fügt 50 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "50x",
 
@@ -86,7 +87,8 @@ const card: Card = {
 
 	description: {
 		en: "From its birth, this savage Pokémon constantly holds bones. It is skilled in using them as weapons.",
-		fr: "Ce Pokémon sauvage possède des os depuis sa naissance. Il s'en sert pour combattre avec dextérité."
+		fr: "Ce Pokémon sauvage possède des os depuis sa naissance. Il s'en sert pour combattre avec dextérité.",
+		de: "Von Geburt an trägt dieses wilde Pokémon Knochen. Es setzt sie talentiert als Waffen ein."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/64.ts
+++ b/data/Diamond & Pearl/Legends Awakened/64.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Beldum",
 		fr: "Terhal",
+		de: "Tanhel"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of an attack, including damage, done to Metang during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, prévenez tous les effets d'une attaque, dégâts inclus, infligés à Metang lors du prochain tour de votre adversaire.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" verhindere während des nächsten Zuges deines Gegners alle Effekte eines Angriffs, einschließlich Schaden, die Metang zugefügt würden."
+				de: "Wirf 1 Münze. Bei „Kopf“ verhindere während des nächsten Zuges deines Gegners alle Effekte eines Angriffs, einschließlich Schaden, die Metang zugefügt würden."
 			},
 			damage: 20,
 
@@ -84,7 +85,8 @@ const card: Card = {
 
 	description: {
 		en: "It is formed by two Beldum joining together. Its steel body won't be scratched if it collides with a jet.",
-		fr: "Il est formé de deux TERHAL soudés. Son corps de fer résiste à un choc avec un avion à réaction."
+		fr: "Il est formé de deux TERHAL soudés. Son corps de fer résiste à un choc avec un avion à réaction.",
+		de: "Das PKMN besteht aus zwei TANHEL. Es bekommt selbst dann keinen Kratzer, wenn ein Jet es streift."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/65.ts
+++ b/data/Diamond & Pearl/Legends Awakened/65.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Beldum",
 		fr: "Terhal",
+		de: "Tanhel"
 	},
 
 	stage: "Stage1",
@@ -44,7 +45,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 			damage: 20,
 
@@ -63,7 +64,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 40 damage plus 20 more damage for each heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 40 dégâts plus 20 dégâts supplémentaires pour chaque face.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte plus 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 40 Schadenspunkte plus 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "40+",
 
@@ -88,7 +89,8 @@ const card: Card = {
 
 	description: {
 		en: "It is formed by two Beldum joining together. Its steel body won't be scratched if it collides with a jet.",
-		fr: "Il est formé de deux Terhal soudés. Son corps de fer résiste à un choc avec un avion à réaction."
+		fr: "Il est formé de deux Terhal soudés. Son corps de fer résiste à un choc avec un avion à réaction.",
+		de: "Das PKMN besteht aus zwei TANHEL. Es bekommt selbst dann keinen Kratzer, wenn ein Jet es streift."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/66.ts
+++ b/data/Diamond & Pearl/Legends Awakened/66.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Poochyena",
 		fr: "Fiffyen",
+		de: "Fiffyen"
 	},
 
 	stage: "Stage1",
@@ -86,7 +87,8 @@ const card: Card = {
 
 	description: {
 		en: "It chases down prey in a pack. It will never disobey the commands of a skilled Trainer.",
-		fr: "Il traque ses proies en groupe. Il ne désobéira jamais aux ordres d'un bon Dresseur."
+		fr: "Il traque ses proies en groupe. Il ne désobéira jamais aux ordres d'un bon Dresseur.",
+		de: "Es jagt seine Beute im Rudel. Den Befehlen eines erfahrenen Trainers wird es stets folgen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/67.ts
+++ b/data/Diamond & Pearl/Legends Awakened/67.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Nincada",
 		fr: "Ningale",
+		de: "Nincada"
 	},
 
 	stage: "Stage1",
@@ -82,7 +83,8 @@ const card: Card = {
 
 	description: {
 		en: "Because it moves so quickly, it sometimes becomes unseeable. It congregates around tree sap.",
-		fr: "Il bouge si vite que l'œil a parfois du mal à le suivre. Ils se regroupent près de la sève des arbres."
+		fr: "Il bouge si vite que l'œil a parfois du mal à le suivre. Ils se regroupent près de la sève des arbres.",
+		de: "Es bewegt sich so schnell, dass es manchmal unsichtbar zu sein scheint. Es liebt Baumsaft."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/68.ts
+++ b/data/Diamond & Pearl/Legends Awakened/68.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Meowth",
 		fr: "Mauzi",
+		de: "Mauzi"
 	},
 
 	stage: "Stage1",
@@ -61,7 +62,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 40 damage plus 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 40 dégâts plus 10 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 40 Schadenspunkte plus 10 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 40 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "40+",
 
@@ -77,7 +78,8 @@ const card: Card = {
 
 	description: {
 		en: "A very haughty Pokémon. Among fans, the size of the jewel in its forehead is a topic of much talk.",
-		fr: "Un Pokémon très snob. La taille du joyau qui orne son front alimente bien des débats parmi ses fans."
+		fr: "Un Pokémon très snob. La taille du joyau qui orne son front alimente bien des débats parmi ses fans.",
+		de: "Ein sehr stolzes Pokémon. Für Fans ist die Größe des Juwels auf seiner Stirn Anlass für Diskussionen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/69.ts
+++ b/data/Diamond & Pearl/Legends Awakened/69.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Swinub",
 		fr: "Quiekel",
+		de: "Quiekel"
 	},
 
 	stage: "Stage1",
@@ -89,7 +90,8 @@ const card: Card = {
 
 	description: {
 		en: "Its shaggy coat makes it unable to see. It checks surroundings with its sensitive nose instead.",
-		fr: "Il ne voit rien à cause de sa fourrure touffue et se repère à l'aide de son nez délicat."
+		fr: "Il ne voit rien à cause de sa fourrure touffue et se repère à l'aide de son nez délicat.",
+		de: "Sein dichtes Fell verdeckt seine Augen. Es untersucht seine Umgebung mit seiner Nase."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/7.ts
+++ b/data/Diamond & Pearl/Legends Awakened/7.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Seadra",
 		fr: "Seemon",
+		de: "Seemon"
 	},
 
 	stage: "Stage2",
@@ -41,7 +42,7 @@ const card: Card = {
 			effect: {
 				en: "Search your discard pile for as many Water Energy cards as you like, show them to your opponent, and this attack does 10 damage for each Water Energy card you chose. Put those cards on top of your deck. Shuffle your deck afterward.",
 				fr: "Cherchez dans votre pile de défausse autant de cartes Énergie Water que vous le voulez et montrez-les à votre adversaire. Cette attaque inflige 10 dégâts pour chaque Énergie Water choisie. Placez ces cartes au-dessus de votre deck. Ensuite, mélangez votre deck.",
-				de: "Durchsuche deinen Ablagestapel nach beliebig vielen -Energiekarten und zeige sie deinem Gegner. Dieser Angriff fügt 10 Schadenspunkte für jede auf diese Weise vorgezeigte -Energiekarte zu. Lege alle diese Energiekarten auf dein Deck. Mische dein Deck danach."
+				de: "Durchsuche deinen Ablagestapel nach beliebig vielen {W}-Energiekarten und zeige sie deinem Gegner. Dieser Angriff fügt 10 Schadenspunkte für jede auf diese Weise vorgezeigte {W}-Energiekarte zu. Lege alle diese Energiekarten auf dein Deck. Mische dein Deck danach."
 			},
 			damage: "10x",
 
@@ -76,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives in caves on the seafloor and creates giant whirlpools every time it moves.",
+		de: "Es lebt in Höhlen auf dem Meeresgrund. Jedes Mal, wenn es sich bewegt, entsteht ein Strudel."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/70.ts
+++ b/data/Diamond & Pearl/Legends Awakened/70.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Horsea",
 		fr: "Seeper",
+		de: "Seeper"
 	},
 
 	stage: "Stage1",
@@ -43,7 +44,7 @@ const card: Card = {
 			effect: {
 				en: "You may discard up to 2 Water Energy cards from your hand. If you do, this attack does 30 damage plus 10 more damage for each Energy card you discarded.",
 				fr: "Vous pouvez défausser jusqu'à 2 cartes Énergie Water de votre main. Cette attaque inflige alors 30 dégâts plus 10 dégâts supplémentaires pour chaque carte Énergie défaussée.",
-				de: "Du kannst bis zu 2 -Energiekarten von deiner Hand auf den Ablagestapel legen. Wenn du das machst, fügt dieser Angriff 30 Schadenspunkte plus 10 weitere Schadenspunkte für jede auf diese Weise auf den Ablagestapel gelegte Energiekarte zu."
+				de: "Du kannst bis zu 2 {W}-Energiekarten von deiner Hand auf den Ablagestapel legen. Wenn du das machst, fügt dieser Angriff 30 Schadenspunkte plus 10 weitere Schadenspunkte für jede auf diese Weise auf den Ablagestapel gelegte Energiekarte zu."
 			},
 			damage: "30+",
 
@@ -76,7 +77,8 @@ const card: Card = {
 
 	description: {
 		en: "Its spines provide protection. Its fins and bones are prized as traditional medicine ingredients.",
-		fr: "Son épine dorsale le protège. Ses os et ses nageoires sont très prisés en médecine traditionnelle."
+		fr: "Son épine dorsale le protège. Ses os et ses nageoires sont très prisés en médecine traditionnelle.",
+		de: "Seine Stacheln schützen es. Seine Flossen und Knochen werden bei der Herstellung von Medizin verwendet."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/71.ts
+++ b/data/Diamond & Pearl/Legends Awakened/71.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Staryu",
 		fr: "Sterndu",
+		de: "Sterndu"
 	},
 
 	stage: "Stage1",
@@ -55,7 +56,7 @@ const card: Card = {
 			name: {
 				en: "Core Flash",
 				fr: "Flash-coeur",
-				de: "Kernlitz"
+				de: "Kernblitz"
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon that has any Poké-Powers or Poké-Bodies. This attack does 50 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
@@ -75,7 +76,8 @@ const card: Card = {
 
 	description: {
 		en: "At the center of its body is a red core, which sends mysterious radio signals into the night sky.",
-		fr: "Un noyau rouge trône en son centre. Il envoie des signaux radio mystérieux vers le ciel nocturne."
+		fr: "Un noyau rouge trône en son centre. Il envoie des signaux radio mystérieux vers le ciel nocturne.",
+		de: "In der Körpermitte befindet sich ein roter Kern, der mysteriöse Radiowellen in die Nacht sendet."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/72.ts
+++ b/data/Diamond & Pearl/Legends Awakened/72.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gulpin",
 		fr: "Schluppuck",
+		de: "Schluppuck"
 	},
 
 	stage: "Stage1",
@@ -81,7 +82,8 @@ const card: Card = {
 
 	description: {
 		en: "It swallows anything whole. It sweats toxic fluids from its follicles to douse foes.",
-		fr: "Il avale tout en une bouchée. Ses follicules sécrètent des fluides toxiques qui endorment l'ennemi."
+		fr: "Il avale tout en une bouchée. Ses follicules sécrètent des fluides toxiques qui endorment l'ennemi.",
+		de: "Es verschluckt alles in einem Stück und sondert giftige Stoffe ab, mit denen es Gegner besprüht."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/73.ts
+++ b/data/Diamond & Pearl/Legends Awakened/73.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Taillow",
 		fr: "Schwalbini",
+		de: "Schwalbini"
 	},
 
 	stage: "Stage1",
@@ -85,7 +86,8 @@ const card: Card = {
 
 	description: {
 		en: "It circles the sky in search of prey. When it spots one, it dive steeply to catch the prey.",
-		fr: "Il vole en cercle en quête d'une proie. Dès qu'il l'a repérée, il fond sur elle en un éclair."
+		fr: "Il vole en cercle en quête d'une proie. Dès qu'il l'a repérée, il fond sur elle en un éclair.",
+		de: "Es fliegt auf der Suche nach Beute ständig umher. Findet es Beute, stürzt es sich im Sturzflug auf sie."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/74.ts
+++ b/data/Diamond & Pearl/Legends Awakened/74.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin for each Tauros you have in play. This attack does 20 damage times the number of heads.",
 				fr: "Lancez une pièce pour chaque Tauros que vous avez en jeu. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf für jedes Tauros, das du im Spiel hast, 1 Münze. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf für jedes Tauros, das du im Spiel hast, 1 Münze. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20x",
 
@@ -58,7 +58,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 40 damage plus 20 more damage. If tails, Tauros does 10 damage to itself.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 40 dégâts plus 20 dégâts supplémentaires. Si c'est pile, Tauros s'inflige 10 dégâts.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 40 Schadenspunkte plus 20 weitere Schadenspunkte zu. Bei \"Zahl\" fügt Tauros sich selbst 10 Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 40 Schadenspunkte plus 20 weitere Schadenspunkte zu. Bei „Zahl“ fügt Tauros sich selbst 10 Schadenspunkte zu."
 			},
 			damage: "40+",
 
@@ -76,7 +76,8 @@ const card: Card = {
 
 	description: {
 		en: "Once it takes aim at its foe, it makes a headlong charge. It is famous for its violent nature.",
-		fr: "Après avoir choisi sa cible, il fonce dessus tête baissée. Il est réputé pour sa nature violente."
+		fr: "Après avoir choisi sa cible, il fonce dessus tête baissée. Il est réputé pour sa nature violente.",
+		de: "Sobald es einen Gegner ins Visier genommen hat, rennt es mit dem Kopf voran auf ihn zu."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/75.ts
+++ b/data/Diamond & Pearl/Legends Awakened/75.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Tentacool",
 		fr: "Tentacha",
+		de: "Tentacha"
 	},
 
 	stage: "Stage1",
@@ -77,7 +78,8 @@ const card: Card = {
 
 	description: {
 		en: "With 80 tentacles for ensnaring victims, it prevents escape until the prey is weakened by poison.",
-		fr: "Ses 80 tentacules ligotent ses proies et les retiennent jusqu'à ce que son poison fasse effet."
+		fr: "Ses 80 tentacules ligotent ses proies et les retiennent jusqu'à ce que son poison fasse effet.",
+		de: "Es besitzt 80 Tentakel, um Beute zu fangen und festzuhalten. Diese wird durch Gift geschwächt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/76.ts
+++ b/data/Diamond & Pearl/Legends Awakened/76.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn, when you put Unown J from your hand onto your Bench, you may flip a coin. If heads, search your discard pile for a Trainer card, show it to your opponent, and put it into your hand.",
 				fr: "Une seule fois lors de votre tour, lorsque vous placez Zarbi J de votre main sur votre Banc, vous pouvez lancer une pièce. Si c'est face, choisissez dans votre pile de défausse une carte Dresseur, montrez-la à votre adversaire et placez-la dans votre main.",
-				de: "Einmal während deines Zuges kannst du, wenn du Icognito J von deiner Hand auf deine Bank legst, 1 Münze werfen. Bei \"Kopf\" durchsuche deinen Ablagestapel nach 1 Trainerkarte, zeige sie deinem Gegner und nimm sie auf die Hand."
+				de: "Einmal während deines Zuges kannst du, wenn du Icognito J von deiner Hand auf deine Bank legst, 1 Münze werfen. Bei „Kopf“ durchsuche deinen Ablagestapel nach 1 Trainerkarte, zeige sie deinem Gegner und nimm sie auf die Hand."
 			},
 		},
 	],
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "Remove the Special Condition Asleep from the Defending Pokémon.",
 				fr: "Retirez au Pokémon Défenseur l'État Spécial Endormi.",
-				de: "Entferne den Speziellen Zustand \"schlafend\" vom Verteidigenden Pokémon."
+				de: "Entferne den Speziellen Zustand „schlafend“ vom Verteidigenden Pokémon."
 			},
 			damage: 10,
 
@@ -72,7 +72,8 @@ const card: Card = {
 
 	description: {
 		en: "Shaped like an ancient writing, it is a huge mystery whether language or Unown came first.",
-		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou de ZARBI est apparu en premier."
+		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou de ZARBI est apparu en premier.",
+		de: "Seine Form sieht aus wie antike Schrift. Was war zuerst da? Die Sprache oder ICOGNITO?"
 	},
 
 	variants: [

--- a/data/Diamond & Pearl/Legends Awakened/77.ts
+++ b/data/Diamond & Pearl/Legends Awakened/77.ts
@@ -69,7 +69,8 @@ const card: Card = {
 
 	description: {
 		en: "Shaped like an ancient writing, it is a huge mystery whether language or Unown came first.",
-		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou de ZARBI est apparu en premier."
+		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou de ZARBI est apparu en premier.",
+		de: "Seine Form sieht aus wie antike Schrift. Was war zuerst da? Die Sprache oder ICOGNITO?"
 	},
 
 	variants: [

--- a/data/Diamond & Pearl/Legends Awakened/78.ts
+++ b/data/Diamond & Pearl/Legends Awakened/78.ts
@@ -71,7 +71,8 @@ const card: Card = {
 
 	description: {
 		en: "Shaped like an ancient writing, it is a huge mystery whether language or Unown came first.",
-		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou de Zarbi est apparu en premier."
+		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou de Zarbi est apparu en premier.",
+		de: "Seine Form sieht aus wie antike Schrift. Was war zuerst da? Die Sprache oder ICOGNITO?"
 	},
 
 	variants: [

--- a/data/Diamond & Pearl/Legends Awakened/79.ts
+++ b/data/Diamond & Pearl/Legends Awakened/79.ts
@@ -72,7 +72,8 @@ const card: Card = {
 
 	description: {
 		en: "Shaped like an ancient writing, it is a huge mystery whether language or Unown came first.",
-		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou de ZARBI est apparu en premier."
+		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou de ZARBI est apparu en premier.",
+		de: "Seine Form sieht aus wie antike Schrift. Was war zuerst da? Die Sprache oder ICOGNITO?"
 	},
 
 	variants: [

--- a/data/Diamond & Pearl/Legends Awakened/8.ts
+++ b/data/Diamond & Pearl/Legends Awakened/8.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Luxio",
 		fr: "Luxio",
+		de: "Luxio"
 	},
 
 	stage: "Stage2",
@@ -60,7 +61,7 @@ const card: Card = {
 			effect: {
 				en: "Search your discard pile for a Lightning Energy card and attach it to Luxray.",
 				fr: "Cherchez dans votre pile de défausse une carte Énergie Lightning et attachez-la à Luxray.",
-				de: "Durchsuche deinen Ablagestapel nach 1 -Energiekarte und lege sie an Luxtra an."
+				de: "Durchsuche deinen Ablagestapel nach 1 {L}-Energiekarte und lege sie an Luxtra an."
 			},
 			damage: 40,
 
@@ -79,7 +80,7 @@ const card: Card = {
 			effect: {
 				en: "Discard all Lightning Energy attached to Luxray.",
 				fr: "Défaussez une Énergie Lightning attachée à Luxray.",
-				de: "Lege alle an Luxtra angelegten -Energien auf deinen Ablagestapel."
+				de: "Lege alle an Luxtra angelegten {L}-Energien auf deinen Ablagestapel."
 			},
 			damage: 100,
 
@@ -102,7 +103,8 @@ const card: Card = {
 
 	description: {
 		en: "It has eyes that can see through anything. It spots and captures prey hiding behind objects.",
-		fr: "Ses yeux voient à travers tout. Il repère les proies cachées derrière un objet pour les capturer."
+		fr: "Ses yeux voient à travers tout. Il repère les proies cachées derrière un objet pour les capturer.",
+		de: "Mit seinen Augen kann es durch alles hindurch sehen. So findet es auch Beute, die sich versteckt hat."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/80.ts
+++ b/data/Diamond & Pearl/Legends Awakened/80.ts
@@ -74,7 +74,8 @@ const card: Card = {
 
 	description: {
 		en: "Shaped like an ancient writing, it is a huge mystery whether language or Unown came first.",
-		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou de ZARBI est apparu en premier."
+		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou de ZARBI est apparu en premier.",
+		de: "Seine Form sieht aus wie antike Schrift. Was war zuerst da? Die Sprache oder ICOGNITO?"
 	},
 
 	variants: [

--- a/data/Diamond & Pearl/Legends Awakened/81.ts
+++ b/data/Diamond & Pearl/Legends Awakened/81.ts
@@ -72,7 +72,8 @@ const card: Card = {
 
 	description: {
 		en: "Shaped like an ancient writing, it is a huge mystery whether language or Unown came first.",
-		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou de Zarbi est apparu en premier."
+		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou de Zarbi est apparu en premier.",
+		de: "Seine Form sieht aus wie antike Schrift. Was war zuerst da? Die Sprache oder ICOGNITO?"
 	},
 
 	variants: [

--- a/data/Diamond & Pearl/Legends Awakened/82.ts
+++ b/data/Diamond & Pearl/Legends Awakened/82.ts
@@ -69,7 +69,8 @@ const card: Card = {
 
 	description: {
 		en: "Shaped like ancient writing, it is a huge mystery whether language or Unown came first.",
-		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou de ZARBI est apparu en premier."
+		fr: "Il rappelle une écriture ancienne. Reste à savoir qui du langage ou de ZARBI est apparu en premier.",
+		de: "Seine Form sieht aus wie antike Schrift. Was war zuerst da? Die Sprache oder ICOGNITO?"
 	},
 
 	variants: [

--- a/data/Diamond & Pearl/Legends Awakened/83.ts
+++ b/data/Diamond & Pearl/Legends Awakened/83.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Once during your turn (before your attack), when you attach a Metal Energy card from your hand to Beldum (excluding effects of attacks or Poké-Powers), you may search your deck for Beldum and put it onto your Bench. Shuffle your deck afterward. This power can't be used if Beldum is affected by a Special Condition.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), lorsque vous attachez une carte Énergie Metal de votre main à Terhal (effets d'attaques ou Poké-Powers exclus), vous pouvez chercher Terhal dans votre deck et le placer sur votre Banc. Ensuite, mélangez votre deck. Ce pouvoir ne peut pas être utilisé si Terhal est affecté par un État Spécial.",
-				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn du 1 -Energiekarte von deiner Hand an Tanhel anlegst (ausgenommen durch Effekte von Angriffen oder Poké-Power), dein Deck nach 1 Tanhel-Karte durchsuchen und auf deine Bank legen. Mische dein Deck danach. Diese Poké-Power kann nicht benutzt werden, wenn Tanhel von einem Speziellen Zustand betroffen ist."
+				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn du 1 {M}-Energiekarte von deiner Hand an Tanhel anlegst (ausgenommen durch Effekte von Angriffen oder Poké-Power), dein Deck nach 1 Tanhel-Karte durchsuchen und auf deine Bank legen. Mische dein Deck danach. Diese Poké-Power kann nicht benutzt werden, wenn Tanhel von einem Speziellen Zustand betroffen ist."
 			},
 		},
 	],
@@ -80,7 +80,8 @@ const card: Card = {
 
 	description: {
 		en: "It converses with others by using magnetic pulses. In a swarm, they move in perfect unison.",
-		fr: "Il dialogue avec les siens par impulsions magnétiques. En bande, ils se déplacent à l'unisson."
+		fr: "Il dialogue avec les siens par impulsions magnétiques. En bande, ils se déplacent à l'unisson.",
+		de: "Es kommuniziert mit anderen durch magnetische Impulse. Im Schwarm bilden sie eine perfekte Einheit."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/84.ts
+++ b/data/Diamond & Pearl/Legends Awakened/84.ts
@@ -76,7 +76,8 @@ const card: Card = {
 
 	description: {
 		en: "It converses with others by using magnetic pulses. In a swarm, they move in perfect unison.",
-		fr: "Il dialogue avec les siens par impulsions magnétiques. En bande, ils se déplacent à l'unisson."
+		fr: "Il dialogue avec les siens par impulsions magnétiques. En bande, ils se déplacent à l'unisson.",
+		de: "Es kommuniziert mit anderen durch magnetische Impulse. Im Schwarm bilden sie eine perfekte Einheit."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/85.ts
+++ b/data/Diamond & Pearl/Legends Awakened/85.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon can't use any Poké-Powers during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur ne peut pas utiliser de Poké-Powers lors du prochain tour de votre adversaire.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" kann das Verteidigende Pokémon während des nächsten Zuges deines Gegners keine Poké-Power benutzen."
+				de: "Wirf 1 Münze. Bei „Kopf“ kann das Verteidigende Pokémon während des nächsten Zuges deines Gegners keine Poké-Power benutzen."
 			},
 
 		},
@@ -72,7 +72,8 @@ const card: Card = {
 
 	description: {
 		en: "It prefers hot and humid environments. It is quick at capturing prey with its vines.",
-		fr: "Il préfère les climats chauds et humides. Ses lianes peuvent capturer une proie en un clin d'œil."
+		fr: "Il préfère les climats chauds et humides. Ses lianes peuvent capturer une proie en un clin d'œil.",
+		de: "Es bevorzugt heiße und feuchte Umgebungen. Seine Beute fängt es blitzschnell mit seinen Ranken."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/86.ts
+++ b/data/Diamond & Pearl/Legends Awakened/86.ts
@@ -55,7 +55,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20x",
 
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "It slams foes by sharply uncoiling its rolled ears. It stings enough to make a grown-up cry in pain.",
-		fr: "Il frappe l'ennemi en déroulant violemment ses oreilles. Cela peut faire pleurer un adulte."
+		fr: "Il frappe l'ennemi en déroulant violemment ses oreilles. Cela peut faire pleurer un adulte.",
+		de: "Es entrollt seine Ohren sehr schnell, um seine Gegner schmerzhaft zu schlagen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/87.ts
+++ b/data/Diamond & Pearl/Legends Awakened/87.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt verwirrt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 
 		},
@@ -68,7 +68,8 @@ const card: Card = {
 
 	description: {
 		en: "It discharges positive and negative electricity from its antenna tips to shock its foes.",
-		fr: "Il envoie des décharges électriques positives et négatives du bout des antennes pour paralyser sa proie."
+		fr: "Il envoie des décharges électriques positives et négatives du bout des antennes pour paralyser sa proie.",
+		de: "Über seine Antennen entlädt es Elektrizität, mit der es seinen Gegnern einen Schlag versetzt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/88.ts
+++ b/data/Diamond & Pearl/Legends Awakened/88.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "If Chinchou has any Water Energy attached to it, this attack does 20 damage plus 10 more damage.",
 				fr: "Si Loupio possède de l'Énergie Water, cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires.",
-				de: "Wenn an Lampi mindestens 1 -Energie angelegt ist, fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu"
+				de: "Wenn an Lampi mindestens 1 {W}-Energie angelegt ist, fügt dieser Angriff 20 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "20+",
 
@@ -70,7 +70,8 @@ const card: Card = {
 
 	description: {
 		en: "It discharges positive and negative electricity from its antenna tips to shock its foes.",
-		fr: "Il envoie des décharges électriques positives et négatives du bout des antennes pour paralyser sa proie."
+		fr: "Il envoie des décharges électriques positives et négatives du bout des antennes pour paralyser sa proie.",
+		de: "Über seine Antennen entlädt es Elektrizität, mit der es seinen Gegnern einen Schlag versetzt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/89.ts
+++ b/data/Diamond & Pearl/Legends Awakened/89.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, choose 1 card from your opponent's hand without looking and discard it.",
 				fr: "Lancez une pièce. Si c'est face, choisissez sans regarder une carte de la main de votre adversaire et défaussez-la.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" wähle 1 Karte von der Hand deines Gegners (ohne sie vorher anzusehen) und lege sie auf seinen Ablagestapel."
+				de: "Wirf 1 Münze. Bei „Kopf“ wähle 1 Karte von der Hand deines Gegners (ohne sie vorher anzusehen) und lege sie auf seinen Ablagestapel."
 			},
 
 		},
@@ -69,7 +69,8 @@ const card: Card = {
 
 	description: {
 		en: "Its hardy vitality enables it to adapt to any environment. Its pincers will never release prey.",
-		fr: "Sa nature robuste lui permet de vivre sur n'importe quel terrain. Ses pinces ne lâchent jamais prise."
+		fr: "Sa nature robuste lui permet de vivre sur n'importe quel terrain. Ses pinces ne lâchent jamais prise.",
+		de: "Ein robustes PKMN, das sich jeder Umgebung anpassen kann. Seine Zangen geben keine Beute frei."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/9.ts
+++ b/data/Diamond & Pearl/Legends Awakened/9.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Piloswine",
 		fr: "Keifel",
+		de: "Keifel"
 	},
 
 	stage: "Stage2",
@@ -45,7 +46,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed and discard an Energy card attached to the Defending Pokémon.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé et défaussez une carte Énergie attachée au Pokémon Défenseur.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt gelähmt und lege 1 am Verteidigenden Pokémon angelegte Energiekarte auf den Ablagestapel deines Gegners."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt und lege 1 am Verteidigenden Pokémon angelegte Energiekarte auf den Ablagestapel deines Gegners."
 			},
 			damage: 40,
 
@@ -90,7 +91,8 @@ const card: Card = {
 
 	description: {
 		en: "Its impressive tusks are made of ice. The population thinned when it turned warm after the ice age.",
-		fr: "Ses défenses spectaculaires sont glacées. Il a failli disparaître dans la canicule suivant l'ère glaciaire."
+		fr: "Ses défenses spectaculaires sont glacées. Il a failli disparaître dans la canicule suivant l'ère glaciaire.",
+		de: "Die beeindruckenden Stoßzähne dieser PKMN sind aus Eis. Nach der Eiszeit nahm ihre Population ab."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/90.ts
+++ b/data/Diamond & Pearl/Legends Awakened/90.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20x",
 
@@ -77,7 +77,8 @@ const card: Card = {
 
 	description: {
 		en: "When it thinks of its dead mother, it cries. Its crying makes the skull it wears rattle hollowly.",
-		fr: "Il pleure en pensant à sa mère disparue, et ses larmes résonnent dans son crâne creux."
+		fr: "Il pleure en pensant à sa mère disparue, et ses larmes résonnent dans son crâne creux.",
+		de: "Denkt es an seine verstorbene Mutter, weint es, wobei der Schädel auf seinem Kopf hohl klingt."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/91.ts
+++ b/data/Diamond & Pearl/Legends Awakened/91.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			effect: {
 				en: "Flip 2 coins. This attack does 20 damage times the number of heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts multipliés par le nombre de faces.",
-				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl \"Kopf\" zu."
+				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "20x",
 
@@ -70,7 +70,8 @@ const card: Card = {
 
 	description: {
 		en: "It is called the \"Mirage Pokémon\" because so few have seen it. Its shed skin has been found.",
-		fr: "On l'appelle \"Pokémon mirage\" en raison de sa rareté. On a découvert sa mue."
+		fr: "On l'appelle \"Pokémon mirage\" en raison de sa rareté. On a découvert sa mue.",
+		de: "Man nennt es “Illusion-Pokémon”, denn nur wenige haben es gesehen. Nur seine Haut wurde oft gefunden."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/92.ts
+++ b/data/Diamond & Pearl/Legends Awakened/92.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt verwirrt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt."
 			},
 			damage: 10,
 
@@ -77,7 +77,8 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon formed by the spirits of people and Pokémon. It loves damp, humid seasons.",
-		fr: "Un Pokémon né de l'esprit des gens et des Pokémon. Il aime les saisons chaudes et humides."
+		fr: "Un Pokémon né de l'esprit des gens et des Pokémon. Il aime les saisons chaudes et humides.",
+		de: "Ein PKMN, entstanden aus den Gefühlen von Menschen und PKMN. Es mag feuchte Jahreszeiten."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/93.ts
+++ b/data/Diamond & Pearl/Legends Awakened/93.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Search your deck for up to 2 in any combination of Grass Basic Pokémon and Psychic Basic Pokémon and put them onto your Bench. Shuffle your deck afterward.",
 				fr: "Choisissez dans votre deck n'importe quelle combinaison de jusqu'à 2 Pokémon de base Grass et Pokémon de base Psychic et placez-les sur votre Banc. Ensuite, mélangez votre deck.",
-				de: "Durchsuche dein Deck nach bis zu 2 Karten in beliebiger Kombination aus - und -Basis-Pokémon-Karten und lege sie auf deine Bank. Mische dein Deck danach."
+				de: "Durchsuche dein Deck nach bis zu 2 Karten in beliebiger Kombination aus {G}- und {P}-Basis-Pokémon-Karten und lege sie auf deine Bank. Mische dein Deck danach."
 			},
 
 		},
@@ -72,7 +72,8 @@ const card: Card = {
 
 	description: {
 		en: "Its six eggs converse using telepathy. They can quickly gather if they become separated.",
-		fr: "Ces six œufs communiquent par télépathie. Ils peuvent se réunir rapidement si on les sépare."
+		fr: "Ces six œufs communiquent par télépathie. Ils peuvent se réunir rapidement si on les sépare.",
+		de: "Die sechs Eier kommunizieren telepathisch. Werden sie getrennt, finden sie sich schnell wieder."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/94.ts
+++ b/data/Diamond & Pearl/Legends Awakened/94.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing. If heads, the Defending Pokémon is now Poisoned.",
 				fr: "Lancez une pièce. Si c'est pile, cette attaque est sans effet. Si c'est face, le Pokémon Défenseur est maintenant Empoisonné.",
-				de: "Wirf 1 Münze. Bei \"Zahl\" hat dieser Angriff keine Auswirkungen. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt vergiftet."
+				de: "Wirf 1 Münze. Bei „Zahl“ hat dieser Angriff keine Auswirkungen. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet."
 			},
 			damage: 10,
 
@@ -53,7 +53,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 10 more damage.",
 				fr: "Lancez une pièce. Si c'est face, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
+				de: "Wirf 1 Münze. Bei „Kopf“ fügt dieser Angriff 10 Schadenspunkte plus 10 weitere Schadenspunkte zu."
 			},
 			damage: "10+",
 
@@ -78,7 +78,8 @@ const card: Card = {
 
 	description: {
 		en: "It sails on the winds with its limbs extended to strike from the sky. It aims for the prey's face.",
-		fr: "Il chevauche les vents en tendant ses membres pour frapper depuis le ciel. Il vise toujours au visage."
+		fr: "Il chevauche les vents en tendant ses membres pour frapper depuis le ciel. Il vise toujours au visage.",
+		de: "Es segelt durch die Lüfte und breitet seine Gliedmaßen aus, um aus der Luft anzugreifen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/95.ts
+++ b/data/Diamond & Pearl/Legends Awakened/95.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Empoisonné.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt vergiftet."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt vergiftet."
 			},
 
 		},
@@ -76,7 +76,8 @@ const card: Card = {
 
 	description: {
 		en: "It sails on the winds with its limbs extended to strike from the sky. It aims for the prey's face.",
-		fr: "Il chevauche les vents en tendant ses membres pour frapper depuis le ciel. Il vise toujours au visage."
+		fr: "Il chevauche les vents en tendant ses membres pour frapper depuis le ciel. Il vise toujours au visage.",
+		de: "Es segelt durch die Lüfte und breitet seine Gliedmaßen aus, um aus der Luft anzugreifen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/96.ts
+++ b/data/Diamond & Pearl/Legends Awakened/96.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Oddish",
 		fr: "Myrapla",
+		de: "Myrapla"
 	},
 
 	stage: "Stage1",
@@ -78,7 +79,8 @@ const card: Card = {
 
 	description: {
 		en: "The honey it drools from its mouth smells so atrocious, it can curl noses more than a mile away.",
-		fr: "L'odeur du nectar de sa bouche est si répugnante qu'elle agresse les narines à deux kilomètres."
+		fr: "L'odeur du nectar de sa bouche est si répugnante qu'elle agresse les narines à deux kilomètres.",
+		de: "Der Honig, den es abgibt, riecht so entsetzlich, dass sich sogar Nasen in 2 km Entfernung rümpfen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/97.ts
+++ b/data/Diamond & Pearl/Legends Awakened/97.ts
@@ -26,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Oddish",
 		fr: "Myrapla",
+		de: "Myrapla"
 	},
 
 	stage: "Stage1",
@@ -58,7 +59,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Confused and Poisoned.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Confus et Empoisonné.",
-				de: "Wirf 1 Münze. Bei \"Kopf\" ist das Verteidigende Pokémon jetzt verwirrt und vergiftet."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt verwirrt und vergiftet."
 			},
 			damage: 30,
 
@@ -76,7 +77,8 @@ const card: Card = {
 
 	description: {
 		en: "The honey it drools from its mouth smells so atrocious, it can curl noses more than a mile away.",
-		fr: "L'odeur du nectar de sa bouche est si répugnante qu'elle agresse les narines à deux kilomètres."
+		fr: "L'odeur du nectar de sa bouche est si répugnante qu'elle agresse les narines à deux kilomètres.",
+		de: "Der Honig, den es abgibt, riecht so entsetzlich, dass sich sogar Nasen in 2 km Entfernung rümpfen."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/98.ts
+++ b/data/Diamond & Pearl/Legends Awakened/98.ts
@@ -54,7 +54,7 @@ const card: Card = {
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé.",
-				de: "Wirf 1 Münze. Bei 'Kopf' ist das Verteidigende Pokémon jetzt gelähmt."
+				de: "Wirf 1 Münze. Bei „Kopf“ ist das Verteidigende Pokémon jetzt gelähmt."
 			},
 
 		},
@@ -71,7 +71,8 @@ const card: Card = {
 
 	description: {
 		en: "Almost all its body is its stomach. Its harsh digestive juices quickly dissolve anything it swallows.",
-		fr: "Il est principalement composé d'un estomac dont les sucs digestifs dissolvent tout ce qu'il avale."
+		fr: "Il est principalement composé d'un estomac dont les sucs digestifs dissolvent tout ce qu'il avale.",
+		de: "Sein Körper besteht fast nur aus Magen. Seine starken Verdauungssäfte zersetzen alles sehr schnell."
 	},
 
 	thirdParty: {

--- a/data/Diamond & Pearl/Legends Awakened/99.ts
+++ b/data/Diamond & Pearl/Legends Awakened/99.ts
@@ -73,7 +73,8 @@ const card: Card = {
 
 	description: {
 		en: "The arm-twisting punches it throws pulverize even concrete. It rests after three minutes of fighting.",
-		fr: "Même le béton cède sous ses poings dévastateurs. Au combat, il s'essouffle au bout de 3 minutes."
+		fr: "Même le béton cède sous ses poings dévastateurs. Au combat, il s'essouffle au bout de 3 minutes.",
+		de: "Die Schläge, die es austeilt, können Beton pulverisieren. Es muss sich im Kampf alle 3 Minuten ausruhen."
 	},
 
 	thirdParty: {


### PR DESCRIPTION
## Add missing German translations for dp6

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
