### PR TITLE
Add missing German translations for ex3

### DIFF
--- a/data/EX/Dragon/94.ts
+++ b/data/EX/Dragon/94.ts
@@ -56,7 +56,7 @@ const card: Card = {
 			effect: {
 				en: "Discard 3 Energy attached to Latios ex.",
 				fr: "Défaussez trois Énergies attachées à Latios ex.",
-				de: "Discard 3 Energy attach to Latios EX"
+				de: "Entferne 3 an Latios ex angelegte Energiekarten und lege sie auf deinen Ablagestapel."
 			},
 			damage: 100,
 


### PR DESCRIPTION
## Add missing German translations for ex3

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
