### PR TITLE
Add missing German translations for sm5

### DIFF
--- a/data/Sun & Moon/Ultra Prism/1.ts
+++ b/data/Sun & Moon/Ultra Prism/1.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "Its six eggs use telepathy to communicate among themselves. It is believed to carry plant genes and the genes of other species.",
+		de: "Die sechs Eier kommunizieren telepathisch miteinander. Sie tragen das Erbgut von Pflanzen sowie Pokémon eines bestimmten Typs in sich."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/10.ts
+++ b/data/Sun & Moon/Ultra Prism/10.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It evolves by sucking the energy out of the small ball where it had been storing nutrients.",
+		de: "Es saugt Nährstoffe, die in seinem Bällchen enthalten sind, und nutzt die Energie für seine Entwicklung."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/100.ts
+++ b/data/Sun & Moon/Ultra Prism/100.ts
@@ -90,7 +90,7 @@ const card: Card = {
 				es: "Intemporal GX",
 				it: "Sospensione Temporale-GX",
 				pt: "Para-tempo GX",
-				de: "Zeitlos GX"
+				de: "Zeitlos-GX"
 			},
 			effect: {
 				en: "Take another turn after this one. (Skip the between-turns step.) (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Ultra Prism/101.ts
+++ b/data/Sun & Moon/Ultra Prism/101.ts
@@ -71,7 +71,7 @@ const card: Card = {
 				es: "Este ataque hace 20 puntos de daño más por cada Energía Water unida a este Pokémon.",
 				it: "Questo attacco infligge 20 danni in più per ogni Energia Water assegnata a questo Pokémon.",
 				pt: "Este ataque causa 20 pontos de dano a mais vezes a quantidade de Energia Water ligada a este Pokémon.",
-				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der an dieses Pokémon angelegten Water-Energien zu."
+				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der an dieses Pokémon angelegten {W}-Energien zu."
 			},
 			damage: "60+",
 
@@ -90,7 +90,7 @@ const card: Card = {
 				es: "Fuga Cero GX",
 				it: "Zero Evanescente-GX",
 				pt: "Sumiço Total GX",
-				de: "Nullwert GX"
+				de: "Nullwert-GX"
 			},
 			effect: {
 				en: "Shuffle all Energy from each of your opponent’s Pokémon into their deck. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Ultra Prism/102.ts
+++ b/data/Sun & Moon/Ultra Prism/102.ts
@@ -90,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "Its tongue is twice the length of its body. It can be moved like an arm for grabbing food and attacking.",
+		de: "Seine Zunge ist doppelt so lang wie sein Körper. Es kann sie wie einen Arm bewegen, um damit Nahrung zu greifen oder zu attackieren."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/103.ts
+++ b/data/Sun & Moon/Ultra Prism/103.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Lickitung",
 		fr: "Excelangue",
+		de: "Schlurp"
 	},
 
 	stage: "Stage1",
@@ -91,6 +92,7 @@ const card: Card = {
 
 	description: {
 		en: "Their saliva contains lots of components that can dissolve anything. The numbness caused by their lick does not dissipate.",
+		de: "Ihr Speichel enthält eine ätzende Substanz, die bei Kontakt mit der Haut anhaltende Taubheit erzeugt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/104.ts
+++ b/data/Sun & Moon/Ultra Prism/104.ts
@@ -58,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "Current studies show it can evolve into an incredible eight different species of Pokémon.",
+		de: "Nach derzeitigem Forschungsstand kann es sich zu acht verschiedenen Pokémon entwickeln."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/105.ts
+++ b/data/Sun & Moon/Ultra Prism/105.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "Possessing an unbalanced and unstable genetic makeup, it conceals many possible evolutions.",
+		de: "Sein instabiles Erbmaterial ermöglicht es ihm, sich zu verschiedenen Pokémon zu entwickeln."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/106.ts
+++ b/data/Sun & Moon/Ultra Prism/106.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "When it senses danger, it perks up its ears. On cold nights, it sleeps with its head tucked into its fur.",
+		de: "Nimmt es Gefahr wahr, richtet es seine Ohren auf. In kalten Nächten vergräbt es den Kopf in seinem Fell."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/107.ts
+++ b/data/Sun & Moon/Ultra Prism/107.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Buneary",
 		fr: "Laporeille",
+		de: "Haspiror"
 	},
 
 	stage: "Stage1",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "The ears appear to be delicate. If they are touched roughly, it kicks with its graceful legs.",
+		de: "Es hat sehr empfindliche Ohren. Fasst man sie zu rau an, wird es mit seinen grazilen Beinen zutreten."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/108.ts
+++ b/data/Sun & Moon/Ultra Prism/108.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "When it's happy, Glameow demonstrates beautiful movements of its tail, like a dancing ribbon.",
+		de: "Je nach Laune lässt es seinen Schweif anmutig wirbeln, ganz wie das Band eines Sportgymnasten."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/109.ts
+++ b/data/Sun & Moon/Ultra Prism/109.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Glameow",
 		fr: "Chaglam",
+		de: "Charmian"
 	},
 
 	stage: "Stage1",
@@ -95,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "To make itself appear intimidatingly beefy, it tightly cinches its waist with its twin tails.",
+		de: "Damit es bedrohlicher und größer aussieht, umschlingt es seine Taille fest mit seinem Schwanz."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/11.ts
+++ b/data/Sun & Moon/Ultra Prism/11.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cherubi",
 		fr: "Ceribou",
+		de: "Kikugi"
 	},
 
 	stage: "Stage1",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Tus Pokémon Grass no tienen Debilidad.",
 				it: "I tuoi Pokémon Grass non hanno debolezza.",
 				pt: "Seus Pokémon Grass não têm Fraqueza.",
-				de: "Deine Grass-Pokémon haben keine Schwäche."
+				de: "Deine {G}-Pokémon haben keine Schwäche."
 			},
 		},
 	],
@@ -85,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "If it senses strong sunlight, it opens its folded petals to absorb the sun's rays with its whole body.",
+		de: "Spürt es Sonnenlicht, öffnet es seine Blütenblätter und nimmt die Energie der Sonnenstrahlen auf."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/110.ts
+++ b/data/Sun & Moon/Ultra Prism/110.ts
@@ -95,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "Its body is composed of plasma. It is known to infiltrate electronic devices and wreak havoc.",
+		de: "Sein Körper besteht aus Plasma. Mit ihm kann es in elektrische Geräte eindringen und für Chaos sorgen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/111.ts
+++ b/data/Sun & Moon/Ultra Prism/111.ts
@@ -87,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "The blooming of Gracidea flowers confers the power of flight upon it. Feelings of gratitude are the message it delivers.",
+		de: "Es heißt, wenn die Gracidea blühen, drückt es seine Dankbarkeit aus, indem es hoch in die Lüfte fliegt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/112.ts
+++ b/data/Sun & Moon/Ultra Prism/112.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It wanders around in a never-ending search for food. At dusk, it collapses from exhaustion and falls asleep on the spot.",
+		de: "Die Futtersuche treibt es unaufhörlich umher, doch sobald die Sonne untergeht, wird es von Müdigkeit überfallen und schläft sofort ein."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/113.ts
+++ b/data/Sun & Moon/Ultra Prism/113.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Yungoos",
 		fr: "Manglouton",
+		de: "Mangunior"
 	},
 
 	stage: "Stage1",
@@ -89,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "It adores having Rattata and Raticate for dinner, but as it's diurnal, it never encounters them. This Pokémon boasts incredible patience.",
+		de: "Rattfratz und Rattikarl sind seine Leibspeise, aber leider nachtaktiv und daher selten auf dem Speiseplan. Ein sehr geduldiges Pokémon."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/114.ts
+++ b/data/Sun & Moon/Ultra Prism/114.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "Deep in the jungle, high in the lofty canopy, this Pokémon abides. On rare occasions, it shows up at the beach to match wits with Slowking.",
+		de: "Lebt auf Baumwipfeln im tiefsten Dschungel. Ab und an erscheint es am Strand, um sich epische Quiz-Duelle mit Laschoking zu liefern."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/115.ts
+++ b/data/Sun & Moon/Ultra Prism/115.ts
@@ -84,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "The heavy control mask it wears suppresses its intrinsic capabilities. This Pokémon has some hidden special power.",
+		de: "Seine schwere Maske unterdrückt seine wahre Macht. In ihm schlummern nämlich besondere Kräfte."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/116.ts
+++ b/data/Sun & Moon/Ultra Prism/116.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Type: Null",
 		fr: "Type:0",
+		de: "Typ:Null"
 	},
 
 	suffix: "GX",
@@ -93,7 +94,7 @@ const card: Card = {
 				es: "Rebelarse GX",
 				it: "Ribelle-GX",
 				pt: "Rebelde GX",
-				de: "Rebellieren GX"
+				de: "Rebellieren-GX"
 			},
 			effect: {
 				en: "This attack does 50 damage for each of your opponent’s Benched Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Ultra Prism/117.ts
+++ b/data/Sun & Moon/Ultra Prism/117.ts
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon is friendly to people and loves children most of all. It comes from deep in the mountains to play with children it likes in town.",
+		de: "Es ist sehr freundlich und liebt Kinder. Häufig kommt es aus den Bergen herab in die Städte, um mit seinen kleinen Freunden zu spielen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/118.ts
+++ b/data/Sun & Moon/Ultra Prism/118.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Los ataques de tu rival hacen 30 puntos de daño menos al Regirock, Regice, Registeel o Regigigas al que esté unida esta carta (después de aplicar Debilidad y Resistencia).",
 		it: "Il Regirock, Regice, Registeel o Regigigas a cui è assegnata questa carta subisce 30 danni in meno dagli attacchi del tuo avversario, dopo aver applicato debolezza e resistenza.",
 		pt: "O Pokémon Regirock, Regice, Registeel ou Regigigas ao qual esta carta está ligada recebe 30 pontos de dano a menos dos ataques do seu oponente (após a aplicação de Fraqueza e Resistência).",
-		de: "Dem Regirock, Regice, Registeel oder Regigigas, an das diese Karte angelegt ist, werden durch Attacken des Gegners 30 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden)."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Dem Regirock, Regice, Registeel oder Regigigas, an das diese Karte angelegt ist, werden durch Attacken des Gegners 30 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden). Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sun & Moon/Ultra Prism/119.ts
+++ b/data/Sun & Moon/Ultra Prism/119.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon las cartas de tu mano en tu baraja y barájalas todas. Después, roba 6 cartas.",
 		it: "Rimischia le carte che hai in mano nel tuo mazzo. Poi pesca sei carte.",
 		pt: "Embaralhe a sua mão no seu baralho. Em seguida, compre 6 cartas.",
-		de: "Mische deine Handkarten in dein Deck. Ziehe anschließend 6 Karten."
+		de: "Mische deine Handkarten in dein Deck. Ziehe anschließend 6 Karten. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Ultra Prism/12.ts
+++ b/data/Sun & Moon/Ultra Prism/12.ts
@@ -90,6 +90,7 @@ const card: Card = {
 
 	description: {
 		en: "It binds itself to trees in marshes. It attracts prey with its sweet-smelling drool and gulps them down.",
+		de: "Klammert sich an Bäume in Sümpfen. Lockt Beute mit seinem süßlichen Speichel an und schluckt sie dann."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/120.ts
+++ b/data/Sun & Moon/Ultra Prism/120.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "No puedes jugar esta carta si no tienes ningún Pokémon Water o Metal en juego.\n\nTu rival elige 2 Pokémon en Banca y pone los demás, y todas las cartas unidas a ellos, en su baraja, y baraja todas las cartas.",
 		it: "Non puoi giocare questa carta se non hai alcun Pokémon Water o Metal in gioco.\n\nIl tuo avversario sceglie due Pokémon in panchina e rimischia gli altri nel proprio mazzo insieme a tutte le carte loro assegnate.",
 		pt: "Você não pode jogar esta carta se não tiver nenhum Pokémon Water ou Metal em jogo.\n\nSeu oponente escolhe 2 Pokémon no Banco e embaralha os outros e todas as cartas ligadas a eles no próprio baralho.",
-		de: "Du kannst diese Karte nicht spielen, wenn du nicht mindestens 1 Water- oder Metal-Pokémon im Spiel hast.\n\nDein Gegner wählt 2 Pokémon auf seiner Bank und mischt die anderen sowie alle an sie angelegten Karten in sein Deck."
+		de: "Du kannst nicht mehr als 1 ◇-Karte mit demselben Namen in deinem Deck haben. Wenn 1 ◇-Karte auf deinen Ablagestapel gelegt würde, lege sie stattdessen ins Nirgendwo. Du kannst diese Karte nicht spielen, wenn du nicht mindestens 1 {W}- oder {M}-Pokémon im Spiel hast. Dein Gegner wählt 2 Pokémon auf seiner Bank und mischt die anderen sowie alle an sie angelegten Karten in sein Deck. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/121.ts
+++ b/data/Sun & Moon/Ultra Prism/121.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "El Silvally-GX al que esté unida esta carta es un Pokémon Lightning.",
 		it: "Il Silvally-GX a cui è assegnata questa carta è di tipo Lightning.",
 		pt: "O Pokémon Silvally-GX ao qual esta carta está ligada é um Pokémon Lightning.",
-		de: "Das Amigento-GX, an das diese Karte angelegt ist, ist ein Lightning-Pokémon."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Das Amigento-GX, an das diese Karte angelegt ist, ist ein {L}-Pokémon. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sun & Moon/Ultra Prism/122.ts
+++ b/data/Sun & Moon/Ultra Prism/122.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "El Coste de Retirada del Pokémon al que esté unida esta carta es de Colorless menos, y puede retirarse incluso si está Dormido o Paralizado.",
 		it: "Il costo di ritirata del Pokémon a cui è assegnata questa carta è ridotto di Colorless e il Pokémon può ritirarsi anche se è addormentato o paralizzato.",
 		pt: "O custo de Recuo do Pokémon ao qual esta carta está ligada é Colorless a menos e ele poderá recuar mesmo que esteja Adormecido ou Paralisado.",
-		de: "Die Rückzugskosten des Pokémon, an das diese Karte angelegt ist, verringern sich um Colorless und es kann sich zurückziehen, auch wenn es schläft oder paralysiert ist."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Die Rückzugskosten des Pokémon, an das diese Karte angelegt ist, verringern sich um {C} und es kann sich zurückziehen, auch wenn es schläft oder paralysiert ist. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sun & Moon/Ultra Prism/123.ts
+++ b/data/Sun & Moon/Ultra Prism/123.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "El Silvally-GX al que esté unida esta carta es un Pokémon Fire.",
 		it: "Il Silvally-GX a cui è assegnata questa carta è di tipo Fire.",
 		pt: "O Pokémon Silvally-GX ao qual esta carta está ligada é um Pokémon Fire.",
-		de: "Das Amigento-GX, an das diese Karte angelegt ist, ist ein Fire-Pokémon."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Das Amigento-GX, an das diese Karte angelegt ist, ist ein {R}-Pokémon. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sun & Moon/Ultra Prism/124.ts
+++ b/data/Sun & Moon/Ultra Prism/124.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cura 80 puntos de daño a 1 de tus Pokémon que tenga alguna Energía Grass unida a él.",
 		it: "Cura uno dei tuoi Pokémon che abbia delle Energie Grass assegnate da 80 danni.",
 		pt: "Cure 80 pontos de dano de 1 dos seus Pokémon que tiver alguma Energia Grass ligada a ele.",
-		de: "Heile 80 Schadenspunkte bei 1 deiner Pokémon, an das mindestens 1 Grass-Energie angelegt ist."
+		de: "Heile 80 Schadenspunkte bei 1 deiner Pokémon, an das mindestens 1 {G}-Energie angelegt ist. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Ultra Prism/125.ts
+++ b/data/Sun & Moon/Ultra Prism/125.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba cartas hasta que tengas 6 cartas en tu mano. Si es tu primer turno, roba cartas hasta que tengas 8 cartas en tu mano.",
 		it: "Pesca fino ad avere sei carte in mano. Se è il tuo primo turno, pesca fino ad avere otto carte in mano.",
 		pt: "Compre cartas até ter 6 cartas na sua mão. Se for a sua primeira vez de jogar, compre cartas até ter 8 cartas na sua mão.",
-		de: "Ziehe so lange Karten, bis du 6 Karten auf der Hand hast. Wenn es dein erster Zug ist, ziehe so lange Karten, bis du 8 Karten auf der Hand hast."
+		de: "Ziehe so lange Karten, bis du 6 Karten auf der Hand hast. Wenn es dein erster Zug ist, ziehe so lange Karten, bis du 8 Karten auf der Hand hast. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Ultra Prism/126.ts
+++ b/data/Sun & Moon/Ultra Prism/126.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba 3 cartas de la parte inferior de tu baraja.",
 		it: "Pesca tre carte in fondo al tuo mazzo.",
 		pt: "Compre as 3 últimas cartas do seu baralho.",
-		de: "Ziehe 3 Karten von unten aus deinem Deck."
+		de: "Ziehe 3 Karten von unten aus deinem Deck. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Ultra Prism/127.ts
+++ b/data/Sun & Moon/Ultra Prism/127.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 2 cartas llamadas Handsome, enséñalas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo fino a due carte chiamate Bellocchio, mostrale e aggiungile alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por até 2 cartas chamadas Looker no seu baralho, revele-as e coloque-as na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach bis zu 2 Karten namens LeBelle, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach bis zu 2 Karten namens LeBelle, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Ultra Prism/128.ts
+++ b/data/Sun & Moon/Ultra Prism/128.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba 2 cartas. Si lo haces, descarta 1 carta aleatoria de la mano de tu rival.",
 		it: "Pesca due carte. Se lo fai, scarta una carta a caso dalla mano del tuo avversario.",
 		pt: "Compre 2 cartas. Se fizer isto, descarte 1 carta aleatória da mão do seu oponente.",
-		de: "Ziehe 2 Karten. Wenn du das machst, lege 1 zufällige Karte aus der Hand deines Gegners auf seinen Ablagestapel."
+		de: "Ziehe 2 Karten. Wenn du das machst, lege 1 zufällige Karte aus der Hand deines Gegners auf seinen Ablagestapel. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Ultra Prism/129.ts
+++ b/data/Sun & Moon/Ultra Prism/129.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Puedes jugar 4 cartas de Trébol Perdido de una vez.\n\n• Si has jugado 1 carta, mira la primera carta de tu baraja.\n• Si has jugado 4 cartas, coge 1 carta de Premio. (Este efecto funciona 1 vez por 4 cartas).",
 		it: "Puoi giocare quattro carte Trifoglio Mancante alla volta.\n\n• Se giochi una carta, guarda la prima carta del tuo mazzo.\n• Se giochi quattro carte, prendi una carta Premio (questo effetto si applica una volta ogni quattro carte).",
 		pt: "Você pode jogar 4 cartas Trevo Perdido de uma vez.\n\n• Se você jogou 1 carta, olhe a primeira carta do seu baralho.\n• Se você jogou 4 cartas, pegue 1 carta de Prêmio (este efeito funciona uma vez para 4 cartas).",
-		de: "Du kannst 4 Fehlendes Kleeblatt-Karten gleichzeitig spielen.\n\n• Wenn du 1 Karte gespielt hast, schau dir die oberste Karte deines Decks an.\n• Wenn du 4 Karten gespielt hast, nimm 1 Preiskarte. (Dieser Effekt funktioniert einmal für 4 Karten.)"
+		de: "Du kannst 4 Fehlendes Kleeblatt-Karten gleichzeitig spielen. Wenn du 1 Karte gespielt hast, schau dir die oberste Karte deines Decks an. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen. Wenn du 4 Karten gespielt hast, nimm 1 Preiskarte. (Dieser Effekt funktioniert einmal für 4 Karten.)"
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Ultra Prism/13.ts
+++ b/data/Sun & Moon/Ultra Prism/13.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	suffix: "GX",
@@ -84,7 +85,7 @@ const card: Card = {
 				es: "Gran Floración GX",
 				it: "Fioritura Formidabile-GX",
 				pt: "Floração Grandiosa GX",
-				de: "Blütezeit GX"
+				de: "Blütezeit-GX"
 			},
 			effect: {
 				en: "For each of your Benched Basic Pokémon, search your deck for a card that evolves from that Pokémon and put it onto that Pokémon to evolve it. Then, shuffle your deck. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Ultra Prism/130.ts
+++ b/data/Sun & Moon/Ultra Prism/130.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Una vez durante el turno de cada jugador, ese jugador puede poner 2 cartas de Energía Metal de su pila de descartes en su mano.",
 		it: "Una sola volta durante il turno di ciascun giocatore, quel giocatore può prendere due carte Energia Metal dalla propria pila degli scarti e aggiungerle alle carte che ha in mano.",
 		pt: "Uma vez durante a vez de jogar de cada jogador, aquele jogador pode colocar 2 cartas de Energia Metal da própria pilha de descarte na própria mão.",
-		de: "Einmal während des Zuges jedes Spielers kann der Spieler 2 Metal-Energiekarten aus seinem Ablagestapel auf seine Hand nehmen."
+		de: "Einmal während des Zuges jedes Spielers kann der Spieler 2 {M}-Energiekarten aus seinem Ablagestapel auf seine Hand nehmen. Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 
 	trainerType: "Stadium",

--- a/data/Sun & Moon/Ultra Prism/131.ts
+++ b/data/Sun & Moon/Ultra Prism/131.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Lanza 1 moneda. Si sale cara, busca en tu baraja 1 carta de Objeto, enséñala y ponla en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Lancia una moneta. Se esce testa, cerca nel tuo mazzo una carta Strumento, mostrala e aggiungila alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Jogue 1 moeda. Se sair cara, procure por 1 carta de Item no seu baralho, revele-a e coloque-a na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Wirf 1 Münze. Durchsuche bei Kopf dein Deck nach 1 Itemkarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Wirf 1 Münze. Durchsuche bei Kopf dein Deck nach 1 Itemkarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Ultra Prism/132.ts
+++ b/data/Sun & Moon/Ultra Prism/132.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon 2 cartas de Partidario de tu pila de descartes en tu baraja y barájalas todas.",
 		it: "Rimischia due carte Aiuto dalla tua pila degli scarti nel tuo mazzo.",
 		pt: "Embaralhe 2 cartas de Apoiador da sua pilha de descarte no seu baralho.",
-		de: "Mische 2 Unterstützerkarten aus deinem Ablagestapel in dein Deck."
+		de: "Mische 2 Unterstützerkarten aus deinem Ablagestapel in dein Deck. Du kannst während deines Zuges (bevor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Ultra Prism/133.ts
+++ b/data/Sun & Moon/Ultra Prism/133.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 2 Pokémon Básicos, enséñalos y ponlos en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo fino a due Pokémon Base, mostrali e aggiungili alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por até 2 Pokémon Básicos no seu baralho, revele-os e coloque-os na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach bis zu 2 Basis-Pokémon, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach bis zu 2 Basis-Pokémon, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Ultra Prism/134.ts
+++ b/data/Sun & Moon/Ultra Prism/134.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Juega esta carta como si fuera un Pokémon Básico Colorless de 60 PS. En cualquier momento durante tu turno (antes de tu ataque), puedes descartar esta carta del juego.\n\nEsta carta no puede retirarse.",
 		it: "Gioca questa carta come se fosse un Pokémon Base Colorless da 60 PS. Durante il tuo turno, in qualsiasi momento, prima di attaccare, puoi scartare questa carta dal gioco.\n\nNon puoi far ritirare questa carta.",
 		pt: "Jogue esta carta como se fosse um Pokémon Colorless Básico com PS 60. A qualquer momento, durante a sua vez de jogar (antes de atacar), você pode descartar esta carta do jogo.\n\nEsta carta não pode recuar.",
-		de: "Spiele diese Karte, als ob sie ein Colorless-Basis-Pokémon mit 60 KP wäre. Du kannst diese Karte jederzeit während deines Zuges (bevor du angreifst) aus dem Spiel nehmen und auf deinen Ablagestapel legen.\n\nDiese Karte kann sich nicht zurückziehen."
+		de: "Spiele diese Karte, als ob sie ein {C}-Basis-Pokémon mit 60 KP wäre. Du kannst diese Karte jederzeit während deines Zuges (bevor du angreifst) aus dem Spiel nehmen und auf deinen Ablagestapel legen. Diese Karte kann sich nicht zurückziehen. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Ultra Prism/135.ts
+++ b/data/Sun & Moon/Ultra Prism/135.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja 1 carta de Objeto y 1 carta de Energía Lightning, enséñalas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo una carta Strumento e una carta Energia Lightning, mostrale e aggiungile alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por 1 carta de Item e por 1 carta de Energia Lightning no seu baralho, revele-as e coloque-as na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach 1 Itemkarte und 1 Lightning-Energiekarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach 1 Itemkarte und 1 {L}-Energiekarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Ultra Prism/136.ts
+++ b/data/Sun & Moon/Ultra Prism/136.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Esta carta proporciona 1 Energía Colorless.\n\nMientras esta carta esté unida a un Pokémon de Fase 2, proporciona cualquier tipo de Energía, pero proporciona solo 1 Energía a la vez. Si tienes 3 o más Pokémon de Fase 2 en juego, proporciona cualquier tipo de Energía, pero proporciona 4 Energías a la vez.",
 		it: "Questa carta fornisce Energia Colorless.\n\nQuando è assegnata a un Pokémon di Fase 2, questa carta fornisce un’Energia di qualsiasi tipo, ma solo una alla volta. Se hai tre o più Pokémon di Fase 2 in gioco, questa carta fornisce Energia di qualsiasi tipo, ma quattro alla volta.",
 		pt: "Esta carta fornece Energia Colorless.\n\nEnquanto esta carta estiver ligada a um Pokémon Estágio 2, ela fornecerá todo tipo de Energia, mas só fornecerá 1 Energia por vez. Se você tiver 3 ou mais Pokémon Estágio 2 em jogo, ela fornecerá todo tipo de Energia, mas fornecerá 4 Energias por vez.",
-		de: "Diese Karte liefert Colorless-Energie.\n\nIst sie an ein Phase-2-Pokémon angelegt, liefert diese Karte jeden beliebigen Energietyp, aber immer nur jeweils 1 Energie. Wenn du 3 oder mehr Phase-2-Pokémon im Spiel hast, liefert sie jeden beliebigen Energietyp, aber immer jeweils 4 Energien."
+		de: "Du kannst nicht mehr als 1 ◇-Karte mit demselben Namen in deinem Deck haben. Wenn 1 ◇-Karte auf deinen Ablagestapel gelegt würde, lege sie stattdessen ins Nirgendwo Diese Karte liefert {C}-Energie. Ist sie an ein Phase-2-Pokémon angelegt, liefert diese Karte jeden beliebigen Energietyp, aber immer nur jeweils 1 Energie. Wenn du 3 oder mehr Phase-2-Pokémon im Spiel hast, liefert sie jeden beliebigen Energietyp, aber immer jeweils 4 Energien."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/139.ts
+++ b/data/Sun & Moon/Ultra Prism/139.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	suffix: "GX",
@@ -84,7 +85,7 @@ const card: Card = {
 				es: "Gran Floración GX",
 				it: "Fioritura Formidabile-GX",
 				pt: "Floração Grandiosa GX",
-				de: "Blütezeit GX"
+				de: "Blütezeit-GX"
 			},
 			effect: {
 				en: "For each of your Benched Basic Pokémon, search your deck for a card that evolves from that Pokémon and put it onto that Pokémon to evolve it. Then, shuffle your deck. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Ultra Prism/14.ts
+++ b/data/Sun & Moon/Ultra Prism/14.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "Its body is composed of plasma. It is known to infiltrate electronic devices and wreak havoc.",
+		de: "Sein Körper besteht aus Plasma. Mit ihm kann es in elektrische Geräte eindringen und für Chaos sorgen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/141.ts
+++ b/data/Sun & Moon/Ultra Prism/141.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	suffix: "GX",
@@ -93,7 +94,7 @@ const card: Card = {
 				es: "Lanza Polar GX",
 				it: "Lancia Polare-GX",
 				pt: "Lança Polar GX",
-				de: "Polarspeer GX"
+				de: "Polarspeer-GX"
 			},
 			effect: {
 				en: "This attack does 50 damage for each damage counter on your opponent’s Active Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Ultra Prism/142.ts
+++ b/data/Sun & Moon/Ultra Prism/142.ts
@@ -86,7 +86,7 @@ const card: Card = {
 				es: "Resplandor GX",
 				it: "Lumen-GX",
 				pt: "Relampejo GX",
-				de: "Beleuchten GX"
+				de: "Beleuchten-GX"
 			},
 			effect: {
 				en: "Your opponent reveals their hand. Add a card you find there to their Prize cards face down. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Ultra Prism/143.ts
+++ b/data/Sun & Moon/Ultra Prism/143.ts
@@ -88,7 +88,7 @@ const card: Card = {
 				es: "Eclipse de Luna GX",
 				it: "Eclissi di Luna-GX",
 				pt: "Eclipse da Lua GX",
-				de: "Lunarfinsternis GX"
+				de: "Lunarfinsternis-GX"
 			},
 			effect: {
 				en: "You can use this attack only if you have more Prize cards remaining than your opponent. Prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Ultra Prism/144.ts
+++ b/data/Sun & Moon/Ultra Prism/144.ts
@@ -49,7 +49,7 @@ const card: Card = {
 				es: "Este ataque hace 30 puntos de daño más por cada Colorless en el Coste de Retirada del Pokémon Activo de tu rival.",
 				it: "Questo attacco infligge 30 danni in più per ogni Colorless nel costo di ritirata del Pokémon attivo del tuo avversario.",
 				pt: "Este ataque causa 30 pontos de dano a mais para cada Colorless no custo de Recuo do Pokémon Ativo do seu oponente.",
-				de: "Diese Attacke fügt 30 Schadenspunkte mehr mal der Anzahl der Colorless-Symbole in den Rückzugskosten des Aktiven Pokémon deines Gegners zu."
+				de: "Diese Attacke fügt 30 Schadenspunkte mehr mal der Anzahl der {C}-Symbole in den Rückzugskosten des Aktiven Pokémon deines Gegners zu."
 			},
 			damage: "30+",
 
@@ -86,7 +86,7 @@ const card: Card = {
 				es: "Cohete GX",
 				it: "Propulsus-GX",
 				pt: "Detonador GX",
-				de: "Blaster GX"
+				de: "Blaster-GX"
 			},
 			effect: {
 				en: "Turn all of your Prize cards face up. (Those Prize cards remain face up for the rest of the game.) (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Ultra Prism/145.ts
+++ b/data/Sun & Moon/Ultra Prism/145.ts
@@ -85,7 +85,7 @@ const card: Card = {
 				es: "Eclipse de Sol GX",
 				it: "Eclissi di Sole-GX",
 				pt: "Eclipse do Sol GX",
-				de: "Solarfinsternis GX"
+				de: "Solarfinsternis-GX"
 			},
 			effect: {
 				en: "You can use this attack only if you have more Prize cards remaining than your opponent. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Ultra Prism/146.ts
+++ b/data/Sun & Moon/Ultra Prism/146.ts
@@ -90,7 +90,7 @@ const card: Card = {
 				es: "Intemporal GX",
 				it: "Sospensione Temporale-GX",
 				pt: "Para-tempo GX",
-				de: "Zeitlos GX"
+				de: "Zeitlos-GX"
 			},
 			effect: {
 				en: "Take another turn after this one. (Skip the between-turns step.) (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Ultra Prism/147.ts
+++ b/data/Sun & Moon/Ultra Prism/147.ts
@@ -71,7 +71,7 @@ const card: Card = {
 				es: "Este ataque hace 20 puntos de daño más por cada Energía Water unida a este Pokémon.",
 				it: "Questo attacco infligge 20 danni in più per ogni Energia Water assegnata a questo Pokémon.",
 				pt: "Este ataque causa 20 pontos de dano a mais vezes a quantidade de Energia Water ligada a este Pokémon.",
-				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der an dieses Pokémon angelegten Water-Energien zu."
+				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der an dieses Pokémon angelegten {W}-Energien zu."
 			},
 			damage: "60+",
 
@@ -90,7 +90,7 @@ const card: Card = {
 				es: "Fuga Cero GX",
 				it: "Zero Evanescente-GX",
 				pt: "Sumiço Total GX",
-				de: "Nullwert GX"
+				de: "Nullwert-GX"
 			},
 			effect: {
 				en: "Shuffle all Energy from each of your opponent’s Pokémon into their deck. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Ultra Prism/148.ts
+++ b/data/Sun & Moon/Ultra Prism/148.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon las cartas de tu mano en tu baraja y barájalas todas. Después, roba 6 cartas.",
 		it: "Rimischia le carte che hai in mano nel tuo mazzo. Poi pesca sei carte.",
 		pt: "Embaralhe a sua mão no seu baralho. Em seguida, compre 6 cartas.",
-		de: "Mische deine Handkarten in dein Deck. Ziehe anschließend 6 Karten."
+		de: "Mische deine Handkarten in dein Deck. Ziehe anschließend 6 Karten. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Ultra Prism/149.ts
+++ b/data/Sun & Moon/Ultra Prism/149.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cura 80 puntos de daño a 1 de tus Pokémon que tenga alguna Energía Grass unida a él.",
 		it: "Cura uno dei tuoi Pokémon che abbia delle Energie Grass assegnate da 80 danni.",
 		pt: "Cure 80 pontos de dano de 1 dos seus Pokémon que tiver alguma Energia Grass ligada a ele.",
-		de: "Heile 80 Schadenspunkte bei 1 deiner Pokémon, an das mindestens 1 Grass-Energie angelegt ist."
+		de: "Heile 80 Schadenspunkte bei 1 deiner Pokémon, an das mindestens 1 {G}-Energie angelegt ist. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Ultra Prism/15.ts
+++ b/data/Sun & Moon/Ultra Prism/15.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "The blooming of Gracidea flowers confers the power of flight upon it. Feelings of gratitude are the message it delivers.",
+		de: "Es heißt, wenn die Gracidea blühen, drückt es seine Dankbarkeit aus, indem es hoch in die Lüfte fliegt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/150.ts
+++ b/data/Sun & Moon/Ultra Prism/150.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cura 50 puntos de daño a cada uno de tus Pokémon que tenga alguna Energía Water unida a él.",
 		it: "Cura ciascuno dei tuoi Pokémon che abbia delle Energie Water assegnate da 50 danni.",
 		pt: "Cure 50 pontos de dano de cada um dos seus Pokémon que tiver alguma Energia Water ligada a ele.",
-		de: "Heile 50 Schadenspunkte bei jedem deiner Pokémon, an das mindestens 1 Water-Energie angelegt ist."
+		de: "Heile 50 Schadenspunkte bei jedem deiner Pokémon, an das mindestens 1 {W}-Energie angelegt ist. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Ultra Prism/151.ts
+++ b/data/Sun & Moon/Ultra Prism/151.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba cartas hasta que tengas 6 cartas en tu mano. Si es tu primer turno, roba cartas hasta que tengas 8 cartas en tu mano.",
 		it: "Pesca fino ad avere sei carte in mano. Se è il tuo primo turno, pesca fino ad avere otto carte in mano.",
 		pt: "Compre cartas até ter 6 cartas na sua mão. Se for a sua primeira vez de jogar, compre cartas até ter 8 cartas na sua mão.",
-		de: "Ziehe so lange Karten, bis du 6 Karten auf der Hand hast. Wenn es dein erster Zug ist, ziehe so lange Karten, bis du 8 Karten auf der Hand hast."
+		de: "Ziehe so lange Karten, bis du 6 Karten auf der Hand hast. Wenn es dein erster Zug ist, ziehe so lange Karten, bis du 8 Karten auf der Hand hast. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Ultra Prism/152.ts
+++ b/data/Sun & Moon/Ultra Prism/152.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba 3 cartas de la parte inferior de tu baraja.",
 		it: "Pesca tre carte in fondo al tuo mazzo.",
 		pt: "Compre as 3 últimas cartas do seu baralho.",
-		de: "Ziehe 3 Karten von unten aus deinem Deck."
+		de: "Ziehe 3 Karten von unten aus deinem Deck. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Ultra Prism/153.ts
+++ b/data/Sun & Moon/Ultra Prism/153.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon 2 cartas de Partidario y de Estadio, en cualquier combinación, de tu pila de descartes en tu mano.",
 		it: "Prendi due carte Aiuto o Stadio in qualsiasi combinazione dalla tua pila degli scarti e aggiungile a quelle che hai in mano.",
 		pt: "Coloque 2 cartas de Apoiador e de Estádio da sua pilha de descarte na sua mão em qualquer combinação.",
-		de: "Nimm eine beliebige Kombination aus 2 Unterstützer- und Stadionkarten aus deinem Ablagestapel auf deine Hand."
+		de: "Nimm eine beliebige Kombination aus 2 Unterstützer- und Stadionkarten aus deinem Ablagestapel auf deine Hand. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Ultra Prism/154.ts
+++ b/data/Sun & Moon/Ultra Prism/154.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba 2 cartas. Si lo haces, descarta 1 carta aleatoria de la mano de tu rival.",
 		it: "Pesca due carte. Se lo fai, scarta una carta a caso dalla mano del tuo avversario.",
 		pt: "Compre 2 cartas. Se fizer isto, descarte 1 carta aleatória da mão do seu oponente.",
-		de: "Ziehe 2 Karten. Wenn du das machst, lege 1 zufällige Karte aus der Hand deines Gegners auf seinen Ablagestapel."
+		de: "Ziehe 2 Karten. Wenn du das machst, lege 1 zufällige Karte aus der Hand deines Gegners auf seinen Ablagestapel. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Ultra Prism/155.ts
+++ b/data/Sun & Moon/Ultra Prism/155.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 2 Pokémon Básicos, enséñalos y ponlos en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo fino a due Pokémon Base, mostrali e aggiungili alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por até 2 Pokémon Básicos no seu baralho, revele-os e coloque-os na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach bis zu 2 Basis-Pokémon, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach bis zu 2 Basis-Pokémon, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Ultra Prism/156.ts
+++ b/data/Sun & Moon/Ultra Prism/156.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja 1 carta de Objeto y 1 carta de Energía Lightning, enséñalas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo una carta Strumento e una carta Energia Lightning, mostrale e aggiungile alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por 1 carta de Item e por 1 carta de Energia Lightning no seu baralho, revele-as e coloque-as na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach 1 Itemkarte und 1 Lightning-Energiekarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach 1 Itemkarte und 1 {L}-Energiekarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Ultra Prism/157.ts
+++ b/data/Sun & Moon/Ultra Prism/157.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	suffix: "GX",
@@ -84,7 +85,7 @@ const card: Card = {
 				es: "Gran Floración GX",
 				it: "Fioritura Formidabile-GX",
 				pt: "Floração Grandiosa GX",
-				de: "Blütezeit GX"
+				de: "Blütezeit-GX"
 			},
 			effect: {
 				en: "For each of your Benched Basic Pokémon, search your deck for a card that evolves from that Pokémon and put it onto that Pokémon to evolve it. Then, shuffle your deck. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Ultra Prism/159.ts
+++ b/data/Sun & Moon/Ultra Prism/159.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	suffix: "GX",
@@ -93,7 +94,7 @@ const card: Card = {
 				es: "Lanza Polar GX",
 				it: "Lancia Polare-GX",
 				pt: "Lança Polar GX",
-				de: "Polarspeer GX"
+				de: "Polarspeer-GX"
 			},
 			effect: {
 				en: "This attack does 50 damage for each damage counter on your opponent’s Active Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Ultra Prism/16.ts
+++ b/data/Sun & Moon/Ultra Prism/16.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "It crawls onto the land in search of food. Its water bubble allows it to breathe and protects its soft head.",
+		de: "Die Futtersuche treibt es an Land. Eine Wasserblase versorgt es mit Atemluft und schützt zugleich seinen weichen Kopf."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/160.ts
+++ b/data/Sun & Moon/Ultra Prism/160.ts
@@ -86,7 +86,7 @@ const card: Card = {
 				es: "Resplandor GX",
 				it: "Lumen-GX",
 				pt: "Relampejo GX",
-				de: "Beleuchten GX"
+				de: "Beleuchten-GX"
 			},
 			effect: {
 				en: "Your opponent reveals their hand. Add a card you find there to their Prize cards face down. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Ultra Prism/161.ts
+++ b/data/Sun & Moon/Ultra Prism/161.ts
@@ -88,7 +88,7 @@ const card: Card = {
 				es: "Eclipse de Luna GX",
 				it: "Eclissi di Luna-GX",
 				pt: "Eclipse da Lua GX",
-				de: "Lunarfinsternis GX"
+				de: "Lunarfinsternis-GX"
 			},
 			effect: {
 				en: "You can use this attack only if you have more Prize cards remaining than your opponent. Prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Ultra Prism/162.ts
+++ b/data/Sun & Moon/Ultra Prism/162.ts
@@ -49,7 +49,7 @@ const card: Card = {
 				es: "Este ataque hace 30 puntos de daño más por cada Colorless en el Coste de Retirada del Pokémon Activo de tu rival.",
 				it: "Questo attacco infligge 30 danni in più per ogni Colorless nel costo di ritirata del Pokémon attivo del tuo avversario.",
 				pt: "Este ataque causa 30 pontos de dano a mais para cada Colorless no custo de Recuo do Pokémon Ativo do seu oponente.",
-				de: "Diese Attacke fügt 30 Schadenspunkte mehr mal der Anzahl der Colorless-Symbole in den Rückzugskosten des Aktiven Pokémon deines Gegners zu."
+				de: "Diese Attacke fügt 30 Schadenspunkte mehr mal der Anzahl der {C}-Symbole in den Rückzugskosten des Aktiven Pokémon deines Gegners zu."
 			},
 			damage: "30+",
 
@@ -86,7 +86,7 @@ const card: Card = {
 				es: "Cohete GX",
 				it: "Propulsus-GX",
 				pt: "Detonador GX",
-				de: "Blaster GX"
+				de: "Blaster-GX"
 			},
 			effect: {
 				en: "Turn all of your Prize cards face up. (Those Prize cards remain face up for the rest of the game.) (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Ultra Prism/163.ts
+++ b/data/Sun & Moon/Ultra Prism/163.ts
@@ -85,7 +85,7 @@ const card: Card = {
 				es: "Eclipse de Sol GX",
 				it: "Eclissi di Sole-GX",
 				pt: "Eclipse do Sol GX",
-				de: "Solarfinsternis GX"
+				de: "Solarfinsternis-GX"
 			},
 			effect: {
 				en: "You can use this attack only if you have more Prize cards remaining than your opponent. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Ultra Prism/164.ts
+++ b/data/Sun & Moon/Ultra Prism/164.ts
@@ -90,7 +90,7 @@ const card: Card = {
 				es: "Intemporal GX",
 				it: "Sospensione Temporale-GX",
 				pt: "Para-tempo GX",
-				de: "Zeitlos GX"
+				de: "Zeitlos-GX"
 			},
 			effect: {
 				en: "Take another turn after this one. (Skip the between-turns step.) (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Ultra Prism/165.ts
+++ b/data/Sun & Moon/Ultra Prism/165.ts
@@ -71,7 +71,7 @@ const card: Card = {
 				es: "Este ataque hace 20 puntos de daño más por cada Energía Water unida a este Pokémon.",
 				it: "Questo attacco infligge 20 danni in più per ogni Energia Water assegnata a questo Pokémon.",
 				pt: "Este ataque causa 20 pontos de dano a mais vezes a quantidade de Energia Water ligada a este Pokémon.",
-				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der an dieses Pokémon angelegten Water-Energien zu."
+				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der an dieses Pokémon angelegten {W}-Energien zu."
 			},
 			damage: "60+",
 
@@ -90,7 +90,7 @@ const card: Card = {
 				es: "Fuga Cero GX",
 				it: "Zero Evanescente-GX",
 				pt: "Sumiço Total GX",
-				de: "Nullwert GX"
+				de: "Nullwert-GX"
 			},
 			effect: {
 				en: "Shuffle all Energy from each of your opponent’s Pokémon into their deck. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Ultra Prism/166.ts
+++ b/data/Sun & Moon/Ultra Prism/166.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Lanza 1 moneda. Si sale cara, descarta 1 Energía de 1 de los Pokémon de tu rival.",
 		it: "Lancia una moneta. Se esce testa, scarta un’Energia assegnata a uno dei Pokémon del tuo avversario.",
 		pt: "Jogue 1 moeda. Se sair cara, descarte 1 Energia de 1 dos Pokémon do seu oponente.",
-		de: "Wirf 1 Münze. Lege bei Kopf 1 Energie von 1 Pokémon deines Gegners auf seinen Ablagestapel."
+		de: "Wirf 1 Münze. Lege bei Kopf 1 Energie von 1 Pokémon deines Gegners auf seinen Ablagestapel. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Ultra Prism/167.ts
+++ b/data/Sun & Moon/Ultra Prism/167.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "El Coste de Retirada del Pokémon al que esté unida esta carta es de Colorless menos, y puede retirarse incluso si está Dormido o Paralizado.",
 		it: "Il costo di ritirata del Pokémon a cui è assegnata questa carta è ridotto di Colorless e il Pokémon può ritirarsi anche se è addormentato o paralizzato.",
 		pt: "O custo de Recuo do Pokémon ao qual esta carta está ligada é Colorless a menos e ele poderá recuar mesmo que esteja Adormecido ou Paralisado.",
-		de: "Die Rückzugskosten des Pokémon, an das diese Karte angelegt ist, verringern sich um Colorless und es kann sich zurückziehen, auch wenn es schläft oder paralysiert ist."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Die Rückzugskosten des Pokémon, an das diese Karte angelegt ist, verringern sich um {C} und es kann sich zurückziehen, auch wenn es schläft oder paralysiert ist. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sun & Moon/Ultra Prism/168.ts
+++ b/data/Sun & Moon/Ultra Prism/168.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Puedes jugar 4 cartas de Trébol Perdido de una vez.\n\n• Si has jugado 1 carta, mira la primera carta de tu baraja.\n• Si has jugado 4 cartas, coge 1 carta de Premio. (Este efecto funciona 1 vez por 4 cartas).",
 		it: "Puoi giocare quattro carte Trifoglio Mancante alla volta.\n\n• Se giochi una carta, guarda la prima carta del tuo mazzo.\n• Se giochi quattro carte, prendi una carta Premio (questo effetto si applica una volta ogni quattro carte).",
 		pt: "Você pode jogar 4 cartas Trevo Perdido de uma vez.\n\n• Se você jogou 1 carta, olhe a primeira carta do seu baralho.\n• Se você jogou 4 cartas, pegue 1 carta de Prêmio (este efeito funciona uma vez para 4 cartas).",
-		de: "Du kannst 4 Fehlendes Kleeblatt-Karten gleichzeitig spielen.\n\n• Wenn du 1 Karte gespielt hast, schau dir die oberste Karte deines Decks an.\n• Wenn du 4 Karten gespielt hast, nimm 1 Preiskarte. (Dieser Effekt funktioniert einmal für 4 Karten.)"
+		de: "Du kannst 4 Fehlendes Kleeblatt-Karten gleichzeitig spielen. Wenn du 1 Karte gespielt hast, schau dir die oberste Karte deines Decks an. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen. Wenn du 4 Karten gespielt hast, nimm 1 Preiskarte. (Dieser Effekt funktioniert einmal für 4 Karten.)"
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Ultra Prism/169.ts
+++ b/data/Sun & Moon/Ultra Prism/169.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Tu rival enseña las cartas de su mano. Puedes hacer que tu rival cuente las cartas de su mano, las ponga en su baraja y las baraje todas, y después robe la misma cantidad de cartas.",
 		it: "Il tuo avversario mostra le carte che ha in mano. Puoi fargliele contare e rimischiare nel suo mazzo e poi fargli pescare lo stesso numero di carte.",
 		pt: "Seu oponente revela a própria mão. Você pode fazer com que o seu oponente conte as cartas na própria mão, embaralhe aquelas cartas no baralho dele(a) e então compre aquele mesmo número de cartas.",
-		de: "Dein Gegner zeigt dir seine Handkarten. Du kannst deinen Gegner dazu veranlassen, die Karten auf seiner Hand zu zählen, jene Karten in sein Deck zu mischen und anschließend dieselbe Anzahl Karten zu ziehen."
+		de: "Dein Gegner zeigt dir seine Handkarten. Du kannst deinen Gegner dazu veranlassen, die Karten auf seiner Hand zu zählen, jene Karten in sein Deck zu mischen und anschließend dieselbe Anzahl Karten zu ziehen. Du kannst während deines Zuges (bevor du angreifst) beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sun & Moon/Ultra Prism/17.ts
+++ b/data/Sun & Moon/Ultra Prism/17.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Dewpider",
 		fr: "Araqua",
+		de: "Araqua"
 	},
 
 	stage: "Stage1",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Evita todo el daño infligido a este Pokémon por ataques de los Pokémon Fire de tu rival.",
 				it: "Previeni tutti i danni da attacchi inflitti a questo Pokémon dai Pokémon Fire del tuo avversario.",
 				pt: "Previne todo o dano causado a este Pokémon por ataques dos Pokémon Fire do seu oponente.",
-				de: "Verhindere allen Schaden, der diesem Pokémon durch Attacken von Fire-Pokémon deines Gegners zugefügt wird."
+				de: "Verhindere allen Schaden, der diesem Pokémon durch Attacken von {R}-Pokémon deines Gegners zugefügt wird."
 			},
 		},
 	],
@@ -87,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It delivers headbutts with the water bubble on its head. Small Pokémon get sucked into the bubble, where they drown.",
+		de: "Es verteilt mit seiner Wasserblase Kopfstöße. Kleine Pokémon werden dabei hineingezogen und ertrinken."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/172.ts
+++ b/data/Sun & Moon/Ultra Prism/172.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cosmoem",
 		fr: "Cosmovum",
+		de: "Cosmovum"
 	},
 
 	suffix: "GX",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Todas las veces que quieras durante tu turno (antes de tu ataque), puedes mover 1 Energía Psychic de 1 de tus Pokémon a otro de tus Pokémon.",
 				it: "Durante il tuo turno, prima di attaccare, puoi spostare un’Energia Psychic da uno a un altro dei tuoi Pokémon tutte le volte che vuoi.",
 				pt: "Quantas vezes desejar durante a sua vez de jogar (antes de atacar), você pode mover 1 Energia Psychic de 1 dos seus Pokémon para outro Pokémon seu.",
-				de: "Beliebig oft während deines Zuges (bevor du angreifst) kannst du 1 Psychic-Energie von 1 deiner Pokémon auf 1 anderes deiner Pokémon verschieben."
+				de: "Beliebig oft während deines Zuges (bevor du angreifst) kannst du 1 {P}-Energie von 1 deiner Pokémon auf 1 anderes deiner Pokémon verschieben."
 			},
 		},
 	],

--- a/data/Sun & Moon/Ultra Prism/173.ts
+++ b/data/Sun & Moon/Ultra Prism/173.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cosmoem",
 		fr: "Cosmovum",
+		de: "Cosmovum"
 	},
 
 	suffix: "GX",

--- a/data/Sun & Moon/Ultra Prism/18.ts
+++ b/data/Sun & Moon/Ultra Prism/18.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "When angered, it spouts brilliant fire from all over its body. It doesn't calm down until its opponent has burned to ash.",
+		de: "Ist es wütend, stößt es glühend heiße Flammen aus. Es hört damit erst auf, wenn von seinem Gegner nur noch Asche übrig ist."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/19.ts
+++ b/data/Sun & Moon/Ultra Prism/19.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Magmar",
 		fr: "Magmar",
+		de: "Magmar"
 	},
 
 	stage: "Stage1",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "From its arm, it launches fireballs hotter than 3,500 degrees Fahrenheit. Its arm starts to melt when it fires a whole barrage.",
+		de: "Aus den Enden seiner Arme feuert es 2 000 °C heiße Feuerbälle ab. Dadurch verkohlen sie nach mehrmaligem Einsatz leicht."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/2.ts
+++ b/data/Sun & Moon/Ultra Prism/2.ts
@@ -73,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "If it flaps its wings really fast, it can generate shock waves that will shatter windows in the area.",
+		de: "Schlägt es schnell mit den Flügeln, erzeugt es Schockwellen, durch die sogar Fenster zerbersten."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/20.ts
+++ b/data/Sun & Moon/Ultra Prism/20.ts
@@ -58,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "The gas made in its belly burns from its rear end. The fire burns weakly when it feels sick.",
+		de: "An seinem Rücken verbrennt es die Gase aus seinem Bauch. Geht es ihm schlecht, leuchtet es weniger hell."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/21.ts
+++ b/data/Sun & Moon/Ultra Prism/21.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "The gas made in its belly burns from its rear end. The fire burns weakly when it feels sick.",
+		de: "An seinem Rücken verbrennt es die Gase aus seinem Bauch. Geht es ihm schlecht, leuchtet es weniger hell."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/22.ts
+++ b/data/Sun & Moon/Ultra Prism/22.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Chimchar",
 		fr: "Ouisticram",
+		de: "Panflam"
 	},
 
 	stage: "Stage1",
@@ -70,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "It uses ceilings and walls to launch aerial attacks. Its fiery tail is but one weapon.",
+		de: "Es stürzt sich von Decken und Wänden auf Beute. Sein feuriger Schweif ist nur eine seiner Waffen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/23.ts
+++ b/data/Sun & Moon/Ultra Prism/23.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Monferno",
 		fr: "Chimpenfeu",
+		de: "Panpyro"
 	},
 
 	stage: "Stage2",
@@ -93,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "It tosses its enemies around with agility. It uses all its limbs to fight in its own unique style.",
+		de: "Es hält den Gegner mit flinken Bewegungen zum Narren. Im Kampf setzt es alle Gliedmaßen ein."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/24.ts
+++ b/data/Sun & Moon/Ultra Prism/24.ts
@@ -82,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "Its body is composed of plasma. It is known to infiltrate electronic devices and wreak havoc.",
+		de: "Sein Körper besteht aus Plasma. Mit ihm kann es in elektrische Geräte eindringen und für Chaos sorgen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/25.ts
+++ b/data/Sun & Moon/Ultra Prism/25.ts
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "Volcanoes or dry, craggy places are its home. It emanates a sweet-smelling poisonous gas that attracts bug Pokémon, then attacks them.",
+		de: "Lebt in Vulkanen und trockenen Felsgebieten. Mit seinem süßlich duftenden Giftgas lockt es Käfer-Pokémon an, um sie anzugreifen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/26.ts
+++ b/data/Sun & Moon/Ultra Prism/26.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Salandit",
 		fr: "Tritox",
+		de: "Molunk"
 	},
 
 	stage: "Stage1",
@@ -93,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "Filled with pheromones, its poisonous gas can be diluted to use in the production of luscious perfumes.",
+		de: "Ihr Giftgas enthält viele Pheromone. Verdünnt man es, lässt sich daraus ein sinnliches Parfüm herstellen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/27.ts
+++ b/data/Sun & Moon/Ultra Prism/27.ts
@@ -84,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "It gushes fire and poisonous gases from its nostrils. Its dung is an explosive substance and can be put to various uses.",
+		de: "Es greift mit Feuer und Giftgas aus den Nasenlöchern an. Sein Kot ist explosiv und vielseitig einsetzbar."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/28.ts
+++ b/data/Sun & Moon/Ultra Prism/28.ts
@@ -63,6 +63,7 @@ const card: Card = {
 
 	description: {
 		en: "An ancient tradition of Alolan festivals, still carried on to this day, is a competition to slide Sandshrew across ice as far as one can.",
+		de: "Bei einem der traditionellen Feste Alolas messen sich die Teilnehmer darin, ihre Sandan so weit wie möglich über Eisflächen gleiten zu lassen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/29.ts
+++ b/data/Sun & Moon/Ultra Prism/29.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Alolan Sandshrew",
 		fr: "Sabelette d’Alola",
+		de: "Alola-Sandan"
 	},
 
 	stage: "Stage1",
@@ -86,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon's steel spikes are sheathed in ice. Stabs from these spikes cause deep wounds and severe frostbite as well.",
+		de: "Eis bedeckt seine stählernen Stacheln. Ein Angriff mit diesen Stacheln führt neben tiefen Wunden auch zu Erfrierungen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/3.ts
+++ b/data/Sun & Moon/Ultra Prism/3.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Yanma",
 		fr: "Yanma",
+		de: "Yanma"
 	},
 
 	stage: "Stage1",
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "This six-legged Pokémon is easily capable of transporting an adult in flight. The wings on its tail help it stay balanced.",
+		de: "Es kann mühelos einen Erwachsenen umhertragen. Die Federn an seinem Hinterteil stabilisieren seinen Flug."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/30.ts
+++ b/data/Sun & Moon/Ultra Prism/30.ts
@@ -78,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "It exhales air colder than -58 degrees Fahrenheit. Elderly people in Alola call this Pokémon by an older name—Keokeo.",
+		de: "Sein eisiger Atem beträgt -50 °C. Einige der älteren Einwohner von Alola nennen es bei seinem früheren Namen „Ke’oke’o“."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/31.ts
+++ b/data/Sun & Moon/Ultra Prism/31.ts
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "Because it is very proud, it hates accepting food from people. Its thick down guards it from cold.",
+		de: "Es ist sehr stolz und nimmt daher kein Futter von anderen an. Seine dicken Daunen schützen vor Kälte."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/32.ts
+++ b/data/Sun & Moon/Ultra Prism/32.ts
@@ -75,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "Because it is very proud, it hates accepting food from people. Its thick down guards it from cold.",
+		de: "Es ist sehr stolz und nimmt daher kein Futter von anderen an. Seine dicken Daunen schützen vor Kälte."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/33.ts
+++ b/data/Sun & Moon/Ultra Prism/33.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Piplup",
 		fr: "Tiplouf",
+		de: "Plinfa"
 	},
 
 	stage: "Stage1",
@@ -87,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives a solitary life. Its wings deliver wicked blows that can snap even the thickest of trees.",
+		de: "Pliprin sind Einzelgänger. Ein Schlag ihrer kräftigen Flügel haut selbst große Bäume entzwei."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/34.ts
+++ b/data/Sun & Moon/Ultra Prism/34.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Prinplup",
 		fr: "Prinplouf",
+		de: "Pliprin"
 	},
 
 	stage: "Stage2",
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "The three horns that extend from its beak attest to its power. The leader has the biggest horns.",
+		de: "Die drei Hörner, die aus dem Schnabel wachsen, stehen für Kraft. Ein Anführer hat die größten Hörner."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/35.ts
+++ b/data/Sun & Moon/Ultra Prism/35.ts
@@ -59,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "It inflates the flotation sac around its neck and pokes its head out of the water to see what is going on.",
+		de: "Es füllt den Schwimmreifen um seinen Hals mit Luft, um den Kopf über dem Wasser zu halten und die Umgebung zu überblicken."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/36.ts
+++ b/data/Sun & Moon/Ultra Prism/36.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Buizel",
 		fr: "Mustébouée",
+		de: "Bamelin"
 	},
 
 	stage: "Stage1",
@@ -76,7 +77,7 @@ const card: Card = {
 				es: "Descarta 1 Energía Water de este Pokémon.",
 				it: "Scarta un’Energia Water assegnata a questo Pokémon.",
 				pt: "Descarte 1 Energia Water deste Pokémon.",
-				de: "Lege 1 Water-Energie von diesem Pokémon auf deinen Ablagestapel."
+				de: "Lege 1 {W}-Energie von diesem Pokémon auf deinen Ablagestapel."
 			},
 			damage: 80,
 
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "Its flotation sac developed as a result of pursuing aquatic prey. It can double as a rubber raft.",
+		de: "Da es seit jeher Beute im Wasser jagt, entwickelte es einen Rettungsring."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/37.ts
+++ b/data/Sun & Moon/Ultra Prism/37.ts
@@ -48,7 +48,7 @@ const card: Card = {
 				es: "Si el Pokémon Activo de tu rival es un Pokémon Fighting, este ataque hace 40 puntos de daño más.",
 				it: "Se il Pokémon attivo del tuo avversario è di tipo Fighting, questo attacco infligge 40 danni in più.",
 				pt: "Se o Pokémon Ativo do seu oponente for um Pokémon Fighting, este ataque causará 40 pontos de dano a mais.",
-				de: "Wenn das Aktive Pokémon deines Gegners ein Fighting-Pokémon ist, fügt diese Attacke 40 Schadenspunkte mehr zu."
+				de: "Wenn das Aktive Pokémon deines Gegners ein {F}-Pokémon ist, fügt diese Attacke 40 Schadenspunkte mehr zu."
 			},
 			damage: "20+",
 
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "In the spring, it grows berries with the texture of frozen treats around its belly.",
+		de: "Im Frühjahr wachsen Beeren, die wie gefrorene Süßigkeiten aussehen, um seinen Bauch herum."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/38.ts
+++ b/data/Sun & Moon/Ultra Prism/38.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Snover",
 		fr: "Blizzi",
+		de: "Shnebedeck"
 	},
 
 	stage: "Stage1",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Cuando juegues este Pokémon de tu mano para hacer evolucionar a 1 de tus Pokémon durante tu turno, puedes unir 1 carta de Energía Water de tu pila de descartes a 1 de tus Pokémon.",
 				it: "Quando giochi questo Pokémon dalla tua mano durante il tuo turno per far evolvere uno dei tuoi Pokémon, puoi assegnare a uno dei tuoi Pokémon una carta Energia Water dalla tua pila degli scarti.",
 				pt: "Quando você joga este Pokémon da sua mão para evoluir 1 dos seus Pokémon durante a sua vez de jogar, você pode ligar 1 carta de Energia Water da sua pilha de descarte a 1 dos seus Pokémon.",
-				de: "Wenn du dieses Pokémon aus deiner Hand spielst, um 1 deiner Pokémon während deines Zuges zu entwickeln, kannst du 1 Water-Energiekarte aus deinem Ablagestapel an 1 deiner Pokémon anlegen."
+				de: "Wenn du dieses Pokémon aus deiner Hand spielst, um 1 deiner Pokémon während deines Zuges zu entwickeln, kannst du 1 {W}-Energiekarte aus deinem Ablagestapel an 1 deiner Pokémon anlegen."
 			},
 		},
 	],
@@ -95,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "It lives a quiet life on mountains that are perpetually covered in snow. It hides itself by whipping up blizzards.",
+		de: "Es haust im Gebirge, wo ewiger Schnee liegt, und löst Blizzards aus, um sich zu verstecken."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/39.ts
+++ b/data/Sun & Moon/Ultra Prism/39.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	suffix: "GX",
@@ -93,7 +94,7 @@ const card: Card = {
 				es: "Lanza Polar GX",
 				it: "Lancia Polare-GX",
 				pt: "Lança Polar GX",
-				de: "Polarspeer GX"
+				de: "Polarspeer-GX"
 			},
 			effect: {
 				en: "This attack does 50 damage for each damage counter on your opponent’s Active Pokémon. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Ultra Prism/4.ts
+++ b/data/Sun & Moon/Ultra Prism/4.ts
@@ -66,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "Roselia that drink nutritionally rich springwater are said to reveal rare coloration when they bloom.",
+		de: "Gibt man ihm besonders nahrhaftes Quellwasser zu trinken, entwickelt es Blüten in seltenen Farben."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/40.ts
+++ b/data/Sun & Moon/Ultra Prism/40.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Its body is composed of plasma. It is known to infiltrate electronic devices and wreak havoc.",
+		de: "Sein Körper besteht aus Plasma. Mit ihm kann es in elektrische Geräte eindringen und für Chaos sorgen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/41.ts
+++ b/data/Sun & Moon/Ultra Prism/41.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Its body is composed of plasma. It is known to infiltrate electronic devices and wreak havoc.",
+		de: "Sein Körper besteht aus Plasma. Mit ihm kann es in elektrische Geräte eindringen und für Chaos sorgen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/42.ts
+++ b/data/Sun & Moon/Ultra Prism/42.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Pon 5 cartas de Energía Water de tu pila de descartes en tu baraja y barájalas todas.",
 				it: "Rimischia cinque carte Energia Water dalla tua pila degli scarti nel tuo mazzo.",
 				pt: "Embaralhe 5 cartas de Energia Water da sua pilha de descarte no seu baralho.",
-				de: "Mische 5 Water-Energiekarten aus deinem Ablagestapel in dein Deck."
+				de: "Mische 5 {W}-Energiekarten aus deinem Ablagestapel in dein Deck."
 			},
 
 		},
@@ -87,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "It starts its life with a wondrous power that permits it to bond with any kind of Pokémon.",
+		de: "Es besitzt die wundersame Fähigkeit, das Herz eines jeden anderen Pokémon anzurühren."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/43.ts
+++ b/data/Sun & Moon/Ultra Prism/43.ts
@@ -91,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "Electricity leaks from it in amounts far greater than the amount of electricity it eats.",
+		de: "Die Menge an Elektrizität, die aus seinem Körper austritt, ist sehr viel größer als jene, die es über seine Nahrung zu sich nimmt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/44.ts
+++ b/data/Sun & Moon/Ultra Prism/44.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Electabuzz",
 		fr: "Élektek",
+		de: "Elektek"
 	},
 
 	stage: "Stage1",
@@ -54,7 +55,7 @@ const card: Card = {
 				es: "Si el Pokémon Activo de tu rival es un Pokémon Metal, este pasa a estar Paralizado.",
 				it: "Se il Pokémon attivo del tuo avversario è di tipo Metal, viene paralizzato.",
 				pt: "Se o Pokémon Ativo do seu oponente for um Pokémon Metal, ele será Paralisado.",
-				de: "Wenn das Aktive Pokémon deines Gegners ein Metal-Pokémon ist, ist es jetzt paralysiert."
+				de: "Wenn das Aktive Pokémon deines Gegners ein {M}-Pokémon ist, ist es jetzt paralysiert."
 			},
 			damage: 60,
 
@@ -98,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "When it gets excited, it thumps its chest. With every thud, thunder roars and electric sparks shower all around.",
+		de: "Wenn es sich aufregt, schlägt es sich kräftig auf die Brust. Bei jedem Schlag sprühen Funken und es ertönt ein Donnern."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/45.ts
+++ b/data/Sun & Moon/Ultra Prism/45.ts
@@ -87,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "All of its fur dazzles if danger is sensed. It flees while the foe is momentarily blinded.",
+		de: "In Gefahr blendet es seinen Gegner mit seinem Fell und flieht, während der Gegner einen Moment blind ist."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/46.ts
+++ b/data/Sun & Moon/Ultra Prism/46.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Busca en tu baraja 1 carta de Energía Lightning y únela a este Pokémon. Después, baraja las cartas de tu baraja.",
 				it: "Cerca nel tuo mazzo una carta Energia Lightning e assegnala a questo Pokémon. Poi rimischia le carte del tuo mazzo.",
 				pt: "Procure por 1 carta de Energia Lightning no seu baralho e ligue-a a este Pokémon. Em seguida, embaralhe o seu baralho.",
-				de: "Durchsuche dein Deck nach 1 Lightning-Energiekarte und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
+				de: "Durchsuche dein Deck nach 1 {L}-Energiekarte und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
 			},
 
 		},
@@ -71,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "All of its fur dazzles if danger is sensed. It flees while the foe is momentarily blinded.",
+		de: "In Gefahr blendet es seinen Gegner mit seinem Fell und flieht, während der Gegner einen Moment blind ist."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/47.ts
+++ b/data/Sun & Moon/Ultra Prism/47.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Shinx",
 		fr: "Lixy",
+		de: "Sheinux"
 	},
 
 	stage: "Stage1",
@@ -77,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "Strong electricity courses through the tips of its sharp claws. A light scratch causes fainting in foes.",
+		de: "Durch die Spitzen seiner scharfen Krallen strömt Elektrizität. Selbst kleine Kratzer verursachen Ohnmacht."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/48.ts
+++ b/data/Sun & Moon/Ultra Prism/48.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Luxio",
 		fr: "Luxio",
+		de: "Luxio"
 	},
 
 	stage: "Stage2",
@@ -76,7 +77,7 @@ const card: Card = {
 				es: "Descarta todas las Energías Lightning de este Pokémon. Este ataque hace 150 puntos de daño a 1 de los Pokémon de tu rival. (No apliques Debilidad y Resistencia a los Pokémon en Banca).",
 				it: "Scarta tutte le Energie Lightning assegnate a questo Pokémon. Questo attacco infligge 150 danni a uno dei Pokémon del tuo avversario. Ricorda che non puoi applicare debolezza e resistenza ai Pokémon in panchina.",
 				pt: "Descarte todas as Energias Lightning deste Pokémon. Este ataque causa 150 pontos de dano a 1 dos Pokémon do seu oponente (não aplique Fraqueza e Resistência aos Pokémon no Banco).",
-				de: "Lege alle Lightning-Energien von diesem Pokémon auf deinen Ablagestapel. Diese Attacke fügt 1 Pokémon deines Gegners 150 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
+				de: "Lege alle {L}-Energien von diesem Pokémon auf deinen Ablagestapel. Diese Attacke fügt 1 Pokémon deines Gegners 150 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -100,6 +101,7 @@ const card: Card = {
 
 	description: {
 		en: "Luxray's ability to see through objects comes in handy when it's scouting for danger.",
+		de: "Beim Aufspüren von Gefahren sind Luxtras hellseherische Fähigkeiten äußerst hilfreich."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/49.ts
+++ b/data/Sun & Moon/Ultra Prism/49.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Por cada uno de tus Pokémon en Banca que tenga el ataque Moflete Estático, busca en tu baraja 1 carta de Energía Lightning y únela a ese Pokémon. Después, baraja las cartas de tu baraja.",
 				it: "Cerca nel tuo mazzo una carta Energia Lightning per ogni Pokémon nella tua panchina che abbia l’attacco Elettrococcola e assegnala a quel Pokémon. Poi rimischia le carte del tuo mazzo.",
 				pt: "Para cada um dos seus Pokémon no Banco que tiver o ataque Chamego, procure por 1 carta de Energia Lightning no seu baralho e ligue-a àquele Pokémon. Em seguida, embaralhe o seu baralho.",
-				de: "Durchsuche für jedes Pokémon auf deiner Bank, das die Attacke Wangenrubbler hat, dein Deck nach 1 Lightning-Energiekarte und lege sie an jenes Pokémon an. Mische anschließend dein Deck."
+				de: "Durchsuche für jedes Pokémon auf deiner Bank, das die Attacke Wangenrubbler hat, dein Deck nach 1 {L}-Energiekarte und lege sie an jenes Pokémon an. Mische anschließend dein Deck."
 			},
 
 		},
@@ -93,6 +93,7 @@ const card: Card = {
 
 	description: {
 		en: "A pair may be seen rubbing their cheek pouches together in an effort to share stored electricity.",
+		de: "Um gespeicherte Elektrizität zu teilen, reiben zwei von ihnen ihre Backentaschen aneinander."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/5.ts
+++ b/data/Sun & Moon/Ultra Prism/5.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Roselia",
 		fr: "Rosélia",
+		de: "Roselia"
 	},
 
 	stage: "Stage1",
@@ -76,7 +77,7 @@ const card: Card = {
 				es: "Mueve cualquier cantidad de Energías Grass de tus Pokémon a tus otros Pokémon de la manera que desees.",
 				it: "Distribuisci a piacimento tutte le Energie Grass assegnate ai tuoi Pokémon.",
 				pt: "Mova qualquer número de Energia Grass dos seus Pokémon para outros Pokémon seus como desejar.",
-				de: "Verschiebe beliebig viele Grass-Energien von deinen Pokémon beliebig auf deine anderen Pokémon."
+				de: "Verschiebe beliebig viele {G}-Energien von deinen Pokémon beliebig auf deine anderen Pokémon."
 			},
 			damage: 100,
 
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "With the movements of a dancer, it strikes with whips that are densely lined with poison thorns.",
+		de: "Mit den Bewegungen eines Tänzers holt es aus und schlägt mit Ranken um sich, die giftige Dornen haben."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/50.ts
+++ b/data/Sun & Moon/Ultra Prism/50.ts
@@ -96,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "Its body is composed of plasma. It is known to infiltrate electronic devices and wreak havoc.",
+		de: "Sein Körper besteht aus Plasma. Mit ihm kann es in elektrische Geräte eindringen und für Chaos sorgen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/51.ts
+++ b/data/Sun & Moon/Ultra Prism/51.ts
@@ -87,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "If for some reason its body bursts, its soul spills out with a screaming sound.",
+		de: "Wenn aus irgendeinem Grund sein Körper platzt, entweicht seine Seele mit einem Geräusch, das wie ein Schrei klingt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/52.ts
+++ b/data/Sun & Moon/Ultra Prism/52.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Drifloon",
 		fr: "Baudrive",
+		de: "Driftlon"
 	},
 
 	stage: "Stage1",
@@ -102,6 +103,7 @@ const card: Card = {
 
 	description: {
 		en: "Even while under careful observation, large flocks of Drifblim flying at dusk will inexplicably disappear from view.",
+		de: "Bemerkt man einen in der Dämmerung driftenden Schwarm von Drifzepeli, verschwindet dieser auch wieder sogleich."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/53.ts
+++ b/data/Sun & Moon/Ultra Prism/53.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It was bound to a fissure in an Odd Keystone as punishment for misdeeds 500 years ago.",
+		de: "Es wurde in einen Spalt eines Steins gebannt, als Sühne für Untaten, die es vor 500 Jahren begangen hatte."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/54.ts
+++ b/data/Sun & Moon/Ultra Prism/54.ts
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "It burrows under the sand to lie in wait for prey. Its tail claws can inject its prey with a savage poison.",
+		de: "Es wartet im Sand versteckt auf Beute, die es sich mit seinem giftigen Schweif krallt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/55.ts
+++ b/data/Sun & Moon/Ultra Prism/55.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Skorupi",
 		fr: "Rapion",
+		de: "Pionskora"
 	},
 
 	stage: "Stage1",
@@ -73,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "It has the power in its clawed arms to make scrap of a car. The tips of its claws release poison.",
+		de: "In seinen Armen steckt so viel Kraft, dass es mit seinen giftigen Krallen Autos zerquetschen kann."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/56.ts
+++ b/data/Sun & Moon/Ultra Prism/56.ts
@@ -65,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "Inflating its poison sacs, it fills the area with an odd sound and hits flinching opponents with a poison jab.",
+		de: "Bläst es seine Giftbeutel auf, ertönt ein unheimliches Geräusch, das Gegner zurückschrecken lässt und vergiftet."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/57.ts
+++ b/data/Sun & Moon/Ultra Prism/57.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Croagunk",
 		fr: "Cradopaud",
+		de: "Glibunkel"
 	},
 
 	stage: "Stage1",
@@ -76,7 +77,7 @@ const card: Card = {
 				es: "Si alguno de tus Pokémon Fighting quedó Fuera de Combate por el daño de un ataque de tu rival durante su último turno, este ataque hace 70 puntos de daño más.",
 				it: "Se uno qualsiasi dei tuoi Pokémon Fighting è stato messo KO dai danni inflitti da un attacco del tuo avversario durante il suo ultimo turno, questo attacco infligge 70 danni in più.",
 				pt: "Se algum dos seus Pokémon Fighting tiver sido Nocauteado pelo dano de um ataque do seu oponente durante a última vez dele(a) jogar, este ataque causará 70 pontos de dano a mais.",
-				de: "Wenn mindestens 1 deiner Fighting-Pokémon während des letzten Zuges deines Gegners durch Schaden einer Attacke kampfunfähig wurde, fügt diese Attacke 70 Schadenspunkte mehr zu."
+				de: "Wenn mindestens 1 deiner {F}-Pokémon während des letzten Zuges deines Gegners durch Schaden einer Attacke kampfunfähig wurde, fügt diese Attacke 70 Schadenspunkte mehr zu."
 			},
 			damage: "50+",
 
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "Its knuckle claws secrete a toxin so vile that even a scratch could prove fatal.",
+		de: "Die Gelenke an seinen Klauen geben ein so starkes Gift ab, dass selbst ein kleiner Kratzer fatal ist."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/58.ts
+++ b/data/Sun & Moon/Ultra Prism/58.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Cuando juegues este Pokémon de tu mano a tu Banca durante tu turno, puedes unirle 2 cartas de Energía Psychic de tu mano.",
 				it: "Quando giochi questo Pokémon dalla tua mano e lo metti in panchina durante il tuo turno, puoi assegnargli due carte Energia Psychic dalla tua mano.",
 				pt: "Quando você joga este Pokémon da sua mão para o seu Banco durante a sua vez de jogar, você pode ligar 2 cartas de Energia Psychic da sua mão a ele.",
-				de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand auf deine Bank spielst, kannst du 2 Psychic-Energiekarten aus deiner Hand an es anlegen."
+				de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand auf deine Bank spielst, kannst du 2 {P}-Energiekarten aus deiner Hand an es anlegen."
 			},
 		},
 	],
@@ -97,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "It was banished for its violence. It silently gazed upon the old world from the Distortion World.",
+		de: "Es wurde aufgrund seines Verhaltens verbannt. Aus der Zerrwelt schaut es auf die alte Welt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/59.ts
+++ b/data/Sun & Moon/Ultra Prism/59.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "Those who sleep holding Cresselia's feather are assured of joyful dreams. It is said to represent the crescent moon.",
+		de: "Hält man eine seiner Federn, träumt man süß. Manche glauben, es sei die Verkörperung der Mondsichel."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/6.ts
+++ b/data/Sun & Moon/Ultra Prism/6.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Busca en tu baraja 1 carta de Energía Grass y únela a 1 de tus Pokémon. Después, baraja las cartas de tu baraja.",
 				it: "Cerca nel tuo mazzo una carta Energia Grass e assegnala a uno dei tuoi Pokémon. Poi rimischia le carte del tuo mazzo.",
 				pt: "Procure por 1 carta de Energia Grass no seu baralho e ligue-a a 1 dos seus Pokémon. Em seguida, embaralhe o seu baralho.",
-				de: "Durchsuche dein Deck nach 1 Grass-Energiekarte und lege sie an 1 deiner Pokémon an. Mische anschließend dein Deck."
+				de: "Durchsuche dein Deck nach 1 {G}-Energiekarte und lege sie an 1 deiner Pokémon an. Mische anschließend dein Deck."
 			},
 
 		},
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "It undertakes photosynthesis with its body, making oxygen. The leaf on its head wilts if it is thirsty.",
+		de: "Sein Körper lebt von der Photosynthese, die Sauerstoff freisetzt. Ist es durstig, welkt sein Blatt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/60.ts
+++ b/data/Sun & Moon/Ultra Prism/60.ts
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "Its body is gaseous and frail. It slowly grows as it collects dust from the atmosphere.",
+		de: "Sein Körper besteht aus flüchtigem Gas. Es wächst durch das Sammeln von Staub aus der Luft."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/61.ts
+++ b/data/Sun & Moon/Ultra Prism/61.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cosmog",
 		fr: "Cosmog",
+		de: "Cosmog"
 	},
 
 	stage: "Stage1",
@@ -69,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "There's something accumulating around the black core within its hard shell. People think this Pokémon may come from another world.",
+		de: "Unter seiner harten Schale häuft sich unaufhörlich etwas in seinem schwarzen Kern an. Er soll aus einer anderen Welt stammen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/62.ts
+++ b/data/Sun & Moon/Ultra Prism/62.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Por cada uno de los Pokémon de tu rival en juego, une 1 carta de Energía Psychic de tu pila de descartes a tus Pokémon de la manera que desees.",
 				it: "Per ogni Pokémon del tuo avversario in gioco, assegna a piacimento ai tuoi Pokémon una carta Energia Psychic dalla tua pila degli scarti.",
 				pt: "Para cada Pokémon em jogo do seu oponente, ligue 1 carta de Energia Psychic da sua pilha de descarte aos seus Pokémon como desejar.",
-				de: "Lege für jedes Pokémon deines Gegners im Spiel 1 Psychic-Energiekarte aus deinem Ablagestapel beliebig an deine Pokémon an."
+				de: "Lege für jedes Pokémon deines Gegners im Spiel 1 {P}-Energiekarte aus deinem Ablagestapel beliebig an deine Pokémon an."
 			},
 
 		},
@@ -95,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "Said to live in another world, this Pokémon devours light, drawing the moonless dark veil of night over the brightness of day.",
+		de: "Man sagt, es komme aus einer anderen Welt. Es verschlingt unaufhörlich Licht und sorgt so auch am helllichten Tag für Dunkelheit."
 	},
 }
 

--- a/data/Sun & Moon/Ultra Prism/63.ts
+++ b/data/Sun & Moon/Ultra Prism/63.ts
@@ -88,7 +88,7 @@ const card: Card = {
 				es: "Eclipse de Luna GX",
 				it: "Eclissi di Luna-GX",
 				pt: "Eclipse da Lua GX",
-				de: "Lunarfinsternis GX"
+				de: "Lunarfinsternis-GX"
 			},
 			effect: {
 				en: "You can use this attack only if you have more Prize cards remaining than your opponent. Prevent all effects of attacks, including damage, done to this Pokémon during your opponent’s next turn. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Ultra Prism/64.ts
+++ b/data/Sun & Moon/Ultra Prism/64.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Unidentified Fossil",
 		fr: "Fossile Inconnu",
+		de: "Unbekanntes Fossil"
 	},
 
 	stage: "Stage1",
@@ -80,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "In rock layers where Cranidos fossils are found, the fossilized trunks of trees snapped in two are also often found.",
+		de: "In den Erdschichten, in denen Fossilien von Koknodon entdeckt werden, finden sich auch Überreste abgebrochener Bäume."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/65.ts
+++ b/data/Sun & Moon/Ultra Prism/65.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Cranidos",
 		fr: "Kranidos",
+		de: "Koknodon"
 	},
 
 	stage: "Stage2",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "Records exist of a revived fossil that evolved into Rampardos. It proceeded to escape and then destroy a skyscraper with a headbutt.",
+		de: "Es ist die Weiterentwicklung eines fossilen Pokémon. Einmal entkam ein Rameidon und zerstörte per Kopfstoß ein ganzes Hochhaus."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/66.ts
+++ b/data/Sun & Moon/Ultra Prism/66.ts
@@ -80,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It's tough enough to run right through the night, and it's also a hard worker, but it's still just a youngster.",
+		de: "Dieses junge Pokémon ist bereits so robust und willensstark, dass es die ganze Nacht hindurch rennen kann."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/67.ts
+++ b/data/Sun & Moon/Ultra Prism/67.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Riolu",
 		fr: "Riolu",
+		de: "Riolu"
 	},
 
 	stage: "Stage1",
@@ -93,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "They can detect the species of a living being—and its emotions—from over half a mile away. They control auras and hunt their prey in packs.",
+		de: "Es kann aus 1 km Entfernung die Art und auch die Gefühle von Lebewesen erfassen. Es jagt im Rudel und manipuliert die Aura der Beute."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/68.ts
+++ b/data/Sun & Moon/Ultra Prism/68.ts
@@ -67,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "It enshrouds itself with sand to protect itself from germs. It does not enjoy getting wet.",
+		de: "Es bedeckt sich mit Sand, um sich vor Keimen zu schützen. Es mag es gar nicht, wenn es nass wird."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/69.ts
+++ b/data/Sun & Moon/Ultra Prism/69.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Hippopotas",
 		fr: "Hippopotas",
+		de: "Hippopotas"
 	},
 
 	stage: "Stage1",
@@ -80,7 +81,7 @@ const card: Card = {
 				es: "Este ataque hace 10 puntos de daño más por cada Colorless en el Coste de Retirada del Pokémon Activo de tu rival.",
 				it: "Questo attacco infligge 10 danni in più per ogni Colorless nel costo di ritirata del Pokémon attivo del tuo avversario.",
 				pt: "Este ataque causa 10 pontos de dano a mais para cada Colorless no custo de Recuo do Pokémon Ativo do seu oponente.",
-				de: "Diese Attacke fügt 10 Schadenspunkte mehr mal der Anzahl der Colorless-Symbole in den Rückzugskosten des Aktiven Pokémon deines Gegners zu."
+				de: "Diese Attacke fügt 10 Schadenspunkte mehr mal der Anzahl der {C}-Symbole in den Rückzugskosten des Aktiven Pokémon deines Gegners zu."
 			},
 			damage: "100+",
 
@@ -98,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "It blasts internally stored sand from ports on its body to create a towering twister for attack.",
+		de: "Es wirbelt im Körper gespeicherten Sand durch Öffnungen und generiert so einen Sandwirbelsturm."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/7.ts
+++ b/data/Sun & Moon/Ultra Prism/7.ts
@@ -77,6 +77,7 @@ const card: Card = {
 
 	description: {
 		en: "It undertakes photosynthesis with its body, making oxygen. The leaf on its head wilts if it is thirsty.",
+		de: "Sein Körper lebt von der Photosynthese, die Sauerstoff freisetzt. Ist es durstig, welkt sein Blatt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/70.ts
+++ b/data/Sun & Moon/Ultra Prism/70.ts
@@ -62,7 +62,7 @@ const card: Card = {
 				es: "Lanzamiento de Rocas",
 				it: "Scaglia Pietre",
 				pt: "Lançamento de Pedras",
-				de: "Steinschleuderer"
+				de: "Steinschleuder"
 			},
 			effect: {
 				en: "This attack’s damage isn’t affected by Resistance.",
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "They battle with hard berries for weapons. Their techniques are passed from the boss to the group, generation upon generation.",
+		de: "Es setzt eine harte Beere im Kampf ein. Diese Technik wird vom Anführer der Gruppe von Generation zu Generation weitervererbt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/71.ts
+++ b/data/Sun & Moon/Ultra Prism/71.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "Seen as a symbol of bad luck, it's generally disliked. Yet it gives presents—objects that sparkle or shine—to Trainers it's close to.",
+		de: "Es ist als Unglücksbringer verschrien, aber wenn es sich mit seinem Trainer gut versteht, schenkt es ihm allerlei funkelnde und glitzernde Objekte."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/72.ts
+++ b/data/Sun & Moon/Ultra Prism/72.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Murkrow",
 		fr: "Cornèbre",
+		de: "Kramurx"
 	},
 
 	stage: "Stage1",
@@ -94,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "If its Murkrow cronies fail to catch food for it, or if it feels they have betrayed it, it will hunt them down wherever they are and punish them.",
+		de: "Untergebene Kramurx, die beim Beutefang versagen und Kramshef damit enttäuschen, jagt es bis ans Ende der Welt, um sie zu bestrafen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/73.ts
+++ b/data/Sun & Moon/Ultra Prism/73.ts
@@ -94,6 +94,7 @@ const card: Card = {
 
 	description: {
 		en: "It uses its claws to poke holes in eggs so it can slurp out the insides. Breeders consider it a scourge and will drive it away or eradicate it.",
+		de: "Es rammt seine Krallen in Eier und schlürft ihren Inhalt aus. Pokémon-Züchter können es aus diesem Grund nicht ausstehen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/74.ts
+++ b/data/Sun & Moon/Ultra Prism/74.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Sneasel",
 		fr: "Farfuret",
+		de: "Sniebel"
 	},
 
 	stage: "Stage1",
@@ -100,6 +101,7 @@ const card: Card = {
 
 	description: {
 		en: "They dwell in cold places. This Pokémon's main food source in Alola is Vulpix and Sandshrew, which they carefully divide among their group.",
+		de: "Sie leben in kalten Gebieten und ernähren sich in Alola hauptsächlich von Vulpix und Sandan. Ihre Beute teilen sie gerecht untereinander auf."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/75.ts
+++ b/data/Sun & Moon/Ultra Prism/75.ts
@@ -72,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "It protects itself by spraying a noxious fluid from its rear. The stench lingers for 24 hours.",
+		de: "Um sich zu schützen, versprüht es eine Substanz aus seinem Hinterleib, die 24 Stunden stinkt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/76.ts
+++ b/data/Sun & Moon/Ultra Prism/76.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Stunky",
 		fr: "Moufouette",
+		de: "Skunkapuh"
 	},
 
 	stage: "Stage1",
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "It sprays a stinky fluid from its tail. The fluid smells worse the longer it is allowed to fester.",
+		de: "Es spritzt eine stinkende Substanz aus seinem Schweif. Hat sie lange gegärt, stinkt sie stärker."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/77.ts
+++ b/data/Sun & Moon/Ultra Prism/77.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Cuando juegues este Pokémon de tu mano a tu Banca durante tu turno, puedes unirle 2 cartas de Energía Darkness de tu mano.",
 				it: "Quando giochi questo Pokémon dalla tua mano e lo metti in panchina durante il tuo turno, puoi assegnargli due carte Energia Darkness dalla tua mano.",
 				pt: "Quando você joga este Pokémon da sua mão para o seu Banco durante a sua vez de jogar, você pode ligar 2 cartas de Energia Darkness da sua mão a ele.",
-				de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand auf deine Bank spielst, kannst du 2 Darkness-Energiekarten aus deiner Hand an es anlegen."
+				de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand auf deine Bank spielst, kannst du 2 {D}-Energiekarten aus deiner Hand an es anlegen."
 			},
 		},
 	],
@@ -97,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "It can lull people to sleep and make them dream. It is active during nights of the new moon.",
+		de: "Es kann andere in Schlaf versetzen und ihnen Träume geben. Es ist nur bei Neumond aktiv."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/78.ts
+++ b/data/Sun & Moon/Ultra Prism/78.ts
@@ -70,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "Its golden hairs function as sensors. It pokes them out of its burrow to monitor its surroundings.",
+		de: "Seine goldenen Haare verfügen über sensorische Funktionen. Es streckt sie aus Löchern heraus, um die Umgebung zu erkunden."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/79.ts
+++ b/data/Sun & Moon/Ultra Prism/79.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Alolan Diglett",
 		fr: "Taupiqueur d’Alola",
+		de: "Alola-Digda"
 	},
 
 	stage: "Stage1",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Descarta cualquier cantidad de cartas de Energía Metal de tu mano. Este ataque hace 30 puntos de daño por cada carta que hayas descartado de esta manera.",
 				it: "Scarta un numero qualsiasi di carte Energia Metal che hai in mano. Questo attacco infligge 30 danni per ogni carta che hai scartato in questo modo.",
 				pt: "Descarte qualquer número de cartas de Energia Metal da sua mão. Este ataque causa 30 pontos de dano para cada carta descartada desta forma.",
-				de: "Lege beliebig viele Metal-Energiekarten aus deiner Hand auf deinen Ablagestapel. Diese Attacke fügt 30 Schadenspunkte mal der Anzahl der auf diese Weise auf deinen Ablagestapel gelegten Karten zu."
+				de: "Lege beliebig viele {M}-Energiekarten aus deiner Hand auf deinen Ablagestapel. Diese Attacke fügt 30 Schadenspunkte mal der Anzahl der auf diese Weise auf deinen Ablagestapel gelegten Karten zu."
 			},
 			damage: "30×",
 
@@ -75,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "These Pokémon are cherished in the Alola region, where they are thought to be feminine deities of the land incarnate.",
+		de: "Man hält es für die Verkörperung der Göttinnen des Landes. In der Alola-Region wird es daher außerordentlich geschätzt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/8.ts
+++ b/data/Sun & Moon/Ultra Prism/8.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Turtwig",
 		fr: "Tortipouss",
+		de: "Chelast"
 	},
 
 	stage: "Stage1",
@@ -90,6 +91,7 @@ const card: Card = {
 
 	description: {
 		en: "It knows where pure water wells up. It carries fellow Pokémon there on its back.",
+		de: "Es weiß, wo es reinstes Quellwasser finden kann. Trägt andere Pokémon auf seinem Rücken dorthin."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/80.ts
+++ b/data/Sun & Moon/Ultra Prism/80.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Busca en tu baraja hasta 3 cartas de Energía Metal, enséñalas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
 				it: "Cerca nel tuo mazzo fino a tre carte Energia Metal, mostrale e aggiungile alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 				pt: "Procure por até 3 cartas de Energia Metal no seu baralho, revele-as e coloque-as na sua mão. Em seguida, embaralhe o seu baralho.",
-				de: "Durchsuche dein Deck nach bis zu 3 Metal-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+				de: "Durchsuche dein Deck nach bis zu 3 {M}-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
 			},
 
 		},
@@ -87,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "It sends out electromagnetic waves, which let it float through the air. Touching it while it's eating electricity will give you a full-body shock.",
+		de: "Es sendet elektromagnetische Wellen aus und segelt durch die Luft. Berührt man es, während es Strom saugt, bekommt man einen Schlag."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/81.ts
+++ b/data/Sun & Moon/Ultra Prism/81.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "It sends out electromagnetic waves, which let it float through the air. Touching it while it's eating electricity will give you a full-body shock.",
+		de: "Es sendet elektromagnetische Wellen aus und segelt durch die Luft. Berührt man es, während es Strom saugt, bekommt man einen Schlag."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/82.ts
+++ b/data/Sun & Moon/Ultra Prism/82.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Magnemite",
 		fr: "Magnéti",
+		de: "Magnetilo"
 	},
 
 	stage: "Stage1",
@@ -95,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "It has about three times the electrical power of Magnemite. For some reason, outbreaks of this Pokémon happen when lots of sunspots appear.",
+		de: "Seine Stromstärke ist fast dreimal so hoch wie die eines Magnetilos. Es erscheint vermehrt, wenn Flecken auf der Sonne auftauchen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/83.ts
+++ b/data/Sun & Moon/Ultra Prism/83.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Magneton",
 		fr: "Magnéton",
+		de: "Magneton"
 	},
 
 	stage: "Stage2",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Todas las veces que quieras durante tu turno (antes de tu ataque), puedes unir 1 carta de Energía Metal de tu mano a 1 de tus Pokémon.",
 				it: "Durante il tuo turno, prima di attaccare, puoi assegnare a uno dei tuoi Pokémon una carta Energia Metal dalla tua mano tutte le volte che vuoi.",
 				pt: "Quantas vezes desejar durante a sua vez de jogar (antes de atacar), você pode ligar 1 carta de Energia Metal da sua mão a 1 dos seus Pokémon.",
-				de: "Beliebig oft während deines Zuges (bevor du angreifst) kannst du 1 Metal-Energiekarte aus deiner Hand an 1 deiner Pokémon anlegen."
+				de: "Beliebig oft während deines Zuges (bevor du angreifst) kannst du 1 {M}-Energiekarte aus deiner Hand an 1 deiner Pokémon anlegen."
 			},
 		},
 	],
@@ -102,6 +103,7 @@ const card: Card = {
 
 	description: {
 		en: "As it zooms through the sky, this Pokémon seems to be receiving signals of unknown origin, while transmitting signals of unknown purpose.",
+		de: "Es heißt, dass es beim Herumfliegen mysteriöse Funkwellen aussende und unbekannte empfange."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/84.ts
+++ b/data/Sun & Moon/Ultra Prism/84.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Unidentified Fossil",
 		fr: "Fossile Inconnu",
+		de: "Unbekanntes Fossil"
 	},
 
 	stage: "Stage1",
@@ -96,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon lived in primeval jungles. Few enemies would have been willing to square off against its heavily armored face, so it's thought.",
+		de: "Man nimmt an, dass es dank seines gepanzerten Gesichts kaum Feinde hatte. Es lebte vor Urzeiten im Dschungel."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/85.ts
+++ b/data/Sun & Moon/Ultra Prism/85.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Shieldon",
 		fr: "Dinoclier",
+		de: "Schilterus"
 	},
 
 	stage: "Stage2",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Evita todo el daño infligido a tus Pokémon Metal por ataques de los Pokémon de tu rival que tengan alguna Energía Especial unida a ellos.",
 				it: "Previeni tutti i danni inflitti ai tuoi Pokémon Metal dagli attacchi dei Pokémon del tuo avversario che abbiano delle Energie speciali assegnate.",
 				pt: "Previne todo o dano causado aos seus Pokémon Metal por ataques dos Pokémon do seu oponente que tenham alguma Energia Especial ligada a eles.",
-				de: "Verhindere allen Schaden, der deinen Metal-Pokémon durch Attacken von Pokémon deines Gegners, an die mindestens 1 Spezial-Energie angelegt ist, zugefügt wird."
+				de: "Verhindere allen Schaden, der deinen {M}-Pokémon durch Attacken von Pokémon deines Gegners, an die mindestens 1 Spezial-Energie angelegt ist, zugefügt wird."
 			},
 		},
 	],
@@ -101,6 +102,7 @@ const card: Card = {
 
 	description: {
 		en: "It lived in the same environments as Rampardos. Their fossils have been found together—seemingly from after they'd fought to the finish.",
+		de: "Es lebte in denselben Gebieten wie Rameidon. Manche Fossilienfunde legen nahe, dass sie sich erbitterte Kämpfe geliefert haben."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/86.ts
+++ b/data/Sun & Moon/Ultra Prism/86.ts
@@ -88,6 +88,7 @@ const card: Card = {
 
 	description: {
 		en: "Implements shaped like it were discovered in ancient tombs. It is unknown if they are related.",
+		de: "Sein Körper sieht aus, als seien Teile davon in alten Gräbern gefunden worden."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/87.ts
+++ b/data/Sun & Moon/Ultra Prism/87.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Bronzor",
 		fr: "Archéomire",
+		de: "Bronzel"
 	},
 
 	stage: "Stage1",
@@ -77,7 +78,7 @@ const card: Card = {
 				es: "Si tu rival tiene algún Pokémon Psychic en juego, este ataque hace 60 puntos de daño más.",
 				it: "Se il tuo avversario ha dei Pokémon Psychic in gioco, questo attacco infligge 60 danni in più.",
 				pt: "Se o seu oponente tiver algum Pokémon Psychic em jogo, este ataque causará 60 pontos de dano a mais.",
-				de: "Wenn dein Gegner mindestens 1 Psychic-Pokémon im Spiel hat, fügt diese Attacke 60 Schadenspunkte mehr zu."
+				de: "Wenn dein Gegner mindestens 1 {P}-Pokémon im Spiel hat, fügt diese Attacke 60 Schadenspunkte mehr zu."
 			},
 			damage: "60+",
 
@@ -102,6 +103,7 @@ const card: Card = {
 
 	description: {
 		en: "Ancient people believed that petitioning Bronzong for rain was the way to make crops grow.",
+		de: "Früher verehrten die Menschen die Bronzong, weil sie sich davon Regen oder gute Ernten erhofften."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/88.ts
+++ b/data/Sun & Moon/Ultra Prism/88.ts
@@ -98,6 +98,7 @@ const card: Card = {
 
 	description: {
 		en: "Boiling blood, like magma, circulates through its body. It makes its dwelling place in volcanic caves.",
+		de: "Das Blut, das durch seinen Körper fließt, brodelt heiß wie Magma. Es lebt in vulkanischen Höhlen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/89.ts
+++ b/data/Sun & Moon/Ultra Prism/89.ts
@@ -47,7 +47,7 @@ const card: Card = {
 				es: "Por cada uno de los Pokémon de tu rival en juego, une 1 carta de Energía Metal de tu pila de descartes a tus Pokémon de la manera que desees.",
 				it: "Per ogni Pokémon del tuo avversario in gioco, assegna a piacimento ai tuoi Pokémon una carta Energia Metal dalla tua pila degli scarti.",
 				pt: "Para cada Pokémon em jogo do seu oponente, ligue 1 carta de Energia Metal da sua pilha de descarte aos seus Pokémon como desejar.",
-				de: "Lege für jedes Pokémon deines Gegners im Spiel 1 Metal-Energiekarte aus deinem Ablagestapel beliebig an deine Pokémon an."
+				de: "Lege für jedes Pokémon deines Gegners im Spiel 1 {M}-Energiekarte aus deinem Ablagestapel beliebig an deine Pokémon an."
 			},
 
 		},
@@ -97,6 +97,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon is said to be a male evolution of Cosmog. At the activation of its third eye, it departs for another world.",
+		de: "Es heißt, es sei die männliche Endstufe der Entwicklungsreihe von Cosmog. Ist sein drittes Auge aktiviert, zieht es in eine andere Welt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/9.ts
+++ b/data/Sun & Moon/Ultra Prism/9.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Grotle",
 		fr: "Boskara",
+		de: "Chelcarain"
 	},
 
 	stage: "Stage2",
@@ -98,6 +99,7 @@ const card: Card = {
 
 	description: {
 		en: "Small Pokémon occasionally gather on its unmoving back to begin building their nests.",
+		de: "Kleine Pokémon fangen manchmal an, auf dem bewegungslosen Rücken Nester zu bauen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/90.ts
+++ b/data/Sun & Moon/Ultra Prism/90.ts
@@ -85,7 +85,7 @@ const card: Card = {
 				es: "Eclipse de Sol GX",
 				it: "Eclissi di Sole-GX",
 				pt: "Eclipse do Sol GX",
-				de: "Solarfinsternis GX"
+				de: "Solarfinsternis-GX"
 			},
 			effect: {
 				en: "You can use this attack only if you have more Prize cards remaining than your opponent. (You can’t use more than 1 GX attack in a game.)",

--- a/data/Sun & Moon/Ultra Prism/91.ts
+++ b/data/Sun & Moon/Ultra Prism/91.ts
@@ -89,6 +89,7 @@ const card: Card = {
 
 	description: {
 		en: "This artificial Pokémon, constructed more than 500 years ago, can understand human speech but cannot itself speak.",
+		de: "Dieses Pokémon wurde vor über 500 Jahren künstlich erschaffen. Es versteht die Sprache der Menschen, ohne sie selbst zu sprechen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/92.ts
+++ b/data/Sun & Moon/Ultra Prism/92.ts
@@ -87,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "It scatters spores that flicker and glow. Anyone seeing these lights falls into a deep slumber.",
+		de: "Es streut blinkende Sporen aus. Jeder der dieses Licht sieht, schläft fest ein."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/93.ts
+++ b/data/Sun & Moon/Ultra Prism/93.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Morelull",
 		fr: "Spododo",
+		de: "Bubungus"
 	},
 
 	stage: "Stage1",
@@ -50,7 +51,7 @@ const card: Card = {
 				es: "Una vez durante tu turno (antes de tu ataque), puedes buscar en tu baraja 1 Pokémon Fairy, enseñarlo y ponerlo en tu mano. Después, baraja las cartas de tu baraja.",
 				it: "Una sola volta durante il tuo turno, prima di attaccare, puoi cercare nel tuo mazzo un Pokémon Fairy, mostrarlo e aggiungerlo alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 				pt: "Uma vez durante a sua vez de jogar (antes de atacar), você pode procurar por 1 Pokémon Fairy no seu baralho, revelá-lo e colocá-lo na sua mão. Em seguida, embaralhe o seu baralho.",
-				de: "Einmal während deines Zuges (bevor du angreifst) kannst du dein Deck nach 1 Fairy-Pokémon durchsuchen, es deinem Gegner zeigen und auf deine Hand nehmen. Mische anschließend dein Deck."
+				de: "Einmal während deines Zuges (bevor du angreifst) kannst du dein Deck nach 1 {FAIRY}-Pokémon durchsuchen, es deinem Gegner zeigen und auf deine Hand nehmen. Mische anschließend dein Deck."
 			},
 		},
 	],
@@ -100,6 +101,7 @@ const card: Card = {
 
 	description: {
 		en: "Forests where Shiinotic live are treacherous to enter at night. People confused by its strange lights can never find their way home again.",
+		de: "Nachts sollte man Wälder meiden, in denen Lamellux lebt. Ihr unheimliches Licht raubt jedem die Orientierung."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/94.ts
+++ b/data/Sun & Moon/Ultra Prism/94.ts
@@ -95,6 +95,7 @@ const card: Card = {
 
 	description: {
 		en: "This guardian deity of Akala is guilelessly cruel. The fragrant aroma of flowers is the source of its energy.",
+		de: "Der arglose, doch unbarmherzige Schutzpatron von Akala. Seine Energie zieht es aus dem lieblichen Duft von Blumen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/95.ts
+++ b/data/Sun & Moon/Ultra Prism/95.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Exeggcute",
 		fr: "Noeunoeuf",
+		de: "Owei"
 	},
 
 	stage: "Stage1",
@@ -74,7 +75,7 @@ const card: Card = {
 				es: "Lanza 1 moneda por cada Energía Grass unida a este Pokémon. Este ataque hace 80 puntos de daño por cada cara.",
 				it: "Lancia una moneta per ogni Energia Grass assegnata a questo Pokémon. Questo attacco infligge 80 danni ogni volta che esce testa.",
 				pt: "Jogue 1 moeda para cada Energia Grass ligada a este Pokémon. Este ataque causa 80 pontos de dano para cada cara.",
-				de: "Wirf 1 Münze für jede an dieses Pokémon angelegte Grass-Energie. Diese Attacke fügt 80 Schadenspunkte pro Kopf zu."
+				de: "Wirf 1 Münze für jede an dieses Pokémon angelegte {G}-Energie. Diese Attacke fügt 80 Schadenspunkte pro Kopf zu."
 			},
 			damage: "80×",
 
@@ -92,6 +93,7 @@ const card: Card = {
 
 	description: {
 		en: "Alola is the best environment for this Pokémon. Local people take pride in its appearance, saying this is how Exeggutor ought to look.",
+		de: "In Alola herrschen für Kokowei die besten Bedingungen. Die Einwohner behaupten voller Stolz, dass dies seine ursprüngliche Form sei."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/96.ts
+++ b/data/Sun & Moon/Ultra Prism/96.ts
@@ -64,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "It skulks in caves, and when prey or an enemy passes by, it leaps out and chomps them. The force of its attack sometimes chips its teeth.",
+		de: "Es verbirgt sich in kleinen Höhlen, aus denen es herausspringt und vorbeilaufende Gegner beißt. Manchmal bricht dabei ein Zahn ab."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/97.ts
+++ b/data/Sun & Moon/Ultra Prism/97.ts
@@ -45,7 +45,7 @@ const card: Card = {
 				es: "Si este Pokémon tiene alguna Energía Fighting unida a él, no tiene ningún Coste de Retirada.",
 				it: "Se questo Pokémon ha delle Energie Fighting assegnate, non ha costo di ritirata.",
 				pt: "Se este Pokémon tiver alguma Energia Fighting ligada a ele, não terá custo de Recuo.",
-				de: "Wenn an dieses Pokémon mindestens 1 Fighting-Energie angelegt ist, hat es keine Rückzugskosten."
+				de: "Wenn an dieses Pokémon mindestens 1 {F}-Energie angelegt ist, hat es keine Rückzugskosten."
 			},
 		},
 	],
@@ -81,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "It skulks in caves, and when prey or an enemy passes by, it leaps out and chomps them. The force of its attack sometimes chips its teeth.",
+		de: "Es verbirgt sich in kleinen Höhlen, aus denen es herausspringt und vorbeilaufende Gegner beißt. Manchmal bricht dabei ein Zahn ab."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/98.ts
+++ b/data/Sun & Moon/Ultra Prism/98.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gible",
 		fr: "Griknot",
+		de: "Kaumalat"
 	},
 
 	stage: "Stage1",
@@ -86,6 +87,7 @@ const card: Card = {
 
 	description: {
 		en: "Shiny objects are its passion. It can be found in its cave, scarcely moving, its gaze fixed on the jewels it's amassed or Carbink it has caught.",
+		de: "Es liebt funkelnde Dinge. Edelsteine und gefangene Rocara nimmt es mit in sein Nest, um sich an ihrem Anblick zu weiden."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Ultra Prism/99.ts
+++ b/data/Sun & Moon/Ultra Prism/99.ts
@@ -29,6 +29,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gabite",
 		fr: "Carmache",
+		de: "Knarksel"
 	},
 
 	stage: "Stage2",
@@ -95,6 +96,7 @@ const card: Card = {
 
 	description: {
 		en: "The protuberances on its head serve as sensors. It can even detect distant prey.",
+		de: "Die beiden Fortsätze an seinem Kopf haben die Funktion eines Sensors. Mit ihnen kann es auch weit entfernte Beute aufspüren."
 	},
 
 	thirdParty: {


### PR DESCRIPTION
## Add missing German translations for sm5

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
