### PR TITLE
Add missing German translations for sm3.5

### DIFF
--- a/data/Sun & Moon/Shining Legends/1.ts
+++ b/data/Sun & Moon/Shining Legends/1.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "A strange seed was planted on its back at birth. The plant sprouts and grows with this Pokémon.",
+		de: "Dieses Pokémon trägt von Geburt an einen Samen auf dem Rücken, der mit ihm keimt und wächst."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/11.ts
+++ b/data/Sun & Moon/Shining Legends/11.ts
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "Coal is the source of Torkoal's energy. Large amounts of coal can be found in the mountains where they live.",
+		de: "Kohle ist die Quelle seiner Energie. Ein Glück, dass in den von Qurtel bewohnten Bergen große Kohlevorkommen schlummern."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/12.ts
+++ b/data/Sun & Moon/Shining Legends/12.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "Said to have been born from the sun, it spews fire from its horns and encases itself in a cocoon of fire when it evolves.",
+		de: "Es heißt, es sei ein Produkt der Sonne. Wenn es sich entwickelt, hüllt es sich in Flammen, die es aus seinen Hörnern bläst."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/13.ts
+++ b/data/Sun & Moon/Shining Legends/13.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Larvesta",
 		fr: "Pyronille",
+		de: "Ignivor"
 	},
 
 	stage: "Stage1",
@@ -86,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "A sea of fire engulfs the surroundings of their battles, since they use their six wings to scatter their ember scales.",
+		de: "Schüttelt sich glühenden Staub aus seinen sechs Flügeln und verwandelt das Umfeld in ein einziges Meer aus Flammen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/14.ts
+++ b/data/Sun & Moon/Shining Legends/14.ts
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "This legendary Pokémon can scorch the world with fire. It helps those who want to build a world of truth.",
+		de: "Ein Legendäres Pokémon mit der Macht, die Welt mit seinen Flammen einzuäschern. Hilft allen, die nach Wirklichkeit streben."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/15.ts
+++ b/data/Sun & Moon/Shining Legends/15.ts
@@ -58,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "While grooming itself, it builds up fur inside its stomach. It sets the fur alight and spews fiery attacks, which change based on how it coughs.",
+		de: "Es verbrennt Haare, die es bei der Körperpflege verschluckt hat, indem es Feuer speit. Die Flammen variieren je nach Art des Speiens."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/16.ts
+++ b/data/Sun & Moon/Shining Legends/16.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Litten",
 		fr: "Flamiaou",
+		de: "Flamiau"
 	},
 
 	stage: "Stage1",
@@ -86,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "At its throat, it bears a bell of fire. The bell rings brightly whenever this Pokémon spits fire.",
+		de: "Es trägt ein feuriges Glöckchen um den Hals. Immer, wenn es Flammen ausstößt, ertönt ein helles Läuten."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/17.ts
+++ b/data/Sun & Moon/Shining Legends/17.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Torracat",
 		fr: "Matoufeu",
+		de: "Miezunder"
 	},
 
 	stage: "Stage2",
@@ -78,7 +79,7 @@ const card: Card = {
 				es: "Descarta todas las Energías Fire de este Pokémon.",
 				it: "Scarta tutte le Energie Fire assegnate a questo Pokémon.",
 				pt: "Descarte todas as Energias Fire deste Pokémon.",
-				de: "Lege alle Fire-Energien von diesem Pokémon auf deinen Ablagestapel."
+				de: "Lege alle {R}-Energien von diesem Pokémon auf deinen Ablagestapel."
 			},
 			damage: 180,
 
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon has a violent, selfish disposition. If it's not in the mood to listen, it will ignore its Trainer's orders with complete nonchalance.",
+		de: "Ein raues und selbstsüchtiges Pokémon. Wenn es keine Lust hat, ignoriert es auch schon mal die Befehle seines Trainers."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/18.ts
+++ b/data/Sun & Moon/Shining Legends/18.ts
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "It is small but rough and tough. It won't hesitate to take a bite out of anything that moves.",
+		de: "Es ist klein, aber zäh und stark. Es zögert nicht, jeden anzugreifen, wenn dieser ihm zu nahe kommt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/19.ts
+++ b/data/Sun & Moon/Shining Legends/19.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Totodile",
 		fr: "Kaiminus",
+		de: "Karnimani"
 	},
 
 	stage: "Stage1",
@@ -87,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "If it loses a fang, a new one grows back in its place. There are always 48 fangs lining its mouth.",
+		de: "Verliert es einen seiner Zähne, wächst ein neuer nach. Es hat immer 48 Zähne in seinem Kiefer."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/2.ts
+++ b/data/Sun & Moon/Shining Legends/2.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Bulbasaur",
 		fr: "Bulbizarre",
+		de: "Bisasam"
 	},
 
 	stage: "Stage1",
@@ -90,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "There is a plant bulb on its back. When it absorbs nutrients, the bulb is said to blossom into a large flower.",
+		de: "Es trägt eine Knospe auf seinem Rücken. Nimmt es Nahrung zu sich, soll aus der Knospe eine große blühende Blume werden."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/20.ts
+++ b/data/Sun & Moon/Shining Legends/20.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Croconaw",
 		fr: "Crocrodil",
+		de: "Tyracroc"
 	},
 
 	stage: "Stage2",
@@ -91,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "It usually moves slowly, but it goes at blinding speed when it attacks and bites prey.",
+		de: "Eigentlich bewegt es sich langsam, doch seine Beute greift es blitzschnell an."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/21.ts
+++ b/data/Sun & Moon/Shining Legends/21.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "To fire its poison spikes, it must inflate its body by drinking over 2.6 gallons of water all at once.",
+		de: "Um seine Giftstacheln abzufeuern, muss es seinen Körper aufpumpen, indem es 10 l trinkt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/22.ts
+++ b/data/Sun & Moon/Shining Legends/22.ts
@@ -76,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "It swims by rotating its two tails like a screw. When it dives, its flotation sac collapses.",
+		de: "Es schwimmt, indem es seine beiden Schweife wie eine Schiffsschraube rotieren lässt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/23.ts
+++ b/data/Sun & Moon/Shining Legends/23.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Buizel",
 		fr: "Mustébouée",
+		de: "Bamelin"
 	},
 
 	stage: "Stage1",
@@ -88,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "It floats using its well-developed flotation sac. It assists in the rescues of drowning people.",
+		de: "Es treibt mithilfe einer Art Rettungsring auf dem Wasser und hilft dem, der zu ertrinken droht."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/24.ts
+++ b/data/Sun & Moon/Shining Legends/24.ts
@@ -84,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said to live in a gap in the spatial dimension parallel to ours. It appears in mythology.",
+		de: "Man sagt, es lebe in einem Spalt in einer Paralleldimension. Es wird in der Mythologie erwähnt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/25.ts
+++ b/data/Sun & Moon/Shining Legends/25.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Una vez durante tu turno (antes de tu ataque), puedes curar 20 puntos de daño a 1 de tus Pokémon que tenga alguna Energía Water unida a él.",
 				it: "Una sola volta durante il tuo turno, prima di attaccare, puoi curare da 20 danni uno dei tuoi Pokémon che ha Energie Water assegnate.",
 				pt: "Uma vez durante a sua vez de jogar (antes de atacar), você pode curar 20 pontos de dano de 1 dos seus Pokémon que tiver alguma Energia Water ligada a ele.",
-				de: "Einmal während deines Zuges (bevor du angreifst) kannst du 20 Schadenspunkte bei 1 deiner Pokémon heilen, an das mindestens 1 Water-Energie angelegt ist."
+				de: "Einmal während deines Zuges (bevor du angreifst) kannst du 20 Schadenspunkte bei 1 deiner Pokémon heilen, an das mindestens 1 {W}-Energie angelegt ist."
 			},
 		},
 	],
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "It is born with a wondrous power that lets it bond with any kind of Pokémon.",
+		de: "Es wird mit einer wundersamen Kraft geboren, die eine Bindung zu jedem anderen Pokémon möglich macht."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/26.ts
+++ b/data/Sun & Moon/Shining Legends/26.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Pon 1 Pokémon Water de tu pila de descartes en tu mano.",
 				it: "Prendi un Pokémon Water dalla tua pila degli scarti e aggiungilo alle carte che hai in mano.",
 				pt: "Coloque 1 Pokémon Water da sua pilha de descarte na sua mão.",
-				de: "Nimm 1 Water-Pokémon aus deinem Ablagestapel auf deine Hand."
+				de: "Nimm 1 {W}-Pokémon aus deinem Ablagestapel auf deine Hand."
 			},
 
 		},
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It crosses the world, running over the surfaces of oceans and rivers. It appears at scenic waterfronts.",
+		de: "Es kann auf dem Wasser laufen und reist auf Flüssen und Meeren um die Welt. Zu sehen in malerischen Küstengebieten."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/27.ts
+++ b/data/Sun & Moon/Shining Legends/27.ts
@@ -92,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "It lets out billows of steam and disappears into the dense fog. It's said to live in mountains where humans do not tread.",
+		de: "Es stößt Wasserdampf aus und versteckt sich im dadurch entstehenden dichten Nebel. Es lebt in Bergen, die von Menschen gemieden werden."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/28.ts
+++ b/data/Sun & Moon/Shining Legends/28.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "A plan was recently announced to gather many Pikachu and make an electric power plant.",
+		de: "Vor Kurzem wurden Pläne verkündet, mithilfe einer großen Anzahl an Pikachu ein ganzes Kraftwerk zu betreiben."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/29.ts
+++ b/data/Sun & Moon/Shining Legends/29.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pikachu",
 		fr: "Pikachu",
+		de: "Pikachu"
 	},
 
 	suffix: "GX",
@@ -53,7 +54,7 @@ const card: Card = {
 				es: "Este ataque hace 20 puntos de daño más por cada Energía Lightning unida a tus Pokémon.",
 				it: "Questo attacco infligge 20 danni in più per ogni Energia Lightning assegnata ai tuoi Pokémon.",
 				pt: "Este ataque causa 20 pontos de dano a mais vezes a quantidade de Energia Lightning ligada aos seus Pokémon.",
-				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der an deine Pokémon angelegten Lightning-Energien zu."
+				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der an deine Pokémon angelegten {L}-Energien zu."
 			},
 			damage: "20+",
 
@@ -95,7 +96,7 @@ const card: Card = {
 				es: "Colavoltio GX",
 				it: "Coda Voltaica-GX",
 				pt: "Cauda Voltaica GX",
-				de: "Voltschweif GX"
+				de: "Voltschweif-GX"
 			},
 			effect: {
 				en: "Your opponent’s Active Pokémon is now Paralyzed. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Shining Legends/3.ts
+++ b/data/Sun & Moon/Shining Legends/3.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Ivysaur",
 		fr: "Herbizarre",
+		de: "Bisaknosp"
 	},
 
 	stage: "Stage2",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Cada Energía Grass Básica unida a tus Pokémon proporciona Energía GrassGrass. No puedes aplicar más de 1 habilidad Dominio de la Selva a la vez.",
 				it: "Ogni Energia base Grass assegnata ai tuoi Pokémon fornisce GrassGrass. Può essere applicata solo un’abilità Signore della Giungla alla volta.",
 				pt: "Cada Energia Grass básica ligada aos seus Pokémon fornece Energias GrassGrass. Você não pode usar mais de 1 Habilidade Totem da Selva por vez.",
-				de: "Jede an deine Pokémon angelegte Grass-Basis-Energie liefert GrassGrass-Energie. Du kannst immer nur jeweils 1 Fähigkeit Dschungelherrschaft einsetzen."
+				de: "Jede an deine Pokémon angelegte {G}-Basis-Energie liefert {G}{G}-Energie. Du kannst immer nur jeweils 1 Fähigkeit Dschungelherrschaft einsetzen."
 			},
 		},
 	],
@@ -88,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "By spreading the broad petals of its flower and catching the sun's rays, it fills its body with power.",
+		de: "Es spreizt die breiten Blätter seiner Blüte, um seinen Körper mit Sonnenenergie zu durchfluten."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/30.ts
+++ b/data/Sun & Moon/Shining Legends/30.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It was discovered when Poké Balls were introduced. It is said that there is some connection.",
+		de: "Es wurde entdeckt, als man Pokébälle einführte. Es scheint, als gäbe es da einen Zusammenhang."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/31.ts
+++ b/data/Sun & Moon/Shining Legends/31.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Voltorb",
 		fr: "Voltorbe",
+		de: "Voltobal"
 	},
 
 	stage: "Stage1",
@@ -77,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "It explodes in response to even minor stimuli. It is feared, with the nickname of \"The Bomb Ball.\"",
+		de: "Es explodiert schon bei kleinsten Reizen. Sein Spitzname „Die Bombenkugel“ spiegelt die Furcht der Menschen wider."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/32.ts
+++ b/data/Sun & Moon/Shining Legends/32.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Une 1 carta de Energía Lightning de tu pila de descartes a 1 de tus Pokémon en Banca.",
 				it: "Assegna a uno dei tuoi Pokémon in panchina una carta Energia Lightning dalla tua pila degli scarti.",
 				pt: "Ligue 1 carta de Energia Lightning da sua pilha de descarte a 1 dos seus Pokémon no Banco.",
-				de: "Lege 1 Lightning-Energiekarte aus deinem Ablagestapel an 1 Pokémon auf deiner Bank an."
+				de: "Lege 1 {L}-Energiekarte aus deinem Ablagestapel an 1 Pokémon auf deiner Bank an."
 			},
 			damage: 30,
 
@@ -90,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "The rain clouds it carries let it fire thunderbolts at will. They say that it descended with lightning.",
+		de: "Die Regenwolken, die es trägt, ermöglichen es ihm, Gewitter zu erzeugen. Es strotzt vor Blitzen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/33.ts
+++ b/data/Sun & Moon/Shining Legends/33.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "It cheers on friends with pom-poms made of sparks. It drains power from telephone poles.",
+		de: "Es feuert Freunde mit Pompons an, die aus Funken besteht. Es holt sich Energie aus Telegrafenmasten."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/34.ts
+++ b/data/Sun & Moon/Shining Legends/34.ts
@@ -94,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "Exposure to electricity from Minun and Plusle promotes blood circulation and relaxes muscles.",
+		de: "Mit elektrischen Schlägen regen Plusle und Minun den Blutkreislauf an und lösen so Verspannungen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/35.ts
+++ b/data/Sun & Moon/Shining Legends/35.ts
@@ -98,6 +98,7 @@ const card: Card = {
 
 	description: {
 		en: "This legendary Pokémon can scorch the world with lightning. It assists those who want to build an ideal world.",
+		de: "Ein Legendäres Pokémon mit der Macht, die Welt durch Donner einzuäschern. Hilft allen, die einer Welt der Wünsche harren."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/36.ts
+++ b/data/Sun & Moon/Shining Legends/36.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "The older it gets, the longer it grows. At night, it wraps its long body around tree branches to rest.",
+		de: "Mit dem Alter wird der Körper dieses Pokémon immer länger. Es schläft um Äste gewickelt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/37.ts
+++ b/data/Sun & Moon/Shining Legends/37.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Ekans",
 		fr: "Abo",
+		de: "Rettan"
 	},
 
 	stage: "Stage1",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "The pattern on its belly appears to be a frightening face. Weak foes will flee just at the sight of the pattern.",
+		de: "Das Muster auf seinem Bauch ähnelt einer Fratze. Schwache Gegner nehmen bereits beim Anblick Reißaus."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/38.ts
+++ b/data/Sun & Moon/Shining Legends/38.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It wiggles its hips as it walks. It can cause people to dance in unison with it.",
+		de: "Der beschwingte Gang dieses Pokémon bezaubert Zuschauer und lässt sie im Takt dazu tanzen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/39.ts
+++ b/data/Sun & Moon/Shining Legends/39.ts
@@ -88,7 +88,7 @@ const card: Card = {
 				es: "Onda Mental GX",
 				it: "Psicobotta-GX",
 				pt: "Golpe Psíquico GX",
-				de: "Psychostoß GX"
+				de: "Psychostoß-GX"
 			},
 			effect: {
 				en: "This attack’s damage isn’t affected by any effects on your opponent’s Active Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Shining Legends/4.ts
+++ b/data/Sun & Moon/Shining Legends/4.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "It prefers damp places. By day it remains still in the forest shade. It releases toxic powder from its head.",
+		de: "Es bevorzugt feuchte Orte. Am Tag sitzt es regungslos im Schatten des Waldes. Von seinem Kopf sondert es einen giftigen Puder ab."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/40.ts
+++ b/data/Sun & Moon/Shining Legends/40.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "Because it can use all kinds of moves, many scientists believe Mew to be the ancestor of Pokémon.",
+		de: "Es beherrscht alle möglichen Attacken, daher sieht man in ihm den Vorfahren aller Pokémon."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/41.ts
+++ b/data/Sun & Moon/Shining Legends/41.ts
@@ -84,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "A highly intelligent Pokémon. By folding back its wings in flight, it can overtake jet planes.",
+		de: "Ein hochintelligentes Pokémon. Wenn es im Flug seine Flügel nach hinten legt, ist es schneller als ein Jet."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/42.ts
+++ b/data/Sun & Moon/Shining Legends/42.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "Generations have believed that any wish written on a note on its head will come true when it awakens.",
+		de: "Wenn Jirachi erwacht, erfüllt es die Wünsche, die man auf die Zettel an seinem Kopf geschrieben hat."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/43.ts
+++ b/data/Sun & Moon/Shining Legends/43.ts
@@ -67,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "The energy that burns inside it enables it to move, but no one has yet been able to identify this energy.",
+		de: "Es wird durch eine Energie angetrieben, die seinem Körper entspringt. Keiner weiß jedoch, woher diese Energie stammt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/44.ts
+++ b/data/Sun & Moon/Shining Legends/44.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Golett",
 		fr: "Gringolem",
+		de: "Golbit"
 	},
 
 	stage: "Stage1",
@@ -98,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "It is said that Golurk were ordered to protect people and Pokémon by the ancient people who made them.",
+		de: "Man munkelt, sein Schöpfer habe ihm aufgetragen, schützend über Pokémon und Menschen zu wachen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/45.ts
+++ b/data/Sun & Moon/Shining Legends/45.ts
@@ -95,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "Able to conceal itself in shadows, it never appears before humans, so its very existence was the stuff of myth.",
+		de: "Da es sich im Schatten verbergen und so für menschliche Augen unsichtbar werden kann, war seine Existenz lange bezweifelt worden."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/46.ts
+++ b/data/Sun & Moon/Shining Legends/46.ts
@@ -84,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "Its skin is very hard, so it is unhurt even if stepped on by sumo wrestlers. It smiles when transmitting electricity.",
+		de: "Dank seiner dicken Haut hält es selbst das Gewicht eines Sumoringers aus. Wenn es Stromschläge verteilt, grinst es."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/47.ts
+++ b/data/Sun & Moon/Shining Legends/47.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "A Pokémon that was formed by 108 spirits. It is bound to a fissure in an odd keystone.",
+		de: "Ein Pokémon, das aus 108 Geistern besteht. Es ist an einen Spalt in einem mysteriösen Stein gebunden."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/48.ts
+++ b/data/Sun & Moon/Shining Legends/48.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "Its cute act is a ruse. When victims let down their guard, they find their items taken. It attacks with sharp claws.",
+		de: "Es lenkt die Menschen durch sein süßes Verhalten ab, um sie zu bestehlen. Ist es wütend, kratzt es gern mal."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/49.ts
+++ b/data/Sun & Moon/Shining Legends/49.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Purrloin",
 		fr: "Chacripan",
+		de: "Felilou"
 	},
 
 	stage: "Stage1",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "Their beautiful form comes from the muscles they have developed. They run silently in the night.",
+		de: "Sein anmutiges Auftreten verdankt es den Muskeln, die es entwickelt hat. Es prescht lautlos durch die Nacht."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/5.ts
+++ b/data/Sun & Moon/Shining Legends/5.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Shroomish",
 		fr: "Balignon",
+		de: "Knilz"
 	},
 
 	stage: "Stage1",
@@ -87,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Its short arms stretch when it throws punches. Its technique is equal to that of pro boxers.",
+		de: "Seine kurzen Arme dehnen sich aus, wenn es zuschlägt. Seine Technik ähnelt der von Profi-Boxern."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/50.ts
+++ b/data/Sun & Moon/Shining Legends/50.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Its skin has a rubbery elasticity, so it can reduce damage by defensively pulling its skin up to its neck.",
+		de: "Es zieht seine gummiartige Haut bis zum Hals hinauf und nimmt eine Abwehrhaltung ein, um sich vor Schaden zu schützen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/51.ts
+++ b/data/Sun & Moon/Shining Legends/51.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Scraggy",
 		fr: "Baggiguane",
+		de: "Zurrokex"
 	},
 
 	stage: "Stage1",
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "It pulls up its shed skin to protect itself while it kicks. The bigger the crest, the more respected it is.",
+		de: "Es wehrt Angriffe mit seiner alten Haut ab und kontert mit Tritten. Sein Ego entspricht der Größe seines Kamms."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/52.ts
+++ b/data/Sun & Moon/Shining Legends/52.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "It changes so it looks like its foe, tricks it, and then uses that opportunity to flee.",
+		de: "Nicht selten überrumpelt es Gegner, indem es ihre Gestalt annimmt und den Überraschungseffekt zur Flucht nutzt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/53.ts
+++ b/data/Sun & Moon/Shining Legends/53.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Zorua",
 		fr: "Zorua",
+		de: "Zorua"
 	},
 
 	suffix: "GX",
@@ -91,7 +92,7 @@ const card: Card = {
 				es: "Ilusionista GX",
 				it: "Illusionista-GX",
 				pt: "Traquino GX",
-				de: "Trickser GX"
+				de: "Trickser-GX"
 			},
 			effect: {
 				en: "Choose 1 of your opponent’s Pokémon’s attacks and use it as this attack. (You can’t use more than 1 GX attack in a game.)",
@@ -99,7 +100,7 @@ const card: Card = {
 				es: "Elige 1 de los ataques de los Pokémon de tu rival y úsalo para este ataque. (No puedes usar más de 1 ataque GX en una partida).",
 				it: "Scegli uno degli attacchi dei Pokémon del tuo avversario e usalo al posto di questo attacco. Non puoi usare più di un attacco GX a partita.",
 				pt: "Escolha 1 ataque dos Pokémon do seu oponente e use-o como este ataque (você não pode usar mais de 1 ataque GX por partida).",
-				de: "Wähle 1 Attacke der Pokémon deines Gegners und setze sie als diese Attacke ein.  (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
+				de: "Wähle 1 Attacke der Pokémon deines Gegners und setze sie als diese Attacke ein. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Shining Legends/54.ts
+++ b/data/Sun & Moon/Shining Legends/54.ts
@@ -73,7 +73,7 @@ const card: Card = {
 				es: "Une 1 carta de Energía Darkness de tu pila de descartes a 1 de tus Pokémon en Banca.",
 				it: "Assegna a uno dei tuoi Pokémon in panchina una carta Energia Darkness dalla tua pila degli scarti.",
 				pt: "Ligue 1 carta de Energia Darkness da sua pilha de descarte a 1 dos seus Pokémon no Banco.",
-				de: "Lege 1 Darkness-Energiekarte aus deinem Ablagestapel an 1 Pokémon auf deiner Bank an."
+				de: "Lege 1 {D}-Energiekarte aus deinem Ablagestapel an 1 Pokémon auf deiner Bank an."
 			},
 			damage: 90,
 
@@ -98,6 +98,7 @@ const card: Card = {
 
 	description: {
 		en: "When this legendary Pokémon's wings and tail feathers spread wide and glow red, it absorbs the life force of living creatures.",
+		de: "Wenn Schwingen und Schwanzgefieder dieses Legendären Pokémon rot leuchten, entzieht es Lebewesen deren Energie."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/55.ts
+++ b/data/Sun & Moon/Shining Legends/55.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "In its true form, it possess a huge amount of power. Legends of its avarice tell how it once carried off an entire castle to gain the treasure hidden within.",
+		de: "In seiner wahren Gestalt verfügt es über enorme Kräfte. Legenden zufolge hat es einst ein ganzes Schloss gestohlen, weil es den darin versteckten Schatz für sich haben wollte."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/56.ts
+++ b/data/Sun & Moon/Shining Legends/56.ts
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives in the ozone layer far above the clouds and cannot be seen from the ground.",
+		de: "Es lebt in der Ozonschicht hoch über den Wolken und kann vom Boden aus nicht gesehen werden."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/57.ts
+++ b/data/Sun & Moon/Shining Legends/57.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "According to the legends of Sinnoh, this Pokémon emerged from an egg and shaped all there is in this world.",
+		de: "In den Legenden Sinnohs heißt es, es sei aus einem Ei geschlüpft und hätte die gesamte Welt geschaffen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/58.ts
+++ b/data/Sun & Moon/Shining Legends/58.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mueve 3 contadores de daño de 1 de tus Pokémon a otro de tus Pokémon.",
 		it: "Sposta tre segnalini danno da uno a un altro dei tuoi Pokémon.",
 		pt: "Mova 3 contadores de dano de 1 dos seus Pokémon para outro Pokémon seu.",
-		de: "Verschiebe 3 Schadensmarken von 1 deiner Pokémon auf 1 anderes deiner Pokémon."
+		de: "Verschiebe 3 Schadensmarken von 1 deiner Pokémon auf 1 anderes deiner Pokémon. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Shining Legends/59.ts
+++ b/data/Sun & Moon/Shining Legends/59.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon 2 cartas de Energía Básica de tu pila de descartes en tu mano.",
 		it: "Prendi due carte Energia base dalla tua pila degli scarti e aggiungile alle carte che hai in mano.",
 		pt: "Coloque 2 cartas de Energia básica da sua pilha de descarte na sua mão.",
-		de: "Nimm 2 Basis-Energiekarten aus deinem Ablagestapel auf deine Hand."
+		de: "Nimm 2 Basis-Energiekarten aus deinem Ablagestapel auf deine Hand. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Shining Legends/6.ts
+++ b/data/Sun & Moon/Shining Legends/6.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It attracts prey with its sweet-smelling saliva, then chomps down. It takes a whole day to eat prey.",
+		de: "Sein süßlich riechender Speichel zieht Beute an, die es frisst. Es braucht einen Tag, sie zu fressen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/60.ts
+++ b/data/Sun & Moon/Shining Legends/60.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mira las 7 primeras cartas de tu baraja. Puedes enseñar 1 Pokémon que encuentres entre ellas y ponerlo en tu mano. Pon el resto de cartas de nuevo en tu baraja y barájalas todas.",
 		it: "Guarda le prime sette carte del tuo mazzo. Puoi mostrare un Pokémon che hai trovato e aggiungerlo alle carte che hai in mano. Poi rimischia le altre carte nel tuo mazzo.",
 		pt: "Olhe as 7 primeiras cartas do seu baralho. Você poderá revelar 1 Pokémon que encontrar lá e colocá-lo na sua mão. Embaralhe as demais cartas de volta no seu baralho.",
-		de: "Schau dir die obersten 7 Karten deines Decks an. Du kannst 1 Pokémon, das du dort findest, deinem Gegner zeigen und auf deine Hand nehmen. Mische die anderen Karten zurück in dein Deck."
+		de: "Schau dir die obersten 7 Karten deines Decks an. Du kannst 1 Pokémon, das du dort findest, deinem Gegner zeigen und auf deine Hand nehmen. Mische die anderen Karten zurück in dein Deck. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Shining Legends/61.ts
+++ b/data/Sun & Moon/Shining Legends/61.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba 3 cartas.",
 		it: "Pesca tre carte.",
 		pt: "Compre 3 cartas.",
-		de: "Ziehe 3 Karten."
+		de: "Ziehe 3 Karten. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Shining Legends/62.ts
+++ b/data/Sun & Moon/Shining Legends/62.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba cartas hasta que tengas 6 cartas en tu mano. Si es tu primer turno, roba cartas hasta que tengas 8 cartas en tu mano.",
 		it: "Pesca fino ad avere sei carte in mano. Se è il tuo primo turno, pesca fino ad avere otto carte in mano.",
 		pt: "Compre cartas até ter 6 cartas na sua mão. Se for a sua primeira vez de jogar, compre cartas até ter 8 cartas na sua mão.",
-		de: "Ziehe so lange Karten, bis du 6 Karten auf der Hand hast. Wenn es dein erster Zug ist, ziehe so lange Karten, bis du 8 Karten auf der Hand hast."
+		de: "Ziehe so lange Karten, bis du 6 Karten auf der Hand hast. Wenn es dein erster Zug ist, ziehe so lange Karten, bis du 8 Karten auf der Hand hast. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Shining Legends/63.ts
+++ b/data/Sun & Moon/Shining Legends/63.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba 2 cartas y cura 20 puntos de daño a tu Pokémon Activo. Si no tienes ninguna carta en tu baraja, no puedes jugar esta carta.",
 		it: "Pesca due carte e cura il tuo Pokémon attivo da 20 danni. Se non hai carte nel mazzo, non puoi giocare questa carta.",
 		pt: "Compre 2 cartas e cure 20 pontos de dano do seu Pokémon Ativo. Se você não tiver nenhuma carta no seu baralho, não poderá jogar esta carta.",
-		de: "Ziehe 2 Karten und heile 20 Schadenspunkte bei deinem Aktiven Pokémon. Wenn du keine Karten in deinem Deck hast, kannst du diese Karte nicht spielen."
+		de: "Ziehe 2 Karten und heile 20 Schadenspunkte bei deinem Aktiven Pokémon. Wenn du keine Karten in deinem Deck hast, kannst du diese Karte nicht spielen. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Shining Legends/64.ts
+++ b/data/Sun & Moon/Shining Legends/64.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Lanza 1 moneda. Si sale cara, cambia 1 de los Pokémon en Banca de tu rival por su Pokémon Activo.",
 		it: "Lancia una moneta. Se esce testa, scambia uno dei Pokémon nella panchina del tuo avversario con il suo Pokémon attivo.",
 		pt: "Jogue 1 moeda. Se sair cara, troque 1 dos Pokémon no Banco do seu oponente pelo Pokémon Ativo dele(a).",
-		de: "Wirf 1 Münze. Tausche bei Kopf 1 Pokémon auf der Bank deines Gegners gegen sein Aktives Pokémon aus."
+		de: "Wirf 1 Münze. Tausche bei Kopf 1 Pokémon auf der Bank deines Gegners gegen sein Aktives Pokémon aus. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Shining Legends/65.ts
+++ b/data/Sun & Moon/Shining Legends/65.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta 2 cartas de tu mano. Si lo haces, roba 4 cartas.",
 		it: "Scarta due delle carte che hai in mano. Se lo fai, pesca quattro carte.",
 		pt: "Descarte 2 cartas da sua mão. Se fizer isto, compre 4 cartas.",
-		de: "Lege 2 Karten aus deiner Hand auf deinen Ablagestapel. Wenn du das machst, ziehe 4 Karten."
+		de: "Lege 2 Karten aus deiner Hand auf deinen Ablagestapel. Wenn du das machst, ziehe 4 Karten. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Shining Legends/66.ts
+++ b/data/Sun & Moon/Shining Legends/66.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Lanza 1 moneda. Si sale cara, pon 1 de tus Pokémon y todas las cartas unidas a él en tu mano.",
 		it: "Lancia una moneta. Se esce testa, riprendi in mano uno dei tuoi Pokémon e tutte le carte a esso assegnate.",
 		pt: "Jogue 1 moeda. Se sair cara, coloque 1 dos seus Pokémon e todas as cartas ligadas a ele na sua mão.",
-		de: "Wirf 1 Münze. Nimm bei Kopf 1 deiner Pokémon und alle an es angelegten Karten auf deine Hand."
+		de: "Wirf 1 Münze. Nimm bei Kopf 1 deiner Pokémon und alle an es angelegten Karten auf deine Hand. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Shining Legends/68.ts
+++ b/data/Sun & Moon/Shining Legends/68.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta 2 cartas de tu mano. Si lo haces, busca en tu baraja 1 Pokémon, enséñalo y ponlo en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Scarta due delle carte che hai in mano. Se lo fai, cerca nel tuo mazzo un Pokémon, mostralo e aggiungilo alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Descarte 2 cartas da sua mão. Se fizer isto, procure por 1 Pokémon no seu baralho, revele-o e coloque-o na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Lege 2 Karten aus deiner Hand auf deinen Ablagestapel. Wenn du das machst, durchsuche dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck."
+		de: "Lege 2 Karten aus deiner Hand auf deinen Ablagestapel. Wenn du das machst, durchsuche dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Shining Legends/69.ts
+++ b/data/Sun & Moon/Shining Legends/69.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Esta carta proporciona 2 Energías Colorless.",
 		it: "Un’Energia Incolore doppia fornisce ColorlessColorless.",
 		pt: "A Energia Incolor Dupla fornece Energias ColorlessColorless.",
-		de: "Doppel-Farblos-Energie liefert ColorlessColorless-Energie."
+		de: "Doppel-Farblos-Energie liefert {C}{C}-Energie."
 	},
 
 	energyType: "Special",

--- a/data/Sun & Moon/Shining Legends/7.ts
+++ b/data/Sun & Moon/Shining Legends/7.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It can dissolve toxins in the air to instantly transform ruined land into a lush field of flowers.",
+		de: "Es kann die Luft von Giften reinigen und Ödland in ein üppig blühendes Blumenfeld verwandeln."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/70.ts
+++ b/data/Sun & Moon/Shining Legends/70.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Esta carta proporciona 1 Energía Colorless.\n\nCuando unas esta carta de tu mano a tu Pokémon Activo, cambia ese Pokémon por 1 de tus Pokémon en Banca.",
 		it: "Questa carta fornisce Energia Colorless.\n\nQuando assegni questa carta dalla tua mano al tuo Pokémon attivo, scambia quel Pokémon con uno della tua panchina.",
 		pt: "Esta carta fornece Energia Colorless. \n\nQuando você liga esta carta da sua mão ao seu Pokémon Ativo, troque aquele Pokémon por 1 dos seus Pokémon no Banco.",
-		de: "Diese Karte liefert Colorless-Energie. \n\nWenn du diese Karte aus deiner Hand an dein Aktives Pokémon anlegst, tausche jenes Pokémon gegen 1 Pokémon auf deiner Bank aus."
+		de: "Diese Karte liefert {C}-Energie. Wenn du diese Karte aus deiner Hand an dein Aktives Pokémon anlegst, tausche jenes Pokémon gegen 1 Pokémon auf deiner Bank aus."
 	},
 
 	energyType: "Special",

--- a/data/Sun & Moon/Shining Legends/72.ts
+++ b/data/Sun & Moon/Shining Legends/72.ts
@@ -88,7 +88,7 @@ const card: Card = {
 				es: "Onda Mental GX",
 				it: "Psicobotta-GX",
 				pt: "Golpe Psíquico GX",
-				de: "Psychostoß GX"
+				de: "Psychostoß-GX"
 			},
 			effect: {
 				en: "This attack’s damage isn’t affected by any effects on your opponent’s Active Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Shining Legends/73.ts
+++ b/data/Sun & Moon/Shining Legends/73.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba 2 cartas y cura 20 puntos de daño a tu Pokémon Activo. Si no tienes ninguna carta en tu baraja, no puedes jugar esta carta.",
 		it: "Pesca due carte e cura il tuo Pokémon attivo da 20 danni. Se non hai carte nel mazzo, non puoi giocare questa carta.",
 		pt: "Compre 2 cartas e cure 20 pontos de dano do seu Pokémon Ativo. Se você não tiver nenhuma carta no seu baralho, não poderá jogar esta carta.",
-		de: "Ziehe 2 Karten und heile 20 Schadenspunkte bei deinem Aktiven Pokémon. Wenn du keine Karten in deinem Deck hast, kannst du diese Karte nicht spielen."
+		de: "Ziehe 2 Karten und heile 20 Schadenspunkte bei deinem Aktiven Pokémon. Wenn du keine Karten in deinem Deck hast, kannst du diese Karte nicht spielen. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Shining Legends/75.ts
+++ b/data/Sun & Moon/Shining Legends/75.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pikachu",
 		fr: "Pikachu",
+		de: "Pikachu"
 	},
 
 	suffix: "GX",
@@ -53,7 +54,7 @@ const card: Card = {
 				es: "Este ataque hace 20 puntos de daño más por cada Energía Lightning unida a tus Pokémon.",
 				it: "Questo attacco infligge 20 danni in più per ogni Energia Lightning assegnata ai tuoi Pokémon.",
 				pt: "Este ataque causa 20 pontos de dano a mais vezes a quantidade de Energia Lightning ligada aos seus Pokémon.",
-				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der an deine Pokémon angelegten Lightning-Energien zu."
+				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der an deine Pokémon angelegten {L}-Energien zu."
 			},
 			damage: "20+",
 
@@ -95,7 +96,7 @@ const card: Card = {
 				es: "Colavoltio GX",
 				it: "Coda Voltaica-GX",
 				pt: "Cauda Voltaica GX",
-				de: "Voltschweif GX"
+				de: "Voltschweif-GX"
 			},
 			effect: {
 				en: "Your opponent’s Active Pokémon is now Paralyzed. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Shining Legends/76.ts
+++ b/data/Sun & Moon/Shining Legends/76.ts
@@ -88,7 +88,7 @@ const card: Card = {
 				es: "Onda Mental GX",
 				it: "Psicobotta-GX",
 				pt: "Golpe Psíquico GX",
-				de: "Psychostoß GX"
+				de: "Psychostoß-GX"
 			},
 			effect: {
 				en: "This attack’s damage isn’t affected by any effects on your opponent’s Active Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Shining Legends/77.ts
+++ b/data/Sun & Moon/Shining Legends/77.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Zorua",
 		fr: "Zorua",
+		de: "Zorua"
 	},
 
 	suffix: "GX",
@@ -91,7 +92,7 @@ const card: Card = {
 				es: "Ilusionista GX",
 				it: "Illusionista-GX",
 				pt: "Traquino GX",
-				de: "Trickser GX"
+				de: "Trickser-GX"
 			},
 			effect: {
 				en: "Choose 1 of your opponent’s Pokémon’s attacks and use it as this attack. (You can’t use more than 1 GX attack in a game.)",
@@ -99,7 +100,7 @@ const card: Card = {
 				es: "Elige 1 de los ataques de los Pokémon de tu rival y úsalo para este ataque. (No puedes usar más de 1 ataque GX en una partida).",
 				it: "Scegli uno degli attacchi dei Pokémon del tuo avversario e usalo al posto di questo attacco. Non puoi usare più di un attacco GX a partita.",
 				pt: "Escolha 1 ataque dos Pokémon do seu oponente e use-o como este ataque (você não pode usar mais de 1 ataque GX por partida).",
-				de: "Wähle 1 Attacke der Pokémon deines Gegners und setze sie als diese Attacke ein.  (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
+				de: "Wähle 1 Attacke der Pokémon deines Gegners und setze sie als diese Attacke ein. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Shining Legends/78.ts
+++ b/data/Sun & Moon/Shining Legends/78.ts
@@ -88,7 +88,7 @@ const card: Card = {
 				es: "Onda Mental GX",
 				it: "Psicobotta-GX",
 				pt: "Golpe Psíquico GX",
-				de: "Psychostoß GX"
+				de: "Psychostoß-GX"
 			},
 			effect: {
 				en: "This attack’s damage isn’t affected by any effects on your opponent’s Active Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Shining Legends/8.ts
+++ b/data/Sun & Moon/Shining Legends/8.ts
@@ -90,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "Its head sprouts horns as sharp as blades. Using whirlwind-like movements, it confounds and swiftly cuts opponents.",
+		de: "Das Horn an seinem Kopf ist eine scharfe Klinge. Neckt seine Gegner mit quirligen Bewegungen und greift blitzartig an."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Shining Legends/9.ts
+++ b/data/Sun & Moon/Shining Legends/9.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Una vez durante tu turno (antes de tu ataque), puedes mover 1 Energía Grass de 1 de tus otros Pokémon a este Pokémon.",
 				it: "Una sola volta durante il tuo turno, prima di attaccare, puoi spostare un’Energia Grass da uno dei tuoi altri Pokémon a questo Pokémon.",
 				pt: "Uma vez durante a sua vez de jogar (antes de atacar), você pode mover 1 Energia Grass de 1 dos seus outros Pokémon para este Pokémon.",
-				de: "Einmal während deines Zuges (bevor du angreifst) kannst du 1 Grass-Energie von 1 deiner anderen Pokémon auf dieses Pokémon verschieben."
+				de: "Einmal während deines Zuges (bevor du angreifst) kannst du 1 {G}-Energie von 1 deiner anderen Pokémon auf dieses Pokémon verschieben."
 			},
 		},
 	],
@@ -71,7 +71,7 @@ const card: Card = {
 				es: "Este ataque hace 20 puntos de daño más por cada Energía Grass unida a este Pokémon.",
 				it: "Questo attacco infligge 20 danni in più per ogni Energia Grass assegnata a questo Pokémon.",
 				pt: "Este ataque causa 20 pontos de dano a mais vezes a quantidade de Energia Grass ligada a este Pokémon.",
-				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der an dieses Pokémon angelegten Grass-Energien zu."
+				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der an dieses Pokémon angelegten {G}-Energien zu."
 			},
 			damage: "50+",
 
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "This ancient bug Pokémon was altered by Team Plasma. They upgraded the cannon on its back.",
+		de: "Ein von Team Plasma modifiziertes Käfer-Pokémon aus dem Altertum. Die Kanone auf seinem Rücken ist nun noch stärker."
 	},
 
 	thirdParty: {


### PR DESCRIPTION
## Add missing German translations for sm3.5

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
