### PR TITLE
Add missing German translations for neo4

### DIFF
--- a/data/Neo/Neo Destiny/50.ts
+++ b/data/Neo/Neo Destiny/50.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			name: {
 				en: "Guiding Flame",
 				fr: "Flambeau",
-				de: "Fire Blast"
+				de: "Leitende Flamme"
 			},
 
 			effect: {

--- a/data/Neo/Neo Destiny/51.ts
+++ b/data/Neo/Neo Destiny/51.ts
@@ -56,7 +56,7 @@ const card: Card = {
 			name: {
 				en: "Slash About",
 				fr: "Grosse trempette",
-				de: "Splash About"
+				de: "Herumspritzen"
 			},
 			effect: {
 				en: "If there are more Energy cards attached to the Defending Pokémon than to Light Slowbro, this attack does 20 damage plus 20 more damage. If not, this attack does 20 damage.",

--- a/data/Neo/Neo Destiny/90.ts
+++ b/data/Neo/Neo Destiny/90.ts
@@ -44,7 +44,7 @@ const card: Card = {
 			name: {
 				en: "Poisonpowder",
 				fr: "Poudre toxik",
-				de: "Poison Barb"
+				de: "Giftpuder"
 			},
 			effect: {
 				en: "The Defending Pokémon is now Poisoned.",


### PR DESCRIPTION
## Add missing German translations for neo4

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
