### PR TITLE
Add missing German translations for g1

### DIFF
--- a/data/XY/Generations/67.ts
+++ b/data/XY/Generations/67.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Poké Ball",
 		fr: "Poké Ball",
+		de: "Pokéball"
 	},
 
 	illustrator: "5ban Graphics",

--- a/data/XY/Generations/81.ts
+++ b/data/XY/Generations/81.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Darkness Energy",
 		fr: "Énergie Darkness de base",
+		de: "Finsternis-Energie"
 	},
 
 	illustrator: undefined,

--- a/data/XY/Generations/82.ts
+++ b/data/XY/Generations/82.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Metal Energy",
 		fr: "Énergie Metal de base",
+		de: "Metall-Energie"
 	},
 
 	illustrator: undefined,

--- a/data/XY/Generations/RC30.ts
+++ b/data/XY/Generations/RC30.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Gardevoir EX",
 		fr: "Gardevoir-EX",
+		de: "Guardevoir-EX"
 	},
 
 	illustrator: "Mizue",

--- a/data/XY/Generations/RC31.ts
+++ b/data/XY/Generations/RC31.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "M Gardevoir EX",
 		fr: "M-Gardevoir-EX",
+		de: "M-Guardevoir-EX"
 	},
 	illustrator: "Megumi Mizutani",
 	rarity: "Ultra Rare",


### PR DESCRIPTION
## Add missing German translations for g1

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
